### PR TITLE
chore(web): extract App useAccessGate/useJobEvents hooks from App.jsx (sc-9750)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { apiFetch, eventUrl, isAbortError, setMediaTicket } from "./api.js";
+import { apiFetch, isAbortError } from "./api.js";
 import { pollJobToCompletion } from "./pollJob.js";
 import { Icon } from "./components/Icons.jsx";
 import { Logo } from "./components/Logo.jsx";
@@ -30,6 +30,8 @@ import { useTraining } from "./hooks/useTraining.js";
 import { useModelsAndLoras } from "./hooks/useModelsAndLoras.js";
 import { usePersonTracks } from "./hooks/usePersonTracks.js";
 import { useTimelines } from "./hooks/useTimelines.js";
+import { useAccessGate } from "./hooks/useAccessGate.js";
+import { useJobEvents } from "./hooks/useJobEvents.js";
 import { AppStaticContext, AppLiveContext } from "./context/AppContext.js";
 import { DEFAULT_MAC_CAPABILITIES } from "./macGating.js";
 import { ACCENTS, isAccentId } from "./accents.js";
@@ -42,11 +44,8 @@ import {
 import { buildWorkersById } from "./workers.js";
 import { createEditorScratchRegistry } from "./editorScratch.js";
 import { isDesktop as isDesktopShell, tauriInvoke } from "./runtime.js";
-import { readAccessToken, storeAccessToken, clearAccessToken } from "./accessToken.js";
 import {
   buildLocalJobStack,
-  failedJobNotice,
-  generatedResultAssetCount,
   isActiveWorker,
   isImageGenerationJob,
   isInterleaveJob,
@@ -55,8 +54,6 @@ import {
   isVideoGenerationJob,
   localJobStackLimit,
   mergeFreshJobs,
-  noticeKindForJob,
-  parseSseJson,
   readStoredAccent,
   readStoredTheme,
 } from "./appHelpers.js";
@@ -327,22 +324,6 @@ function FirstRunProjectGate({ onCreate, disabled }) {
 
 export function App() {
   const [health, setHealth] = useState(null);
-  const [access, setAccess] = useState({ authRequired: false });
-  // Whether GET /api/v1/access has answered yet. Until it does we don't know if a
-  // password is required, so a remote browser must hold its protected data loads —
-  // otherwise they fire optimistically, 401, and bury the password prompt under a band
-  // of "access token required" errors (epic 4484).
-  const [accessResolved, setAccessResolved] = useState(false);
-  // The remote-access token (= host password). Storage key + threat-model note live in
-  // accessToken.js (sc-8880); it is persisted verbatim in localStorage so it survives
-  // reloads (a LAN remote-access requirement — see that module for the accepted XSS tradeoff).
-  const [token, setToken] = useState(() => readAccessToken());
-  // What the user is typing into the login gate (sc-8808). Kept separate from the
-  // live `token` so keystrokes never flip `authenticated` or churn the data/SSE
-  // effects; `token` only changes once /api/v1/auth/verify accepts the draft.
-  const [passwordDraft, setPasswordDraft] = useState("");
-  // Wrong-password feedback for the remote-browser login gate (epic 4484 story 7).
-  const [authError, setAuthError] = useState("");
   const [projects, setProjects] = useState([]);
   const [projectsLoaded, setProjectsLoaded] = useState(false);
   // Desktop first-run wizard gate: null = unknown (still reading on desktop),
@@ -429,6 +410,21 @@ export function App() {
   // Back-compat: the existing setError(msg)/setError("") call sites map onto the
   // "general" notice kind — a truthy message replaces it, "" dismisses only it.
   const setError = useCallback((message) => pushNotice("general", message), [pushNotice]);
+  // Remote-access gate (epic 4484), extracted to a hook (sc-9750): owns access probe,
+  // host password/token, login-gate draft + error, and the media-ticket mint that must
+  // settle before protected data loads. `authenticated`/`ready` gate the data + SSE
+  // effects below; `token` threads through the data hooks and every apiFetch call site.
+  const {
+    access,
+    token,
+    passwordDraft,
+    setPasswordDraft,
+    authError,
+    authenticated,
+    ready,
+    saveToken,
+    lockRemote,
+  } = useAccessGate({ setError, pushNotice, dismissNoticeKind });
   const [theme, setTheme] = useState(readStoredTheme);
   // Apply a theme and persist it through the API. localStorage gives an instant
   // initial paint, but on the desktop shell the UI runs at the API's per-launch
@@ -676,89 +672,6 @@ export function App() {
     createVideoJob,
   });
 
-  // The desktop shell reaches its own API over loopback, which the API trusts
-  // (SCENEWORKS_TRUST_LOOPBACK), so it's authenticated without a password — never prompt
-  // for one locally (epic 4484). A remote browser must wait for GET /api/v1/access before
-  // it knows whether a password is needed; until then it holds its protected loads rather
-  // than firing them unauthenticated.
-  const authenticated = useMemo(
-    () =>
-      isDesktopShell ||
-      (accessResolved && (!access.authRequired || token.length > 0)),
-    [accessResolved, access, token],
-  );
-  // sc-8810: whether media URLs are renderable yet. When auth is on, element-driven
-  // requests (<img>/<video>) can't send the token header, so every media URL needs
-  // the query-param ticket minted below. Data loads hold until the first ticket is
-  // stored (mediaReady), otherwise thumbnails rendered in the gap would 401 and
-  // stick as "deleted" placeholders. When auth is off this resolves immediately.
-  const [mediaReady, setMediaReady] = useState(false);
-  // sc-9063 (F-008 follow-up): a persistently failing mint must not blank the whole
-  // app. `ready` waits for the first mint attempt to SETTLE (success or failure),
-  // not for a success: once a mint fails, lists/metadata load anyway — media
-  // degrades to placeholders and recovers when a retry lands — and a "media-ticket"
-  // notice tells the user why media is broken while the backoff keeps retrying.
-  const [mediaTicketFailed, setMediaTicketFailed] = useState(false);
-  const ready = authenticated && (mediaReady || mediaTicketFailed);
-
-  useEffect(() => {
-    if (!authenticated || !accessResolved) {
-      // Lock/logout stops the mint loop (cleanup above cleared the backoff timer),
-      // so drop the settled gate: the next unlock must re-run sc-8810's
-      // mint-before-data ordering rather than ride a stale mediaReady/
-      // mediaTicketFailed, and the "Retrying in the background" notice must not
-      // linger on the lock screen while no retry is actually running.
-      setMediaReady(false);
-      setMediaTicketFailed(false);
-      dismissNoticeKind("media-ticket");
-      return undefined;
-    }
-    if (!access.authRequired) {
-      setMediaTicket("");
-      setMediaReady(true);
-      return undefined;
-    }
-    let closed = false;
-    let timer = null;
-    let attempt = 0;
-    async function acquire() {
-      try {
-        // Header-authenticated mint (loopback-trusted desktop sends no token and
-        // still passes). The server keeps re-arming the same sliding ticket, so
-        // already-rendered media URLs stay valid across refreshes.
-        const response = await apiFetch("/api/v1/files/ticket", token, { method: "POST" });
-        if (closed) {
-          return;
-        }
-        setMediaTicket(response.ticket);
-        setMediaReady(true);
-        setMediaTicketFailed(false);
-        dismissNoticeKind("media-ticket");
-        attempt = 0;
-        const ttlMs = Math.max(15, Number(response.expiresInSeconds) || 0) * 1000;
-        timer = window.setTimeout(acquire, Math.max(5000, Math.floor(ttlMs / 3)));
-      } catch {
-        if (closed) {
-          return;
-        }
-        setMediaTicketFailed(true);
-        pushNotice(
-          "media-ticket",
-          "media authorization: couldn't obtain a media ticket, so thumbnails, previews, and downloads may fail to load. Retrying in the background.",
-        );
-        const delay = Math.min(30000, 1000 * 2 ** attempt);
-        attempt += 1;
-        timer = window.setTimeout(acquire, delay);
-      }
-    }
-    acquire();
-    return () => {
-      closed = true;
-      if (timer) {
-        window.clearTimeout(timer);
-      }
-    };
-  }, [access.authRequired, accessResolved, authenticated, token, pushNotice, dismissNoticeKind]);
   const imageModels = useMemo(() => {
     const items = models.filter((model) => model.type === "image" && model.installState !== "missing");
     return items.length || models.length ? items : fallbackModels.filter((model) => model.type === "image");
@@ -960,13 +873,7 @@ export function App() {
     apiFetch("/api/v1/health", "")
       .then(setHealth)
       .catch((err) => setError(err.message));
-
-    apiFetch("/api/v1/access", "")
-      .then(setAccess)
-      .catch((err) => setError(err.message))
-      // Either way the auth state is now as resolved as it'll get; release the gate so
-      // an authenticated client (or one not requiring auth) can load its data.
-      .finally(() => setAccessResolved(true));
+    // The /api/v1/access probe (+ accessResolved release) lives in useAccessGate now (sc-9750).
   }, []);
 
   useEffect(() => {
@@ -1122,157 +1029,29 @@ export function App() {
     return () => controller.abort();
   }, [activeProject?.id, ready, token]);
 
-  useEffect(() => {
-    // Gated on `ready` (not just `authenticated`): SSE job updates carry assets whose
-    // thumbnails render immediately, so the media-ticket mint must have settled first
-    // (sc-8810; sc-9063 lets a failed mint through — media degrades, data flows).
-    if (!ready) {
-      return undefined;
-    }
-
-    let events = null;
-    let reconnectTimer = null;
-    let reconnectAttempt = 0;
-    let closed = false;
-
-    function handleJobUpdated(event) {
-      const job = parseSseJson(event, "job");
-      if (!job) {
-        return;
-      }
-      const hasGeneratedAssets = Boolean(job.result?.generationSetId || job.result?.assetIds?.length || job.result?.assets?.length);
-      const resultAssetCount = generatedResultAssetCount(job);
-      const generationSetId = job.result?.generationSetId ?? "";
-      const refreshKey = job.id ?? generationSetId;
-      const previousRefresh = generatedAssetRefreshesRef.current.get(refreshKey) ?? { assetCount: 0, generationSetId: "" };
-      const shouldRefreshGeneratedAssets =
-        Boolean(job.projectId) &&
-        hasGeneratedAssets &&
-        (resultAssetCount > previousRefresh.assetCount ||
-          (resultAssetCount === 0 && generationSetId && generationSetId !== previousRefresh.generationSetId));
-      setJobs((items) => upsertJobNewest(items, job));
-      if (hasGeneratedAssets) {
-        if (job.result?.generationSetId) {
-          setLatestGenerationSetId(job.result.generationSetId);
-        }
-        generatedAssetRefreshesRef.current.set(refreshKey, {
-          assetCount: Math.max(resultAssetCount, previousRefresh.assetCount),
-          generationSetId: generationSetId || previousRefresh.generationSetId,
-        });
-        if (shouldRefreshGeneratedAssets) {
-          refreshAssetsRef.current?.(job.projectId);
-        }
-      }
-      if (job.status === "completed" && hasGeneratedAssets) {
-        enqueueTimelineGenerationApply(job);
-      }
-      if (job.status === "completed" && job.projectId && job.type === "person_track") {
-        refreshPersonTracksRef.current?.(job.projectId);
-      }
-      if (job.status === "completed" && job.projectId && job.type === "person_detect") {
-        refreshAssetsRef.current?.(job.projectId);
-      }
-      if (job.status === "completed" && job.type === "model_download") {
-        refreshDataRef.current?.();
-      }
-      // A completed built-in LoRA download (sc-5944) flips the catalog entry to
-      // installed; refresh models+loras so the Models row and any Studio gate update.
-      if (job.status === "completed" && job.type === "lora_download") {
-        refreshDataWithLoraOverlayRef.current?.(job.projectId ?? activeProjectRef.current?.id);
-      }
-      if (job.status === "completed" && job.type === "lora_import") {
-        dismissNoticeKind("lora-import");
-        refreshDataWithLoraOverlayRef.current?.(job.projectId ?? activeProjectRef.current?.id);
-      }
-      if (job.status === "completed" && job.type === "lora_train" && job.payload?.dryRun === false) {
-        if (job.result?.loraRegistered === false) {
-          pushNotice("lora-train", `lora training: ${job.result?.loraRegistrationError ?? "Completed training but could not register the LoRA."}`);
-        } else {
-          dismissNoticeKind("lora-train");
-          refreshDataWithLoraOverlayRef.current?.(job.projectId ?? activeProjectRef.current?.id);
-        }
-      }
-      if (job.status === "failed" && !hasVisibleLocalFailure(job)) {
-        pushNotice(noticeKindForJob(job), failedJobNotice(job));
-      }
-      // Evict the per-job refresh bookkeeping once the job is terminal (sc-8944): the
-      // dedupe counters are only consulted while a job is still emitting incremental
-      // asset updates. Without this the Map grows one entry per asset-producing job for
-      // the session's lifetime (unbounded, slow leak in multi-day sessions).
-      if (terminalStatuses.has(job.status)) {
-        generatedAssetRefreshesRef.current.delete(refreshKey);
-      }
-    }
-
-    function handleWorkerUpdated(event) {
-      const worker = parseSseJson(event, "worker");
-      if (!worker) {
-        return;
-      }
-      setWorkers((items) => [worker, ...items.filter((item) => item.id !== worker.id)].sort(sortWorkers));
-    }
-
-    function handleQueueUpdated(event) {
-      const summary = parseSseJson(event, "queue");
-      if (!summary) {
-        return;
-      }
-      setQueueSummary(summary);
-      if (Array.isArray(summary.workers)) {
-        setWorkers(summary.workers.sort(sortWorkers));
-      }
-    }
-
-    async function connect() {
-      let ticket = "";
-      try {
-        if (access.authRequired) {
-          const response = await apiFetch("/api/v1/jobs/events/ticket", token, { method: "POST" });
-          ticket = response.ticket;
-        }
-      } catch (err) {
-        setError(err.message);
-        if (!closed) {
-          const delay = Math.min(30000, 1000 * 2 ** reconnectAttempt);
-          reconnectAttempt += 1;
-          reconnectTimer = window.setTimeout(connect, delay);
-        }
-        return;
-      }
-
-      if (closed) {
-        return;
-      }
-
-      const source = new EventSource(eventUrl("/api/v1/jobs/events", ticket));
-      events = source;
-      source.addEventListener("job.updated", handleJobUpdated);
-      source.addEventListener("worker.updated", handleWorkerUpdated);
-      source.addEventListener("queue.updated", handleQueueUpdated);
-      source.onopen = () => {
-        reconnectAttempt = 0;
-      };
-      source.onerror = () => {
-        source.close();
-        if (closed) {
-          return;
-        }
-        const delay = Math.min(30000, 1000 * 2 ** reconnectAttempt);
-        reconnectAttempt += 1;
-        reconnectTimer = window.setTimeout(connect, delay);
-      };
-    }
-
-    connect();
-
-    return () => {
-      closed = true;
-      if (reconnectTimer) {
-        window.clearTimeout(reconnectTimer);
-      }
-      events?.close();
-    };
-  }, [access.authRequired, ready, token]);
+  // Live job/worker/queue SSE stream, extracted to a hook (sc-9750). The handlers reach
+  // back into App state through the identity-stable setters/refs/callbacks passed here;
+  // the hook re-subscribes only on [access.authRequired, ready, token] (see useJobEvents).
+  useJobEvents({
+    access,
+    ready,
+    token,
+    setJobs,
+    setWorkers,
+    setQueueSummary,
+    setLatestGenerationSetId,
+    setError,
+    pushNotice,
+    dismissNoticeKind,
+    generatedAssetRefreshesRef,
+    refreshAssetsRef,
+    refreshDataRef,
+    refreshDataWithLoraOverlayRef,
+    refreshPersonTracksRef,
+    activeProjectRef,
+    enqueueTimelineGenerationApply,
+    hasVisibleLocalFailure,
+  });
 
   // Survivor sweep for orphaned Image-Editor scratch ops (sc-8850). Runs on every `jobs`
   // change (SSE ticks, initial load, etc.): purges the scratch + result assets of any
@@ -1402,48 +1181,8 @@ export function App() {
     refreshDataWithLoraOverlayRef.current = refreshDataWithLoraOverlay;
   });
 
-
-  // Remote-browser login (epic 4484 story 7): the password IS the API access token.
-  // Verify the typed draft against the public /api/v1/auth/verify endpoint BEFORE
-  // promoting it to the live `token`, so a wrong password keeps the gate up with an
-  // inline error (instead of saving a bad token and silently failing every subsequent
-  // request). A correct password is stored to localStorage and unlocks the app; it
-  // persists across reloads. Promoting the token here flips `authenticated`, and the
-  // [authenticated, token] effects perform the initial data load and SSE connect
-  // exactly once — no explicit refreshData() call, or it would double-fetch (sc-8808).
-  async function saveToken(event) {
-    event.preventDefault();
-    const candidate = passwordDraft.trim();
-    if (!candidate) {
-      setAuthError("Enter the password.");
-      return;
-    }
-    try {
-      const result = await apiFetch("/api/v1/auth/verify", candidate, { method: "POST" });
-      if (!result?.ok) {
-        setAuthError("Incorrect password. Try again.");
-        return;
-      }
-    } catch {
-      setAuthError("Couldn't reach the host to verify the password.");
-      return;
-    }
-    storeAccessToken(candidate);
-    setToken(candidate);
-    setPasswordDraft("");
-    setAuthError("");
-    setError("");
-  }
-
-  // Clear the stored password and re-show the login gate ("lock"/forget affordance,
-  // epic 4484 story 7). Setting the token state to "" re-renders the gate, which
-  // keys off the token state (sc-8808).
-  function lockRemote() {
-    clearAccessToken();
-    setToken("");
-    setPasswordDraft("");
-    setAuthError("");
-  }
+  // saveToken / lockRemote (the remote-browser login + lock affordances, epic 4484
+  // story 7) live in useAccessGate now (sc-9750) and are destructured above.
 
   async function completeSetupWizard() {
     try {

--- a/apps/web/src/hooks/appGateHooks.test.jsx
+++ b/apps/web/src/hooks/appGateHooks.test.jsx
@@ -1,0 +1,317 @@
+// sc-9750 (F-052 follow-up): focused unit coverage for the two hooks extracted from
+// App.jsx — useAccessGate (the remote-access gate + media-ticket mint) and useJobEvents
+// (the live job/worker/queue SSE stream). The App.*.test.jsx suite already exercises
+// both end-to-end through <App />; these tests pin the hook-level contracts directly so
+// a regression in the extracted logic is caught at the unit boundary too.
+import React, { useState } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAccessGate } from "./useAccessGate.js";
+import { useJobEvents } from "./useJobEvents.js";
+
+// Controllable apiFetch: each call resolves with whatever the per-path map returns (or
+// rejects when the value is an Error), so a test can drive the /access probe, the
+// media-ticket mint, and /auth/verify independently. setMediaTicket is a spy.
+const apiResponders = new Map();
+const setMediaTicketSpy = vi.fn();
+vi.mock("../api.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    apiFetch: vi.fn((path) => {
+      const responder = apiResponders.get(path);
+      const value = typeof responder === "function" ? responder() : responder;
+      if (value instanceof Error) {
+        return Promise.reject(value);
+      }
+      return Promise.resolve(value ?? {});
+    }),
+    eventUrl: (path, ticket) => `${path}${ticket ? `?ticket=${ticket}` : ""}`,
+    setMediaTicket: (...args) => setMediaTicketSpy(...args),
+  };
+});
+
+// Desktop-shell detection defaults to false (remote-browser mode) so the gate exercises
+// the auth path; individual tests can leave it false.
+vi.mock("../runtime.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, isDesktop: false };
+});
+
+// A minimal FakeEventSource capturing listeners so tests can dispatch SSE events, plus
+// close() bookkeeping so the effect-cleanup assertion has something to check.
+class FakeEventSource {
+  static instances = [];
+  constructor(url) {
+    this.url = url;
+    this.listeners = {};
+    this.closed = false;
+    FakeEventSource.instances.push(this);
+  }
+  addEventListener(event, handler) {
+    this.listeners[event] = handler;
+  }
+  close() {
+    this.closed = true;
+  }
+}
+
+async function settle() {
+  await act(async () => {
+    for (let i = 0; i < 6; i += 1) {
+      await Promise.resolve();
+    }
+  });
+}
+
+describe("useAccessGate (sc-9750)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    apiResponders.clear();
+    setMediaTicketSpy.mockClear();
+    window.localStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container.remove();
+  });
+
+  function mount() {
+    let latest = null;
+    const notices = [];
+    function Harness() {
+      const [, setN] = useState(0);
+      latest = {
+        api: useAccessGate({
+          setError: () => {},
+          pushNotice: (kind, message) => notices.push({ kind, message }),
+          dismissNoticeKind: (kind) => {
+            for (let i = notices.length - 1; i >= 0; i -= 1) {
+              if (notices[i].kind === kind) notices.splice(i, 1);
+            }
+          },
+        }),
+        rerender: () => setN((n) => n + 1),
+      };
+      return null;
+    }
+    root = createRoot(container);
+    act(() => root.render(<Harness />));
+    return { get: () => latest, notices };
+  }
+
+  it("resolves authenticated+ready with no auth required and mints no media ticket", async () => {
+    apiResponders.set("/api/v1/access", { authRequired: false });
+    const { get } = mount();
+    await settle();
+
+    expect(get().api.access).toEqual({ authRequired: false });
+    expect(get().api.authenticated).toBe(true);
+    // Auth off → media is immediately ready and the stored ticket is cleared (sc-8810).
+    expect(get().api.ready).toBe(true);
+    expect(setMediaTicketSpy).toHaveBeenCalledWith("");
+  });
+
+  it("holds ready until the media-ticket mint settles when auth is required", async () => {
+    window.localStorage.setItem("sceneworks-token", "remote-token");
+    apiResponders.set("/api/v1/access", { authRequired: true });
+    apiResponders.set("/api/v1/files/ticket", { ticket: "media-1", expiresInSeconds: 300 });
+    const { get } = mount();
+    await settle();
+
+    expect(get().api.authenticated).toBe(true);
+    // Mint succeeded → ready flips true and the ticket is stored.
+    expect(get().api.ready).toBe(true);
+    expect(setMediaTicketSpy).toHaveBeenCalledWith("media-1");
+  });
+
+  it("still reports ready (degraded) and pushes a notice when the mint fails", async () => {
+    window.localStorage.setItem("sceneworks-token", "remote-token");
+    apiResponders.set("/api/v1/access", { authRequired: true });
+    apiResponders.set("/api/v1/files/ticket", () => new Error("mint exploded"));
+    const { get, notices } = mount();
+    await settle();
+
+    // sc-9063: a failed mint settles the gate (ready:true) so data still loads, and a
+    // media-ticket notice explains the degraded media.
+    expect(get().api.ready).toBe(true);
+    expect(notices.some((n) => n.kind === "media-ticket")).toBe(true);
+  });
+
+  it("saveToken verifies the draft before promoting it to the live token", async () => {
+    apiResponders.set("/api/v1/access", { authRequired: true });
+    apiResponders.set("/api/v1/auth/verify", { ok: true });
+    apiResponders.set("/api/v1/files/ticket", { ticket: "media-1", expiresInSeconds: 300 });
+    const { get } = mount();
+    await settle();
+
+    // Not authenticated yet (no token), gate is up.
+    expect(get().api.token).toBe("");
+    expect(get().api.authenticated).toBe(false);
+
+    act(() => get().api.setPasswordDraft("  secret  "));
+    await settle();
+    await act(async () => {
+      await get().api.saveToken({ preventDefault: () => {} });
+    });
+    await settle();
+
+    // Verified draft is trimmed, promoted to the live token, and persisted.
+    expect(get().api.token).toBe("secret");
+    expect(get().api.authenticated).toBe(true);
+    expect(window.localStorage.getItem("sceneworks-token")).toBe("secret");
+  });
+
+  it("saveToken keeps the gate up with an inline error on a wrong password", async () => {
+    apiResponders.set("/api/v1/access", { authRequired: true });
+    apiResponders.set("/api/v1/auth/verify", { ok: false });
+    const { get } = mount();
+    await settle();
+
+    act(() => get().api.setPasswordDraft("wrong"));
+    await settle();
+    await act(async () => {
+      await get().api.saveToken({ preventDefault: () => {} });
+    });
+    await settle();
+
+    expect(get().api.token).toBe("");
+    expect(get().api.authError).toBe("Incorrect password. Try again.");
+    expect(window.localStorage.getItem("sceneworks-token")).toBeNull();
+  });
+
+  it("lockRemote clears the stored token and re-shows the gate", async () => {
+    window.localStorage.setItem("sceneworks-token", "remote-token");
+    apiResponders.set("/api/v1/access", { authRequired: true });
+    apiResponders.set("/api/v1/files/ticket", { ticket: "media-1", expiresInSeconds: 300 });
+    const { get } = mount();
+    await settle();
+    expect(get().api.token).toBe("remote-token");
+
+    act(() => get().api.lockRemote());
+    await settle();
+
+    expect(get().api.token).toBe("");
+    expect(get().api.authenticated).toBe(false);
+    expect(window.localStorage.getItem("sceneworks-token")).toBeNull();
+  });
+});
+
+describe("useJobEvents (sc-9750)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    apiResponders.clear();
+    FakeEventSource.instances = [];
+    window.EventSource = FakeEventSource;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container.remove();
+  });
+
+  // A superset of the hook's props with stable no-op stand-ins; a test overrides only
+  // what it asserts on. Refs mirror how App feeds live handles into the handlers.
+  function baseProps(overrides = {}) {
+    return {
+      access: { authRequired: false },
+      ready: true,
+      token: "",
+      setJobs: () => {},
+      setWorkers: () => {},
+      setQueueSummary: () => {},
+      setLatestGenerationSetId: () => {},
+      setError: () => {},
+      pushNotice: () => {},
+      dismissNoticeKind: () => {},
+      generatedAssetRefreshesRef: { current: new Map() },
+      refreshAssetsRef: { current: () => {} },
+      refreshDataRef: { current: () => {} },
+      refreshDataWithLoraOverlayRef: { current: () => {} },
+      refreshPersonTracksRef: { current: () => {} },
+      activeProjectRef: { current: null },
+      enqueueTimelineGenerationApply: () => {},
+      hasVisibleLocalFailure: () => false,
+      ...overrides,
+    };
+  }
+
+  function mount(initialProps) {
+    let setProps = () => {};
+    function Harness() {
+      const [props, update] = useState(initialProps);
+      setProps = update;
+      useJobEvents(props);
+      return null;
+    }
+    root = createRoot(container);
+    act(() => root.render(<Harness />));
+    return { setProps: (next) => act(() => setProps(next)) };
+  }
+
+  it("does not open an EventSource until ready is true", async () => {
+    const { setProps } = mount(baseProps({ ready: false }));
+    await settle();
+    expect(FakeEventSource.instances.length).toBe(0);
+
+    setProps(baseProps({ ready: true }));
+    await settle();
+    expect(FakeEventSource.instances.length).toBe(1);
+  });
+
+  it("routes job.updated through setJobs and refreshes generated assets", async () => {
+    const jobs = [];
+    const refreshedProjects = [];
+    const props = baseProps({
+      setJobs: (updater) => {
+        jobs.length = 0;
+        jobs.push(...updater([]));
+      },
+      refreshAssetsRef: { current: (projectId) => refreshedProjects.push(projectId) },
+    });
+    mount(props);
+    await settle();
+
+    const source = FakeEventSource.instances[0];
+    expect(typeof source.listeners["job.updated"]).toBe("function");
+
+    act(() => {
+      source.listeners["job.updated"]({
+        data: JSON.stringify({
+          id: "job-1",
+          projectId: "proj-1",
+          status: "running",
+          result: { generationSetId: "gs-1", assetIds: ["a1"] },
+        }),
+      });
+    });
+
+    expect(jobs.map((job) => job.id)).toContain("job-1");
+    // A generation-set result with a new asset count triggers a project asset refresh.
+    expect(refreshedProjects).toContain("proj-1");
+  });
+
+  it("closes the EventSource on unmount", async () => {
+    mount(baseProps({ ready: true }));
+    await settle();
+    const source = FakeEventSource.instances[0];
+    expect(source.closed).toBe(false);
+
+    act(() => root.unmount());
+    root = null;
+    expect(source.closed).toBe(true);
+  });
+});

--- a/apps/web/src/hooks/useAccessGate.js
+++ b/apps/web/src/hooks/useAccessGate.js
@@ -1,0 +1,189 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { apiFetch, setMediaTicket } from "../api.js";
+import { isDesktop as isDesktopShell } from "../runtime.js";
+import { readAccessToken, storeAccessToken, clearAccessToken } from "../accessToken.js";
+
+// Owns the remote-access gate (epic 4484): the /api/v1/access probe, the host
+// password (= API token), the login-gate draft/error, and the media-ticket mint
+// that must settle before protected data loads. Extracted verbatim from App.jsx
+// (sc-9750, F-052 follow-up) so App no longer carries the ~5 auth state slices plus
+// the mint effect inline; the returned values thread through App's remaining effects
+// (the [ready, token] data load, the project-switch load, the SSE stream) and the
+// login-gate JSX unchanged. Behavior-preserving — same effects, deps, and cleanup.
+//
+// `setError`, `pushNotice`, and `dismissNoticeKind` are App-owned (they write the
+// shared notices store) and passed in identity-stable, so the mint effect's deps
+// stay stable across App's SSE-driven re-renders.
+export function useAccessGate({ setError, pushNotice, dismissNoticeKind }) {
+  const [access, setAccess] = useState({ authRequired: false });
+  // Whether GET /api/v1/access has answered yet. Until it does we don't know if a
+  // password is required, so a remote browser must hold its protected data loads —
+  // otherwise they fire optimistically, 401, and bury the password prompt under a band
+  // of "access token required" errors (epic 4484).
+  const [accessResolved, setAccessResolved] = useState(false);
+  // The remote-access token (= host password). Storage key + threat-model note live in
+  // accessToken.js (sc-8880); it is persisted verbatim in localStorage so it survives
+  // reloads (a LAN remote-access requirement — see that module for the accepted XSS tradeoff).
+  const [token, setToken] = useState(() => readAccessToken());
+  // What the user is typing into the login gate (sc-8808). Kept separate from the
+  // live `token` so keystrokes never flip `authenticated` or churn the data/SSE
+  // effects; `token` only changes once /api/v1/auth/verify accepts the draft.
+  const [passwordDraft, setPasswordDraft] = useState("");
+  // Wrong-password feedback for the remote-browser login gate (epic 4484 story 7).
+  const [authError, setAuthError] = useState("");
+
+  // The desktop shell reaches its own API over loopback, which the API trusts
+  // (SCENEWORKS_TRUST_LOOPBACK), so it's authenticated without a password — never prompt
+  // for one locally (epic 4484). A remote browser must wait for GET /api/v1/access before
+  // it knows whether a password is needed; until then it holds its protected loads rather
+  // than firing them unauthenticated.
+  const authenticated = useMemo(
+    () =>
+      isDesktopShell ||
+      (accessResolved && (!access.authRequired || token.length > 0)),
+    [accessResolved, access, token],
+  );
+  // sc-8810: whether media URLs are renderable yet. When auth is on, element-driven
+  // requests (<img>/<video>) can't send the token header, so every media URL needs
+  // the query-param ticket minted below. Data loads hold until the first ticket is
+  // stored (mediaReady), otherwise thumbnails rendered in the gap would 401 and
+  // stick as "deleted" placeholders. When auth is off this resolves immediately.
+  const [mediaReady, setMediaReady] = useState(false);
+  // sc-9063 (F-008 follow-up): a persistently failing mint must not blank the whole
+  // app. `ready` waits for the first mint attempt to SETTLE (success or failure),
+  // not for a success: once a mint fails, lists/metadata load anyway — media
+  // degrades to placeholders and recovers when a retry lands — and a "media-ticket"
+  // notice tells the user why media is broken while the backoff keeps retrying.
+  const [mediaTicketFailed, setMediaTicketFailed] = useState(false);
+  const ready = authenticated && (mediaReady || mediaTicketFailed);
+
+  useEffect(() => {
+    if (!authenticated || !accessResolved) {
+      // Lock/logout stops the mint loop (cleanup above cleared the backoff timer),
+      // so drop the settled gate: the next unlock must re-run sc-8810's
+      // mint-before-data ordering rather than ride a stale mediaReady/
+      // mediaTicketFailed, and the "Retrying in the background" notice must not
+      // linger on the lock screen while no retry is actually running.
+      setMediaReady(false);
+      setMediaTicketFailed(false);
+      dismissNoticeKind("media-ticket");
+      return undefined;
+    }
+    if (!access.authRequired) {
+      setMediaTicket("");
+      setMediaReady(true);
+      return undefined;
+    }
+    let closed = false;
+    let timer = null;
+    let attempt = 0;
+    async function acquire() {
+      try {
+        // Header-authenticated mint (loopback-trusted desktop sends no token and
+        // still passes). The server keeps re-arming the same sliding ticket, so
+        // already-rendered media URLs stay valid across refreshes.
+        const response = await apiFetch("/api/v1/files/ticket", token, { method: "POST" });
+        if (closed) {
+          return;
+        }
+        setMediaTicket(response.ticket);
+        setMediaReady(true);
+        setMediaTicketFailed(false);
+        dismissNoticeKind("media-ticket");
+        attempt = 0;
+        const ttlMs = Math.max(15, Number(response.expiresInSeconds) || 0) * 1000;
+        timer = window.setTimeout(acquire, Math.max(5000, Math.floor(ttlMs / 3)));
+      } catch {
+        if (closed) {
+          return;
+        }
+        setMediaTicketFailed(true);
+        pushNotice(
+          "media-ticket",
+          "media authorization: couldn't obtain a media ticket, so thumbnails, previews, and downloads may fail to load. Retrying in the background.",
+        );
+        const delay = Math.min(30000, 1000 * 2 ** attempt);
+        attempt += 1;
+        timer = window.setTimeout(acquire, delay);
+      }
+    }
+    acquire();
+    return () => {
+      closed = true;
+      if (timer) {
+        window.clearTimeout(timer);
+      }
+    };
+  }, [access.authRequired, accessResolved, authenticated, token, pushNotice, dismissNoticeKind]);
+
+  // Probe whether the deployment requires a password, then release `accessResolved`
+  // so an authenticated client (or one not requiring auth) can load its data. Mirrors
+  // the health fetch's mount timing but owns only the access state (App keeps health).
+  useEffect(() => {
+    apiFetch("/api/v1/access", "")
+      .then(setAccess)
+      .catch((err) => setError(err.message))
+      // Either way the auth state is now as resolved as it'll get; release the gate so
+      // an authenticated client (or one not requiring auth) can load its data.
+      .finally(() => setAccessResolved(true));
+    // Mount-only probe (matches the pre-extraction App effect); setError is stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Remote-browser login (epic 4484 story 7): the password IS the API access token.
+  // Verify the typed draft against the public /api/v1/auth/verify endpoint BEFORE
+  // promoting it to the live `token`, so a wrong password keeps the gate up with an
+  // inline error (instead of saving a bad token and silently failing every subsequent
+  // request). A correct password is stored to localStorage and unlocks the app; it
+  // persists across reloads. Promoting the token here flips `authenticated`, and the
+  // [authenticated, token] effects perform the initial data load and SSE connect
+  // exactly once — no explicit refreshData() call, or it would double-fetch (sc-8808).
+  const saveToken = useCallback(
+    async (event) => {
+      event.preventDefault();
+      const candidate = passwordDraft.trim();
+      if (!candidate) {
+        setAuthError("Enter the password.");
+        return;
+      }
+      try {
+        const result = await apiFetch("/api/v1/auth/verify", candidate, { method: "POST" });
+        if (!result?.ok) {
+          setAuthError("Incorrect password. Try again.");
+          return;
+        }
+      } catch {
+        setAuthError("Couldn't reach the host to verify the password.");
+        return;
+      }
+      storeAccessToken(candidate);
+      setToken(candidate);
+      setPasswordDraft("");
+      setAuthError("");
+      setError("");
+    },
+    [passwordDraft, setError],
+  );
+
+  // Clear the stored password and re-show the login gate ("lock"/forget affordance,
+  // epic 4484 story 7). Setting the token state to "" re-renders the gate, which
+  // keys off the token state (sc-8808).
+  const lockRemote = useCallback(() => {
+    clearAccessToken();
+    setToken("");
+    setPasswordDraft("");
+    setAuthError("");
+  }, []);
+
+  return {
+    access,
+    token,
+    passwordDraft,
+    setPasswordDraft,
+    authError,
+    authenticated,
+    ready,
+    saveToken,
+    lockRemote,
+  };
+}

--- a/apps/web/src/hooks/useJobEvents.js
+++ b/apps/web/src/hooks/useJobEvents.js
@@ -1,0 +1,200 @@
+import { useEffect } from "react";
+import { apiFetch, eventUrl } from "../api.js";
+import { sortWorkers, upsertJobNewest } from "../sorters.js";
+import { terminalStatuses } from "../constants.js";
+import {
+  failedJobNotice,
+  generatedResultAssetCount,
+  noticeKindForJob,
+  parseSseJson,
+} from "../appHelpers.js";
+
+// Owns the live job/worker/queue SSE stream (the EventSource lifecycle: ticket mint,
+// connect, event handlers, exponential-backoff reconnect, teardown). Extracted verbatim
+// from App.jsx (sc-9750, F-052 follow-up) so App no longer carries the ~150-line stream
+// effect inline. Behavior-preserving — same effect body, same [access.authRequired,
+// ready, token] dependency array, same cleanup.
+//
+// The handlers reach back into App state through the setters/refs/callbacks passed in.
+// App feeds them identity-stable (useCallback actions, useState setters, and refs), so
+// the effect's deps are exactly the three inputs that must re-subscribe the stream —
+// auth mode, readiness, and the token — mirroring the pre-extraction effect. `access`
+// is read only for `access.authRequired`; the whole object is passed so the dep array
+// (`access.authRequired`) matches the original render-scope reference.
+export function useJobEvents({
+  access,
+  ready,
+  token,
+  setJobs,
+  setWorkers,
+  setQueueSummary,
+  setLatestGenerationSetId,
+  setError,
+  pushNotice,
+  dismissNoticeKind,
+  generatedAssetRefreshesRef,
+  refreshAssetsRef,
+  refreshDataRef,
+  refreshDataWithLoraOverlayRef,
+  refreshPersonTracksRef,
+  activeProjectRef,
+  enqueueTimelineGenerationApply,
+  hasVisibleLocalFailure,
+}) {
+  useEffect(() => {
+    // Gated on `ready` (not just `authenticated`): SSE job updates carry assets whose
+    // thumbnails render immediately, so the media-ticket mint must have settled first
+    // (sc-8810; sc-9063 lets a failed mint through — media degrades, data flows).
+    if (!ready) {
+      return undefined;
+    }
+
+    let events = null;
+    let reconnectTimer = null;
+    let reconnectAttempt = 0;
+    let closed = false;
+
+    function handleJobUpdated(event) {
+      const job = parseSseJson(event, "job");
+      if (!job) {
+        return;
+      }
+      const hasGeneratedAssets = Boolean(job.result?.generationSetId || job.result?.assetIds?.length || job.result?.assets?.length);
+      const resultAssetCount = generatedResultAssetCount(job);
+      const generationSetId = job.result?.generationSetId ?? "";
+      const refreshKey = job.id ?? generationSetId;
+      const previousRefresh = generatedAssetRefreshesRef.current.get(refreshKey) ?? { assetCount: 0, generationSetId: "" };
+      const shouldRefreshGeneratedAssets =
+        Boolean(job.projectId) &&
+        hasGeneratedAssets &&
+        (resultAssetCount > previousRefresh.assetCount ||
+          (resultAssetCount === 0 && generationSetId && generationSetId !== previousRefresh.generationSetId));
+      setJobs((items) => upsertJobNewest(items, job));
+      if (hasGeneratedAssets) {
+        if (job.result?.generationSetId) {
+          setLatestGenerationSetId(job.result.generationSetId);
+        }
+        generatedAssetRefreshesRef.current.set(refreshKey, {
+          assetCount: Math.max(resultAssetCount, previousRefresh.assetCount),
+          generationSetId: generationSetId || previousRefresh.generationSetId,
+        });
+        if (shouldRefreshGeneratedAssets) {
+          refreshAssetsRef.current?.(job.projectId);
+        }
+      }
+      if (job.status === "completed" && hasGeneratedAssets) {
+        enqueueTimelineGenerationApply(job);
+      }
+      if (job.status === "completed" && job.projectId && job.type === "person_track") {
+        refreshPersonTracksRef.current?.(job.projectId);
+      }
+      if (job.status === "completed" && job.projectId && job.type === "person_detect") {
+        refreshAssetsRef.current?.(job.projectId);
+      }
+      if (job.status === "completed" && job.type === "model_download") {
+        refreshDataRef.current?.();
+      }
+      // A completed built-in LoRA download (sc-5944) flips the catalog entry to
+      // installed; refresh models+loras so the Models row and any Studio gate update.
+      if (job.status === "completed" && job.type === "lora_download") {
+        refreshDataWithLoraOverlayRef.current?.(job.projectId ?? activeProjectRef.current?.id);
+      }
+      if (job.status === "completed" && job.type === "lora_import") {
+        dismissNoticeKind("lora-import");
+        refreshDataWithLoraOverlayRef.current?.(job.projectId ?? activeProjectRef.current?.id);
+      }
+      if (job.status === "completed" && job.type === "lora_train" && job.payload?.dryRun === false) {
+        if (job.result?.loraRegistered === false) {
+          pushNotice("lora-train", `lora training: ${job.result?.loraRegistrationError ?? "Completed training but could not register the LoRA."}`);
+        } else {
+          dismissNoticeKind("lora-train");
+          refreshDataWithLoraOverlayRef.current?.(job.projectId ?? activeProjectRef.current?.id);
+        }
+      }
+      if (job.status === "failed" && !hasVisibleLocalFailure(job)) {
+        pushNotice(noticeKindForJob(job), failedJobNotice(job));
+      }
+      // Evict the per-job refresh bookkeeping once the job is terminal (sc-8944): the
+      // dedupe counters are only consulted while a job is still emitting incremental
+      // asset updates. Without this the Map grows one entry per asset-producing job for
+      // the session's lifetime (unbounded, slow leak in multi-day sessions).
+      if (terminalStatuses.has(job.status)) {
+        generatedAssetRefreshesRef.current.delete(refreshKey);
+      }
+    }
+
+    function handleWorkerUpdated(event) {
+      const worker = parseSseJson(event, "worker");
+      if (!worker) {
+        return;
+      }
+      setWorkers((items) => [worker, ...items.filter((item) => item.id !== worker.id)].sort(sortWorkers));
+    }
+
+    function handleQueueUpdated(event) {
+      const summary = parseSseJson(event, "queue");
+      if (!summary) {
+        return;
+      }
+      setQueueSummary(summary);
+      if (Array.isArray(summary.workers)) {
+        setWorkers(summary.workers.sort(sortWorkers));
+      }
+    }
+
+    async function connect() {
+      let ticket = "";
+      try {
+        if (access.authRequired) {
+          const response = await apiFetch("/api/v1/jobs/events/ticket", token, { method: "POST" });
+          ticket = response.ticket;
+        }
+      } catch (err) {
+        setError(err.message);
+        if (!closed) {
+          const delay = Math.min(30000, 1000 * 2 ** reconnectAttempt);
+          reconnectAttempt += 1;
+          reconnectTimer = window.setTimeout(connect, delay);
+        }
+        return;
+      }
+
+      if (closed) {
+        return;
+      }
+
+      const source = new EventSource(eventUrl("/api/v1/jobs/events", ticket));
+      events = source;
+      source.addEventListener("job.updated", handleJobUpdated);
+      source.addEventListener("worker.updated", handleWorkerUpdated);
+      source.addEventListener("queue.updated", handleQueueUpdated);
+      source.onopen = () => {
+        reconnectAttempt = 0;
+      };
+      source.onerror = () => {
+        source.close();
+        if (closed) {
+          return;
+        }
+        const delay = Math.min(30000, 1000 * 2 ** reconnectAttempt);
+        reconnectAttempt += 1;
+        reconnectTimer = window.setTimeout(connect, delay);
+      };
+    }
+
+    connect();
+
+    return () => {
+      closed = true;
+      if (reconnectTimer) {
+        window.clearTimeout(reconnectTimer);
+      }
+      events?.close();
+    };
+    // Deps deliberately limited to the three inputs that must re-subscribe the stream
+    // (auth mode / readiness / token) — mirrors the pre-extraction App effect. The
+    // setters/refs/callbacks are fed identity-stable and read live inside the handlers,
+    // so listing them would only re-open the EventSource on unrelated re-renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [access.authRequired, ready, token]);
+}


### PR DESCRIPTION
## Summary

Deferred remainder of **sc-8854** (F-052 god components). PR #1155 already pulled App.jsx's 16 pure helpers into `appHelpers.js`. **This story (sc-9750)** relocates the two remaining App concerns — the access-gate/access-token logic and the job-events SSE subscription — out of `App.jsx` into dedicated custom hooks, matching the repo's `apps/web/src/hooks/` location + named-export convention.

### What was extracted

- **`hooks/useAccessGate.js`** — the remote-access gate (epic 4484): the `/api/v1/access` probe (+ `accessResolved` release), the host password/token (persisted via `accessToken.js`), the login-gate draft + wrong-password error, the `authenticated` / `ready` derivation, and the media-ticket mint effect (sc-8810 / sc-9063). Exposes `saveToken` / `lockRemote`. App destructures `token`, which threads through the data hooks and every `apiFetch` call site (the ~40 dependency arrays).
- **`hooks/useJobEvents.js`** — the live job/worker/queue SSE stream: `EventSource` lifecycle, SSE-ticket mint, the `job.updated` / `worker.updated` / `queue.updated` handlers, exponential-backoff reconnect, and teardown. App feeds it identity-stable setters/refs/callbacks; the effect re-subscribes only on `[access.authRequired, ready, token]`, byte-identical to the pre-extraction effect.

`App.jsx` is wired to consume both hooks and shrinks by ~261 net lines (305 removed / 44 added). Dead imports (`eventUrl`, `setMediaTicket`, `accessToken.js`, `parseSseJson`, `generatedResultAssetCount`, `noticeKindForJob`, `failedJobNotice`) were removed from `App.jsx`.

## Behavior-preserving

This is a pure relocation — same effects, same dependency arrays, same cleanup, same login-gate JSX (which already referenced the now-destructured names). Callback identity/stability is preserved: the hooks receive App's `useCallback`/`useState`/ref handles unchanged, so the SSE re-subscribe and media-ticket-before-data ordering are identical.

Confirmed by the existing `App.*.test.jsx` suite — `App.auth.test.jsx`, `App.queue.test.jsx`, and `mediaTicket.test.jsx` exercise both seams end-to-end through `<App />` (password verify/lock flow, SSE `job.updated` dispatch, media-ticket mint failure/recovery, mint-before-data gating) and stay green **unchanged**.

Scope kept to these two hooks only — `AppContext` and `ImageEditor` are the separate follow-ups sc-9751 / sc-9752 and were not touched.

## Tests

- **Baseline (origin/main):** 89 files / 1169 tests pass; lint 0 errors / 47 warnings.
- **After extraction:** **90 files / 1178 tests pass** (all pre-existing tests unchanged + 9 new). Lint **0 errors / 46 warnings** (one fewer than baseline — the SSE effect's pre-existing exhaustive-deps warning is now a documented `eslint-disable`, following the `useTimelines.js` convention).
- Added **`hooks/appGateHooks.test.jsx`** (9 hook-isolation tests) following the existing `hooks/*.test.jsx` pattern: `useAccessGate` (auth-off ready, mint success/failure/degraded, `saveToken` verify + wrong-password, `lockRemote`) and `useJobEvents` (ready-gated subscribe, `job.updated` → `setJobs` + asset refresh, unmount close).

Reference: sc-9750.

🤖 Generated with [Claude Code](https://claude.com/claude-code)