### PR TITLE
chore(docs): clean up dangling scene_worker/*.py references (sc-9854)

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,3 @@ some non-commercial (e.g. FLUX.1 [dev], FLUX.2 [klein] 9B), some permissive
 (Apache-2.0 / OpenRAIL). You are responsible for complying with each model's
 license when you download and use it; the SceneWorks license here applies only
 to SceneWorks' own code, not to the weights it runs.
-
-Bundled third-party source under `apps/*/scene_worker/_vendor/` is covered by
-its own `LICENSE` files (Apache-2.0 / MIT), retained alongside that code.

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -3707,9 +3707,9 @@
       // macOS-only MLX backend. The MLX-SDXL generator is the Rust `mlx-gen-sdxl`
       // path, claimed by the in-process `mlx` GPU worker via the Rust API claim
       // layer (jobs_store::sdxl_mlx_eligible). sc-3060 RETIRED the old in-process
-      // vendored Apple `mlx-examples/stable_diffusion` (scene_worker/_vendor/mlx_sd/)
-      // adapter — the Python worker always routes the torch SdxlDiffusersAdapter now
-      // (every host, every shape); it never runs MLX-SDXL.
+      // vendored Apple `mlx-examples/stable_diffusion` MLX-SDXL adapter (it lived in
+      // the now-deleted Python worker, removed in epic 8283); MLX-SDXL now runs only
+      // through the Rust `mlx-gen-sdxl` path above.
       //
       // mlx.quantize/tier config below is consumed by the RUST worker
       // (standard_tier_subdir / resolve_quant), NOT the retired Apple adapter. The

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -856,9 +856,9 @@ mod tests {
     // ── sc-9513 (F-059 follow-up of sc-8861): character_image ⇄ engine-wiring honesty guards ─────────
     //
     // These three guards were extracted to `tests/test_builtin_manifest_audit.py` by sc-8861 but still
-    // cross-referenced the retired Python worker's `scene_worker.image_adapters.MODEL_TARGETS` engine
-    // table via a lazy `importorskip` — so once epic-8283 deletes `apps/worker` they degrade to a clean
-    // SKIP and their coverage is lost. They are reimplemented here against the Rust worker's own engine
+    // cross-referenced the (now-deleted) Python worker's `MODEL_TARGETS` engine table via a lazy
+    // `importorskip` — so once epic-8283 deleted `apps/worker` they would have degraded to a clean
+    // SKIP and lost their coverage. They are reimplemented here against the Rust worker's own engine
     // wiring, reading the SAME embedded `config/manifests/builtin.models.jsonc` the Python audit parsed,
     // so the character_image ⇄ engine-declaration invariants keep running Python-free (and on CI's ubuntu
     // lane, since they need neither a linked provider registry nor a macos/candle build).

--- a/docs/mac-rust-gaps.md
+++ b/docs/mac-rust-gaps.md
@@ -10,8 +10,9 @@ run it yet. When the list is empty, the Mac build can stop shipping a Python ven
 > inverse of the `*_mlx_eligible` predicates. The same routing constants are the source of
 > truth: `MLX_ROUTED_MODELS`, `VIDEO_MLX_ROUTED_MODELS`, `MLX_ROUTED_TRAINING_KERNELS`, and the
 > per-family `*_mlx_eligible` gates in `crates/sceneworks-core/src/jobs_store.rs`; the model
-> registry is `MODEL_TARGETS` (`apps/worker/scene_worker/image_adapters.py` /
-> `video_adapters.py`); training kernels are the builtin targets in
+> registry is the embedded `config/manifests/builtin.models.jsonc` (the Rust worker's engine
+> wiring in `crates/sceneworks-worker/src/engines.rs` restates the per-model defaults that the
+> retired Python `MODEL_TARGETS` once held); training kernels are the builtin targets in
 > `crates/sceneworks-core/src/training.rs`. **Keep this file in sync when a surface flips** —
 > when a model lands in a `*_ROUTED_*` set or an `*_mlx_eligible` gate opens, move its row to
 > *Done* and delete the gap. A row here that no longer matches the predicates is a bug.

--- a/documents/MULTI_MODEL_REFERENCE_CONDITIONING.md
+++ b/documents/MULTI_MODEL_REFERENCE_CONDITIONING.md
@@ -5,6 +5,17 @@
 > **What this is**: The model-agnostic contract that lets Character Studio render a recognizable subject from a single reference image across diverse backbone families — IP-Adapter (Kolors, SDXL, RealVisXL, FLUX), face-specialized identity (InstantID), and edit-as-reference (Qwen-Image-Edit / 2509). Distilled from the shipped code, not designed up-front.
 >
 > **Audience**: Engineers wiring a new reference-capable image backbone into SceneWorks.
+>
+> **Note (epic 8283 / sc-9854):** the `apps/worker/scene_worker/*.py` worker-engine layer this
+> doc originally described was **deleted** when the Python worker was retired (epic 8283 Python
+> eradication). The current reference-conditioning implementation lives in the Rust worker
+> (`crates/sceneworks-worker/src/engines.rs`) with the model/tuning surface declared in
+> `config/manifests/builtin.models.jsonc`. The manifest (§3), web payload (§4), Rust passthrough
+> (§5), and CI-enforcement (§6) sections still describe current wiring; the `scene_worker/*.py`
+> pointers in §2 and §7 (including the "Engine templates" links below) are retained as the
+> historical mechanism description — read them for the *contract shape*, not as current file paths.
+> New backbones are wired through the Rust engine seam (`engines.rs` + the manifest), not the
+> deleted Python adapters.
 
 ---
 
@@ -23,7 +34,12 @@ The contract has four layers: worker engine, manifest declarations, web payload 
 
 ---
 
-## 2. Worker engine layer — `apps/worker/scene_worker/image_adapters.py`
+## 2. Worker engine layer — `apps/worker/scene_worker/image_adapters.py` *(retired — see epic-8283 note above)*
+
+> *(Retired file path. `scene_worker/image_adapters.py` was deleted in epic 8283; the current
+> worker-engine layer is the Rust engine seam in `crates/sceneworks-worker/src/engines.rs`. The
+> code shapes below are kept as the historical description of the conditioning contract, not as
+> current source.)*
 
 ### 2.1 Per-model registry (`MODEL_TARGETS`)
 
@@ -228,11 +244,11 @@ Plus `scripts/check-scaffold.mjs::assertCharacterImageTuningSurface()` runs audi
 Concrete recipe based on the sc-2007 → sc-2011 → sc-2014 cadence. Step-by-step for an IP-Adapter-family backbone; analogous for face-identity or edit-as-reference. Plan on 6–8 files touched, ~250–400 lines of new code, no Rust changes unless the backbone introduces a new typed payload field.
 
 1. **Spike** (desktop-first per sc-2010 / sc-2013 pattern): pick the upstream adapter weights, confirm license posture, identify the diffusers API shape (`FluxIPAdapterMixin` vs `IPAdapterMixin` vs custom pipeline), estimate Mac MPS memory peak. Capture findings in a Shortcut story comment.
-2. **Worker engine** ([apps/worker/scene_worker/image_adapters.py](../apps/worker/scene_worker/image_adapters.py)): add the `MODEL_TARGETS` entry with an `ipAdapter` block (or `instantId` for face-ID); add `_use_ip_adapter` / `_use_reference` static gate, `_text_ip_adapter` cache flag, `_ip_adapter_scale` + (for guidance-distilled backbones) `_true_cfg_scale` helpers; modify `_load_pipeline` for encoder load + `pipe.load_ip_adapter`; modify `_run_pipeline` to pass `ip_adapter_image=` (or `image=` for edit-style). Mirror the SDXL adapter as the template — it's the cleanest reference.
+2. **Worker engine** *(retired — see epic-8283 note; current wiring is the Rust engine seam `crates/sceneworks-worker/src/engines.rs`, not the deleted `scene_worker/image_adapters.py`)*: the historical Python recipe was — add the `MODEL_TARGETS` entry with an `ipAdapter` block (or `instantId` for face-ID); add `_use_ip_adapter` / `_use_reference` static gate, `_text_ip_adapter` cache flag, `_ip_adapter_scale` + (for guidance-distilled backbones) `_true_cfg_scale` helpers; wire encoder load + `pipe.load_ip_adapter` into the pipeline load path; pass `ip_adapter_image=` (or `image=` for edit-style) into the run path; mirror the SDXL adapter as the template. Today the equivalent lives in the Rust worker's engine wiring (`engines.rs` `CHARACTER_IMAGE_ENGINE_WIRING`); wire the new backbone there instead.
 3. **Manifest** ([config/manifests/builtin.models.jsonc](../config/manifests/builtin.models.jsonc)): add the model entry with `character_image` in `capabilities` + `ui.recommendedFor`; add per-model `ui.*` tuning hints (`referenceStrengthDefault`, `variationStrength`, etc.) as the mechanism requires; declare license / gating posture.
 4. **Web constants** ([apps/web/src/constants.js](../apps/web/src/constants.js)): mirror the manifest entry (fallback for desktop-disconnected mode).
 5. **Prompt guide** (`apps/web/public/prompt-guides/<id>.md`): scene-flexible prompt shape, comparison vs other backbones, tunable defaults.
-6. **Tests** ([tests/test_worker_runtime.py](../tests/test_worker_runtime.py)): mirror the SDXL or FLUX test set — `_model_target_defaults`, `_use_ip_adapter` gate, `_ip_adapter_scale` default + clamp, `_run_pipeline` torch-free verification with a **named-param** `FakePipe` (var-keyword params fail `filter_call_kwargs`).
+6. **Tests** *(retired file — `tests/test_worker_runtime.py` was deleted with the Python worker in epic 8283; cover the Rust engine wiring in `crates/sceneworks-worker/src/engines.rs` tests instead)*: the historical Python test set mirrored the SDXL or FLUX set — `_model_target_defaults`, `_use_ip_adapter` gate, `_ip_adapter_scale` default + clamp, `_run_pipeline` torch-free verification with a **named-param** `FakePipe` (var-keyword params fail `filter_call_kwargs`).
 7. **Run the sc-2018 audits** — they catch drift between (1)–(4). The scaffold check covers the picker-symmetry half at build time.
 8. **PR** with the standard test plan checklist: CI passes, Mac MPS E2E owed (the engine code is correct without a real hardware run, but identity quality + memory budget can only be confirmed there).
 
@@ -255,6 +271,6 @@ Rust changes are only needed if the new payload field needs typed validation (e.
 ## References
 
 - [Epic 2003 — SceneWorks: Multi-Model Character Studio Reference & Identity Conditioning](https://app.shortcut.com/trefry/epic/2003)
-- Engine templates: [SdxlDiffusersAdapter](../apps/worker/scene_worker/image_adapters.py), [InstantIDAdapter](../apps/worker/scene_worker/instantid_adapter.py), [FluxDiffusersAdapter](../apps/worker/scene_worker/image_adapters.py), [QwenImageAdapter](../apps/worker/scene_worker/image_adapters.py)
+- Engine templates *(retired — the Python adapters `SdxlDiffusersAdapter` / `InstantIDAdapter` / `FluxDiffusersAdapter` / `QwenImageAdapter` in `scene_worker/*.py` were deleted in epic 8283; current engine wiring is `CHARACTER_IMAGE_ENGINE_WIRING` in [engines.rs](../crates/sceneworks-worker/src/engines.rs))*
 - Picker: [ImageStudio.jsx](../apps/web/src/screens/ImageStudio.jsx)
-- Audits: [tests/test_worker_runtime.py](../tests/test_worker_runtime.py) (search for "Multi-model Character Studio reference matrix")
+- Audits: engine-wiring guards now live in [engines.rs](../crates/sceneworks-worker/src/engines.rs) (sc-9513, epic 8283); the pure-manifest guard is in [tests/test_builtin_manifest_audit.py](../tests/test_builtin_manifest_audit.py). *(The former `tests/test_worker_runtime.py` was deleted with the Python worker.)*

--- a/documents/TRAINING_QUICKSTART.md
+++ b/documents/TRAINING_QUICKSTART.md
@@ -226,9 +226,10 @@ under-fit; use earlier checkpoints if a 3000-step balanced run starts overfittin
 > Manager before a real run. Another source is selectable via
 > `advanced.baseModelRepo`.
 >
-> Like the Lens inference path, training runs in the isolated **Lens sidecar venv**
-> (`/opt/lens-venv`: transformers 5.x + diffusers 0.38), not the main worker venv,
-> via `scene_worker/lens_train_runner.py`. The gpt-oss-20b text encoder + Flux.2
+> Lens LoRA training runs through the native Rust worker's `mlx-gen-lens` trainer
+> on macOS (routed via `MLX_ROUTED_TRAINING_KERNELS`, sc-5148/sc-5180); off-Mac it
+> uses the candle Lens trainer. (The retired Python `scene_worker/lens_train_runner.py`
+> sidecar was deleted in epic 8283.) The gpt-oss-20b text encoder + Flux.2
 > VAE encode the dataset once (latents + the 4 selected-layer text features are
 > cached), then the flow-matching loop trains a PEFT LoRA on the transformer's
 > **fused-QKV** projections (`img_qkv`/`txt_qkv`/`to_out`/`to_add_out` — Z-Image's
@@ -387,5 +388,10 @@ messages:
 | *"… required model files were not available."* (runtime) | Model files missing/incomplete | Re-install the base model; ensure the utility worker is running; set `HF_TOKEN` for gated repos. |
 | *"… disk ran out of space."* (runtime) | Volume filled mid-run | Free space and retry. |
 
-See `apps/worker/README.md` for the kernel's runtime dependencies and a local
-smoke check (`python -m scene_worker --check`).
+The training kernel now runs inside the native Rust worker
+(`apps/rust-worker/` + `crates/sceneworks-worker/`); the retired Python worker
+and its `python -m scene_worker --check` smoke were deleted in epic 8283. To
+sanity-check the worker locally, build it with
+`cargo build -p sceneworks-rust-worker` and confirm it claims jobs from the Rust
+API; see `crates/sceneworks-worker/ARCHITECTURE.md` for the capability matrix and
+runtime roles.


### PR DESCRIPTION
## Summary

Follow-up to F-155 / epic 8283 (Python eradication). The retired Python worker tree (`apps/worker/scene_worker/*.py`) was deleted, but a handful of living docs, one config comment, and one Rust doc-comment still cited now-deleted `scene_worker/*.py` paths as *current* references — dangling pointers to files that no longer exist. This is **pure doc/comment cleanup**: no behavior change, no functional config key/value changed, no code logic touched.

Ref: sc-9854.

## Full grep sweep

`git grep -i scene_worker` across the whole repo was the starting point. Contrary to the story's ~7-file list, most of the named Rust `src` files (`jobs_store/routing/mlx.rs`, `image_jobs/instantid.rs`, `person_replace.rs`, `video_jobs.rs`) had **already** been cleaned in prior work — they contain no `scene_worker` reference today. The genuinely-dangling references in **living** docs/config/code were fixed; **dated historical artifacts** were intentionally left intact (they are accurate point-in-time records).

### Files changed (6) — rewritten vs removed

| File | Action |
|---|---|
| `README.md` | **Removed** the "Bundled third-party source under `apps/*/scene_worker/_vendor/`" license paragraph — no `_vendor/` source exists in the repo anymore (verified: zero `_vendor` dirs). |
| `config/manifests/builtin.models.jsonc` | **Rewrote a comment only** (lines 3707–3712). The retired-adapter note pointed at the deleted `scene_worker/_vendor/mlx_sd/` path and made a now-false present-tense claim about the Python worker; it now says the vendored Apple MLX-SDXL adapter lived in the now-deleted Python worker (epic 8283) and MLX-SDXL runs through the Rust `mlx-gen-sdxl` path. **No functional key/value changed** — all six touched lines are `//` comments. |
| `crates/sceneworks-worker/src/engines.rs` | **Rewrote the sc-9513 guard-rationale comment** to past tense (the epic-8283 deletion already happened) and dropped the dangling `scene_worker.image_adapters.MODEL_TARGETS` dotted path. |
| `docs/mac-rust-gaps.md` | **Rewrote the source-of-truth pointer**: the model registry is now the embedded `config/manifests/builtin.models.jsonc` + the Rust engine wiring in `engines.rs`, not `scene_worker/{image,video}_adapters.py`. |
| `documents/TRAINING_QUICKSTART.md` | **Rewrote two stale references**: (1) Lens training now runs via the native `mlx-gen-lens` (macOS) / candle (off-Mac) trainer, not `scene_worker/lens_train_runner.py`; (2) replaced the deleted `python -m scene_worker --check` smoke instruction with native-worker `cargo build -p sceneworks-rust-worker` + ARCHITECTURE.md guidance. |
| `documents/MULTI_MODEL_REFERENCE_CONDITIONING.md` | **Added an epic-8283 "retired Python worker" banner** near the top (mirroring the `docs/sc-3031-parity.md` note style) and **annotated the three dangling as-if-current sites** so they no longer read as current guidance: §2 header + a retired-file note redirecting to `crates/sceneworks-worker/src/engines.rs`; §7 step 2 (worker-engine wiring) and step 6 (tests) redirected to the Rust engine seam; the References "Engine templates" + Audits links repointed from the deleted `scene_worker/*.py` / `tests/test_worker_runtime.py` to `engines.rs` / `tests/test_builtin_manifest_audit.py`. The manifest/web/Rust/CI sections (§3–§6) already described current wiring and were left intact. This closes the adversarial-review gap: it is a living, CI-enforced "Status: Shipped" contract doc, so its `scene_worker/*.py` pointers must not read as current. **No methodology-body rewrite** — the historical mechanism description is retained, just clearly marked historical. |

### Intentionally left as-is (historical / accurate point-in-time records)

- `CODE_REVIEW_2026-05-17.md`, `CODE_REVIEW_2026-05-17_VERIFICATION.md`, `CODE_REVIEW_2026-07-01.md` — dated review artifacts describing repo state at review time.
- `docs/sc-1338/`, `docs/sc-3031-parity.md`, `docs/sc-3489/`, `docs/sc-3494/`, `docs/sc-3668/`, `docs/sc-4422-kps-experiment/`, `docs/sc-5525/` — dated spike/parity records citing the then-current Python reference they ported from (`sc-3031-parity.md` already carries an epic-8283 "historical record" note).
- `scripts/spikes/*` (incl. the `sc3489_ort_upscale` / `sc3635_ort_sam2` crates — **not** workspace members, not compiled) — historical spike scripts noting what they mirrored.
- `tests/conftest.py`, `tests/test_builtin_manifest_audit.py`, `tests/test_rust_api_worker_smoke.py` — reference `scene_worker` in **past tense to document that the coupling was removed**; rewriting would be inaccurate.
- `documents/EPIC_NATIVE_LTX23_VIDEO_ADAPTER.md` — a frozen point-in-time epic spec; its `scene_worker` citation was accurate when authored. Left as historical.

## Verification

- `npm run rust:check` — **clean** (cargo fmt --check, clippy, 621 tests passed / 0 failed, plus `cargo build`). The passing set includes `engines.rs::parse_builtin_models` and the manifest-audit tests, which strip JSONC comments and `serde_json::from_str` the manifest — proving `builtin.models.jsonc` still parses after the comment-only edit.
- `cargo check -p sceneworks-worker --no-default-features -F backend-candle --all-targets` — **clean**.
- `cargo check -p sceneworks-worker --all-targets` — **clean** (re-run after the MULTI_MODEL_REFERENCE_CONDITIONING.md annotation; doc-only, unaffected).
- Web `controlModesParity.test.js` (which JSON5-parses the manifest) could not run in the isolated worktree (no `node_modules`), but the change is comment-only and the Rust manifest-parse tests are green, so the parsed model data is provably unchanged.

## Confirmation

No functional config or code changed — every edit is a comment, doc, or doc-ish text line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
