### PR TITLE
chore(worker): name the smoke degenerate-std floors as documented constants (sc-9838)

### DIFF
--- a/crates/sceneworks-worker/src/chroma1_base_q4_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/chroma1_base_q4_mlx_smoke.rs
@@ -27,7 +27,9 @@ use std::path::{Path, PathBuf};
 
 use gen_core::{GenerationOutput, GenerationRequest, LoadSpec, Quant, WeightsSource};
 
-use super::smoke_support::{env_or, image_mean, image_std, is_all_zero, save_png};
+use super::smoke_support::{
+    env_or, image_mean, image_std, is_all_zero, save_png, DEGENERATE_STD_FLOOR_TIGHT,
+};
 
 /// The engine-complete packed subdir to load: mirror `image_jobs::base::standard_tier_subdir`'s q4
 /// selection — prefer `<root>/q4` (chroma turnkeys pack the backbone under `transformer/`), else `root`
@@ -162,7 +164,7 @@ fn chroma1_base_q4_mlx_gpu_smoke() {
         "chroma1_base Q4 decode is ALL-ZERO — a broken packed load/decode"
     );
     assert!(
-        std > 20.0,
+        std > DEGENERATE_STD_FLOOR_TIGHT,
         "chroma1_base Q4 render looks degenerate (std {std:.2}) — possible NaN / all-black / flat decode"
     );
     println!(

--- a/crates/sceneworks-worker/src/flux1_control_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/flux1_control_mlx_smoke.rs
@@ -29,7 +29,7 @@ use gen_core::{
     Conditioning, ControlKind, GenerationOutput, GenerationRequest, Image, LoadSpec, WeightsSource,
 };
 
-use super::smoke_support::{env_or, image_std};
+use super::smoke_support::{env_or, image_std, DEGENERATE_STD_FLOOR_DEFAULT};
 
 fn env_path(key: &str) -> PathBuf {
     PathBuf::from(
@@ -158,7 +158,7 @@ fn flux1_dev_control_mlx_smoke() {
         .save(out_dir.join("flux1_control_baseline.png"))
         .expect("save baseline");
     assert!(
-        base_std > 5.0,
+        base_std > DEGENERATE_STD_FLOOR_DEFAULT,
         "control-free baseline looks degenerate (std {base_std:.2})"
     );
 
@@ -192,7 +192,7 @@ fn flux1_dev_control_mlx_smoke() {
         println!("[smoke] flux1 {label}: std {std:.2}, steer(meanAbsΔ vs control-free) {steer:.2}");
         assert_eq!((image.width, image.height), (w, h));
         assert!(
-            std > 5.0,
+            std > DEGENERATE_STD_FLOOR_DEFAULT,
             "flux1 {label} control render looks degenerate (std {std:.2})"
         );
         assert!(

--- a/crates/sceneworks-worker/src/flux2_dev_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/flux2_dev_gpu_smoke.rs
@@ -23,7 +23,7 @@ use std::path::PathBuf;
 
 use gen_core::{GenerationOutput, GenerationRequest, Image, LoadSpec, Quant, WeightsSource};
 
-use super::smoke_support::{env_or, image_std, save_png};
+use super::smoke_support::{env_or, image_std, save_png, DEGENERATE_STD_FLOOR_DEFAULT};
 
 /// A synthetic RGB test image (a smooth diagonal gradient with a centered block) — enough to exercise
 /// the VAE encode + reference/control token path on real weights without shipping a fixture. The dev
@@ -171,7 +171,7 @@ fn flux2_dev_candle_gpu_smoke() {
     );
     assert_eq!((image.width, image.height), (w, h));
     assert!(
-        std > 5.0,
+        std > DEGENERATE_STD_FLOOR_DEFAULT,
         "flux2_dev render looks degenerate (std {std:.2}) — possible NaN / all-black decode \
          (check CUDA_COMPUTE_CAP=120: cap=80 JIT-no-ops the quantized matmul on sm_120, sc-7457)"
     );
@@ -262,7 +262,7 @@ fn flux2_dev_edit_candle_gpu_smoke() {
     );
     assert_eq!((image.width, image.height), (w, h));
     assert!(
-        std > 5.0,
+        std > DEGENERATE_STD_FLOOR_DEFAULT,
         "dev edit render degenerate (std {std:.2}) — check CUDA_COMPUTE_CAP=120"
     );
     println!("[smoke] DONE: flux2_dev edit (candle) coherent");
@@ -345,7 +345,7 @@ fn flux2_dev_control_candle_gpu_smoke() {
     );
     assert_eq!((image.width, image.height), (w, h));
     assert!(
-        std > 5.0,
+        std > DEGENERATE_STD_FLOOR_DEFAULT,
         "dev control render degenerate (std {std:.2}) — check CUDA_COMPUTE_CAP=120"
     );
     println!("[smoke] DONE: flux2_dev control (candle) coherent");

--- a/crates/sceneworks-worker/src/footprint_measure.rs
+++ b/crates/sceneworks-worker/src/footprint_measure.rs
@@ -54,7 +54,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use gen_core::{GenerationOutput, GenerationRequest, LoadSpec, Quant, WeightsSource};
 
-use super::smoke_support::{env_or, image_std};
+use super::smoke_support::{env_or, image_std, DEGENERATE_STD_FLOOR_DEFAULT};
 
 /// One-tier-per-process guard (sc-8925). The MLX memory counters + allocator peak high-water mark are
 /// PROCESS-GLOBAL and persist across tests in the same binary, so measuring a second tier in the same
@@ -193,7 +193,7 @@ fn measure_footprint(model: &str, tier: &str, engine_id: &str, dir: &Path, req: 
     };
     let std = image_std(&image);
     assert!(
-        std > 5.0,
+        std > DEGENERATE_STD_FLOOR_DEFAULT,
         "{model} {tier} render looks degenerate (std {std:.2}) — measured footprint would be bogus"
     );
     let peak = mlx_rs::memory::get_peak_memory() as u64;

--- a/crates/sceneworks-worker/src/krea_turbo_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/krea_turbo_mlx_smoke.rs
@@ -22,7 +22,7 @@ use std::path::{Path, PathBuf};
 
 use gen_core::{GenerationOutput, GenerationRequest, LoadSpec, Quant, WeightsSource};
 
-use super::smoke_support::{env_or, image_std, save_png};
+use super::smoke_support::{env_or, image_std, save_png, DEGENERATE_STD_FLOOR_DEFAULT};
 
 /// The engine-complete packed subdir to load: mirror `image_jobs::base::krea_model_subdir`'s default —
 /// prefer `<root>/q8` (the shipped default; carries `transformer/diffusion_pytorch_model.safetensors`),
@@ -146,7 +146,7 @@ fn krea_turbo_mlx_gpu_smoke() {
         "engine returned the wrong dimensions"
     );
     assert!(
-        std > 5.0,
+        std > DEGENERATE_STD_FLOOR_DEFAULT,
         "krea_2_turbo render looks degenerate (std {std:.2}) — possible NaN / all-black / flat decode"
     );
     println!(

--- a/crates/sceneworks-worker/src/lens_base_q4_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/lens_base_q4_mlx_smoke.rs
@@ -28,7 +28,7 @@ use std::path::{Path, PathBuf};
 use gen_core::{GenerationOutput, GenerationRequest, LoadSpec, Quant, WeightsSource};
 
 use super::smoke_support::{
-    env_or, image_mean, image_std, is_all_zero, save_png, DEGENERATE_STD_FLOOR_LENS,
+    env_or, image_mean, image_std, is_all_zero, save_png, DEGENERATE_STD_FLOOR_TIGHT,
 };
 
 /// The engine-complete packed subdir to load: mirror `image_jobs::base::standard_tier_subdir`'s q4
@@ -165,7 +165,7 @@ fn lens_base_q4_mlx_gpu_smoke() {
         "lens (base) Q4 decode is ALL-ZERO — a broken packed load/decode"
     );
     assert!(
-        std > DEGENERATE_STD_FLOOR_LENS,
+        std > DEGENERATE_STD_FLOOR_TIGHT,
         "lens (base) Q4 render looks degenerate (std {std:.2}) — possible NaN / all-black / flat decode"
     );
     println!(

--- a/crates/sceneworks-worker/src/lens_base_q4_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/lens_base_q4_mlx_smoke.rs
@@ -27,7 +27,9 @@ use std::path::{Path, PathBuf};
 
 use gen_core::{GenerationOutput, GenerationRequest, LoadSpec, Quant, WeightsSource};
 
-use super::smoke_support::{env_or, image_mean, image_std, is_all_zero, save_png};
+use super::smoke_support::{
+    env_or, image_mean, image_std, is_all_zero, save_png, DEGENERATE_STD_FLOOR_LENS,
+};
 
 /// The engine-complete packed subdir to load: mirror `image_jobs::base::standard_tier_subdir`'s q4
 /// selection — prefer `<root>/q4` (lens turnkeys pack the backbone under `transformer/`), else `root`
@@ -163,7 +165,7 @@ fn lens_base_q4_mlx_gpu_smoke() {
         "lens (base) Q4 decode is ALL-ZERO — a broken packed load/decode"
     );
     assert!(
-        std > 20.0,
+        std > DEGENERATE_STD_FLOOR_LENS,
         "lens (base) Q4 render looks degenerate (std {std:.2}) — possible NaN / all-black / flat decode"
     );
     println!(

--- a/crates/sceneworks-worker/src/lens_turbo_q4_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/lens_turbo_q4_mlx_smoke.rs
@@ -28,7 +28,7 @@ use std::path::{Path, PathBuf};
 use gen_core::{GenerationOutput, GenerationRequest, LoadSpec, Quant, WeightsSource};
 
 use super::smoke_support::{
-    env_or, image_mean, image_std, is_all_zero, save_png, DEGENERATE_STD_FLOOR_LENS,
+    env_or, image_mean, image_std, is_all_zero, save_png, DEGENERATE_STD_FLOOR_TIGHT,
 };
 
 /// The engine-complete packed subdir to load: mirror `image_jobs::base::standard_tier_subdir`'s q4
@@ -170,7 +170,7 @@ fn lens_turbo_q4_mlx_gpu_smoke() {
         "lens_turbo Q4 decode is ALL-ZERO — a broken packed load/decode"
     );
     assert!(
-        std > DEGENERATE_STD_FLOOR_LENS,
+        std > DEGENERATE_STD_FLOOR_TIGHT,
         "lens_turbo Q4 render looks degenerate (std {std:.2}) — possible NaN / all-black / flat decode"
     );
     println!(

--- a/crates/sceneworks-worker/src/lens_turbo_q4_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/lens_turbo_q4_mlx_smoke.rs
@@ -27,7 +27,9 @@ use std::path::{Path, PathBuf};
 
 use gen_core::{GenerationOutput, GenerationRequest, LoadSpec, Quant, WeightsSource};
 
-use super::smoke_support::{env_or, image_mean, image_std, is_all_zero, save_png};
+use super::smoke_support::{
+    env_or, image_mean, image_std, is_all_zero, save_png, DEGENERATE_STD_FLOOR_LENS,
+};
 
 /// The engine-complete packed subdir to load: mirror `image_jobs::base::standard_tier_subdir`'s q4
 /// selection — prefer `<root>/q4` (lens turnkeys pack the backbone under `transformer/`), else `root`
@@ -168,7 +170,7 @@ fn lens_turbo_q4_mlx_gpu_smoke() {
         "lens_turbo Q4 decode is ALL-ZERO — a broken packed load/decode"
     );
     assert!(
-        std > 20.0,
+        std > DEGENERATE_STD_FLOOR_LENS,
         "lens_turbo Q4 render looks degenerate (std {std:.2}) — possible NaN / all-black / flat decode"
     );
     println!(

--- a/crates/sceneworks-worker/src/realvisxl_lightning_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/realvisxl_lightning_gpu_smoke.rs
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 
 use gen_core::{GenerationOutput, GenerationRequest, Image, LoadSpec, WeightsSource};
 
-use super::smoke_support::{env_or, image_std, save_png};
+use super::smoke_support::{env_or, image_std, save_png, DEGENERATE_STD_FLOOR_DEFAULT};
 
 fn env_path(key: &str) -> PathBuf {
     // Trim: a cmd `set VAR=value && ...` keeps the trailing space before `&&`.
@@ -129,7 +129,7 @@ fn realvisxl_lightning_candle_gpu_smoke() {
     }
 
     assert!(
-        lightning_std > 5.0,
+        lightning_std > DEGENERATE_STD_FLOOR_DEFAULT,
         "lightning render looks degenerate (std {lightning_std:.2}) — possible NaN / all-black decode"
     );
     println!("[smoke] DONE: lightning render coherent at {steps} steps");

--- a/crates/sceneworks-worker/src/scail2_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/scail2_gpu_smoke.rs
@@ -23,7 +23,7 @@ use gen_core::{
     ReplacementMode, WeightsSource,
 };
 
-use super::smoke_support::env_or;
+use super::smoke_support::{env_or, DEGENERATE_STD_FLOOR_DEFAULT};
 
 fn env_path(key: &str) -> PathBuf {
     // Trim: a cmd `set VAR=value && ...` keeps the trailing space before `&&`.
@@ -256,7 +256,7 @@ fn scail2_candle_gpu_smoke() {
         avg_std
     );
     assert!(
-        avg_std > 5.0,
+        avg_std > DEGENERATE_STD_FLOOR_DEFAULT,
         "output frames look degenerate (avg std {avg_std:.2}) — possible NaN / all-black decode"
     );
 }

--- a/crates/sceneworks-worker/src/sdxl_base_q8_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/sdxl_base_q8_mlx_smoke.rs
@@ -27,7 +27,9 @@ use std::path::{Path, PathBuf};
 
 use gen_core::{GenerationOutput, GenerationRequest, LoadSpec, Quant, WeightsSource};
 
-use super::smoke_support::{env_or, image_mean, image_std, is_all_zero, save_png};
+use super::smoke_support::{
+    env_or, image_mean, image_std, is_all_zero, save_png, DEGENERATE_STD_FLOOR_TIGHT,
+};
 
 /// The engine-complete packed subdir to load: mirror `image_jobs::base::standard_tier_subdir`'s q8
 /// selection — prefer `<root>/q8` (SDXL-family turnkeys pack the backbone under `unet/`), else `root`
@@ -156,7 +158,7 @@ fn sdxl_base_q8_mlx_gpu_smoke() {
          mlx-gen Q8 path (sc-2641) must not reproduce it"
     );
     assert!(
-        std > 20.0,
+        std > DEGENERATE_STD_FLOOR_TIGHT,
         "sdxl base Q8 render looks degenerate (std {std:.2}) — possible NaN / all-black / flat decode"
     );
     println!(

--- a/crates/sceneworks-worker/src/smoke_support.rs
+++ b/crates/sceneworks-worker/src/smoke_support.rs
@@ -19,6 +19,24 @@ use std::path::Path;
 
 use gen_core::Image;
 
+/// General degenerate-decode floor for the mean per-pixel std-dev sanity check (sc-9838, F-122).
+///
+/// This is the model-agnostic "is the decode alive?" guard: a NaN / all-black / flat collapse pulls
+/// `image_std` toward 0, so any coherent render for the common t2i/edit/control lanes clears this by a
+/// wide margin. Used by every smoke EXCEPT the Lens pair, which needs the tighter [`DEGENERATE_STD_FLOOR_LENS`]
+/// floor below. It is deliberately generous — it exists to catch a broken decode, not to grade quality
+/// (the real quality call is the saved-PNG eyeball).
+pub(crate) const DEGENERATE_STD_FLOOR_DEFAULT: f64 = 5.0;
+
+/// Tighter degenerate-decode floor for the Lens smokes (sc-9838, F-122).
+///
+/// Lens (turbo + base) packs the transformer DiT alongside the heavier gpt-oss-20b MoE text encoder, and
+/// its coherent output sits at a materially higher per-pixel std-dev than the other lanes. A render that
+/// clears the general [`DEGENERATE_STD_FLOOR_DEFAULT`] but stalls below this floor is a Lens-specific
+/// half-collapsed decode, so the Lens smokes intentionally hold to this stricter bar rather than the
+/// shared default. This is a per-model floor by design — do NOT collapse it back to the default.
+pub(crate) const DEGENERATE_STD_FLOOR_LENS: f64 = 20.0;
+
 /// Read `key` from the environment, falling back to `default` when it is unset, empty, or
 /// whitespace-only. Trims the value. Filtering set-but-empty values keeps a bare `FOO_STEPS=` (or a
 /// whitespace-only value) from feeding `""` into a downstream `.parse()` and panicking (sc-8924).

--- a/crates/sceneworks-worker/src/smoke_support.rs
+++ b/crates/sceneworks-worker/src/smoke_support.rs
@@ -27,6 +27,12 @@ use gen_core::Image;
 /// whose coherent baseline runs materially hotter hold to the tighter [`DEGENERATE_STD_FLOOR_TIGHT`]
 /// floor below instead. It is deliberately generous — it exists to catch a broken decode, not to grade
 /// quality (the real quality call is the saved-PNG eyeball).
+///
+// Which smokes consume these floors is lane-conditional: several callers are MLX/macOS-gated, so on a
+// given build lane (e.g. candle) a floor can have no consumer and read as unused. That per-lane "unused"
+// is expected and benign — allow(dead_code) keeps clippy -D warnings green on every lane without
+// cfg-gating the constants themselves. It is a no-op on lanes where the const IS used.
+#[allow(dead_code)]
 pub(crate) const DEGENERATE_STD_FLOOR_DEFAULT: f64 = 5.0;
 
 /// Tighter degenerate-decode floor for the lanes whose coherent output runs hotter (sc-9838, F-122).
@@ -37,6 +43,11 @@ pub(crate) const DEGENERATE_STD_FLOOR_DEFAULT: f64 = 5.0;
 /// the Lens pair (transformer DiT alongside the heavy gpt-oss-20b MoE text encoder), chroma1_base, and
 /// sdxl_base all sit here. This is a per-model tighter floor by design — it is NOT Lens-specific, and it
 /// should NOT be collapsed back into the default.
+///
+// Lane-conditional consumer set (see DEGENERATE_STD_FLOOR_DEFAULT above): its callers are MLX/macOS-gated
+// smokes, so on a lane where those are cfg'd out this const is unused. allow(dead_code) keeps clippy
+// -D warnings green per-lane without cfg-gating; it is a no-op on lanes where the const IS used.
+#[allow(dead_code)]
 pub(crate) const DEGENERATE_STD_FLOOR_TIGHT: f64 = 20.0;
 
 /// Read `key` from the environment, falling back to `default` when it is unset, empty, or

--- a/crates/sceneworks-worker/src/smoke_support.rs
+++ b/crates/sceneworks-worker/src/smoke_support.rs
@@ -23,19 +23,21 @@ use gen_core::Image;
 ///
 /// This is the model-agnostic "is the decode alive?" guard: a NaN / all-black / flat collapse pulls
 /// `image_std` toward 0, so any coherent render for the common t2i/edit/control lanes clears this by a
-/// wide margin. Used by every smoke EXCEPT the Lens pair, which needs the tighter [`DEGENERATE_STD_FLOOR_LENS`]
-/// floor below. It is deliberately generous — it exists to catch a broken decode, not to grade quality
-/// (the real quality call is the saved-PNG eyeball).
+/// wide margin. Used by the lanes whose coherent output sits at a normal per-pixel std-dev; the lanes
+/// whose coherent baseline runs materially hotter hold to the tighter [`DEGENERATE_STD_FLOOR_TIGHT`]
+/// floor below instead. It is deliberately generous — it exists to catch a broken decode, not to grade
+/// quality (the real quality call is the saved-PNG eyeball).
 pub(crate) const DEGENERATE_STD_FLOOR_DEFAULT: f64 = 5.0;
 
-/// Tighter degenerate-decode floor for the Lens smokes (sc-9838, F-122).
+/// Tighter degenerate-decode floor for the lanes whose coherent output runs hotter (sc-9838, F-122).
 ///
-/// Lens (turbo + base) packs the transformer DiT alongside the heavier gpt-oss-20b MoE text encoder, and
-/// its coherent output sits at a materially higher per-pixel std-dev than the other lanes. A render that
-/// clears the general [`DEGENERATE_STD_FLOOR_DEFAULT`] but stalls below this floor is a Lens-specific
-/// half-collapsed decode, so the Lens smokes intentionally hold to this stricter bar rather than the
-/// shared default. This is a per-model floor by design — do NOT collapse it back to the default.
-pub(crate) const DEGENERATE_STD_FLOOR_LENS: f64 = 20.0;
+/// Some lanes render at a materially higher per-pixel std-dev than the common case, so a half-collapsed
+/// decode can still clear the general [`DEGENERATE_STD_FLOOR_DEFAULT`] while stalling below the level a
+/// live render on that lane actually reaches. Those lanes hold to this stricter per-model bar instead:
+/// the Lens pair (transformer DiT alongside the heavy gpt-oss-20b MoE text encoder), chroma1_base, and
+/// sdxl_base all sit here. This is a per-model tighter floor by design — it is NOT Lens-specific, and it
+/// should NOT be collapsed back into the default.
+pub(crate) const DEGENERATE_STD_FLOOR_TIGHT: f64 = 20.0;
 
 /// Read `key` from the environment, falling back to `default` when it is unset, empty, or
 /// whitespace-only. Trims the value. Filtering set-but-empty values keeps a bare `FOO_STEPS=` (or a


### PR DESCRIPTION
## sc-9838 — [F-122 follow-up] Decide + document the smoke degenerate-floor threshold (std>5 vs >20)

### The decision
F-122 flagged bare-magic-number drift in the real-weight smoke degenerate-decode sanity check (the mean per-pixel std-dev floor, `image_std`): most smokes used `std > 5.0`, while several used `std > 20.0`.

**The floors STAY per-model and behavior-equivalent** (decision made, not re-litigated here):
- `5.0` is the general all-black / NaN / flat degenerate guard — the model-agnostic "is the decode alive?" floor. A NaN / all-black / flat collapse pulls std toward 0; any coherent t2i/edit/control render at a normal baseline clears this by a wide margin.
- `20.0` is an intentionally **tighter** floor for the lanes whose coherent output runs hotter (higher baseline per-pixel std). A half-collapsed decode on those lanes can still clear the general 5.0 floor while stalling below what a live render actually reaches, so they hold to a stricter per-model bar.

This PR is pure documentation/naming of the existing values so they stop reading as unexplained magic numbers. **No numeric threshold is changed anywhere — behavior is identical.**

### Naming correction (review fix)
The first pass named the 20.0 floor `DEGENERATE_STD_FLOOR_LENS` and documented it as a "Lens-specific half-collapsed decode." That was **factually wrong** and re-entrenched the exact F-122 drift: `chroma1_base_q4_mlx_smoke.rs` and `sdxl_base_q8_mlx_smoke.rs` also gated on a bare `std > 20.0` with identical degenerate-floor semantics, and `krea_turbo_mlx_smoke.rs` gated on a bare `std > 5.0`. The 20.0 bar is a **per-model tighter floor, not Lens-unique**.

Fixed by renaming the constant to describe what it IS and converging every sibling:

```rust
pub(crate) const DEGENERATE_STD_FLOOR_DEFAULT: f64 = 5.0;   // general all-black/NaN/flat guard
pub(crate) const DEGENERATE_STD_FLOOR_TIGHT: f64 = 20.0;    // per-model tighter floor for hotter-baseline lanes
```

### Where the constants live
Two documented named constants live in the shared `smoke_support` module (`crates/sceneworks-worker/src/smoke_support.rs`), each with an accurate rationale doc-comment. That module is gated on the **superset** of both smoke lanes (`test` AND (macOS OR the off-Mac candle build)), so the constants are visible to both the macOS/MLX lane and the off-Mac candle lane smokes — the preferred shared-const approach, no per-file fallback needed.

### Every degenerate-std floor now on the shared constants (single source of truth)
`DEGENERATE_STD_FLOOR_DEFAULT` (5.0):
- `flux2_dev_gpu_smoke.rs` (3 sites)
- `realvisxl_lightning_gpu_smoke.rs`
- `scail2_gpu_smoke.rs`
- `flux1_control_mlx_smoke.rs` (2 sites)
- `footprint_measure.rs`
- `krea_turbo_mlx_smoke.rs` (converged this pass, was bare `5.0`)

`DEGENERATE_STD_FLOOR_TIGHT` (20.0):
- `lens_turbo_q4_mlx_smoke.rs` (renamed from `_LENS`)
- `lens_base_q4_mlx_smoke.rs` (renamed from `_LENS`)
- `chroma1_base_q4_mlx_smoke.rs` (converged this pass, was bare `20.0`)
- `sdxl_base_q8_mlx_smoke.rs` (converged this pass, was bare `20.0`)

### Intentionally NOT converged
- `sd3_5_mlx_smoke.rs` — `max_std > 8.0`. This is a **different metric** (max channel std from `channel_stats`, not the `image_std` mean-per-pixel floor) with a **distinct value (8.0)**, and it belongs to a separate multi-signal coherence gate (max-std + neighbor-gradient bounds), not the `image_std` degenerate-floor family. Forcing it onto these constants would change behavior, so it was left alone per the sweep rule.

### Verification
The smokes themselves are `#[ignore]`d real-weight tests (several cfg-gated to a lane) and were **not run**. Both lanes were verified to COMPILE so the constants resolve in each:
- `cargo check -p sceneworks-worker --all-targets` (macOS/default lane) — clean
- `cargo check -p sceneworks-worker --no-default-features -F backend-candle --all-targets` (candle lane) — clean
- `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
