### PR TITLE
chore(worker): pin first-party Real-ESRGAN ONNX + person detector HF fetches (sc-9682)

### DIFF
--- a/crates/sceneworks-worker/src/person_jobs.rs
+++ b/crates/sceneworks-worker/src/person_jobs.rs
@@ -104,6 +104,15 @@ const DET_REPO: &str = "SceneWorks/yolo11m-person-detect-mlx";
 const DET_FILE: &str = "yolo11m.onnx";
 #[cfg(not(target_os = "macos"))]
 const DET_REPO: &str = "SceneWorks/yolo11m-person-detect-onnx";
+/// Pinned detector-weights revision (sc-9682, F-077 follow-up). Even though `DET_REPO` is
+/// a first-party repo, fetching the mutable `main` branch means a re-push (or a compromised
+/// token) could silently swap the detector weights we load. Pin the exact commit per repo
+/// for defense-in-depth, mirroring the SeedVR2 pin (sc-8879). HF's tree API still reports
+/// each file's `lfs.oid`, which `ensure_hf_cached_file` verifies the content against.
+#[cfg(target_os = "macos")]
+const DET_REVISION: &str = "d7027d3a8812bdebbf7862fc1c7dcfdeebb0f777";
+#[cfg(not(target_os = "macos"))]
+const DET_REVISION: &str = "3cffbaccca4f239ae6301d8b66ba721401ecfa8d";
 // ---------------------------------------------------------------------------
 // pure detector math (unit-tested without weights)
 // ---------------------------------------------------------------------------
@@ -989,7 +998,7 @@ pub(crate) async fn ensure_detector_weights(
         .join("cache")
         .join("person-detect")
         .join(DET_FILE);
-    ensure_hf_cached_file(context, DET_REPO, "main", DET_FILE, &target).await
+    ensure_hf_cached_file(context, DET_REPO, DET_REVISION, DET_FILE, &target).await
 }
 
 #[cfg(test)]

--- a/crates/sceneworks-worker/src/person_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/person_jobs/tests.rs
@@ -219,6 +219,29 @@ fn detections_to_json_normalizes_orders_and_drops_degenerate() {
     assert_eq!(json[0]["maskState"], "missing");
 }
 
+/// sc-9682 (F-077 follow-up): the first-party YOLO11 detector repo is fetched at a pinned
+/// commit, never the mutable `main` branch, so a re-push (or a compromised token) can't
+/// silently swap the detector weights we load. `DET_REVISION` is cfg-split per platform
+/// (MLX vs ONNX repo); this asserts whichever variant compiles is a real 40-hex commit id.
+#[test]
+fn det_revision_is_pinned_commit_not_main() {
+    assert_ne!(
+        DET_REVISION, "main",
+        "the detector must pin a fixed revision"
+    );
+    assert_eq!(
+        DET_REVISION.len(),
+        40,
+        "a pinned HF revision is a 40-char commit sha"
+    );
+    assert!(
+        DET_REVISION
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+        "the pinned revision must be lowercase hex"
+    );
+}
+
 /// Cache fixtures staged during development (sc-3633): the exported detector,
 /// the bus.jpg test image, and the `ultralytics.predict` reference detections.
 #[cfg(target_os = "macos")]

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -94,6 +94,13 @@ const CANCEL_MESSAGE: &str = "Image upscale canceled by user.";
 /// (sc-5499). Overridable via the manifest `onnx` resource or the env pin
 /// `SCENEWORKS_REALESRGAN_X{2,4}_ONNX`.
 const ONNX_REPO: &str = "SceneWorks/real-esrgan-onnx";
+/// Pinned Real-ESRGAN ONNX revision (sc-9682, F-077 follow-up). Even though
+/// `SceneWorks/real-esrgan-onnx` is a first-party repo, fetching the mutable `main`
+/// branch means a re-push (or a compromised token) could silently swap the ONNX graph
+/// we load. Pin the exact commit for defense-in-depth, mirroring the SeedVR2 pin
+/// (sc-8879). HF's tree API still reports each file's `lfs.oid`, which
+/// `ensure_hf_cached_file` verifies the downloaded content against.
+const ONNX_REVISION: &str = "09f741bac80a246b407da3ee902bf5f3291b602f";
 
 fn onnx_file(factor: u8) -> String {
     format!("real_esrgan_x{factor}.onnx")
@@ -464,7 +471,15 @@ async fn ensure_onnx(
         cancel_message: "Image upscale canceled while fetching Real-ESRGAN weights.",
         fresh_download: false,
     };
-    ensure_hf_cached_file(&context, &repo, "main", &file, &target)
+    // Pin the exact commit for the default first-party repo so `main` moving under us
+    // can't swap the ONNX graph (sc-9682). A manifest-supplied override repo may carry
+    // its own revision layout, so only pin when we're using the default repo.
+    let revision = if repo == ONNX_REPO {
+        ONNX_REVISION
+    } else {
+        "main"
+    };
+    ensure_hf_cached_file(&context, &repo, revision, &file, &target)
         .await
         .map_err(|error| match error {
             WorkerError::InvalidPayload(detail) => WorkerError::InvalidPayload(format!(

--- a/crates/sceneworks-worker/src/upscale_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs/tests.rs
@@ -681,6 +681,28 @@ fn seedvr2_revision_is_pinned_commit_not_main() {
     );
 }
 
+/// sc-9682 (F-077 follow-up): the first-party Real-ESRGAN ONNX repo is fetched at a
+/// pinned commit, never the mutable `main` branch, so a re-push (or a compromised token)
+/// can't silently swap the ONNX graph we load. Lock the constant to a real 40-hex commit id.
+#[test]
+fn onnx_revision_is_pinned_commit_not_main() {
+    assert_ne!(
+        ONNX_REVISION, "main",
+        "Real-ESRGAN ONNX must pin a fixed revision"
+    );
+    assert_eq!(
+        ONNX_REVISION.len(),
+        40,
+        "a pinned HF revision is a 40-char commit sha"
+    );
+    assert!(
+        ONNX_REVISION
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+        "the pinned revision must be lowercase hex"
+    );
+}
+
 #[test]
 fn dataset_repoint_body_maps_records_with_a_null_asset_id() {
     let body = dataset_repoint_body(&[


### PR DESCRIPTION
## sc-9682 — [F-077 follow-up] Pin first-party Real-ESRGAN ONNX + person-track detector HF downloads to fixed revisions

sc-8879 (F-077) already pinned the **third-party** DWPose (openmmlab) + SeedVR2 (`numz/SeedVR2_comfyUI`) fetches to fixed revisions with sha256 verify retained. This follow-up applies the same defense-in-depth to the two remaining **first-party (SceneWorks-controlled)** runtime-weight fetches that still rode HF `main`. Even for a repo we own, fetching the mutable `main` branch means a re-push (or a compromised push token) could silently swap the weights we load.

### The two fetches pinned

**1. Real-ESRGAN ONNX** — `crates/sceneworks-worker/src/upscale_jobs.rs` (`ensure_onnx`)
- Repo id: `SceneWorks/real-esrgan-onnx`
- Pinned SHA: `09f741bac80a246b407da3ee902bf5f3291b602f`
- New `const ONNX_REVISION`, applied via `if repo == ONNX_REPO { ONNX_REVISION } else { "main" }` so a **manifest-supplied override repo** keeps `main` (it carries its own revision layout) — exactly mirroring the sc-8879 SeedVR2 guard.

**2. YOLO11 person detector** — `crates/sceneworks-worker/src/person_jobs.rs` (`ensure_detector_weights`, called from the person-detect / person-track paths in `media_jobs.rs`)
- Repo ids (cfg-split by platform):
  - macOS: `SceneWorks/yolo11m-person-detect-mlx` → `d7027d3a8812bdebbf7862fc1c7dcfdeebb0f777`
  - off-Mac: `SceneWorks/yolo11m-person-detect-onnx` → `3cffbaccca4f239ae6301d8b66ba721401ecfa8d`
- New `const DET_REVISION` (cfg-split to match `DET_REPO`), passed to `ensure_hf_cached_file` instead of `"main"`.

### sha256 verification retained
No change to download behavior beyond the revision. `ensure_hf_cached_file` still reads each file's `lfs.oid` from HF's tree API and verifies the downloaded content against it — the pin is purely defense-in-depth on top of that.

### Tests
Added `onnx_revision_is_pinned_commit_not_main` (upscale_jobs/tests.rs) and `det_revision_is_pinned_commit_not_main` (person_jobs/tests.rs), each asserting the new const is a real 40-char lowercase-hex commit sha — mirroring sc-8879's `seedvr2_revision_is_pinned_commit_not_main`.

Verified locally: `npm run rust:check` (fmt --check + clippy -D warnings + test + build) clean; candle lane `cargo check -p sceneworks-worker --no-default-features -F backend-candle --all-targets` clean; candle-lane `cargo clippy ... -F backend-candle --all-targets -- -D warnings` clean. All 3 revision-pin tests pass.

Mirrors sc-8879. References sc-9682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)