### PR TITLE
fix(worker): harden path confinement against intermediate-dir symlink escapes (sc-9812)

### DIFF
--- a/crates/sceneworks-worker/src/caption_jobs.rs
+++ b/crates/sceneworks-worker/src/caption_jobs.rs
@@ -760,7 +760,17 @@ mod tests {
         ]);
         let items = caption_items(&settings, &payload).expect("items parse");
         assert_eq!(items[0].item_id, "item_1");
-        assert_eq!(items[0].image_path, image_path);
+        // sc-9812: path confinement now canonicalizes the deepest existing ancestor
+        // before re-appending the (not-yet-created) tail, so the resolved image path
+        // is expressed via the canonical tempdir root (on macOS `/var` -> `/private/var`).
+        let expected = dir
+            .path()
+            .canonicalize()
+            .expect("tempdir canonicalizes")
+            .join("datasets")
+            .join("ds-1")
+            .join("image.png");
+        assert_eq!(items[0].image_path, expected);
         assert_eq!(items[0].trigger_words, vec!["miraStyle"]);
     }
 

--- a/crates/sceneworks-worker/src/paths.rs
+++ b/crates/sceneworks-worker/src/paths.rs
@@ -218,8 +218,58 @@ pub(crate) fn normalize_app_managed_lora_path(
 pub(crate) fn normalize_existing_or_absolute(path: &Path) -> WorkerResult<PathBuf> {
     match std::fs::canonicalize(path) {
         Ok(canonical) => normalize_absolute_path(&canonical),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => normalize_absolute_path(path),
+        // `canonicalize` fails `NotFound` as soon as *any* component (leaf or an
+        // intermediate dir) is absent, so a purely-lexical fallback would leave
+        // intermediate symlinks unresolved: a planted `<data>/loras/evil -> /outside`
+        // with a not-yet-created leaf `<data>/loras/evil/newdir` would still satisfy a
+        // lexical `starts_with(<data>)` and escape the managed root (sc-9812 / F-075
+        // follow-up). Instead canonicalize the deepest *existing* ancestor — resolving
+        // every symlink in the real portion of the path — then re-append the missing
+        // tail lexically, so a legitimate not-yet-created leaf under the root still
+        // resolves while an intermediate-symlink escape is caught by the confinement
+        // check that runs on the returned path.
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            normalize_nonexistent_via_ancestor(path)
+        }
         Err(error) => Err(error.into()),
+    }
+}
+
+/// Resolve a path whose leaf (and possibly deeper ancestors) does not yet exist by
+/// canonicalizing the deepest existing ancestor and re-appending the missing tail.
+/// This resolves any symlink in the *existing* portion of the path (closing the
+/// intermediate-symlink escape lexical normalization missed) while still returning a
+/// usable path for a legitimate not-yet-created target under a managed root.
+fn normalize_nonexistent_via_ancestor(path: &Path) -> WorkerResult<PathBuf> {
+    // Start from a lexically-absolute, `.`/`..`-collapsed form so the tail we peel off
+    // is composed only of `Normal` components (no `..` to re-introduce a traversal
+    // after the existing prefix is canonicalized).
+    let absolute = normalize_absolute_path(path)?;
+    let mut tail: Vec<std::ffi::OsString> = Vec::new();
+    let mut ancestor = absolute.as_path();
+    loop {
+        match std::fs::canonicalize(ancestor) {
+            Ok(canonical) => {
+                let mut resolved = canonical;
+                for component in tail.iter().rev() {
+                    resolved.push(component);
+                }
+                return normalize_absolute_path(&resolved);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                match (ancestor.file_name(), ancestor.parent()) {
+                    (Some(name), Some(parent)) => {
+                        tail.push(name.to_owned());
+                        ancestor = parent;
+                    }
+                    // Reached the filesystem root without finding an existing ancestor
+                    // (e.g. a path on a non-mounted volume): fall back to the lexical
+                    // form. There is no symlink to resolve, so this cannot escape.
+                    _ => return Ok(absolute),
+                }
+            }
+            Err(error) => return Err(error.into()),
+        }
     }
 }
 

--- a/crates/sceneworks-worker/src/prompt_refine_jobs.rs
+++ b/crates/sceneworks-worker/src/prompt_refine_jobs.rs
@@ -1824,7 +1824,14 @@ mod tests {
             "Image caption reference image",
         )
         .expect("an in-root reference path is accepted");
-        assert!(resolved.starts_with(dir.path()), "stays under the data dir");
+        // sc-9812: confinement canonicalizes the deepest existing ancestor before
+        // re-appending the not-yet-created tail, so the resolved path is under the
+        // canonical data-dir root (on macOS `/var` -> `/private/var`).
+        let canonical_root = dir.path().canonicalize().expect("tempdir canonicalizes");
+        assert!(
+            resolved.starts_with(&canonical_root),
+            "stays under the data dir"
+        );
 
         // Out-of-root absolute path: rejected.
         let outside_dir = tempfile::tempdir().expect("tempdir2");

--- a/crates/sceneworks-worker/src/tests/media_and_paths.rs
+++ b/crates/sceneworks-worker/src/tests/media_and_paths.rs
@@ -147,7 +147,12 @@ fn model_destinations_are_constrained_to_data_models() {
     let temp = tempdir().expect("tempdir creates");
     let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
     settings.data_dir = temp.path().to_path_buf();
-    let models_root = super::normalize_absolute_path(&temp.path().join("models"))
+    // sc-9812: the confinement helpers canonicalize the deepest existing ancestor of a
+    // (possibly not-yet-created) target, so the returned path is expressed via the
+    // canonical data-dir root (on macOS `/var` -> `/private/var`). Build the expected
+    // prefix from the canonical tempdir so `starts_with` matches.
+    let canonical_root = temp.path().canonicalize().expect("tempdir canonicalizes");
+    let models_root = super::normalize_absolute_path(&canonical_root.join("models"))
         .expect("models root normalizes");
     let fallback = temp.path().join("models").join("fallback");
 
@@ -325,6 +330,69 @@ fn app_managed_helpers_resolve_symlinks_before_root_check() {
     std::fs::create_dir_all(&real).expect("real model dir creates");
     super::normalize_app_managed_model_path(&settings, &real.display().to_string(), "Model")
         .expect("a real managed dir is still accepted");
+}
+
+// sc-9812 / F-075 follow-up: the sc-8877 fix canonicalizes before the confinement
+// check, but `normalize_existing_or_absolute` fell back to purely-*lexical*
+// normalization whenever `canonicalize` returned `NotFound` — which fires as soon as
+// the *leaf* is absent, even if an *intermediate* directory is a symlink escaping the
+// root. So `<data>/loras/evil-symlink/newdir` (evil-symlink -> outside, newdir not yet
+// created) resolved lexically and still satisfied `starts_with(<data>)`. The fix
+// canonicalizes the deepest existing ancestor (resolving the intermediate symlink)
+// before re-appending the missing tail, so the confinement check now catches it.
+#[cfg(unix)]
+#[test]
+fn intermediate_dir_symlink_escape_with_nonexistent_leaf_is_rejected() {
+    let temp = tempdir().expect("tempdir creates");
+    let data_dir = temp.path().join("data");
+    let loras_dir = data_dir.join("loras");
+    let outside_dir = temp.path().join("outside");
+    std::fs::create_dir_all(&loras_dir).expect("loras dir creates");
+    std::fs::create_dir_all(&outside_dir).expect("outside dir creates");
+
+    let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+    settings.data_dir = data_dir.clone();
+
+    // 1. A normal not-yet-existing leaf under the root still resolves and passes.
+    let fresh_leaf = loras_dir.join("brand-new-dir");
+    let normalized =
+        super::normalize_app_managed_path(&settings, &fresh_leaf.display().to_string(), "Path")
+            .expect("a not-yet-created leaf under the root is still accepted");
+    // The resolved path stays under the (canonicalized) managed root.
+    assert!(normalized.starts_with(
+        data_dir
+            .canonicalize()
+            .expect("data dir canonicalizes")
+    ));
+
+    // 2. An existing valid path under the root still passes.
+    let existing = loras_dir.join("existing-dir");
+    std::fs::create_dir_all(&existing).expect("existing dir creates");
+    super::normalize_app_managed_path(&settings, &existing.display().to_string(), "Path")
+        .expect("an existing dir under the root is still accepted");
+
+    // 3. The exploit: an *intermediate* directory symlink escaping the root, with a
+    //    nonexistent leaf beyond it. Pre-fix this passed the lexical `starts_with`.
+    let outside_target = outside_dir.join("escape");
+    std::fs::create_dir_all(&outside_target).expect("outside target creates");
+    let evil_symlink = loras_dir.join("evil-symlink");
+    std::os::unix::fs::symlink(&outside_target, &evil_symlink).expect("symlink creates");
+    let escaped = evil_symlink.join("newdir"); // newdir does not exist yet
+    let err =
+        super::normalize_app_managed_path(&settings, &escaped.display().to_string(), "Path")
+            .expect_err("intermediate-symlink escape with a nonexistent leaf rejects");
+    assert!(err.to_string().contains("app-managed directory"));
+
+    // 4. Regression guard for sc-8877: a *leaf* symlink escape is still rejected.
+    let leaf_symlink = loras_dir.join("leaf-escape");
+    std::os::unix::fs::symlink(&outside_target, &leaf_symlink).expect("symlink creates");
+    let err = super::normalize_app_managed_path(
+        &settings,
+        &leaf_symlink.display().to_string(),
+        "Path",
+    )
+    .expect_err("leaf-symlink escape still rejects");
+    assert!(err.to_string().contains("app-managed directory"));
 }
 
 // sc-8821 / F-019: payload-supplied weight filenames (`advanced.controlWeights.filename`,

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -836,7 +836,19 @@ impl SamplePersister {
             ProjectStore::new(settings.data_dir.clone(), "worker")
                 .get_project(project_id)
                 .ok()
-                .map(|project| PathBuf::from(project.path))
+                // Canonicalize the project root with the SAME normalization the output
+                // path went through (`resolve_training_output_dir` -> `normalize_app_managed_path`
+                // -> `normalize_existing_or_absolute`). The project store persists `path`
+                // lexically (`data_dir.join(...).display()`), so on macOS it stays `/var/...`
+                // while `output_dir` resolves to `/private/var/...`; without this, the
+                // `strip_prefix(project_root)` in `write_training_sample` fails and every
+                // sample record silently loses its `relativePath` (sc-9812 / F-075 follow-up).
+                // The project dir always exists here (`find_project_path` requires it), so
+                // this canonicalizes fully; fall back to the lexical path if resolution fails.
+                .map(|project| {
+                    let lexical = PathBuf::from(project.path);
+                    normalize_existing_or_absolute(&lexical).unwrap_or(lexical)
+                })
         });
         let stem = Path::new(&plan.output.file_name)
             .file_stem()
@@ -2199,6 +2211,130 @@ mod tests {
         // The PNG must decode back to the source dimensions.
         let decoded = image::open(&png).expect("re-open png").to_rgb8();
         assert_eq!((decoded.width(), decoded.height()), (4, 2));
+    }
+
+    /// sc-9812 (F-075 follow-up) — INTEGRATION-level guard for the caller-symmetry regression the
+    /// unit test above cannot catch. `SamplePersister::new` derives its two `strip_prefix` operands
+    /// from DIFFERENT provenance: `output_dir` from `resolve_training_output_dir`
+    /// (`normalize_app_managed_path` -> `normalize_existing_or_absolute`, canonicalized) and
+    /// `project_root` from the project store (`get_project(...).path`, persisted LEXICALLY as
+    /// `data_dir.join(...).display()`). On macOS the app data dir under `/var/...` canonicalizes to
+    /// `/private/var/...`, so before the fix the two forms diverged and `write_training_sample`'s
+    /// `strip_prefix` dropped `relativePath` from every project-scoped sample record. We build the
+    /// project root the way `project_store` does (a real `create_project`), NOT a hand-matched
+    /// lexical pair, and assert the record's `relativePath` is populated and correct. This FAILS
+    /// before the `SamplePersister::new` canonicalization and PASSES after.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn sample_persister_populates_relative_path_for_project_store_provisioned_root() {
+        let data_dir = tempfile::tempdir().expect("data dir tempdir");
+        let settings = test_settings(data_dir.path());
+
+        // Provision the project exactly as production does: the store persists `path`
+        // lexically (`project_path.display().to_string()`), which on macOS keeps the
+        // `/var/...` form even though the real path resolves under `/private/var/...`.
+        let store = ProjectStore::new(settings.data_dir.to_path_buf(), "test");
+        let project = store
+            .create_project("Char Studio")
+            .expect("project provisions");
+
+        // Project-scoped output lives under the owning project's tree, the default scope.
+        // `resolve_training_output_dir` (via `normalize_app_managed_path`) canonicalizes it,
+        // so this is the operand whose form diverges from the lexical `project.path`.
+        let output_dir = PathBuf::from(&project.path).join("loras").join("lora-1");
+
+        let mut plan_value = plan_json(
+            data_dir.path(),
+            "z_image_lora",
+            "z_image_turbo",
+            "lora",
+            &["x.png"],
+        );
+        plan_value["output"]["outputDir"] = json!(output_dir.display().to_string());
+        plan_value["output"]["fileName"] = json!("mychar.safetensors");
+        let plan = parse(plan_value);
+
+        let job: JobSnapshot = serde_json::from_value(json!({
+            "id": "job-1",
+            "type": "train_lora",
+            "status": "running",
+            "projectId": project.id,
+            "projectName": "Char Studio",
+            "payload": {},
+            "result": {},
+            "requestedGpu": "auto",
+            "assignedGpu": null,
+            "workerId": "test-worker",
+            "progress": 0.0,
+            "stage": "queued",
+            "message": "queued",
+            "error": null,
+            "etaSeconds": null,
+            "elapsedSeconds": null,
+            "attempts": 1,
+            "sourceJobId": null,
+            "duplicateOfJobId": null,
+            "cancelRequested": false,
+            "createdAt": "2026-07-04T00:00:00Z",
+            "updatedAt": "2026-07-04T00:00:00Z",
+            "startedAt": null,
+            "completedAt": null,
+            "canceledAt": null,
+            "lastHeartbeatAt": null
+        }))
+        .expect("job snapshot deserializes");
+
+        // Drive the REAL provenance — this is where the two operands are resolved.
+        let persister = SamplePersister::new(&settings, &job, &plan);
+        let resolved_output = persister
+            .output_dir
+            .clone()
+            .expect("output dir resolves under the projects tree");
+        let resolved_project_root = persister
+            .project_root
+            .clone()
+            .expect("project root resolves from the store");
+
+        let image = gen_core::Image {
+            width: 4,
+            height: 2,
+            pixels: vec![255u8, 0, 0]
+                .into_iter()
+                .cycle()
+                .take(4 * 2 * 3)
+                .collect(),
+        };
+        let record = write_training_sample(
+            Some(resolved_output.as_path()),
+            Some(resolved_project_root.as_path()),
+            &persister.stem,
+            250,
+            2,
+            "mychar, studio portrait",
+            image,
+            8,
+            1.5,
+        )
+        .expect("sample persists");
+
+        // The regression: before the fix, `strip_prefix(project_root)` fails on macOS and this
+        // key is absent. It must be present and project-root-relative (the shape the Training
+        // Studio resolves as `/api/v1/projects/<id>/files/<relativePath>`).
+        let relative = record
+            .get("relativePath")
+            .and_then(|value| value.as_str())
+            .expect("relativePath is populated for a project-scoped sample");
+        assert!(
+            !relative.is_empty(),
+            "relativePath must be non-empty, got {relative:?}"
+        );
+        assert_eq!(
+            relative, "loras/lora-1/samples/step-000250/mychar-step000250-2.png",
+            "relativePath must be project-root-relative"
+        );
     }
 
     /// Real-weights smoke (sc-4732 + sc-4764): load the Kolors trainer from the installed

--- a/crates/sceneworks-worker/src/upscale_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs/tests.rs
@@ -476,7 +476,17 @@ fn parse_dataset_upscale_items_reads_valid_entries_and_skips_malformed() {
         parse_dataset_upscale_items(&settings, payload.as_object().unwrap()).expect("items parse");
     assert_eq!(items.len(), 2);
     assert_eq!(items[0].item_id, "a");
-    assert_eq!(items[0].image_path, a);
+    // sc-9812: path confinement canonicalizes the deepest existing ancestor before
+    // re-appending the (not-yet-created) tail, so the resolved image path is expressed
+    // via the canonical tempdir root (on macOS `/var` -> `/private/var`).
+    let expected_a = dir
+        .path()
+        .canonicalize()
+        .expect("tempdir canonicalizes")
+        .join("datasets")
+        .join("ds-1")
+        .join("a.png");
+    assert_eq!(items[0].image_path, expected_a);
     assert_eq!(items[1].item_id, "d");
 }
 


### PR DESCRIPTION
## sc-9812 — [F-075 follow-up] Harden `normalize_existing_or_absolute` against intermediate-dir symlink escapes with a nonexistent leaf

### The vulnerability
sc-8877 (F-075) canonicalizes before the confinement check and closed the **leaf**-symlink escape. A residual, narrower defect remained (not a regression):

`normalize_existing_or_absolute` (`crates/sceneworks-worker/src/paths.rs`) fell back to **purely-lexical** normalization whenever `std::fs::canonicalize` returned `NotFound`. But `canonicalize` fails `NotFound` as soon as *any* path component is absent — leaf **or** an intermediate directory. So a symlink at an **intermediate** directory whose leaf does not yet exist:

```
<data>/loras/evil-symlink/newdir     # evil-symlink -> /outside, newdir absent
```

was left unresolved by the lexical fallback and still satisfied the lexical `starts_with(<data>)` confinement check — escaping the managed root. Every confinement helper (`normalize_app_managed_path`, `..._model_path`, `..._lora_path`, `resolve_lora_import_target`, `resolve_model_import_target`, `resolve_model_convert_output`, etc.) routes through this function, so all of them inherited the hole.

Exploit precondition: prior write access to the managed root to plant the symlink.

### The fix (approach a: canonicalize the deepest existing ancestor)
When the full path is `NotFound`, walk up to the deepest **existing** ancestor, `canonicalize` it (resolving every symlink in the real portion of the path), then re-append the missing tail lexically. The path returned is exactly what the `starts_with(root)` confinement check runs against, so:

- an intermediate-symlink escape is now **caught** (the resolved ancestor points outside the root), while
- a legitimate not-yet-created leaf under the root **still resolves and passes**.

A lexically-absolute, `.`/`..`-collapsed form is computed first so the peeled-off tail is composed only of `Normal` components (no `..` can re-introduce a traversal after the prefix is canonicalized). If no existing ancestor is found up to the filesystem root, it falls back to the lexical form — there is no symlink to resolve in that case, so it cannot escape.

### Tests added (security-first, `tempdir` + real `std::os::unix::fs::symlink`)
New `intermediate_dir_symlink_escape_with_nonexistent_leaf_is_rejected` in `crates/sceneworks-worker/src/tests/media_and_paths.rs`:
1. a normal nonexistent leaf under the root still resolves/passes,
2. an existing valid path under the root still passes,
3. an **intermediate-dir symlink** pointing outside the root, with a nonexistent leaf beyond it, is **REJECTED** (the previously-passing exploit),
4. a **leaf** symlink escape is still rejected (regression guard for sc-8877).

Confirmed the exploit test **fails without the fix** and passes with it.

### Collateral test updates
Because the helper now returns the **canonical** form for nonexistent-leaf targets, four pre-existing tests that compared resolved paths against the *lexical* tempdir root (on macOS `/var` -> `/private/var`) were updated to expect the canonical root. These are assertion-expectation updates, not confinement changes — every rejection assertion in those tests still holds:
- `tests/media_and_paths.rs::model_destinations_are_constrained_to_data_models`
- `caption_jobs::tests::caption_items_require_ids_and_paths`
- `prompt_refine_jobs::tests::image_caption_reference_path_confined_to_app_managed_root`
- `upscale_jobs::tests::parse_dataset_upscale_items_reads_valid_entries_and_skips_malformed`

### Verification
- `cargo test -p sceneworks-worker --lib` → **619 passed, 0 failed**
- `cargo fmt --check` → clean
- `cargo clippy --all-targets -- -D warnings` (worker) → clean
- candle lane: `cargo check -p sceneworks-worker --no-default-features -F backend-candle --all-targets` → clean; new test also passes under the candle lane

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Follow-up: caller-symmetry fix (restore training-sample `relativePath`)

The return-form change above (nonexistent-leaf targets now resolve to the **canonical** form, macOS `/private/var/...` instead of lexical `/var/...`) broke one downstream caller whose two `strip_prefix` operands come from **different** provenance:

`SamplePersister::new` (`crates/sceneworks-worker/src/training_jobs.rs`) resolved:
- `output_dir` via `resolve_training_output_dir` → `normalize_app_managed_path` → `normalize_existing_or_absolute` (**canonical**), and
- `project_root` from the project store: `get_project(...).path`, which `project_store` persists **lexically** (`project_path.display().to_string()`).

Project-scope is the default. Pre-fix both were lexical, so `write_training_sample`'s `path.strip_prefix(project_root)` succeeded. Post-fix the two forms diverged on macOS, so `strip_prefix` failed **silently** and every project-scoped sample record dropped its `relativePath` — the field the Training Studio UI resolves as `/api/v1/projects/<id>/files/<relativePath>`.

**Fix:** run the project store's lexical `path` through the **same** `normalize_existing_or_absolute` the output path uses, inside `SamplePersister::new`, so both `strip_prefix` operands share one canonical form. The project dir always exists at that point (`find_project_path` requires it). The security fix is preserved unchanged.

**Test:** added `sample_persister_populates_relative_path_for_project_store_provisioned_root` — an integration-level test that drives the **real** `SamplePersister::new` provenance with a project-store-provisioned root (via `ProjectStore::create_project`, **not** a hand-matched lexical pair) and asserts `relativePath` is populated and project-root-relative. Confirmed it **fails before this fix** and passes after. The prior unit test only passed lexically-identical operands, masking the regression.

**model_jobs path-persistence audit:** the `model_jobs` result/manifest writes (`paths.model` → `user.models.jsonc`, and the `path` result fields) now persist paths in canonical form. Audited both consumers of a persisted model path (independently + via a second reviewer):
- `model_is_installed` (`apps/rust-api/src/models.rs`) — pure filesystem existence check (`is_dir()` + marker file), inode-based and form-agnostic; and
- `remove_owned_artifact_path` (`apps/rust-api/src/lib.rs`) — canonicalizes **both** the artifact path and each allowed root before `starts_with`.

**No lexical-vs-canonical comparator is broken by this PR.** No further change needed there.

### Follow-up verification
- `cargo test -p sceneworks-worker --lib` → **620 passed, 0 failed** (incl. the new test; the previously-masking `write_training_sample_writes_png_and_project_relative_record` still passes)
- `cargo fmt -p sceneworks-worker --check` → clean
- candle lane: `cargo check -p sceneworks-worker --no-default-features -F backend-candle --all-targets` → clean
