### PR TITLE
fix(worker): interpolate real backend label in remaining model_jobs conversion strings (sc-9863)

### DIFF
--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -919,9 +919,10 @@ pub(crate) async fn run_model_convert_job(
     let quantize_bits = job.payload.get("quantizeBits").and_then(Value::as_u64);
 
     // The active backend label (mlx on macOS, candle off-Mac, cpu fallback) so the user-facing
-    // conversion-cancel strings name the REAL backend instead of a hardcoded "MLX" (sc-9801, the
-    // F-114 follow-up to sc-8916). Same `backend_label(&settings.gpu_id)` mechanism the caption /
-    // training paths use.
+    // conversion progress / failure / completion / cancel strings name the REAL backend instead of a
+    // hardcoded "MLX" (sc-9801 fixed the cancel strings; sc-9863 extended it to the remaining
+    // progress/failure/completion strings — the F-114 follow-up to sc-8916). Same
+    // `backend_label(&settings.gpu_id)` mechanism the caption / training paths use.
     let backend = backend_label(&settings.gpu_id).to_uppercase();
 
     heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
@@ -932,7 +933,7 @@ pub(crate) async fn run_model_convert_job(
             JobStatus::Preparing,
             ProgressStage::Preparing,
             0.05,
-            &format!("Preparing MLX conversion for {model_id}."),
+            &format!("Preparing {backend} conversion for {model_id}."),
             None,
             None,
             None,
@@ -952,7 +953,7 @@ pub(crate) async fn run_model_convert_job(
             &job.id,
             "Native checkpoint is not downloaded.",
             Some(format!(
-                "Download {source_repo} before converting it to MLX."
+                "Download {source_repo} before converting it to {backend}."
             )),
         )
         .await?;
@@ -967,7 +968,7 @@ pub(crate) async fn run_model_convert_job(
         fail_job(
             api,
             &job.id,
-            "Quantize-only MLX conversion is no longer supported.",
+            &format!("Quantize-only {backend} conversion is no longer supported."),
             Some(
                 "In-place re-quantization of a pre-converted MLX model was removed with the legacy \
                  mlx-video converter (sc-3240). Convert the native checkpoint with quantization \
@@ -1022,7 +1023,7 @@ pub(crate) async fn run_model_convert_job(
             JobStatus::Running,
             ProgressStage::Running,
             0.2,
-            &format!("Converting {model_id} to MLX. This can take several minutes."),
+            &format!("Converting {model_id} to {backend}. This can take several minutes."),
             None,
             None,
             None,
@@ -1088,12 +1089,15 @@ pub(crate) async fn run_model_convert_job(
         Ok(Err(detail)) => {
             let _ = tokio::fs::remove_dir_all(&temp_dir).await;
             return Err(WorkerError::Engine(format!(
-                "MLX conversion failed. {detail}"
+                "{backend} conversion failed. {detail}"
             )));
         }
         Err(join_error) => {
             let _ = tokio::fs::remove_dir_all(&temp_dir).await;
-            return Err(task_join_error("MLX conversion task", join_error));
+            return Err(task_join_error(
+                &format!("{backend} conversion task"),
+                join_error,
+            ));
         }
     }
 
@@ -1120,7 +1124,7 @@ pub(crate) async fn run_model_convert_job(
             JobStatus::Completed,
             ProgressStage::Completed,
             1.0,
-            "MLX conversion completed.",
+            &format!("{backend} conversion completed."),
             None,
             Some(result),
             None,


### PR DESCRIPTION
## Summary

F-114 follow-up to **sc-9801**. sc-9801 fixed the two conversion-CANCEL strings in `run_model_convert_job` (`crates/sceneworks-worker/src/model_jobs.rs`) to name the real backend via `backend_label(&settings.gpu_id).to_uppercase()`. This PR extends that same mechanism to the remaining user-facing conversion strings that still hardcoded `"MLX"` and mislabeled the candle (Windows/CUDA) and cpu backends — the same F-114 anti-pattern.

All fixes reuse the existing `backend` binding already in scope from sc-9801 (`let backend = backend_label(&settings.gpu_id).to_uppercase();`), keeping interpolation consistent with sc-9801 (`.to_uppercase()` for message prose).

## Strings fixed (all in `run_model_convert_job`)

| Site | Before | After |
| --- | --- | --- |
| Preparing progress | `"Preparing MLX conversion for {model_id}."` | `"Preparing {backend} conversion for {model_id}."` |
| Not-downloaded detail | `"Download {source_repo} before converting it to MLX."` | `"...converting it to {backend}."` |
| Quantize-only failure msg | `"Quantize-only MLX conversion is no longer supported."` | `"Quantize-only {backend} conversion is no longer supported."` |
| Running progress | `"Converting {model_id} to MLX. This can take several minutes."` | `"Converting {model_id} to {backend}. ..."` |
| Engine failure | `"MLX conversion failed. {detail}"` | `"{backend} conversion failed. {detail}"` |
| Task-join error label | `task_join_error("MLX conversion task", ...)` | `task_join_error(&format!("{backend} conversion task"), ...)` |
| Completion | `"MLX conversion completed."` | `"{backend} conversion completed."` |

The sc-9801 comment above the `backend` binding was updated to note the scope now covers progress/failure/completion/cancel (not just cancel).

## Left untouched (semantic, NOT display labels)

- **`storage: "mlx_local"` result marker** — the CRITICAL EXCLUSION from the story. A semantic storage key, not a display label; changing it would alter behavior. Untouched.
- `.unwrap_or("mlx")` temp-dir filename fallback — file path, not display.
- `"No MLX converter is configured for this model."` / `"Unknown MLX converter."` in `resolve_convert_plan` — these name the manifest `mlx.converter` discriminator (their detail strings reference `mlx.converter` literally), and that function has no `settings`/`backend` binding in scope. Semantic, left as-is (reported in the story, not a happy-path omission).
- `"pre-converted MLX model"` / `"mlx-video converter"` in the quantize-only detail — the first refers to the on-disk MLX format, the second is a named legacy Python component (`mlx_video.convert_wan`). Left intact.
- All doc comments (`///`, `//`) describing the MLX format/converters.

## Tests

No test added — mirrors sc-9801's judgment. The inline `format!` strings live in an async job function with API/heartbeat side effects and have no clean unit seam.

## Verification

- `npm run rust:check` (fmt --check + clippy + build + test): clean — 623 passed, 0 failed.
- Candle lane `cargo clippy -p sceneworks-worker --no-default-features -F backend-candle --all-targets -- -D warnings`: clean.

Refs sc-9863.

🤖 Generated with [Claude Code](https://claude.com/claude-code)