### PR TITLE
feat(worker): wire the candle-only INT8-ConvRot Krea 2 tier (sc-9300)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -495,7 +495,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -510,7 +510,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -524,7 +524,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -577,7 +577,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -605,7 +605,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -615,7 +615,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -630,7 +630,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -645,7 +645,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -660,7 +660,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-gen",
  "image",
@@ -683,12 +683,13 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
  "candle-gen-face",
  "candle-gen-flux",
+ "candle-gen-pid",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-transformers",
  "rand 0.9.4",
@@ -699,7 +700,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -713,7 +714,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -724,7 +725,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -739,7 +740,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -756,7 +757,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -776,7 +777,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -787,7 +788,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -800,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -811,7 +812,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -824,7 +825,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=93627450bc22f70a55aebfd0a0f154f33b3fe484#93627450bc22f70a55aebfd0a0f154f33b3fe484"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -8162,7 +8163,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/apps/web/src/imageJobAdvanced.js
+++ b/apps/web/src/imageJobAdvanced.js
@@ -1,5 +1,5 @@
 import { buildStructuredPromptRecipe } from "./ideogramCaption.js";
-import { tierQuantize } from "./quantTier.js";
+import { tierQuantize, isConvRotTier } from "./quantTier.js";
 
 // sc-8854 (F-052): pure builder for the Image Studio job's `advanced` payload. Extracted
 // verbatim from ImageStudio.submit() — the ~110-line object literal that assembled the
@@ -133,6 +133,12 @@ export function buildImageJobAdvanced(state) {
     ...(showTierPicker && tierQuantize(quantTier) !== null
       ? { mlxQuantize: tierQuantize(quantTier) }
       : {}),
+    // Krea 2 INT8-ConvRot tier (sc-9300, epic 9083): the online-rotation int8 DiT is NOT a bits-based
+    // quant, so it can't ride `mlxQuantize` (its `tierQuantize` is null, so the spread above omits it).
+    // Instead send a distinct `convRot: true` the worker maps to the ConvRot LoadSpec construction
+    // (weights = Dir(bf16 snapshot) + text_encoder = File(convrot DiT)). Emitted only when the picker
+    // is shown AND the picked tier is int8-convrot — disjoint from the mlxQuantize spread above.
+    ...(showTierPicker && isConvRotTier(quantTier) ? { convRot: true } : {}),
     // PiD decoder (epic 7840, sc-7851): emit usePid:true only when the toggle is shown
     // (model PiD-eligible AND checkpoint installed) AND on. The worker swaps the native
     // VAE for the PiD decode + 2K/4K super-resolve pass; it rides `advanced` (opaque

--- a/apps/web/src/imageJobAdvanced.test.js
+++ b/apps/web/src/imageJobAdvanced.test.js
@@ -144,6 +144,20 @@ describe("buildImageJobAdvanced", () => {
     );
   });
 
+  it("emits convRot (not mlxQuantize) for the INT8-ConvRot tier (sc-9300)", () => {
+    const advanced = buildImageJobAdvanced(
+      offState({ showTierPicker: true, quantTier: "int8-convrot" }),
+    );
+    expect(advanced.convRot).toBe(true);
+    // The online-rotation int8 DiT is not a bits-based quant, so it must NOT leak an mlxQuantize.
+    expect(advanced).not.toHaveProperty("mlxQuantize");
+    // convRot is only emitted when the tier picker is shown AND int8-convrot is picked.
+    expect(buildImageJobAdvanced(offState({ showTierPicker: false, quantTier: "int8-convrot" }))).not.toHaveProperty(
+      "convRot",
+    );
+    expect(buildImageJobAdvanced(offState({ showTierPicker: true, quantTier: "q4" }))).not.toHaveProperty("convRot");
+  });
+
   it("emits usePid only when the PiD toggle is shown and on", () => {
     expect(buildImageJobAdvanced(offState({ showPidToggle: false, usePid: true }))).not.toHaveProperty("usePid");
     expect(buildImageJobAdvanced(offState({ showPidToggle: true, usePid: true })).usePid).toBe(true);

--- a/apps/web/src/quantTier.js
+++ b/apps/web/src/quantTier.js
@@ -20,6 +20,18 @@ const TIER_QUANTIZE = {
   q4: 4,
 };
 
+// The candle-only Krea 2 INT8-ConvRot tier key (sc-9300, epic 9083). NOT a bits-based quant — the
+// online-rotation int8 DiT can't be expressed as an `mlxQuantize` value — so it is DELIBERATELY absent
+// from TIER_QUANTIZE and instead sends a distinct `advanced.convRot: true` signal (see
+// imageJobAdvanced.js). It is a selectable tier (`isSelectableTier` accepts it) but `tierQuantize`
+// returns null for it, so it never leaks an `mlxQuantize` into the payload.
+export const INT8_CONVROT_TIER = "int8-convrot";
+
+// Whether a tier key names the candle INT8-ConvRot tier.
+export function isConvRotTier(tier) {
+  return tier === INT8_CONVROT_TIER;
+}
+
 // Human labels for the picker, keyed by tier. Unknown/"default" tiers fall back to the raw key.
 // "training" is NOT a quant tier: it's the flat-diffusers LoRA-training base some tiered models
 // (lens, sc-8797) additionally host on macOS. It's absent from TIER_QUANTIZE, so the generation
@@ -29,10 +41,13 @@ const TIER_LABELS = {
   q8: "Q8 (balanced)",
   q4: "Q4 (smallest)",
   training: "LoRA training base (bf16 diffusers)",
+  // Candle-only (Windows/Linux, sm_89+). Online-rotation int8 DiT — closer to bf16 than Q4 (sc-9300).
+  [INT8_CONVROT_TIER]: "INT8-ConvRot (candle, sm_89+)",
 };
 
-// Display order (smallest → largest); tiers not in this list sort after, alphabetically.
-const TIER_ORDER = ["q4", "q8", "bf16"];
+// Display order (smallest → largest); tiers not in this list sort after, alphabetically. int8-convrot
+// sits between q4 and q8 by footprint/fidelity (int8 DiT, PSNR 34.4 dB — better than Q4's 22.7 dB).
+const TIER_ORDER = ["q4", INT8_CONVROT_TIER, "q8", "bf16"];
 
 // Map a tier key to its `advanced.mlxQuantize` value, or null when the key isn't a known quant
 // tier (e.g. "default" on a single-variant model — such models never render the picker).
@@ -46,10 +61,26 @@ export function tierLabel(tier) {
   return TIER_LABELS[tier] ?? tier;
 }
 
-// The installed, selectable quant tiers of a model, in display order. A tier is selectable when
-// it is a known quant tier (bf16/q8/q4 — the "default" pseudo-variant of a single-variant model
-// is excluded) AND its files are installed. Returns [] when the model has no variant matrix.
-export function installedTiers(model) {
+// Whether a tier key is a user-selectable generation tier: a known bits-based quant (bf16/q8/q4) OR
+// the candle INT8-ConvRot tier. Excludes the "default" pseudo-variant of a single-variant model and
+// non-generation pseudo-tiers like "training". Distinct from `tierQuantize` (which returns null for
+// int8-convrot because it has no mlxQuantize value — the tier still selects, via `advanced.convRot`).
+export function isSelectableTier(tier) {
+  return tierQuantize(tier) !== null || isConvRotTier(tier);
+}
+
+// The installed, selectable quant tiers of a model, in display order. A tier is selectable when it is
+// a known quant tier (bf16/q8/q4) OR the candle INT8-ConvRot tier (`isSelectableTier` — the "default"
+// pseudo-variant of a single-variant model is excluded) AND its files are installed. Returns [] when
+// the model has no variant matrix.
+//
+// `options.convRotEligible` (sc-9300, default true) gates the candle-only INT8-ConvRot tier: the
+// caller passes `false` when NO live worker advertises the `int8_convrot` capability (macOS/MLX, or a
+// pre-Ada NVIDIA GPU that fails the sm_89 compute-cap probe), so the tier is HIDDEN on an ineligible
+// host even when its files happen to be present in the cache. Every other tier is unaffected. Default
+// true keeps existing single-lane call sites (and tests) unchanged.
+export function installedTiers(model, options = {}) {
+  const { convRotEligible = true } = options;
   if (!model?.hasVariantMatrix || !Array.isArray(model.variants)) {
     return [];
   }
@@ -57,7 +88,8 @@ export function installedTiers(model) {
     .filter(
       (variant) =>
         variant &&
-        tierQuantize(variant.variant) !== null &&
+        isSelectableTier(variant.variant) &&
+        (convRotEligible || !isConvRotTier(variant.variant)) &&
         variant.installState === "installed",
     )
     .map((variant) => variant.variant)
@@ -79,8 +111,10 @@ export function installedTiers(model) {
 
 // Whether the studio should render the tier picker: only when MORE THAN ONE quant tier is
 // installed (a single installed tier — the common case — shows no toggle, per acceptance).
-export function shouldShowTierPicker(model) {
-  return installedTiers(model).length > 1;
+// `options` (sc-9300) forwards the `convRotEligible` gate so an ineligible host doesn't count the
+// hidden INT8-ConvRot tier toward the >1 threshold.
+export function shouldShowTierPicker(model, options = {}) {
+  return installedTiers(model, options).length > 1;
 }
 
 // The tier that declares itself the default download (`variant.default === true`) IF it is
@@ -100,9 +134,10 @@ function defaultInstalledTier(model, tiers) {
 //   2. the model's declared default tier (`variant.default: true`), when installed.
 //   3. q4 if installed (the catalog's smallest/default convention).
 //   4. the first installed tier.
-// Returns null when nothing is installed (no picker will render anyway).
-export function defaultTierSelection(model, lastUsed) {
-  const tiers = installedTiers(model);
+// Returns null when nothing is installed (no picker will render anyway). `options` (sc-9300) forwards
+// the `convRotEligible` gate so a hidden INT8-ConvRot tier is never seeded as the selection.
+export function defaultTierSelection(model, lastUsed, options = {}) {
+  const tiers = installedTiers(model, options);
   if (tiers.length === 0) {
     return null;
   }

--- a/apps/web/src/quantTier.test.js
+++ b/apps/web/src/quantTier.test.js
@@ -2,9 +2,12 @@ import { describe, expect, it } from "vitest";
 import {
   defaultTierSelection,
   installedTiers,
+  isConvRotTier,
+  isSelectableTier,
   shouldShowTierPicker,
   tierLabel,
   tierQuantize,
+  INT8_CONVROT_TIER,
 } from "./quantTier.js";
 
 // Build a /models-shaped model with a variant matrix. `installed` is the set of tier keys whose
@@ -38,7 +41,51 @@ describe("quantTier mapping", () => {
     expect(tierLabel("bf16")).toBe("Full precision (bf16)");
     expect(tierLabel("q8")).toBe("Q8 (balanced)");
     expect(tierLabel("q4")).toBe("Q4 (smallest)");
+    expect(tierLabel(INT8_CONVROT_TIER)).toBe("INT8-ConvRot (candle, sm_89+)");
     expect(tierLabel("mystery")).toBe("mystery");
+  });
+});
+
+describe("INT8-ConvRot tier (sc-9300)", () => {
+  it("is a selectable tier but has no mlxQuantize value", () => {
+    expect(isConvRotTier(INT8_CONVROT_TIER)).toBe(true);
+    expect(isConvRotTier("q4")).toBe(false);
+    expect(isSelectableTier(INT8_CONVROT_TIER)).toBe(true);
+    // It rides a distinct advanced.convRot signal, not mlxQuantize — so tierQuantize is null.
+    expect(tierQuantize(INT8_CONVROT_TIER)).toBe(null);
+  });
+
+  it("is offered only when convRotEligible (candle + sm_89 worker present)", () => {
+    const model = matrixModel({
+      tiers: ["q4", INT8_CONVROT_TIER, "bf16"],
+      installed: ["q4", INT8_CONVROT_TIER, "bf16"],
+    });
+    // Eligible host (default): the tier appears, ordered between q4 and bf16.
+    expect(installedTiers(model)).toEqual(["q4", INT8_CONVROT_TIER, "bf16"]);
+    // Ineligible host (macOS/MLX or pre-Ada NVIDIA — no int8_convrot worker): the tier is hidden.
+    expect(installedTiers(model, { convRotEligible: false })).toEqual(["q4", "bf16"]);
+  });
+
+  it("is never seeded as the default selection on an ineligible host", () => {
+    const model = matrixModel({
+      tiers: [INT8_CONVROT_TIER, "bf16"],
+      installed: [INT8_CONVROT_TIER, "bf16"],
+      defaultTier: INT8_CONVROT_TIER,
+    });
+    // Eligible: the declared default (convrot) is picked.
+    expect(defaultTierSelection(model, null)).toBe(INT8_CONVROT_TIER);
+    // Ineligible: convrot is filtered out, so the remaining installed tier (bf16) is picked.
+    expect(defaultTierSelection(model, null, { convRotEligible: false })).toBe("bf16");
+  });
+
+  it("does not count a hidden convrot tier toward the picker's >1 threshold", () => {
+    const model = matrixModel({
+      tiers: ["bf16", INT8_CONVROT_TIER],
+      installed: ["bf16", INT8_CONVROT_TIER],
+    });
+    expect(shouldShowTierPicker(model)).toBe(true);
+    // On an ineligible host only bf16 remains → single tier → no picker.
+    expect(shouldShowTierPicker(model, { convRotEligible: false })).toBe(false);
   });
 });
 

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -256,7 +256,23 @@ export function ImageStudio() {
     setRequestedGpu,
     updateAssetStatus,
     macCapabilities = DEFAULT_MAC_CAPABILITIES,
+    visibleWorkers = [],
   } = useAppContext();
+  // Krea 2 INT8-ConvRot eligibility (sc-9300, epic 9083): the candle-only tier is offered ONLY when a
+  // live worker advertises the `int8_convrot` capability — which the worker emits solely on the candle
+  // lane AND when its GPU clears the sm_89 compute-cap floor (gpu.rs). So macOS/MLX and pre-Ada NVIDIA
+  // hosts (where no worker advertises it) HIDE the tier gracefully rather than only failing at submit.
+  const convRotEligible = useMemo(
+    () =>
+      visibleWorkers.some(
+        (worker) =>
+          worker?.status !== "offline" &&
+          Array.isArray(worker?.capabilities) &&
+          worker.capabilities.includes("int8_convrot"),
+      ),
+    [visibleWorkers],
+  );
+  const tierOptions = useMemo(() => ({ convRotEligible }), [convRotEligible]);
   // Prompt-refinement model catalog entry (sc-5605) — drives the "download the
   // refinement model" affordance in RefinePromptControl when Refine fails because the
   // model isn't provisioned on the native worker.
@@ -625,8 +641,14 @@ export function ImageStudio() {
   // The picker renders only when MORE THAN ONE tier is installed; a single installed tier keeps
   // the studio unchanged (no toggle). Boogu's `precisionToggle` is orthogonal — those models are
   // single-download (no variant matrix), so they never hit this path.
-  const availableTiers = useMemo(() => installedTiers(selectedModel), [selectedModel]);
-  const showTierPicker = useMemo(() => shouldShowTierPicker(selectedModel), [selectedModel]);
+  const availableTiers = useMemo(
+    () => installedTiers(selectedModel, tierOptions),
+    [selectedModel, tierOptions],
+  );
+  const showTierPicker = useMemo(
+    () => shouldShowTierPicker(selectedModel, tierOptions),
+    [selectedModel, tierOptions],
+  );
   // PiD decoder toggle visibility (epic 7840, sc-7851): the model's latent space has a PiD
   // backbone (ui.pid) AND that backbone's PiD checkpoint is installed. Hidden otherwise — for
   // non-eligible models (e.g. SenseNova) and for eligible models whose checkpoint isn't
@@ -872,7 +894,7 @@ export function ImageStudio() {
     if (availableTiers.includes(quantTier)) {
       return;
     }
-    setQuantTier(defaultTierSelection(selectedModel, lastUsedTiers[model]) ?? "");
+    setQuantTier(defaultTierSelection(selectedModel, lastUsedTiers[model], tierOptions) ?? "");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [model, availableTiersKey]);
   // Switch the active quant tier (sc-8515): persist it as this model's last-used tier and surface

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2036,6 +2036,11 @@
           // 20,554,619,613 B = transformer 14.57 + text_encoder 5.47 + vae 0.48 GB; rounded up).
           "provider": "huggingface",
           "repo": "SceneWorks/krea-2-turbo-mlx",
+          // sc-9300: the per-tier `variant` keys make Krea 2 a proper variant matrix (like the
+          // standard-tier models) so `/models` emits a `variants[]` entry per tier and the studio tier
+          // picker (`quantTier.js`) can toggle installed tiers. q8 is the shipped default.
+          "variant": "q8",
+          "default": true,
           "files": [
             "q8/transformer/*",
             "q8/text_encoder/*",
@@ -2052,6 +2057,7 @@
           // selectable via advanced mlxQuantize<=4 (sc-8508/8509). Same complete-root shape as q8.
           "provider": "huggingface",
           "repo": "SceneWorks/krea-2-turbo-mlx",
+          "variant": "q4",
           "files": [
             "q4/transformer/*",
             "q4/text_encoder/*",
@@ -2069,6 +2075,7 @@
           // via advanced mlxQuantize<=0 (sc-8508/8509). Mirror of the dense `krea/Krea-2-Turbo` tree.
           "provider": "huggingface",
           "repo": "SceneWorks/krea-2-turbo-mlx",
+          "variant": "bf16",
           "files": [
             "bf16/transformer/*",
             "bf16/text_encoder/*",
@@ -2079,6 +2086,31 @@
           ],
           "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 35678119918
+        },
+        {
+          // INT8-ConvRot tier (sc-9300, epic 9083) — candle-ONLY (Windows/Linux; NOT macOS/mlx). The
+          // community INT8-ConvRot DiT (online-rotation IGEMM, sc-9601: PSNR 34.4 dB vs bf16, > Q4's
+          // 22.7 dB) hosted PRIVATELY at `SceneWorks/krea-2-turbo-int8-convrot` as a single 13.5 GB
+          // `krea2_turbo_int8_convrot.safetensors`. It REPLACES only the DiT — the rest of the surface
+          // (tokenizer / Qwen3-VL TE / Qwen-Image VAE / config) comes from the canonical bf16 Krea 2
+          // snapshot, which this tier lists as a co-requisite so the worker fetches both. The LoadSpec
+          // the worker builds is `weights = Dir(<bf16 snapshot root>)` + `text_encoder =
+          // File(<convrot .safetensors>)` (see `image_jobs/base.rs resolve_krea_convrot`). Authed HF
+          // download (SceneWorks token, like every private SceneWorks repo). `platforms` OMITS macos so
+          // the Mac picker never lists it; the worker's sm_89 compute-cap capability + the candle
+          // `vramGbByTier.int8-convrot` gate hide it on ineligible cards.
+          // The ConvRot download pulls ONLY the DiT single-file. The canonical bf16 Krea 2 snapshot
+          // (`SceneWorks/krea-2-turbo-mlx` `bf16/` subdir) supplies the non-quantized surface (tokenizer
+          // / Qwen3-VL TE / Qwen-Image VAE / config) the ConvRot LoadSpec `Dir` root points at; the
+          // worker fetches it on-demand when this tier is selected (`ensure_krea_convrot_base_present`,
+          // the sibling of `ensure_boogu_tier_present`) rather than forcing it on q4/q8 users via a
+          // global co-requisite. `platforms` OMITS macos so the Mac picker never lists this tier.
+          "provider": "huggingface",
+          "repo": "SceneWorks/krea-2-turbo-int8-convrot",
+          "variant": "int8-convrot",
+          "files": ["krea2_turbo_int8_convrot.safetensors"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 13500000000
         }
       ],
       "paths": {
@@ -2125,13 +2157,19 @@
       // measurement.
       "candle": {
         "minMemoryGb": 32,
-        "vramGbByTier": { "q4": 26.4, "q8": 31.0, "bf16": 44.0 },
+        // sc-9300: the INT8-ConvRot tier's VRAM ceiling. The int8 DiT is ~half the bf16 DiT, but the
+        // rest of the resident surface (Qwen3-VL-4B TE + Qwen-Image VAE) is unchanged and the online
+        // Hadamard rotation adds transient activation, so ESTIMATE it near the q8 tier (~31 GB) pending
+        // measurement. It gates the `int8-convrot` variant through the SAME per-tier memory-eligibility
+        // path as q4/q8/bf16 (the third of the three ConvRot gates; the candle lane + sm_89 compute-cap
+        // are the worker's `int8_convrot` capability).
+        "vramGbByTier": { "q4": 26.4, "q8": 31.0, "bf16": 44.0, "int8-convrot": 31.0 },
         "measured": false
       },
       "licenseUrl": "https://www.krea.ai/krea-2-licensing",
       "ui": {
         "label": "Krea 2 Turbo",
-        "description": "Krea 2 Turbo — Krea AI's from-scratch foundation image model, distilled to a fast few-step (~8), CFG-free variant: a 28-block single-stream rectified-flow DiT with a Qwen3-VL-4B text encoder, native MLX (Apple Silicon). Strong photorealism up to 2048². Pre-quantized Q8 (~20.5 GB download, default). Krea 2 Community License (non-commercial). Needs a 48 GB-class Mac.",
+        "description": "Krea 2 Turbo — Krea AI's from-scratch foundation image model, distilled to a fast few-step (~8), CFG-free variant: a 28-block single-stream rectified-flow DiT with a Qwen3-VL-4B text encoder, native MLX (Apple Silicon). Strong photorealism up to 2048². Pre-quantized Q8 (~20.5 GB download, default). Krea 2 Community License (non-commercial). Needs a 48 GB-class Mac. Candle (Windows/Linux) adds an INT8-ConvRot tier (online-rotation int8 DiT), an sm_89-exclusive visibility feature: A/B @1024²/8-step — bf16 ~8.8 s (reference, coherent) · Q4-packed ~9.8 s (PSNR 22.7 dB vs bf16, coherent) · INT8-ConvRot (coherent, PSNR 34.4 dB vs bf16 — visibly closer to full precision than Q4). Requires an RTX 40xx / RTX PRO Blackwell (sm_89+) GPU; hidden on Mac and pre-Ada cards.",
         "recommendedFor": ["text_to_image"],
         // PiD decoder (epic 7840, qwenimage latent space — Krea 2 Turbo reuses the Qwen
         // VAE) — optional per-generation VAE replacement, decode + 2K/4K SR; NC output.

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2093,7 +2093,7 @@
           // 22.7 dB) hosted PRIVATELY at `SceneWorks/krea-2-turbo-int8-convrot` as a single 13.5 GB
           // `krea2_turbo_int8_convrot.safetensors`. It REPLACES only the DiT — the rest of the surface
           // (tokenizer / Qwen3-VL TE / Qwen-Image VAE / config) comes from the canonical bf16 Krea 2
-          // snapshot, which this tier lists as a co-requisite so the worker fetches both. The LoadSpec
+          // snapshot, which the worker fetches on-demand when this tier is selected. The LoadSpec
           // the worker builds is `weights = Dir(<bf16 snapshot root>)` + `text_encoder =
           // File(<convrot .safetensors>)` (see `image_jobs/base.rs resolve_krea_convrot`). Authed HF
           // download (SceneWorks token, like every private SceneWorks repo). `platforms` OMITS macos so

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1449,15 +1449,27 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520
 # UNCHANGED at b520a0e7 (= this worker's mlx-gen pin), so `--features backend-candle --target all` still
 # resolves the SINGLE gen-core rev b520a0e7 (the skew gate) — no testkit reconcile. ALL candle-gen-* rev
 # lines move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
+# Bumped `9362745` -> `8db956d` (sc-9300, epic 9083): candle-gen #343 (squash-merged to main as 8db956d)
+# makes the INT8-ConvRot Krea 2 consume path reachable through the normal Generator/LoadSpec API — the
+# ConvRot DiT single-file checkpoint rides the already-optional `LoadSpec::text_encoder` as a
+# `WeightsSource::File` while `spec.weights` stays the canonical Krea 2 snapshot `Dir`; krea's `build`
+# routes a `File` there to `load_components_convrot` (which enforces the sm_89 compute-cap floor). This
+# is what lets THIS worker's ConvRot routing (base.rs `resolve_krea_convrot` + `generate_candle_stream`)
+# construct that spec and reach the merged engine path. `git diff 9362745..8db956d -- gen-core/
+# gen-core-testkit/` is EMPTY — the range is candle-gen-ONLY Rust (krea/flux loader hygiene, bespoke-PiD
+# seams, sdxl packed-CLIP/LoRA fold) + CODEGRAPH docs, no shared type changed. candle-gen's OWN gen-core
+# pin is UNCHANGED at b520a0e7 (= this worker's mlx-gen pin), so `--features backend-candle --target all`
+# still resolves the SINGLE gen-core rev b520a0e7 (the skew gate) — no testkit reconcile. ALL candle-gen-*
+# rev lines move together.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1465,17 +1477,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1485,7 +1497,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1493,21 +1505,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1516,17 +1528,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1535,7 +1547,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1568,7 +1580,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1577,12 +1589,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1590,7 +1602,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1599,7 +1611,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1607,7 +1619,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1621,7 +1633,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1648,7 +1660,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1659,7 +1671,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "93627450bc22f70a55aebfd0a0f154f33b3fe484", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/flux2_dev_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/flux2_dev_gpu_smoke.rs
@@ -244,6 +244,8 @@ fn flux2_dev_edit_candle_gpu_smoke() {
         steps,
         guidance: 4.0,
         seed: 42,
+        // Native VAE decode (no PiD backbone on this smoke) — matches candle-gen Default.
+        use_pid: false,
         cancel: gen_core::runtime::CancelFlag::new(),
     };
     println!("[smoke] dev edit {w}x{h} @ {steps} steps (single ref) ...");
@@ -327,6 +329,8 @@ fn flux2_dev_control_candle_gpu_smoke() {
         guidance: 4.0,
         control_scale: 0.75,
         seed: 42,
+        // Native VAE decode (no PiD backbone on this smoke) — matches candle-gen Default.
+        use_pid: false,
         cancel: gen_core::runtime::CancelFlag::new(),
     };
     println!("[smoke] dev control {w}x{h} @ {steps} steps (scale 0.75) ...");

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -29,7 +29,12 @@ pub(crate) async fn discover_gpu(settings: &Settings) -> DiscoveredGpu {
             .find(|gpu| gpu.id == requested_gpu_id)
             .unwrap_or_else(|| fallback_gpu(requested_gpu_id))
     };
-    with_candle_capabilities(gpu, settings)
+    // Compute-capability probe for the INT8-ConvRot sm_89 gate (sc-9300). Probed here (the async
+    // discovery) and threaded into the sync `with_candle_capabilities` — the worker has no nvml, so
+    // this is a bounded `nvidia-smi --query-gpu=compute_cap` subprocess like the utilization query.
+    // Only meaningful on the candle lane; a cheap no-op probe on CPU / non-NVIDIA (returns `None`).
+    let compute_cap = nvidia_max_compute_cap().await;
+    with_candle_capabilities(gpu, settings, compute_cap)
 }
 
 /// Light up the Windows/CUDA candle SDXL lane on the discovered nvidia GPU (epic 3672, sc-3678).
@@ -48,7 +53,11 @@ pub(crate) async fn discover_gpu(settings: &Settings) -> DiscoveredGpu {
     not(all(not(target_os = "macos"), feature = "backend-candle")),
     allow(unused_mut, unused_variables)
 )]
-fn with_candle_capabilities(mut gpu: DiscoveredGpu, settings: &Settings) -> DiscoveredGpu {
+fn with_candle_capabilities(
+    mut gpu: DiscoveredGpu,
+    settings: &Settings,
+    compute_cap: Option<f32>,
+) -> DiscoveredGpu {
     #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
     if settings.backend_candle_enabled && gpu.capabilities.contains(&WorkerCapability::Gpu) {
         let derived = crate::engines::registry_capabilities(settings);
@@ -166,6 +175,19 @@ fn with_candle_capabilities(mut gpu: DiscoveredGpu, settings: &Settings) -> Disc
             // The lane marker the routing gate keys off (mirrors the existing `nvidia` marker).
             gpu.capabilities
                 .push(WorkerCapability::Unknown("candle".to_owned()));
+            // Krea 2 INT8-ConvRot eligibility marker (sc-9300, epic 9083). Advertised ONLY when this
+            // candle worker's GPU clears the sm_89 compute-cap floor (the online-rotation IGEMM path;
+            // the candle-gen engine hard-floors it via `ensure_int8_floor` too). Bundling the candle
+            // lane (this block only runs under `backend_candle_enabled`) with the compute-cap check
+            // into one advertised capability lets the api/web picker HIDE the `int8-convrot` tier on
+            // an ineligible card (macOS/MLX never reaches here; a pre-Ada NVIDIA GPU probes < 8.9) —
+            // graceful, rather than only erroring at generate time. Per-tier VRAM is the manifest's
+            // separate memory-eligibility gate, like every other tier.
+            if compute_cap_meets_int8_convrot(compute_cap) {
+                gpu.capabilities.push(WorkerCapability::Unknown(
+                    INT8_CONVROT_CAPABILITY.to_owned(),
+                ));
+            }
         }
     }
     gpu
@@ -212,6 +234,63 @@ pub(crate) async fn query_nvidia_gpus() -> Vec<DiscoveredGpu> {
         }
         _ => Vec::new(),
     }
+}
+
+/// The advertised marker capability meaning "this candle worker can run the Krea 2 INT8-ConvRot
+/// variant" (sc-9300, epic 9083). It bundles the two worker-side gates the ConvRot lane needs
+/// (locked decision 7): the candle lane (only pushed under `backend_candle_enabled` in
+/// [`with_candle_capabilities`]) AND a GPU compute capability >= 8.9 (sm_89 / RTX 40xx+, the online-
+/// rotation IGEMM floor the candle-gen engine enforces via `ensure_int8_floor`). The api surfaces
+/// this on the worker snapshot and the web picker (`quantTier.js`) shows the `int8-convrot` tier only
+/// when a registered worker advertises it — so an ineligible card (macOS/MLX, or a pre-Ada NVIDIA GPU)
+/// HIDES the variant gracefully rather than only failing at generate time. The third gate (per-tier
+/// VRAM / `candle.minMemoryGb`) rides the existing manifest memory-eligibility path, like every tier.
+///
+/// Consumed only by the candle-lane capability block in [`with_candle_capabilities`], so gate to the
+/// candle build to avoid a dead-code warning in the non-candle (macOS / plain-CUDA) build.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+pub(crate) const INT8_CONVROT_CAPABILITY: &str = "int8_convrot";
+
+/// The minimum NVIDIA compute capability the INT8-ConvRot online-rotation IGEMM path requires
+/// (sm_89 / Ada — RTX 40xx and the RTX PRO Blackwell line). Pre-Ada cards (sm_80 A100, sm_86 RTX 30xx)
+/// lack the int8 IMMA throughput the path assumes; the candle-gen engine hard-floors it too.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const INT8_CONVROT_MIN_COMPUTE_CAP: f32 = 8.9;
+
+/// Highest CUDA compute capability across the visible NVIDIA GPUs, via
+/// `nvidia-smi --query-gpu=compute_cap` (e.g. `8.9`, `12.0`). `None` when nvidia-smi is absent /
+/// times out / reports no parseable cap (a non-NVIDIA or CPU worker) — the caller then treats the
+/// worker as ConvRot-ineligible. Cheap, bounded (3s) subprocess, matching [`query_nvidia_gpus`]; the
+/// `compute_cap` query field is a stable nvidia-smi column (driver R495+, well below any CUDA-12 box).
+pub(crate) async fn nvidia_max_compute_cap() -> Option<f32> {
+    let output = tokio::time::timeout(
+        Duration::from_secs(3),
+        Command::new("nvidia-smi")
+            .args(["--query-gpu=compute_cap", "--format=csv,noheader,nounits"])
+            .output(),
+    )
+    .await;
+    match output {
+        Ok(Ok(output)) if output.status.success() => {
+            parse_max_compute_cap(&String::from_utf8_lossy(&output.stdout))
+        }
+        _ => None,
+    }
+}
+
+/// Parse the highest `major.minor` compute cap from the `nvidia-smi --query-gpu=compute_cap` CSV
+/// (one row per GPU). Ignores blank / unparseable rows; `None` when nothing parses.
+pub(crate) fn parse_max_compute_cap(output: &str) -> Option<f32> {
+    output
+        .lines()
+        .filter_map(|line| line.trim().parse::<f32>().ok())
+        .fold(None, |acc, cap| Some(acc.map_or(cap, |m: f32| m.max(cap))))
+}
+
+/// Whether a probed compute cap clears the INT8-ConvRot sm_89 floor. `None` (no probe) ⇒ ineligible.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+pub(crate) fn compute_cap_meets_int8_convrot(cap: Option<f32>) -> bool {
+    cap.is_some_and(|c| c >= INT8_CONVROT_MIN_COMPUTE_CAP)
 }
 
 pub(crate) fn parse_nvidia_smi_gpus(output: &str) -> Vec<DiscoveredGpu> {

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -769,6 +769,140 @@ fn krea_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
         .unwrap_or_else(|| root.to_path_buf())
 }
 
+/// The private HF repo hosting the Krea 2 INT8-ConvRot DiT single-file checkpoint (sc-9300, epic
+/// 9083). Authed download with the SceneWorks HF token, like every private SceneWorks tier.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const KREA_CONVROT_REPO: &str = "SceneWorks/krea-2-turbo-int8-convrot";
+
+/// The ConvRot DiT filename inside [`KREA_CONVROT_REPO`] (mirrors the manifest download `files`).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const KREA_CONVROT_DIT_FILE: &str = "krea2_turbo_int8_convrot.safetensors";
+
+/// Whether this Krea 2 request selected the candle-only INT8-ConvRot tier (sc-9300). The studio's tier
+/// picker sends `advanced.convRot: true` for the `int8-convrot` variant (it has no `mlxQuantize` — the
+/// online-rotation int8 DiT isn't a bits-based quant). Candle-lane only: the tier is `platforms`-scoped
+/// off macOS and the worker only advertises the `int8_convrot` capability on the candle lane, so this
+/// never fires on the MLX path even if a stray flag arrives. Confined to `krea_2_turbo`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn wants_krea_convrot(request: &ImageRequest) -> bool {
+    request.model == "krea_2_turbo"
+        && request
+            .advanced
+            .get("convRot")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+}
+
+/// Resolve the INT8-ConvRot LoadSpec inputs for a Krea 2 request (sc-9300): the canonical bf16 Krea 2
+/// snapshot DIR (the LoadSpec `weights` root — tokenizer / Qwen3-VL TE / Qwen-Image VAE / config + the
+/// non-quantized surface) and the downloaded ConvRot DiT single-file (the LoadSpec `text_encoder`
+/// `File`, which the candle-gen krea engine's `convrot_selector` routes to `load_components_convrot`).
+///
+/// `None` when the request didn't select ConvRot, OR either artifact isn't present yet (the bf16
+/// `bf16/` subdir of the `krea-2-turbo-mlx` turnkey, or the ConvRot DiT `.safetensors`) — the caller
+/// then falls back to the normal dense/packed path rather than half-loading. The bf16 base is fetched
+/// on demand by [`ensure_krea_convrot_base_present`] before this resolves. The sm_89 compute-cap floor
+/// is enforced ENGINE-side (`ensure_int8_floor` inside `load_components_convrot`) AND surfaced as the
+/// worker's `int8_convrot` capability, so an ineligible card never reaches here (the picker hides it).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn resolve_krea_convrot(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> Option<(PathBuf, PathBuf)> {
+    if !wants_krea_convrot(request) {
+        return None;
+    }
+    // The bf16 base surface: the `bf16/` subdir of the shared `krea-2-turbo-mlx` turnkey (the SAME dir
+    // the bf16 tier ships), a candle-readable `transformer/ text_encoder/ vae/ tokenizer/` root. The
+    // ConvRot DiT replaces only the transformer at load, but the pipeline still reads the dense TE/VAE/
+    // tokenizer/config from here.
+    let base_dir = huggingface_snapshot_dir(&settings.data_dir, KREA_MLX_TURNKEY_REPO)
+        .map(|root| root.join("bf16"))
+        .filter(|dir| {
+            dir.join("model_index.json").is_file()
+                && dir.join("text_encoder").is_dir()
+                && dir.join("vae").is_dir()
+        })?;
+    // The ConvRot DiT single-file inside the private repo's snapshot.
+    let convrot_dit = huggingface_snapshot_dir(&settings.data_dir, KREA_CONVROT_REPO)
+        .map(|root| root.join(KREA_CONVROT_DIT_FILE))
+        .filter(|file| file.is_file())?;
+    Some((base_dir, convrot_dit))
+}
+
+/// The shared `krea-2-turbo-mlx` turnkey repo (its `bf16/` subdir supplies the ConvRot base surface).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const KREA_MLX_TURNKEY_REPO: &str = "SceneWorks/krea-2-turbo-mlx";
+
+/// On-demand fetch of the canonical bf16 Krea 2 base surface for the INT8-ConvRot tier (sc-9300),
+/// the sibling of [`ensure_boogu_tier_present`]. The ConvRot catalog download pulls only the DiT
+/// single-file; the bf16 `bf16/` subdir of the `krea-2-turbo-mlx` turnkey (tokenizer / Qwen3-VL TE /
+/// Qwen-Image VAE / config) is fetched here when the ConvRot tier is selected and it isn't present —
+/// so q4/q8 users are never forced to download the 35 GB bf16 base (it isn't a global co-requisite).
+/// No-op when the request isn't a ConvRot job, the bf16 base is already complete, or the `hf` CLI is
+/// absent (then `resolve_krea_convrot` returns `None` and the job falls back / surfaces a load error).
+/// Fails loud on a real download error — fast, before any compute.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+async fn ensure_krea_convrot_base_present(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &ImageRequest,
+) -> WorkerResult<()> {
+    if !wants_krea_convrot(request) {
+        return Ok(());
+    }
+    let Some(root) = huggingface_snapshot_dir(&settings.data_dir, KREA_MLX_TURNKEY_REPO) else {
+        // Turnkey never fetched → `hf` may still pull it below; probe the eventual bf16 subdir path.
+        // (If the repo is entirely absent, the fetch below installs the requested bf16 leaf dirs.)
+        return fetch_krea_convrot_base(api, settings, job).await;
+    };
+    let bf16 = root.join("bf16");
+    // Present already (dense sharded transformer index + the dense TE/VAE) → no fetch.
+    if bf16.join("model_index.json").is_file()
+        && bf16.join("text_encoder").is_dir()
+        && bf16.join("vae").is_dir()
+    {
+        return Ok(());
+    }
+    fetch_krea_convrot_base(api, settings, job).await
+}
+
+/// Pull the bf16 base leaf dirs of the `krea-2-turbo-mlx` turnkey into the HF cache (sc-9300). Same
+/// leaf-glob shape as the manifest bf16 tier download; scratched marker dir keyed by job id.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+async fn fetch_krea_convrot_base(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<()> {
+    let scratch = settings
+        .data_dir
+        .join("cache")
+        .join(format!(".krea-convrot-base-fetch-{}", job.id));
+    tokio::fs::create_dir_all(&scratch).await?;
+    let files = vec![
+        "bf16/transformer/*".to_owned(),
+        "bf16/text_encoder/*".to_owned(),
+        "bf16/vae/*".to_owned(),
+        "bf16/tokenizer/*".to_owned(),
+        "bf16/scheduler/*".to_owned(),
+        "bf16/model_index.json".to_owned(),
+    ];
+    let result = crate::model_jobs::download_model_with_hf_cli(
+        api,
+        settings,
+        job,
+        KREA_MLX_TURNKEY_REPO,
+        "main",
+        &files,
+        &scratch,
+    )
+    .await;
+    let _ = tokio::fs::remove_dir_all(&scratch).await;
+    result.map(|_| ())
+}
+
 /// On-demand fetch of a non-default Boogu tier subfolder (sc-6568 / sc-8513). The catalog download
 /// pulls only the packed Q8 `<variant>/` subfolder, so when a job opts into another tier
 /// ([`boogu_tier_subdir`]: `<=0` → `<variant>-bf16/` dense, `1..=4` → `<variant>-q4/` packed) and that
@@ -3211,10 +3345,21 @@ async fn generate_candle_stream(
     // default tier / every other family / an unfetched turnkey (falls through to the load error below).
     ensure_boogu_tier_present(api, settings, job, request).await?;
     ensure_ideogram_tier_present(api, settings, job, request).await?;
-    let weights_dir = resolve_weights_dir(request, settings)?.ok_or_else(|| {
-        let repo = model_repo(request, &model);
-        WorkerError::InvalidPayload(format!("candle weights snapshot not found for {repo}"))
-    })?;
+    // Krea 2 INT8-ConvRot tier (sc-9300, epic 9083): fetch the canonical bf16 base surface on demand
+    // (the ConvRot catalog download pulls only the DiT single-file), then resolve the two LoadSpec
+    // inputs. `None` = not a ConvRot job (or an artifact still absent) → the normal dense/packed path
+    // below. When it resolves, the LoadSpec `weights` becomes the bf16 base DIR and `text_encoder` the
+    // ConvRot DiT `File` — the exact shape the candle-gen krea engine's `convrot_selector` expects.
+    ensure_krea_convrot_base_present(api, settings, job, request).await?;
+    let convrot = resolve_krea_convrot(request, settings);
+    let weights_dir = if let Some((base_dir, _)) = convrot.as_ref() {
+        base_dir.clone()
+    } else {
+        resolve_weights_dir(request, settings)?.ok_or_else(|| {
+            let repo = model_repo(request, &model);
+            WorkerError::InvalidPayload(format!("candle weights snapshot not found for {repo}"))
+        })?
+    };
 
     // Descriptor-derived denoise/guidance surface (distilled families → no guidance/negative; guided
     // families → the scale + negative prompt). Identical to the MLX path; quant + LoRA are omitted.
@@ -3246,12 +3391,20 @@ async fn generate_candle_stream(
     // it resolves them like the MLX path; the sc-3675/sc-5096 families advertise neither and skip both
     // (dense bf16/fp16, no adapters) — preserving their shipped behavior. The router only lets a quant
     // request / LoRA reach this worker for a family that supports it (`image_request_candle_eligible`).
-    let (quant, quant_bits) = if model.supports_quant() {
+    let (quant, quant_bits) = if convrot.is_some() {
+        // INT8-ConvRot (sc-9300): the int8 DiT replaces the dense transformer wholesale — a bits-based
+        // load-time `Quant` is meaningless (and the candle-gen krea engine rejects a quant overlay on
+        // the ConvRot path). Force dense-None; the recipe records no `mlxQuantize` bits for this tier.
+        (None, None)
+    } else if model.supports_quant() {
         resolve_quant(request)
     } else {
         (None, None)
     };
-    let adapters = if model.supports_adapters() {
+    let adapters = if convrot.is_some() {
+        // ConvRot does not combine with LoRA/LoKr (the int8 DiT is not adapter-wired); skip adapters.
+        Vec::new()
+    } else if model.supports_adapters() {
         resolve_adapters(request, settings)?
     } else {
         Vec::new()
@@ -3358,11 +3511,26 @@ async fn generate_candle_stream(
     // ideogram/kolors/krea/lens), so this un-gates the toggle across the whole off-Mac catalog — using the
     // SAME `resolve_pid_weights` model→backbone gate as the macOS lane (a non-eligible model → `None` →
     // native VAE, so this is a no-op for anything without a PiD backbone).
-    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
+    // ConvRot (sc-9300) does not combine with a PiD decode overlay — the int8 DiT consume path replaces
+    // the transformer wholesale and is not PiD-wired (the candle-gen krea engine rejects the combo). So
+    // suppress PiD when ConvRot is selected; every non-ConvRot job resolves PiD exactly as before.
+    let pid_weights = if convrot.is_some() {
+        None
+    } else {
+        resolve_pid_weights(request, &settings.data_dir, &request.model)?
+    };
     let use_pid = pid_weights.is_some();
     let mut spec = load_spec(weights_dir, quant, adapters, None);
     if let Some(pid) = pid_weights {
         spec = spec.with_pid(pid.checkpoint, pid.gemma);
+    }
+    // INT8-ConvRot LoadSpec seam (sc-9300, epic 9083): ride the ConvRot DiT single-file on the shared,
+    // already-optional `LoadSpec::text_encoder` as a `WeightsSource::File` while `spec.weights` stays the
+    // canonical Krea 2 bf16 snapshot `Dir` (set as `weights_dir` above). The candle-gen krea engine's
+    // `convrot_selector` decodes a `File` here → `load_components_convrot` (which enforces the sm_89
+    // compute-cap floor); a `Dir`/`None` there is the normal dense/packed path. Other engines ignore it.
+    if let Some((_, convrot_dit)) = convrot {
+        spec.text_encoder = Some(WeightsSource::File(convrot_dit));
     }
 
     let (cancel, rx, blocking) = start_cached_gen_stream(

--- a/crates/sceneworks-worker/src/image_jobs/flux2_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_control_candle.rs
@@ -255,6 +255,9 @@ impl CandleStrictControl for Flux2StrictControl {
             guidance: self.guidance,
             control_scale: self.control_scale,
             seed,
+            // No PiD backbone on this lane (native VAE decode) — behavior-preserving across the
+            // candle-gen PiD seam bump (sc-8373 / sc-9300); matches candle-gen Default.
+            use_pid: false,
             cancel: cancel.clone(),
         };
         model.generate(&req, control, on_progress).map_err(|error| {

--- a/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
@@ -303,6 +303,9 @@ async fn generate_candle_flux2_edit_stream(
                     steps: steps as usize,
                     guidance,
                     seed: seed as u64,
+                    // No PiD backbone on this lane (native VAE decode) — behavior-preserving across the
+                    // candle-gen PiD seam bump (sc-8373 / sc-9300); matches candle-gen Default.
+                    use_pid: false,
                     cancel: cancel.clone(),
                 };
                 let result = model.generate(&req, &references, &mut *on_progress);

--- a/crates/sceneworks-worker/src/image_jobs/kolors_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_control.rs
@@ -250,6 +250,9 @@ impl CandleStrictControl for KolorsStrictControl {
             seed,
             sampler: self.sampler.clone(),
             scheduler: self.scheduler.clone(),
+            // No PiD backbone on this lane (native VAE decode) — behavior-preserving across the
+            // candle-gen PiD seam bump (sc-8373 / sc-9300); matches candle-gen Default.
+            use_pid: false,
             cancel: cancel.clone(),
         };
         model.generate(&req, control, on_progress).map_err(|error| {

--- a/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
@@ -359,6 +359,9 @@ async fn generate_candle_pulid_stream(
                     seed: seed as u64,
                     sampler: sampler.clone(),
                     scheduler: scheduler.clone(),
+                    // No PiD backbone on this lane (native VAE decode) — behavior-preserving across the
+                    // candle-gen PiD seam bump (sc-8373 / sc-9300); matches candle-gen Default.
+                    use_pid: false,
                     cancel: cancel.clone(),
                 };
                 let out = match model.generate(&req, &reference, &mut *on_progress) {

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
@@ -311,6 +311,9 @@ async fn generate_candle_sdxl_edit_stream(
                     guidance,
                     strength,
                     seed: seed as u64,
+                    // No PiD backbone on this lane (native VAE decode) — behavior-preserving across the
+                    // candle-gen PiD seam bump (sc-8373 / sc-9300); matches candle-gen Default.
+                    use_pid: false,
                     cancel: cancel.clone(),
                 };
                 let result = match &mask {

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
@@ -333,6 +333,10 @@ async fn generate_candle_sdxl_ipadapter_stream(
                     seed: seed as u64,
                     sampler: sampler.clone(),
                     scheduler: scheduler.clone(),
+                    // This lane never resolves a PiD backbone (no `resolve_pid_weights` call), so keep
+                    // the native VAE decode — behavior-preserving across the candle-gen PiD seam bump
+                    // (sc-8373 / sc-9300). Matches the candle-gen request `Default` (use_pid: false).
+                    use_pid: false,
                     cancel: cancel.clone(),
                 };
                 let out = match model.generate(&req, &reference, &mut *on_progress) {

--- a/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
@@ -317,6 +317,9 @@ impl CandleStrictControl for ZImageStrictControl {
                 .then(|| self.negative_prompt.clone())
                 .filter(|value| !value.trim().is_empty()),
             seed,
+            // No PiD backbone on this lane (native VAE decode) — behavior-preserving across the
+            // candle-gen PiD seam bump (sc-8373 / sc-9300); matches candle-gen Default.
+            use_pid: false,
             cancel: cancel.clone(),
         };
         model.generate(&req, control, on_progress).map_err(|error| {

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -45,8 +45,8 @@ use super::downloads::{
 #[cfg(target_os = "macos")]
 use super::gpu::mlx_gpu;
 use super::gpu::{
-    cpu_gpu, cpu_worker_id, fallback_gpu, gpu_worker_id, parse_nvidia_smi_gpus, visible_gpu_ids,
-    worker_capabilities_with_utility,
+    cpu_gpu, cpu_worker_id, fallback_gpu, gpu_worker_id, parse_max_compute_cap,
+    parse_nvidia_smi_gpus, visible_gpu_ids, worker_capabilities_with_utility,
 };
 use super::media_jobs::{
     candidate_people, concat_file_contents, crossfade_duration, output_dimensions, plan_segments,

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -40,6 +40,24 @@ fn nvidia_smi_parsing_and_visible_device_filtering_match_python_worker() {
     );
 }
 
+// sc-9300 (epic 9083): the INT8-ConvRot sm_89 compute-cap probe parses `nvidia-smi
+// --query-gpu=compute_cap` and takes the HIGHEST cap across GPUs (a multi-GPU box may mix an Ada card
+// with an older one). Blank / unparseable rows are ignored; nothing parseable ⇒ `None` (ineligible).
+#[test]
+fn compute_cap_parse_takes_the_highest_and_tolerates_junk() {
+    // Single Ada card (RTX 4090 = 8.9) clears the floor.
+    assert_eq!(parse_max_compute_cap("8.9\n"), Some(8.9));
+    // Blackwell (12.0).
+    assert_eq!(parse_max_compute_cap("12.0\n"), Some(12.0));
+    // Multi-GPU: an A100 (8.0) + an RTX 4090 (8.9) → the max (8.9) is what the gate sees.
+    assert_eq!(parse_max_compute_cap("8.0\n8.9\n"), Some(8.9));
+    // Junk / blank rows are ignored; a trailing blank line doesn't break the max.
+    assert_eq!(parse_max_compute_cap("  \n7.5\nN/A\n"), Some(7.5));
+    // No parseable cap (nvidia-smi absent / empty) ⇒ None ⇒ ConvRot-ineligible.
+    assert_eq!(parse_max_compute_cap(""), None);
+    assert_eq!(parse_max_compute_cap("\n[N/A]\n"), None);
+}
+
 #[test]
 fn auto_worker_ids_and_child_environment_match_python_supervisor() {
     assert_eq!(gpu_worker_id("worker-gpu-auto-0", "0"), "worker-gpu-auto-0");


### PR DESCRIPTION
## sc-9300 — INT8-ConvRot Krea 2 runs natively on the candle lane (worker wiring, part 2)

The candle-gen engine side is already merged (main `8db956d`, PR #343): `Generator::generate` reaches the ConvRot path when given a `LoadSpec` with `weights = Dir(canonical Krea2 snapshot root)` and `text_encoder = Some(File(convrot DiT .safetensors))`. This PR wires the worker + UI to construct that spec.

### Pin bump
All `candle-gen-*` deps `9362745` → `8db956d`. gen-core stays byte-identical at `b520a0e7` (the range is candle-gen-only Rust + docs — `git diff … -- gen-core/` is empty), so the `--features backend-candle` skew gate holds single-rev. Verified locally with `scripts/check-gen-core-skew.sh` → **exactly one gen-core**.

### Triple-gated `int8-convrot` variant (locked decision 7)
Offered only when ALL hold:
1. **Candle lane (Windows/Linux) only** — the manifest download OMITS the `macos` platform, and the worker advertises the `int8_convrot` capability solely on the candle lane (`gpu.rs` `with_candle_capabilities`, only under `backend_candle_enabled`). The Mac/MLX picker never lists it.
2. **Compute cap ≥ 8.9 (sm_89 / RTX 40xx+)** — the worker has no nvml, so a bounded `nvidia-smi --query-gpu=compute_cap` probe (`gpu.rs::nvidia_max_compute_cap`) threads the max cap into `with_candle_capabilities`, which pushes the `int8_convrot` marker only when `compute_cap_meets_int8_convrot` passes. An ineligible card HIDES the variant (the web picker keys off the live capability) rather than only failing at generate time. The engine also hard-floors it (`ensure_int8_floor`).
3. **Per-tier VRAM** — via the existing manifest memory-eligibility path (`candle.minMemoryGb: 32` + `vramGbByTier.int8-convrot: 31.0`).

### ConvRot LoadSpec routing
In `image_jobs/base.rs`, when `advanced.convRot` is set for `krea_2_turbo`:
- `resolve_krea_convrot` returns `(bf16 snapshot Dir, ConvRot DiT File)`.
- `generate_candle_stream` sets `weights = Dir(<canonical bf16 Krea2 snapshot>)` + `spec.text_encoder = Some(WeightsSource::File(<convrot DiT>))` — the exact shape the engine's `convrot_selector` routes to `load_components_convrot`.
- Quant / LoRA / PiD are suppressed on this path (the int8 DiT replaces the transformer wholesale).
- The bf16 base is fetched on demand (`ensure_krea_convrot_base_present`, sibling of `ensure_boogu_tier_present`) so q4/q8 users are not forced to download the 35 GB base.

Because ConvRot is not bits-based, it can't ride `mlxQuantize` — a distinct `advanced.convRot` signal maps to this LoadSpec construction, parallel to `resolve_quant`. Existing q4/q8/bf16 routing is untouched.

### Manifest + private download
Adds the `int8-convrot` download from the **PRIVATE** `SceneWorks/krea-2-turbo-int8-convrot` repo (`krea2_turbo_int8_convrot.safetensors`, 13.5 GB, authed HF token like every private SceneWorks tier). Also gives every krea tier a `variant` key (making Krea 2 a proper variant matrix so `/models` emits `variants[]`).

### UI + A/B doc
- `quantTier.js`: adds the `int8-convrot` tier (label + order + `isConvRotTier`/`isSelectableTier`), gated by `convRotEligible` so it's hidden on ineligible hosts (and never seeded as default / counted toward the picker threshold).
- `imageJobAdvanced.js`: emits `advanced.convRot: true` for the tier (never `mlxQuantize`).
- `ImageStudio.jsx`: derives `convRotEligible` from a live worker advertising `int8_convrot`.
- Honest A/B note in the catalog description: **bf16 ~8.8 s coherent · Q4-packed ~9.8 s / PSNR 22.7 dB · INT8-ConvRot PSNR 34.4 dB vs bf16** (sc-9601) — framed as the candle-only visibility feature.

### Tests
- Worker lib (251) + rust-api models + web (1174) all green.
- New coverage: compute-cap parse (highest-across-GPUs + junk tolerance), tier gating (`convRotEligible` hide/seed/threshold), and the `convRot` advanced emission.
- `cargo fmt --all --check` clean.
- The full `--features backend-candle` CUDA build was **not run locally** (manual-only CI lane; a concurrent CUDA gate held the toolchain). The non-candle build compiles clean with zero warnings, and the candle-only additions mirror existing compiling patterns (`ensure_boogu_tier_present`, the candle-capability pushes, the `spec.with_pid` field-set).

Story: sc-9300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
