### PR TITLE
feat(worker): wire the qwen 2512-Fun packed control tier into the catalog (sc-9870)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -390,6 +390,41 @@
           "files": ["bf16/*"],
           "estimatedSizeBytes": 57731960832,
           "footprint": { "diskSizeBytes": 57731960832, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        // Packed 2512-Fun-Controlnet-Union strict-control tier (sc-9870, epic 8236). SceneWorks re-host
+        // of alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union as a per-tier packed matrix — each subdir
+        // is a SINGLE `model.safetensors` control overlay: q4/ q8/ bf16/. This replaces the old dense
+        // alibaba-pai overlay staging (sc-8350): the base-Qwen strict-pose lane (candle `qwen_control.rs`
+        // + MLX `qwen.rs`, engine id `qwen_image_control`) now resolves the control subdir that MATCHES
+        // the selected transformer tier (advanced.mlxQuantize → q4/q8/bf16, via `qwen_control_tier_subdir`)
+        // for a coherent A/B — a q4 base pairs with the q4 control overlay, etc. Listed as co-requisites
+        // (FETCH-ALL) so the whole control matrix installs alongside the base and A/B tier-toggling never
+        // needs a gen-time fetch; the drivers still on-demand-fetch a missing tier as a safety net. The
+        // packed overlays are small (q4 ~0.99 GB / q8 ~1.87 GB / bf16 ~3.51 GB) relative to the 20B base.
+        // The sc-8350 two-overlay ambiguity is gone: each tier subdir ships exactly one control file.
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/qwen-image-2512-fun-controlnet-union",
+          "coRequisite": true,
+          "files": ["q4/model.safetensors"],
+          "estimatedSizeBytes": 989855744,
+          "footprint": { "diskSizeBytes": 989855744, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/qwen-image-2512-fun-controlnet-union",
+          "coRequisite": true,
+          "files": ["q8/model.safetensors"],
+          "estimatedSizeBytes": 1873805312,
+          "footprint": { "diskSizeBytes": 1873805312, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/qwen-image-2512-fun-controlnet-union",
+          "coRequisite": true,
+          "files": ["bf16/model.safetensors"],
+          "estimatedSizeBytes": 3506438144,
+          "footprint": { "diskSizeBytes": 3506438144, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -1,9 +1,29 @@
 /// The engine registry id for the Qwen-Image ControlNet-Union variant. The default control repo is
 /// the `STRICT_CONTROL_ENGINES` table row for this id (resolved via `strict_control_default_repo`),
 /// not a duplicated local constant — so a table repoint keeps the resolver, error message, and
-/// download hint in lockstep.
+/// download hint in lockstep. As of sc-9870 that row is the SceneWorks PACKED tier
+/// (`SceneWorks/qwen-image-2512-fun-controlnet-union`), replacing the dense alibaba-pai overlay.
 const QWEN_CONTROL_ENGINE_ID: &str = "qwen_image_control";
-const QWEN_CONTROL_FILE: &str = "diffusion_pytorch_model.safetensors";
+/// The single packed control file inside each tier subdir (`q4/`, `q8/`, `bf16/`). Deterministic —
+/// the packed tier ships exactly one `model.safetensors` per subdir (sc-9870), so the sc-8350
+/// two-overlay ambiguity is naturally resolved.
+const QWEN_CONTROL_FILE: &str = "model.safetensors";
+
+/// The packed control tier subdir the request's `advanced.mlxQuantize` selects (sc-9870): `bf16` (opt
+/// out of quantization, `<= 0` / "none"), `q8` (`> 4`), else the `q4` default — the SAME mapping
+/// `standard_tier_subdir` uses for the base transformer tier, so the control overlay tier tracks the
+/// base tier for a coherent A/B. Mirrors the candle `qwen_control_tier_subdir` (`qwen_control.rs`).
+fn qwen_control_tier_subdir(request: &ImageRequest) -> &'static str {
+    let bits = request
+        .advanced
+        .get("mlxQuantize")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()));
+    match bits {
+        Some(b) if b <= 0 => "bf16",
+        Some(b) if b > 4 => "q8",
+        _ => "q4",
+    }
+}
 
 /// True when this is the base-Qwen strict-pose tier: `qwen_image` + non-empty object
 /// `advanced.poses`, not edit mode, and base weights available. A `referenceAssetId`, if present,
@@ -16,18 +36,42 @@ fn qwen_control_available(request: &ImageRequest, settings: &Settings) -> bool {
         && matches!(resolve_weights_dir(request, settings), Ok(Some(_)))
 }
 
+/// Resolve the 2512-Fun-Controlnet-Union checkpoint to a single `.safetensors` in the HF cache
+/// (sc-9870). Default: the SceneWorks packed tier (repo from the shared `STRICT_CONTROL_ENGINES` row —
+/// single source of truth) at `<tier>/model.safetensors`, where `<tier>` tracks the selected transformer
+/// quant via [`qwen_control_tier_subdir`]. `advanced.controlWeights.{repo,filename}` overrides still
+/// address a flat repo with a plain-component file (sc-8821 / F-019); when a `filename` override is
+/// present the tier subdir is NOT applied. `Ok(None)` when the file is absent (the download flow /
+/// on-demand fetch provisions it ahead of generation, like base weights).
 fn resolve_qwen_control_weights(
     request: &ImageRequest,
     settings: &Settings,
 ) -> WorkerResult<Option<PathBuf>> {
-    // Default repo from the shared strict-control table (single source of truth); the file stays
-    // engine-specific.
-    resolve_control_weights_for(
-        request,
-        settings,
-        strict_control_default_repo(QWEN_CONTROL_ENGINE_ID),
-        QWEN_CONTROL_FILE,
-    )
+    let control = request
+        .advanced
+        .get("controlWeights")
+        .and_then(Value::as_object);
+    let override_field = |key: &str| -> Option<String> {
+        control
+            .and_then(|control| control.get(key))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned)
+    };
+    let repo =
+        override_field("repo").unwrap_or_else(|| strict_control_default_repo(QWEN_CONTROL_ENGINE_ID).to_owned());
+    // Repo-relative path: an explicit override filename (plain component, no tier subdir) else the packed
+    // tier subdir `<tier>/model.safetensors` selected by `advanced.mlxQuantize`.
+    let rel = match override_field("filename") {
+        Some(name) => safe_weight_filename(&name, "advanced.controlWeights.filename")?,
+        None => format!("{}/{QWEN_CONTROL_FILE}", qwen_control_tier_subdir(request)),
+    };
+    let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, &repo) else {
+        return Ok(None);
+    };
+    let path = snapshot.join(rel);
+    Ok(path.exists().then_some(path))
 }
 
 /// Load the Qwen-Image ControlNet-Union generator (base snapshot + 2512-Fun control overlay).

--- a/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
@@ -3,7 +3,9 @@
 // `candle_gen_qwen_image::QwenFunControl`. The candle sibling of the MLX Qwen 2512-Fun strict-control path
 // (qwen.rs `generate_qwen_control_stream`): one image per pose (or, with `advanced.controlMode =
 // canny|depth` + a source, an auto-derived canny / Depth-Anything-V2 map), each fed to the VACE-style
-// `alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union` branch overlaid on the Qwen-Image-2512 base.
+// 2512-Fun-Controlnet-Union branch overlaid on the Qwen-Image-2512 base. sc-9870: the control overlay is
+// now the SceneWorks PACKED tier (`SceneWorks/qwen-image-2512-fun-controlnet-union`, per-quant q4/q8/bf16
+// subdirs), resolved per `advanced.mlxQuantize`, replacing the dense alibaba-pai overlay staging.
 //
 // **sc-8350 source swap.** This lane previously loaded the InstantX `Qwen-Image-ControlNet-Union`
 // checkpoint (`QwenControl`, a residual-ControlNet on the `Qwen/Qwen-Image` base). It now rides the
@@ -18,10 +20,18 @@
 // module's imports (`parse_poses`/`Settings`/`WorkerResult`/`huggingface_snapshot_dir`/
 // `ensure_hf_cached_file`/`start_gen_stream`/… all in scope unqualified).
 
-/// Default 2512-Fun-Controlnet-Union weights (Apache-2.0, input-agnostic VACE control) — same repo/file
-/// the MLX path uses (`qwen.rs` 2512-Fun constants); the candle lane keeps its own constant (sc-8350).
-const QWEN_CONTROL_REPO: &str = "alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union";
-const QWEN_CONTROL_FILE: &str = "diffusion_pytorch_model.safetensors";
+/// Default 2512-Fun-Controlnet-Union weights (Apache-2.0, input-agnostic VACE control). As of sc-9870
+/// (epic 8236) this points at the SceneWorks PACKED control tier — a per-quant matrix whose q4/ q8/ bf16/
+/// subdirs each ship a single `model.safetensors` overlay — NOT the old dense alibaba-pai overlay
+/// (sc-8350). The exact subdir is selected per `advanced.mlxQuantize` by [`qwen_control_tier_subdir`] so
+/// the control overlay tier tracks the base transformer tier for a coherent A/B. The candle
+/// `QwenFunControl` engine already packed-detects the overlay (sc-9869), so nothing downstream changes.
+/// Same repo the MLX path uses (`qwen.rs` — the shared `STRICT_CONTROL_ENGINES` `qwen_image_control` row).
+const QWEN_CONTROL_REPO: &str = "SceneWorks/qwen-image-2512-fun-controlnet-union";
+/// The single packed control file inside each tier subdir (`q4/`, `q8/`, `bf16/`). Deterministic —
+/// the packed tier ships exactly one `model.safetensors` per subdir, so the sc-8350 two-overlay
+/// ambiguity is naturally resolved.
+const QWEN_CONTROL_FILE: &str = "model.safetensors";
 /// The Qwen-Image-2512 base diffusers repo when the manifest omits `repo` (the 2512-Fun base, sc-8350).
 const QWEN_CONTROL_DEFAULT_REPO: &str = "Qwen/Qwen-Image-2512";
 /// ControlNet conditioning-scale default (the strict-pose tier).
@@ -35,8 +45,9 @@ const QWEN_CONTROL_DEFAULT_GUIDANCE: f32 = 4.0;
 const QWEN_CONTROL_ENGINE: &str = "candle_qwen_control";
 /// The [`STRICT_CONTROL_ENGINES`] catalog id this candle lane validates `advanced.controlMode` against
 /// (the `qwen_image_control` row — `{Pose, Canny, Depth}`). As of sc-8350 the candle lane loads the
-/// 2512-Fun-Controlnet-Union checkpoint on the Qwen-Image-2512 base (`QwenFunControl`), matching the
-/// table's `qwen_image_control` repo (`alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union`) exactly.
+/// 2512-Fun-Controlnet-Union checkpoint on the Qwen-Image-2512 base (`QwenFunControl`); sc-9870 repoints
+/// the control overlay at the packed tier, matching the table's `qwen_image_control` repo
+/// (`SceneWorks/qwen-image-2512-fun-controlnet-union`) exactly — consistent with the MLX `qwen.rs` lane.
 const QWEN_CONTROL_ENGINE_ID: &str = "qwen_image_control";
 
 /// Model ids the candle Qwen ControlNet route accepts.
@@ -98,26 +109,48 @@ fn qwen_control_guidance(request: &ImageRequest) -> f32 {
     )
 }
 
-/// The (repo, filename) of the ControlNet weights — `advanced.controlWeights.{repo,filename}` overrides,
-/// else the 2512-Fun-Controlnet-Union default (parity with the MLX `resolve_control_weights_for`).
-/// The payload filename must be a plain component (sc-8821 / F-019).
+/// The packed control tier subdir the request's `advanced.mlxQuantize` selects (sc-9870): `bf16` (opt
+/// out of quantization, `<= 0` / "none"), `q8` (`> 4`), else the `q4` default — the SAME mapping
+/// [`standard_tier_subdir`] uses for the base transformer tier, so the control overlay tier tracks the
+/// base tier for a coherent A/B. Mirrors the MLX `qwen_control_tier_subdir`.
+fn qwen_control_tier_subdir(request: &ImageRequest) -> &'static str {
+    let bits = request
+        .advanced
+        .get("mlxQuantize")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()));
+    match bits {
+        Some(b) if b <= 0 => "bf16",
+        Some(b) if b > 4 => "q8",
+        _ => "q4",
+    }
+}
+
+/// The (repo, repo-relative file path) of the ControlNet weights.
+///
+/// Default (sc-9870): the SceneWorks packed control tier — repo [`QWEN_CONTROL_REPO`], file
+/// `<tier>/model.safetensors` where `<tier>` is [`qwen_control_tier_subdir`] (per `advanced.mlxQuantize`).
+/// Deterministic single-file resolution — each tier subdir ships exactly one `model.safetensors`.
+///
+/// Override: `advanced.controlWeights.{repo,filename}` still points at a flat repo with a plain-component
+/// weight file (sc-8821 / F-019 — the filename must have no path separators). When a `filename` override
+/// is present the tier subdir is NOT applied (the override addresses a specific file directly).
 fn qwen_control_repo_file(request: &ImageRequest) -> WorkerResult<(String, String)> {
     let cw = request.advanced.get("controlWeights").and_then(Value::as_object);
-    let pick = |key: &str, default: &str| {
+    let pick = |key: &str| {
         cw.and_then(|m| m.get(key))
             .and_then(Value::as_str)
             .map(str::trim)
             .filter(|v| !v.is_empty())
-            .unwrap_or(default)
-            .to_owned()
+            .map(str::to_owned)
     };
-    Ok((
-        pick("repo", QWEN_CONTROL_REPO),
-        safe_weight_filename(
-            &pick("filename", QWEN_CONTROL_FILE),
-            "advanced.controlWeights.filename",
-        )?,
-    ))
+    let repo = pick("repo").unwrap_or_else(|| QWEN_CONTROL_REPO.to_owned());
+    let file = match pick("filename") {
+        // Explicit override — a plain-component file in the override repo (no tier subdir).
+        Some(name) => safe_weight_filename(&name, "advanced.controlWeights.filename")?,
+        // Default packed tier — `<tier>/model.safetensors` selected by `advanced.mlxQuantize`.
+        None => format!("{}/{QWEN_CONTROL_FILE}", qwen_control_tier_subdir(request)),
+    };
+    Ok((repo, file))
 }
 
 /// Resolve the 2512-Fun-Controlnet-Union weight **file** the `QwenFunControl` provider loads (sc-8350),

--- a/crates/sceneworks-worker/src/image_jobs/strict_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/strict_control.rs
@@ -75,8 +75,14 @@ const STRICT_CONTROL_ENGINES: &[StrictControlEngine] = &[
         supported_kinds: &[ControlKind::Pose, ControlKind::Canny, ControlKind::Depth],
     },
     StrictControlEngine {
+        // sc-9870 (epic 8236): the default control-weights repo is now the SceneWorks PACKED tier
+        // (`SceneWorks/qwen-image-2512-fun-controlnet-union`, per-quant q4/q8/bf16 subdirs, one
+        // `model.safetensors` overlay each), replacing the dense alibaba-pai overlay (sc-8350). BOTH the
+        // MLX (`qwen.rs`) and candle (`qwen_control.rs`) lanes resolve the tier subdir matching the
+        // selected transformer quant (`advanced.mlxQuantize`), so this `(engine_id, control_repo,
+        // supported_kinds)` row stays consistent across both drivers.
         engine_id: "qwen_image_control",
-        repo: "alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union",
+        repo: "SceneWorks/qwen-image-2512-fun-controlnet-union",
         supported_kinds: &[ControlKind::Pose, ControlKind::Canny, ControlKind::Depth],
     },
     StrictControlEngine {

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -3333,7 +3333,9 @@ fn zimage_base_control_real_weights_generates_per_mode() {
 #[ignore = "needs real Qwen-Image + 2512-Fun-Controlnet-Union weights + Metal device"]
 fn qwen_control_real_weights_generates_one_pose() {
     let base = hf_snapshot("models--Qwen--Qwen-Image");
-    let control = hf_snapshot("models--alibaba-pai--Qwen-Image-2512-Fun-Controlnet-Union")
+    // sc-9870: packed control tier — the Q8 base pairs with the q8/ overlay subdir.
+    let control = hf_snapshot("models--SceneWorks--qwen-image-2512-fun-controlnet-union")
+        .join("q8")
         .join(super::QWEN_CONTROL_FILE);
     assert!(
         control.exists(),
@@ -6453,10 +6455,9 @@ fn strict_control_table_is_the_authority() {
 
     let qwen = strict_control_engine("qwen_image_control").expect("qwen row");
     // sc-8267 source swap: InstantX → alibaba-pai 2512-Fun-Controlnet-Union (input-agnostic VACE branch).
-    assert_eq!(
-        qwen.repo,
-        "alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union"
-    );
+    // sc-9870: repointed to the SceneWorks PACKED tier (per-quant q4/q8/bf16 subdirs) — the row stays
+    // consistent across the MLX (`qwen.rs`) and candle (`qwen_control.rs`) drivers.
+    assert_eq!(qwen.repo, "SceneWorks/qwen-image-2512-fun-controlnet-union");
     // sc-8250 exposure: the 2512-Fun Union admits pose + canny + depth.
     assert_eq!(
         qwen.supported_kinds,
@@ -7633,7 +7634,11 @@ fn real_weight_matrix_zimage_base_depth() {
 #[cfg(target_os = "macos")]
 fn matrix_qwen_paths() -> (std::path::PathBuf, std::path::PathBuf) {
     let base = hf_snapshot("models--Qwen--Qwen-Image");
-    let control = hf_snapshot("models--alibaba-pai--Qwen-Image-2512-Fun-Controlnet-Union")
+    // sc-9870: the packed control tier (`SceneWorks/qwen-image-2512-fun-controlnet-union`) ships one
+    // `model.safetensors` per q4/q8/bf16 subdir. This smoke loads the Q8 base, so pair it with the q8/
+    // control overlay subdir.
+    let control = hf_snapshot("models--SceneWorks--qwen-image-2512-fun-controlnet-union")
+        .join("q8")
         .join(super::QWEN_CONTROL_FILE);
     assert!(
         control.exists(),
@@ -7912,13 +7917,32 @@ fn candle_control_providers_resolve_models_and_repos() {
         "black-forest-labs/FLUX.1-dev"
     );
 
-    // sc-8350 — qwen InstantX → 2512-Fun: the default control repo + base repo are the 2512-Fun row, NOT
-    // the retired InstantX `Qwen-Image-ControlNet-Union`.
+    // sc-8350 — qwen InstantX → 2512-Fun. sc-9870 — repointed to the SceneWorks PACKED tier: the default
+    // control repo is the per-quant `SceneWorks/qwen-image-2512-fun-controlnet-union` matrix (NOT the dense
+    // alibaba-pai overlay, and NOT the retired InstantX repo), and the default file is the q4 tier subdir's
+    // single `model.safetensors` when no `mlxQuantize` is requested. The base repo is unchanged (2512 base).
     let qwen = request(json!({ "projectId": "p", "model": "qwen_image" }));
-    let (q_repo, _q_file) = qwen_control_repo_file(&qwen).expect("defaults resolve");
-    assert_eq!(q_repo, "alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union");
+    let (q_repo, q_file) = qwen_control_repo_file(&qwen).expect("defaults resolve");
+    assert_eq!(q_repo, "SceneWorks/qwen-image-2512-fun-controlnet-union");
+    assert_eq!(q_file, "q4/model.safetensors");
     assert_eq!(QWEN_CONTROL_DEFAULT_REPO, "Qwen/Qwen-Image-2512");
+    assert_ne!(q_repo, "alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union");
     assert_ne!(q_repo, "InstantX/Qwen-Image-ControlNet-Union");
+    // Tier tracks `advanced.mlxQuantize`: q8 selects the q8 subdir, bf16 opt-out selects the bf16 subdir.
+    let qwen_q8 = request(
+        json!({ "projectId": "p", "model": "qwen_image", "advanced": { "mlxQuantize": 8 } }),
+    );
+    assert_eq!(
+        qwen_control_repo_file(&qwen_q8).unwrap().1,
+        "q8/model.safetensors"
+    );
+    let qwen_bf16 = request(
+        json!({ "projectId": "p", "model": "qwen_image", "advanced": { "mlxQuantize": 0 } }),
+    );
+    assert_eq!(
+        qwen_control_repo_file(&qwen_bf16).unwrap().1,
+        "bf16/model.safetensors"
+    );
 
     // sc-8379 — z-image base: both Turbo and base are recognized; the base selects the base repos + the
     // ~50-step default + the `z_image_control` engine-id row.


### PR DESCRIPTION
## sc-9870 — worker: wire the qwen 2512-Fun packed control tier into the catalog

Repoints the base-Qwen strict-pose control lane (engine id `qwen_image_control`) off the dense alibaba-pai overlay (sc-8350) onto the shared **SceneWorks packed control tier** `SceneWorks/qwen-image-2512-fun-controlnet-union`, resolved **per selected quant** so the control overlay tier tracks the base transformer tier for a coherent A/B. No candle-gen pin bump (worker main already at `8db956d`; the candle `QwenFunControl` already packed-detects the overlay, sc-9869).

### Manifest tier addition
`config/manifests/builtin.models.jsonc` — the `qwen_image` model gains the packed control tier as **per-tier (q4/q8/bf16) co-requisite downloads**, each subdir a single `model.safetensors` overlay (q4 ~0.99 GB / q8 ~1.87 GB / bf16 ~3.51 GB). Installs alongside the base so A/B tier-toggling never needs a gen-time fetch. Mirrors the base `SceneWorks/qwen-image-mlx` packed-tier manifest shape; the base tiers stay the per-variant install-tracked matrix (sc-8508), the control tiers are FETCH-ALL co-requisites (sc-9696).

### resolve_quant / mlxQuantize threading
Both drivers gain a `qwen_control_tier_subdir` mapping `advanced.mlxQuantize` to `bf16` (`<=0`) / `q8` (`>4`) / `q4` (default) — the **same mapping** `standard_tier_subdir` uses for the base transformer tier — and resolve `<tier>/model.safetensors`.

### Both-driver repoint + consistency
The shared `STRICT_CONTROL_ENGINES` `(engine_id, control_repo, supported_kinds)` row now names the packed repo. **Both** the MLX (`qwen.rs`) and candle (`qwen_control.rs`) lanes resolve the same packed subdir per quant off that single-source-of-truth row.

### Deterministic single-file resolution
Each tier subdir ships exactly one `model.safetensors`, so the sc-8350 two-overlay ambiguity is naturally gone. Nothing hardcodes the dense alibaba-pai path or an overlay filename anymore. `advanced.controlWeights.{repo,filename}` overrides still address a flat repo with a plain-component file (sc-8821 / F-019) and skip the tier subdir.

### Dense staging removed from default select
Q4/Q8 selection downloads the packed control tier (no dense alibaba-pai staging); bf16 selectable. No dense fallback retained on the default path.

### Build / test status
- Non-candle worker build + tests: green (251 pass)
- core (manifest embed/validate) + api (variant-install/manifest-behavior) tests: green
- candle `--features backend-candle` test (CUDA_COMPUTE_CAP=120, vcvars64): **green, 443 pass** + clippy `-D warnings` clean
- web vitest: green (1190 pass)
- `cargo fmt --all --check`: clean

Link: sc-9870