### PR TITLE
feat(worker): wire PiD into the candle bespoke advanced sub-mode streams (sc-8044)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/flux2_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_control_candle.rs
@@ -212,6 +212,11 @@ struct Flux2StrictControl {
     steps: u32,
     guidance: f32,
     control_scale: f32,
+    /// Per-generation PiD decoder weights (epic 7840, sc-8044): `Some` only when this generation opted in
+    /// (`advanced.usePid`) AND the `flux2` PiD + Gemma snapshots are cached. Threaded into `with_pid` at
+    /// load; `use_pid` on the request is `is_some()` so the two stay in lockstep (the engine rejects a
+    /// mismatch). `None` ⇒ native FLUX.2 VAE decode.
+    pid: Option<gen_core::PidWeights>,
 }
 
 impl CandleStrictControl for Flux2StrictControl {
@@ -234,9 +239,16 @@ impl CandleStrictControl for Flux2StrictControl {
             root: self.base.clone(),
             control: self.control.clone(),
         };
-        Flux2Control::load(&paths, self.quant).map_err(|error| {
+        let model = Flux2Control::load(&paths, self.quant).map_err(|error| {
             WorkerError::Engine(format!("FLUX.2-dev strict-pose control load failed: {error}"))
-        })
+        })?;
+        // Attach the optional PiD decoder (sc-8044): `Some` only when opted in AND the snapshots are cached.
+        match &self.pid {
+            Some(pid) => model.with_pid(pid).map_err(|error| {
+                WorkerError::Engine(format!("FLUX.2 control PiD decoder load failed: {error}"))
+            }),
+            None => Ok(model),
+        }
     }
 
     fn generate_one(
@@ -255,9 +267,8 @@ impl CandleStrictControl for Flux2StrictControl {
             guidance: self.guidance,
             control_scale: self.control_scale,
             seed,
-            // No PiD backbone on this lane (native VAE decode) — behavior-preserving across the
-            // candle-gen PiD seam bump (sc-8373 / sc-9300); matches candle-gen Default.
-            use_pid: false,
+            // PiD opt-in (sc-8044): in lockstep with the `with_pid` load — `is_some()` ⇒ decoder loaded.
+            use_pid: self.pid.is_some(),
             cancel: cancel.clone(),
         };
         model.generate(&req, control, on_progress).map_err(|error| {
@@ -309,7 +320,10 @@ async fn generate_candle_flux2_control_stream(
         .to_owned();
 
     let pose_count = pose_entries(request).len();
-    let raw_settings = flux2_control_candle_raw_settings(
+    // Per-generation PiD decode (epic 7840, sc-8044): resolve the `flux2` PiD student + Gemma when
+    // `advanced.usePid` is set and the snapshots are cached; else `None` → native FLUX.2 VAE.
+    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
+    let mut raw_settings = flux2_control_candle_raw_settings(
         request,
         &repo,
         steps,
@@ -318,6 +332,8 @@ async fn generate_candle_flux2_control_stream(
         control_scale,
         pose_count,
     );
+    // Mark PiD output on the sidecar (NSCLv1 NC flows to PiD output); record whether PiD actually ran.
+    raw_settings.insert("usePid".to_owned(), Value::Bool(pid_weights.is_some()));
 
     let provider = Flux2StrictControl {
         base,
@@ -329,6 +345,7 @@ async fn generate_candle_flux2_control_stream(
         steps,
         guidance,
         control_scale,
+        pid: pid_weights,
     };
 
     run_candle_strict_control(

--- a/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
@@ -266,8 +266,15 @@ async fn generate_candle_flux2_edit_stream(
         },
     );
     let repo = flux2_edit_candle_repo(request);
-    let raw_settings =
+    // Per-generation PiD decode (epic 7840, sc-8044): resolve the `flux2` PiD student + Gemma when
+    // `advanced.usePid` is set and the snapshots are cached; else `None` → native FLUX.2 VAE. `use_pid`
+    // and the engine's `with_pid` load stay in lockstep (the engine rejects a mismatch).
+    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
+    let use_pid = pid_weights.is_some();
+    let mut raw_settings =
         flux2_edit_candle_raw_settings(request, &repo, steps, guidance, quant_bits, references.len());
+    // Mark PiD output on the sidecar (NSCLv1 NC flows to PiD output); record whether PiD actually ran.
+    raw_settings.insert("usePid".to_owned(), Value::Bool(use_pid));
 
     // Per-image work items: (seed, prompt) — `request.count` edits of the same reference set.
     let work: Vec<(i64, String)> = (0..request.count as usize)
@@ -288,6 +295,13 @@ async fn generate_candle_flux2_edit_stream(
                 Flux2Edit::load(&paths)
             }
             .map_err(|error| WorkerError::Engine(format!("FLUX.2 edit load failed: {error}")))?;
+            // Attach the optional PiD decoder (sc-8044): `Some` only when opted in AND snapshots cached.
+            let model = match &pid_weights {
+                Some(pid) => model.with_pid(pid).map_err(|error| {
+                    WorkerError::Engine(format!("FLUX.2 edit PiD decoder load failed: {error}"))
+                })?,
+                None => model,
+            };
             Ok((model, references))
         },
         move |(model, references), tx, cancel| {
@@ -303,9 +317,8 @@ async fn generate_candle_flux2_edit_stream(
                     steps: steps as usize,
                     guidance,
                     seed: seed as u64,
-                    // No PiD backbone on this lane (native VAE decode) — behavior-preserving across the
-                    // candle-gen PiD seam bump (sc-8373 / sc-9300); matches candle-gen Default.
-                    use_pid: false,
+                    // PiD opt-in (sc-8044): in lockstep with the `with_pid` load above.
+                    use_pid,
                     cancel: cancel.clone(),
                 };
                 let result = model.generate(&req, &references, &mut *on_progress);

--- a/crates/sceneworks-worker/src/image_jobs/kolors_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_control.rs
@@ -204,6 +204,10 @@ struct KolorsStrictControl {
     /// async preamble; `None` keeps the native leading-Euler default byte-exact.
     sampler: Option<String>,
     scheduler: Option<String>,
+    /// Per-generation PiD decoder weights (epic 7840, sc-8044): `Some` only when opted in (`advanced.usePid`)
+    /// AND the `sdxl` PiD + Gemma snapshots are cached (Kolors composes the SDXL VAE). Threaded into
+    /// `with_pid` at load; `use_pid` on the request is `is_some()`. `None` ⇒ native SDXL VAE decode.
+    pid: Option<gen_core::PidWeights>,
 }
 
 impl CandleStrictControl for KolorsStrictControl {
@@ -226,9 +230,16 @@ impl CandleStrictControl for KolorsStrictControl {
             kolors_base: self.kolors_base.clone(),
             controlnet: self.controlnet.clone(),
         };
-        KolorsControl::load(&paths).map_err(|error| {
+        let model = KolorsControl::load(&paths).map_err(|error| {
             WorkerError::Engine(format!("Kolors strict-pose control load failed: {error}"))
-        })
+        })?;
+        // Attach the optional PiD decoder (sc-8044): `Some` only when opted in AND the snapshots are cached.
+        match &self.pid {
+            Some(pid) => model.with_pid(pid).map_err(|error| {
+                WorkerError::Engine(format!("Kolors control PiD decoder load failed: {error}"))
+            }),
+            None => Ok(model),
+        }
     }
 
     fn generate_one(
@@ -250,9 +261,8 @@ impl CandleStrictControl for KolorsStrictControl {
             seed,
             sampler: self.sampler.clone(),
             scheduler: self.scheduler.clone(),
-            // No PiD backbone on this lane (native VAE decode) — behavior-preserving across the
-            // candle-gen PiD seam bump (sc-8373 / sc-9300); matches candle-gen Default.
-            use_pid: false,
+            // PiD opt-in (sc-8044): in lockstep with the `with_pid` load — `is_some()` ⇒ decoder loaded.
+            use_pid: self.pid.is_some(),
             cancel: cancel.clone(),
         };
         model.generate(&req, control, on_progress).map_err(|error| {
@@ -322,8 +332,13 @@ async fn generate_candle_kolors_control_stream(
         .to_owned();
 
     let pose_count = pose_entries(request).len();
-    let raw_settings =
+    // Per-generation PiD decode (epic 7840, sc-8044): resolve the `sdxl` PiD student + Gemma when
+    // `advanced.usePid` is set and the snapshots are cached; else `None` → native SDXL VAE.
+    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
+    let mut raw_settings =
         kolors_control_raw_settings(request, &repo, steps, guidance, control_scale, pose_count);
+    // Mark PiD output on the sidecar (NSCLv1 NC flows to PiD output); record whether PiD actually ran.
+    raw_settings.insert("usePid".to_owned(), Value::Bool(pid_weights.is_some()));
 
     let provider = KolorsStrictControl {
         kolors_base,
@@ -337,6 +352,7 @@ async fn generate_candle_kolors_control_stream(
         control_scale,
         sampler,
         scheduler,
+        pid: pid_weights,
     };
 
     run_candle_strict_control(

--- a/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
@@ -309,7 +309,15 @@ async fn generate_candle_pulid_stream(
         .filter(|value| !value.is_empty())
         .unwrap_or(PULID_CANDLE_FLUX_REPO)
         .to_owned();
-    let raw_settings = pulid_candle_raw_settings(request, &repo, steps, guidance, id_weight);
+    // Per-generation PiD decode (epic 7840, sc-8044): resolve the `flux` PiD student + Gemma when
+    // `advanced.usePid` is set and the snapshots are cached; else `None` → native FLUX.1 VAE. PiD is a
+    // generative decoder, so face likeness may shift — the user's per-gen call. `use_pid` and the engine's
+    // `with_pid` load stay in lockstep (the engine rejects a mismatch).
+    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
+    let use_pid = pid_weights.is_some();
+    let mut raw_settings = pulid_candle_raw_settings(request, &repo, steps, guidance, id_weight);
+    // Mark PiD output on the sidecar (NSCLv1 NC flows to PiD output); record whether PiD actually ran.
+    raw_settings.insert("usePid".to_owned(), Value::Bool(use_pid));
 
     // Per-image work items: (seed, prompt) — `request.count` images at the reference identity.
     let (width, height) = (request.width, request.height);
@@ -332,6 +340,13 @@ async fn generate_candle_pulid_stream(
             let model = PulidFlux::load(&paths).map_err(|error| {
                 WorkerError::Engine(format!("PuLID-FLUX load failed: {error}"))
             })?;
+            // Attach the optional PiD decoder (sc-8044): `Some` only when opted in AND snapshots cached.
+            let model = match &pid_weights {
+                Some(pid) => model.with_pid(pid).map_err(|error| {
+                    WorkerError::Engine(format!("PuLID-FLUX PiD decoder load failed: {error}"))
+                })?,
+                None => model,
+            };
             // Build the per-job identity-likeness scorer ONCE here (on the blocking thread where the
             // `!Send` face stack is allowed), embedding the source identity face a single time and
             // reusing it across every output (sc-4411 caching AC). `None` ⇒ non-fatal staging /
@@ -359,9 +374,8 @@ async fn generate_candle_pulid_stream(
                     seed: seed as u64,
                     sampler: sampler.clone(),
                     scheduler: scheduler.clone(),
-                    // No PiD backbone on this lane (native VAE decode) — behavior-preserving across the
-                    // candle-gen PiD seam bump (sc-8373 / sc-9300); matches candle-gen Default.
-                    use_pid: false,
+                    // PiD opt-in (sc-8044): in lockstep with the `with_pid` load above.
+                    use_pid,
                     cancel: cancel.clone(),
                 };
                 let out = match model.generate(&req, &reference, &mut *on_progress) {

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
@@ -278,8 +278,21 @@ async fn generate_candle_sdxl_edit_stream(
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| sdxl_edit_candle_default_repo(&request.model))
         .to_owned();
-    let raw_settings =
+    // Per-generation PiD decode (epic 7840, sc-8044): resolve the `sdxl` PiD student + Gemma when
+    // `advanced.usePid` is set and the snapshots are cached; else `None` → native VAE. SDXL edit composes
+    // the SDXL VAE, so it shares the one `sdxl` student. The inpaint/outpaint mask blend runs in latent
+    // space and ends in a single decode, so PiD sees the same final latent as the VAE path — the output
+    // is just 2K/4K. `use_pid` and the engine's `with_pid` load stay in lockstep (the engine rejects a
+    // mismatch).
+    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
+    let use_pid = pid_weights.is_some();
+
+    let mut raw_settings =
         sdxl_edit_candle_raw_settings(request, &repo, steps, guidance, strength, mode_tag);
+    // Mark PiD output on the sidecar (epic 7840): the NSCLv1 non-commercial restriction flows to PiD-
+    // decoded output. Record whether PiD ACTUALLY ran (not merely whether it was requested) — a request
+    // that opted in but has no cached snapshots decodes on the native VAE.
+    raw_settings.insert("usePid".to_owned(), Value::Bool(use_pid));
 
     // Per-image work items: (seed, prompt) — `request.count` edits of the same source.
     let work: Vec<(i64, String)> = (0..request.count as usize)
@@ -295,6 +308,14 @@ async fn generate_candle_sdxl_edit_stream(
         move || {
             let model = SdxlEdit::load(&SdxlEditPaths { sdxl_base })
                 .map_err(|error| WorkerError::Engine(format!("SDXL edit load failed: {error}")))?;
+            // Attach the optional PiD decoder (sc-8044): `Some` only when this generation opted in AND the
+            // snapshots are cached, so a native-VAE edit is a no-op here.
+            let model = match &pid_weights {
+                Some(pid) => model.with_pid(pid).map_err(|error| {
+                    WorkerError::Engine(format!("SDXL edit PiD decoder load failed: {error}"))
+                })?,
+                None => model,
+            };
             Ok((model, gen_source, gen_mask))
         },
         move |(model, source, mask), tx, cancel| {
@@ -311,9 +332,9 @@ async fn generate_candle_sdxl_edit_stream(
                     guidance,
                     strength,
                     seed: seed as u64,
-                    // No PiD backbone on this lane (native VAE decode) — behavior-preserving across the
-                    // candle-gen PiD seam bump (sc-8373 / sc-9300); matches candle-gen Default.
-                    use_pid: false,
+                    // PiD opt-in (sc-8044): in lockstep with the `with_pid` load above — the engine errors
+                    // if set without a loaded student, so `use_pid` is `pid_weights.is_some()`.
+                    use_pid,
                     cancel: cancel.clone(),
                 };
                 let result = match &mask {

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
@@ -280,7 +280,17 @@ async fn generate_candle_sdxl_ipadapter_stream(
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| sdxl_ipadapter_default_repo(&request.model))
         .to_owned();
-    let raw_settings = sdxl_ipadapter_raw_settings(request, &repo, steps, guidance, ip_scale);
+    // Per-generation PiD decode (epic 7840, sc-8044): resolve the `sdxl` PiD student + Gemma when
+    // `advanced.usePid` is set and the snapshots are cached; else `None` → native VAE. The SDXL IP-Adapter
+    // composes the SDXL VAE, so it shares the one `sdxl` student. `use_pid` and the engine's `with_pid`
+    // load stay in lockstep (the engine rejects a mismatch).
+    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
+    let use_pid = pid_weights.is_some();
+
+    let mut raw_settings = sdxl_ipadapter_raw_settings(request, &repo, steps, guidance, ip_scale);
+    // Mark PiD output on the sidecar (epic 7840): the NSCLv1 NC restriction flows to PiD output. Record
+    // whether PiD ACTUALLY ran (opted in AND snapshots cached), not merely whether it was requested.
+    raw_settings.insert("usePid".to_owned(), Value::Bool(use_pid));
 
     // Per-image work items: (seed, prompt) — `request.count` images at the reference identity.
     let (width, height) = (request.width, request.height);
@@ -303,6 +313,14 @@ async fn generate_candle_sdxl_ipadapter_stream(
             let model = IpAdapterSdxl::load(&paths).map_err(|error| {
                 WorkerError::Engine(format!("SDXL IP-Adapter load failed: {error}"))
             })?;
+            // Attach the optional PiD decoder (sc-8044): `Some` only when this generation opted in AND the
+            // snapshots are cached, so a native-VAE generation is a no-op here.
+            let model = match &pid_weights {
+                Some(pid) => model.with_pid(pid).map_err(|error| {
+                    WorkerError::Engine(format!("SDXL IP-Adapter PiD decoder load failed: {error}"))
+                })?,
+                None => model,
+            };
             // Per-job identity-likeness scorer built ONCE here (on the blocking thread where the `!Send`
             // face stack is allowed); source embedded once, reused across every output (sc-4411 caching
             // AC). `None` ⇒ non-fatal staging / construction failure ⇒ scores omitted.
@@ -333,10 +351,8 @@ async fn generate_candle_sdxl_ipadapter_stream(
                     seed: seed as u64,
                     sampler: sampler.clone(),
                     scheduler: scheduler.clone(),
-                    // This lane never resolves a PiD backbone (no `resolve_pid_weights` call), so keep
-                    // the native VAE decode — behavior-preserving across the candle-gen PiD seam bump
-                    // (sc-8373 / sc-9300). Matches the candle-gen request `Default` (use_pid: false).
-                    use_pid: false,
+                    // PiD opt-in (sc-8044): in lockstep with the `with_pid` load above.
+                    use_pid,
                     cancel: cancel.clone(),
                 };
                 let out = match model.generate(&req, &reference, &mut *on_progress) {

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -8035,6 +8035,7 @@ fn candle_strict_control_trait_routes_each_provider() {
         guidance: 0.0,
         negative_prompt: String::new(),
         engine_id: ZIMAGE_CTRL_ENGINE_ID,
+        pid: None,
     };
     assert_eq!(zimage.engine_id(), ZIMAGE_CTRL_ENGINE_ID);
     assert_eq!(zimage.engine_label(), ZIMAGE_CTRL_ENGINE);
@@ -8055,6 +8056,7 @@ fn candle_strict_control_trait_routes_each_provider() {
         guidance: 4.0,
         negative_prompt: "blurry".to_owned(),
         engine_id: ZIMAGE_CTRL_BASE_ENGINE_ID,
+        pid: None,
     };
     assert_eq!(zimage_base.engine_id(), ZIMAGE_CTRL_BASE_ENGINE_ID);
     assert_eq!(zimage_base.engine_label(), ZIMAGE_CTRL_ENGINE);
@@ -8088,6 +8090,7 @@ fn candle_strict_control_trait_routes_each_provider() {
         steps: 28,
         guidance: 4.0,
         control_scale: 0.75,
+        pid: None,
     };
     assert_eq!(flux2.engine_id(), FLUX2_CONTROL_CANDLE_ENGINE_ID);
     assert_eq!(flux2.engine_label(), FLUX2_CONTROL_CANDLE_ENGINE);
@@ -8122,6 +8125,7 @@ fn candle_strict_control_trait_routes_each_provider() {
         control_scale: 1.0,
         sampler: None,
         scheduler: None,
+        pid: None,
     };
     assert_eq!(kolors.engine_id(), KOLORS_CONTROL_ENGINE_ID);
     assert_eq!(kolors.engine_label(), KOLORS_CONTROL_ENGINE);

--- a/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
@@ -264,6 +264,10 @@ struct ZImageStrictControl {
     /// The [`STRICT_CONTROL_ENGINES`] catalog id for this job's model — `z_image_turbo_control` (Turbo) or
     /// `z_image_control` (base, sc-8379) — the `advanced.controlMode` validation key.
     engine_id: &'static str,
+    /// Per-generation PiD decoder weights (epic 7840, sc-8044): `Some` only when opted in (`advanced.usePid`)
+    /// AND the PiD + Gemma snapshots are cached (Z-Image is the FLUX.1 latent space → `zimage-turbo` alias).
+    /// Threaded into `with_pid` at load; `use_pid` on the request is `is_some()`. `None` ⇒ native VAE decode.
+    pid: Option<gen_core::PidWeights>,
 }
 
 impl CandleStrictControl for ZImageStrictControl {
@@ -289,9 +293,16 @@ impl CandleStrictControl for ZImageStrictControl {
             // real CFG); `z_image_turbo` → the distilled Turbo path (byte-unchanged).
             base: self.is_base,
         };
-        ZImageControl::load(&paths).map_err(|error| {
+        let model = ZImageControl::load(&paths).map_err(|error| {
             WorkerError::Engine(format!("Z-Image strict-pose control load failed: {error}"))
-        })
+        })?;
+        // Attach the optional PiD decoder (sc-8044): `Some` only when opted in AND the snapshots are cached.
+        match &self.pid {
+            Some(pid) => model.with_pid(pid).map_err(|error| {
+                WorkerError::Engine(format!("Z-Image control PiD decoder load failed: {error}"))
+            }),
+            None => Ok(model),
+        }
     }
 
     fn generate_one(
@@ -317,9 +328,8 @@ impl CandleStrictControl for ZImageStrictControl {
                 .then(|| self.negative_prompt.clone())
                 .filter(|value| !value.trim().is_empty()),
             seed,
-            // No PiD backbone on this lane (native VAE decode) — behavior-preserving across the
-            // candle-gen PiD seam bump (sc-8373 / sc-9300); matches candle-gen Default.
-            use_pid: false,
+            // PiD opt-in (sc-8044): in lockstep with the `with_pid` load — `is_some()` ⇒ decoder loaded.
+            use_pid: self.pid.is_some(),
             cancel: cancel.clone(),
         };
         model.generate(&req, control, on_progress).map_err(|error| {
@@ -380,7 +390,10 @@ async fn generate_candle_zimage_control_stream(
     let negative_prompt = request.negative_prompt.clone();
 
     let pose_count = pose_entries(request).len();
-    let raw_settings = zimage_control_raw_settings(
+    // Per-generation PiD decode (epic 7840, sc-8044): resolve the `zimage-turbo`/`flux` PiD student + Gemma
+    // when `advanced.usePid` is set and the snapshots are cached; else `None` → native Z-Image VAE.
+    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
+    let mut raw_settings = zimage_control_raw_settings(
         request,
         &repo,
         steps,
@@ -389,6 +402,8 @@ async fn generate_candle_zimage_control_stream(
         is_base,
         guidance,
     );
+    // Mark PiD output on the sidecar (NSCLv1 NC flows to PiD output); record whether PiD actually ran.
+    raw_settings.insert("usePid".to_owned(), Value::Bool(pid_weights.is_some()));
 
     let provider = ZImageStrictControl {
         snapshot: base,
@@ -402,6 +417,7 @@ async fn generate_candle_zimage_control_stream(
         guidance,
         negative_prompt,
         engine_id,
+        pid: pid_weights,
     };
 
     run_candle_strict_control(

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -184,6 +184,11 @@ mod scail2_gpu_smoke;
 // drives `gen_core::load("sdxl")` with the forced `lightning` sampler against the distilled checkpoint.
 #[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
 mod realvisxl_lightning_gpu_smoke;
+// Real-weight GPU smoke for the candle SDXL edit + PiD super-resolving decode (epic 7840, sc-8044).
+// Test-only + candle-only; drives the bespoke `candle_gen_sdxl::SdxlEdit` provider (inpaint) with the
+// `pid_sdxl` student attached, asserting the PiD decode super-resolves the render-sized native decode.
+#[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
+mod sdxl_edit_pid_gpu_smoke;
 // Real-weight GPU smoke for the candle FLUX.2-dev lane (epic 6564 sc-7458). Test-only + candle-only;
 // drives `gen_core::load("flux2_dev")` with a Q4 LoadSpec (CPU-stage → quantize-onto-GPU) against the
 // dense diffusers snapshot — the worker-lane validation backing the off-Mac candle routing wire.

--- a/crates/sceneworks-worker/src/sdxl_edit_pid_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/sdxl_edit_pid_gpu_smoke.rs
@@ -1,0 +1,206 @@
+//! Local real-weight GPU smoke for the candle **SDXL edit + PiD super-resolving decode** (sc-8044,
+//! epic 7840). `#[ignore]`d — run by hand on the RTX PRO 6000. Drives the bespoke
+//! `candle_gen_sdxl::SdxlEdit` provider (the same one `sdxl_edit_candle.rs` loads) with the PiD decoder
+//! attached (`with_pid`), exercising the **inpaint** path (`generate_masked`) — a latent-space
+//! mask-blend that ends in a single decode, so PiD sees the same final latent and emits it at 4× (2K/4K)
+//! instead of the native SDXL VAE. Represents the whole `sdxl`-latent bespoke group (SdxlEdit /
+//! IpAdapterSdxl / KolorsControl / InstantID) — they all reuse this one `pid_sdxl` student + decode seam.
+//!
+//! Contrast: the same request with `use_pid = false` decodes on the native VAE at the render size, so the
+//! smoke asserts (a) the native decode is render-sized + coherent, and (b) the PiD decode is 4× that size
+//! + coherent — proving the decode routes through PiD and super-resolves without collapsing.
+//!
+//! Setup (PowerShell; all three snapshots are in the HF cache — the SDXL base + the NC `pid_sdxl` +
+//! gemma-2-2b-it):
+//! ```text
+//! $env:SDXL_PID_BASE="D:\.cache\huggingface\hub\models--stabilityai--stable-diffusion-xl-base-1.0\snapshots\462165984030d82259a11f4367a4eed129e94a7b"
+//! $env:SDXL_PID_CKPT="D:\.cache\huggingface\hub\models--SceneWorks--pid-sdxl\snapshots\70b494831561dc2c181f04a7f057260b8785419a\pid_sdxl_2kto4k.safetensors"
+//! $env:SDXL_PID_GEMMA="D:\.cache\huggingface\hub\models--SceneWorks--gemma-2-2b-it\snapshots\684c553b5b41a1c835989d89f62f585e6269a7de"
+//! $env:SDXL_PID_OUT="D:\sceneworks-pid-validate\sdxl-edit"
+//! # optional: SDXL_PID_SIZE=512 (render size; PiD output is 4x)
+//! cargo test -p sceneworks-worker --features backend-candle --release sdxl_edit_pid_gpu_smoke -- --ignored --nocapture
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use candle_gen_sdxl::{SdxlEdit, SdxlEditPaths, SdxlEditRequest};
+use gen_core::runtime::CancelFlag;
+use gen_core::{Image, PidWeights, WeightsSource};
+
+fn env_path(key: &str) -> PathBuf {
+    PathBuf::from(
+        std::env::var(key)
+            .unwrap_or_else(|_| panic!("set ${key}"))
+            .trim(),
+    )
+}
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key)
+        .map(|v| v.trim().to_string())
+        .unwrap_or_else(|_| default.to_string())
+}
+
+/// Mean per-pixel std-dev — the cheap non-degenerate floor (an all-black / NaN decode collapses to ~0).
+fn image_std(img: &Image) -> f64 {
+    let n = img.pixels.len() as f64;
+    if n == 0.0 {
+        return 0.0;
+    }
+    let mean = img.pixels.iter().map(|&p| p as f64).sum::<f64>() / n;
+    let var = img
+        .pixels
+        .iter()
+        .map(|&p| (p as f64 - mean).powi(2))
+        .sum::<f64>()
+        / n;
+    var.sqrt()
+}
+
+fn save_png(img: &Image, path: &Path) {
+    image::RgbImage::from_raw(img.width, img.height, img.pixels.clone())
+        .expect("rgb buffer")
+        .save(path)
+        .unwrap_or_else(|e| panic!("save {}: {e}", path.display()));
+}
+
+/// A deterministic non-flat source: a smooth RGB gradient (so the VAE-encode has real structure to keep
+/// in the black region and the smoke isn't decoding a constant).
+fn synthetic_source(w: u32, h: u32) -> Image {
+    let mut pixels = Vec::with_capacity((w * h * 3) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            pixels.push((x * 255 / w.max(1)) as u8);
+            pixels.push((y * 255 / h.max(1)) as u8);
+            pixels.push(((x + y) * 255 / (w + h).max(1)) as u8);
+        }
+    }
+    Image {
+        width: w,
+        height: h,
+        pixels,
+    }
+}
+
+/// Center-box inpaint mask: white (repaint) in the middle third, black (keep) elsewhere.
+fn center_box_mask(w: u32, h: u32) -> Image {
+    let mut pixels = Vec::with_capacity((w * h * 3) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let inside = x >= w / 3 && x < 2 * w / 3 && y >= h / 3 && y < 2 * h / 3;
+            let v = if inside { 255u8 } else { 0u8 };
+            pixels.extend_from_slice(&[v, v, v]);
+        }
+    }
+    Image {
+        width: w,
+        height: h,
+        pixels,
+    }
+}
+
+fn inpaint(model: &SdxlEdit, source: &Image, mask: &Image, w: u32, h: u32, use_pid: bool) -> Image {
+    let req = SdxlEditRequest {
+        prompt: env_or(
+            "SDXL_PID_PROMPT",
+            "a red vintage sports car, studio product photo, sharp focus, high detail",
+        ),
+        negative: "blurry, lowres, deformed, watermark".to_owned(),
+        width: w,
+        height: h,
+        steps: env_or("SDXL_PID_STEPS", "30")
+            .parse()
+            .expect("SDXL_PID_STEPS"),
+        guidance: 5.0,
+        strength: 0.85,
+        seed: 42,
+        use_pid,
+        cancel: CancelFlag::new(),
+    };
+    model
+        .generate_masked(&req, source, mask, &mut |_| {})
+        .expect("sdxl inpaint generate")
+}
+
+#[test]
+#[ignore = "real-weight GPU smoke; needs the SDXL base + NC pid_sdxl + gemma-2-2b-it snapshots (cap=120)"]
+fn sdxl_edit_pid_gpu_smoke() {
+    let base = env_path("SDXL_PID_BASE");
+    assert!(
+        base.join("unet").is_dir(),
+        "SDXL_PID_BASE must be a diffusers SDXL snapshot (unet/ missing): {}",
+        base.display()
+    );
+    let ckpt = env_path("SDXL_PID_CKPT");
+    let gemma = env_path("SDXL_PID_GEMMA");
+    let out_dir = PathBuf::from(env_or("SDXL_PID_OUT", "sdxl-edit-pid-out"));
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+
+    let size: u32 = env_or("SDXL_PID_SIZE", "512")
+        .parse()
+        .expect("SDXL_PID_SIZE");
+    let (w, h) = (size, size);
+    let source = synthetic_source(w, h);
+    let mask = center_box_mask(w, h);
+
+    println!("[smoke] loading SdxlEdit from {} ...", base.display());
+    let model = SdxlEdit::load(&SdxlEditPaths {
+        sdxl_base: base.clone(),
+    })
+    .expect("load candle SdxlEdit");
+    let model = model
+        .with_pid(&PidWeights {
+            checkpoint: WeightsSource::File(ckpt.clone()),
+            gemma: WeightsSource::Dir(gemma.clone()),
+        })
+        .expect("attach pid_sdxl decoder");
+
+    // Native VAE decode (render-sized): the byte-exact default path.
+    println!("[smoke] native-VAE inpaint {w}x{h} ...");
+    let native = inpaint(&model, &source, &mask, w, h, false);
+    let native_std = image_std(&native);
+    save_png(&native, &out_dir.join("sdxl_inpaint_native.png"));
+    println!(
+        "[smoke] native {}x{} std {:.2}",
+        native.width, native.height, native_std
+    );
+    assert_eq!(
+        (native.width, native.height),
+        (w, h),
+        "native VAE decode must be render-sized"
+    );
+
+    // PiD decode (super-resolving): the same final latent, decoded through the `sdxl` PiD student at 4x.
+    println!("[smoke] PiD inpaint {w}x{h} -> expect 4x ...");
+    let pid = inpaint(&model, &source, &mask, w, h, true);
+    let pid_std = image_std(&pid);
+    save_png(&pid, &out_dir.join("sdxl_inpaint_pid.png"));
+    println!(
+        "[smoke] PiD {}x{} std {:.2} -> {}",
+        pid.width,
+        pid.height,
+        pid_std,
+        out_dir.join("sdxl_inpaint_pid.png").display()
+    );
+
+    assert!(
+        native_std > 5.0,
+        "native inpaint render degenerate (std {native_std:.2})"
+    );
+    assert!(
+        pid_std > 5.0,
+        "PiD inpaint render degenerate (std {pid_std:.2}) — check pid_sdxl + gemma snapshots + cap=120"
+    );
+    assert!(
+        pid.width > native.width && pid.height > native.height,
+        "PiD decode must super-resolve past the native size (native {}x{}, pid {}x{})",
+        native.width,
+        native.height,
+        pid.width,
+        pid.height
+    );
+    println!(
+        "[smoke] DONE: SDXL inpaint PiD super-resolve {}x{} -> {}x{} coherent",
+        native.width, native.height, pid.width, pid.height
+    );
+}


### PR DESCRIPTION
Wires the per-generation PiD decoder into the candle **bespoke advanced sub-mode** streams (control / edit / IP-Adapter / inpaint / outpaint / PuLID). Epic [7840](https://app.shortcut.com/trefry/epic/7840), story [sc-8044](https://app.shortcut.com/trefry/story/8044). Off-Mac / candle-only.

## What changed
Before, the bespoke streams passed `None` to the decode seam, so `advanced.usePid` was silently ignored and they stayed on the native VAE. This threads `resolve_pid_weights` → `with_pid` → `use_pid` + the `usePid` NC sidecar marker through the worker streams:
`sdxl_edit_candle` (img2img/inpaint/outpaint), `sdxl_ipadapter`, `flux2_control_candle`, `flux2_edit_candle`, `kolors_control`, `zimage_control`, `pulid_candle`.

Control lanes use a `CandleStrictControl` driver struct → added a `pid: Option<PidWeights>` field (`with_pid` at load, `use_pid = is_some()`); inline lanes (edit/ip/pulid) resolve per-stream. Inpaint/outpaint blend the kept region in **latent** space then decode once, so PiD is correct there — output becomes 2K/4K.

## No pin bump
The bespoke `with_pid`/`use_pid` engine methods (candle-gen [#341](https://github.com/SceneWorks/candle-gen/pull/341), `bf24bc8`) are **already** in main's current candle-gen pin `8db956db` (bumped by sc-9300 / #1181, a descendant of `bf24bc8`). sc-9300 had added `use_pid: false` stubs to these request literals to compile against the new field; this replaces the stubs with the real routing. So this PR touches **only worker source** — no `Cargo.toml`/`Cargo.lock` change, skew gate untouched.

## Re-land notice
The original sc-8044 work was on PR #1150, which **squash-merged only sc-9727**; the sc-8044 commits were orphaned on the merged branch and never reached `main`. This is a clean re-land off current `main`.

## Validation (RTX PRO 6000, cap=120)
- Worker `--features backend-candle` lib tests: **443 passed, 0 failed, 23 ignored** (against main's pin `8db956db`).
- Real-weight smoke `sdxl_edit_pid_gpu_smoke` (new): SDXL **inpaint** with `pid_sdxl` — native VAE **512²** (std 71.74) vs PiD **2048²** (4× SR, std 68.32), both coherent. Represents the `sdxl`-latent bespoke group (SdxlEdit/IpAdapterSdxl/KolorsControl/InstantID reuse this one student + seam). The flux/flux2/zimage students are t2i-validated (sc-7846/47/48) and reuse the identical `PidDecoder` + decode seam.

## Eligibility
Unchanged: non-eligible model / toggle off / snapshots-not-cached → native VAE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
