### PR TITLE
fix(web): route useAssetBatch through the split AppContext providers (sc-9751)

### DIFF
--- a/apps/web/src/assetBatch.jsx
+++ b/apps/web/src/assetBatch.jsx
@@ -1,10 +1,10 @@
-import React, { useContext, useState } from "react";
+import React, { useState } from "react";
 import { apiFetch } from "./api.js";
 import { batchEligibleAssets, batchItemStatus, buildBatchJob, summarizeBatchProgress } from "./batchOps.js";
 import { assetSupportsCharacterLink } from "./components/assetPanels.jsx";
 import { assetUrl } from "./components/assetMedia.jsx";
 import { BatchOperationsPanel } from "./components/BatchOperationsPanel.jsx";
-import { AppContext } from "./context/AppContext.js";
+import { useAppContextOptional } from "./context/AppContext.js";
 import { detailCapableModels, editCapableModels, UPSCALE_ENGINES } from "./imageJobs.js";
 import { DEFAULT_MAC_CAPABILITIES, macUpscaleEngineBlocked } from "./macGating.js";
 
@@ -20,7 +20,11 @@ export const LIBRARY_MOVE_TARGET = "__sceneworks_library__";
 // and render <AssetSelectionBar batch={…}/> + <AssetBatchModal batch={…}/>.
 export function useAssetBatch() {
   // Read the app context optionally: the toolbar should stay inert (not crash) when a host
-  // component is rendered in isolation without an <AppContext.Provider> (e.g. unit tests).
+  // component is rendered in isolation without any provider (e.g. unit tests). The app
+  // renders the split AppStaticContext/AppLiveContext providers (not the legacy combined
+  // <AppContext.Provider>), so we read the merged view across both — useContext(AppContext)
+  // alone would resolve to null in the real app and blank the toolbar. `jobs` is a live
+  // field, so this still (correctly) re-renders the toolbar on job ticks.
   const {
     activeProject,
     assets = [],
@@ -33,7 +37,7 @@ export function useAssetBatch() {
     token = "",
     requestedGpu = "auto",
     macCapabilities = DEFAULT_MAC_CAPABILITIES,
-  } = useContext(AppContext) ?? {};
+  } = useAppContextOptional() ?? {};
 
   const [selectedAssetIds, setSelectedAssetIds] = useState(() => new Set());
   const [batchOpen, setBatchOpen] = useState(false);

--- a/apps/web/src/assetBatch.split.test.jsx
+++ b/apps/web/src/assetBatch.split.test.jsx
@@ -1,0 +1,94 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAssetBatch } from "./assetBatch.jsx";
+import { AppStaticContext, AppLiveContext, AppContext } from "./context/AppContext.js";
+
+// sc-9751 (F-052 follow-up): the App renders the split AppStaticContext + AppLiveContext
+// providers, NOT the legacy combined <AppContext.Provider>. useAssetBatch previously read
+// useContext(AppContext) directly, which resolves to null under the split tree and blanked
+// the batch toolbar (empty assets/characters, no delete/move actions) in the real app —
+// while unit tests that render a single <AppContext.Provider> kept passing. These tests
+// pin the fix: the hook reads the merged view across BOTH split providers, and still
+// degrades to inert defaults when rendered with no provider at all.
+
+const assets = [
+  { id: "a1", kind: "image", file: { path: "a1.png" } },
+  { id: "a2", kind: "image", file: { path: "a2.png" } },
+];
+const characters = [
+  { id: "c1", name: "Ada", archived: false },
+  { id: "c2", name: "Grace", archived: true },
+];
+
+// Probe: run the hook, select an asset, and surface the values a real toolbar would show.
+function AssetBatchProbe({ onReady }) {
+  const batch = useAssetBatch();
+  React.useEffect(() => {
+    batch.toggleSelect("a1");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  onReady(batch);
+  return null;
+}
+
+function render(ui) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+  return {
+    cleanup() {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+describe("useAssetBatch under the split context providers (sc-9751)", () => {
+  let harness;
+
+  afterEach(() => {
+    harness?.cleanup();
+    harness = null;
+  });
+
+  it("reads assets/characters through the split AppStatic + AppLive providers", () => {
+    let latest;
+    const staticValue = { assets, characters, imageModels: [] };
+    const liveValue = { jobs: [] };
+    harness = render(
+      <AppStaticContext.Provider value={staticValue}>
+        <AppLiveContext.Provider value={liveValue}>
+          <AssetBatchProbe onReady={(b) => { latest = b; }} />
+        </AppLiveContext.Provider>
+      </AppStaticContext.Provider>,
+    );
+    // Selecting a1 must surface the matching asset — proving the hook read `assets` from
+    // the split static context rather than falling back to the empty [] default.
+    expect(latest.selectedAssetList.map((a) => a.id)).toEqual(["a1"]);
+    // Only the non-archived character is a valid move target — proving `characters` was read.
+    expect(latest.availableCharacters.map((c) => c.id)).toEqual(["c1"]);
+  });
+
+  it("still degrades to inert defaults when rendered with no provider", () => {
+    let latest;
+    harness = render(<AssetBatchProbe onReady={(b) => { latest = b; }} />);
+    // No provider at all: the toolbar stays inert (no crash), empty selection/derived lists.
+    expect(latest.selectedAssetList).toEqual([]);
+    expect(latest.availableCharacters).toEqual([]);
+  });
+
+  it("remains backward-compatible with a lone legacy <AppContext.Provider> (tests)", () => {
+    let latest;
+    harness = render(
+      <AppContext.Provider value={{ assets, characters, imageModels: [], jobs: [] }}>
+        <AssetBatchProbe onReady={(b) => { latest = b; }} />
+      </AppContext.Provider>,
+    );
+    expect(latest.selectedAssetList.map((a) => a.id)).toEqual(["a1"]);
+    expect(latest.availableCharacters.map((c) => c.id)).toEqual(["c1"]);
+  });
+});

--- a/apps/web/src/context/AppContext.js
+++ b/apps/web/src/context/AppContext.js
@@ -64,6 +64,26 @@ export function useAppLive() {
   return value;
 }
 
+// Non-throwing merge of the three contexts into the flat combined shape. Returns null
+// when NONE of the providers is present (rather than throwing), so a consumer that must
+// degrade gracefully when rendered in isolation (e.g. useAssetBatch's toolbar, which
+// falls back to inert defaults in unit tests) can share the exact merge logic the
+// throwing useAppContext() facade uses. Subscribes to both split contexts, so a caller
+// that reads live fields still re-renders on job/worker ticks — behavior-preserving.
+export function useAppContextOptional() {
+  const staticValue = useContext(AppStaticContext);
+  const liveValue = useContext(AppLiveContext);
+  const combined = useContext(AppContext);
+  return useMemo(() => {
+    // Only the legacy single <AppContext.Provider> present (tests): return it directly so
+    // its identity is preserved and no field is dropped.
+    if (staticValue === null && liveValue === null) {
+      return combined;
+    }
+    return { ...(combined ?? {}), ...(staticValue ?? {}), ...(liveValue ?? {}) };
+  }, [staticValue, liveValue, combined]);
+}
+
 // Backward-compatible combined hook: merges the two split contexts into the flat shape
 // the monolithic context used to expose. Consumers that read live fields (or a mix of
 // live + static) keep using this and lose no field. Consumers that read only static
@@ -76,15 +96,7 @@ export function useAppLive() {
 // When only the legacy combined <AppContext.Provider> is present (tests), both split
 // contexts are null and we return the combined value directly.
 export function useAppContext() {
-  const staticValue = useContext(AppStaticContext);
-  const liveValue = useContext(AppLiveContext);
-  const combined = useContext(AppContext);
-  const merged = useMemo(() => {
-    if (staticValue === null && liveValue === null) {
-      return combined;
-    }
-    return { ...(combined ?? {}), ...(staticValue ?? {}), ...(liveValue ?? {}) };
-  }, [staticValue, liveValue, combined]);
+  const merged = useAppContextOptional();
   if (merged === null || merged === undefined) {
     throw new Error("useAppContext must be used within the App context providers");
   }


### PR DESCRIPTION
## [F-052 follow-up / sc-9751] Complete the high-churn / low-churn AppContext consumer migration

### Background — the split already exists
The monolithic `AppContext` re-rendered **every** consumer on every SSE tick because `jobs`/`workersById` change identity continuously. That was fixed in **sc-8855 (F-053, PR #1108, merged)**, which split the context into:

- **`AppLiveContext`** — the 9 high-churn fields derived from the SSE jobs/workers state (`jobs`, `filteredJobs`, `imageLocalJobs`, `videoLocalJobs`, `documentLocalJobs`, `visibleWorkers`, `workersById`, `personReadiness`, `gpuOptions`).
- **`AppStaticContext`** — everything else (actions/catalogs/project/presets/characters/training/timelines/models). Its `useMemo` dependency array **excludes** every churning field, so its identity survives a job/worker tick — static-only consumers stop re-rendering on ticks.

App.jsx renders both split providers with two separately-memoized values; hooks are `useAppStatic()` (static-only), `useAppLive()` (live-only), and a back-compat `useAppContext()` that merges both with zero field loss. Consumer routing from sc-8855: 8 static-only → `useAppStatic()`, 1 live-only → `useAppLive()`, the mixed screens → `useAppContext()`.

### The gap this PR closes
Auditing **every** context consumer for sc-9751 surfaced **one that was missed**: `useAssetBatch()` (in `assetBatch.jsx`, used by LibraryScreen + Character Assets) still read `useContext(AppContext) ?? {}` directly.

The app renders **only** the two split providers — never the legacy combined `<AppContext.Provider>`, which now exists **solely for tests**. So in the real app that read resolved to `null → {}`, blanking the batch toolbar: empty `assets`/`characters`, and `deleteAsset`/`addCharacterReference`/`moveAssetToLibrary` all `undefined` (no delete/move/upscale/detail actions). Unit tests kept passing because they render a single `<AppContext.Provider>`, so the regression was invisible to CI.

### The fix — minimal, behavior-preserving
- Extracted the non-throwing merge already living inside `useAppContext()` into a shared **`useAppContextOptional()`** that returns `null` (instead of throwing) when no provider is present.
- `useAssetBatch()` now reads `useAppContextOptional() ?? {}`. It subscribes to **both** split contexts, so:
  - it reads the real merged `assets`/`characters`/`imageModels`/actions under the split provider tree (bug fixed), and
  - because it reads the live `jobs` field, it still (correctly) re-renders the toolbar on job ticks — **no behavior change**, and
  - it still degrades to inert defaults (`{}`) when rendered with no provider at all.
- `useAppContext()` now delegates to the same `useAppContextOptional()` helper → identical behavior, single source of merge logic, no field loss.

### How consumer values are preserved
`useAppContextOptional()` spreads `{ ...combined, ...static, ...live }` exactly as `useAppContext()` did — every field a consumer destructured is still present, from whichever provider supplies it. When only the legacy single provider is present (tests), it returns that value directly, preserving its identity.

### Memoization / re-render reduction
The re-render split is achieved by App.jsx's two separately-memoized provider values (from sc-8855): the static value's dep array omits all 9 churning keys, so its identity survives a job/worker tick and `useAppStatic()`-only consumers skip the re-render. This PR does not change that; it ensures the one remaining mixed consumer reads through the split tree correctly.

### Behavior-preservation evidence
- New `assetBatch.split.test.jsx` (3 tests):
  1. `useAssetBatch` reads `assets`/`characters` through the **real** `AppStaticContext` + `AppLiveContext` split tree (selecting an asset surfaces it; only non-archived characters are move targets). **This test fails against the old legacy-only read** (verified: empty `selectedAssetList`) and passes with the fix.
  2. Still degrades to inert defaults with **no** provider.
  3. Still backward-compatible with a lone legacy `<AppContext.Provider>`.
- Existing sc-8855 churn-split test in `App.shell.test.jsx` (renders real `<App/>`, fires a `job.updated` tick, asserts static value identity unchanged while live value changes) continues to pass — the low-churn consumer does not re-render on a high-churn tick.

### Validation
- **Full web vitest suite:** 1188/1188 passing across 92 files (+3 new). No pre-existing flakes observed.
- **eslint:** 0 errors (touched files clean; 46 pre-existing warnings unchanged).
- **vite build:** clean.

### Scope
Confined to the context-consumer migration (the one missed consumer) + one focused test. No App-hooks (sc-9750) or ImageEditor (sc-9752) re-refactoring beyond their existing context reads, which were already correct.

Refs sc-9751 (relates to sc-8854 / F-052; builds on sc-8855 / F-053).

🤖 Generated with [Claude Code](https://claude.com/claude-code)