### PR TITLE
test(worker): PiD real-weight smokes — InstantID (sc-8386) + Z-Image (sc-8033)

### DIFF
--- a/crates/sceneworks-worker/src/instantid_pid_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/instantid_pid_gpu_smoke.rs
@@ -1,0 +1,361 @@
+//! Local real-weight GPU smoke for the candle **InstantID + PiD super-resolving decode** (sc-8386,
+//! epic 7840). `#[ignore]`d — run by hand on the RTX PRO 6000. Drives the bespoke
+//! `candle_gen_instantid::InstantId` provider (the same one `image_jobs/instantid.rs` loads off-Mac)
+//! with the PiD decoder attached (`with_pid`), across **all three InstantID modes** the story names:
+//!
+//!   * **Identity** (`generate`) — the reference face's ArcFace embedding + its detected kps,
+//!   * **Angles** (`generate_angle`) — the same identity re-posed to a canonical view-angle kps pack,
+//!   * **Poses** (`generate_pose` + OpenPose CN) — the identity driven onto a COCO-18 body skeleton.
+//!
+//! Each mode ends in a single latent decode. With `use_pid = false` that latent decodes on the native
+//! SDXL VAE at the render size; with `use_pid = true` the same final latent routes through the `sdxl`
+//! PiD student (4× → 2K/4K). InstantID reuses the `sdxl` PiD student (it composes the SDXL VAE latent
+//! space), so this is the InstantID-lane cousin of `sdxl_edit_pid_gpu_smoke` — same `pid_sdxl`
+//! checkpoint + decode seam, different driver (identity conditioning + a likeness assertion).
+//!
+//! Asserts, per the sc-8386 acceptance:
+//!   1. the native Identity decode is render-sized + coherent (the byte-exact baseline),
+//!   2. every PiD decode (Identity / Angle / Pose) super-resolves the render size + stays coherent, and
+//!   3. **likeness survives PiD**: the ArcFace cosine between the reference face and each PiD output
+//!      clears a preservation floor (InstantID's identity envelope is ~0.82 @1024²; a conservative
+//!      floor keeps the smoke non-flaky while proving the identity clearly transferred).
+//!
+//! Setup (PowerShell; all six weight snapshots are in the HF cache — the RealVisXL base + InstantX
+//! IdentityNet + the converted `instantid-mlx` face/ip-adapter bundle + the NC `pid_sdxl` + gemma-2-2b-it;
+//! Pose mode additionally needs the OpenPose SDXL ControlNet. The reference face defaults to an InstantX
+//! example portrait already in the cache):
+//! ```text
+//! $H="D:\.cache\huggingface\hub"
+//! $env:INSTANTID_PID_BASE="$H\models--SG161222--RealVisXL_V5.0\snapshots\ac93e0dda1f6d448cae19bbfab8c5e720a5e48bc"
+//! $env:INSTANTID_PID_IDENTITYNET="$H\models--InstantX--InstantID\snapshots\57b32dfee076092ad2930c71fd6d439c2c3b1820\ControlNetModel"
+//! $env:INSTANTID_PID_FACEDIR="$H\models--SceneWorks--instantid-mlx\snapshots\bca0cacf8e5e04529bb2b326a521361b02be84fd"
+//! $env:INSTANTID_PID_CKPT="$H\models--SceneWorks--pid-sdxl\snapshots\70b494831561dc2c181f04a7f057260b8785419a\pid_sdxl_2kto4k.safetensors"
+//! $env:INSTANTID_PID_GEMMA="$H\models--SceneWorks--gemma-2-2b-it\snapshots\684c553b5b41a1c835989d89f62f585e6269a7de"
+//! # Pose mode (optional — omit to run Identity + Angle only):
+//! $env:INSTANTID_PID_OPENPOSE="$H\models--xinsir--controlnet-openpose-sdxl-1.0\snapshots\23f966cd5cfdd3f7729c903e243d87152162d2b7"
+//! # reference face: defaults to $INSTANTID_PID_IDENTITYNET's sibling examples/0.png; override with a portrait:
+//! # $env:INSTANTID_PID_FACE="$H\models--InstantX--InstantID\snapshots\57b32dfee076092ad2930c71fd6d439c2c3b1820\examples\0.png"
+//! $env:INSTANTID_PID_OUT="D:\sceneworks-pid-validate\instantid"
+//! # optional: INSTANTID_PID_SIZE=1024 (render side; PiD output is 4x), INSTANTID_PID_STEPS=30
+//! cargo test -p sceneworks-worker --features backend-candle --release instantid_pid_gpu_smoke -- --ignored --nocapture
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use candle_gen_instantid::{BodyPoint, InstantId, InstantIdPaths, InstantIdRequest};
+use gen_core::runtime::CancelFlag;
+use gen_core::{Image, PidWeights, WeightsSource};
+
+/// The InstantID identity-preservation floor. InstantID's target envelope is ArcFace-cosine ~0.82
+/// @1024²; a conservative 0.35 floor proves the reference identity clearly transferred (an unrelated
+/// face sits near 0) without making the smoke flaky on prompt/seed/pose variance.
+const LIKENESS_FLOOR: f64 = 0.35;
+
+fn env_path(key: &str) -> PathBuf {
+    PathBuf::from(
+        std::env::var(key)
+            .unwrap_or_else(|_| panic!("set ${key}"))
+            .trim(),
+    )
+}
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key)
+        .map(|v| v.trim().to_string())
+        .unwrap_or_else(|_| default.to_string())
+}
+
+/// Mean per-pixel std-dev — the cheap non-degenerate floor (an all-black / NaN decode collapses to ~0).
+fn image_std(img: &Image) -> f64 {
+    let n = img.pixels.len() as f64;
+    if n == 0.0 {
+        return 0.0;
+    }
+    let mean = img.pixels.iter().map(|&p| p as f64).sum::<f64>() / n;
+    let var = img
+        .pixels
+        .iter()
+        .map(|&p| (p as f64 - mean).powi(2))
+        .sum::<f64>()
+        / n;
+    var.sqrt()
+}
+
+/// ArcFace cosine similarity between two 512-d identity embeddings (both come off the same face stack,
+/// so this is the InstantID identity-preservation metric: 1.0 = same face, ~0 = unrelated).
+fn cosine(a: &[f32], b: &[f32]) -> f64 {
+    let dot: f64 = a.iter().zip(b).map(|(&x, &y)| x as f64 * y as f64).sum();
+    let na: f64 = a.iter().map(|&x| (x as f64).powi(2)).sum::<f64>().sqrt();
+    let nb: f64 = b.iter().map(|&x| (x as f64).powi(2)).sum::<f64>().sqrt();
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot / (na * nb)
+}
+
+fn load_png(path: &Path) -> Image {
+    let img = image::open(path)
+        .unwrap_or_else(|e| panic!("open reference {}: {e}", path.display()))
+        .to_rgb8();
+    let (width, height) = img.dimensions();
+    Image {
+        width,
+        height,
+        pixels: img.into_raw(),
+    }
+}
+
+fn save_png(img: &Image, path: &Path) {
+    image::RgbImage::from_raw(img.width, img.height, img.pixels.clone())
+        .expect("rgb buffer")
+        .save(path)
+        .unwrap_or_else(|e| panic!("save {}: {e}", path.display()));
+}
+
+fn base_request(w: u32, h: u32, use_pid: bool) -> InstantIdRequest {
+    InstantIdRequest {
+        prompt: env_or(
+            "INSTANTID_PID_PROMPT",
+            "a cinematic studio portrait, dramatic lighting, sharp focus, high detail",
+        ),
+        negative: "blurry, lowres, deformed, disfigured, watermark".to_owned(),
+        width: w,
+        height: h,
+        steps: env_or("INSTANTID_PID_STEPS", "30")
+            .parse()
+            .expect("INSTANTID_PID_STEPS"),
+        seed: 42,
+        use_pid,
+        cancel: CancelFlag::new(),
+        // Everything else (guidance 5.0, the InstantID IP/controlnet/openpose scales, no sampler /
+        // scheduler override) keeps the engine's vendored identity defaults.
+        ..Default::default()
+    }
+}
+
+/// Detect + embed the largest face in `img` through the loaded InstantID face stack; the ArcFace
+/// embedding is the identity vector the likeness assertion compares.
+fn face_embedding(model: &InstantId, img: &Image, what: &str) -> Vec<f32> {
+    model
+        .largest_face(img)
+        .unwrap_or_else(|e| panic!("no detectable face in {what}: {e}"))
+        .embedding
+}
+
+/// A canonical frontal standing COCO-18 skeleton, normalized `[0,1]` (x centered at 0.5, y down). The
+/// head box sits near the top so `generate_pose` places the reference face there; arms + legs give the
+/// OpenPose ControlNet a real body to condition on.
+fn standing_skeleton() -> Vec<BodyPoint> {
+    // COCO-18 order: 0 nose,1 neck,2 r-sho,3 r-elb,4 r-wri,5 l-sho,6 l-elb,7 l-wri,8 r-hip,9 r-knee,
+    // 10 r-ank,11 l-hip,12 l-knee,13 l-ank,14 r-eye,15 l-eye,16 r-ear,17 l-ear.
+    vec![
+        Some((0.50, 0.20)), // 0 nose
+        Some((0.50, 0.28)), // 1 neck
+        Some((0.42, 0.30)), // 2 r shoulder
+        Some((0.38, 0.45)), // 3 r elbow
+        Some((0.35, 0.58)), // 4 r wrist
+        Some((0.58, 0.30)), // 5 l shoulder
+        Some((0.62, 0.45)), // 6 l elbow
+        Some((0.65, 0.58)), // 7 l wrist
+        Some((0.45, 0.55)), // 8 r hip
+        Some((0.45, 0.72)), // 9 r knee
+        Some((0.45, 0.90)), // 10 r ankle
+        Some((0.55, 0.55)), // 11 l hip
+        Some((0.55, 0.72)), // 12 l knee
+        Some((0.55, 0.90)), // 13 l ankle
+        Some((0.47, 0.18)), // 14 r eye
+        Some((0.53, 0.18)), // 15 l eye
+        Some((0.44, 0.19)), // 16 r ear
+        Some((0.56, 0.19)), // 17 l ear
+    ]
+}
+
+/// Assert one PiD output: non-degenerate, super-resolved past the render side, and identity-preserving.
+fn assert_pid_output(
+    img: &Image,
+    ref_embedding: &[f32],
+    model: &InstantId,
+    side: u32,
+    label: &str,
+    out_dir: &Path,
+) {
+    let std = image_std(img);
+    let cos = cosine(
+        ref_embedding,
+        &face_embedding(model, img, &format!("{label} PiD output")),
+    );
+    save_png(img, &out_dir.join(format!("instantid_{label}_pid.png")));
+    println!(
+        "[smoke] {label} PiD {}x{} std {:.2} likeness {:.3}",
+        img.width, img.height, std, cos
+    );
+    assert!(std > 5.0, "{label} PiD render degenerate (std {std:.2})");
+    assert!(
+        img.width > side && img.height > side,
+        "{label} PiD decode must super-resolve past the render side {side} (got {}x{})",
+        img.width,
+        img.height
+    );
+    assert!(
+        cos > LIKENESS_FLOOR,
+        "{label} PiD likeness {cos:.3} below floor {LIKENESS_FLOOR} — the 4x PiD decode scrubbed the face"
+    );
+}
+
+#[test]
+#[ignore = "real-weight GPU smoke; needs RealVisXL + InstantX IdentityNet + instantid-mlx face/ip + NC pid_sdxl + gemma-2-2b-it (+ optional OpenPose CN) (cap=120)"]
+fn instantid_pid_gpu_smoke() {
+    let base = env_path("INSTANTID_PID_BASE");
+    assert!(
+        base.join("unet").is_dir(),
+        "INSTANTID_PID_BASE must be a diffusers SDXL/RealVisXL snapshot (unet/ missing): {}",
+        base.display()
+    );
+    let identitynet = env_path("INSTANTID_PID_IDENTITYNET");
+    let face_dir = env_path("INSTANTID_PID_FACEDIR");
+    let ip_adapter = face_dir.join("ip-adapter.safetensors");
+    assert!(
+        ip_adapter.is_file(),
+        "converted ip-adapter.safetensors missing from INSTANTID_PID_FACEDIR: {}",
+        ip_adapter.display()
+    );
+    let ckpt = env_path("INSTANTID_PID_CKPT");
+    let gemma = env_path("INSTANTID_PID_GEMMA");
+    // Pose mode is optional: attach OpenPose only when its snapshot is provided; otherwise the smoke
+    // runs Identity + Angle (both share the `generate_with` decode seam) and skips Pose.
+    let openpose = std::env::var("INSTANTID_PID_OPENPOSE")
+        .ok()
+        .map(|v| PathBuf::from(v.trim()))
+        .filter(|p| p.is_dir());
+    // Reference portrait: default to an InstantX example that ships in the same snapshot as IdentityNet
+    // (examples/0.png), overridable with any face photo.
+    let reference_path = PathBuf::from(env_or(
+        "INSTANTID_PID_FACE",
+        identitynet
+            .parent()
+            .map(|p| p.join("examples").join("0.png"))
+            .unwrap_or_else(|| PathBuf::from("0.png"))
+            .to_string_lossy()
+            .as_ref(),
+    ));
+    let out_dir = PathBuf::from(env_or("INSTANTID_PID_OUT", "instantid-pid-out"));
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+
+    let size: u32 = env_or("INSTANTID_PID_SIZE", "1024")
+        .parse()
+        .expect("INSTANTID_PID_SIZE");
+    let (w, h) = (size, size);
+
+    let reference = load_png(&reference_path);
+    println!(
+        "[smoke] reference {} ({}x{})",
+        reference_path.display(),
+        reference.width,
+        reference.height
+    );
+
+    println!("[smoke] loading InstantId from {} ...", base.display());
+    let model = InstantId::load(&InstantIdPaths {
+        sdxl_base: base.clone(),
+        identitynet: WeightsSource::Dir(identitynet.clone()),
+        ip_adapter: ip_adapter.clone(),
+        adapters: Vec::new(),
+    })
+    .expect("load candle InstantId");
+    // Attach OpenPose (pose mode) BEFORE the face stack — the engine's documented order. Harmless for
+    // Identity / Angle (only `generate_pose` uses it), so one model serves all three modes.
+    let model = match &openpose {
+        Some(dir) => {
+            println!("[smoke] attaching OpenPose CN from {} ...", dir.display());
+            model
+                .with_openpose(&WeightsSource::Dir(dir.clone()))
+                .expect("attach OpenPose ControlNet")
+        }
+        None => {
+            println!("[smoke] INSTANTID_PID_OPENPOSE unset/not-a-dir -> skipping Pose mode");
+            model
+        }
+    };
+    let mut model = model
+        .with_face(&face_dir)
+        .expect("attach SCRFD + ArcFace face stack")
+        .with_pid(&PidWeights {
+            checkpoint: WeightsSource::File(ckpt.clone()),
+            gemma: WeightsSource::Dir(gemma.clone()),
+        })
+        .expect("attach pid_sdxl decoder");
+
+    // Reference identity embedding — the target every output is scored against.
+    let ref_embedding = face_embedding(&model, &reference, "reference portrait");
+
+    // --- Identity: native VAE baseline (render-sized) then PiD (super-resolving) ---
+    println!("[smoke] Identity native-VAE {w}x{h} ...");
+    let native = model
+        .generate(&base_request(w, h, false), &reference, &mut |_| {})
+        .expect("instantid identity native generate");
+    let native_std = image_std(&native);
+    let native_cos = cosine(
+        &ref_embedding,
+        &face_embedding(&model, &native, "identity native output"),
+    );
+    save_png(&native, &out_dir.join("instantid_identity_native.png"));
+    println!(
+        "[smoke] Identity native {}x{} std {:.2} likeness {:.3}",
+        native.width, native.height, native_std, native_cos
+    );
+    assert_eq!(
+        (native.width, native.height),
+        (w, h),
+        "native VAE decode must be render-sized"
+    );
+    assert!(
+        native_std > 5.0,
+        "native identity render degenerate (std {native_std:.2})"
+    );
+    assert!(
+        native_cos > LIKENESS_FLOOR,
+        "native identity likeness {native_cos:.3} below floor {LIKENESS_FLOOR} — InstantID not conditioning on the reference"
+    );
+
+    println!("[smoke] Identity PiD {w}x{h} -> expect 4x ...");
+    let identity_pid = model
+        .generate(&base_request(w, h, true), &reference, &mut |_| {})
+        .expect("instantid identity PiD generate");
+    assert_pid_output(
+        &identity_pid,
+        &ref_embedding,
+        &model,
+        size,
+        "identity",
+        &out_dir,
+    );
+
+    // --- Angles: canonical view-angle kps pack, PiD decode ---
+    let angle = env_or("INSTANTID_PID_ANGLE", "front");
+    println!("[smoke] Angle {angle:?} PiD side {size} -> expect 4x ...");
+    let angle_pid = model
+        .generate_angle(&base_request(size, size, true), &reference, &angle, &mut |_| {})
+        .unwrap_or_else(|e| panic!("instantid angle {angle:?} PiD generate: {e}"));
+    assert_pid_output(&angle_pid, &ref_embedding, &model, size, "angle", &out_dir);
+
+    // --- Poses: COCO-18 body skeleton + OpenPose CN, PiD decode (only when OpenPose was attached) ---
+    if openpose.is_some() {
+        let skeleton = standing_skeleton();
+        println!("[smoke] Pose (standing skeleton) PiD side {size} -> expect 4x ...");
+        let pose_pid = model
+            .generate_pose(
+                &base_request(size, size, true),
+                &reference,
+                &skeleton,
+                &mut |_| {},
+            )
+            .expect("instantid pose PiD generate");
+        assert_pid_output(&pose_pid, &ref_embedding, &model, size, "pose", &out_dir);
+    }
+
+    println!(
+        "[smoke] DONE: InstantID PiD super-resolve {size}x{size} -> 4x across Identity/Angle{} — likeness preserved (native identity {:.3})",
+        if openpose.is_some() { "/Pose" } else { "" },
+        native_cos
+    );
+}

--- a/crates/sceneworks-worker/src/instantid_pid_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/instantid_pid_gpu_smoke.rs
@@ -334,7 +334,12 @@ fn instantid_pid_gpu_smoke() {
     let angle = env_or("INSTANTID_PID_ANGLE", "front");
     println!("[smoke] Angle {angle:?} PiD side {size} -> expect 4x ...");
     let angle_pid = model
-        .generate_angle(&base_request(size, size, true), &reference, &angle, &mut |_| {})
+        .generate_angle(
+            &base_request(size, size, true),
+            &reference,
+            &angle,
+            &mut |_| {},
+        )
         .unwrap_or_else(|e| panic!("instantid angle {angle:?} PiD generate: {e}"));
     assert_pid_output(&angle_pid, &ref_embedding, &model, size, "angle", &out_dir);
 

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -189,6 +189,18 @@ mod realvisxl_lightning_gpu_smoke;
 // dense diffusers snapshot — the worker-lane validation backing the off-Mac candle routing wire.
 #[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
 mod flux2_dev_gpu_smoke;
+// Real-weight GPU smoke for the candle InstantID + PiD super-resolving decode (epic 7840, sc-8386).
+// Test-only + candle-only; drives the bespoke `candle_gen_instantid::InstantId` provider across
+// Identity/Angle/Pose with the `pid_sdxl` student attached, asserting the PiD decode 4×-super-resolves
+// the native decode AND the ArcFace identity likeness survives. Validates the sc-8373 InstantID lane.
+#[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
+mod instantid_pid_gpu_smoke;
+// Real-weight GPU smoke for the candle Z-Image + PiD decode (epic 7840, sc-8033). Test-only +
+// candle-only; drives `gen_core::load("z_image_turbo", spec.with_pid(pid_flux, gemma))` — the generic
+// candle t2i lane (sc-9727) — proving Z-Image's flux-aliased latent decodes through the pid_flux
+// student at 4× (native 1024² -> 4096²). Z-Image has no dedicated pid_zimage; it reuses pid_flux.
+#[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
+mod zimage_pid_gpu_smoke;
 // Real-weight MLX smoke for the Krea 2 Turbo worker lane (epic 7565 sc-7575). Test-only + macOS-only;
 // drives `gen_core::load("krea_2_turbo")` with a Q8 LoadSpec against the packed `q8/` turnkey subdir —
 // the worker-lane validation (the crate links + drives the engine), not just the mlx-gen-krea crate.

--- a/crates/sceneworks-worker/src/zimage_pid_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/zimage_pid_gpu_smoke.rs
@@ -1,0 +1,167 @@
+//! Local real-weight GPU smoke for the candle **Z-Image + PiD super-resolving decode** (sc-8033,
+//! epic 7840). `#[ignore]`d — run by hand on the RTX PRO 6000. Proves the end-to-end claim sc-8033
+//! exists to close: `z_image_turbo` is engine-ready for PiD but had never actually been *run* through
+//! the decoder.
+//!
+//! The routing is already wired — `image_jobs/pid.rs` maps `z_image_turbo` / `z_image_edit` →
+//! backbone `"flux"` → the `SceneWorks/pid-flux` checkpoint (Z-Image is the **FLUX.1** VAE latent
+//! space; PiD's `zimage`/`zimage-turbo` tags alias the flux checkpoint — the 2026-06-24 epic scope
+//! correction, so there is NO dedicated `pid_zimage`), and the manifest gives both Z-Image models
+//! `ui.pid.checkpointId = "pid_flux"`. This smoke drives the exact generic candle t2i seam
+//! `generate_candle_stream` uses (sc-9727): `gen_core::load("z_image_turbo", spec.with_pid(pid_flux,
+//! gemma))` + `GenerationRequest.use_pid`, decoding the SAME Z-Image latent through the native VAE
+//! (render size) then the `pid_flux` student (4× → 2K/4K).
+//!
+//! Setup (PowerShell; the upstream Z-Image-Turbo diffusers snapshot + the NC `pid-flux` checkpoint +
+//! gemma-2-2b-it are all in the HF cache):
+//! ```text
+//! $H="D:\.cache\huggingface\hub"
+//! $env:ZIMAGE_PID_BASE="$H\models--Tongyi-MAI--Z-Image-Turbo\snapshots\f332072aa78be7aecdf3ee76d5c247082da564a6"
+//! $env:ZIMAGE_PID_CKPT="$H\models--SceneWorks--pid-flux\snapshots\<rev>\pid_flux_2kto4k.safetensors"
+//! $env:ZIMAGE_PID_GEMMA="$H\models--SceneWorks--gemma-2-2b-it\snapshots\684c553b5b41a1c835989d89f62f585e6269a7de"
+//! $env:ZIMAGE_PID_OUT="D:\sceneworks-pid-validate\zimage"
+//! # optional: ZIMAGE_PID_STEPS=8 ZIMAGE_PID_SIZE=1024 (render side; PiD output is 4x) ZIMAGE_PID_PROMPT="..."
+//! cargo test -p sceneworks-worker --features backend-candle --release zimage_pid_gpu_smoke -- --ignored --nocapture
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use gen_core::{GenerationOutput, GenerationRequest, Image, LoadSpec, WeightsSource};
+
+fn env_path(key: &str) -> PathBuf {
+    PathBuf::from(
+        std::env::var(key)
+            .unwrap_or_else(|_| panic!("set ${key}"))
+            .trim(),
+    )
+}
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key)
+        .map(|v| v.trim().to_string())
+        .unwrap_or_else(|_| default.to_string())
+}
+
+/// Mean per-pixel std-dev — the cheap non-degenerate floor (an all-black / NaN decode collapses to ~0).
+fn image_std(img: &Image) -> f64 {
+    let n = img.pixels.len() as f64;
+    if n == 0.0 {
+        return 0.0;
+    }
+    let mean = img.pixels.iter().map(|&p| p as f64).sum::<f64>() / n;
+    let var = img
+        .pixels
+        .iter()
+        .map(|&p| (p as f64 - mean).powi(2))
+        .sum::<f64>()
+        / n;
+    var.sqrt()
+}
+
+fn save_png(img: &Image, path: &Path) {
+    image::RgbImage::from_raw(img.width, img.height, img.pixels.clone())
+        .expect("rgb buffer")
+        .save(path)
+        .unwrap_or_else(|e| panic!("save {}: {e}", path.display()));
+}
+
+fn render(spec: &LoadSpec, w: u32, h: u32, steps: u32, use_pid: bool) -> Image {
+    let generator = gen_core::load("z_image_turbo", spec).expect("load candle z_image_turbo provider");
+    let req = GenerationRequest {
+        prompt: env_or(
+            "ZIMAGE_PID_PROMPT",
+            "a serene mountain lake at golden hour, crisp reflections, highly detailed",
+        ),
+        width: w,
+        height: h,
+        count: 1,
+        seed: Some(42),
+        steps: Some(steps),
+        use_pid,
+        ..Default::default()
+    };
+    let output = generator
+        .generate(&req, &mut |_| {})
+        .unwrap_or_else(|e| panic!("z_image_turbo generate (use_pid={use_pid}): {e}"));
+    match output {
+        GenerationOutput::Images(mut images) => images.pop().expect("engine returned no image"),
+        other => panic!("expected Images output, got {other:?}"),
+    }
+}
+
+#[test]
+#[ignore = "real-weight GPU smoke; needs the Z-Image-Turbo diffusers snapshot + NC pid-flux + gemma-2-2b-it (cap=120)"]
+fn zimage_pid_gpu_smoke() {
+    let base = env_path("ZIMAGE_PID_BASE");
+    assert!(
+        base.join("transformer").is_dir(),
+        "ZIMAGE_PID_BASE must be a Tongyi-MAI/Z-Image-Turbo diffusers snapshot (transformer/ missing): {}",
+        base.display()
+    );
+    let ckpt = env_path("ZIMAGE_PID_CKPT");
+    let gemma = env_path("ZIMAGE_PID_GEMMA");
+    let out_dir = PathBuf::from(env_or("ZIMAGE_PID_OUT", "zimage-pid-out"));
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+
+    let size: u32 = env_or("ZIMAGE_PID_SIZE", "1024")
+        .parse()
+        .expect("ZIMAGE_PID_SIZE");
+    let (w, h) = (size, size);
+    let steps: u32 = env_or("ZIMAGE_PID_STEPS", "8").parse().expect("ZIMAGE_PID_STEPS");
+
+    // Native VAE decode (render-sized) — the byte-exact default path, spec WITHOUT pid.
+    println!("[smoke] Z-Image native-VAE {w}x{h} @ {steps} steps ...");
+    let native_spec = LoadSpec::new(WeightsSource::Dir(base.clone()));
+    let native = render(&native_spec, w, h, steps, false);
+    let native_std = image_std(&native);
+    save_png(&native, &out_dir.join("zimage_native.png"));
+    println!(
+        "[smoke] Z-Image native {}x{} std {:.2}",
+        native.width, native.height, native_std
+    );
+    assert_eq!(
+        (native.width, native.height),
+        (w, h),
+        "native VAE decode must be render-sized"
+    );
+
+    // PiD decode (super-resolving) — the SAME Z-Image latent decoded through the flux-aliased `pid_flux`
+    // student at 4×. `spec.with_pid` + `use_pid` is exactly the generic candle lane (sc-9727) for a
+    // usePid Z-Image request.
+    println!("[smoke] Z-Image PiD {w}x{h} -> expect 4x ...");
+    let pid_spec = LoadSpec::new(WeightsSource::Dir(base.clone())).with_pid(
+        WeightsSource::File(ckpt.clone()),
+        WeightsSource::Dir(gemma.clone()),
+    );
+    let pid = render(&pid_spec, w, h, steps, true);
+    let pid_std = image_std(&pid);
+    save_png(&pid, &out_dir.join("zimage_pid.png"));
+    println!(
+        "[smoke] Z-Image PiD {}x{} std {:.2} -> {}",
+        pid.width,
+        pid.height,
+        pid_std,
+        out_dir.join("zimage_pid.png").display()
+    );
+
+    assert!(
+        native_std > 5.0,
+        "native Z-Image render degenerate (std {native_std:.2})"
+    );
+    assert!(
+        pid_std > 5.0,
+        "PiD Z-Image render degenerate (std {pid_std:.2}) — check pid-flux + gemma snapshots + cap=120"
+    );
+    assert!(
+        pid.width > native.width && pid.height > native.height,
+        "PiD decode must super-resolve past the native size (native {}x{}, pid {}x{})",
+        native.width,
+        native.height,
+        pid.width,
+        pid.height
+    );
+    println!(
+        "[smoke] DONE: Z-Image (flux latent) PiD super-resolve {}x{} -> {}x{} via pid_flux — coherent",
+        native.width, native.height, pid.width, pid.height
+    );
+}

--- a/crates/sceneworks-worker/src/zimage_pid_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/zimage_pid_gpu_smoke.rs
@@ -66,7 +66,8 @@ fn save_png(img: &Image, path: &Path) {
 }
 
 fn render(spec: &LoadSpec, w: u32, h: u32, steps: u32, use_pid: bool) -> Image {
-    let generator = gen_core::load("z_image_turbo", spec).expect("load candle z_image_turbo provider");
+    let generator =
+        gen_core::load("z_image_turbo", spec).expect("load candle z_image_turbo provider");
     let req = GenerationRequest {
         prompt: env_or(
             "ZIMAGE_PID_PROMPT",
@@ -107,7 +108,9 @@ fn zimage_pid_gpu_smoke() {
         .parse()
         .expect("ZIMAGE_PID_SIZE");
     let (w, h) = (size, size);
-    let steps: u32 = env_or("ZIMAGE_PID_STEPS", "8").parse().expect("ZIMAGE_PID_STEPS");
+    let steps: u32 = env_or("ZIMAGE_PID_STEPS", "8")
+        .parse()
+        .expect("ZIMAGE_PID_STEPS");
 
     // Native VAE decode (render-sized) — the byte-exact default path, spec WITHOUT pid.
     println!("[smoke] Z-Image native-VAE {w}x{h} @ {steps} steps ...");


### PR DESCRIPTION
Two `#[ignore]`d candle GPU smokes validating the already-merged **epic [7840](https://app.shortcut.com/trefry/epic/7840)** PiD lanes end-to-end. Both depend only on content already in `main` (sc-8373 InstantID + sc-9727 generic candle t2i, candle-gen pin `9362745`) — **no pin bump, test-only, off-Mac candle-only**.

## sc-8386 — InstantID + PiD ([story](https://app.shortcut.com/trefry/story/8386))
`instantid_pid_gpu_smoke` drives the bespoke `candle_gen_instantid::InstantId` provider across **Identity / Angle / Pose** with the `pid_sdxl` student (`with_pid`). Asserts each PiD decode 4×-super-resolves (1024² → 4096²) and the ArcFace identity likeness survives.

RTX PRO 6000, cap=120:
| mode | decode | size | ArcFace likeness |
|---|---|---|---|
| Identity | native VAE | 1024² | 0.485 |
| Identity | PiD | 4096² | 0.491 |
| Angle "front" | PiD | 4096² | 0.833 (in InstantID's ~0.82 envelope) |
| Pose standing | PiD | 4096² | 0.506 |

## sc-8033 — Z-Image + PiD ([story](https://app.shortcut.com/trefry/story/8033))
`zimage_pid_gpu_smoke` drives `gen_core::load("z_image_turbo", spec.with_pid(pid_flux, gemma))` — the generic candle lane (sc-9727). Proves Z-Image's **flux-aliased** latent (there is no dedicated `pid_zimage`; `zimage` tags alias the flux checkpoint) decodes through `pid_flux` at 4×.

cap=120: native VAE 1024² (std 66.63) → PiD 4096² (4× SR, std 65.51), coherent.

## Why a fresh branch
The original commits were pushed onto the already-squash-merged PR #1150 branch (which merged only sc-9727's `base.rs`) and were orphaned — not in `main`, not in any open PR. Re-landed here off `main`.

## Validation
Worker `--features backend-candle` compiles clean against main's pin `9362745`. Both smokes are `#[ignore]`d (real-weight, run by hand); the code they exercise (sc-8373 InstantID engine, sc-9727 generic z-image lane) is unchanged since the numbers above were captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
