### PR TITLE
fix(worker): reject unsupported image-upscale factors instead of silent coercion (sc-9794)

### DIFF
--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -835,6 +835,20 @@ fn resolve_source(
 // job handler
 // ---------------------------------------------------------------------------
 
+/// Resolve the requested image-upscale factor, rejecting anything other than the two supported
+/// scales (2x/4x — the only `real_esrgan_x{factor}.onnx` exports and SeedVR2 targets). Mirrors the
+/// video path's [`resolve_video_upscale_factor`](crate::video_jobs) (F-118 / sc-8920): an
+/// unsupported factor now fails loudly instead of being silently coerced to 2x, which produced a
+/// quietly-different output at a different resolution.
+fn resolve_image_upscale_factor(factor: u64) -> WorkerResult<u8> {
+    match factor {
+        2 | 4 => Ok(factor as u8),
+        other => Err(WorkerError::InvalidPayload(format!(
+            "Image upscale supports only factor 2 or 4 (got {other})."
+        ))),
+    }
+}
+
 pub(crate) async fn run_image_upscale_job(
     api: &ApiClient,
     settings: &Settings,
@@ -866,10 +880,10 @@ pub(crate) async fn run_image_upscale_job(
             WorkerError::InvalidPayload("Upscale jobs require a source image asset.".to_owned())
         })?
         .to_owned();
-    let factor: u8 = match payload.get("factor").and_then(Value::as_u64).unwrap_or(2) {
-        4 => 4,
-        _ => 2,
-    };
+    // Reject an unsupported factor early rather than silently coercing it to 2x (F-118 / sc-8920,
+    // mirroring the video path). A missing factor still defaults to 2x.
+    let factor: u8 =
+        resolve_image_upscale_factor(payload.get("factor").and_then(Value::as_u64).unwrap_or(2))?;
     let engine = payload
         .get("engine")
         .and_then(Value::as_str)
@@ -1242,10 +1256,10 @@ pub(crate) async fn run_dataset_upscale_job(
 ) -> WorkerResult<()> {
     heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
     let payload = &job.payload;
-    let factor: u8 = match payload.get("factor").and_then(Value::as_u64).unwrap_or(2) {
-        4 => 4,
-        _ => 2,
-    };
+    // Reject an unsupported factor early rather than silently coercing it to 2x (F-118 / sc-8920,
+    // mirroring the video path). A missing factor still defaults to 2x.
+    let factor: u8 =
+        resolve_image_upscale_factor(payload.get("factor").and_then(Value::as_u64).unwrap_or(2))?;
     let project_id = payload
         .get("projectId")
         .and_then(Value::as_str)

--- a/crates/sceneworks-worker/src/upscale_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs/tests.rs
@@ -206,6 +206,25 @@ fn onnx_filename_per_factor() {
     assert_eq!(onnx_file(4), "real_esrgan_x4.onnx");
 }
 
+/// F-118 / sc-9794 follow-up: image upscale accepts only 2x and 4x. Any other factor is rejected
+/// with a clear `InvalidPayload` error rather than silently coerced to 2x (which produced a
+/// quietly-different output), mirroring the video path's `resolve_video_upscale_factor`
+/// (F-118 / sc-8920). Both `run_image_upscale_job` and `run_dataset_upscale_job` route through
+/// this guard.
+#[test]
+fn image_upscale_factor_accepts_2_and_4_rejects_others() {
+    assert_eq!(resolve_image_upscale_factor(2).expect("2x"), 2);
+    assert_eq!(resolve_image_upscale_factor(4).expect("4x"), 4);
+    for bad in [0u64, 1, 3, 5, 8, 16] {
+        let err = resolve_image_upscale_factor(bad)
+            .expect_err("unsupported factor must be rejected, not coerced");
+        assert!(
+            matches!(err, WorkerError::InvalidPayload(ref m) if m.contains("factor 2 or 4")),
+            "factor {bad} should yield a clear InvalidPayload error, got {err:?}"
+        );
+    }
+}
+
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")


### PR DESCRIPTION
## sc-9794 — [F-118 follow-up] Reject (don't silently coerce) unsupported factors in `run_image_upscale_job`

### The anti-pattern
sc-8920 (F-118) made the **video** upscale path reject unsupported scale factors with a clear error (`resolve_video_upscale_factor`, only 2x/4x). The **image** upscale entry point `run_image_upscale_job` in `crates/sceneworks-worker/src/upscale_jobs.rs` still silently coerced any factor:

```rust
let factor: u8 = match payload.get("factor").and_then(Value::as_u64).unwrap_or(2) {
    4 => 4,
    _ => 2,
};
```

An unsupported image-upscale factor (e.g. 3, 8) was quietly downgraded to 2x — a quietly-different output at a different resolution than requested, the same F-118 anti-pattern on the image path. `run_dataset_upscale_job` shared the identical coercion.

### The reject guard (consistent with sc-8920)
Added `resolve_image_upscale_factor`, mirroring the video helper's error style and message shape:

```rust
fn resolve_image_upscale_factor(factor: u64) -> WorkerResult<u8> {
    match factor {
        2 | 4 => Ok(factor as u8),
        other => Err(WorkerError::InvalidPayload(format!(
            "Image upscale supports only factor 2 or 4 (got {other})."
        ))),
    }
}
```

Both `run_image_upscale_job` and `run_dataset_upscale_job` now route through it. Supported factors 2x/4x are accepted and behave exactly as before; a **missing** factor still defaults to 2x (unchanged). Supported factors align with the only exported `real_esrgan_x{factor}.onnx` weights and SeedVR2 targets.

### Test added
`image_upscale_factor_accepts_2_and_4_rejects_others` (mirroring `video_upscale_factor_accepts_2_and_4_rejects_others`): 2 and 4 accepted; factors `[0, 1, 3, 5, 8, 16]` each yield a clear `InvalidPayload` error containing "factor 2 or 4" rather than a coerced value.

### Verification
- `cargo test -p sceneworks-worker upscale` — new test passes (23 passed, 2 ignored)
- `npm run rust:check` — exit 0 (fmt --check, clippy -D warnings, workspace test, build)
- candle lane: `cargo check -p sceneworks-worker --no-default-features -F backend-candle --all-targets` — clean

Scope note: extended the fix to `run_dataset_upscale_job` in the same file since it carried the identical silent-coercion anti-pattern with identical image-factor semantics; leaving it would have half-fixed F-118 on the image path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)