### PR TITLE
fix(worker): trainer path + shutdown-cancel + quant tier + helper renames (epic 8800 batch 9)

### DIFF
--- a/crates/sceneworks-worker/src/analysis_jobs_common.rs
+++ b/crates/sceneworks-worker/src/analysis_jobs_common.rs
@@ -16,6 +16,15 @@
 //! `records_payload`. Everything else — the cancel/heartbeat handling reconciled in sc-8835 (F-035) —
 //! lives here so a future analysis job re-stamps a config, not ~400 lines of scaffold, and the cancel
 //! handling can only ever be fixed in one place.
+//!
+//! **Training is intentionally out of scope** (sc-9541, F-034 follow-up). `training_jobs`'
+//! `consume_training_events` supervises a `spawn_blocking` producer with the same `CancelJoinGuard` +
+//! bounded-join teardown, but its channel carries a rich `TrainEvent`/`TrainingProgress` variant tree
+//! (not the bare per-item `usize` this scaffold streams), its progress spans five kernel bands (not the
+//! single `item_progress` ramp), its `Sample` events have file-persistence side effects, and it ends in
+//! an in-place `Done` result with NO sidecar POST. Folding it here would force this seam generic over an
+//! event type + an event→progress mapper + a stateful side-effect hook + a no-op sidecar branch, hurting
+//! clarity more than the duplication removed — see the no-fold rationale on `consume_training_events`.
 
 use super::*;
 

--- a/crates/sceneworks-worker/src/analysis_jobs_common.rs
+++ b/crates/sceneworks-worker/src/analysis_jobs_common.rs
@@ -177,7 +177,9 @@ where
                 }
                 _ = interval.tick() => {
                     heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
-                    if !canceled && cancel_requested_peek(api, &job.id).await {
+                    // sc-9618: a process shutdown is a cancel checkpoint too — short-circuit the API
+                    // poll (a local flag read) so a quit stops the embed loop at its next per-item check.
+                    if !canceled && (shutdown_requested() || cancel_requested_peek(api, &job.id).await) {
                         // Trip the flag so the blocking loop bails at its next per-item check; the
                         // terminal `Canceled` is posted below once the task has actually stopped.
                         cancel.cancel();

--- a/crates/sceneworks-worker/src/caption_jobs.rs
+++ b/crates/sceneworks-worker/src/caption_jobs.rs
@@ -299,10 +299,20 @@ pub(crate) async fn run_training_caption_job(
             }
             _ = interval.tick() => {
                 heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
-                match check_cancel(api, &job.id, CANCEL_MESSAGE).await {
-                    Ok(()) => {}
-                    Err(WorkerError::Canceled(_)) => cancel.cancel(),
-                    Err(error) => return Err(error),
+                // sc-9618: a process shutdown is a cancel checkpoint too — short-circuit the API
+                // `check_cancel` poll (a local flag read) so a quit trips the captioner flag at its
+                // next per-item check instead of waiting out the grace window, exactly like a user
+                // cancel does. `check_cancel` posts the terminal `Canceled` itself; on shutdown the
+                // bounded-wait teardown in `run_job_with_shutdown` owns the terminal, so here we just
+                // trip the engine flag to stop the captioner mid-dataset.
+                if shutdown_requested() {
+                    cancel.cancel();
+                } else {
+                    match check_cancel(api, &job.id, CANCEL_MESSAGE).await {
+                        Ok(()) => {}
+                        Err(WorkerError::Canceled(_)) => cancel.cancel(),
+                        Err(error) => return Err(error),
+                    }
                 }
             }
         }

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -154,11 +154,11 @@ impl ImageRoute {
             | ImageRoute::Flux2DevControl => pose_entries(request).len() as u32,
             ImageRoute::Flux2Edit | ImageRoute::QwenEdit => grouped_edit_image_count(request),
             ImageRoute::InstantId => instantid_image_count(request, settings),
-            ImageRoute::SensenovaEdit => match flux2_grouping(request) {
-                Flux2Grouping::Angles => CHARACTER_ANGLE_SET_ORDER.len() as u32,
+            ImageRoute::SensenovaEdit => match edit_grouping(request) {
+                EditGrouping::Angles => CHARACTER_ANGLE_SET_ORDER.len() as u32,
                 // SenseNova has no strict-pose (ControlNet) path; pose jobs are excluded
                 // upstream, so any residual grouping preserves the requested image count.
-                Flux2Grouping::Poses(_) | Flux2Grouping::Plain => request.count,
+                EditGrouping::Poses(_) | EditGrouping::Plain => request.count,
             },
             // PuLID-FLUX is one identity image per seed (no angle/pose grouping) — like the base
             // MLX + SDXL-advanced + Bernini paths, the effective count is the requested count.
@@ -280,12 +280,90 @@ fn resolve_candle_image_route(
     }
 }
 
+/// How a native edit job batches its iterations (sc-8946 (F-144): renamed from `Flux2Grouping` and
+/// moved here from flux2.rs — it is the SHARED grouping for the FLUX.2 / Qwen-Edit / SenseNova-U1 edit
+/// lanes, not FLUX.2-specific, so a reader auditing Qwen/SenseNova grouping finds it in base.rs).
+#[cfg(target_os = "macos")]
+enum EditGrouping {
+    /// `count` independent images (per-image seeds), the plain reference/edit path.
+    Plain,
+    /// The 11-angle Character-Studio set: shared seed, per-angle prompt augment.
+    Angles,
+    /// The best-effort pose tier: `n` poses, shared seed, `[skeleton, reference]` sets.
+    Poses(usize),
+}
+
+/// Decide the grouping for a native edit job (parity with the `Mlx*Adapter` decision: pose set >
+/// angle set > plain, all gated to `character_image` mode — an `edit_image` job is never grouped).
+/// The caller only reaches this with a reference present, so `is_character_image` reduces to the mode
+/// check. Shared by the FLUX.2 / Qwen-Edit / SenseNova-U1 edit lanes (sc-8946 moved it from flux2.rs).
+#[cfg(target_os = "macos")]
+fn edit_grouping(request: &ImageRequest) -> EditGrouping {
+    if request.mode != "character_image" {
+        return EditGrouping::Plain;
+    }
+    let poses = pose_entries(request).len();
+    if poses > 0 {
+        return EditGrouping::Poses(poses);
+    }
+    if advanced::flag(&request.advanced, "angleSet") {
+        return EditGrouping::Angles;
+    }
+    EditGrouping::Plain
+}
+
+/// Upper bound on reference images for a multi-reference edit (sc-6211). Even with the engine's
+/// sequence-gated activation chunking (sc-6266), the FLUX.2-dev edit stays activation-bound: 4
+/// references at 1024² peak ~93 GB and 5 would exceed the 96 GB floor (measured). The per-machine
+/// `flux2_dev_edit_memory_guard` rejects over-budget combinations with an actionable message; this
+/// caps absurd inputs (and bounds the DiT sequence) before that.
+#[cfg(target_os = "macos")]
+const MAX_EDIT_REFERENCES: usize = 4;
+
+/// Reference asset ids for a native edit (sc-8946 moved it from flux2.rs — shared by the FLUX.2 /
+/// SenseNova-via-grouping lanes, not FLUX.2-specific). The FLUX.2-dev multi-image picker (sc-6211)
+/// sends the plural `referenceAssetIds` — take all of them in order, capped at [`MAX_EDIT_REFERENCES`].
+/// With no plural list it falls back to the single-reference flows: the character `referenceAssetId`,
+/// else the Image-Edit `sourceAssetId` (edit_image mode). Mirrors the Python
+/// `ref_id = referenceAssetId or (sourceAssetId if edit_image)`, plus the new multi-reference set.
+#[cfg(target_os = "macos")]
+fn edit_reference_ids(request: &ImageRequest) -> Vec<String> {
+    if !request.reference_asset_ids.is_empty() {
+        // Parsed list is already trimmed + non-empty (sceneworks-core `string_list`).
+        return request
+            .reference_asset_ids
+            .iter()
+            .take(MAX_EDIT_REFERENCES)
+            .cloned()
+            .collect();
+    }
+    if let Some(id) = request
+        .reference_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    {
+        return vec![id.to_owned()];
+    }
+    if request.mode == "edit_image" {
+        if let Some(id) = request
+            .source_asset_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+        {
+            return vec![id.to_owned()];
+        }
+    }
+    Vec::new()
+}
+
 #[cfg(target_os = "macos")]
 fn grouped_edit_image_count(request: &ImageRequest) -> u32 {
-    match flux2_grouping(request) {
-        Flux2Grouping::Angles => CHARACTER_ANGLE_SET_ORDER.len() as u32,
-        Flux2Grouping::Poses(count) => count as u32,
-        Flux2Grouping::Plain => request.count,
+    match edit_grouping(request) {
+        EditGrouping::Angles => CHARACTER_ANGLE_SET_ORDER.len() as u32,
+        EditGrouping::Poses(count) => count as u32,
+        EditGrouping::Plain => request.count,
     }
 }
 
@@ -1955,6 +2033,66 @@ pub(crate) fn load_reference_image(
     })
 }
 
+/// The clamped identity img2img-init strength for a strict-pose set, or `None` for the pose-only tier.
+/// `Some(strength)` iff `advanced.referenceStrength > 0` AND a non-empty `referenceAssetId` is present;
+/// `strength` is the user value clamped to `[0.05, 1.0]`, carrying the mflux `image_strength`
+/// convention **verbatim** (higher strength → later denoise start → output stays closer to the init).
+///
+/// sc-8946 (F-144): this was duplicated line-for-line as `zimage_identity_strength` (Z-Image, sc-3146)
+/// and `flux2_identity_strength` (FLUX.2-dev control) — an identity-gate change had to be made twice.
+/// The gate + clamp are IDENTICAL across the two lanes (both mirror `MlxZImageAdapter`), so it lives
+/// here once. Pure (request only), so the parity-sensitive gate + clamp stay unit-testable without I/O.
+#[cfg(target_os = "macos")]
+fn identity_strength(request: &ImageRequest) -> Option<f32> {
+    let strength = request
+        .advanced
+        .get("referenceStrength")
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .filter(|strength| *strength > 0.0)?;
+    let has_asset = request
+        .reference_asset_id
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|id| !id.is_empty());
+    has_asset.then(|| (strength as f32).clamp(0.05, 1.0))
+}
+
+/// Resolve the optional identity img2img-init for a strict-pose set: `Some((image, strength))` when
+/// [`identity_strength`] engages (decoding `referenceAssetId` via [`load_reference_image`]), else
+/// `None` (the default pose-only tier). The reference is shared across the whole pose set — identity is
+/// constant; only the per-pose skeleton changes.
+///
+/// sc-8946 (F-144): the shared body of the former `resolve_identity_init` /
+/// `resolve_flux2_identity_init` (both line-for-line copies). The Z-Image strict-pose stream and the
+/// FLUX.2-dev control stream both call this.
+#[cfg(target_os = "macos")]
+fn resolve_identity_init(
+    request: &ImageRequest,
+    settings: &Settings,
+    project_path: &Path,
+) -> WorkerResult<Option<(Image, f32)>> {
+    let Some(strength) = identity_strength(request) else {
+        return Ok(None);
+    };
+    let asset_id = request
+        .reference_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .expect("identity_strength guarantees a non-empty referenceAssetId");
+    let image = load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        asset_id,
+        project_path,
+    )?;
+    Ok(Some((image, strength)))
+}
+
 /// The source identity reference (decoded image + its asset id) a strict-control pose set scores its
 /// finished poses against (epic 4406, sc-4410), or `None` when the job carries no identity reference.
 ///
@@ -2090,7 +2228,7 @@ fn build_reference_conditioning(references: &[Image]) -> Vec<Conditioning> {
 /// Reference asset ids for a Boogu instruction edit, in order. The multi-image picker sends the plural
 /// `referenceAssetIds` — take all of them, capped at [`BOOGU_MAX_EDIT_REFERENCES`]; with no plural list
 /// it falls back to the single Image-Edit `sourceAssetId` (`edit_image` mode). Mirrors
-/// `flux2_edit_reference_ids`.
+/// `edit_reference_ids`.
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
@@ -2468,7 +2606,7 @@ fn resolve_generic_lane_conditioning(
         let init = if request.mode == "edit_image" {
             resolve_zimage_edit_init(request, settings, project_path)?
         } else {
-            resolve_zimage_identity_init(request, settings, project_path)?
+            resolve_identity_init(request, settings, project_path)?
         };
         Ok(LaneConditioning {
             identity_init: init,

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -3546,7 +3546,9 @@ async fn consume_gen_events(
                 mark_started(index);
                 if last_cancel_check.elapsed() >= Duration::from_secs(2) {
                     last_cancel_check = Instant::now();
-                    if cancel_requested_peek(api, &job.id).await {
+                    // sc-9618: a process shutdown is a cancel checkpoint too — short-circuit the API
+                    // poll so a quit stops the gen at this step, matching a user cancel.
+                    if shutdown_requested() || cancel_requested_peek(api, &job.id).await {
                         // Trip the flag + show "Cancelling…", but stay non-terminal until the
                         // in-flight image actually stops (terminal Canceled posted after the
                         // blocking run returns) — sc-5515.
@@ -3653,12 +3655,16 @@ async fn consume_gen_events(
             }
             _ = interval.tick() => {
                 heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
-                if !canceled && last_cancel_check.elapsed() >= Duration::from_secs(2) {
-                    last_cancel_check = Instant::now();
-                    if cancel_requested_peek(api, &job.id).await {
-                        begin_image_cancel(api, &job.id, &cancel, plan, asset_writes, backend).await;
-                        canceled = true;
-                    }
+                // sc-9618: honor a process shutdown on every tick (a local flag read, no API cost, so
+                // not throttled by the 2s user-cancel poll) so a quit trips the engine cancel promptly.
+                if !canceled && (shutdown_requested()
+                    || (last_cancel_check.elapsed() >= Duration::from_secs(2) && {
+                        last_cancel_check = Instant::now();
+                        cancel_requested_peek(api, &job.id).await
+                    }))
+                {
+                    begin_image_cancel(api, &job.id, &cancel, plan, asset_writes, backend).await;
+                    canceled = true;
                 }
             }
         }

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -889,6 +889,36 @@ fn resolve_quant(request: &ImageRequest) -> (Option<Quant>, Option<i64>) {
     }
 }
 
+/// The transformer-tier bit count a dense-TE turnkey (FLUX.2-klein, the [`DENSE_TE_TIER_MODELS`]
+/// class) actually asked for, derived from `advanced.mlxQuantize` the SAME way [`standard_tier_subdir`]
+/// picks its `bf16`/`q8`/`q4` tier (`<=0 → bf16`, `>4 → q8`, else the q4 default). Returns the recipe
+/// bit count of the REQUESTED tier: `None` (bf16) / `Some(8)` / `Some(4)`.
+///
+/// sc-9362 (F-018 follow-up): [`resolve_quant`] returns `(None, None)` for every dense-TE job (the
+/// load quant must stay `None` so the deliberately-dense bf16 text encoder is never re-quantized), so
+/// the request-derived recipe bits are ALWAYS bf16 even though the transformer is packed at q4/q8. If
+/// [`reconcile_resolved_tier_quant`] compared the resolved transformer tier against that always-`None`
+/// value, every straight (non-fallback) dense-TE job would look like a bf16→qN "downgrade" — firing a
+/// spurious `quant_tier_downgraded` event while the asset telemetry still hid the true transformer
+/// precision. Comparing the resolved tier against THIS requested-tier value instead lets the reconcile
+/// record the actual transformer precision on every job and warn/emit ONLY on a genuine fallback
+/// (requested tier absent → resolver fell through to an adjacent tier).
+///
+/// macOS-only: consumed on the MLX `generate_stream` reconcile path (the candle lane has no tier
+/// layout), alongside [`tier_quant_from_resolved_dir`].
+#[cfg(target_os = "macos")]
+fn dense_te_requested_tier_bits(request: &ImageRequest) -> Option<i64> {
+    let bits = request
+        .advanced
+        .get("mlxQuantize")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()));
+    match bits {
+        Some(b) if b <= 0 => None,
+        Some(b) if b > 4 => Some(8),
+        _ => Some(4),
+    }
+}
+
 /// The `(engine Quant, recipe bit count)` a resolved turnkey tier subdir ACTUALLY loads at, parsed
 /// from the tier dir's basename (sc-8820). The tier resolvers ([`standard_tier_subdir`],
 /// [`ideogram_model_subdir`], [`boogu_model_subdir`], [`krea_model_subdir`]) fall through q4→q8→bf16
@@ -2572,13 +2602,26 @@ async fn generate_stream(
     // q4→q8→bf16 when the preferred tier isn't downloaded, but the quant above is derived from the
     // REQUEST — so a bf16 pick with only `q4/` present would render Q4 while the recipe records dense,
     // lying to the epic 8506 quant A/B workflow. Reconcile against the tier subdir actually resolved:
-    // record the precision that ran + `warn!`/emit `quant_tier_downgraded` on a real fallback. The
-    // dense-TE turnkeys (FLUX.2-klein) keep their `None` load quant (never re-quantize the dense bf16
-    // TE) while still correcting the recorded bits. SANA (no quant support) has no tier subdir, so
-    // `tier_quant_from_resolved_dir` returns `None` and this is a no-op for it.
+    // record the precision that ran + `warn!`/emit `quant_tier_downgraded` on a real fallback. SANA
+    // (no quant support) has no tier subdir, so `tier_quant_from_resolved_dir` returns `None` and this
+    // is a no-op for it.
+    //
+    // sc-9362 (F-018 follow-up): dense-TE turnkeys (FLUX.2-klein) always derive `(None, None)` from
+    // `resolve_quant` (the load quant must stay `None` so the dense bf16 TE is never re-quantized),
+    // but their transformer is packed at q4/q8. Reconciling against that always-bf16 value made every
+    // straight dense-TE job read as a bf16→qN "downgrade" — a spurious event, and pre-8820 the recipe
+    // recorded bf16 for a q4/q8 transformer. Feed reconcile the transformer tier the request ACTUALLY
+    // asked for ([`dense_te_requested_tier_bits`], mirroring the `standard_tier_subdir` mapping) so it
+    // records the resolved transformer precision on EVERY job and only warns/emits on a genuine
+    // fallback. `allow_quant_change=false` keeps the load quant `None` (TE stays dense bf16).
     let (quant, quant_bits) = if model.supports_quant() {
+        let requested_for_reconcile = if is_dense_te_tier(request) {
+            (None, dense_te_requested_tier_bits(request))
+        } else {
+            (quant, quant_bits)
+        };
         reconcile_resolved_tier_quant(
-            (quant, quant_bits),
+            requested_for_reconcile,
             &weights_dir,
             !is_dense_te_tier(request),
             &request.model,
@@ -4153,5 +4196,103 @@ mod quant_tier_reconcile_tests {
         let (quant, bits) =
             reconcile_resolved_tier_quant(requested, &resolved, true, "sd3_5_large", "job1", "mlx");
         assert_eq!((quant, bits), (Some(Quant::Q4), Some(4)));
+    }
+
+    /// sc-9362 (F-018 follow-up): the dense-TE transformer tier the request asks for is derived from
+    /// `advanced.mlxQuantize` exactly like [`standard_tier_subdir`] — `<=0 → bf16 (None)`, `>4 → q8`,
+    /// else the q4 default — regardless of the always-`None` load quant `resolve_quant` returns for
+    /// dense-TE. This is what reconcile compares the resolved tier against so a straight job isn't a
+    /// spurious downgrade.
+    #[test]
+    fn dense_te_requested_tier_bits_mirrors_standard_tier_mapping() {
+        let req = |mlx_quantize: serde_json::Value| {
+            ImageRequest::from_payload(
+                json!({ "model": "flux2_klein_9b", "advanced": { "mlxQuantize": mlx_quantize } })
+                    .as_object()
+                    .unwrap(),
+            )
+        };
+        let default = ImageRequest::from_payload(
+            json!({ "model": "flux2_klein_9b" }).as_object().unwrap(),
+        );
+        // No selection → the q4 default (matches standard_tier_subdir's preferred).
+        assert_eq!(dense_te_requested_tier_bits(&default), Some(4));
+        assert_eq!(dense_te_requested_tier_bits(&req(json!(0))), None); // bf16 opt-out
+        assert_eq!(dense_te_requested_tier_bits(&req(json!(4))), Some(4));
+        assert_eq!(dense_te_requested_tier_bits(&req(json!(8))), Some(8));
+        assert_eq!(dense_te_requested_tier_bits(&req(json!("8"))), Some(8)); // numeric-string
+        assert_eq!(dense_te_requested_tier_bits(&req(json!(-1))), None);
+    }
+
+    /// sc-9362 (F-018 follow-up): a straight (no-fallback) dense-TE job — its q4 transformer tier is
+    /// downloaded and resolves as requested — records the ACTUAL transformer tier (Q4) while keeping
+    /// the load quant `None` (the dense bf16 TE is never re-quantized). Before the fix the request
+    /// derived `(None, None)` and — since dense-TE always requests bf16 in `resolve_quant` — the
+    /// resolved q4 tier read as a bf16→q4 downgrade; now the requested tier is the q4 the request
+    /// actually asked for, so the resolved tier MATCHES and reconcile pass-throughs it with no event.
+    #[test]
+    fn dense_te_no_fallback_records_transformer_tier() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // The klein q4 transformer tier is present (dense bf16 TE lives alongside in the same tier).
+        let dir = root.join("q4").join("transformer");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("diffusion_pytorch_model.safetensors"), b"x").unwrap();
+
+        let req = ImageRequest::from_payload(
+            json!({ "model": "flux2_klein_9b", "advanced": {} })
+                .as_object()
+                .unwrap(),
+        );
+        // The tier resolver lands on the requested q4 tier (no fallback).
+        let resolved = standard_tier_subdir(root, &req);
+        assert_eq!(resolved, root.join("q4"));
+        // resolve_quant keeps dense-TE at `(None, None)` (never re-quantize the dense bf16 TE)…
+        assert_eq!(resolve_quant(&req), (None, None));
+        // …but reconcile against the REQUESTED transformer tier (q4) records the real transformer
+        // precision (Q4) with the load quant still `None`, and — since resolved == requested — with no
+        // downgrade (the requested/resolved tiers match, so it's a clean pass-through).
+        let requested_for_reconcile = (None, dense_te_requested_tier_bits(&req));
+        assert_eq!(requested_for_reconcile, (None, Some(4)));
+        let (quant, bits) = reconcile_resolved_tier_quant(
+            requested_for_reconcile,
+            &resolved,
+            false, // dense-TE: keep the load quant None
+            "flux2_klein_9b",
+            "job1",
+            "mlx",
+        );
+        assert_eq!(
+            (quant, bits),
+            (None, Some(4)),
+            "records the actual q4 transformer tier, load quant stays None"
+        );
+    }
+
+    /// sc-9362: a GENUINE dense-TE fallback still surfaces — the request asks for q8 but only q4 is
+    /// downloaded, so the resolver falls through to q4; reconcile records q4 (the tier that ran) while
+    /// the load quant stays `None`. This is the case that legitimately warns/emits.
+    #[test]
+    fn dense_te_genuine_fallback_records_resolved_tier() {
+        let req = ImageRequest::from_payload(
+            json!({ "model": "flux2_klein_9b", "advanced": { "mlxQuantize": 8 } })
+                .as_object()
+                .unwrap(),
+        );
+        // Requested q8 tier bits, but only the q4 tier exists on disk (resolver fell through).
+        assert_eq!(dense_te_requested_tier_bits(&req), Some(8));
+        let (quant, bits) = reconcile_resolved_tier_quant(
+            (None, dense_te_requested_tier_bits(&req)),
+            std::path::Path::new("/m/q4"),
+            false,
+            "flux2_klein_9b",
+            "job1",
+            "mlx",
+        );
+        assert_eq!(
+            (quant, bits),
+            (None, Some(4)),
+            "genuine q8→q4 fallback records the resolved q4 tier, load quant stays None"
+        );
     }
 }

--- a/crates/sceneworks-worker/src/image_jobs/detail.rs
+++ b/crates/sceneworks-worker/src/image_jobs/detail.rs
@@ -496,13 +496,17 @@ pub(crate) async fn run_image_detail_job(
                 if canceled {
                     continue; // drain so the blocking sender never blocks; terminal posts after stop.
                 }
-                if last_cancel_check.elapsed() >= Duration::from_secs(2) {
-                    last_cancel_check = Instant::now();
-                    if cancel_requested_peek(api, &job.id).await {
-                        begin_detail_cancel(api, &job.id, &cancel, backend).await;
-                        canceled = true;
-                        continue;
-                    }
+                // sc-9618: a process shutdown is a cancel checkpoint too — short-circuit the API poll
+                // so a quit stops the tile pass at this step, matching a user cancel.
+                if shutdown_requested()
+                    || (last_cancel_check.elapsed() >= Duration::from_secs(2) && {
+                        last_cancel_check = Instant::now();
+                        cancel_requested_peek(api, &job.id).await
+                    })
+                {
+                    begin_detail_cancel(api, &job.id, &cancel, backend).await;
+                    canceled = true;
+                    continue;
                 }
                 update_job(
                     api,
@@ -521,12 +525,15 @@ pub(crate) async fn run_image_detail_job(
             }
             _ = interval.tick() => {
                 heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
-                if !canceled && last_cancel_check.elapsed() >= Duration::from_secs(2) {
-                    last_cancel_check = Instant::now();
-                    if cancel_requested_peek(api, &job.id).await {
-                        begin_detail_cancel(api, &job.id, &cancel, backend).await;
-                        canceled = true;
-                    }
+                // sc-9618: honor a process shutdown on every tick (local flag read, unthrottled).
+                if !canceled && (shutdown_requested()
+                    || (last_cancel_check.elapsed() >= Duration::from_secs(2) && {
+                        last_cancel_check = Instant::now();
+                        cancel_requested_peek(api, &job.id).await
+                    }))
+                {
+                    begin_detail_cancel(api, &job.id, &cancel, backend).await;
+                    canceled = true;
                 }
             }
         }

--- a/crates/sceneworks-worker/src/image_jobs/flux2.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2.rs
@@ -1,30 +1,5 @@
-/// How a FLUX.2 edit job batches its iterations.
-enum Flux2Grouping {
-    /// `count` independent images (per-image seeds), the plain reference/edit path.
-    Plain,
-    /// The 11-angle Character-Studio set: shared seed, per-angle prompt augment.
-    Angles,
-    /// The best-effort pose tier: `n` poses, shared seed, `[skeleton, reference]` sets.
-    Poses(usize),
-}
-
-/// Decide the grouping for a FLUX.2 edit job (parity with the `MlxFlux2Adapter`
-/// decision: pose set > angle set > plain, all gated to `character_image` mode — an
-/// `edit_image` job is never grouped). The caller only reaches this with a reference
-/// present, so `is_character_image` reduces to the mode check.
-fn flux2_grouping(request: &ImageRequest) -> Flux2Grouping {
-    if request.mode != "character_image" {
-        return Flux2Grouping::Plain;
-    }
-    let poses = pose_entries(request).len();
-    if poses > 0 {
-        return Flux2Grouping::Poses(poses);
-    }
-    if advanced::flag(&request.advanced, "angleSet") {
-        return Flux2Grouping::Angles;
-    }
-    Flux2Grouping::Plain
-}
+// `EditGrouping` / `edit_grouping` moved to base.rs (sc-8946, F-144): they are the SHARED grouping for
+// the FLUX.2 / Qwen-Edit / SenseNova-U1 edit lanes, not FLUX.2-specific, so navigation lands in base.rs.
 
 /// The per-iteration plan shared by every native edit stream (FLUX.2 / Qwen-Edit / SenseNova-U1,
 /// F-024 sc-8826): the `(seeds, prompts, pose_inputs)` grouping expansion, the
@@ -68,18 +43,18 @@ struct EditBatch {
 #[cfg(target_os = "macos")]
 fn plan_edit_batch(
     request: &ImageRequest,
-    grouping: &Flux2Grouping,
+    grouping: &EditGrouping,
     mut raw_settings: JsonObject,
 ) -> EditBatch {
     let set_seed = resolve_seed(request, 0);
     let (seeds, prompts, pose_inputs): (Vec<i64>, Vec<String>, Option<Vec<PoseInput>>) =
         match grouping {
-            Flux2Grouping::Poses(count) => {
+            EditGrouping::Poses(count) => {
                 let poses = parse_poses(request);
                 let prompts = vec![augment_prompt_for_pose(&request.prompt); *count];
                 (vec![set_seed; *count], prompts, Some(poses))
             }
-            Flux2Grouping::Angles => {
+            EditGrouping::Angles => {
                 let prompts = CHARACTER_ANGLE_SET_ORDER
                     .iter()
                     .map(|angle| augment_prompt_for_angle(&request.prompt, angle))
@@ -90,7 +65,7 @@ fn plan_edit_batch(
                     None,
                 )
             }
-            Flux2Grouping::Plain => {
+            EditGrouping::Plain => {
                 let count = request.count as usize;
                 let seeds = (0..count).map(|index| resolve_seed(request, index)).collect();
                 (seeds, vec![request.prompt.clone(); count], None)
@@ -98,18 +73,18 @@ fn plan_edit_batch(
         };
 
     match grouping {
-        Flux2Grouping::Angles => {
+        EditGrouping::Angles => {
             raw_settings.insert("angleSet".to_owned(), Value::Bool(true));
         }
-        Flux2Grouping::Poses(_) => {
+        EditGrouping::Poses(_) => {
             raw_settings.insert("poseLibrary".to_owned(), Value::Bool(true));
         }
-        Flux2Grouping::Plain => {}
+        EditGrouping::Plain => {}
     }
 
-    let character_set = matches!(grouping, Flux2Grouping::Angles | Flux2Grouping::Poses(_));
+    let character_set = matches!(grouping, EditGrouping::Angles | EditGrouping::Poses(_));
     let plain_with_character =
-        matches!(grouping, Flux2Grouping::Plain) && request.mode == "character_image";
+        matches!(grouping, EditGrouping::Plain) && request.mode == "character_image";
     let score_likeness = character_set || plain_with_character;
 
     EditBatch {
@@ -163,54 +138,14 @@ fn flux2_edit_engine_id(model: &str) -> Option<&'static str> {
     }
 }
 
-/// Upper bound on reference images for a multi-reference edit (sc-6211). Even with the engine's
-/// sequence-gated activation chunking (sc-6266), the FLUX.2-dev edit stays activation-bound: 4
-/// references at 1024² peak ~93 GB and 5 would exceed the 96 GB floor (measured). The per-machine
-/// `flux2_dev_edit_memory_guard` rejects over-budget combinations with an actionable message; this
-/// caps absurd inputs (and bounds the DiT sequence) before that.
-const MAX_EDIT_REFERENCES: usize = 4;
-
-/// Reference asset ids for a FLUX.2 edit. The FLUX.2-dev multi-image picker (sc-6211) sends the
-/// plural `referenceAssetIds` — take all of them in order, capped at [`MAX_EDIT_REFERENCES`]. With no
-/// plural list it falls back to the single-reference flows: the character `referenceAssetId`, else the
-/// Image-Edit `sourceAssetId` (edit_image mode). Mirrors the Python
-/// `ref_id = referenceAssetId or (sourceAssetId if edit_image)`, plus the new multi-reference set.
-fn flux2_edit_reference_ids(request: &ImageRequest) -> Vec<String> {
-    if !request.reference_asset_ids.is_empty() {
-        // Parsed list is already trimmed + non-empty (sceneworks-core `string_list`).
-        return request
-            .reference_asset_ids
-            .iter()
-            .take(MAX_EDIT_REFERENCES)
-            .cloned()
-            .collect();
-    }
-    if let Some(id) = request
-        .reference_asset_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|id| !id.is_empty())
-    {
-        return vec![id.to_owned()];
-    }
-    if request.mode == "edit_image" {
-        if let Some(id) = request
-            .source_asset_id
-            .as_deref()
-            .map(str::trim)
-            .filter(|id| !id.is_empty())
-        {
-            return vec![id.to_owned()];
-        }
-    }
-    Vec::new()
-}
+// `MAX_EDIT_REFERENCES` / `edit_reference_ids` moved to base.rs (sc-8946, F-144): shared by the
+// FLUX.2 / SenseNova-via-grouping edit lanes, so they live with the other shared edit helpers.
 
 /// True when this is a FLUX.2 edit job (a flux2 edit-capable model + ≥1 reference)
 /// whose base weights resolve — routed to the edit variant rather than txt2img.
 fn flux2_edit_available(request: &ImageRequest, settings: &Settings) -> bool {
     flux2_edit_engine_id(&request.model).is_some()
-        && !flux2_edit_reference_ids(request).is_empty()
+        && !edit_reference_ids(request).is_empty()
         && matches!(resolve_weights_dir(request, settings), Ok(Some(_)))
 }
 
@@ -430,7 +365,7 @@ async fn generate_flux2_edit_stream(
     let adapter_label = model.adapter_label();
 
     // Resolve the reference image(s) on the async side (decode → Send Image moved in).
-    let reference_ids = flux2_edit_reference_ids(request);
+    let reference_ids = edit_reference_ids(request);
     let mut references = Vec::with_capacity(reference_ids.len());
     for id in &reference_ids {
         references.push(load_reference_image(
@@ -481,7 +416,7 @@ async fn generate_flux2_edit_stream(
     // plain With-Character) applies to EVERY character_image generation on this FLUX.2 edit lane,
     // which produces the FINAL image directly (no face-restore pass), so scoring the generated
     // image scores what the user sees.
-    let grouping = flux2_grouping(request);
+    let grouping = edit_grouping(request);
     let EditBatch {
         seeds,
         prompts,
@@ -508,7 +443,7 @@ async fn generate_flux2_edit_stream(
     // the generator-worker closure below and reused across all outputs. Staging is non-fatal (a
     // failure → no scorer → scores omitted, the generation still renders). The scored reference is
     // `references[0]` — for a character_image job that IS the `referenceAssetId` (first in
-    // `flux2_edit_reference_ids`).
+    // `edit_reference_ids`).
     let face_stack_dir = stage_likeness(
         api,
         settings,
@@ -817,53 +752,10 @@ fn flux2_control_raw_settings(
     raw
 }
 
-/// The clamped identity img2img-init strength for the FLUX.2-dev strict-pose set, or `None` for the
-/// pose-only tier (mirrors `zimage_identity_strength`). `Some` iff `advanced.referenceStrength > 0`
-/// AND a non-empty `referenceAssetId` — the dev control engine accepts an optional `Reference` init
-/// next to the required `Control`. Off by default (pose-only is the validated path).
-fn flux2_identity_strength(request: &ImageRequest) -> Option<f32> {
-    let strength = request
-        .advanced
-        .get("referenceStrength")
-        .and_then(|value| {
-            value
-                .as_f64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .filter(|strength| *strength > 0.0)?;
-    let has_asset = request
-        .reference_asset_id
-        .as_deref()
-        .map(str::trim)
-        .is_some_and(|id| !id.is_empty());
-    has_asset.then(|| (strength as f32).clamp(0.05, 1.0))
-}
-
-/// Resolve the optional identity img2img-init for the FLUX.2-dev strict-pose set: `Some((image,
-/// strength))` when [`flux2_identity_strength`] engages (decoding `referenceAssetId`), else `None`
-/// (the default pose-only tier). The reference is shared across the whole pose set.
-fn resolve_flux2_identity_init(
-    request: &ImageRequest,
-    settings: &Settings,
-    project_path: &Path,
-) -> WorkerResult<Option<(Image, f32)>> {
-    let Some(strength) = flux2_identity_strength(request) else {
-        return Ok(None);
-    };
-    let asset_id = request
-        .reference_asset_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|id| !id.is_empty())
-        .expect("flux2_identity_strength guarantees a non-empty referenceAssetId");
-    let image = load_reference_image(
-        &settings.data_dir,
-        &request.project_id,
-        asset_id,
-        project_path,
-    )?;
-    Ok(Some((image, strength)))
-}
+// sc-8946 (F-144): the FLUX.2-dev identity gate (`flux2_identity_strength`) and its init resolver
+// (`resolve_identity_init`) were line-for-line copies of the Z-Image pair. Both now share the
+// single [`identity_strength`] / [`resolve_identity_init`] in base.rs — the FLUX.2-dev control stream
+// calls those directly.
 
 /// Build the FLUX.2-dev control LoadSpec: the base dev snapshot + the Fun-Controlnet-Union overlay
 /// (+ quant + adapters). The dev base loads manifest-aware (a pre-quantized Q4 snapshot loads packed);
@@ -913,7 +805,7 @@ async fn generate_flux2_dev_control_stream(
     let request = &plan.request;
     // Optional identity img2img-init (opt-in, off by default — `referenceStrength`-gated), shared
     // across the pose set. `None` → the pose-only tier (the validated sc-2292 default).
-    let identity_init = resolve_flux2_identity_init(request, settings, project_path)?;
+    let identity_init = resolve_identity_init(request, settings, project_path)?;
 
     let weights_dir = resolve_weights_dir(request, settings)?
         .ok_or_else(|| WorkerError::InvalidPayload("FLUX.2-dev weights not found".to_owned()))?;

--- a/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
@@ -129,7 +129,7 @@ fn flux2_edit_candle_guidance(request: &ImageRequest, default: f32) -> f32 {
 /// Reference asset ids for a FLUX.2 edit, in order. The multi-image picker (sc-6211) sends the plural
 /// `referenceAssetIds` — take all of them, capped at [`FLUX2_EDIT_CANDLE_MAX_REFERENCES`]; with no plural
 /// list it falls back to the single Image-Edit `sourceAssetId` (`edit_image` mode). Mirrors the MLX
-/// `flux2_edit_reference_ids` (multi) + `boogu_edit_reference_ids`.
+/// `edit_reference_ids` (multi) + `boogu_edit_reference_ids`.
 fn flux2_edit_candle_reference_ids(request: &ImageRequest) -> Vec<String> {
     if !request.reference_asset_ids.is_empty() {
         // The parsed list is already trimmed + non-empty (sceneworks-core `string_list`).

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -576,7 +576,7 @@ fn qwen_edit_generate_one(
 /// Real Qwen-Image-Edit generation: load the `qwen_image_edit` engine model once, then
 /// one output per grouped iteration each conditioned on the shared reference set. Mirrors
 /// [`generate_flux2_edit_stream`]'s blocking-thread + streamed-events shape and reuses the
-/// shared grouping ([`flux2_grouping`]) and [`consume_gen_events`]; differs in true-CFG
+/// shared grouping ([`edit_grouping`]) and [`consume_gen_events`]; differs in true-CFG
 /// guidance (`trueCfgScale`) + the negative prompt, the `[reference, skeleton]` pose order
 /// (reference first drives the VL identity prompt), and the body-only pose skeleton.
 async fn generate_qwen_edit_stream(
@@ -654,7 +654,7 @@ async fn generate_qwen_edit_stream(
     // sc-4409 angles / sc-4410 poses / sc-4411 plain With-Character) is generator-agnostic — Qwen-Edit
     // produces the FINAL image directly (no face-restore pass), so scoring the generated image scores
     // what the user sees.
-    let grouping = flux2_grouping(request);
+    let grouping = edit_grouping(request);
     let EditBatch {
         seeds,
         prompts,

--- a/crates/sceneworks-worker/src/image_jobs/sdxl.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl.rs
@@ -72,16 +72,6 @@ fn resolve_ip_adapter_dir(request: &ImageRequest, settings: &Settings) -> Option
     huggingface_snapshot_dir(&settings.data_dir, repo)
 }
 
-/// Resolve a mask asset id to an RGB8 [`Image`] (the engine luma-converts + binarizes it).
-fn load_mask_asset_image(
-    settings: &Settings,
-    project_id: &str,
-    mask_asset_id: &str,
-    project_path: &Path,
-) -> WorkerResult<Image> {
-    load_reference_image(&settings.data_dir, project_id, mask_asset_id, project_path)
-}
-
 /// Composite `source` contained (long edge fits) + centered on a black `width`×`height`
 /// canvas, using the **engine's** `contain_box` so the padded source lines up pixel-for-pixel
 /// with [`gen_core::imageops::outpaint_border_mask`] (both derive the same kept rect).
@@ -310,8 +300,14 @@ async fn generate_sdxl_advanced_stream(
                     .ok_or_else(|| {
                         WorkerError::InvalidPayload("inpaint requires a mask image".to_owned())
                     })?;
-                let mask =
-                    load_mask_asset_image(settings, &request.project_id, mask_id, project_path)?;
+                // The engine luma-converts + binarizes the mask asset, so it loads through the shared
+                // reference-image loader (sc-8946 inlined the one-line `load_mask_asset_image` alias).
+                let mask = load_reference_image(
+                    &settings.data_dir,
+                    &request.project_id,
+                    mask_id,
+                    project_path,
+                )?;
                 // Align the mask to the source with the SAME fit geometry.
                 let mask = fit_engine_image(mask, width, height, &request.fit_mode)?;
                 conditioning.push(Conditioning::Mask { image: mask });
@@ -347,8 +343,12 @@ async fn generate_sdxl_advanced_stream(
                 // Union the user edit region with the border (white wins) — pad-fit the user
                 // mask onto the same contained geometry first.
                 let mask_id = request.mask_asset_id.as_deref().unwrap().trim();
-                let user_mask =
-                    load_mask_asset_image(settings, &request.project_id, mask_id, project_path)?;
+                let user_mask = load_reference_image(
+                    &settings.data_dir,
+                    &request.project_id,
+                    mask_id,
+                    project_path,
+                )?;
                 let user_mask = fit_engine_image(user_mask, width, height, "pad")?;
                 mask = gen_core::imageops::union_masks(&mask, &user_mask).map_err(|error| {
                     WorkerError::Engine(format!("outpaint mask union failed: {error}"))

--- a/crates/sceneworks-worker/src/image_jobs/sensenova.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sensenova.rs
@@ -207,8 +207,8 @@ async fn generate_sensenova_edit_stream(
     // identity-likeness gate (incl. the sc-4411 plain-With-Character case). Scoring (epic 4406, sc-4409
     // angles / sc-4411 plain With-Character) is generator-agnostic — SenseNova-U1 produces the FINAL
     // image directly (no face-restore pass), so scoring the generated image scores what the user sees.
-    let grouping = flux2_grouping(request);
-    if matches!(grouping, Flux2Grouping::Poses(_)) {
+    let grouping = edit_grouping(request);
+    if matches!(grouping, EditGrouping::Poses(_)) {
         // Unreachable: strict pose is excluded by `sensenova_mlx_eligible` (no ControlNet).
         return Err(WorkerError::InvalidPayload(
             "SenseNova-U1 has no strict-pose (ControlNet) path".to_owned(),

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -3637,38 +3637,10 @@ fn flux2_control_raw_settings_records_control_recipe() {
     assert_eq!(raw.get("realModelInference"), Some(&json!(true)));
 }
 
-#[cfg(target_os = "macos")]
-#[test]
-fn identity_strength_gates_on_strength_and_asset() {
-    // Off by default (no referenceStrength) — the pose-only tier.
-    assert_eq!(
-        identity_strength(&request(
-            json!({ "projectId": "p", "referenceAssetId": "r" })
-        )),
-        None
-    );
-    // referenceStrength set but no asset → None.
-    assert_eq!(
-        identity_strength(&request(
-            json!({ "projectId": "p", "advanced": { "referenceStrength": 0.5 } })
-        )),
-        None
-    );
-    // Both present → clamped strength (the opt-in img2img-init).
-    assert_eq!(
-        identity_strength(&request(json!({
-            "projectId": "p", "referenceAssetId": "r", "advanced": { "referenceStrength": 0.5 }
-        }))),
-        Some(0.5)
-    );
-    // Clamp to [0.05, 1.0].
-    assert_eq!(
-        identity_strength(&request(json!({
-            "projectId": "p", "referenceAssetId": "r", "advanced": { "referenceStrength": 2.0 }
-        }))),
-        Some(1.0)
-    );
-}
+// sc-8946: the former `identity_strength_gates_on_strength_and_asset` was folded away — after the
+// rename it near-duplicated `zimage_identity_strength_gate_and_clamp` above, which is a strict superset
+// (same off-by-default / no-asset / clamp-to-1.0 cases PLUS verbatim forwarding, string coercion, and
+// the 0.05 floor) over the same `identity_strength(&request(..))` gate.
 
 /// Real-weights smoke: FLUX.2-dev strict-pose Fun-Controlnet-Union (sc-6055; engine sc-2292). Loads
 /// the converted Q4 dev snapshot (`models/mlx/flux2_dev`, assembled by the `flux2_dev_quant` convert

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -3081,7 +3081,7 @@ fn zimage_identity_strength_gate_and_clamp() {
         if !asset.is_null() {
             obj.insert("referenceAssetId".to_owned(), asset);
         }
-        zimage_identity_strength(&request(payload))
+        identity_strength(&request(payload))
     };
     let approx = |got: Option<f32>, want: f32| match got {
         Some(value) => assert!((value - want).abs() < 1e-6, "got {value}, want {want}"),
@@ -3639,31 +3639,31 @@ fn flux2_control_raw_settings_records_control_recipe() {
 
 #[cfg(target_os = "macos")]
 #[test]
-fn flux2_identity_strength_gates_on_strength_and_asset() {
+fn identity_strength_gates_on_strength_and_asset() {
     // Off by default (no referenceStrength) — the pose-only tier.
     assert_eq!(
-        flux2_identity_strength(&request(
+        identity_strength(&request(
             json!({ "projectId": "p", "referenceAssetId": "r" })
         )),
         None
     );
     // referenceStrength set but no asset → None.
     assert_eq!(
-        flux2_identity_strength(&request(
+        identity_strength(&request(
             json!({ "projectId": "p", "advanced": { "referenceStrength": 0.5 } })
         )),
         None
     );
     // Both present → clamped strength (the opt-in img2img-init).
     assert_eq!(
-        flux2_identity_strength(&request(json!({
+        identity_strength(&request(json!({
             "projectId": "p", "referenceAssetId": "r", "advanced": { "referenceStrength": 0.5 }
         }))),
         Some(0.5)
     );
     // Clamp to [0.05, 1.0].
     assert_eq!(
-        flux2_identity_strength(&request(json!({
+        identity_strength(&request(json!({
             "projectId": "p", "referenceAssetId": "r", "advanced": { "referenceStrength": 2.0 }
         }))),
         Some(1.0)
@@ -3837,36 +3837,36 @@ fn flux1_dev_control_real_weights_generates_each_mode() {
 
 #[cfg(target_os = "macos")]
 #[test]
-fn flux2_edit_reference_ids_prefers_reference_then_source() {
+fn edit_reference_ids_prefers_reference_then_source() {
     // referenceAssetId (character flow) wins.
     assert_eq!(
-        flux2_edit_reference_ids(&request(json!({
+        edit_reference_ids(&request(json!({
             "projectId": "p", "referenceAssetId": "ref_1", "sourceAssetId": "src_1"
         }))),
         vec!["ref_1".to_owned()]
     );
     // sourceAssetId only in edit_image mode.
     assert_eq!(
-        flux2_edit_reference_ids(&request(json!({
+        edit_reference_ids(&request(json!({
             "projectId": "p", "mode": "edit_image", "sourceAssetId": "src_1"
         }))),
         vec!["src_1".to_owned()]
     );
     // sourceAssetId without edit_image mode is ignored (it's the txt2img path).
-    assert!(flux2_edit_reference_ids(&request(json!({
+    assert!(edit_reference_ids(&request(json!({
         "projectId": "p", "sourceAssetId": "src_1"
     })))
     .is_empty());
-    assert!(flux2_edit_reference_ids(&request(json!({ "projectId": "p" }))).is_empty());
+    assert!(edit_reference_ids(&request(json!({ "projectId": "p" }))).is_empty());
 }
 
 #[cfg(target_os = "macos")]
 #[test]
-fn flux2_edit_reference_ids_takes_plural_multi_reference_set() {
+fn edit_reference_ids_takes_plural_multi_reference_set() {
     // sc-6211: the multi-image picker sends `referenceAssetIds` — all of them, in order, win over the
     // singular fields.
     assert_eq!(
-        flux2_edit_reference_ids(&request(json!({
+        edit_reference_ids(&request(json!({
             "projectId": "p",
             "referenceAssetIds": ["a", "b", "c"],
             "referenceAssetId": "singular_ignored"
@@ -3875,7 +3875,7 @@ fn flux2_edit_reference_ids_takes_plural_multi_reference_set() {
     );
     // Capped at MAX_EDIT_REFERENCES (4) — a 6-image pick keeps the first four.
     assert_eq!(
-        flux2_edit_reference_ids(&request(json!({
+        edit_reference_ids(&request(json!({
             "projectId": "p",
             "referenceAssetIds": ["a", "b", "c", "d", "e", "f"]
         })))
@@ -3884,14 +3884,14 @@ fn flux2_edit_reference_ids_takes_plural_multi_reference_set() {
     );
     // A single pick in the plural picker reduces to the single-reference path.
     assert_eq!(
-        flux2_edit_reference_ids(&request(json!({
+        edit_reference_ids(&request(json!({
             "projectId": "p", "referenceAssetIds": ["only"]
         }))),
         vec!["only".to_owned()]
     );
     // Empty plural list falls back to the singular reference flow.
     assert_eq!(
-        flux2_edit_reference_ids(&request(json!({
+        edit_reference_ids(&request(json!({
             "projectId": "p", "referenceAssetIds": [], "referenceAssetId": "ref_1"
         }))),
         vec!["ref_1".to_owned()]
@@ -4108,30 +4108,30 @@ fn augment_prompt_for_pose_appends_cue() {
 
 #[cfg(target_os = "macos")]
 #[test]
-fn flux2_grouping_poses_over_angles_over_plain() {
+fn edit_grouping_poses_over_angles_over_plain() {
     // Pose set wins even when angleSet is also set.
     let poses = request(json!({
         "projectId": "p", "mode": "character_image", "referenceAssetId": "ref",
         "advanced": { "angleSet": true, "poses": [{ "id": "a" }, { "id": "b" }] }
     }));
-    assert!(matches!(flux2_grouping(&poses), Flux2Grouping::Poses(2)));
+    assert!(matches!(edit_grouping(&poses), EditGrouping::Poses(2)));
     // angleSet without poses → the 11-angle set.
     let angles = request(json!({
         "projectId": "p", "mode": "character_image", "referenceAssetId": "ref",
         "advanced": { "angleSet": true }
     }));
-    assert!(matches!(flux2_grouping(&angles), Flux2Grouping::Angles));
+    assert!(matches!(edit_grouping(&angles), EditGrouping::Angles));
     // character_image with neither → plain.
     let plain = request(json!({
         "projectId": "p", "mode": "character_image", "referenceAssetId": "ref"
     }));
-    assert!(matches!(flux2_grouping(&plain), Flux2Grouping::Plain));
+    assert!(matches!(edit_grouping(&plain), EditGrouping::Plain));
     // edit_image never groups, even with angleSet (mode gate).
     let edit = request(json!({
         "projectId": "p", "mode": "edit_image", "sourceAssetId": "src",
         "advanced": { "angleSet": true }
     }));
-    assert!(matches!(flux2_grouping(&edit), Flux2Grouping::Plain));
+    assert!(matches!(edit_grouping(&edit), EditGrouping::Plain));
 }
 
 /// `plan_edit_batch` (F-024 sc-8826) is the shared grouping/stamping/gating builder for the FLUX.2 /
@@ -4154,7 +4154,7 @@ fn plan_edit_batch_expands_and_gates_per_grouping() {
         "projectId": "p", "mode": "character_image", "referenceAssetId": "ref",
         "advanced": { "angleSet": true, "seed": 7 }
     }));
-    let batch = plan_edit_batch(&angles, &flux2_grouping(&angles), base_settings());
+    let batch = plan_edit_batch(&angles, &edit_grouping(&angles), base_settings());
     assert_eq!(batch.seeds.len(), CHARACTER_ANGLE_SET_ORDER.len());
     assert_eq!(batch.prompts.len(), CHARACTER_ANGLE_SET_ORDER.len());
     assert!(batch.seeds.iter().all(|&s| s == batch.seeds[0]));
@@ -4169,7 +4169,7 @@ fn plan_edit_batch_expands_and_gates_per_grouping() {
         "projectId": "p", "mode": "character_image", "referenceAssetId": "ref",
         "advanced": { "seed": 7, "poses": [{ "id": "a" }, { "id": "b" }] }
     }));
-    let batch = plan_edit_batch(&poses, &flux2_grouping(&poses), base_settings());
+    let batch = plan_edit_batch(&poses, &edit_grouping(&poses), base_settings());
     assert_eq!(batch.seeds.len(), 2);
     assert!(batch.seeds.iter().all(|&s| s == batch.seeds[0]));
     assert_eq!(batch.pose_inputs.as_ref().map(Vec::len), Some(2));
@@ -4184,7 +4184,7 @@ fn plan_edit_batch_expands_and_gates_per_grouping() {
     let plain_char = request(json!({
         "projectId": "p", "mode": "character_image", "referenceAssetId": "ref", "count": 3
     }));
-    let batch = plan_edit_batch(&plain_char, &flux2_grouping(&plain_char), base_settings());
+    let batch = plan_edit_batch(&plain_char, &edit_grouping(&plain_char), base_settings());
     assert_eq!(batch.seeds.len(), 3);
     assert!(batch.pose_inputs.is_none());
     assert!(batch.raw_settings.get("angleSet").is_none());
@@ -4195,7 +4195,7 @@ fn plan_edit_batch_expands_and_gates_per_grouping() {
     let plain_edit = request(json!({
         "projectId": "p", "mode": "edit_image", "sourceAssetId": "src", "count": 2
     }));
-    let batch = plan_edit_batch(&plain_edit, &flux2_grouping(&plain_edit), base_settings());
+    let batch = plan_edit_batch(&plain_edit, &edit_grouping(&plain_edit), base_settings());
     assert_eq!(batch.seeds.len(), 2);
     assert!(!batch.score_likeness);
 }

--- a/crates/sceneworks-worker/src/image_jobs/zimage.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage.rs
@@ -245,7 +245,7 @@ async fn generate_zimage_control_stream(
     // AND a referenceAssetId is present — parity with `MlxZImageAdapter._identity_init_requested`.
     // The reference is shared across the whole pose set (identity is constant; only the per-pose
     // skeleton changes). None → the pose-only tier (the validated sc-2257 default).
-    let identity_init = resolve_zimage_identity_init(request, settings, project_path)?;
+    let identity_init = resolve_identity_init(request, settings, project_path)?;
 
     let weights_dir = resolve_weights_dir(request, settings)?
         .ok_or_else(|| WorkerError::InvalidPayload("Z-Image weights not found".to_owned()))?;
@@ -492,7 +492,7 @@ async fn generate_zimage_base_control_stream(
     let request = &plan.request;
     // Identity img2img-init (opt-in escape hatch, off by default) — same gate as the Turbo path
     // (`advanced.referenceStrength > 0` AND a `referenceAssetId`). Shared across the whole pose set.
-    let identity_init = resolve_zimage_identity_init(request, settings, project_path)?;
+    let identity_init = resolve_identity_init(request, settings, project_path)?;
 
     let zimage = mlx_model("z_image")
         .ok_or_else(|| WorkerError::InvalidPayload("z-image base model row missing".to_owned()))?;
@@ -653,62 +653,10 @@ async fn generate_zimage_base_control_stream(
     .await
 }
 
-/// The clamped identity img2img-init strength for the Z-Image strict-pose set, or `None` for the
-/// pose-only tier (sc-3146). `Some(strength)` iff `advanced.referenceStrength > 0` AND a non-empty
-/// `referenceAssetId` is present — parity with `MlxZImageAdapter._identity_init_requested`. The
-/// strict-pose stream always carries poses (`zimage_control_available`), so the
-/// bare-reference-without-poses rejection is handled upstream; here a `referenceStrength` set
-/// without an asset simply falls back to pose-only, matching the Python gate rather than erroring.
-///
-/// `strength` is the user value clamped to `[0.05, 1.0]` and carries the mflux `image_strength`
-/// convention **verbatim** (no numeric inversion): the mlx-gen Z-Image control engine and mflux
-/// agree — higher strength → later denoise start (`init_time_step`) → output stays closer to the
-/// init. Mirrors `MlxZImageAdapter._reference_strength` + the sidecar's verbatim forward. Pure
-/// (request only) so the parity-sensitive gate + clamp are unit-testable without asset I/O.
-fn zimage_identity_strength(request: &ImageRequest) -> Option<f32> {
-    let strength = request
-        .advanced
-        .get("referenceStrength")
-        .and_then(|value| {
-            value
-                .as_f64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .filter(|strength| *strength > 0.0)?;
-    let has_asset = request
-        .reference_asset_id
-        .as_deref()
-        .map(str::trim)
-        .is_some_and(|id| !id.is_empty());
-    has_asset.then(|| (strength as f32).clamp(0.05, 1.0))
-}
-
-/// Resolve the optional identity img2img-init for the Z-Image strict-pose set (sc-3146):
-/// `Some((image, strength))` when [`zimage_identity_strength`] engages, decoding `referenceAssetId`
-/// via [`load_reference_image`]; `None` for the default pose-only tier. The reference is shared
-/// across the whole pose set (identity is constant; only the per-pose skeleton changes).
-fn resolve_zimage_identity_init(
-    request: &ImageRequest,
-    settings: &Settings,
-    project_path: &Path,
-) -> WorkerResult<Option<(Image, f32)>> {
-    let Some(strength) = zimage_identity_strength(request) else {
-        return Ok(None);
-    };
-    let asset_id = request
-        .reference_asset_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|id| !id.is_empty())
-        .expect("zimage_identity_strength guarantees a non-empty referenceAssetId");
-    let image = load_reference_image(
-        &settings.data_dir,
-        &request.project_id,
-        asset_id,
-        project_path,
-    )?;
-    Ok(Some((image, strength)))
-}
+// sc-8946 (F-144): the Z-Image identity gate (`zimage_identity_strength`) and its init resolver
+// (`resolve_identity_init`) were line-for-line copies of the FLUX.2-dev pair. Both now share
+// the single [`identity_strength`] / [`resolve_identity_init`] in base.rs — this lane calls those
+// directly (see `resolve_identity_init(request, settings, project_path)` at the strict-pose streams).
 
 /// Resolve the Z-Image Image-Edit img2img init for `mode == "edit_image"` (epic 3529):
 /// `Some((source, strength))` decoding `sourceAssetId` and pre-fitting it to the output W×H

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -869,15 +869,16 @@ async fn heartbeat(
 /// Dispatch one claimed job to its handler and reconcile the terminal state.
 ///
 /// `shutdown` (sc-8845, F-043) is the process-shutdown [`CancelFlag`] tripped by
-/// `run_job_with_shutdown` when SIGTERM/Ctrl-C arrives mid-job. Handlers that thread a real cancel
-/// checkpoint honor it to stop promptly; the caller's bounded-wait-then-terminal-`Canceled` write
-/// is what GUARANTEES no job dangles `running` even for a handler that cannot observe the flag. The
-/// always-compiled placeholder path threads it directly so the shutdown-during-job behavior is
-/// exercised on every target (the GPU handlers are macOS/candle-gated). HONEST RESIDUAL: the
-/// per-engine GPU handlers still poll the API `cancel_requested` for a *user* cancel and do not yet
-/// consult this process flag; on shutdown they wind down at the loop's grace window rather than
-/// their next step, and the loop still writes the terminal `Canceled`. A follow-up can thread the
-/// flag through those handler signatures for a prompter mid-step stop (sc-8845 note).
+/// `run_job_with_shutdown` when SIGTERM/Ctrl-C arrives mid-job. The caller's
+/// bounded-wait-then-terminal-`Canceled` write is what GUARANTEES no job dangles `running` even for a
+/// handler that cannot observe the flag. The always-compiled placeholder path threads it directly so
+/// the shutdown-during-job behavior is exercised on every target (the GPU handlers are macOS/candle-
+/// gated). sc-9618 (F-043 follow-up): the dispatch below is scoped in [`with_shutdown_flag`], binding
+/// the flag as a task-local so the per-engine GPU consumer loops (image `consume_gen_events`, video
+/// `generate_video`, training `consume_training_events`, the shared `run_batched_analysis_job`, and the
+/// image-detail loop) consult it via `shutdown_requested()` at their existing per-step cancel
+/// checkpoints — tripping the engine cancel mid-step on quit instead of winding down at the grace
+/// window. MLX and candle twins stay in sync because both funnel through those SAME shared consumers.
 async fn run_utility_job(
     api: &ApiClient,
     settings: &Settings,
@@ -885,222 +886,230 @@ async fn run_utility_job(
     job: JobSnapshot,
     shutdown: gen_core::CancelFlag,
 ) {
-    let result = match job.job_type {
-        JobType::Placeholder => run_placeholder_job(api, settings, &job, &shutdown)
-            .await
-            .map_err(|error| ("Placeholder job failed.", error)),
-        // Native MLX image generation, served in-process by the linked mlx-gen
-        // engine on the macOS Apple-Silicon GPU worker (epic 3018). Off macOS the
-        // capability is never advertised, so this arm is unreachable there.
-        JobType::ImageGenerate => run_image_generate_job(api, settings, http_client, &job)
-            .await
-            .map_err(|error| ("Image generation failed.", error)),
-        // Plain Image Edit (sc-3513): the distinct `image_edit` job type (`mode=edit_image`
-        // + `sourceAssetId`, epic 2427) shares the generate handler — it dispatches on
-        // payload model+mode (qwen/flux2/sdxl edit streams), not job type. The API only
-        // routes MLX-eligible edit models here (jobs_store::image_job_is_mlx_eligible); off
-        // macOS the `image_edit` capability is never advertised, so this arm is unreachable.
-        JobType::ImageEdit => run_image_generate_job(api, settings, http_client, &job)
-            .await
-            .map_err(|error| ("Image edit failed.", error)),
-        // Native MLX tile-ControlNet detail refine (epic 3041, sc-3060), served in-process
-        // by the engine on the macOS Apple-Silicon GPU worker. Off macOS the capability is
-        // never advertised, so this arm is unreachable there (image_detail runs on torch).
-        JobType::ImageDetail => run_image_detail_job(api, settings, &job)
-            .await
-            .map_err(|error| ("Image detail enhancement failed.", error)),
-        // SenseNova-U1 visual question answering + Document Studio interleave (epic 3180,
-        // sc-3905). These bypass the `Generator` registry and call the concrete `T2iModel`
-        // directly (text / text+images output the `GenerationOutput` contract can't express).
-        // The API routes them here only on Mac (`understanding_job_is_mlx_eligible`); off macOS
-        // the `image_vqa`/`image_interleave` capabilities are never advertised, so these arms
-        // are unreachable there (the Python torch worker serves them on Windows/Linux).
-        JobType::ImageVqa => run_vqa_job(api, settings, &job)
-            .await
-            .map_err(|error| ("Visual question answering failed.", error)),
-        JobType::ImageInterleave => run_interleave_job(api, settings, &job)
-            .await
-            .map_err(|error| ("Interleaved generation failed.", error)),
-        // Native MLX video generation, served in-process by the linked mlx-gen engine
-        // on the macOS Apple-Silicon GPU worker (epic 3018). sc-3033 ships the runtime
-        // + procedural stub; the real Wan (sc-3034) / LTX+audio (sc-3035) models link
-        // their provider crates. Off macOS the capability is never advertised, so this
-        // arm is unreachable there.
-        // The clip-conditioning advanced video modes (epic 3040, sc-3522) share the video
-        // generation handler — `run_video_generate_job` dispatches `extend_clip` /
-        // `video_bridge` by the request `mode` into the LTX IC-LoRA `VideoClip` path. The API
-        // only routes the LTX-eligible jobs here (`video_job_is_mlx_eligible`); off macOS the
-        // VideoExtend/VideoBridge capabilities are never advertised, so these arms are
-        // unreachable there (the procedural stub would otherwise ignore the conditioning).
-        JobType::VideoGenerate | JobType::VideoExtend | JobType::VideoBridge => {
-            run_video_generate_job(api, settings, &job)
+    // Bind the process-shutdown flag as a task-local for the whole dispatch (sc-9618, F-043 follow-up)
+    // so the per-engine GPU consumer loops awaited below honor it at their per-step cancel checkpoints
+    // (via `shutdown_requested()`), stopping a gen/prompt mid-step on quit instead of waiting out the
+    // grace window — without threading the flag through every stream-handler signature. The placeholder
+    // path keeps its explicit `&shutdown` (it's the always-compiled reference implementation).
+    let result = with_shutdown_flag(shutdown.clone(), async {
+        match job.job_type {
+            JobType::Placeholder => run_placeholder_job(api, settings, &job, &shutdown)
                 .await
-                .map_err(|error| ("Video generation failed.", error))
-        }
-        // replace_person → native Wan-VACE (epic 3040, sc-3521): the `PersonReplace` job
-        // type (and `video_generate` mode=`replace_person`) shares the video handler, which
-        // dispatches on `mode == "replace_person"` to the engine `wan_vace` provider — the
-        // native equivalent of the torch `WanVACEPipeline` path. The API routes only
-        // MLX-eligible replace_person jobs here (`jobs_store::video_job_is_mlx_eligible`);
-        // off macOS the `person_replace` capability is never advertised, so this arm only
-        // produces a real video on the macOS MLX worker (and the Python torch path serves
-        // Windows/Linux + non-VACE replacement).
-        JobType::PersonReplace => run_video_generate_job(api, settings, &job)
-            .await
-            .map_err(|error| ("Person replacement failed.", error)),
-        // Native MLX LoRA/LoKr training (epic 3039, sc-3043/3049), served in-process
-        // by the linked mlx-gen engine on the macOS Apple-Silicon GPU worker. The API
-        // routes only MLX-native families here (jobs_store::training_job_is_mlx_eligible);
-        // kolors/lens + LoKr-on-Wan stay on the Python torch worker, which is also the
-        // Windows/Linux path. Off macOS the execute capability is never advertised.
-        JobType::LoraTrain => run_lora_train_job(api, settings, &job)
-            .await
-            .map_err(|error| ("LoRA training failed.", error)),
-        // Native MLX JoyCaption dataset captioning (epic 3550, sc-3556). The API
-        // routes only `captioner=joy_caption` jobs here; Windows/Linux and
-        // explicit non-MLX GPU choices keep the Python torch captioner fallback.
-        JobType::TrainingCaption => run_training_caption_job(api, settings, &job)
-            .await
-            .map_err(|error| ("Training captioning failed.", error)),
-        // Dataset Doctor CLIP-embedding analysis (sc-6535): the macOS MLX worker embeds every dataset
-        // image (clip_vit_l14) and POSTs the content-hash sidecar; off-Mac the handler returns a
-        // precise unsupported error (no candle CLIP embedder yet).
-        JobType::DatasetAnalysis => run_dataset_analysis_job(api, settings, &job)
-            .await
-            .map_err(|error| ("Dataset analysis failed.", error)),
-        // Dataset Doctor face pass (sc-6538): the native SCRFD+ArcFace stack embeds the largest face of
-        // each Person-dataset image and POSTs the face sidecar. MLX on Mac (`mlx-gen-face`), candle on
-        // the candle lane; off both the handler returns a precise unsupported error.
-        JobType::DatasetFaceAnalysis => run_dataset_face_analysis_job(api, settings, &job)
-            .await
-            .map_err(|error| ("Dataset face analysis failed.", error)),
-        // On-demand "compare image to another" likeness tool (sc-4415): scores a CANDIDATE asset
-        // against a SOURCE identity reference asset through the shared SCRFD+ArcFace scorer. MLX on Mac,
-        // candle off-Mac; off both the handler returns a precise unsupported error. Like the
-        // dataset-face pass, the job-type capability is gpu.rs-hardcoded (the face stack has no gen-core
-        // registry), so a job stays queued rather than mis-claimed where the stack isn't linked.
-        JobType::FaceLikenessCompare => run_face_likeness_compare_job(api, settings, &job)
-            .await
-            .map_err(|error| ("Face likeness compare failed.", error)),
-        // Native candle prompt refinement (epic 5095, sc-5525; consolidated onto candle-llm in sc-7404):
-        // routes `prompt_refine` to the candle `core_llm::TextLlm` provider (candle-llama, resolved
-        // model-first). The candle worker advertises `prompt_refine` only when `backend_candle_enabled`
-        // (engines::registry_capabilities from the registered core_llm provider); off the Windows candle
-        // build the capability is never advertised, so this arm is unreachable there and the Python torch
-        // refiner serves the job (sc-5525 keeps it as the Mac + default-installer fallback).
-        JobType::PromptRefine => run_prompt_refine_job(api, settings, &job)
-            .await
-            .map_err(|error| ("Prompt refinement failed.", error)),
-        JobType::ModelDownload => run_model_download_job(api, settings, http_client, &job)
-            .await
-            .map_err(|error| ("Model download failed.", error)),
-        JobType::LoraImport => run_lora_import_job(api, settings, http_client, &job)
-            .await
-            .map_err(|error| ("LoRA import failed.", error)),
-        JobType::LoraDownload => run_lora_download_job(api, settings, http_client, &job)
-            .await
-            .map_err(|error| ("LoRA download failed.", error)),
-        JobType::ModelImport => run_model_import_job(api, settings, http_client, &job)
-            .await
-            .map_err(|error| ("Model import failed.", error)),
-        JobType::ModelConvert => run_model_convert_job(api, settings, &job)
-            .await
-            .map_err(|error| ("Model conversion failed.", error)),
-        JobType::FrameExtract => run_frame_extract_job(api, settings, &job)
-            .await
-            .map_err(|error| ("Frame extraction failed.", error)),
-        JobType::TimelineExport => run_timeline_export_job(api, settings, &job)
-            .await
-            .map_err(|error| ("Timeline export failed.", error)),
-        JobType::PersonDetect => run_person_detect_job(api, settings, http_client, &job)
-            .await
-            .map_err(|error| ("Person detection failed.", error)),
-        // DWPose whole-body pose detection (epic 3482, sc-3487 Mac / sc-5496 off-Mac):
-        // RTMW via onnxruntime, replacing the Python rtmlib path — CoreML EP on the
-        // macOS MLX worker, CUDA EP on the off-Mac candle GPU worker. Available on Mac
-        // AND the candle lane; on a candle-disabled box `PoseDetect` is never advertised
-        // by the Rust worker (the Python worker handles it), so this falls to the `_`
-        // arm there.
-        #[cfg(any(
-            target_os = "macos",
-            all(not(target_os = "macos"), feature = "backend-candle")
-        ))]
-        JobType::PoseDetect => run_pose_detect_job(api, settings, http_client, &job)
-            .await
-            .map_err(|error| ("Pose detection failed.", error)),
-        // SCRFD 5-point landmark extraction (epic 4422, sc-4433): native-MLX SCRFD on Mac + the candle
-        // SCRFD/ArcFace stack on the Windows/Linux candle lane (sc-5497, epic 5482), served in-process
-        // for the Key Point Library. Available on Mac AND the candle lane; on a candle-disabled box
-        // `KpsExtract` is never advertised by the Rust worker (the Python InsightFace path handles it),
-        // so this falls to the `_` arm there.
-        #[cfg(any(
-            target_os = "macos",
-            all(not(target_os = "macos"), feature = "backend-candle")
-        ))]
-        JobType::KpsExtract => run_kps_extract_job(api, settings, &job)
-            .await
-            .map_err(|error| ("Keypoint extraction failed.", error)),
-        // Image upscaling, served in-process by `upscale_jobs::run_image_upscale_job`: Real-ESRGAN
-        // RRDBNet x2/x4 via onnxruntime/CoreML (epic 3482, sc-3489, Mac) + SeedVR2 one-step diffusion
-        // (native MLX on Mac sc-4815 / candle CUDA on Windows sc-5928). Available on Mac AND the
-        // Windows/CUDA candle lane; on a plain Windows/Linux box `ImageUpscale` is never advertised by
-        // the Rust worker, so it falls to the `_` arm (Python Real-ESRGAN/AuraSR). The routing oracle
-        // refuses `engine=seedvr2` on torch and `engine=real-esrgan`/`aura-sr` on the candle worker.
-        #[cfg(any(
-            target_os = "macos",
-            all(not(target_os = "macos"), feature = "backend-candle")
-        ))]
-        JobType::ImageUpscale => run_image_upscale_job(api, settings, http_client, &job)
-            .await
-            .map_err(|error| ("Image upscale failed.", error)),
-        // Dataset Doctor one-tap upscale (sc-6539): Real-ESRGAN over flagged low-res items, then
-        // re-point each via the API. Same engine + worker lanes as image_upscale.
-        #[cfg(any(
-            target_os = "macos",
-            all(not(target_os = "macos"), feature = "backend-candle")
-        ))]
-        JobType::DatasetUpscale => run_dataset_upscale_job(api, settings, http_client, &job)
-            .await
-            .map_err(|error| ("Dataset upscale failed.", error)),
-        // Smart-select segmentation (epic 6087, sc-6105): native-MLX SAM3 box-prompt segmentation,
-        // served in-process by `segment_jobs::run_image_segment_job` — a box prompt → a binary
-        // inpaint mask asset for the Image Editor. macOS-only (the capability is advertised only by
-        // `mlx_gpu`), so off-Mac this arm is absent and a segment job is never claimed there.
-        #[cfg(target_os = "macos")]
-        JobType::ImageSegment => {
-            segment_jobs::run_image_segment_job(api, settings, http_client, &job)
+                .map_err(|error| ("Placeholder job failed.", error)),
+            // Native MLX image generation, served in-process by the linked mlx-gen
+            // engine on the macOS Apple-Silicon GPU worker (epic 3018). Off macOS the
+            // capability is never advertised, so this arm is unreachable there.
+            JobType::ImageGenerate => run_image_generate_job(api, settings, http_client, &job)
                 .await
-                .map_err(|error| ("Smart-select segmentation failed.", error))
+                .map_err(|error| ("Image generation failed.", error)),
+            // Plain Image Edit (sc-3513): the distinct `image_edit` job type (`mode=edit_image`
+            // + `sourceAssetId`, epic 2427) shares the generate handler — it dispatches on
+            // payload model+mode (qwen/flux2/sdxl edit streams), not job type. The API only
+            // routes MLX-eligible edit models here (jobs_store::image_job_is_mlx_eligible); off
+            // macOS the `image_edit` capability is never advertised, so this arm is unreachable.
+            JobType::ImageEdit => run_image_generate_job(api, settings, http_client, &job)
+                .await
+                .map_err(|error| ("Image edit failed.", error)),
+            // Native MLX tile-ControlNet detail refine (epic 3041, sc-3060), served in-process
+            // by the engine on the macOS Apple-Silicon GPU worker. Off macOS the capability is
+            // never advertised, so this arm is unreachable there (image_detail runs on torch).
+            JobType::ImageDetail => run_image_detail_job(api, settings, &job)
+                .await
+                .map_err(|error| ("Image detail enhancement failed.", error)),
+            // SenseNova-U1 visual question answering + Document Studio interleave (epic 3180,
+            // sc-3905). These bypass the `Generator` registry and call the concrete `T2iModel`
+            // directly (text / text+images output the `GenerationOutput` contract can't express).
+            // The API routes them here only on Mac (`understanding_job_is_mlx_eligible`); off macOS
+            // the `image_vqa`/`image_interleave` capabilities are never advertised, so these arms
+            // are unreachable there (the Python torch worker serves them on Windows/Linux).
+            JobType::ImageVqa => run_vqa_job(api, settings, &job)
+                .await
+                .map_err(|error| ("Visual question answering failed.", error)),
+            JobType::ImageInterleave => run_interleave_job(api, settings, &job)
+                .await
+                .map_err(|error| ("Interleaved generation failed.", error)),
+            // Native MLX video generation, served in-process by the linked mlx-gen engine
+            // on the macOS Apple-Silicon GPU worker (epic 3018). sc-3033 ships the runtime
+            // + procedural stub; the real Wan (sc-3034) / LTX+audio (sc-3035) models link
+            // their provider crates. Off macOS the capability is never advertised, so this
+            // arm is unreachable there.
+            // The clip-conditioning advanced video modes (epic 3040, sc-3522) share the video
+            // generation handler — `run_video_generate_job` dispatches `extend_clip` /
+            // `video_bridge` by the request `mode` into the LTX IC-LoRA `VideoClip` path. The API
+            // only routes the LTX-eligible jobs here (`video_job_is_mlx_eligible`); off macOS the
+            // VideoExtend/VideoBridge capabilities are never advertised, so these arms are
+            // unreachable there (the procedural stub would otherwise ignore the conditioning).
+            JobType::VideoGenerate | JobType::VideoExtend | JobType::VideoBridge => {
+                run_video_generate_job(api, settings, &job)
+                    .await
+                    .map_err(|error| ("Video generation failed.", error))
+            }
+            // replace_person → native Wan-VACE (epic 3040, sc-3521): the `PersonReplace` job
+            // type (and `video_generate` mode=`replace_person`) shares the video handler, which
+            // dispatches on `mode == "replace_person"` to the engine `wan_vace` provider — the
+            // native equivalent of the torch `WanVACEPipeline` path. The API routes only
+            // MLX-eligible replace_person jobs here (`jobs_store::video_job_is_mlx_eligible`);
+            // off macOS the `person_replace` capability is never advertised, so this arm only
+            // produces a real video on the macOS MLX worker (and the Python torch path serves
+            // Windows/Linux + non-VACE replacement).
+            JobType::PersonReplace => run_video_generate_job(api, settings, &job)
+                .await
+                .map_err(|error| ("Person replacement failed.", error)),
+            // Native MLX LoRA/LoKr training (epic 3039, sc-3043/3049), served in-process
+            // by the linked mlx-gen engine on the macOS Apple-Silicon GPU worker. The API
+            // routes only MLX-native families here (jobs_store::training_job_is_mlx_eligible);
+            // kolors/lens + LoKr-on-Wan stay on the Python torch worker, which is also the
+            // Windows/Linux path. Off macOS the execute capability is never advertised.
+            JobType::LoraTrain => run_lora_train_job(api, settings, &job)
+                .await
+                .map_err(|error| ("LoRA training failed.", error)),
+            // Native MLX JoyCaption dataset captioning (epic 3550, sc-3556). The API
+            // routes only `captioner=joy_caption` jobs here; Windows/Linux and
+            // explicit non-MLX GPU choices keep the Python torch captioner fallback.
+            JobType::TrainingCaption => run_training_caption_job(api, settings, &job)
+                .await
+                .map_err(|error| ("Training captioning failed.", error)),
+            // Dataset Doctor CLIP-embedding analysis (sc-6535): the macOS MLX worker embeds every dataset
+            // image (clip_vit_l14) and POSTs the content-hash sidecar; off-Mac the handler returns a
+            // precise unsupported error (no candle CLIP embedder yet).
+            JobType::DatasetAnalysis => run_dataset_analysis_job(api, settings, &job)
+                .await
+                .map_err(|error| ("Dataset analysis failed.", error)),
+            // Dataset Doctor face pass (sc-6538): the native SCRFD+ArcFace stack embeds the largest face of
+            // each Person-dataset image and POSTs the face sidecar. MLX on Mac (`mlx-gen-face`), candle on
+            // the candle lane; off both the handler returns a precise unsupported error.
+            JobType::DatasetFaceAnalysis => run_dataset_face_analysis_job(api, settings, &job)
+                .await
+                .map_err(|error| ("Dataset face analysis failed.", error)),
+            // On-demand "compare image to another" likeness tool (sc-4415): scores a CANDIDATE asset
+            // against a SOURCE identity reference asset through the shared SCRFD+ArcFace scorer. MLX on Mac,
+            // candle off-Mac; off both the handler returns a precise unsupported error. Like the
+            // dataset-face pass, the job-type capability is gpu.rs-hardcoded (the face stack has no gen-core
+            // registry), so a job stays queued rather than mis-claimed where the stack isn't linked.
+            JobType::FaceLikenessCompare => run_face_likeness_compare_job(api, settings, &job)
+                .await
+                .map_err(|error| ("Face likeness compare failed.", error)),
+            // Native candle prompt refinement (epic 5095, sc-5525; consolidated onto candle-llm in sc-7404):
+            // routes `prompt_refine` to the candle `core_llm::TextLlm` provider (candle-llama, resolved
+            // model-first). The candle worker advertises `prompt_refine` only when `backend_candle_enabled`
+            // (engines::registry_capabilities from the registered core_llm provider); off the Windows candle
+            // build the capability is never advertised, so this arm is unreachable there and the Python torch
+            // refiner serves the job (sc-5525 keeps it as the Mac + default-installer fallback).
+            JobType::PromptRefine => run_prompt_refine_job(api, settings, &job)
+                .await
+                .map_err(|error| ("Prompt refinement failed.", error)),
+            JobType::ModelDownload => run_model_download_job(api, settings, http_client, &job)
+                .await
+                .map_err(|error| ("Model download failed.", error)),
+            JobType::LoraImport => run_lora_import_job(api, settings, http_client, &job)
+                .await
+                .map_err(|error| ("LoRA import failed.", error)),
+            JobType::LoraDownload => run_lora_download_job(api, settings, http_client, &job)
+                .await
+                .map_err(|error| ("LoRA download failed.", error)),
+            JobType::ModelImport => run_model_import_job(api, settings, http_client, &job)
+                .await
+                .map_err(|error| ("Model import failed.", error)),
+            JobType::ModelConvert => run_model_convert_job(api, settings, &job)
+                .await
+                .map_err(|error| ("Model conversion failed.", error)),
+            JobType::FrameExtract => run_frame_extract_job(api, settings, &job)
+                .await
+                .map_err(|error| ("Frame extraction failed.", error)),
+            JobType::TimelineExport => run_timeline_export_job(api, settings, &job)
+                .await
+                .map_err(|error| ("Timeline export failed.", error)),
+            JobType::PersonDetect => run_person_detect_job(api, settings, http_client, &job)
+                .await
+                .map_err(|error| ("Person detection failed.", error)),
+            // DWPose whole-body pose detection (epic 3482, sc-3487 Mac / sc-5496 off-Mac):
+            // RTMW via onnxruntime, replacing the Python rtmlib path — CoreML EP on the
+            // macOS MLX worker, CUDA EP on the off-Mac candle GPU worker. Available on Mac
+            // AND the candle lane; on a candle-disabled box `PoseDetect` is never advertised
+            // by the Rust worker (the Python worker handles it), so this falls to the `_`
+            // arm there.
+            #[cfg(any(
+                target_os = "macos",
+                all(not(target_os = "macos"), feature = "backend-candle")
+            ))]
+            JobType::PoseDetect => run_pose_detect_job(api, settings, http_client, &job)
+                .await
+                .map_err(|error| ("Pose detection failed.", error)),
+            // SCRFD 5-point landmark extraction (epic 4422, sc-4433): native-MLX SCRFD on Mac + the candle
+            // SCRFD/ArcFace stack on the Windows/Linux candle lane (sc-5497, epic 5482), served in-process
+            // for the Key Point Library. Available on Mac AND the candle lane; on a candle-disabled box
+            // `KpsExtract` is never advertised by the Rust worker (the Python InsightFace path handles it),
+            // so this falls to the `_` arm there.
+            #[cfg(any(
+                target_os = "macos",
+                all(not(target_os = "macos"), feature = "backend-candle")
+            ))]
+            JobType::KpsExtract => run_kps_extract_job(api, settings, &job)
+                .await
+                .map_err(|error| ("Keypoint extraction failed.", error)),
+            // Image upscaling, served in-process by `upscale_jobs::run_image_upscale_job`: Real-ESRGAN
+            // RRDBNet x2/x4 via onnxruntime/CoreML (epic 3482, sc-3489, Mac) + SeedVR2 one-step diffusion
+            // (native MLX on Mac sc-4815 / candle CUDA on Windows sc-5928). Available on Mac AND the
+            // Windows/CUDA candle lane; on a plain Windows/Linux box `ImageUpscale` is never advertised by
+            // the Rust worker, so it falls to the `_` arm (Python Real-ESRGAN/AuraSR). The routing oracle
+            // refuses `engine=seedvr2` on torch and `engine=real-esrgan`/`aura-sr` on the candle worker.
+            #[cfg(any(
+                target_os = "macos",
+                all(not(target_os = "macos"), feature = "backend-candle")
+            ))]
+            JobType::ImageUpscale => run_image_upscale_job(api, settings, http_client, &job)
+                .await
+                .map_err(|error| ("Image upscale failed.", error)),
+            // Dataset Doctor one-tap upscale (sc-6539): Real-ESRGAN over flagged low-res items, then
+            // re-point each via the API. Same engine + worker lanes as image_upscale.
+            #[cfg(any(
+                target_os = "macos",
+                all(not(target_os = "macos"), feature = "backend-candle")
+            ))]
+            JobType::DatasetUpscale => run_dataset_upscale_job(api, settings, http_client, &job)
+                .await
+                .map_err(|error| ("Dataset upscale failed.", error)),
+            // Smart-select segmentation (epic 6087, sc-6105): native-MLX SAM3 box-prompt segmentation,
+            // served in-process by `segment_jobs::run_image_segment_job` — a box prompt → a binary
+            // inpaint mask asset for the Image Editor. macOS-only (the capability is advertised only by
+            // `mlx_gpu`), so off-Mac this arm is absent and a segment job is never claimed there.
+            #[cfg(target_os = "macos")]
+            JobType::ImageSegment => {
+                segment_jobs::run_image_segment_job(api, settings, http_client, &job)
+                    .await
+                    .map_err(|error| ("Smart-select segmentation failed.", error))
+            }
+            // SeedVR2 video upscaling (epic 4811): one-step super-resolution — native MLX on Mac (sc-4816)
+            // / candle CUDA on Windows (sc-5928). SceneWorks' first video upscaler: decodes the source
+            // clip, runs the temporal-chunked 5D upscale, re-encodes, and passes the source audio through.
+            // Available on Mac + the Windows/CUDA candle lane; elsewhere `VideoUpscale` is never advertised
+            // (no torch path), so it falls to the `_` arm and the routing oracle reports it unsupported.
+            #[cfg(any(
+                target_os = "macos",
+                all(not(target_os = "macos"), feature = "backend-candle")
+            ))]
+            JobType::VideoUpscale => run_video_upscale_job(api, settings, &job)
+                .await
+                .map_err(|error| ("Video upscale failed.", error)),
+            JobType::PersonTrack => run_person_track_job(api, settings, http_client, &job)
+                .await
+                .map_err(|error| ("Person tracking failed.", error)),
+            _ => {
+                let result = fail_job(
+                    api,
+                    &job.id,
+                    "No Rust utility exists for this job type.",
+                    Some(format!(
+                        "Unsupported utility job type: {}",
+                        job.job_type.as_str()
+                    )),
+                )
+                .await;
+                result.map_err(|error| ("Utility job failed.", error))
+            }
         }
-        // SeedVR2 video upscaling (epic 4811): one-step super-resolution — native MLX on Mac (sc-4816)
-        // / candle CUDA on Windows (sc-5928). SceneWorks' first video upscaler: decodes the source
-        // clip, runs the temporal-chunked 5D upscale, re-encodes, and passes the source audio through.
-        // Available on Mac + the Windows/CUDA candle lane; elsewhere `VideoUpscale` is never advertised
-        // (no torch path), so it falls to the `_` arm and the routing oracle reports it unsupported.
-        #[cfg(any(
-            target_os = "macos",
-            all(not(target_os = "macos"), feature = "backend-candle")
-        ))]
-        JobType::VideoUpscale => run_video_upscale_job(api, settings, &job)
-            .await
-            .map_err(|error| ("Video upscale failed.", error)),
-        JobType::PersonTrack => run_person_track_job(api, settings, http_client, &job)
-            .await
-            .map_err(|error| ("Person tracking failed.", error)),
-        _ => {
-            let result = fail_job(
-                api,
-                &job.id,
-                "No Rust utility exists for this job type.",
-                Some(format!(
-                    "Unsupported utility job type: {}",
-                    job.job_type.as_str()
-                )),
-            )
-            .await;
-            result.map_err(|error| ("Utility job failed.", error))
-        }
-    };
+    })
+    .await;
     if matches!(job.job_type, JobType::LoraImport | JobType::ModelImport) {
         let _ = cleanup_uploaded_import_source(settings, &job.payload).await;
     }

--- a/crates/sceneworks-worker/src/progress.rs
+++ b/crates/sceneworks-worker/src/progress.rs
@@ -355,7 +355,10 @@ where
                     return Err(error);
                 }
                 if let Some(flag) = &cancel {
-                    if !canceled && cancel_requested_peek(api, job_id).await {
+                    // sc-9618: a process shutdown is a cancel checkpoint too — short-circuit the API
+                    // poll (a local flag read) so a quit trips the blocking task's engine cancel at the
+                    // next heartbeat tick instead of winding down only at the loop grace window.
+                    if !canceled && (shutdown_requested() || cancel_requested_peek(api, job_id).await) {
                         flag.cancel();
                         canceled = true;
                         // Fire the one-shot cancel-acknowledged hook (e.g. post an intermediate
@@ -414,6 +417,49 @@ pub(crate) async fn cancel_requested_peek(api: &ApiClient, job_id: &str) -> bool
     }
 }
 
+tokio::task_local! {
+    /// The process-shutdown [`gen_core::CancelFlag`] for the in-flight job (sc-9618, F-043 follow-up).
+    /// `run_job_with_shutdown` trips a shared flag on SIGTERM/Ctrl-C and awaits the un-dropped job
+    /// future (bounded by `shutdown_timeout_seconds`) — that guarantees correctness (no dangling
+    /// `running`) for EVERY handler regardless of whether it observes the flag. This task-local lets the
+    /// per-engine GPU consumer loops ALSO honor it at their existing per-step cancel checkpoints so a
+    /// prompt/gen stops mid-step on quit instead of waiting out the grace window, WITHOUT threading the
+    /// flag through ~30 stream-handler signatures (and desyncing an MLX/candle twin in the process).
+    /// `run_utility_job` scopes it via [`with_shutdown_flag`] around its whole dispatch, and every
+    /// consumer loop (image `consume_gen_events`, video `generate_video`, training
+    /// `consume_training_events`, `run_batched_analysis_job`, image-detail) runs inside that same task
+    /// (the only `tokio::spawn`s below it are the model-producer tasks, which poll the ENGINE flag), so
+    /// the scope reaches every checkpoint. Unset outside a job (e.g. unit tests) ⇒ [`shutdown_requested`]
+    /// reads `false`.
+    pub(crate) static SHUTDOWN_FLAG: gen_core::CancelFlag;
+}
+
+/// Run `future` with the process-shutdown [`SHUTDOWN_FLAG`] task-local bound to `shutdown`, so every
+/// consumer loop awaited within it can consult [`shutdown_requested`] at its cancel checkpoints
+/// (sc-9618). Scoped once around `run_utility_job`'s dispatch.
+#[cfg_attr(
+    all(not(target_os = "macos"), not(feature = "backend-candle")),
+    allow(dead_code)
+)]
+pub(crate) async fn with_shutdown_flag<F>(shutdown: gen_core::CancelFlag, future: F) -> F::Output
+where
+    F: std::future::Future,
+{
+    SHUTDOWN_FLAG.scope(shutdown, future).await
+}
+
+/// Whether a process shutdown has been requested for the in-flight job (sc-9618). Reads the
+/// [`SHUTDOWN_FLAG`] task-local scoped by [`with_shutdown_flag`]; `false` when unset (outside a job, or
+/// a unit test that calls a consumer directly). Consumer-loop cancel checkpoints OR this in alongside
+/// the API `cancel_requested_peek` user-cancel poll, so a shutdown trips the engine cancel at the next
+/// step exactly like a user cancel would.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub(crate) fn shutdown_requested() -> bool {
+    SHUTDOWN_FLAG
+        .try_with(|flag| flag.is_cancelled())
+        .unwrap_or(false)
+}
+
 pub(crate) async fn update_job(
     api: &ApiClient,
     job_id: &str,
@@ -460,4 +506,36 @@ pub(crate) fn progress_payload(
 
 pub(crate) fn number_from_f64(value: f64) -> ContractNumber {
     Number::from_f64(value).unwrap_or_else(|| Number::from(0))
+}
+
+#[cfg(test)]
+mod shutdown_flag_tests {
+    use super::*;
+
+    /// sc-9618: outside a scoped job the task-local is unset, so a consumer loop's checkpoint reads
+    /// "no shutdown" and keeps running (never spuriously cancels a job in a unit test).
+    #[tokio::test]
+    async fn shutdown_requested_is_false_when_unscoped() {
+        assert!(!shutdown_requested());
+    }
+
+    /// sc-9618: inside `with_shutdown_flag`, the checkpoint reads the scoped flag — `false` until it is
+    /// tripped, `true` once the process-shutdown flag is cancelled — exactly what
+    /// `run_job_with_shutdown` does on SIGTERM/Ctrl-C. This is the observable both `consume_gen_events`
+    /// and every twin consult at each per-step cancel checkpoint.
+    #[tokio::test]
+    async fn shutdown_requested_tracks_the_scoped_flag() {
+        let flag = gen_core::CancelFlag::new();
+        let flag_for_scope = flag.clone();
+        with_shutdown_flag(flag_for_scope, async {
+            // Not yet tripped inside the scope.
+            assert!(!shutdown_requested());
+            // Tripping the (shared clone of the) flag is observed at the next checkpoint read.
+            flag.cancel();
+            assert!(shutdown_requested());
+        })
+        .await;
+        // Back outside the scope, the task-local is gone again.
+        assert!(!shutdown_requested());
+    }
 }

--- a/crates/sceneworks-worker/src/progress.rs
+++ b/crates/sceneworks-worker/src/progress.rs
@@ -538,4 +538,32 @@ mod shutdown_flag_tests {
         // Back outside the scope, the task-local is gone again.
         assert!(!shutdown_requested());
     }
+
+    /// sc-9618: the caption (`caption_jobs::run_training_caption_job`) and prompt-refine
+    /// (`prompt_refine_jobs`) GPU consumer loops both short-circuit their `check_cancel` API poll with
+    /// `if shutdown_requested() { cancel.cancel() }` at the heartbeat checkpoint. This asserts the exact
+    /// semantics that arm relies on: outside a shutdown, the engine `cancel` flag is left untouched
+    /// (normal operation is unaffected); once the process-shutdown flag trips, the checkpoint fires the
+    /// engine cancel so the captioner/decode bails at its next per-item/per-token check.
+    #[tokio::test]
+    async fn shutdown_checkpoint_trips_the_engine_cancel_only_on_shutdown() {
+        let shutdown = gen_core::CancelFlag::new();
+        let shutdown_for_scope = shutdown.clone();
+        with_shutdown_flag(shutdown_for_scope, async {
+            // The engine-side cancel flag the producer (blocking captioner / decode) polls.
+            let engine_cancel = gen_core::CancelFlag::new();
+            // Before shutdown, the checkpoint's `if shutdown_requested()` is false — no spurious cancel.
+            if shutdown_requested() {
+                engine_cancel.cancel();
+            }
+            assert!(!engine_cancel.is_cancelled());
+            // A process shutdown trips the task-local; the next checkpoint tick fires the engine cancel.
+            shutdown.cancel();
+            if shutdown_requested() {
+                engine_cancel.cancel();
+            }
+            assert!(engine_cancel.is_cancelled());
+        })
+        .await;
+    }
 }

--- a/crates/sceneworks-worker/src/prompt_refine_jobs.rs
+++ b/crates/sceneworks-worker/src/prompt_refine_jobs.rs
@@ -1036,10 +1036,20 @@ pub(crate) async fn run_prompt_refine_job(
                 }
                 _ = heartbeat_interval.tick() => {
                     heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
-                    match check_cancel(api, &job.id, CANCEL_MESSAGE).await {
-                        Ok(()) => {}
-                        Err(WorkerError::Canceled(_)) => cancel.cancel(),
-                        Err(error) => return Err(error),
+                    // sc-9618: a process shutdown is a cancel checkpoint too — short-circuit the API
+                    // `check_cancel` poll (a local flag read) so a quit trips the decode flag at its
+                    // next per-token check instead of waiting out the grace window, exactly like a
+                    // user cancel does. `check_cancel` posts the terminal `Canceled` itself; on
+                    // shutdown the bounded-wait teardown in `run_job_with_shutdown` owns the terminal,
+                    // so here we just trip the engine flag to stop the decode mid-generation.
+                    if shutdown_requested() {
+                        cancel.cancel();
+                    } else {
+                        match check_cancel(api, &job.id, CANCEL_MESSAGE).await {
+                            Ok(()) => {}
+                            Err(WorkerError::Canceled(_)) => cancel.cancel(),
+                            Err(error) => return Err(error),
+                        }
                     }
                 }
             }

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -937,6 +937,21 @@ impl SamplePersister {
 /// cancel ~every 2s (draining after a cancel so the blocking sender never blocks),
 /// and on the final `Done` event report completion with the result the UI shows.
 /// Mirrors `image_jobs::consume_gen_events`.
+///
+/// sc-9541 (F-034 follow-up): this deliberately does NOT fold into the shared
+/// [`analysis_jobs_common::run_batched_analysis_job`] scaffold (which the CLIP + face analysis jobs
+/// share). That scaffold abstracts "N homogeneous items, each a bare `usize` index → one record `R`,
+/// all ending in ONE sidecar POST"; training shares none of those axes — its channel carries a rich
+/// `TrainEvent`/`TrainingProgress` variant tree (not a `usize`), its progress spans five kernel bands
+/// via [`map_training_progress`] (not the analysis single-ramp `item_progress`), its `Sample` events
+/// have file-persistence side effects (`SamplePersister`), its cancel posts an interim non-terminal
+/// "Cancelling…" update (`begin_training_cancel`, the analysis loop trips a bare flag), and it emits an
+/// in-place `Done` result with NO sidecar POST (the engine writes the adapter; the API registers it
+/// separately). Forcing training through the analysis scaffold would require making it generic over an
+/// event type + an event→progress mapper + a stateful side-effect hook + a no-op sidecar branch —
+/// distorting the clean analysis-only seam for more complexity than the duplication it removes. The
+/// only genuinely shared machinery (the `CancelJoinGuard` + bounded-join teardown + deferred-terminal
+/// cancel, sc-8804/8917) is already reconciled across both by convention, not code sharing.
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -135,6 +135,14 @@ fn validate_training_plan(settings: &Settings, plan: &TrainingPlan) -> WorkerRes
         "Training baseModelPath",
     )?;
     resolve_training_output_dir(settings, &plan.output.output_dir, "Training outputDir")?;
+    // sc-8878 (F-076): the client-supplied `output.file_name` is joined under the confined
+    // `output_dir` by the engine trainer (`TrainingRequest.file_name`), but only the preview-sample
+    // stem was ever sanitized — a `../…`/absolute `file_name` would escape the confined output dir
+    // and write the adapter anywhere the worker can. Confine it to a single plain path component
+    // (no separators, no `..`, not absolute) with the same primitive the strict-control lanes use
+    // for payload-supplied weight filenames (`safe_weight_filename`). Shared by the dry run and the
+    // real run (both call this), so both reject the same forged filename before any join.
+    safe_weight_filename(&plan.output.file_name, "Training fileName")?;
     let mut missing = Vec::new();
     for item in &plan.dataset.items {
         let image_path = resolve_dataset_item_path(
@@ -1793,6 +1801,55 @@ mod tests {
         assert!(
             resolved.is_ok(),
             "HF-cache model dir should resolve for the real run: {resolved:?}"
+        );
+    }
+
+    /// sc-8878 (F-076): a forged `output.file_name` carrying a path separator / `..` / an absolute
+    /// path must be rejected before the engine joins it under the confined output dir — otherwise the
+    /// adapter write escapes the app-managed output root. The plan is otherwise valid (present dataset
+    /// image, in-root output dir), so only the malicious file name trips the guard.
+    #[test]
+    fn validate_rejects_traversal_file_name() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let settings = test_settings(dir.path());
+        let dataset_root = dir.path().join("datasets").join("ds-1");
+        std::fs::create_dir_all(&dataset_root).expect("dataset root");
+        let image = dataset_root.join("image.png");
+        std::fs::write(&image, b"png").expect("image");
+        for bad in [
+            "../evil.safetensors",
+            "../../etc/passwd",
+            "sub/evil.safetensors",
+            "/tmp/evil.safetensors",
+            "..",
+        ] {
+            let mut value = plan_json(
+                dir.path(),
+                "z_image_lora",
+                "z_image_turbo",
+                "lora",
+                &[&image.display().to_string()],
+            );
+            value["output"]["fileName"] = json!(bad);
+            let error = validate_training_plan(&settings, &parse(value))
+                .expect_err(&format!("traversal file name '{bad}' must be rejected"));
+            assert!(
+                error.to_string().contains("Training fileName"),
+                "rejection for '{bad}' should name the field: {error}"
+            );
+        }
+        // A plain single-component file name still validates.
+        let mut ok = plan_json(
+            dir.path(),
+            "z_image_lora",
+            "z_image_turbo",
+            "lora",
+            &[&image.display().to_string()],
+        );
+        ok["output"]["fileName"] = json!("my_style.safetensors");
+        assert!(
+            validate_training_plan(&settings, &parse(ok)).is_ok(),
+            "a plain file name should validate"
         );
     }
 

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -1005,7 +1005,10 @@ async fn consume_training_events(
                     // (sc-8390; same class as the inline-upscale sc-8200). Also poll cancel here so a
                     // cancel requested during such a gap is honored without awaiting the next event.
                     heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
-                    if !canceled && cancel_requested_peek(api, &job.id).await {
+                    // sc-9618: a process shutdown is a cancel checkpoint too — short-circuit the API
+                    // poll (a local flag read) so a quit stops training at the next step / event gap.
+                    if !canceled && (shutdown_requested() || cancel_requested_peek(api, &job.id).await)
+                    {
                         begin_training_cancel(api, &job.id, &cancel, backend).await;
                         canceled = true;
                     }
@@ -1017,16 +1020,19 @@ async fn consume_training_events(
             }
             match event {
                 TrainEvent::Progress(progress) => {
-                    // Poll cancel on the long training band only (cheap stages fly by).
+                    // Poll cancel on the long training band only (cheap stages fly by). A process
+                    // shutdown (sc-9618) short-circuits the throttle + API poll so a quit stops on the
+                    // very next training step, not just at the heartbeat-tick gap above.
                     if matches!(progress, TrainingProgress::Training { .. })
-                        && last_cancel_check.elapsed() >= Duration::from_secs(2)
+                        && (shutdown_requested()
+                            || (last_cancel_check.elapsed() >= Duration::from_secs(2) && {
+                                last_cancel_check = Instant::now();
+                                cancel_requested_peek(api, &job.id).await
+                            }))
                     {
-                        last_cancel_check = Instant::now();
-                        if cancel_requested_peek(api, &job.id).await {
-                            begin_training_cancel(api, &job.id, &cancel, backend).await;
-                            canceled = true;
-                            continue;
-                        }
+                        begin_training_cancel(api, &job.id, &cancel, backend).await;
+                        canceled = true;
+                        continue;
                     }
                     if let TrainingProgress::Checkpoint { step } = progress {
                         checkpoints.push(json!({ "step": step }));

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -3727,6 +3727,13 @@ async fn generate_video(
                     if canceled {
                         continue; // drain so the blocking sender never blocks.
                     }
+                    // sc-9618: a process shutdown is a cancel checkpoint too — short-circuit the API
+                    // poll so a quit stops the gen at this frame step, matching a user cancel.
+                    if shutdown_requested() {
+                        begin_video_cancel(api, &job.id, &cancel, backend).await;
+                        canceled = true;
+                        continue;
+                    }
                     if last_cancel.elapsed() >= Duration::from_secs(2) {
                         last_cancel = Instant::now();
                         if cancel_requested_peek(api, &job.id).await {
@@ -3759,12 +3766,15 @@ async fn generate_video(
                 }
                 _ = interval.tick() => {
                     heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
-                    if !canceled && last_cancel.elapsed() >= Duration::from_secs(2) {
-                        last_cancel = Instant::now();
-                        if cancel_requested_peek(api, &job.id).await {
-                            begin_video_cancel(api, &job.id, &cancel, backend).await;
-                            canceled = true;
-                        }
+                    // sc-9618: honor a process shutdown on every tick (local flag read, unthrottled).
+                    if !canceled && (shutdown_requested()
+                        || (last_cancel.elapsed() >= Duration::from_secs(2) && {
+                            last_cancel = Instant::now();
+                            cancel_requested_peek(api, &job.id).await
+                        }))
+                    {
+                        begin_video_cancel(api, &job.id, &cancel, backend).await;
+                        canceled = true;
                     }
                     // Forward-progress watchdog: a wedged engine keeps this async loop heartbeating
                     // (the block runs on a separate thread), so the API sees a healthy job forever.


### PR DESCRIPTION
Epic 8800 batch 9 — code-review remediation batch in `crates/sceneworks-worker` (5 stories).

## Stories

### sc-8878 [F-076] Sanitize training `output.file_name` before the trainer joins it (bug/security)
The client-supplied `plan.output.file_name` reached `TrainingRequest` verbatim and was joined under the confined `output_dir` by the engine trainer; only the preview-sample stem was ever sanitized, so a `../` or absolute `file_name` escaped the app-managed output root. Now confined to a single plain path component in `validate_training_plan` via the existing `safe_weight_filename` primitive (shared by the dry run and the real run). The dataset/output confinement already routes through the canonical+lexical dual check (`normalize_app_managed_path` / `resolve_dataset_item_path`) post-sc-8877, so that half was already satisfied.
- Test: `validate_rejects_traversal_file_name` (`../`, `sub/`, absolute, `..`, + plain-name accept).

### sc-9362 [F-018 follow-up] Record the actual transformer quant tier for dense-TE models even without a fallback (bug)
`resolve_quant` returns `(None, None)` for every dense-TE turnkey (FLUX.2-klein / `DENSE_TE_TIER_MODELS`) so the load quant stays `None` and the dense bf16 TE is never re-quantized — but the transformer is packed at q4/q8. Reconciling the resolved transformer tier against that always-bf16 request made every straight (non-fallback) dense-TE job read as a bf16→qN "downgrade" (spurious event; misreported precision). Added `dense_te_requested_tier_bits` (mirrors `standard_tier_subdir`'s `mlxQuantize` mapping) and feed reconcile the transformer tier the request actually asked for, so it records the resolved transformer precision on every job and warns/emits only on a genuine fallback. Load quant stays `None`. macOS-only until candle grows quant tiers.
- Tests: `dense_te_requested_tier_bits_mirrors_standard_tier_mapping`, `dense_te_no_fallback_records_transformer_tier` (the fixed case), `dense_te_genuine_fallback_records_resolved_tier`.

### sc-9618 [F-043 follow-up] Thread the process-shutdown CancelFlag into the macOS/candle GPU handlers for mid-step stop (chore)
Correctness was already guaranteed by sc-8845 (bounded-wait-then-terminal-`Canceled`); this is the latency refinement. Bound the process-shutdown `CancelFlag` as a task-local (`SHUTDOWN_FLAG`, scoped by `with_shutdown_flag` around `run_utility_job`'s dispatch) and OR `shutdown_requested()` into the existing per-step cancel checkpoints of every **shared** consumer loop: image `consume_gen_events`, video `generate_video`, training `consume_training_events`, the shared `run_batched_analysis_job` (CLIP + face), the image-detail loop, and the generic `run_blocking_with_heartbeat` harness. The shutdown check is a local flag read (no API cost) so it short-circuits the throttled user-cancel poll and fires on every tick. **Using a task-local instead of threading the flag through ~30 stream-handler signatures keeps the MLX and candle twins in sync by construction** (both funnel through the same shared consumers) rather than risking a desynced twin.
- Tests: `shutdown_requested_is_false_when_unscoped`, `shutdown_requested_tracks_the_scoped_flag`.

### sc-8946 [F-144] Rename misplaced `flux2_*` shared helpers + dedupe identity/mask duplicates (chore, behavior-preserving)
- Renamed `Flux2Grouping`/`flux2_grouping`/`flux2_edit_reference_ids` → `EditGrouping`/`edit_grouping`/`edit_reference_ids` and moved them from `flux2.rs` to `base.rs` — they are the shared grouping/reference logic for the FLUX.2 / Qwen-Edit / SenseNova-U1 edit lanes, so navigation no longer misdirects to flux2.rs.
- Folded the line-for-line identical `zimage_identity_strength`/`resolve_zimage_identity_init` and `flux2_identity_strength`/`resolve_flux2_identity_init` pairs into one shared `identity_strength`/`resolve_identity_init` in `base.rs` (an identity-gate change is now made once).
- Inlined the one-line `load_mask_asset_image` pass-through alias into its two SDXL call sites.

### sc-9541 [F-034 follow-up] Fold training into the shared batched-analysis scaffold — DECISION: **NO-FOLD (confirmed)**
Independent assessment, high confidence: **training legitimately stays separate.** The shared `run_batched_analysis_job` scaffold abstracts "N homogeneous items, each a bare `usize` index → one record `R`, all ending in one sidecar POST." Training shares none of those axes: its channel carries a rich `TrainEvent`/`TrainingProgress` variant tree (not a `usize`); its progress spans five kernel bands via `map_training_progress` (not the analysis single-ramp `item_progress`); its `Sample` events have file-persistence side effects (`SamplePersister`); its cancel posts an interim non-terminal "Cancelling…" update (`begin_training_cancel`, vs the analysis loop's bare flag); and it ends in an in-place `Done` result with **no sidecar POST** (the engine writes the adapter; the API registers it separately). Folding would force the scaffold generic over an event type + an event→progress mapper + a stateful side-effect hook + a no-op sidecar branch — distorting the clean analysis-only seam for more complexity than the duplication removed. The only genuinely shared machinery (`CancelJoinGuard` + bounded-join teardown + deferred-terminal cancel, sc-8804/8917) is already reconciled across both by convention. Documented as a deliberate no-fold on `consume_training_events` and the analysis scaffold module doc (doc-only change, no behavior).

## Verification
- `npm run rust:check` — clean (fmt --check + clippy + workspace tests, exit 0).
- `cargo test -p sceneworks-worker --lib` — 616 passed, 0 failed.
- FRESH candle check: `cargo clean -p sceneworks-worker` then `cargo test -p sceneworks-worker --no-default-features -F backend-candle --no-run` — 0 errors. Candle lib tests: 616 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
