### PR TITLE
fix(worker): interpolate real backend label in model_jobs conversion-cancel strings (sc-9801)

### DIFF
--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -918,6 +918,12 @@ pub(crate) async fn run_model_convert_job(
     let quantize_only = payload_bool(&job.payload, "quantizeOnly");
     let quantize_bits = job.payload.get("quantizeBits").and_then(Value::as_u64);
 
+    // The active backend label (mlx on macOS, candle off-Mac, cpu fallback) so the user-facing
+    // conversion-cancel strings name the REAL backend instead of a hardcoded "MLX" (sc-9801, the
+    // F-114 follow-up to sc-8916). Same `backend_label(&settings.gpu_id)` mechanism the caption /
+    // training paths use.
+    let backend = backend_label(&settings.gpu_id).to_uppercase();
+
     heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
     update_job(
         api,
@@ -933,7 +939,12 @@ pub(crate) async fn run_model_convert_job(
         ),
     )
     .await?;
-    check_cancel(api, &job.id, "MLX conversion canceled before it started.").await?;
+    check_cancel(
+        api,
+        &job.id,
+        &format!("{backend} conversion canceled before it started."),
+    )
+    .await?;
 
     let Some(checkpoint_dir) = huggingface_snapshot_dir(&settings.data_dir, &source_repo) else {
         fail_job(
@@ -1023,7 +1034,12 @@ pub(crate) async fn run_model_convert_job(
     // weights), so honor cancel up front and run on a blocking thread. On any failure the partial
     // temp dir is removed so it can never be promoted by the atomic rename below. The Flux2 path's
     // borrowed vae/text-encoder/tokenizer are absolute symlinks that survive the rename.
-    check_cancel(api, &job.id, "MLX conversion canceled by user.").await?;
+    check_cancel(
+        api,
+        &job.id,
+        &format!("{backend} conversion canceled by user."),
+    )
+    .await?;
     let temp = temp_dir.clone();
     let outcome = match plan {
         ConvertPlan::Flux2 {


### PR DESCRIPTION
## What changed

`sc-8916` (F-114) replaced hardcoded `MLX`/`mlx` backend labels with the interpolated real backend label in `caption_jobs` + `training_jobs`, but two user-facing conversion-cancel strings in `crates/sceneworks-worker/src/model_jobs.rs` still hardcoded `MLX` — so on the candle (off-Mac) lane a canceled conversion was mislabeled as MLX.

This derives the active backend label once inside `run_model_convert_job` via `backend_label(&settings.gpu_id).to_uppercase()` — the exact mechanism sc-8916 used in the caption/training paths — and interpolates it into both cancel messages:

- `"MLX conversion canceled before it started."` → `"{backend} conversion canceled before it started."`
- `"MLX conversion canceled by user."` → `"{backend} conversion canceled by user."`

`{backend}` resolves to `MLX` on macOS, `CANDLE` off-Mac, or `CPU` on the CPU fallback. Behavior-preserving except the labels.

## Scope covered vs the story

The story cited two strings (≈ line 936 and ≈ line 1040) and asked for the COMPLETE fix — every conversion-cancel string in the file that hardcodes MLX. I audited all seven `check_cancel(...)` sites in `model_jobs.rs`: only these two hardcoded `MLX`. The other five (model/LoRA download, LoRA/model import, model download by user) are already backend-neutral. So the two cited sites are the complete set of the anti-pattern in this file; both are fixed.

## Tests

No new test added — this mirrors sc-8916, which added no test for its analogous string interpolations. The reused `backend_label` helper is already unit-tested (`image_jobs/tests.rs::backend_label_defaults_empty_to_cpu`), and the `.to_uppercase()` transform is trivial std behavior. The cancel strings are emitted only from deep inside `run_model_convert_job` (requires a live `ApiClient` + a downloaded checkpoint), so there is no practical unit seam for the string itself without a hollow harness.

## How verified

- `npm run rust:check` (CI-equivalent: `cargo fmt --all --check` + `cargo clippy --all-targets -D warnings` + `cargo test` + `cargo build`) — all green; 618 tests passed, 0 failed.
- Candle lane compile: `cargo check -p sceneworks-worker --no-default-features -F backend-candle --all-targets` — clean.

Refs sc-9801 (F-114 follow-up to sc-8916).

🤖 Generated with [Claude Code](https://claude.com/claude-code)