### PR TITLE
fix(desktop): atomic settings + sidecar supervision + streamed wheels + release pins (epic 8800 batch D1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5718,6 +5718,7 @@ dependencies = [
 name = "sceneworks-desktop"
 version = "0.2.0"
 dependencies = [
+ "futures-util",
  "if-addrs",
  "keyring",
  "nix",

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -49,6 +49,11 @@ nix = { version = "0.29", default-features = false, features = ["signal"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 sha2 = "0.10"
+# Stream the wheel download chunk-by-chunk (StreamExt::next over reqwest's
+# bytes_stream) so a ~660 MB wheel is hashed + written to disk incrementally rather than
+# buffered whole in RAM (F-129, sc-8931). Already in the workspace lock (0.3.x), so no
+# new locked version is pulled; `alloc` is needed for the stream combinators.
+futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 
 [lints.rust]
 # Tauri's generate_context!/Builder can emit unsafe at the webview FFI boundary,

--- a/apps/desktop/scripts/build-sidecar.mjs
+++ b/apps/desktop/scripts/build-sidecar.mjs
@@ -2,7 +2,7 @@
 // Builds the sceneworks-rust-api binary (with the embedded web UI) and stages it
 // as a Tauri sidecar named for the host target triple. Wired as the
 // tauri.conf.json `beforeBuildCommand` so `tauri build` is self-contained.
-import { execFileSync, execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import {
   copyFileSync,
   mkdirSync,
@@ -21,13 +21,28 @@ const repoRoot = resolve(desktopDir, "..", ".."); // repository root
 const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
 
 function run(cmd, args, extraEnv = {}) {
-  const cmdStr = `${cmd} ${args.join(" ")}`;
-  console.log(`> ${cmdStr}`);
-  execSync(cmdStr, {
+  console.log(`> ${cmd} ${args.join(" ")}`);
+  // execFileSync (argv), NOT a joined execSync shell string (F-127, sc-8929): a
+  // `PYTHON` path containing spaces (e.g. "C:\\Program Files\\Python\\python.exe")
+  // would break when re-split by the shell. Each arg is passed as a discrete argv
+  // entry, so no quoting is needed and spaces are safe. (`shell:true` is deliberately
+  // NOT used — under it Node concatenates args WITHOUT escaping (DEP0190), which would
+  // reintroduce the very space-splitting this fixes.)
+  const opts = {
     stdio: "inherit",
     cwd: repoRoot,
     env: { ...process.env, ...extraEnv },
-  });
+  };
+  // Windows can't exec a batch shim (npm.cmd) directly post-CVE-2024-27980; route it
+  // through cmd.exe with each token discretely quoted so spaces stay intact. Real
+  // executables (python.exe, rustc.exe) spawn directly via argv on every platform.
+  if (process.platform === "win32" && /\.(cmd|bat)$/i.test(cmd)) {
+    const quote = (s) => (/[\s"]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s);
+    const line = [cmd, ...args].map(quote).join(" ");
+    execFileSync(process.env.ComSpec || "cmd.exe", ["/d", "/s", "/c", line], opts);
+    return;
+  }
+  execFileSync(cmd, args, opts);
 }
 
 // Host target triple, e.g. aarch64-apple-darwin or x86_64-pc-windows-msvc.

--- a/apps/desktop/src/cuda_provision.rs
+++ b/apps/desktop/src/cuda_provision.rs
@@ -23,9 +23,10 @@
 #![cfg(target_os = "windows")]
 
 use std::fs;
-use std::io::Read;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use futures_util::StreamExt;
 use sha2::{Digest, Sha256};
 use tauri::AppHandle;
 
@@ -197,8 +198,12 @@ fn hex(bytes: &[u8]) -> String {
 }
 
 /// Download one wheel into `tmp`, verify its sha256, and extract its DLLs into the
-/// destination dir. Network IO is async (reqwest stream); the CPU-bound hash + unzip
-/// run on a blocking thread so they don't stall the async runtime.
+/// destination dir. The wheel is STREAMED chunk-by-chunk to disk while the sha256 is fed
+/// incrementally (F-129, sc-8931), so a ~660 MB wheel never sits whole in RAM — the peak
+/// transient allocation is one HTTP chunk, not the entire file (previously the file was
+/// buffered by `bytes()`, then moved into the hash task while ALSO being written to
+/// disk). The CPU-bound unzip runs on a blocking thread so it doesn't stall the async
+/// runtime.
 async fn fetch_component(
     client: &reqwest::Client,
     component: &Component,
@@ -213,38 +218,48 @@ async fn fetch_component(
         .map_err(|error| format!("download {}: {error}", component.label))?
         .error_for_status()
         .map_err(|error| format!("download {}: {error}", component.label))?;
-    let bytes = response
-        .bytes()
-        .await
-        .map_err(|error| format!("download {}: {error}", component.label))?;
 
     let wheel_path = tmp_dir.join(format!(
         "{}.whl",
         component.label.replace(['/', ' ', '(', ')'], "_")
     ));
-    fs::write(&wheel_path, &bytes)
+
+    // Stream the body to the temp file, hashing each chunk as it lands. Peak RAM is one
+    // chunk instead of the whole wheel.
+    let mut file =
+        fs::File::create(&wheel_path).map_err(|error| format!("create wheel: {error}"))?;
+    let mut hasher = Sha256::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|error| format!("download {}: {error}", component.label))?;
+        hasher.update(&chunk);
+        file.write_all(&chunk)
+            .map_err(|error| format!("write {}: {error}", component.label))?;
+    }
+    file.flush()
         .map_err(|error| format!("write {}: {error}", component.label))?;
+    drop(file);
+
+    let digest = hex(&hasher.finalize());
+    if digest != component.sha256 {
+        return Err(format!(
+            "{}: sha256 mismatch (expected {}, got {digest})",
+            component.label, component.sha256
+        ));
+    }
 
     let dest = match component.dest {
         Dest::Cuda => cuda.to_path_buf(),
         Dest::Onnxruntime => ort.to_path_buf(),
     };
-    let expected = component.sha256.to_owned();
     let label = component.label.to_owned();
     let dlls: Option<Vec<String>> = component
         .dlls
         .map(|names| names.iter().map(|name| name.to_string()).collect());
 
-    // Hashing + unzip are CPU/IO bound — keep them off the async executor.
+    // Unzip is CPU/IO bound — keep it off the async executor. The wheel is already on
+    // disk and sha256-verified, so this just extracts from the temp file.
     tauri::async_runtime::spawn_blocking(move || -> Result<usize, String> {
-        let mut hasher = Sha256::new();
-        hasher.update(&bytes);
-        let digest = hex(&hasher.finalize());
-        if digest != expected {
-            return Err(format!(
-                "{label}: sha256 mismatch (expected {expected}, got {digest})"
-            ));
-        }
         extract_dlls(&wheel_path, dlls.as_deref(), &dest)
             .map_err(|error| format!("{label}: {error}"))
     })
@@ -279,11 +294,12 @@ fn extract_dlls(wheel: &Path, names: Option<&[String]>, dest: &Path) -> Result<u
             }
         }
         let out_path = dest.join(base);
-        let mut buffer = Vec::with_capacity(entry.size() as usize);
-        entry
-            .read_to_end(&mut buffer)
-            .map_err(|error| format!("extract {base}: {error}"))?;
-        fs::write(&out_path, &buffer).map_err(|error| format!("write {base}: {error}"))?;
+        // Stream the entry straight to disk (F-129, sc-8931) instead of reading the whole
+        // DLL into a Vec first — a cuDNN DLL can be hundreds of MB, and io::copy uses a
+        // fixed-size buffer.
+        let mut out =
+            fs::File::create(&out_path).map_err(|error| format!("write {base}: {error}"))?;
+        std::io::copy(&mut entry, &mut out).map_err(|error| format!("extract {base}: {error}"))?;
         written += 1;
     }
     Ok(written)

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -200,13 +200,29 @@ pub fn load_settings() -> AppSettings {
         .unwrap_or_default()
 }
 
-fn save_settings(settings: &AppSettings) -> Result<(), String> {
-    let path = settings_path();
+/// Write `body` to `path` atomically via temp-file + rename, so a crash / full disk
+/// mid-write can't leave a truncated file (F-127, sc-8929). The temp file sits next to
+/// the target so the rename stays on the same filesystem (a cross-device rename is not
+/// atomic). Mirrors the sidecar pidfile writer's temp+rename. Extracted from
+/// [`save_settings`] so the atomicity contract is unit-testable against a scratch path.
+fn atomic_write(path: &std::path::Path, body: &[u8]) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, body).map_err(|error| error.to_string())?;
+    std::fs::rename(&tmp, path).map_err(|error| {
+        // Leave no stray temp file behind if the rename fails.
+        let _ = std::fs::remove_file(&tmp);
+        error.to_string()
+    })
+}
+
+fn save_settings(settings: &AppSettings) -> Result<(), String> {
     let body = serde_json::to_string_pretty(settings).map_err(|error| error.to_string())?;
-    std::fs::write(&path, body).map_err(|error| error.to_string())
+    // Atomic (temp+rename) so a torn write never wipes the data-dir/HF-home overrides
+    // + credential metadata (F-127, sc-8929).
+    atomic_write(&settings_path(), body.as_bytes())
 }
 
 /// Hugging Face token for injecting `HF_TOKEN` into the worker, from the host-keyed
@@ -479,7 +495,17 @@ pub struct GpuInfo {
 }
 
 fn run_capture(program: &str, args: &[&str]) -> Option<String> {
-    let output = Command::new(program).args(args).output().ok()?;
+    let mut command = Command::new(program);
+    command.args(args);
+    // Don't flash a console window when probing a CLI (e.g. nvidia-smi) from the GUI
+    // app on Windows (F-127, sc-8929). CREATE_NO_WINDOW; mirrors `cuda_preflight` in
+    // setup.rs. No-op / not applicable off Windows.
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        command.creation_flags(0x0800_0000);
+    }
+    let output = command.output().ok()?;
     if !output.status.success() {
         return None;
     }
@@ -1145,6 +1171,40 @@ mod tests {
         std::fs::create_dir_all(&dir).expect("create dir");
         let padded = format!("  {}  ", dir.to_string_lossy());
         assert_eq!(sanitized_start_dir(Some(&padded)), Some(dir.clone()));
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// sc-8929 (F-127): the settings writer is atomic — the final file holds exactly
+    /// the new bytes, an existing file is replaced rather than truncated-then-written,
+    /// and no `.json.tmp` scratch file is left behind on success.
+    #[test]
+    fn atomic_write_replaces_file_and_leaves_no_temp() {
+        let root = scratch_dir("atomic");
+        let path = root.join("settings.json");
+
+        // Seed an existing file so we prove replace-in-place (not append/truncate).
+        std::fs::write(&path, b"{\"old\":true}").expect("seed old");
+        atomic_write(&path, b"{\"new\":1}").expect("atomic write");
+        assert_eq!(std::fs::read(&path).expect("read back"), b"{\"new\":1}");
+
+        // The temp file used for the rename must not survive a successful write.
+        let tmp = path.with_extension("json.tmp");
+        assert!(
+            !tmp.exists(),
+            "temp file must be renamed away, not left behind"
+        );
+
+        // A round-trip of real settings through save-shaped bytes stays valid JSON.
+        let settings = AppSettings {
+            data_dir: Some("/tmp/data".to_owned()),
+            ..AppSettings::default()
+        };
+        let body = serde_json::to_string_pretty(&settings).unwrap();
+        atomic_write(&path, body.as_bytes()).expect("atomic write settings");
+        let back: AppSettings =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).expect("parse back");
+        assert_eq!(back.data_dir.as_deref(), Some("/tmp/data"));
 
         std::fs::remove_dir_all(&root).ok();
     }

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -269,14 +269,26 @@ fn append_log(path: &Path, line: &str) {
 }
 
 /// Extract the port from the API's bound-address startup line. In loopback mode the
-/// API logs `…address=127.0.0.1:PORT`; in LAN mode (epic 4484) it binds 0.0.0.0 and
-/// logs `…address=0.0.0.0:PORT`, so both markers are tried. (LAN mode also pre-sets
-/// the known fixed port, so this is the fallback for the dynamic loopback case.)
+/// API logs `event="api_listening" … address=127.0.0.1:PORT`; in LAN mode (epic 4484)
+/// it binds 0.0.0.0 and logs `address=0.0.0.0:PORT`. (LAN mode also pre-sets the known
+/// fixed port, so this is the fallback for the dynamic loopback case.)
+///
+/// Anchored to the API's own startup marker (F-127, sc-8929): the port is read from the
+/// `address=` field of the `api_listening` event ONLY. An earlier diagnostic line that
+/// merely mentions a loopback `host:port` (e.g. a credential-socket or health-probe log)
+/// no longer seeds the wrong port, which previously left window-gating polling a dead
+/// port until the 30 s timeout fired.
 fn parse_listening_port(line: &str) -> Option<u16> {
+    // Only the API's bound-address startup line carries a port we should trust.
+    if !line.contains("api_listening") {
+        return None;
+    }
+    // Read the port from the `address=` field specifically (not any bare host:port
+    // elsewhere on the line), for either the loopback or the LAN bind host.
+    let rest = line.split("address=").nth(1)?;
     for marker in ["127.0.0.1:", "0.0.0.0:"] {
-        if let Some(index) = line.find(marker) {
-            let start = index + marker.len();
-            if let Ok(port) = line[start..]
+        if let Some(addr) = rest.strip_prefix(marker) {
+            if let Ok(port) = addr
                 .chars()
                 .take_while(char::is_ascii_digit)
                 .collect::<String>()
@@ -1691,5 +1703,31 @@ mod bind_tests {
             Some(8787)
         );
         assert_eq!(parse_listening_port("nothing to see here"), None);
+    }
+
+    /// F-127 (sc-8929): the port is read ONLY from the `api_listening` event's
+    /// `address=` field. An earlier diagnostic line that merely mentions a loopback
+    /// `host:port` (a health probe, the credential socket, etc.) must NOT seed a port —
+    /// doing so previously pointed window-gating at a dead port for the full 30 s.
+    #[test]
+    fn parse_listening_port_ignores_unrelated_lines_with_a_host_port() {
+        // A diagnostic line with a loopback host:port but no api_listening marker.
+        assert_eq!(
+            parse_listening_port("probing health at 127.0.0.1:9999 before start"),
+            None
+        );
+        // A line that mentions the event but whose host:port isn't in the address field
+        // (e.g. an incidental reference) doesn't get mis-parsed from the wrong token.
+        assert_eq!(
+            parse_listening_port("api_listening address=127.0.0.1:54321 (peer 127.0.0.1:1)"),
+            Some(54321)
+        );
+        // Real logfmt-style line with fields before/after address= still parses.
+        assert_eq!(
+            parse_listening_port(
+                "2026-07-04 event=api_listening address=127.0.0.1:41234 msg=\"listening\""
+            ),
+            Some(41234)
+        );
     }
 }

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -644,11 +644,19 @@ fn spawn_api(app: &AppHandle) -> Result<(), String> {
                     }
                     text
                 }
-                CommandEvent::Terminated(payload) => format!(
-                    "[desktop] api sidecar terminated: code={:?} signal={:?}\n",
-                    payload.code, payload.signal
-                ),
-                CommandEvent::Error(error) => format!("[desktop] api sidecar error: {error}\n"),
+                CommandEvent::Terminated(payload) => {
+                    let line = format!(
+                        "[desktop] api sidecar terminated: code={:?} signal={:?}\n",
+                        payload.code, payload.signal
+                    );
+                    handle_api_exit(&app_handle);
+                    line
+                }
+                CommandEvent::Error(error) => {
+                    let line = format!("[desktop] api sidecar error: {error}\n");
+                    handle_api_exit(&app_handle);
+                    line
+                }
                 _ => continue,
             };
             if let Some(file) = file.as_mut() {
@@ -661,6 +669,38 @@ fn spawn_api(app: &AppHandle) -> Result<(), String> {
         }
     });
     Ok(())
+}
+
+/// Handle an unexpected exit of the API sidecar (F-128, sc-8930). The API is spawned
+/// once and `run_startup`'s `Managed.api.is_some()` guard blocks a re-spawn; the GPU
+/// workers self-supervise with backoff but the API did not, so if it crashed mid-session
+/// the webview pointed at a dead origin with the "Retry" button inert (its `start_setup`
+/// re-entry short-circuited on the still-populated `api` slot).
+///
+/// Clear the `Managed.api` slot + the recorded PID so the guard now sees `None` and a
+/// Retry re-spawns the API, and surface a setup `error` event so the UI shows the
+/// recoverable error screen instead of a silently-dead window. No-op during a graceful
+/// shutdown (the child was killed on purpose) — see `begin_shutdown`, which `take()`s the
+/// child before this reader observes the resulting `Terminated`.
+fn handle_api_exit(app: &AppHandle) {
+    if app.state::<Managed>().shutting_down.load(Ordering::SeqCst) {
+        return;
+    }
+    // Drop the child handle + its recorded PID so `run_startup`'s spawn-once guard
+    // re-arms and a Retry actually re-spawns the API.
+    let _ = app.state::<Managed>().api.lock().expect("api lock").take();
+    record_api_pid_cleared(app);
+    // Forget the discovered port so window-gating re-derives it from the fresh spawn.
+    *app.state::<Managed>()
+        .api_port
+        .lock()
+        .expect("api port lock") = None;
+    emit(
+        app,
+        "error",
+        "The local API stopped unexpectedly. Click Retry to restart it.",
+        true,
+    );
 }
 
 /// Health-gate the window on a background thread: wait for the API's
@@ -1205,6 +1245,17 @@ fn record_api_pid(app: &AppHandle, pid: u32) {
     write_sidecar_pidfile(&pids);
 }
 
+/// Clear the recorded API PID after the sidecar exits unexpectedly (F-128, sc-8930), so
+/// the next launch's `reap_stale_sidecars` doesn't try to reap a PID that already died
+/// (or, worse, a recycled one). Paired with clearing the in-memory `Managed.api` slot so
+/// a Retry re-spawns the API.
+fn record_api_pid_cleared(app: &AppHandle) {
+    let state = app.state::<Managed>();
+    let mut pids = state.pids.lock().expect("pids lock");
+    pids.api = None;
+    write_sidecar_pidfile(&pids);
+}
+
 #[cfg(target_os = "macos")]
 fn record_mlx_worker_pid(app: &AppHandle, pid: Option<u32>) {
     let state = app.state::<Managed>();
@@ -1674,14 +1725,25 @@ mod bind_tests {
     /// var in prose or `backticks` are allowed and don't match.) The needle is
     /// assembled from parts so this test's own source doesn't trip the `include_str!`
     /// scan of this very file.
+    ///
+    /// F-128 (sc-8930): scans ALL of the crate's source modules, not just four — the
+    /// invariant is only enforced where it's checked, so a `.env("SCENEWORKS_ALLOW_
+    /// OPEN_BIND", …)` added to `update.rs` / `cred_ipc.rs` / `cuda_provision.rs` would
+    /// previously have slipped past. Keep this list in lockstep with `apps/desktop/src`.
     #[test]
     fn desktop_never_sets_allow_open_bind() {
         let needle = concat!("\"SCENEWORKS_", "ALLOW_OPEN_BIND\"");
+        // Every .rs module in apps/desktop/src (cuda_provision.rs is Windows-gated at
+        // compile time, but include_str! reads its source on any host, so its bind env
+        // is scanned everywhere too).
         for source in [
             include_str!("setup.rs"),
             include_str!("settings.rs"),
             include_str!("main.rs"),
             include_str!("net.rs"),
+            include_str!("update.rs"),
+            include_str!("cred_ipc.rs"),
+            include_str!("cuda_provision.rs"),
         ] {
             assert!(
                 !source.contains(needle),

--- a/scripts/smoke-lens.ps1
+++ b/scripts/smoke-lens.ps1
@@ -78,15 +78,18 @@ Remove-Item (Join-Path $DataDir "recent-projects.json") -Force -ErrorAction Sile
 function Submit-Job($body) {
   Invoke-RestMethod -Method Post -Uri "$base/api/v1/image/jobs" -ContentType "application/json" -Body ($body | ConvertTo-Json -Depth 8)
 }
-function Get-Job($id) { Invoke-RestMethod -Method Get -Uri "$base/api/v1/jobs/$id" -TimeoutSec 10 }
-function Wait-Job($id, $timeoutSec) {
+# Named Get-SwJob / Wait-SwJob (not Get-Job / Wait-Job) so they don't shadow the
+# built-in PowerShell background-job cmdlets (F-131, sc-8933): a caller expecting the
+# real Get-Job/Wait-Job would otherwise silently get these HTTP pollers instead.
+function Get-SwJob($id) { Invoke-RestMethod -Method Get -Uri "$base/api/v1/jobs/$id" -TimeoutSec 10 }
+function Wait-SwJob($id, $timeoutSec) {
   $deadline = (Get-Date).AddSeconds($timeoutSec)
   while ((Get-Date) -lt $deadline) {
-    $j = Get-Job $id
+    $j = Get-SwJob $id
     if ($j.status -in @("completed","failed","canceled","interrupted")) { return $j }
     Start-Sleep -Seconds 3
   }
-  Get-Job $id
+  Get-SwJob $id
 }
 
 try {
@@ -152,7 +155,7 @@ try {
     Write-Host "`n=== $($c.name) ==="
     $job = Submit-Job $c.body
     Write-Host "submitted $($job.id)"
-    $j = Wait-Job $job.id $JobTimeoutSec
+    $j = Wait-SwJob $job.id $JobTimeoutSec
     $adapter = $null; $assetPath = $null
     if ($j.result -and $j.result.assets -and @($j.result.assets).Count -gt 0) {
       $a = @($j.result.assets)[0]


### PR DESCRIPTION
Code-review remediation batch D1 (epic 8800), from `CODE_REVIEW_2026-07-01.md`. All four
findings are Low severity, scoped to the desktop shell (`apps/desktop`) + release CI.

## Stories

### sc-8929 [F-127] — atomic settings write; suppress console flash; harden port/exec parsing
- `settings.rs` `save_settings` → atomic temp+rename (new `atomic_write` helper) so a torn
  write can't wipe the data-dir/HF-home overrides + credential metadata.
- `settings.rs` `run_capture` → `CREATE_NO_WINDOW` (0x0800_0000) under `#[cfg(windows)]` so
  the nvidia-smi probe no longer flashes a console (mirrors `cuda_preflight`).
- `setup.rs` `parse_listening_port` → anchored to the API's `api_listening` event + its
  `address=` field, so an earlier diagnostic line with a loopback host:port no longer seeds
  the wrong port (previously a 30 s dead-port poll).
- `build-sidecar.mjs` `run()` → `execFileSync` (argv) instead of a joined `execSync` shell
  string, so a spaced `PYTHON` path can't break the build (Windows `.cmd` shims routed
  through `cmd.exe` with per-token quoting; `shell:true` deliberately avoided — Node
  concatenates args un-escaped under it, DEP0190).

### sc-8930 [F-128] — extend invariant-guard coverage; supervise the API sidecar
- `desktop_never_sets_allow_open_bind` now `include_str!`-scans ALL 7 crate modules (adds
  `update.rs`, `cred_ipc.rs`, `cuda_provision.rs`), not just 4.
- The API sidecar was spawn-once (Terminated only logged; `is_some()` guard blocked
  respawn). New `handle_api_exit` clears `Managed.api` + the recorded PID + the discovered
  port and emits a setup `error` on an unexpected exit, so the inert Retry button now
  re-spawns the API. No-ops during graceful shutdown.

### sc-8931 [F-129] — stream CUDA wheel downloads instead of buffering whole files
- `fetch_component` streams the wheel body chunk-by-chunk to the temp file while feeding
  Sha256 incrementally (instead of `response.bytes().await` buffering the whole wheel);
  `extract_dlls` uses `std::io::copy` from the zip entry to disk. Peak transient RAM drops
  from full wheel size (cuDNN ~660 MB) to one HTTP chunk. Behavior-preserving.

### sc-8933 [F-131] — align CI action versions + Python deps; rename shadowing PS helpers
- `scripts/smoke-lens.ps1` `Get-Job`/`Wait-Job` → `Get-SwJob`/`Wait-SwJob` (they shadowed
  the built-in cmdlets). All call sites updated.
- Action-version + Python-dep items were **already resolved** by the concurrent CI effort
  and verified here: `release.yml` both jobs SHA-pin checkout@v7.0.0 + setup-node@v6.4.0
  identically; `check.yml` installs only exact-pinned `pytest==9.0.2` + `httpx==0.28.1`
  (pillow/numpy/opencv removed with the retired Python worker, sc-8863).

## Verification
- `cargo fmt --all --check` clean; `cargo clippy -p sceneworks-desktop --all-targets` clean.
- `cargo test -p sceneworks-desktop` → 25 passed (incl. new `atomic_write_replaces_file_and_leaves_no_temp`,
  `parse_listening_port_ignores_unrelated_lines_with_a_host_port`, and the widened
  `desktop_never_sets_allow_open_bind`).
- Desktop crate compiled on the macOS host after staging the `sceneworks-rust-api` sidecar
  binary (+ placeholder `onnxruntime/`+`ffmpeg/` resource dirs) that `build.rs` requires.
- Windows-only `cuda_provision.rs` couldn't be built on this macOS host (the full Windows
  cross-build fails on `ring`'s C deps — no Windows SDK). Its streaming pattern was instead
  type-checked against the real reqwest 0.12.28 / futures-util 0.3 / zip 2 / sha2 0.10
  versions in an isolated crate; **CI's Windows candle lane must validate the full build.**
- `node --check build-sidecar.mjs` OK; `release.yml` + `check.yml` YAML parse OK. `pwsh`
  wasn't available on this host — the PowerShell rename is a verified textual substitution
  (no orphan `Get-Job`/`Wait-Job` references remain); CI's Windows smoke lane exercises it.

sc-8929 · sc-8930 · sc-8931 · sc-8933

🤖 Generated with [Claude Code](https://claude.com/claude-code)