### PR TITLE
feat(web): collapse topbar accent picker into a single swatch with 2x3 dropdown

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { apiFetch, isAbortError } from "./api.js";
 import { pollJobToCompletion } from "./pollJob.js";
+import { AccentPicker } from "./components/AccentPicker.jsx";
 import { Icon } from "./components/Icons.jsx";
 import { Logo } from "./components/Logo.jsx";
 import { StatusDot } from "./components/StatusDot.jsx";
@@ -34,7 +35,7 @@ import { useAccessGate } from "./hooks/useAccessGate.js";
 import { useJobEvents } from "./hooks/useJobEvents.js";
 import { AppStaticContext, AppLiveContext } from "./context/AppContext.js";
 import { DEFAULT_MAC_CAPABILITIES } from "./macGating.js";
-import { ACCENTS, isAccentId } from "./accents.js";
+import { isAccentId } from "./accents.js";
 import {
   dropUpscaledVariants,
   findFoldedAssetById,
@@ -2100,20 +2101,7 @@ export function App() {
           <button className="icon-btn" title="Notifications" type="button">
             <Icon.Bell />
           </button>
-          <div className="accent-picker" role="group" aria-label="Accent color">
-            {ACCENTS.map((option) => (
-              <button
-                aria-label={option.name}
-                aria-pressed={accent === option.id}
-                className={accent === option.id ? "accent-swatch active" : "accent-swatch"}
-                key={option.id}
-                onClick={() => changeAccent(option.id)}
-                style={{ "--sw": option.swatch }}
-                title={option.name}
-                type="button"
-              />
-            ))}
-          </div>
+          <AccentPicker accent={accent} onChange={changeAccent} />
           <button
             className="icon-btn"
             onClick={() => changeTheme(theme === "light" ? "dark" : "light")}

--- a/apps/web/src/components/AccentPicker.jsx
+++ b/apps/web/src/components/AccentPicker.jsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useRef, useState } from "react";
+import { ACCENTS } from "../accents.js";
+
+// Topbar accent picker (sc-accent): collapses the old full swatch row down to a
+// single trigger showing the current accent. Clicking opens a 2x3 dropdown of the
+// remaining accents; picking one recolors the app and closes the menu. Mirrors the
+// CompactSelector outside-click + Escape close pattern.
+export function AccentPicker({ accent, onChange }) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef(null);
+  const selected = ACCENTS.find((option) => option.id === accent) ?? ACCENTS[0];
+  const others = ACCENTS.filter((option) => option.id !== selected.id);
+
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+    function onDocMouseDown(event) {
+      if (!containerRef.current?.contains(event.target)) {
+        setOpen(false);
+      }
+    }
+    function onDocKey(event) {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onDocMouseDown);
+    document.addEventListener("keydown", onDocKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocMouseDown);
+      document.removeEventListener("keydown", onDocKey);
+    };
+  }, [open]);
+
+  return (
+    <div className="accent-picker" ref={containerRef}>
+      <button
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-label={`Accent color: ${selected.name}`}
+        className="accent-swatch active"
+        onClick={() => setOpen((value) => !value)}
+        style={{ "--sw": selected.swatch }}
+        title={`Accent color: ${selected.name}`}
+        type="button"
+      />
+      {open ? (
+        <div className="accent-picker-menu" role="listbox" aria-label="Accent color">
+          {others.map((option) => (
+            <button
+              aria-label={option.name}
+              className="accent-swatch"
+              key={option.id}
+              onClick={() => {
+                onChange(option.id);
+                setOpen(false);
+              }}
+              role="option"
+              style={{ "--sw": option.swatch }}
+              title={option.name}
+              type="button"
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -907,12 +907,28 @@ button:focus-visible {
   color: var(--accent);
 }
 
-/* Accent picker — topbar swatch row */
+/* Accent picker — topbar trigger swatch + dropdown */
 .accent-picker {
+  position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
   padding: 0 4px;
+}
+
+/* 2x3 grid of the remaining accents, anchored under the trigger swatch. */
+.accent-picker-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 40;
+  display: grid;
+  grid-template-columns: repeat(3, auto);
+  gap: 8px;
+  padding: 8px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: var(--shadow-lg, 0 8px 24px rgba(0, 0, 0, 0.18));
 }
 
 .accent-swatch {


### PR DESCRIPTION
## Summary

The UI-theme accent picker previously rendered all seven accents in a row across the topbar, taking up noticeable horizontal space. This collapses it to a single trigger swatch showing the currently-selected accent. Clicking it opens a 2×3 dropdown of the remaining accents; selecting one recolors the app and closes the menu.

## Changes

- **New `apps/web/src/components/AccentPicker.jsx`** — trigger swatch + dropdown. Reuses the established `CompactSelector` outside-click + Escape close pattern. The seven accents map cleanly: 1 shown as the trigger, the other 6 in a 2×3 grid.
- **`apps/web/src/App.jsx`** — replaced the inline seven-swatch row with `<AccentPicker accent={accent} onChange={changeAccent} />`; dropped the now-unused `ACCENTS` import in favor of the component import.
- **`apps/web/src/styles.css`** — `.accent-picker` is now a relative-positioned trigger container; added `.accent-picker-menu` (`grid-template-columns: repeat(3, auto)` → 2 rows × 3 cols) using existing `--surface`/`--border`/`--shadow-lg` tokens. Existing `.accent-swatch` styles are reused unchanged for both the trigger and the menu swatches.

No changes to the accent data model or persistence — `changeAccent` still drives `data-accent` + localStorage/API persistence exactly as before.

## Testing

- Full web suite: **90/90 files, 1178/1178 tests pass**
- Production build: **succeeds**

🤖 Generated with [Claude Code](https://claude.com/claude-code)