### PR TITLE
refactor(worker): control/sdxl/ort/smoke cleanups (epic 8800 batch 10)

### DIFF
--- a/crates/sceneworks-worker/src/flux1_control_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/flux1_control_mlx_smoke.rs
@@ -150,7 +150,7 @@ fn flux1_dev_control_mlx_smoke() {
         "FLUX1_DEV_DIR must point at the dense FLUX.1-dev diffusers snapshot: {}",
         weights_dir.display()
     );
-    let out_dir = PathBuf::from(env_or("FLUX1_OUT_DIR", "flux1-control-smoke"));
+    let out_dir = PathBuf::from(env_or("FLUX1_OUT_DIR", "/tmp/flux1_control_smoke"));
     std::fs::create_dir_all(&out_dir).expect("create out dir");
     let w: u32 = env_or("FLUX1_W", "768").parse().expect("FLUX1_W");
     let h: u32 = env_or("FLUX1_H", "768").parse().expect("FLUX1_H");

--- a/crates/sceneworks-worker/src/flux2_dev_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/flux2_dev_gpu_smoke.rs
@@ -57,9 +57,50 @@ fn env_path(key: &str) -> PathBuf {
 }
 
 fn env_or(key: &str, default: &str) -> String {
+    // Filter set-but-empty values so `FLUX2_DEV_STEPS=` (or a whitespace-only value) falls back to the
+    // default instead of feeding "" into a downstream `.parse()` and panicking (sc-8924: unify on the
+    // empty-filtering env_or the MLX-side smokes already use).
     std::env::var(key)
+        .ok()
         .map(|v| v.trim().to_string())
-        .unwrap_or_else(|_| default.to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| default.to_string())
+}
+
+/// The requested quant tier + its lowercase label (for the output filename). `q4` -> Q4 (the shipped
+/// worker default), `q8` -> Q8 (optional contrast run). An unrecognized `FLUX2_DEV_QUANT` panics with a
+/// clear hint rather than silently defaulting to Q4 (sc-8924): a hand-run tier validation with a typo'd
+/// value would otherwise PASS the wrong tier and record a bogus result. Pure over the raw string so the
+/// reject behavior is unit-testable without touching process env.
+fn parse_quant(raw: &str) -> (Quant, &'static str) {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "q4" => (Quant::Q4, "q4"),
+        "q8" => (Quant::Q8, "q8"),
+        other => panic!("FLUX2_DEV_QUANT must be q4 or q8, got {other:?}"),
+    }
+}
+
+fn quant_from_env() -> (Quant, &'static str) {
+    parse_quant(&env_or("FLUX2_DEV_QUANT", "q4"))
+}
+
+#[cfg(test)]
+mod quant_tests {
+    use super::{parse_quant, Quant};
+
+    #[test]
+    fn parse_quant_accepts_q4_q8_case_insensitively() {
+        assert!(matches!(parse_quant("q4"), (Quant::Q4, "q4")));
+        assert!(matches!(parse_quant("Q8"), (Quant::Q8, "q8")));
+        assert!(matches!(parse_quant(" q4 "), (Quant::Q4, "q4")));
+    }
+
+    #[test]
+    #[should_panic(expected = "FLUX2_DEV_QUANT must be q4 or q8")]
+    fn parse_quant_rejects_unknown_value() {
+        // A typo'd tier must NOT silently default (sc-8924) — it would record a bogus tier validation.
+        let _ = parse_quant("q2");
+    }
 }
 
 /// Mean per-pixel std-dev across the RGB channels — a cheap "is the image non-degenerate" check. The
@@ -96,7 +137,7 @@ fn flux2_dev_candle_gpu_smoke() {
         "FLUX2_DEV_DIR must point at the dense FLUX.2-dev diffusers snapshot (model_index.json missing): {}",
         weights_dir.display()
     );
-    let out_dir = PathBuf::from(env_or("FLUX2_DEV_OUT_DIR", "flux2-dev-out"));
+    let out_dir = PathBuf::from(env_or("FLUX2_DEV_OUT_DIR", "/tmp/flux2_dev_smoke"));
     std::fs::create_dir_all(&out_dir).expect("create out dir");
 
     let steps: u32 = env_or("FLUX2_DEV_STEPS", "28")
@@ -109,10 +150,7 @@ fn flux2_dev_candle_gpu_smoke() {
         .expect("FLUX2_DEV_GUIDANCE");
     // The shipped worker forces Q4 (manifest `mlx.quantize: 4` → `resolve_quant`); allow Q8 for an
     // optional contrast run. dev advertises only Q4/Q8 — dense doesn't fit the GPU.
-    let quant = match env_or("FLUX2_DEV_QUANT", "q4").as_str() {
-        "q8" | "Q8" => Quant::Q8,
-        _ => Quant::Q4,
-    };
+    let (quant, quant_label) = quant_from_env();
     let prompt = env_or(
         "FLUX2_DEV_PROMPT",
         "a rusty robot holding a lit candle in a dark workshop, cinematic, sharp focus",
@@ -156,10 +194,7 @@ fn flux2_dev_candle_gpu_smoke() {
     };
 
     let std = image_std(&image);
-    let png = out_dir.join(format!(
-        "flux2_dev_{}_{steps}step.png",
-        env_or("FLUX2_DEV_QUANT", "q4")
-    ));
+    let png = out_dir.join(format!("flux2_dev_{quant_label}_{steps}step.png"));
     save_png(&image, &png);
     println!(
         "[smoke] flux2_dev {}x{} std {:.2} -> {}",
@@ -198,7 +233,7 @@ fn flux2_dev_edit_candle_gpu_smoke() {
         "FLUX2_DEV_DIR must point at the dense FLUX.2-dev diffusers snapshot: {}",
         weights_dir.display()
     );
-    let out_dir = PathBuf::from(env_or("FLUX2_DEV_OUT_DIR", "flux2-dev-out"));
+    let out_dir = PathBuf::from(env_or("FLUX2_DEV_OUT_DIR", "/tmp/flux2_dev_smoke"));
     std::fs::create_dir_all(&out_dir).expect("create out dir");
     let (w, h) = (
         env_or("FLUX2_DEV_W", "512").parse().expect("FLUX2_DEV_W"),
@@ -290,7 +325,7 @@ fn flux2_dev_control_candle_gpu_smoke() {
         "FLUX2_DEV_DIR must point at the dense FLUX.2-dev diffusers snapshot: {}",
         weights_dir.display()
     );
-    let out_dir = PathBuf::from(env_or("FLUX2_DEV_OUT_DIR", "flux2-dev-out"));
+    let out_dir = PathBuf::from(env_or("FLUX2_DEV_OUT_DIR", "/tmp/flux2_dev_smoke"));
     std::fs::create_dir_all(&out_dir).expect("create out dir");
     let (w, h) = (
         env_or("FLUX2_DEV_W", "768").parse().expect("FLUX2_DEV_W"),

--- a/crates/sceneworks-worker/src/footprint_measure.rs
+++ b/crates/sceneworks-worker/src/footprint_measure.rs
@@ -50,8 +50,16 @@
 //! panics with a download hint and is simply not part of the run.
 
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use gen_core::{GenerationOutput, GenerationRequest, Image, LoadSpec, Quant, WeightsSource};
+
+/// One-tier-per-process guard (sc-8925). The MLX memory counters + allocator peak high-water mark are
+/// PROCESS-GLOBAL and persist across tests in the same binary, so measuring a second tier in the same
+/// process folds the first tier's residue into its numbers. `measure_footprint` flips this once and
+/// asserts it was previously false — an unfiltered `cargo test … footprint -- --ignored` run (more than
+/// one tier in one process) now fails loudly instead of silently emitting corrupt `[[FOOTPRINT]]` lines.
+static FOOTPRINT_RAN: AtomicBool = AtomicBool::new(false);
 
 fn env_or(key: &str, default: &str) -> String {
     std::env::var(key)
@@ -163,6 +171,16 @@ fn image_std(img: &Image) -> f64 {
 // `[[FOOTPRINT]]` scrape line, not the return value — so this reports through stdout and returns
 // nothing (sc-8952).
 fn measure_footprint(model: &str, tier: &str, engine_id: &str, dir: &Path, req: GenerationRequest) {
+    // Enforce the "RUN ONE TIER PER PROCESS" invariant (sc-8925): the MLX counters are process-global,
+    // so a second measurement in the same binary invocation would report numbers contaminated by the
+    // first tier's allocator residue + peak high-water mark. Fail loudly instead of scraping garbage.
+    assert!(
+        !FOOTPRINT_RAN.swap(true, Ordering::SeqCst),
+        "footprint harness measured a second tier in one process — the MLX peak/active counters are \
+         process-global, so run exactly one `footprint_<x>` per `cargo test … -- --ignored` invocation \
+         (see the module doc). The just-attempted {model} {tier} measurement would be corrupt."
+    );
+
     println!(
         "[footprint] loading {model} ({tier}) from {} ...",
         dir.display()

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -1,8 +1,8 @@
-/// The engine registry id for the Qwen-Image ControlNet-Union variant.
+/// The engine registry id for the Qwen-Image ControlNet-Union variant. The default control repo is
+/// the `STRICT_CONTROL_ENGINES` table row for this id (resolved via `strict_control_default_repo`),
+/// not a duplicated local constant — so a table repoint keeps the resolver, error message, and
+/// download hint in lockstep.
 const QWEN_CONTROL_ENGINE_ID: &str = "qwen_image_control";
-/// Default alibaba-pai Qwen-Image-2512-Fun-Controlnet-Union weights (input-agnostic VACE branch:
-/// pose/canny/depth share one control path — sc-8267 source swap, sc-8250 canny+depth exposure).
-const QWEN_CONTROL_REPO: &str = "alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union";
 const QWEN_CONTROL_FILE: &str = "diffusion_pytorch_model.safetensors";
 
 /// True when this is the base-Qwen strict-pose tier: `qwen_image` + non-empty object
@@ -153,7 +153,8 @@ async fn generate_qwen_control_stream(
         .ok_or_else(|| WorkerError::InvalidPayload("Qwen-Image weights not found".to_owned()))?;
     let control_weights = resolve_qwen_control_weights(request, settings)?.ok_or_else(|| {
         WorkerError::InvalidPayload(format!(
-            "Qwen strict-pose control weights not found (download {QWEN_CONTROL_REPO})."
+            "Qwen strict-pose control weights not found (download {}).",
+            strict_control_default_repo(QWEN_CONTROL_ENGINE_ID)
         ))
     })?;
     let (quant, quant_bits) = resolve_quant(request);

--- a/crates/sceneworks-worker/src/image_jobs/sdxl.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl.rs
@@ -72,23 +72,6 @@ fn resolve_ip_adapter_dir(request: &ImageRequest, settings: &Settings) -> Option
     huggingface_snapshot_dir(&settings.data_dir, repo)
 }
 
-/// Composite `source` contained (long edge fits) + centered on a black `width`×`height`
-/// canvas, using the **engine's** `contain_box` so the padded source lines up pixel-for-pixel
-/// with [`gen_core::imageops::outpaint_border_mask`] (both derive the same kept rect).
-fn sdxl_outpaint_canvas(source: &image::RgbImage, width: u32, height: u32) -> Image {
-    use image::imageops::FilterType::Lanczos3;
-    let (new_w, new_h, left, top) =
-        gen_core::imageops::contain_box(source.width(), source.height(), width, height);
-    let resized = image::imageops::resize(source, new_w.max(1), new_h.max(1), Lanczos3);
-    let mut canvas = image::RgbImage::from_pixel(width, height, image::Rgb([0, 0, 0]));
-    image::imageops::overlay(&mut canvas, &resized, left as i64, top as i64);
-    Image {
-        width,
-        height,
-        pixels: canvas.into_raw(),
-    }
-}
-
 /// An [`Image`] (RGB8) as an `image::RgbImage` for host-side compositing.
 fn engine_image_to_rgb(image: Image) -> WorkerResult<image::RgbImage> {
     image::RgbImage::from_raw(image.width, image.height, image.pixels)
@@ -329,14 +312,18 @@ async fn generate_sdxl_advanced_stream(
                 .ok_or_else(|| {
                     WorkerError::InvalidPayload("outpaint requires a source image".to_owned())
                 })?;
-            let source = engine_image_to_rgb(load_reference_image(
+            let source = load_reference_image(
                 &settings.data_dir,
                 &request.project_id,
                 source_id,
                 project_path,
-            )?)?;
-            let (src_w, src_h) = (source.width(), source.height());
-            let canvas = sdxl_outpaint_canvas(&source, width, height);
+            )?;
+            let (src_w, src_h) = (source.width, source.height);
+            // Letterbox composite is the SHARED `fit_engine_image(.., "outpaint")` (base.rs) — the
+            // same `gen_core::imageops::contain_box` + Lanczos3 + black-canvas overlay the outpaint
+            // border mask keys off, so fit + mask stay pixel-identical (sc-9420 dedupe of the old
+            // per-lane `sdxl_outpaint_canvas` twin).
+            let canvas = fit_engine_image(source, width, height, "outpaint")?;
             // White = generate (the padded border), black = keep (the centered source).
             let mut mask = gen_core::imageops::outpaint_border_mask(src_w, src_h, width, height);
             if non_empty(&request.mask_asset_id) {

--- a/crates/sceneworks-worker/src/image_jobs/strict_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/strict_control.rs
@@ -254,8 +254,9 @@ fn depth_control_image(
 ) -> WorkerResult<Image> {
     let source = source.ok_or_else(|| {
         WorkerError::InvalidPayload(
-            "depth control requires either a source image to estimate from or a user-supplied \
-             depth map (advanced.controlImage)"
+            "depth control requires either a source image to estimate from \
+             (sourceAssetId / referenceAssetId) or a user-supplied depth map \
+             (advanced.controlImage)"
                 .to_owned(),
         )
     })?;
@@ -381,7 +382,10 @@ fn preprocess_control_entry(
         ControlKind::Canny => {
             let source = source.ok_or_else(|| {
                 WorkerError::InvalidPayload(
-                    "canny control requires a source image (advanced.controlImage)".to_owned(),
+                    "canny control requires either a source image to derive edges from \
+                     (sourceAssetId / referenceAssetId) or a user-supplied edge map \
+                     (advanced.controlImage)"
+                        .to_owned(),
                 )
             })?;
             let rgb = image::RgbImage::from_raw(source.width, source.height, source.pixels.clone())

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -4550,7 +4550,9 @@ fn character_image_likeness_source_gates_to_plain_with_character() {
     );
 }
 
-#[cfg(target_os = "macos")]
+// Asserts against `gen_core::imageops::contain_box` directly (not a macOS-only symbol), so it runs
+// on the candle lane too where the same letterbox geometry is shared (sc-9420).
+#[cfg(any(target_os = "macos", feature = "backend-candle"))]
 #[test]
 fn contain_box_centers_the_contained_rect() {
     // `fit_rgb`'s pad arm now rides the engine's `contain_box` (sc-8824), the same geometry the

--- a/crates/sceneworks-worker/src/image_jobs/zimage.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage.rs
@@ -1,15 +1,15 @@
-/// The engine registry id for the Z-Image Fun-Controlnet-Union variant.
+/// The engine registry id for the Z-Image Fun-Controlnet-Union variant. The default control repo is
+/// the `STRICT_CONTROL_ENGINES` table row for this id (resolved via `strict_control_default_repo`),
+/// so the resolver, error message, and download hint stay in lockstep on a table repoint (sc-2257
+/// parity).
 const ZIMAGE_CONTROL_ENGINE_ID: &str = "z_image_turbo_control";
-/// Default Fun-Controlnet-Union control-weights repo + file (sc-2257 parity).
-const ZIMAGE_CONTROL_REPO: &str = "alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1";
 const ZIMAGE_CONTROL_FILE: &str = "Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps.safetensors";
 
 /// The engine registry id for the **base** (non-distilled, full-CFG) Z-Image Fun-Controlnet-Union
 /// variant (sc-8251). Same VACE Fun-Union control branch as the Turbo variant, but assembled from a
-/// base `Tongyi-MAI/Z-Image` snapshot + the base control checkpoint, and driven with REAL CFG.
+/// base `Tongyi-MAI/Z-Image` snapshot + the base control checkpoint, and driven with REAL CFG. Default
+/// control repo comes from the `STRICT_CONTROL_ENGINES` table (via `strict_control_default_repo`).
 const ZIMAGE_BASE_CONTROL_ENGINE_ID: &str = "z_image_control";
-/// Default base Fun-Controlnet-Union control-weights repo + file (sc-8251).
-const ZIMAGE_BASE_CONTROL_REPO: &str = "alibaba-pai/Z-Image-Fun-Controlnet-Union-2.1";
 const ZIMAGE_BASE_CONTROL_FILE: &str = "Z-Image-Fun-Controlnet-Union-2.1.safetensors";
 
 // `pose_entries` / `parse_poses` / `PoseInput` moved to `base.rs` (shared by the candle InstantID
@@ -251,7 +251,8 @@ async fn generate_zimage_control_stream(
         .ok_or_else(|| WorkerError::InvalidPayload("Z-Image weights not found".to_owned()))?;
     let control_weights = resolve_control_weights(request, settings)?.ok_or_else(|| {
         WorkerError::InvalidPayload(format!(
-            "Z-Image strict-pose control weights not found (download {ZIMAGE_CONTROL_REPO})."
+            "Z-Image strict-pose control weights not found (download {}).",
+            strict_control_default_repo(ZIMAGE_CONTROL_ENGINE_ID)
         ))
     })?;
     let (quant, quant_bits) = resolve_quant(request);
@@ -500,7 +501,8 @@ async fn generate_zimage_base_control_stream(
         .ok_or_else(|| WorkerError::InvalidPayload("Z-Image base weights not found".to_owned()))?;
     let control_weights = resolve_base_control_weights(request, settings)?.ok_or_else(|| {
         WorkerError::InvalidPayload(format!(
-            "Z-Image base strict-control weights not found (download {ZIMAGE_BASE_CONTROL_REPO})."
+            "Z-Image base strict-control weights not found (download {}).",
+            strict_control_default_repo(ZIMAGE_BASE_CONTROL_ENGINE_ID)
         ))
     })?;
     let (quant, quant_bits) = resolve_quant(request);

--- a/crates/sceneworks-worker/src/lens_base_q4_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/lens_base_q4_mlx_smoke.rs
@@ -14,10 +14,12 @@
 //! Setup — point at the published turnkey `SceneWorks/lens-mlx` (the worker default). With the q4 tier
 //! already in the HF cache, no env is needed: the smoke auto-resolves the cached snapshot's `q4/` subdir
 //! (the same selection `image_jobs::base::standard_tier_subdir` makes for `mlxQuantize: 4`). Override
-//! `LENS_BASE_Q4_DIR` to point at a snapshot root or a `q4/`-bearing dir directly.
+//! `LENS_BASE_Q4_DIR` to point at a snapshot root or a `q4/`-bearing dir directly. Env keys are
+//! `LENS_BASE_*`-prefixed so this smoke and `lens_turbo_q4_mlx_smoke` (its `LENS_TURBO_*` sibling) can
+//! share one `--ignored` run without bleeding each other's step count / out dir (sc-8924).
 //! ```text
 //! # optional: LENS_BASE_Q4_DIR=/path/to/lens-mlx  (root containing q4/, or the q4/ dir itself)
-//! # optional: LENS_STEPS=20 LENS_W=1024 LENS_H=1024 LENS_PROMPT="..." LENS_OUT_DIR=/tmp/lens_base_q4_smoke
+//! # optional: LENS_BASE_STEPS=20 LENS_BASE_W=1024 LENS_BASE_H=1024 LENS_BASE_PROMPT="..." LENS_BASE_OUT_DIR=/tmp/lens_base_q4_smoke
 //! cargo test -p sceneworks-worker --release lens_base_q4_mlx_gpu_smoke -- --ignored --nocapture
 //! ```
 
@@ -127,14 +129,19 @@ fn lens_base_q4_mlx_gpu_smoke() {
     };
     let q4_dir = resolve_q4_dir(&root);
 
-    let out_dir = PathBuf::from(env_or("LENS_OUT_DIR", "/tmp/lens_base_q4_smoke"));
+    // Per-test env prefix `LENS_BASE_*` (sc-8924): previously this smoke and lens_turbo_q4 shared the
+    // bare `LENS_OUT_DIR` / `LENS_STEPS` / `LENS_W` / `LENS_H` / `LENS_PROMPT` keys, so co-running both
+    // under one `--ignored` invocation bled the turbo smoke's 4-step config into this 20-step base run.
+    let out_dir = PathBuf::from(env_or("LENS_BASE_OUT_DIR", "/tmp/lens_base_q4_smoke"));
     std::fs::create_dir_all(&out_dir).expect("create out dir");
 
-    let steps: u32 = env_or("LENS_STEPS", "20").parse().expect("LENS_STEPS");
-    let w: u32 = env_or("LENS_W", "1024").parse().expect("LENS_W");
-    let h: u32 = env_or("LENS_H", "1024").parse().expect("LENS_H");
+    let steps: u32 = env_or("LENS_BASE_STEPS", "20")
+        .parse()
+        .expect("LENS_BASE_STEPS");
+    let w: u32 = env_or("LENS_BASE_W", "1024").parse().expect("LENS_BASE_W");
+    let h: u32 = env_or("LENS_BASE_H", "1024").parse().expect("LENS_BASE_H");
     let prompt = env_or(
-        "LENS_PROMPT",
+        "LENS_BASE_PROMPT",
         "a photorealistic portrait of a red fox sitting in a sunlit autumn forest, sharp focus, \
          shallow depth of field",
     );

--- a/crates/sceneworks-worker/src/lens_turbo_q4_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/lens_turbo_q4_mlx_smoke.rs
@@ -14,10 +14,12 @@
 //! Setup — point at the published turnkey `SceneWorks/lens-turbo-mlx` (the worker default). With the q4
 //! tier already in the HF cache, no env is needed: the smoke auto-resolves the cached snapshot's `q4/`
 //! subdir (the same selection `image_jobs::base::standard_tier_subdir` makes for `mlxQuantize: 4`).
-//! Override `LENS_Q4_DIR` to point at a snapshot root or a `q4/`-bearing dir directly.
+//! Override `LENS_TURBO_Q4_DIR` to point at a snapshot root or a `q4/`-bearing dir directly. Env keys
+//! are `LENS_TURBO_*`-prefixed so this smoke and `lens_base_q4_mlx_smoke` (its `LENS_BASE_*` sibling)
+//! can share one `--ignored` run without bleeding each other's step count / out dir (sc-8924).
 //! ```text
-//! # optional: LENS_Q4_DIR=/path/to/lens-turbo-mlx  (root containing q4/, or the q4/ dir itself)
-//! # optional: LENS_STEPS=4 LENS_W=1024 LENS_H=1024 LENS_PROMPT="..." LENS_OUT_DIR=/tmp/lens_turbo_q4_smoke
+//! # optional: LENS_TURBO_Q4_DIR=/path/to/lens-turbo-mlx  (root containing q4/, or the q4/ dir itself)
+//! # optional: LENS_TURBO_STEPS=4 LENS_TURBO_W=1024 LENS_TURBO_H=1024 LENS_TURBO_PROMPT="..." LENS_TURBO_OUT_DIR=/tmp/lens_turbo_q4_smoke
 //! cargo test -p sceneworks-worker --release lens_turbo_q4_mlx_gpu_smoke -- --ignored --nocapture
 //! ```
 
@@ -115,26 +117,36 @@ fn save_png(img: &Image, path: &Path) {
 #[test]
 #[ignore = "real-weight MLX smoke; needs the SceneWorks/lens-turbo-mlx q4 turnkey cached + an Apple-Silicon Mac"]
 fn lens_turbo_q4_mlx_gpu_smoke() {
-    let root = match std::env::var("LENS_Q4_DIR") {
+    // Per-test env prefix `LENS_TURBO_*` (sc-8924): the two Lens smokes previously shared the bare
+    // `LENS_OUT_DIR` / `LENS_STEPS` / `LENS_W` / `LENS_H` / `LENS_PROMPT` keys, so a single `--ignored`
+    // run of both bled the base smoke's 20-step config into this 4-step turbo run (and both wrote the
+    // same out dir). The dir override is now the consistent `LENS_TURBO_Q4_DIR` (was `LENS_Q4_DIR`).
+    let root = match std::env::var("LENS_TURBO_Q4_DIR") {
         Ok(p) if !p.trim().is_empty() => PathBuf::from(p.trim()),
         _ => cached_turnkey_root().unwrap_or_else(|| {
             panic!(
                 "no cached SceneWorks/lens-turbo-mlx q4 turnkey found; download it via the manifest \
-                 (`hf download SceneWorks/lens-turbo-mlx --include 'q4/*'`) or set LENS_Q4_DIR to the \
-                 turnkey root (containing q4/)"
+                 (`hf download SceneWorks/lens-turbo-mlx --include 'q4/*'`) or set LENS_TURBO_Q4_DIR to \
+                 the turnkey root (containing q4/)"
             )
         }),
     };
     let q4_dir = resolve_q4_dir(&root);
 
-    let out_dir = PathBuf::from(env_or("LENS_OUT_DIR", "/tmp/lens_turbo_q4_smoke"));
+    let out_dir = PathBuf::from(env_or("LENS_TURBO_OUT_DIR", "/tmp/lens_turbo_q4_smoke"));
     std::fs::create_dir_all(&out_dir).expect("create out dir");
 
-    let steps: u32 = env_or("LENS_STEPS", "4").parse().expect("LENS_STEPS");
-    let w: u32 = env_or("LENS_W", "1024").parse().expect("LENS_W");
-    let h: u32 = env_or("LENS_H", "1024").parse().expect("LENS_H");
+    let steps: u32 = env_or("LENS_TURBO_STEPS", "4")
+        .parse()
+        .expect("LENS_TURBO_STEPS");
+    let w: u32 = env_or("LENS_TURBO_W", "1024")
+        .parse()
+        .expect("LENS_TURBO_W");
+    let h: u32 = env_or("LENS_TURBO_H", "1024")
+        .parse()
+        .expect("LENS_TURBO_H");
     let prompt = env_or(
-        "LENS_PROMPT",
+        "LENS_TURBO_PROMPT",
         "a photorealistic portrait of a red fox sitting in a sunlit autumn forest, sharp focus, \
          shallow depth of field",
     );

--- a/crates/sceneworks-worker/src/ort_cuda.rs
+++ b/crates/sceneworks-worker/src/ort_cuda.rs
@@ -60,6 +60,12 @@ const DEFAULT_CUDA_DIR: &str = r"C:\Program Files\NVIDIA GPU Computing Toolkit\C
 const DEFAULT_CUDA_DIR: &str = "/usr/local/cuda/lib64";
 
 /// An existing directory from `env_key`, if set + non-empty + present.
+///
+/// When the override is set to a non-empty value but the directory does not exist, this `warn!`s
+/// and returns `None` rather than swallowing it: a typo'd override is otherwise indistinguishable
+/// from unset, so resolution silently falls through to `PATH` / the toolkit default and the wrong-
+/// version DLLs load, surfacing as a confusing deferred cuDNN failure mid-inference with no clue
+/// that the override was ignored.
 fn dir_from_env(env_key: &str) -> Option<PathBuf> {
     let value = std::env::var(env_key).ok()?;
     let trimmed = value.trim();
@@ -67,7 +73,17 @@ fn dir_from_env(env_key: &str) -> Option<PathBuf> {
         return None;
     }
     let path = PathBuf::from(trimmed);
-    path.is_dir().then_some(path)
+    if path.is_dir() {
+        return Some(path);
+    }
+    tracing::warn!(
+        event = "ort_cuda_dir_override_missing",
+        env = env_key,
+        path = %trimmed,
+        "the CUDA/cuDNN dir override points at a missing directory; ignoring it and falling back \
+         to PATH / the toolkit default (this can load wrong-version DLLs and fail mid-inference)"
+    );
+    None
 }
 
 /// Resolve the CUDA runtime directory: the explicit `SCENEWORKS_ORT_CUDA_DIR`, then

--- a/crates/sceneworks-worker/src/realvisxl_lightning_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/realvisxl_lightning_gpu_smoke.rs
@@ -65,7 +65,7 @@ fn save_png(img: &Image, path: &Path) {
 }
 
 fn render(
-    weights_dir: &Path,
+    generator: &dyn gen_core::Generator,
     prompt: &str,
     w: u32,
     h: u32,
@@ -73,10 +73,9 @@ fn render(
     guidance: f32,
     sampler: Option<&str>,
 ) -> Image {
-    // Same seam as `generate_candle_stream`: registry load of the candle `sdxl` engine + a dense
-    // (no-quant, no-adapter) LoadSpec pointed at the RealVisXL Lightning diffusers components.
-    let spec = LoadSpec::new(WeightsSource::Dir(weights_dir.to_path_buf()));
-    let generator = gen_core::load("sdxl", &spec).expect("load candle sdxl provider");
+    // The generator is loaded ONCE by the caller and reused across the lightning + optional ddim
+    // contrast render (sc-8925): the SDXL snapshot is multi-GB, so re-loading it per render() (as the
+    // old per-call `gen_core::load` did) doubled the load wall-clock + VRAM on the RVXL_CONTRAST=1 run.
     let req = GenerationRequest {
         prompt: prompt.to_owned(),
         width: w,
@@ -124,10 +123,17 @@ fn realvisxl_lightning_candle_gpu_smoke() {
         "a photorealistic portrait of a red fox in a snowy forest, golden hour, sharp focus",
     );
 
+    // Same seam as `generate_candle_stream`: registry load of the candle `sdxl` engine + a dense
+    // (no-quant, no-adapter) LoadSpec pointed at the RealVisXL Lightning diffusers components. Loaded
+    // ONCE here and reused across both renders (sc-8925) — the multi-GB snapshot is not re-loaded for
+    // the RVXL_CONTRAST=1 ddim run.
+    let spec = LoadSpec::new(WeightsSource::Dir(weights_dir.to_path_buf()));
+    let generator = gen_core::load("sdxl", &spec).expect("load candle sdxl provider");
+
     // The shipped behavior: realvisxl_lightning forces the few-step `lightning` sampler, CFG-off
     // (guidance 1.0 — the distilled checkpoint is trained CFG-free).
     println!("[smoke] rendering lightning @ {steps} steps ({w}x{h}) ...");
-    let lightning = render(&weights_dir, &prompt, w, h, steps, 1.0, Some("lightning"));
+    let lightning = render(&*generator, &prompt, w, h, steps, 1.0, Some("lightning"));
     let lightning_std = image_std(&lightning);
     save_png(
         &lightning,
@@ -147,7 +153,7 @@ fn realvisxl_lightning_candle_gpu_smoke() {
     // so render it at the base SDXL default 7.5. Saved for the eyeball only.
     if env_or("RVXL_CONTRAST", "0") == "1" {
         println!("[smoke] rendering ddim @ {steps} steps (contrast) ...");
-        let ddim = render(&weights_dir, &prompt, w, h, steps, 7.5, Some("ddim"));
+        let ddim = render(&*generator, &prompt, w, h, steps, 7.5, Some("ddim"));
         save_png(&ddim, &out_dir.join(format!("ddim_{steps}step.png")));
         println!(
             "[smoke] ddim contrast std {:.2} -> {}",

--- a/crates/sceneworks-worker/src/realvisxl_lightning_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/realvisxl_lightning_gpu_smoke.rs
@@ -29,9 +29,14 @@ fn env_path(key: &str) -> PathBuf {
 }
 
 fn env_or(key: &str, default: &str) -> String {
+    // Filter set-but-empty values so `RVXL_STEPS=` (or a whitespace-only value) falls back to the
+    // default instead of feeding "" into a downstream `.parse()` and panicking (sc-8924: unify on the
+    // empty-filtering env_or the MLX-side smokes already use).
     std::env::var(key)
+        .ok()
         .map(|v| v.trim().to_string())
-        .unwrap_or_else(|_| default.to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| default.to_string())
 }
 
 /// Mean per-pixel std-dev across the RGB channels — a cheap "is the image non-degenerate" check (an
@@ -108,7 +113,7 @@ fn realvisxl_lightning_candle_gpu_smoke() {
         "REALVISXL_LIGHTNING_DIR must point at the diffusers snapshot (model_index.json missing): {}",
         weights_dir.display()
     );
-    let out_dir = PathBuf::from(env_or("RVXL_OUT_DIR", "rvxl-lightning-out"));
+    let out_dir = PathBuf::from(env_or("RVXL_OUT_DIR", "/tmp/rvxl_lightning_smoke"));
     std::fs::create_dir_all(&out_dir).expect("create out dir");
 
     let steps: u32 = env_or("RVXL_STEPS", "5").parse().expect("RVXL_STEPS");

--- a/crates/sceneworks-worker/src/scail2_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/scail2_gpu_smoke.rs
@@ -33,9 +33,14 @@ fn env_path(key: &str) -> PathBuf {
 }
 
 fn env_or(key: &str, default: &str) -> String {
+    // Filter set-but-empty values so `SCAIL2_STEPS=` (or a whitespace-only value) falls back to the
+    // default instead of feeding "" into a downstream `.parse()` and panicking (sc-8924: unify on the
+    // empty-filtering env_or the MLX-side smokes already use).
     std::env::var(key)
+        .ok()
         .map(|v| v.trim().to_string())
-        .unwrap_or_else(|_| default.to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| default.to_string())
 }
 
 fn load_rgb(path: &Path) -> Image {

--- a/crates/sceneworks-worker/src/sd3_5_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/sd3_5_mlx_smoke.rs
@@ -375,11 +375,17 @@ fn sd3_5_lora_apply_mlx_gpu_smoke() {
     let lora = match std::env::var("SD3_LORA") {
         Ok(p) if !p.trim().is_empty() => PathBuf::from(p.trim()),
         _ => {
-            eprintln!(
-                "[skip] SD3_LORA not set — point it at an sd3 LoRA .safetensors (a community adapter, or \
-                 the `train_sd3_lora` smoke output) to exercise the worker apply seam (with_adapters -> \
-                 apply_sd3_adapters)"
-            );
+            // Make the self-skip UNMISTAKABLE in a recorded validation run (sc-8926): libtest reports a
+            // bare `return` as `ok`, so a green line here would falsely read as "the LoRA apply path was
+            // exercised". Emit a loud, greppable `[SKIPPED]` marker naming the test + the missing lever on
+            // BOTH streams (stdout is captured and printed on the hand-run; stderr shows even without
+            // --nocapture) so a story-recorded run cannot mistake this skip for a real pass.
+            let msg = "[SKIPPED] sd3_5_lora_apply_mlx_gpu_smoke: SD3_LORA not set — the worker LoRA \
+                       apply seam (with_adapters -> apply_sd3_adapters) was NOT exercised. Point SD3_LORA \
+                       at an sd3 LoRA .safetensors (a community adapter, or the `train_sd3_lora` smoke \
+                       output) to run it.";
+            println!("{msg}");
+            eprintln!("{msg}");
             return;
         }
     };

--- a/crates/sceneworks-worker/src/sd3_5_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/sd3_5_mlx_smoke.rs
@@ -45,11 +45,38 @@ fn env_or(key: &str, default: &str) -> String {
         .unwrap_or_else(|| default.to_string())
 }
 
-/// `q4` -> Q4, anything else -> Q8 (the manifest default for all three SD3.5 tiers).
-fn quant_from_env() -> Quant {
-    match env_or("SD3_QUANT", "q8").to_ascii_lowercase().as_str() {
+/// `q4` -> Q4, `q8` -> Q8 (the manifest default for all three SD3.5 tiers). An unrecognized value
+/// panics with a clear hint rather than silently defaulting to Q8 (sc-8924): a hand-run tier
+/// validation with a typo'd `SD3_QUANT` would otherwise PASS the wrong tier and record a bogus result.
+/// Pure over the raw string so the reject behavior is unit-testable without touching process env.
+fn parse_quant(raw: &str) -> Quant {
+    match raw.trim().to_ascii_lowercase().as_str() {
         "q4" => Quant::Q4,
-        _ => Quant::Q8,
+        "q8" => Quant::Q8,
+        other => panic!("SD3_QUANT must be q4 or q8, got {other:?}"),
+    }
+}
+
+fn quant_from_env() -> Quant {
+    parse_quant(&env_or("SD3_QUANT", "q8"))
+}
+
+#[cfg(test)]
+mod quant_tests {
+    use super::{parse_quant, Quant};
+
+    #[test]
+    fn parse_quant_accepts_q4_q8_case_insensitively() {
+        assert!(matches!(parse_quant("q4"), Quant::Q4));
+        assert!(matches!(parse_quant("Q4"), Quant::Q4));
+        assert!(matches!(parse_quant(" q8 "), Quant::Q8));
+    }
+
+    #[test]
+    #[should_panic(expected = "SD3_QUANT must be q4 or q8")]
+    fn parse_quant_rejects_unknown_value() {
+        // A typo'd tier must NOT silently default (sc-8924) — it would record a bogus tier validation.
+        let _ = parse_quant("q5");
     }
 }
 

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -925,6 +925,38 @@ fn model_table_rows_resolve_and_flags_match_descriptor() {
     }
 }
 
+/// Parse the embedded `builtin.models.jsonc` manifest (the exact bytes shipped) and return its
+/// `models` array. Shared by the manifest-gating catalog-eligibility tests so the ~15-line
+/// load→strip-comments→parse→get-array boilerplate lives in ONE place (sc-8926 dedupe of the
+/// near-verbatim copies that had drifted between the SD3.5 / SANA / SANA-Sprint gate tests).
+fn builtin_models_manifest() -> Vec<Value> {
+    use sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS;
+    use sceneworks_core::jsonc::strip_jsonc_comments;
+
+    let raw = BUILTIN_MANIFESTS
+        .iter()
+        .find(|(name, _)| *name == "builtin.models.jsonc")
+        .map(|(_, contents)| *contents)
+        .expect("builtin.models.jsonc present");
+    let manifest: Value =
+        serde_json::from_str(&strip_jsonc_comments(raw)).expect("builtin models parses as JSON");
+    manifest
+        .get("models")
+        .and_then(Value::as_array)
+        .expect("models array")
+        .clone()
+}
+
+/// The builtin-manifest entry for `id`, panicking with a clear hint if the id is absent. Shared by
+/// the manifest-gating tests (sc-8926) so each gate test asserts on the entry directly instead of
+/// re-implementing the manifest lookup.
+fn builtin_model_entry(id: &str) -> Value {
+    builtin_models_manifest()
+        .into_iter()
+        .find(|m| m.get("id").and_then(Value::as_str) == Some(id))
+        .unwrap_or_else(|| panic!("{id} present in builtin.models.jsonc"))
+}
+
 /// sc-7875 (SD3.5 S6, MLX-path validation boundary): the three SD3.5 builtin-manifest entries gate
 /// correctly at the catalog layer — `macOnly: false` (cross-platform now that the candle off-Mac lane
 /// is wired, sc-7880/epic 7982; availability is driven by the routing tables, not this flag),
@@ -937,21 +969,6 @@ fn model_table_rows_resolve_and_flags_match_descriptor() {
 /// by the rust-api `gated_credential_tests`; this is the catalog-eligibility counterpart.)
 #[test]
 fn sd3_5_manifest_entries_gate_correctly() {
-    use sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS;
-    use sceneworks_core::jsonc::strip_jsonc_comments;
-
-    let raw = BUILTIN_MANIFESTS
-        .iter()
-        .find(|(name, _)| *name == "builtin.models.jsonc")
-        .map(|(_, contents)| *contents)
-        .expect("builtin.models.jsonc present");
-    let manifest: Value =
-        serde_json::from_str(&strip_jsonc_comments(raw)).expect("builtin models parses as JSON");
-    let models = manifest
-        .get("models")
-        .and_then(Value::as_array)
-        .expect("models array");
-
     // (id, expected minMemoryGb) — Large/Turbo flagship-tier 64, Medium light-tier 56
     // (S6 worker-lane footprint ~52 GB Q8 / ~48.6 GB Q4 + headroom, below the 64 flagship tier).
     let expected: &[(&str, u64)] = &[
@@ -960,10 +977,7 @@ fn sd3_5_manifest_entries_gate_correctly() {
         ("sd3_5_medium", 56),
     ];
     for (id, min_mem) in expected {
-        let entry = models
-            .iter()
-            .find(|m| m.get("id").and_then(Value::as_str) == Some(id))
-            .unwrap_or_else(|| panic!("{id} present in builtin.models.jsonc"));
+        let entry = builtin_model_entry(id);
 
         assert_eq!(
             entry.get("family").and_then(Value::as_str),
@@ -1054,24 +1068,7 @@ fn sd3_5_manifest_entries_gate_correctly() {
 /// `model_table_rows_resolve_and_flags_match_descriptor`.
 #[test]
 fn sana_manifest_entry_gates_correctly() {
-    use sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS;
-    use sceneworks_core::jsonc::strip_jsonc_comments;
-
-    let raw = BUILTIN_MANIFESTS
-        .iter()
-        .find(|(name, _)| *name == "builtin.models.jsonc")
-        .map(|(_, contents)| *contents)
-        .expect("builtin.models.jsonc present");
-    let manifest: Value =
-        serde_json::from_str(&strip_jsonc_comments(raw)).expect("builtin models parses as JSON");
-    let models = manifest
-        .get("models")
-        .and_then(Value::as_array)
-        .expect("models array");
-    let entry = models
-        .iter()
-        .find(|m| m.get("id").and_then(Value::as_str) == Some("sana_1600m"))
-        .expect("sana_1600m present in builtin.models.jsonc");
+    let entry = builtin_model_entry("sana_1600m");
 
     assert_eq!(
         entry.get("family").and_then(Value::as_str),
@@ -1147,24 +1144,7 @@ fn sana_manifest_entry_gates_correctly() {
 /// `model_table_rows_resolve_and_flags_match_descriptor`.
 #[test]
 fn sana_sprint_manifest_entry_gates_correctly() {
-    use sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS;
-    use sceneworks_core::jsonc::strip_jsonc_comments;
-
-    let raw = BUILTIN_MANIFESTS
-        .iter()
-        .find(|(name, _)| *name == "builtin.models.jsonc")
-        .map(|(_, contents)| *contents)
-        .expect("builtin.models.jsonc present");
-    let manifest: Value =
-        serde_json::from_str(&strip_jsonc_comments(raw)).expect("builtin models parses as JSON");
-    let models = manifest
-        .get("models")
-        .and_then(Value::as_array)
-        .expect("models array");
-    let entry = models
-        .iter()
-        .find(|m| m.get("id").and_then(Value::as_str) == Some("sana_sprint_1600m"))
-        .expect("sana_sprint_1600m present in builtin.models.jsonc");
+    let entry = builtin_model_entry("sana_sprint_1600m");
 
     assert_eq!(
         entry.get("family").and_then(Value::as_str),


### PR DESCRIPTION
Code-review remediation batch 10 (epic 8800, last worker-crate batch). Five Low-severity findings from `CODE_REVIEW_2026-07-01.md`, all in `crates/sceneworks-worker`.

## Stories

- **sc-8945 [F-143]** — Fix misleading canny / control-repo error messages that named the wrong field.
  - `strict_control.rs`: the canny no-source error pointed only at `advanced.controlImage`, but the auto-derive source is `sourceAssetId` / `referenceAssetId`; it now names both (depth message aligned to name the source fields too).
  - `qwen.rs` / `zimage.rs`: the "control weights not found (download …)" hints interpolated local `*_CONTROL_REPO` constants that duplicated the `STRICT_CONTROL_ENGINES` table (a table repoint would tell users the wrong repo). They now build the repo from `strict_control_default_repo(ENGINE_ID)`; the redundant `QWEN_CONTROL_REPO` / `ZIMAGE_CONTROL_REPO` / `ZIMAGE_BASE_CONTROL_REPO` constants are deleted.

- **sc-9420 [F-022 follow-up]** — Dedupe the macOS `sdxl_outpaint_canvas` (a fourth operation-for-operation copy of the letterbox composite) onto the shared `fit_engine_image(.., "outpaint")`; widen `contain_box_centers_the_contained_rect` cfg to `any(macos, feature="backend-candle")` (it asserts on `gen_core::imageops::contain_box` directly). `fit_pad_content_rect_matches_outpaint_mask_keep_rect` still passes → fit + outpaint mask stay pixel-identical.

- **sc-8926 [F-124]** — ORT / manifest-gate / SD3.5-skip.
  - `ort_cuda::dir_from_env` now `warn!`s when the CUDA/cuDNN dir override is set-but-missing (was indistinguishable from unset → wrong-version DLLs, deferred cuDNN failure).
  - Extracted `builtin_models_manifest()` + `builtin_model_entry(id)` test helpers; folded the three near-verbatim manifest lookups (SD3.5 / SANA / SANA-Sprint gate tests, where SANA had drifted from SD3.5) onto them.
  - SD3.5 LoRA smoke self-skip is now a loud, greppable `[SKIPPED]` marker on both streams (was a silent `Ok`/green PASS having exercised nothing).

- **sc-8924 [F-122]** — Unify drifted smoke helpers; reject unknown quant env values.
  - Unified the three candle-side `env_or` (flux2_dev / realvisxl / scail2) onto the empty-filtering variant so `FOO_STEPS=` no longer panics in `.parse()`.
  - `SD3_QUANT` / `FLUX2_DEV_QUANT` now panic on an unrecognized value (was silent default → hand-run PASSes the wrong tier). Extracted pure `parse_quant` helpers with non-ignored unit tests (accept q4/q8 case-insensitively; `#[should_panic]` on unknown).
  - Absolute `/tmp/<name>` out-dir defaults for flux2_dev / realvisxl / flux1_control (were cwd-relative).
  - Per-test env prefixes for the two Lens smokes (`LENS_BASE_*` vs `LENS_TURBO_*`; turbo dir override renamed `LENS_Q4_DIR` → `LENS_TURBO_Q4_DIR`) — they previously shared bare `LENS_*` keys and bled configs across a single `--ignored` run.

- **sc-8925 [F-123]** — Hoist the SDXL load out of RealVisXL `render()` (load once, pass `&dyn Generator` — the flux1 smoke's pattern; the `RVXL_CONTRAST=1` run no longer loads the multi-GB snapshot twice); enforce one-tier-per-process in the footprint harness via `assert!(!FOOTPRINT_RAN.swap(true, SeqCst))` (the MLX peak/active counters are process-global; an unfiltered `--ignored` run silently corrupted every `[[FOOTPRINT]]` number).

## Tests & verification

- Added: `parse_quant` accept + `#[should_panic]` reject unit tests in `sd3_5_mlx_smoke` (ran on macOS) and `flux2_dev_gpu_smoke` (compiled on the candle lane).
- `npm run rust:check` — fmt + clippy + test + build all green (618 tests passed, 0 failed).
- `cargo test -p sceneworks-worker --lib` — green; the sc-9420 letterbox tests and the three manifest-gate tests pass.
- FRESH candle check: `cargo clean -p sceneworks-worker` then `cargo test -p sceneworks-worker --no-default-features -F backend-candle --no-run` — 0 errors.
- Note: the three `not(target_os="macos")`-only smokes (flux2_dev / realvisxl / scail2) can't be compiled on this macOS host (a Linux cross-check dies on `cudarc`'s `nvcc` build script, unrelated to these changes); their changes were verified by inspection against the proven flux1/MLX-side sibling patterns and will be compiled by CI's candle parity lane.

## Scope note

The degenerate-floor thresholds (std>5 general vs >20 for Lens's cleaner MoE decode) are left per-model rather than homogenized to a single value — forcing one threshold across unrelated models is an unvalidatable behavior change. Filed as a follow-up rather than done silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)