### PR TITLE
chore(worker): pin remaining HF runtime-weight fetches to fixed revisions (sc-9879)

### DIFF
--- a/crates/sceneworks-worker/src/depth.rs
+++ b/crates/sceneworks-worker/src/depth.rs
@@ -33,6 +33,13 @@
 /// platform); only the estimation function is backend-gated.
 pub const DEPTH_ANYTHING_V2_SMALL_REPO: &str = "depth-anything/Depth-Anything-V2-Small-hf";
 
+/// Pinned Depth-Anything-V2 revision (sc-9879, F-077 follow-up). The depth estimator is a fixed,
+/// non-overridable repo (the env pin points at a local snapshot dir, not another HF repo), so fetching
+/// the mutable `main` branch means an upstream re-push could silently swap the weights we load. Pin the
+/// exact commit for defense-in-depth (mirrors sc-8879/sc-9682). HF's tree API still reports the file's
+/// `lfs.oid`, which `ensure_hf_cached_file` verifies the downloaded content against.
+pub const DEPTH_ANYTHING_V2_REVISION: &str = "5426e4f0f36572d16453bbda7a8389317b1bef99";
+
 /// The single weight file the estimator loads from its snapshot dir. (Both the MLX and candle
 /// loaders read every `*.safetensors` in the dir; the published Small checkpoint ships exactly
 /// this one file.)

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -833,6 +833,13 @@ fn resolve_krea_convrot(
 /// The shared `krea-2-turbo-mlx` turnkey repo (its `bf16/` subdir supplies the ConvRot base surface).
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const KREA_MLX_TURNKEY_REPO: &str = "SceneWorks/krea-2-turbo-mlx";
+/// Pinned revision for the fixed [`KREA_MLX_TURNKEY_REPO`] (sc-9879, F-077 follow-up). The repo is a
+/// hard-coded const (no manifest/payload override reaches this on-demand ConvRot-base fetch), so pulling
+/// the mutable `main` branch would let an upstream re-push silently swap the bf16 DiT / Qwen3-VL TE /
+/// Qwen-Image VAE we load. Pin the exact commit for defense-in-depth (mirrors the SeedVR2/Real-ESRGAN
+/// pins, sc-8879/sc-9682). The `hf` CLI still verifies each file's own hash on download.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const KREA_MLX_TURNKEY_REVISION: &str = "d009674080cc1bccf2b629d834c34bf5eccdb723";
 
 /// On-demand fetch of the canonical bf16 Krea 2 base surface for the INT8-ConvRot tier (sc-9300),
 /// the sibling of [`ensure_boogu_tier_present`]. The ConvRot catalog download pulls only the DiT
@@ -894,7 +901,7 @@ async fn fetch_krea_convrot_base(
         settings,
         job,
         KREA_MLX_TURNKEY_REPO,
-        "main",
+        KREA_MLX_TURNKEY_REVISION,
         &files,
         &scratch,
     )

--- a/crates/sceneworks-worker/src/image_jobs/flux1_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux1_control.rs
@@ -15,6 +15,13 @@ const FLUX1_DEV_CONTROL_ENGINE_ID: &str = "flux1_dev_control";
 /// (the diffusers checkpoint). The default *repo* is the shared strict-control table (single source of
 /// truth — `STRICT_CONTROL_ENGINES`).
 const FLUX1_CONTROL_FILE: &str = "diffusion_pytorch_model.safetensors";
+/// Pinned revision for the default `Shakker-Labs/FLUX.1-dev-ControlNet-Union-Pro-2.0` control-weights
+/// repo (sc-9879, F-077 follow-up). Fetching the mutable `main` branch means a re-push (or a compromised
+/// token) could silently swap the ControlNet checkpoint we load; pin the exact commit for defense-in-depth
+/// (mirrors the SeedVR2/Real-ESRGAN pins, sc-8879/sc-9682). Applied ONLY to the default table repo — a
+/// manifest `controlWeights.repo` override carries its own revision layout, so it keeps `main`. HF's tree
+/// API still reports the file's `lfs.oid`, which `ensure_hf_cached_file` verifies against.
+const FLUX1_CONTROL_REVISION: &str = "5d700aaad96c5ddcdf8a38ef9b22a82aac2c38e5";
 /// The asset `adapter` id recorded on FLUX.1-dev strict-control assets (the dev base MLX label —
 /// shared with the plain FLUX.1 path).
 const FLUX1_CONTROL_ADAPTER_LABEL: &str = "mlx_flux";
@@ -100,7 +107,15 @@ async fn ensure_flux1_control_weights(
         .join("cache")
         .join("controlnet-flux1")
         .join(&file);
-    crate::downloads::ensure_hf_cached_file(&context, &repo, "main", &file, &dst).await
+    // Pin the exact commit for the default table control repo so `main` moving under us can't swap the
+    // ControlNet checkpoint (sc-9879). A manifest `controlWeights.repo` override may carry its own
+    // revision layout, so only pin when we're on the default repo.
+    let revision = if repo == strict_control_default_repo(FLUX1_DEV_CONTROL_ENGINE_ID) {
+        FLUX1_CONTROL_REVISION
+    } else {
+        "main"
+    };
+    crate::downloads::ensure_hf_cached_file(&context, &repo, revision, &file, &dst).await
 }
 
 /// Control lock strength for FLUX.1-dev: `advanced.controlScale` (default 0.7, clamp [0,2]). The Shakker

--- a/crates/sceneworks-worker/src/image_jobs/flux1_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux1_control_candle.rs
@@ -24,6 +24,12 @@
 /// like the other candle control lanes).
 const FLUX1_CONTROL_CANDLE_REPO: &str = "Shakker-Labs/FLUX.1-dev-ControlNet-Union-Pro-2.0";
 const FLUX1_CONTROL_CANDLE_FILE: &str = "diffusion_pytorch_model.safetensors";
+/// Pinned revision for the default `FLUX1_CONTROL_CANDLE_REPO` (sc-9879, F-077 follow-up). Fetching the
+/// mutable `main` branch means a re-push (or a compromised token) could silently swap the ControlNet
+/// checkpoint we load; pin the exact commit for defense-in-depth (mirrors sc-8879/sc-9682). Applied ONLY
+/// to the default repo — a manifest `controlWeights.repo` override keeps `main`. HF's tree API still
+/// reports the file's `lfs.oid`, which `ensure_hf_cached_file` verifies against.
+const FLUX1_CONTROL_CANDLE_REVISION: &str = "5d700aaad96c5ddcdf8a38ef9b22a82aac2c38e5";
 /// The FLUX.1-dev base diffusers repo when the manifest omits `repo` (HF-gated). The candle lane loads
 /// the dense bf16 snapshot.
 const FLUX1_CONTROL_CANDLE_BASE_REPO: &str = "black-forest-labs/FLUX.1-dev";
@@ -165,7 +171,15 @@ async fn ensure_flux1_control_candle_weights(
         .join("cache")
         .join("controlnet-flux1-candle")
         .join(&file);
-    ensure_hf_cached_file(&context, &repo, "main", &file, &dst).await?;
+    // Pin the exact commit for the default control repo so `main` moving under us can't swap the
+    // ControlNet checkpoint (sc-9879). A manifest `controlWeights.repo` override may carry its own
+    // revision layout, so only pin when we're on the default repo.
+    let revision = if repo == FLUX1_CONTROL_CANDLE_REPO {
+        FLUX1_CONTROL_CANDLE_REVISION
+    } else {
+        "main"
+    };
+    ensure_hf_cached_file(&context, &repo, revision, &file, &dst).await?;
     Ok(dst)
 }
 

--- a/crates/sceneworks-worker/src/image_jobs/flux2.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2.rs
@@ -584,6 +584,13 @@ const FLUX2_DEV_CONTROL_ENGINE_ID: &str = "flux2_dev_control";
 /// recommended one — the previous version lost CFG distillation after control training). The default
 /// *repo* is the shared strict-control table (single source of truth — `STRICT_CONTROL_ENGINES`).
 const FLUX2_CONTROL_FILE: &str = "FLUX.2-dev-Fun-Controlnet-Union-2602.safetensors";
+/// Pinned revision for the default `alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union` control-weights repo
+/// (sc-9879, F-077 follow-up). Fetching the mutable `main` branch means a re-push (or a compromised token)
+/// could silently swap the ControlNet checkpoint we load; pin the exact commit for defense-in-depth
+/// (mirrors sc-8879/sc-9682). Applied ONLY to the default table repo — a manifest `controlWeights.repo`
+/// override carries its own revision layout, so it keeps `main`. HF's tree API still reports the file's
+/// `lfs.oid`, which `ensure_hf_cached_file` verifies the downloaded content against.
+const FLUX2_CONTROL_REVISION: &str = "b3dcd7836a0e926248dac3ccba8fc0853495764b";
 /// The asset `adapter` id recorded on FLUX.2-dev strict-pose assets (the dev base MLX label).
 const FLUX2_CONTROL_ADAPTER_LABEL: &str = "mlx_flux2";
 
@@ -666,7 +673,15 @@ async fn ensure_flux2_control_weights(
         .join("cache")
         .join("controlnet-flux2")
         .join(&file);
-    crate::downloads::ensure_hf_cached_file(&context, &repo, "main", &file, &dst).await
+    // Pin the exact commit for the default table control repo so `main` moving under us can't swap the
+    // ControlNet checkpoint (sc-9879). A manifest `controlWeights.repo` override may carry its own
+    // revision layout, so only pin when we're on the default repo.
+    let revision = if repo == strict_control_default_repo(FLUX2_DEV_CONTROL_ENGINE_ID) {
+        FLUX2_CONTROL_REVISION
+    } else {
+        "main"
+    };
+    crate::downloads::ensure_hf_cached_file(&context, &repo, revision, &file, &dst).await
 }
 
 /// Pose ControlNet lock strength for FLUX.2-dev: `advanced.controlScale` (default 0.75, clamp [0,2]).

--- a/crates/sceneworks-worker/src/image_jobs/flux2_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_control_candle.rs
@@ -23,6 +23,12 @@
 /// `FLUX2_CONTROL_REPO` / `FLUX2_CONTROL_FILE`.
 const FLUX2_CONTROL_CANDLE_REPO: &str = "alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union";
 const FLUX2_CONTROL_CANDLE_FILE: &str = "FLUX.2-dev-Fun-Controlnet-Union-2602.safetensors";
+/// Pinned revision for the default `FLUX2_CONTROL_CANDLE_REPO` (sc-9879, F-077 follow-up). Fetching the
+/// mutable `main` branch means a re-push (or a compromised token) could silently swap the ControlNet
+/// checkpoint we load; pin the exact commit for defense-in-depth (mirrors sc-8879/sc-9682). Applied ONLY
+/// to the default repo — a manifest `controlWeights.repo` override keeps `main`. HF's tree API still
+/// reports the file's `lfs.oid`, which `ensure_hf_cached_file` verifies against.
+const FLUX2_CONTROL_CANDLE_REVISION: &str = "b3dcd7836a0e926248dac3ccba8fc0853495764b";
 /// The FLUX.2-dev base diffusers repo when the manifest omits `repo` (the 32B flagship). The candle lane
 /// loads the dense snapshot and Q4-quantizes it at load.
 const FLUX2_CONTROL_CANDLE_BASE_REPO: &str = "black-forest-labs/FLUX.2-dev";
@@ -164,7 +170,15 @@ async fn ensure_flux2_control_candle_weights(
         .join("cache")
         .join("controlnet-flux2")
         .join(&file);
-    ensure_hf_cached_file(&context, &repo, "main", &file, &dst).await?;
+    // Pin the exact commit for the default control repo so `main` moving under us can't swap the
+    // ControlNet checkpoint (sc-9879). A manifest `controlWeights.repo` override may carry its own
+    // revision layout, so only pin when we're on the default repo.
+    let revision = if repo == FLUX2_CONTROL_CANDLE_REPO {
+        FLUX2_CONTROL_CANDLE_REVISION
+    } else {
+        "main"
+    };
+    ensure_hf_cached_file(&context, &repo, revision, &file, &dst).await?;
     Ok(dst)
 }
 

--- a/crates/sceneworks-worker/src/image_jobs/flux_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux_ipadapter.rs
@@ -20,8 +20,14 @@ const FLUX_IPADAPTER_ADAPTER_FILE: &str = "ip_adapter.safetensors";
 /// pooled image embeds) + the weight file the provider's `resolve_image_encoder` looks for in the dir.
 const FLUX_IPADAPTER_ENCODER_REPO: &str = "openai/clip-vit-large-patch14";
 const FLUX_IPADAPTER_ENCODER_FILE: &str = "model.safetensors";
-/// Both repos ship the safetensors on `main` (unlike the Kolors `refs/pr/4`).
-const FLUX_IPADAPTER_REVISION: &str = "main";
+/// Pinned revisions for the two IP-Adapter repos (sc-9879, F-077 follow-up). Both are fixed,
+/// non-overridable consts, so fetching the mutable `main` branch means an upstream re-push could silently
+/// swap the adapter / CLIP-image-encoder weights we load. Pin each to its exact commit for
+/// defense-in-depth (mirrors sc-8879/sc-9682). HF's tree API still reports each file's `lfs.oid`, which
+/// `ensure_hf_cached_file` verifies the downloaded content against. (Split per repo because a single sha
+/// cannot address two different repos.)
+const FLUX_IPADAPTER_ADAPTER_REVISION: &str = "18f6940238ab5dc3744df7a8e30315892279d5f9";
+const FLUX_IPADAPTER_ENCODER_REVISION: &str = "32bd64288804d66eefd0ccbe215aa642df71cc41";
 /// IP-Adapter scale default — the XLabs resemblance tier 0.7 (matches `base.rs` `FLUX_IP_SCALE`, the MLX
 /// path, and the candle `IpAdapterFlux::DEFAULT_IP_SCALE`).
 const FLUX_IPADAPTER_IP_SCALE: f32 = 0.7;
@@ -163,7 +169,7 @@ async fn ensure_flux_ipadapter_weights(
             ensure_hf_cached_file(
                 &context,
                 FLUX_IPADAPTER_ADAPTER_REPO,
-                FLUX_IPADAPTER_REVISION,
+                FLUX_IPADAPTER_ADAPTER_REVISION,
                 FLUX_IPADAPTER_ADAPTER_FILE,
                 &dst,
             )
@@ -182,7 +188,7 @@ async fn ensure_flux_ipadapter_weights(
             ensure_hf_cached_file(
                 &context,
                 FLUX_IPADAPTER_ENCODER_REPO,
-                FLUX_IPADAPTER_REVISION,
+                FLUX_IPADAPTER_ENCODER_REVISION,
                 FLUX_IPADAPTER_ENCODER_FILE,
                 &dir.join(FLUX_IPADAPTER_ENCODER_FILE),
             )

--- a/crates/sceneworks-worker/src/image_jobs/instantid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/instantid.rs
@@ -4,11 +4,20 @@ const INSTANTID_MODEL: &str = "instantid_realvisxl";
 const INSTANTID_SDXL_REPO: &str = "SG161222/RealVisXL_V5.0";
 /// Stock InstantID checkpoint repo — the IdentityNet `ControlNetModel/` lives here.
 const INSTANTID_CONTROLNET_REPO: &str = "InstantX/InstantID";
+/// Pinned revision for the stock InstantX IdentityNet repo (sc-9879, F-077 follow-up).
+const INSTANTID_CONTROLNET_REVISION: &str = "57b32dfee076092ad2930c71fd6d439c2c3b1820";
 /// Converted-weights bundle (download-on-first-use): the MLX `ip-adapter.safetensors`
 /// (`tools/convert_instantid.py`) + the native face stack `scrfd_10g.safetensors`
 /// (`convert_scrfd.py`) + `arcface_iresnet100.safetensors` (`convert_glintr100.py`). Public
 /// repo, mirroring the YOLO11 / SAM2 `SceneWorks/*-mlx` uploads (sc-3633 / sc-3707).
 const INSTANTID_MLX_REPO: &str = "SceneWorks/instantid-mlx";
+/// Pinned revision for the first-party converted InstantID bundle (sc-9879, F-077 follow-up). Even
+/// though `SceneWorks/instantid-mlx` is a first-party repo, fetching the mutable `main` branch means a
+/// re-push (or a compromised token) could silently swap the ip-adapter / SCRFD / ArcFace weights we
+/// load. Pin the exact commit for defense-in-depth (mirrors sc-8879/sc-9682). HF's tree API still reports
+/// each file's `lfs.oid`, which `ensure_hf_cached_file` verifies against. NOTE: the candle PuLID lane
+/// reuses this SAME repo (`pulid_candle.rs` `PULID_CANDLE_FACE_REPO`); its pin must match this sha.
+const INSTANTID_MLX_REVISION: &str = "bca0cacf8e5e04529bb2b326a521361b02be84fd";
 const INSTANTID_IP_ADAPTER_FILE: &str = "ip-adapter.safetensors";
 // `pub(crate)` so the Dataset Doctor face pass (sc-6538) can join them under the bundle dir that
 // `ensure_face_stack_dir` stages, to load the MLX `FaceAnalysis` (SCRFD + ArcFace) directly.
@@ -33,6 +42,8 @@ const INSTANTID_ANGLE_CONTROLNET_SCALE: f32 = 0.65;
 /// xinsir OpenPose-SDXL ControlNet (the pose-mode second branch, sc-3117). Loads via the stock
 /// `load_controlnet` (no conversion) — `image_adapters.py:615-617` parity.
 const INSTANTID_OPENPOSE_REPO: &str = "xinsir/controlnet-openpose-sdxl-1.0";
+/// Pinned revision for the xinsir OpenPose-SDXL ControlNet (sc-9879, F-077 follow-up).
+const INSTANTID_OPENPOSE_REVISION: &str = "23f966cd5cfdd3f7729c903e243d87152162d2b7";
 /// Torch-parity default OpenPose lock (`instantid_adapter.py::_openpose_scale`, default 0.7).
 const INSTANTID_OPENPOSE_SCALE: f32 = 0.7;
 /// The face-restore re-render side (the engine's production crop size, sc-3380).
@@ -273,6 +284,21 @@ fn instantid_raw_settings(
     raw
 }
 
+/// The pinned commit revision for each InstantID download repo (sc-9879, F-077 follow-up). Every
+/// InstantID weight repo is a fixed, non-overridable const (the env pins point at local snapshot dirs,
+/// never another HF repo), so fetching the mutable `main` branch means a re-push (or a compromised token)
+/// could silently swap the weights we load. Pin each to its exact commit for defense-in-depth (mirrors
+/// sc-8879/sc-9682); the `lfs.oid` sha256 verify in `ensure_hf_cached_file` is retained. Any repo not in
+/// this table (a caller passing something unexpected) falls back to `main` rather than a wrong sha.
+fn instantid_revision(repo: &str) -> &'static str {
+    match repo {
+        INSTANTID_MLX_REPO => INSTANTID_MLX_REVISION,
+        INSTANTID_CONTROLNET_REPO => INSTANTID_CONTROLNET_REVISION,
+        INSTANTID_OPENPOSE_REPO => INSTANTID_OPENPOSE_REVISION,
+        _ => "main",
+    }
+}
+
 /// Resolve a single InstantID weight file: return it if already present in `dir`, else
 /// download `url` into `dir` (atomic `.tmp` + rename, so a partial download is never mistaken
 /// for a complete one — same shape as `person_segment::ensure_segmenter_weights`).
@@ -282,7 +308,7 @@ async fn ensure_instantid_file(
     dir: &Path,
     name: &str,
 ) -> WorkerResult<PathBuf> {
-    ensure_hf_cached_file(context, repo, "main", name, &dir.join(name)).await
+    ensure_hf_cached_file(context, repo, instantid_revision(repo), name, &dir.join(name)).await
 }
 
 /// Resolve only the SCRFD detector weights (`scrfd_10g.safetensors`) from the same converted
@@ -430,7 +456,7 @@ async fn ensure_instantid_weights(
         ensure_hf_cached_file(
             &context,
             INSTANTID_CONTROLNET_REPO,
-            "main",
+            INSTANTID_CONTROLNET_REVISION,
             &source,
             &controlnet_dir.join(file),
         )

--- a/crates/sceneworks-worker/src/image_jobs/kolors_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_control.rs
@@ -23,6 +23,12 @@
 /// `.safetensors` on `main` (no `refs/pr` dance, unlike the Kolors IP-Adapter).
 const KOLORS_CONTROL_REPO: &str = "Kwai-Kolors/Kolors-ControlNet-Pose";
 const KOLORS_CONTROL_FILE: &str = "diffusion_pytorch_model.safetensors";
+/// Pinned revision for the default `KOLORS_CONTROL_REPO` (sc-9879, F-077 follow-up). Fetching the
+/// mutable `main` branch means a re-push (or a compromised token) could silently swap the ControlNet
+/// checkpoint we load; pin the exact commit for defense-in-depth (mirrors sc-8879/sc-9682). Applied ONLY
+/// to the default repo — a manifest `controlWeights.repo` override carries its own revision layout, so it
+/// keeps `main`. HF's tree API still reports the file's `lfs.oid`, which `ensure_hf_cached_file` verifies.
+const KOLORS_CONTROL_REVISION: &str = "83e35a8033a89d2e75044b412d0e2474111578f7";
 /// The Kolors base diffusers repo when the manifest omits `repo`.
 const KOLORS_CONTROL_DEFAULT_REPO: &str = "Kwai-Kolors/Kolors-diffusers";
 /// ControlNet conditioning-scale default (the strict-pose tier).
@@ -151,7 +157,15 @@ async fn ensure_kolors_control_weights(
         .join("cache")
         .join("controlnet-kolors")
         .join(&file);
-    ensure_hf_cached_file(&context, &repo, "main", &file, &dst).await?;
+    // Pin the exact commit for the default control repo so `main` moving under us can't swap the
+    // ControlNet checkpoint (sc-9879). A manifest `controlWeights.repo` override may carry its own
+    // revision layout, so only pin when we're on the default repo.
+    let revision = if repo == KOLORS_CONTROL_REPO {
+        KOLORS_CONTROL_REVISION
+    } else {
+        "main"
+    };
+    ensure_hf_cached_file(&context, &repo, revision, &file, &dst).await?;
     Ok(dst)
 }
 

--- a/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
@@ -32,8 +32,26 @@ const PULID_CANDLE_BISENET_FILE: &str = "bisenet_parsing.safetensors";
 const PULID_CANDLE_FACE_REPO: &str = "SceneWorks/instantid-mlx";
 const PULID_CANDLE_SCRFD_FILE: &str = "scrfd_10g.safetensors";
 const PULID_CANDLE_ARCFACE_FILE: &str = "arcface_iresnet100.safetensors";
-/// Both bundle repos ship the safetensors on `main`.
-const PULID_CANDLE_REVISION: &str = "main";
+/// Pinned commit revisions for the three PuLID download repos (sc-9879, F-077 follow-up). Every repo is
+/// a fixed, non-overridable const, so fetching the mutable `main` branch means a re-push (or a compromised
+/// token) could silently swap the adapter / EVA-BiSeNet / face-stack weights we load. Pin each to its
+/// exact commit for defense-in-depth (mirrors sc-8879/sc-9682); the `lfs.oid` sha256 verify in
+/// `ensure_hf_cached_file` is retained. `PULID_CANDLE_FACE_REPO` == `SceneWorks/instantid-mlx`, so its
+/// sha MUST equal `instantid.rs` `INSTANTID_MLX_REVISION` (they fetch the same repo).
+const PULID_CANDLE_ADAPTER_REVISION: &str = "492b1451255dc9d9bc3c857259690b5f8b998d4a";
+const PULID_CANDLE_MLX_REVISION: &str = "78ef91f977eae16d66fb191caf003154b7a0a0b8";
+const PULID_CANDLE_FACE_REVISION: &str = "bca0cacf8e5e04529bb2b326a521361b02be84fd";
+
+/// The pinned revision for one PuLID download repo (sc-9879). Any repo not in this table falls back to
+/// `main` rather than a wrong sha.
+fn pulid_candle_revision(repo: &str) -> &'static str {
+    match repo {
+        PULID_CANDLE_ADAPTER_REPO => PULID_CANDLE_ADAPTER_REVISION,
+        PULID_CANDLE_MLX_REPO => PULID_CANDLE_MLX_REVISION,
+        PULID_CANDLE_FACE_REPO => PULID_CANDLE_FACE_REVISION,
+        _ => "main",
+    }
+}
 
 /// Torch/MLX-parity defaults (the `pulid_flux_dev` "photoreal" preset): 30 steps at guidance 4.0,
 /// id_weight 1.0.
@@ -160,7 +178,7 @@ async fn ensure_pulid_candle_weights(
             return Ok(snapshot);
         }
         let dst = bundle.join(file);
-        ensure_hf_cached_file(context, repo, PULID_CANDLE_REVISION, file, &dst).await?;
+        ensure_hf_cached_file(context, repo, pulid_candle_revision(repo), file, &dst).await?;
         Ok(dst)
     }
 
@@ -189,7 +207,8 @@ async fn ensure_pulid_candle_weights(
         (PULID_CANDLE_FACE_REPO, PULID_CANDLE_ARCFACE_FILE),
         (PULID_CANDLE_MLX_REPO, PULID_CANDLE_BISENET_FILE),
     ] {
-        ensure_hf_cached_file(&context, repo, PULID_CANDLE_REVISION, file, &bundle.join(file)).await?;
+        ensure_hf_cached_file(&context, repo, pulid_candle_revision(repo), file, &bundle.join(file))
+            .await?;
     }
 
     Ok((adapter, eva, bundle))

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -397,13 +397,23 @@ struct LightningDistill {
     file: &'static str,
 }
 
+/// The default Lightning distill-LoRA repo (`qwen_image_edit_2511_lightning`). A fixed default; a
+/// manifest-supplied `LightningDistill.repo` (should one ever appear) is honored but not pinned.
+const QWEN_LIGHTNING_LORA_REPO: &str = "lightx2v/Qwen-Image-Edit-2511-Lightning";
+/// Pinned revision for the default Lightning distill-LoRA repo (sc-9879, F-077 follow-up). Fetching the
+/// mutable `main` branch means an upstream re-push could silently swap the distill LoRA we stack at load.
+/// Pin the exact commit for defense-in-depth (mirrors sc-8879/sc-9682). `HuggingFaceSnapshot::resolve`
+/// still verifies each file's `lfs.oid` sha256 against the downloaded content. Applied ONLY to the default
+/// repo — a non-default repo keeps `main`.
+const QWEN_LIGHTNING_LORA_REVISION: &str = "d74eba145674fd7e31b949324e148e21e7118abd";
+
 /// The Lightning distill config for a SceneWorks model id, or `None` for every
 /// production variant. Only `qwen_image_edit_2511_lightning` is a distilled variant today.
 fn qwen_edit_lightning(model: &str) -> Option<LightningDistill> {
     match model {
         "qwen_image_edit_2511_lightning" => Some(LightningDistill {
             sampler: "lightning",
-            repo: "lightx2v/Qwen-Image-Edit-2511-Lightning",
+            repo: QWEN_LIGHTNING_LORA_REPO,
             file: "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
         }),
         _ => None,
@@ -438,7 +448,13 @@ async fn ensure_distill_lora_cached(
             "Unable to resolve Hugging Face cache path for {repo}."
         ))
     })?;
-    let revision = "main";
+    // Pin the exact commit for the default distill-LoRA repo so `main` moving under us can't swap the
+    // LoRA (sc-9879). A non-default repo (none exists today, but the param is repo-agnostic) keeps `main`.
+    let revision = if repo == QWEN_LIGHTNING_LORA_REPO {
+        QWEN_LIGHTNING_LORA_REVISION
+    } else {
+        "main"
+    };
     let client = reqwest::Client::new();
     let snapshot =
         HuggingFaceSnapshot::resolve(&client, settings, repo, revision, &[file.to_owned()]).await?;

--- a/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
@@ -189,6 +189,11 @@ async fn ensure_qwen_control_weights(
         .join("cache")
         .join("controlnet-qwen")
         .join(&file);
+    // sc-9879 pinned this fetch to a fixed commit, but sc-9870 (merged concurrently) repointed
+    // `QWEN_CONTROL_REPO` from `alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union` to the first-party
+    // SceneWorks PACKED tier (`SceneWorks/qwen-image-2512-fun-controlnet-union`) with a per-quant
+    // `<tier>/model.safetensors` layout. The old alibaba-pai SHA is invalid for the new repo, so this
+    // fetch is left on `main` here pending a re-pin to a verified SceneWorks packed-tier commit.
     ensure_hf_cached_file(&context, &repo, "main", &file, &dst).await?;
     Ok(dst)
 }

--- a/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
@@ -28,6 +28,14 @@
 /// `QwenFunControl` engine already packed-detects the overlay (sc-9869), so nothing downstream changes.
 /// Same repo the MLX path uses (`qwen.rs` — the shared `STRICT_CONTROL_ENGINES` `qwen_image_control` row).
 const QWEN_CONTROL_REPO: &str = "SceneWorks/qwen-image-2512-fun-controlnet-union";
+/// Pinned revision for the default `QWEN_CONTROL_REPO` (sc-9879, F-077 follow-up). Fetching the mutable
+/// `main` branch means a re-push (or a compromised token) could silently swap the ControlNet overlay we
+/// load; pin the exact commit for defense-in-depth (mirrors the other candle control lanes, e.g.
+/// `FLUX1_CONTROL_CANDLE_REVISION`). Applied ONLY to the default repo — a manifest/user
+/// `controlWeights.repo` override keeps `main`. The pin is the packed-tier repo's `main` HEAD as of the
+/// sc-9870 repoint. HF's tree API still reports each tier file's `lfs.oid`, which `ensure_hf_cached_file`
+/// verifies against.
+const QWEN_CONTROL_REVISION: &str = "a061fbc42a4744d6a7ec206370fbd3a37d4a7cca";
 /// The single packed control file inside each tier subdir (`q4/`, `q8/`, `bf16/`). Deterministic —
 /// the packed tier ships exactly one `model.safetensors` per subdir, so the sc-8350 two-overlay
 /// ambiguity is naturally resolved.
@@ -189,12 +197,18 @@ async fn ensure_qwen_control_weights(
         .join("cache")
         .join("controlnet-qwen")
         .join(&file);
-    // sc-9879 pinned this fetch to a fixed commit, but sc-9870 (merged concurrently) repointed
-    // `QWEN_CONTROL_REPO` from `alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union` to the first-party
-    // SceneWorks PACKED tier (`SceneWorks/qwen-image-2512-fun-controlnet-union`) with a per-quant
-    // `<tier>/model.safetensors` layout. The old alibaba-pai SHA is invalid for the new repo, so this
-    // fetch is left on `main` here pending a re-pin to a verified SceneWorks packed-tier commit.
-    ensure_hf_cached_file(&context, &repo, "main", &file, &dst).await?;
+    // Pin the exact commit for the default control repo so `main` moving under us can't swap the
+    // ControlNet overlay (sc-9879). sc-9870 (merged concurrently) repointed `QWEN_CONTROL_REPO` from
+    // `alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union` to the first-party SceneWorks PACKED tier
+    // (`SceneWorks/qwen-image-2512-fun-controlnet-union`, per-quant `<tier>/model.safetensors`); the pin
+    // below is that repo's verified `main` HEAD. A manifest/user `controlWeights.repo` override may carry
+    // its own revision layout, so only pin when we're on the default repo.
+    let revision = if repo == QWEN_CONTROL_REPO {
+        QWEN_CONTROL_REVISION
+    } else {
+        "main"
+    };
+    ensure_hf_cached_file(&context, &repo, revision, &file, &dst).await?;
     Ok(dst)
 }
 

--- a/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
@@ -34,6 +34,12 @@ const QWEN_EDIT_CANDLE_2511_REPO: &str = "Qwen/Qwen-Image-Edit-2511";
 const QWEN_EDIT_CANDLE_LIGHTNING_LORA_REPO: &str = "lightx2v/Qwen-Image-Edit-2511-Lightning";
 const QWEN_EDIT_CANDLE_LIGHTNING_LORA_FILE: &str =
     "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors";
+/// Pinned revision for the default candle Lightning distill-LoRA repo (sc-9879, F-077 follow-up).
+/// Fetching the mutable `main` branch means an upstream re-push could silently swap the distill LoRA we
+/// stack at load; pin the exact commit for defense-in-depth (mirrors sc-8879/sc-9682).
+/// `HuggingFaceSnapshot::resolve` still verifies each file's `lfs.oid` sha256. Applied ONLY to the
+/// default repo — a non-default repo keeps `main`. Matches the MLX `QWEN_LIGHTNING_LORA_REVISION`.
+const QWEN_EDIT_CANDLE_LIGHTNING_LORA_REVISION: &str = "d74eba145674fd7e31b949324e148e21e7118abd";
 
 /// Qwen-Image-Edit model ids the candle edit route accepts. The base variants map to the single edit
 /// engine (the architecture is identical; `-2511` only flips `zero_cond_t`, which `QwenEdit` auto-detects
@@ -210,7 +216,13 @@ async fn ensure_qwen_lightning_lora_cached(
                 "Unable to resolve Hugging Face cache path for {repo}."
             ))
         })?;
-    let revision = "main";
+    // Pin the exact commit for the default distill-LoRA repo so `main` moving under us can't swap the
+    // LoRA (sc-9879). A non-default repo (none exists today, but the param is repo-agnostic) keeps `main`.
+    let revision = if repo == QWEN_EDIT_CANDLE_LIGHTNING_LORA_REPO {
+        QWEN_EDIT_CANDLE_LIGHTNING_LORA_REVISION
+    } else {
+        "main"
+    };
     let client = reqwest::Client::new();
     let snapshot = crate::downloads::HuggingFaceSnapshot::resolve(
         &client,

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
@@ -12,6 +12,12 @@
 /// h94 IP-Adapter repo (the ViT-H encoder + the plus/plus-face SDXL weights), matching the MLX SDXL IP
 /// path's `SDXL_IP_ADAPTER_REPO`.
 const SDXL_IPADAPTER_REPO: &str = "h94/IP-Adapter";
+/// Pinned revision for the `h94/IP-Adapter` repo (sc-9879, F-077 follow-up). A fixed, non-overridable
+/// repo (the env pin points at a local dir, not another HF repo), so fetching the mutable `main` branch
+/// means an upstream re-push could silently swap the adapter / CLIP-encoder weights we load. Pin the
+/// exact commit for defense-in-depth (mirrors sc-8879/sc-9682). HF's tree API still reports each file's
+/// `lfs.oid`, which `ensure_hf_cached_file` verifies the downloaded content against.
+const SDXL_IPADAPTER_REVISION: &str = "018e402774aeeddd60609b4ecdb7e298259dc729";
 /// The IP-Adapter-Plus (ViT-H) bundle inside the repo (`image_proj` Resampler + `ip_adapter.*` K/V).
 const SDXL_IPADAPTER_BUNDLE_SRC: &str = "sdxl_models/ip-adapter-plus_sdxl_vit-h.safetensors";
 /// The CLIP ViT-H image-encoder files inside the repo (config + weights).
@@ -141,7 +147,7 @@ async fn ensure_sdxl_ipadapter_weights(
     let bundle = ensure_hf_cached_file(
         &context,
         SDXL_IPADAPTER_REPO,
-        "main",
+        SDXL_IPADAPTER_REVISION,
         SDXL_IPADAPTER_BUNDLE_SRC,
         &cache.join("ip-adapter-plus_sdxl_vit-h.safetensors"),
     )
@@ -152,7 +158,7 @@ async fn ensure_sdxl_ipadapter_weights(
         ensure_hf_cached_file(
             &context,
             SDXL_IPADAPTER_REPO,
-            "main",
+            SDXL_IPADAPTER_REVISION,
             source,
             &encoder.join(name),
         )

--- a/crates/sceneworks-worker/src/image_jobs/strict_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/strict_control.rs
@@ -297,7 +297,9 @@ async fn ensure_depth_estimator_dir(
     settings: &Settings,
     job: &JobSnapshot,
 ) -> WorkerResult<PathBuf> {
-    use crate::depth::{DEPTH_ANYTHING_V2_FILE, DEPTH_ANYTHING_V2_SMALL_REPO};
+    use crate::depth::{
+        DEPTH_ANYTHING_V2_FILE, DEPTH_ANYTHING_V2_REVISION, DEPTH_ANYTHING_V2_SMALL_REPO,
+    };
 
     if let Ok(p) = std::env::var("SCENEWORKS_DEPTH_ANYTHING_V2") {
         let p = PathBuf::from(p);
@@ -324,7 +326,7 @@ async fn ensure_depth_estimator_dir(
     crate::downloads::ensure_hf_cached_file(
         &context,
         DEPTH_ANYTHING_V2_SMALL_REPO,
-        "main",
+        DEPTH_ANYTHING_V2_REVISION,
         DEPTH_ANYTHING_V2_FILE,
         &dir.join(DEPTH_ANYTHING_V2_FILE),
     )

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -8480,3 +8480,12 @@ fn candle_ipadapter_and_pulid_revisions_are_pinned_commits_not_main() {
     );
     assert_eq!(pulid_candle_revision("some/override-repo"), "main");
 }
+
+/// The candle-only Krea 2 ConvRot bf16-base pin (`base.rs`, sc-9300 tier). Fetches the fixed
+/// `SceneWorks/krea-2-turbo-mlx` turnkey const on-demand; the repo is non-overridable here, so it must
+/// pin an exact commit rather than the mutable `main` branch (sc-9879, F-077 follow-up).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn krea_convrot_base_revision_is_pinned_commit_not_main() {
+    assert_pinned_revision("KREA_MLX_TURNKEY_REVISION", KREA_MLX_TURNKEY_REVISION);
+}

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -8358,3 +8358,125 @@ fn candle_preprocess_depth_requires_source_and_weights() {
     )
     .is_err());
 }
+
+// ---------------------------------------------------------------------------
+// sc-9879 (F-077 follow-up): every worker HF runtime-weight fetch pins a fixed commit revision, never
+// the mutable `main` branch, so a re-push (or a compromised token) can't silently swap the weights we
+// load. Each `_REVISION` const below is locked to a real 40-hex lowercase commit sha (mirrors the
+// sc-9682 `onnx_revision_is_pinned_commit_not_main` format tests). Grouped per lane so each assertion
+// only compiles where its const does (MLX-only files vs candle-only include!s vs both-lane).
+// ---------------------------------------------------------------------------
+
+/// Assert a pinned HF revision is a real 40-hex lowercase commit sha (never `main`). Referenced on
+/// BOTH lanes (the depth + InstantID pins compile everywhere), so no cfg gating on the helper itself.
+fn assert_pinned_revision(name: &str, revision: &str) {
+    assert_ne!(revision, "main", "{name} must pin a fixed revision");
+    assert_eq!(
+        revision.len(),
+        40,
+        "{name}: a pinned HF revision is a 40-char commit sha"
+    );
+    assert!(
+        revision
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+        "{name}: the pinned revision must be lowercase hex"
+    );
+}
+
+/// The Depth-Anything-V2 estimator pin (`strict_control.rs`) — resolved on both lanes.
+#[test]
+fn depth_anything_revision_is_pinned_commit_not_main() {
+    assert_pinned_revision(
+        "DEPTH_ANYTHING_V2_REVISION",
+        crate::depth::DEPTH_ANYTHING_V2_REVISION,
+    );
+}
+
+/// The InstantID download pins (`instantid.rs`) — compiled on macOS AND the candle lane.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[test]
+fn instantid_revisions_are_pinned_commits_not_main() {
+    assert_pinned_revision("INSTANTID_MLX_REVISION", INSTANTID_MLX_REVISION);
+    assert_pinned_revision(
+        "INSTANTID_CONTROLNET_REVISION",
+        INSTANTID_CONTROLNET_REVISION,
+    );
+    assert_pinned_revision("INSTANTID_OPENPOSE_REVISION", INSTANTID_OPENPOSE_REVISION);
+    // `instantid_revision` returns the pin for a known repo and falls back to `main` otherwise.
+    assert_eq!(
+        instantid_revision(INSTANTID_MLX_REPO),
+        INSTANTID_MLX_REVISION
+    );
+    assert_eq!(instantid_revision("some/override-repo"), "main");
+}
+
+/// The MLX-only strict-control pins (`flux1_control.rs` / `flux2.rs`) + the MLX Qwen distill-LoRA pin
+/// (`qwen.rs`). These files are `#[cfg(target_os = "macos")]`-gated `include!`s.
+#[cfg(target_os = "macos")]
+#[test]
+fn mlx_control_and_distill_revisions_are_pinned_commits_not_main() {
+    assert_pinned_revision("FLUX1_CONTROL_REVISION", FLUX1_CONTROL_REVISION);
+    assert_pinned_revision("FLUX2_CONTROL_REVISION", FLUX2_CONTROL_REVISION);
+    assert_pinned_revision("QWEN_LIGHTNING_LORA_REVISION", QWEN_LIGHTNING_LORA_REVISION);
+}
+
+/// The candle-only strict-control pins (qwen / kolors / zimage / flux1 / flux2 control branches). These
+/// files are `#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]`-gated `include!`s.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn candle_control_revisions_are_pinned_commits_not_main() {
+    // NOTE: QWEN_CONTROL_REVISION was dropped during the sc-9879 rebase — sc-9870 repointed
+    // QWEN_CONTROL_REPO to the SceneWorks packed tier, invalidating the old alibaba-pai SHA. The
+    // qwen_control fetch is temporarily back on `main` pending a re-pin to a verified SceneWorks commit.
+    assert_pinned_revision("KOLORS_CONTROL_REVISION", KOLORS_CONTROL_REVISION);
+    assert_pinned_revision("ZIMAGE_CTRL_REVISION", ZIMAGE_CTRL_REVISION);
+    assert_pinned_revision("ZIMAGE_CTRL_BASE_REVISION", ZIMAGE_CTRL_BASE_REVISION);
+    assert_pinned_revision(
+        "FLUX1_CONTROL_CANDLE_REVISION",
+        FLUX1_CONTROL_CANDLE_REVISION,
+    );
+    assert_pinned_revision(
+        "FLUX2_CONTROL_CANDLE_REVISION",
+        FLUX2_CONTROL_CANDLE_REVISION,
+    );
+}
+
+/// The candle-only IP-Adapter / PuLID / Qwen-edit distill pins. Candle-lane `include!`s.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn candle_ipadapter_and_pulid_revisions_are_pinned_commits_not_main() {
+    assert_pinned_revision(
+        "FLUX_IPADAPTER_ADAPTER_REVISION",
+        FLUX_IPADAPTER_ADAPTER_REVISION,
+    );
+    assert_pinned_revision(
+        "FLUX_IPADAPTER_ENCODER_REVISION",
+        FLUX_IPADAPTER_ENCODER_REVISION,
+    );
+    assert_pinned_revision("SDXL_IPADAPTER_REVISION", SDXL_IPADAPTER_REVISION);
+    assert_pinned_revision(
+        "PULID_CANDLE_ADAPTER_REVISION",
+        PULID_CANDLE_ADAPTER_REVISION,
+    );
+    assert_pinned_revision("PULID_CANDLE_MLX_REVISION", PULID_CANDLE_MLX_REVISION);
+    assert_pinned_revision("PULID_CANDLE_FACE_REVISION", PULID_CANDLE_FACE_REVISION);
+    assert_pinned_revision(
+        "QWEN_EDIT_CANDLE_LIGHTNING_LORA_REVISION",
+        QWEN_EDIT_CANDLE_LIGHTNING_LORA_REVISION,
+    );
+    // The PuLID face-stack repo IS `SceneWorks/instantid-mlx`, so its pin must match the InstantID pin.
+    assert_eq!(
+        PULID_CANDLE_FACE_REVISION, INSTANTID_MLX_REVISION,
+        "PuLID + InstantID fetch the same SceneWorks/instantid-mlx repo; pins must agree"
+    );
+    // `pulid_candle_revision` returns the pin for a known repo and falls back to `main` otherwise.
+    assert_eq!(
+        pulid_candle_revision(PULID_CANDLE_FACE_REPO),
+        PULID_CANDLE_FACE_REVISION
+    );
+    assert_eq!(pulid_candle_revision("some/override-repo"), "main");
+}

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -8429,9 +8429,7 @@ fn mlx_control_and_distill_revisions_are_pinned_commits_not_main() {
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 #[test]
 fn candle_control_revisions_are_pinned_commits_not_main() {
-    // NOTE: QWEN_CONTROL_REVISION was dropped during the sc-9879 rebase — sc-9870 repointed
-    // QWEN_CONTROL_REPO to the SceneWorks packed tier, invalidating the old alibaba-pai SHA. The
-    // qwen_control fetch is temporarily back on `main` pending a re-pin to a verified SceneWorks commit.
+    assert_pinned_revision("QWEN_CONTROL_REVISION", QWEN_CONTROL_REVISION);
     assert_pinned_revision("KOLORS_CONTROL_REVISION", KOLORS_CONTROL_REVISION);
     assert_pinned_revision("ZIMAGE_CTRL_REVISION", ZIMAGE_CTRL_REVISION);
     assert_pinned_revision("ZIMAGE_CTRL_BASE_REVISION", ZIMAGE_CTRL_BASE_REVISION);

--- a/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
@@ -15,6 +15,12 @@
 /// `ZIMAGE_CONTROL_FILE`); the candle `ZImageControl::generate` runs the matching 8-step schedule.
 const ZIMAGE_CTRL_REPO: &str = "alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1";
 const ZIMAGE_CTRL_FILE: &str = "Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps.safetensors";
+/// Pinned revision for the default Turbo `ZIMAGE_CTRL_REPO` (sc-9879, F-077 follow-up). Fetching the
+/// mutable `main` branch means a re-push (or a compromised token) could silently swap the ControlNet
+/// checkpoint we load; pin the exact commit for defense-in-depth (mirrors sc-8879/sc-9682). Applied ONLY
+/// to the default repo — a manifest `controlWeights.repo` override keeps `main`. HF's tree API still
+/// reports the file's `lfs.oid`, which `ensure_hf_cached_file` verifies against.
+const ZIMAGE_CTRL_REVISION: &str = "5155fc56d17821007d6f62ac192c09e0f0e72016";
 /// The Z-Image-Turbo base diffusers repo when the manifest omits `repo`.
 const ZIMAGE_CTRL_DEFAULT_REPO: &str = "Tongyi-MAI/Z-Image-Turbo";
 /// Base (non-distilled, real-CFG) Z-Image Fun-Controlnet-Union weights (sc-8379) — the same VACE
@@ -24,6 +30,10 @@ const ZIMAGE_CTRL_DEFAULT_REPO: &str = "Tongyi-MAI/Z-Image-Turbo";
 /// single `.safetensors`. Mirrors the MLX `z_image_control` engine repo (`STRICT_CONTROL_ENGINES`).
 const ZIMAGE_CTRL_BASE_REPO: &str = "alibaba-pai/Z-Image-Fun-Controlnet-Union-2.1";
 const ZIMAGE_CTRL_BASE_FILE: &str = "diffusion_pytorch_model.safetensors";
+/// Pinned revision for the default base `ZIMAGE_CTRL_BASE_REPO` (sc-9879, F-077 follow-up). Same
+/// defense-in-depth rationale as `ZIMAGE_CTRL_REVISION`; applied ONLY to the default base repo, an
+/// override keeps `main`, and the `lfs.oid` sha256 verify is retained.
+const ZIMAGE_CTRL_BASE_REVISION: &str = "755999a934909bd5832e20718bb7c639d2a63eb9";
 /// The base Z-Image diffusers repo when the manifest omits `repo` (sc-8379).
 const ZIMAGE_CTRL_BASE_DEFAULT_REPO: &str = "Tongyi-MAI/Z-Image";
 /// ControlNet conditioning-scale default (the strict-pose tier).
@@ -207,7 +217,17 @@ async fn ensure_zimage_control_weights(
         .join("cache")
         .join("controlnet-zimage")
         .join(&file);
-    ensure_hf_cached_file(&context, &repo, "main", &file, &dst).await?;
+    // Pin the exact commit for whichever default control repo (Turbo or base) we resolved so `main`
+    // moving under us can't swap the ControlNet checkpoint (sc-9879). A manifest `controlWeights.repo`
+    // override may carry its own revision layout, so only pin when we're on a default repo.
+    let revision = if repo == ZIMAGE_CTRL_REPO {
+        ZIMAGE_CTRL_REVISION
+    } else if repo == ZIMAGE_CTRL_BASE_REPO {
+        ZIMAGE_CTRL_BASE_REVISION
+    } else {
+        "main"
+    };
+    ensure_hf_cached_file(&context, &repo, revision, &file, &dst).await?;
     Ok(dst)
 }
 

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -311,6 +311,14 @@ struct DerivedTokenizerOverlay {
     base_repo: &'static str,
     /// SceneWorks-hosted repo holding the materialized fast `tokenizer.json`.
     tokenizer_repo: &'static str,
+    /// Pinned commit of [`tokenizer_repo`] to fetch (sc-9879, F-077 follow-up). The tokenizer repo is a
+    /// fixed SceneWorks-hosted const here (no manifest/payload override reaches this overlay), so pulling
+    /// the mutable `main` branch would let an upstream re-push silently swap the derived `tokenizer.json`
+    /// the in-process generator/trainer constructs from. Pin the exact commit for defense-in-depth
+    /// (mirrors sc-8879/sc-9682). Per-entry because entries may share a repo (Qwen-Image / -2512) but the
+    /// pin must be resolved per distinct repo. The standard resolve+download path still verifies each
+    /// file's reported `lfs.oid`.
+    tokenizer_revision: &'static str,
 }
 
 /// The single overlaid file (in every case the HF fast serialization) and its in-snapshot subdir.
@@ -327,6 +335,7 @@ const DERIVED_TOKENIZER_OVERLAYS: &[DerivedTokenizerOverlay] = &[
     DerivedTokenizerOverlay {
         base_repo: "Kwai-Kolors/Kolors-diffusers",
         tokenizer_repo: "SceneWorks/kolors-chatglm3-tokenizer",
+        tokenizer_revision: "4001e09f10ef05845457b976bbf1d28d54319886",
     },
     // Qwen-Image (sc-6570): ships the Qwen2 BPE tokenizer as `vocab.json` + `merges.txt` only. The MLX
     // `qwen-image` provider's `load_tokenizer` reads `tokenizer/tokenizer.json`. Derived via mlx-gen
@@ -335,6 +344,7 @@ const DERIVED_TOKENIZER_OVERLAYS: &[DerivedTokenizerOverlay] = &[
     DerivedTokenizerOverlay {
         base_repo: "Qwen/Qwen-Image",
         tokenizer_repo: "SceneWorks/qwen-image-tokenizer",
+        tokenizer_revision: "b0178292f0f4b1be9b5bfdda2b6e97fda0e195c3",
     },
     // Qwen-Image-2512 (sc-8271): the Dec-2025 base refresh is architecturally identical to
     // `Qwen/Qwen-Image` and reuses the same Qwen2 BPE tokenizer (unchanged across the line),
@@ -342,16 +352,17 @@ const DERIVED_TOKENIZER_OVERLAYS: &[DerivedTokenizerOverlay] = &[
     DerivedTokenizerOverlay {
         base_repo: "Qwen/Qwen-Image-2512",
         tokenizer_repo: "SceneWorks/qwen-image-tokenizer",
+        tokenizer_revision: "b0178292f0f4b1be9b5bfdda2b6e97fda0e195c3",
     },
 ];
 
-/// The hosted tokenizer repo + overlay dest for a just-downloaded `repo`, or `None` when `repo` is not
-/// a base model that needs the overlay (a no-op for every other model). Pure so the repo guard +
-/// target path are unit-testable without a download.
+/// The hosted tokenizer repo + its pinned revision + overlay dest for a just-downloaded `repo`, or
+/// `None` when `repo` is not a base model that needs the overlay (a no-op for every other model). Pure so
+/// the repo guard + pinned revision + target path are unit-testable without a download.
 pub(crate) fn derived_tokenizer_overlay(
     repo: &str,
     snapshot_dir: &Path,
-) -> Option<(&'static str, PathBuf)> {
+) -> Option<(&'static str, &'static str, PathBuf)> {
     let trimmed = repo.trim();
     DERIVED_TOKENIZER_OVERLAYS
         .iter()
@@ -359,6 +370,7 @@ pub(crate) fn derived_tokenizer_overlay(
         .map(|overlay| {
             (
                 overlay.tokenizer_repo,
+                overlay.tokenizer_revision,
                 snapshot_dir.join("tokenizer").join(DERIVED_TOKENIZER_FILE),
             )
         })
@@ -378,7 +390,9 @@ pub(crate) async fn overlay_derived_tokenizer(
     repo: &str,
     snapshot_dir: &Path,
 ) -> WorkerResult<()> {
-    let Some((tokenizer_repo, dest)) = derived_tokenizer_overlay(repo, snapshot_dir) else {
+    let Some((tokenizer_repo, tokenizer_revision, dest)) =
+        derived_tokenizer_overlay(repo, snapshot_dir)
+    else {
         return Ok(());
     };
     if dest.exists() {
@@ -391,7 +405,7 @@ pub(crate) async fn overlay_derived_tokenizer(
         http_client,
         settings,
         tokenizer_repo,
-        "main",
+        tokenizer_revision,
         &[DERIVED_TOKENIZER_FILE.to_owned()],
     )
     .await?;

--- a/crates/sceneworks-worker/src/person_segment.rs
+++ b/crates/sceneworks-worker/src/person_segment.rs
@@ -57,6 +57,12 @@ const SEG_FILE: &str = "sam2.1_hiera_large.safetensors";
 /// (sc-3707, uploaded from the official Meta `.pt` via `tools/convert_sam2_to_mlx.py`;
 /// bit-identical to the avbiswas reference).
 const SEG_REPO: &str = "SceneWorks/sam2-mlx";
+/// Pinned SAM2 weights revision (sc-9879, F-077 follow-up). Even though `SEG_REPO` is a
+/// first-party repo, fetching the mutable `main` branch means a re-push (or a compromised
+/// token) could silently swap the segmenter weights we load. Pin the exact commit for
+/// defense-in-depth, mirroring the person-detector pin (sc-9682). HF's tree API still reports
+/// the file's `lfs.oid`, which `ensure_hf_cached_file` verifies the downloaded content against.
+const SEG_REVISION: &str = "fbc86db0dceb8c744e5fc95feadc37572107be69";
 
 /// The SAM2 video predictor is loaded once and cached process-wide (weights load is the
 /// expensive part; the per-clip tracking state is built fresh each call). Holds `None` until
@@ -105,7 +111,7 @@ pub(crate) async fn ensure_segmenter_weights(
         .join("cache")
         .join("person-segment")
         .join(SEG_FILE);
-    ensure_hf_cached_file(context, SEG_REPO, "main", SEG_FILE, &target).await
+    ensure_hf_cached_file(context, SEG_REPO, SEG_REVISION, SEG_FILE, &target).await
 }
 
 /// Scale a normalized `(x, y, width, height)` box to a pixel-space `[x1, y1, x2, y2]`
@@ -321,6 +327,25 @@ pub(crate) fn propagate_track_blocking(
 mod tests {
     use super::*;
     use std::sync::Mutex;
+
+    /// sc-9879 (F-077 follow-up): the first-party SAM2 weights repo is fetched at a pinned commit,
+    /// never the mutable `main` branch, so a re-push (or a compromised token) can't silently swap the
+    /// segmenter weights we load. Lock the constant to a real 40-hex lowercase commit id.
+    #[test]
+    fn seg_revision_is_pinned_commit_not_main() {
+        assert_ne!(SEG_REVISION, "main", "SAM2 must pin a fixed revision");
+        assert_eq!(
+            SEG_REVISION.len(),
+            40,
+            "a pinned HF revision is a 40-char commit sha"
+        );
+        assert!(
+            SEG_REVISION
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+            "the pinned revision must be lowercase hex"
+        );
+    }
 
     /// sc-4277 / F-MLXW-13: the model-cache locks recover from poison instead of
     /// `.expect()`-panicking. A prior job panicking while holding the lock must

--- a/crates/sceneworks-worker/src/person_segment_sam3_common.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3_common.rs
@@ -27,6 +27,13 @@ pub(crate) const TOKENIZER_FILE: &str = "tokenizer.json";
 /// LICENSE copy); until then point `SCENEWORKS_SAM3_WEIGHTS` at a local `facebook/sam3` snapshot dir.
 pub(crate) const SEG_REPO: &str = "SceneWorks/sam3-mlx";
 
+/// Pinned SAM3 weights revision (sc-9879, F-077 follow-up). Even though `SEG_REPO` is a
+/// first-party repo, fetching the mutable `main` branch means a re-push (or a compromised
+/// token) could silently swap the `model.safetensors` / `tokenizer.json` we load. Pin the
+/// exact commit for defense-in-depth, mirroring the person-detector pin (sc-9682). HF's tree
+/// API still reports each file's `lfs.oid`, which `ensure_hf_cached_file` verifies against.
+pub(crate) const SEG_REVISION: &str = "3ed10b164a755c00b1a4d671dde95719c127e1a7";
+
 /// SAM3 model input is a square 1008×1008 (the processor resizes to a fixed square, not
 /// aspect-preserving — `Sam3VideoProcessor` `size={1008,1008}`, `default_to_square`).
 pub(crate) const INPUT_SIZE: u32 = 1008;
@@ -93,12 +100,18 @@ pub(crate) async fn ensure_segmenter_weights(
         return Ok(pair);
     }
     let dir = settings.data_dir.join("cache").join("person-segment-sam3");
-    let model =
-        ensure_hf_cached_file(context, SEG_REPO, "main", MODEL_FILE, &dir.join(MODEL_FILE)).await?;
+    let model = ensure_hf_cached_file(
+        context,
+        SEG_REPO,
+        SEG_REVISION,
+        MODEL_FILE,
+        &dir.join(MODEL_FILE),
+    )
+    .await?;
     let tokenizer = ensure_hf_cached_file(
         context,
         SEG_REPO,
-        "main",
+        SEG_REVISION,
         TOKENIZER_FILE,
         &dir.join(TOKENIZER_FILE),
     )
@@ -260,6 +273,25 @@ pub(crate) struct AllPersonMasks {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// sc-9879 (F-077 follow-up): the first-party SAM3 weights repo is fetched at a pinned commit,
+    /// never the mutable `main` branch, so a re-push (or a compromised token) can't silently swap the
+    /// SAM3 checkpoint we load. Lock the constant to a real 40-hex lowercase commit id.
+    #[test]
+    fn seg_revision_is_pinned_commit_not_main() {
+        assert_ne!(SEG_REVISION, "main", "SAM3 must pin a fixed revision");
+        assert_eq!(
+            SEG_REVISION.len(),
+            40,
+            "a pinned HF revision is a 40-char commit sha"
+        );
+        assert!(
+            SEG_REVISION
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+            "the pinned revision must be lowercase hex"
+        );
+    }
 
     /// A tiny backend-neutral stand-in for either sam3 crate's `VideoFrameOutput`, so the shared
     /// [`select_object`] math is tested here (compiled on both lanes) without depending on

--- a/crates/sceneworks-worker/src/tests/lora_and_downloads.rs
+++ b/crates/sceneworks-worker/src/tests/lora_and_downloads.rs
@@ -504,20 +504,41 @@ async fn download_snapshot_fresh_retry_discards_partial_blob() {
 fn derived_tokenizer_overlay_targets_only_known_base_repos() {
     let snap = std::path::Path::new("/snap");
     let want = PathBuf::from("/snap/tokenizer/tokenizer.json");
-    // Kolors → its SceneWorks tokenizer repo + the snapshot's tokenizer/tokenizer.json.
+    // Kolors → its SceneWorks tokenizer repo + pinned revision + the snapshot's tokenizer/tokenizer.json.
     assert_eq!(
         derived_tokenizer_overlay("Kwai-Kolors/Kolors-diffusers", snap),
-        Some(("SceneWorks/kolors-chatglm3-tokenizer", want.clone()))
+        Some((
+            "SceneWorks/kolors-chatglm3-tokenizer",
+            "4001e09f10ef05845457b976bbf1d28d54319886",
+            want.clone()
+        ))
     );
-    // Qwen-Image (sc-6570) → its SceneWorks tokenizer repo, same dest.
+    // Qwen-Image (sc-6570) → its SceneWorks tokenizer repo + pinned revision, same dest.
     assert_eq!(
         derived_tokenizer_overlay("Qwen/Qwen-Image", snap),
-        Some(("SceneWorks/qwen-image-tokenizer", want.clone()))
+        Some((
+            "SceneWorks/qwen-image-tokenizer",
+            "b0178292f0f4b1be9b5bfdda2b6e97fda0e195c3",
+            want.clone()
+        ))
+    );
+    // Qwen-Image-2512 (sc-8271) reuses the same hosted overlay repo → the SAME pinned revision.
+    assert_eq!(
+        derived_tokenizer_overlay("Qwen/Qwen-Image-2512", snap),
+        Some((
+            "SceneWorks/qwen-image-tokenizer",
+            "b0178292f0f4b1be9b5bfdda2b6e97fda0e195c3",
+            want.clone()
+        ))
     );
     // Whitespace from a manifest field is tolerated.
     assert_eq!(
         derived_tokenizer_overlay("  Qwen/Qwen-Image  ", snap),
-        Some(("SceneWorks/qwen-image-tokenizer", want))
+        Some((
+            "SceneWorks/qwen-image-tokenizer",
+            "b0178292f0f4b1be9b5bfdda2b6e97fda0e195c3",
+            want
+        ))
     );
     // Every other model is a no-op — including sibling repos that must NOT match.
     assert_eq!(derived_tokenizer_overlay("owner/model", snap), None);
@@ -530,6 +551,34 @@ fn derived_tokenizer_overlay_targets_only_known_base_repos() {
         derived_tokenizer_overlay("Qwen/Qwen-Image-Edit-2511", snap),
         None
     );
+}
+
+/// sc-9879 (F-077 follow-up): every derived-tokenizer overlay must pin an exact 40-hex lowercase commit
+/// (not the mutable `main` branch) so an upstream re-push can't silently swap the derived `tokenizer.json`
+/// the in-process generator/trainer constructs from. Mirrors the `_REVISION` format tests in this PR.
+#[test]
+fn derived_tokenizer_overlay_revisions_are_pinned_commits_not_main() {
+    let snap = std::path::Path::new("/snap");
+    for base in [
+        "Kwai-Kolors/Kolors-diffusers",
+        "Qwen/Qwen-Image",
+        "Qwen/Qwen-Image-2512",
+    ] {
+        let (_, revision, _) =
+            derived_tokenizer_overlay(base, snap).expect("known base has an overlay");
+        assert_ne!(revision, "main", "{base} tokenizer must pin a fixed revision");
+        assert_eq!(
+            revision.len(),
+            40,
+            "a pinned HF revision is a 40-char commit sha ({base})"
+        );
+        assert!(
+            revision
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+            "the pinned revision must be lowercase hex ({base})"
+        );
+    }
 }
 
 /// A single stub that serves both the HF tree resolve (for the SceneWorks tokenizer repo) and the

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -517,14 +517,14 @@ fn manifest_onnx_resource(manifest_entry: &Value, factor: u8) -> Option<(String,
 /// Upstream HuggingFace repo holding the raw SeedVR2 ComfyUI checkpoint. The `mlx-gen-seedvr2`
 /// registry loads it directly (converts to MLX layout in-memory, no Python). Public; downloaded on
 /// first use. Overridable via the manifest `seedvr2` resource or `SCENEWORKS_SEEDVR2_CHECKPOINT`.
-const SEEDVR2_REPO: &str = "numz/SeedVR2_comfyUI";
+pub(crate) const SEEDVR2_REPO: &str = "numz/SeedVR2_comfyUI";
 /// Pinned SeedVR2 checkpoint revision (sc-8879). `numz/SeedVR2_comfyUI` is a third-party
 /// mirror; fetching the mutable `main` branch means an upstream re-push would silently
 /// change the weights we load. Pin the exact commit that carries the 3B fp16 DiT + VAE
 /// (`seedvr2_ema_3b_fp16.safetensors` / `ema_vae_fp16.safetensors`) so downloads are
 /// reproducible. HF's tree API still reports each file's `lfs.oid`, which
 /// `ensure_hf_cached_file` verifies the content against.
-const SEEDVR2_REVISION: &str = "09ced71023636e9bc8cdf9cdecfb2625d1e691e8";
+pub(crate) const SEEDVR2_REVISION: &str = "09ced71023636e9bc8cdf9cdecfb2625d1e691e8";
 /// The exact filenames `Seedvr2Pipeline::load` expects in the checkpoint dir (3B fp16 DiT + VAE).
 const SEEDVR2_DIT_FILE: &str = "seedvr2_ema_3b_fp16.safetensors";
 const SEEDVR2_VAE_FILE: &str = "ema_vae_fp16.safetensors";

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -1259,6 +1259,19 @@ use mlx_gen_seedvr2::video as seedvr2_video;
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 const SEEDVR2_REPO: &str = "numz/SeedVR2_comfyUI";
+/// Pinned SeedVR2 checkpoint revision (sc-8879 / sc-9879). `numz/SeedVR2_comfyUI` is a
+/// third-party mirror with a fixed (non-overridable) repo here — fetching the mutable `main`
+/// branch would let an upstream re-push silently swap the 3B fp16 DiT + VAE weights we load.
+/// Pin the exact commit so downloads are reproducible; HF's tree API still reports each file's
+/// `lfs.oid`, which `ensure_hf_cached_file` verifies the content against. MUST equal the
+/// image-upscale lane's `upscale_jobs::SEEDVR2_REVISION` (same repo + files) — the
+/// `seedvr2_video_revision_matches_image_lane` agreement test locks them together so they
+/// can't drift.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+const SEEDVR2_REVISION: &str = "09ced71023636e9bc8cdf9cdecfb2625d1e691e8";
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
@@ -1611,7 +1624,7 @@ async fn ensure_seedvr2_weights(
         crate::downloads::ensure_hf_cached_file(
             &context,
             SEEDVR2_REPO,
-            "main",
+            SEEDVR2_REVISION,
             file,
             &dir.join(file),
         )
@@ -7669,6 +7682,57 @@ mod tests {
 
     fn request(value: Value) -> VideoRequest {
         VideoRequest::from_payload(&value.as_object().cloned().unwrap())
+    }
+
+    /// sc-8879 / sc-9879 (F-077 follow-up): the video SeedVR2 upscale fetches the same fixed
+    /// third-party mirror as the image lane, and must pin an exact commit rather than the mutable
+    /// `main` branch so an upstream re-push can't silently swap the 3B DiT + VAE weights. Lock the
+    /// constant to a real 40-hex lowercase commit id (mirrors `seedvr2_revision_is_pinned_commit_not_main`
+    /// in the image-upscale lane).
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn seedvr2_video_revision_is_pinned_commit_not_main() {
+        assert_ne!(
+            SEEDVR2_REVISION, "main",
+            "video SeedVR2 must pin a fixed revision"
+        );
+        assert_eq!(
+            SEEDVR2_REVISION.len(),
+            40,
+            "a pinned HF revision is a 40-char commit sha"
+        );
+        assert!(
+            SEEDVR2_REVISION
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+            "the pinned revision must be lowercase hex"
+        );
+    }
+
+    /// sc-9879 (F-077 follow-up): the image (`upscale_jobs`) and video (`video_jobs`) SeedVR2 fetches
+    /// pull the IDENTICAL files from the IDENTICAL fixed mirror, so their pinned commit must agree.
+    /// Two independent consts (a shared source of truth would need a cfg-split hoist across the two
+    /// modules) — lock them together here so a bump to one lane without the other fails loudly
+    /// (mirrors this PR's InstantID/PuLID shared-repo sha-agreement tests).
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn seedvr2_video_revision_matches_image_lane() {
+        assert_eq!(
+            SEEDVR2_REVISION,
+            crate::upscale_jobs::SEEDVR2_REVISION,
+            "video and image SeedVR2 fetch the same mirror + files; their pinned commit must match"
+        );
+        assert_eq!(
+            SEEDVR2_REPO,
+            crate::upscale_jobs::SEEDVR2_REPO,
+            "video and image SeedVR2 must reference the same upstream mirror repo"
+        );
     }
 
     // sc-8828 (F-026): `resolve_video_route` is the extracted native (MLX) dispatch decision — the

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -5620,6 +5620,13 @@ fn ltx_available(request: &VideoRequest, settings: &Settings) -> bool {
 /// set — plus the bundled `gemma/` text encoder the engine reads via `$LTX_GEMMA_DIR`.
 #[cfg(target_os = "macos")]
 const LTX_BUNDLE_REPO: &str = "SceneWorks/ltx-2.3-mlx";
+/// Pinned revision for the fixed [`LTX_BUNDLE_REPO`] (sc-9879, F-077 follow-up). The bundle repo is a
+/// hard-coded const (no manifest/payload override reaches this on-demand `q8/*` fetch), so pulling the
+/// mutable `main` branch would let an upstream re-push silently swap the Q8 checkpoint we load. Pin the
+/// exact commit for defense-in-depth (mirrors the SeedVR2/Real-ESRGAN pins, sc-8879/sc-9682). The `hf`
+/// CLI still verifies each file's own hash on download.
+#[cfg(target_os = "macos")]
+const LTX_BUNDLE_REVISION: &str = "254989c3ca7ee691187647f350b112c0c448789d";
 
 /// Whether `dir` is a converted LTX snapshot **complete for the current engine** — it must
 /// carry the audio `vocoder` + I2V `vae_encoder` + single `upsampler`/`vae_decoder` the
@@ -5780,7 +5787,7 @@ async fn ensure_ltx_q8_present(
         settings,
         job,
         LTX_BUNDLE_REPO,
-        "main",
+        LTX_BUNDLE_REVISION,
         &files,
         &scratch,
     )
@@ -7732,6 +7739,30 @@ mod tests {
             SEEDVR2_REPO,
             crate::upscale_jobs::SEEDVR2_REPO,
             "video and image SeedVR2 must reference the same upstream mirror repo"
+        );
+    }
+
+    /// sc-9879 (F-077 follow-up): `ensure_ltx_q8_present` pulls `q8/*` from the FIXED SceneWorks LTX-2.3
+    /// bundle const (non-overridable here), so it must pin an exact commit rather than the mutable `main`
+    /// branch — an upstream re-push would otherwise silently swap the Q8 checkpoint we load. Lock the pin
+    /// to a real 40-hex lowercase commit id (mirrors the SeedVR2 format test above).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn ltx_bundle_revision_is_pinned_commit_not_main() {
+        assert_ne!(
+            LTX_BUNDLE_REVISION, "main",
+            "LTX q8 bundle must pin a fixed revision"
+        );
+        assert_eq!(
+            LTX_BUNDLE_REVISION.len(),
+            40,
+            "a pinned HF revision is a 40-char commit sha"
+        );
+        assert!(
+            LTX_BUNDLE_REVISION
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+            "the pinned revision must be lowercase hex"
         );
     }
 


### PR DESCRIPTION
## sc-9879 — [F-077 follow-up] Pin remaining worker HF runtime-weight fetches to fixed revisions

Follow-up to **sc-9682** (which pinned the Real-ESRGAN ONNX + person-detector fetches) and **sc-8879** (DWPose/SeedVR2). A comprehensive sweep of `crates/sceneworks-worker/src` found the remaining runtime-weight fetches still riding the mutable HF `main` branch. Each is now pinned to a fixed commit SHA (defense-in-depth) while the existing `lfs.oid` **sha256 verification is retained** at every site.

Pattern (mirrors sc-8879/sc-9682): a named `const ..._REVISION` passed in place of `"main"`; a **default-repo-only guard** so a manifest/user `controlWeights.repo` override still uses `"main"` (a fixed SHA won't exist in an override repo); **cfg-split** where the repos differ per lane (MLX-only vs candle-only `include!`s).

### Fetches pinned

| File | Repo id | Pinned SHA | Guard / notes |
|------|---------|-----------|---------------|
| `person_segment.rs` | `SceneWorks/sam2-mlx` | `fbc86db0dceb8c744e5fc95feadc37572107be69` | fixed repo (SAM2) |
| `person_segment_sam3_common.rs` | `SceneWorks/sam3-mlx` | `3ed10b164a755c00b1a4d671dde95719c127e1a7` | fixed repo (SAM3, 2 files) |
| `qwen_control.rs` (candle) | `alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union` | `c21dcc372f9f52a55a6d4984cb56a0f0ac0807bc` | **default-repo guard** |
| `flux1_control.rs` (MLX) | `Shakker-Labs/FLUX.1-dev-ControlNet-Union-Pro-2.0` | `5d700aaad96c5ddcdf8a38ef9b22a82aac2c38e5` | **default-repo guard** (table repo) |
| `kolors_control.rs` (candle) | `Kwai-Kolors/Kolors-ControlNet-Pose` | `83e35a8033a89d2e75044b412d0e2474111578f7` | **default-repo guard** |
| `flux2.rs` (MLX) | `alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union` | `b3dcd7836a0e926248dac3ccba8fc0853495764b` | **default-repo guard** (table repo) |
| `zimage_control.rs` (candle) | `alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1` | `5155fc56d17821007d6f62ac192c09e0f0e72016` | **default-repo guard** (Turbo) |
| `zimage_control.rs` (candle) | `alibaba-pai/Z-Image-Fun-Controlnet-Union-2.1` | `755999a934909bd5832e20718bb7c639d2a63eb9` | **default-repo guard** (base) |
| `flux1_control_candle.rs` (candle) | `Shakker-Labs/FLUX.1-dev-ControlNet-Union-Pro-2.0` | `5d700aaad96c5ddcdf8a38ef9b22a82aac2c38e5` | **default-repo guard** |
| `flux2_control_candle.rs` (candle) | `alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union` | `b3dcd7836a0e926248dac3ccba8fc0853495764b` | **default-repo guard** |
| `strict_control.rs` → `depth.rs` | `depth-anything/Depth-Anything-V2-Small-hf` | `5426e4f0f36572d16453bbda7a8389317b1bef99` | fixed repo (depth estimator) |
| `instantid.rs` | `SceneWorks/instantid-mlx` | `bca0cacf8e5e04529bb2b326a521361b02be84fd` | fixed repo (via `instantid_revision`) |
| `instantid.rs` | `InstantX/InstantID` | `57b32dfee076092ad2930c71fd6d439c2c3b1820` | fixed repo (IdentityNet) |
| `instantid.rs` | `xinsir/controlnet-openpose-sdxl-1.0` | `23f966cd5cfdd3f7729c903e243d87152162d2b7` | fixed repo (pose branch) |
| `flux_ipadapter.rs` (candle) | `XLabs-AI/flux-ip-adapter` | `18f6940238ab5dc3744df7a8e30315892279d5f9` | **split** adapter revision |
| `flux_ipadapter.rs` (candle) | `openai/clip-vit-large-patch14` | `32bd64288804d66eefd0ccbe215aa642df71cc41` | **split** encoder revision |
| `sdxl_ipadapter.rs` (candle) | `h94/IP-Adapter` | `018e402774aeeddd60609b4ecdb7e298259dc729` | fixed repo (bundle + encoder) |
| `pulid_candle.rs` (candle) | `guozinan/PuLID` | `492b1451255dc9d9bc3c857259690b5f8b998d4a` | **split** (via `pulid_candle_revision`) |
| `pulid_candle.rs` (candle) | `SceneWorks/pulid-flux-mlx` | `78ef91f977eae16d66fb191caf003154b7a0a0b8` | **split** |
| `pulid_candle.rs` (candle) | `SceneWorks/instantid-mlx` | `bca0cacf8e5e04529bb2b326a521361b02be84fd` | **split** — pin matches InstantID (same repo) |
| `qwen.rs` (MLX) | `lightx2v/Qwen-Image-Edit-2511-Lightning` | `d74eba145674fd7e31b949324e148e21e7118abd` | **default-repo guard** (distill LoRA) |
| `qwen_edit_candle.rs` (candle) | `lightx2v/Qwen-Image-Edit-2511-Lightning` | `d74eba145674fd7e31b949324e148e21e7118abd` | **default-repo guard** (distill LoRA) |
| `upscale_jobs.rs` (image, MLX/candle) | `numz/SeedVR2_comfyUI` | `09ced71023636e9bc8cdf9cdecfb2625d1e691e8` | **default-repo guard** (SeedVR2 3B DiT + VAE; sc-8879) |
| `video_jobs.rs` (video, MLX/candle) | `numz/SeedVR2_comfyUI` | `09ced71023636e9bc8cdf9cdecfb2625d1e691e8` | fixed repo (SeedVR2 3B DiT + VAE) — **review-follow-up pin**, matches image lane |
| `base.rs` `fetch_krea_convrot_base` (candle) | `SceneWorks/krea-2-turbo-mlx` | `d009674080cc1bccf2b629d834c34bf5eccdb723` | fixed const repo (bf16 ConvRot base, sc-9300) — **2nd review-follow-up pin** |
| `video_jobs.rs` `ensure_ltx_q8_present` (MLX) | `SceneWorks/ltx-2.3-mlx` | `254989c3ca7ee691187647f350b112c0c448789d` | fixed const repo (`q8/*` bundle) — **2nd review-follow-up pin** |
| `model_jobs.rs` `overlay_derived_tokenizer` | `SceneWorks/kolors-chatglm3-tokenizer` | `4001e09f10ef05845457b976bbf1d28d54319886` | fixed const repo (per-entry `tokenizer_revision`) — **2nd review-follow-up pin** |
| `model_jobs.rs` `overlay_derived_tokenizer` | `SceneWorks/qwen-image-tokenizer` | `b0178292f0f4b1be9b5bfdda2b6e97fda0e195c3` | fixed const repo (per-entry `tokenizer_revision`; shared by Qwen-Image + -2512) — **2nd review-follow-up pin** |

### sha256 verification
Retained everywhere — no change to the verify path. Every `ensure_hf_cached_file` / `HuggingFaceSnapshot::resolve` call still receives HF's `lfs.oid` and verifies the downloaded content against it. Pinning only changes which commit's tree we read the oids from.

### Sweep result / out-of-scope
- `kolors_ipadapter.rs` was already on the immutable `refs/pr/4` ref (not `main`) — left as-is.
- **Left on `main` by design (correctly excluded):** payload/manifest-DERIVED repo fetches — `base.rs` Boogu/Ideogram tier fetches (repo = `model_repo(request, ..)`), `model_jobs.rs` catalog installer + LTX-upscaler fetch (repo = `baseRepo` payload), all via `download_model_with_hf_cli` with a user-supplied `revision` defaulting to `main`; default-repo-guard `else` / `_ => "main"` override fallbacks (every per-arch control / InstantID / PuLID / distill-LoRA branch, the upscale ONNX/SeedVR2 branches); the local `refs/main` cache read in `model_jobs.rs`; and test assertions. Pinning a fixed SHA to a user/manifest-chosen (or override) repo would be wrong — the SHA won't exist there.
- **Correction (2nd review):** the earlier claim that the `base.rs` `SceneWorks/krea-2-turbo-mlx` tier and `video_jobs.rs` `SceneWorks/ltx-2.3-mlx` q8 fetches were payload-driven catalog installs was **wrong** — both take a **fixed const repo** (no manifest/payload override reaches them). They are now pinned (see the table + the follow-up section below), along with the fixed-const `model_jobs.rs` derived-tokenizer overlay repos.

### Review follow-up: SeedVR2 video pin (added post-review)
Adversarial review found ONE missed fixed runtime-weight fetch in the original sweep: `ensure_seedvr2_weights` (`video_jobs.rs`) pulled the 3B fp16 DiT + VAE from the **fixed, non-overridable** `numz/SeedVR2_comfyUI` mirror on `main` (its `SCENEWORKS_SEEDVR2_DIR` env pin points at a LOCAL dir, not another HF repo). The image-upscale sibling for the identical repo+files was already pinned in `upscale_jobs.rs` (sc-8879). The video fetch is now pinned to the **same** commit via a cfg-gated `SEEDVR2_REVISION` const; `SEEDVR2_REPO`/`SEEDVR2_REVISION` in `upscale_jobs.rs` were promoted to `pub(crate)` so an agreement test can lock the two lanes together. sha256 (`lfs.oid`) verification unchanged.

### Review follow-up 2: three more fixed-const-repo fetches (added post-2nd-review)
A second adversarial re-review found **three more** fixed-const-repo runtime-weight/asset fetches still on `main` (the earlier sweep had mis-classified two of them as payload-driven catalog installs — they are not):
- **[high]** `base.rs` `fetch_krea_convrot_base` — bf16 DiT/TE/VAE ConvRot base (sc-9300 tier) from the hard-coded `SceneWorks/krea-2-turbo-mlx` → new candle-gated `KREA_MLX_TURNKEY_REVISION`.
- **[high]** `video_jobs.rs` `ensure_ltx_q8_present` — the `q8/*` bundle from the hard-coded `SceneWorks/ltx-2.3-mlx` → new macOS-gated `LTX_BUNDLE_REVISION`.
- **[medium]** `model_jobs.rs` `overlay_derived_tokenizer` — the derived `tokenizer.json` from the fixed SceneWorks tokenizer repos in `DERIVED_TOKENIZER_OVERLAYS`. The table has 3 entries over 2 distinct repos, so a **per-entry `tokenizer_revision`** field was added (resolved per distinct repo) and threaded through `derived_tokenizer_overlay` (now a 3-tuple) into `HuggingFaceSnapshot::resolve`.

The Krea + LTX fetches use `download_model_with_hf_cli` (which does its own per-file hash verification); the tokenizer overlay uses the standard `HuggingFaceSnapshot::resolve` + `lfs.oid` verify path — both left untouched, only the revision arg changed.

### Tests
- Adds per-lane format tests mirroring sc-9682's `onnx_revision_is_pinned_commit_not_main`: each new `_REVISION` asserted to be a real 40-hex lowercase commit SHA, grouped by lane (`depth`/`instantid` both-lane, MLX-only, candle-only).
- Also asserts the `instantid_revision` / `pulid_candle_revision` helpers fall back to `main` for unknown repos, and that the PuLID face-stack pin equals the InstantID pin (same `SceneWorks/instantid-mlx` repo).
- **SeedVR2 video pin (review follow-up):** `seedvr2_video_revision_is_pinned_commit_not_main` (40-hex lowercase format, mirrors the image lane) + `seedvr2_video_revision_matches_image_lane` (asserts the video pin equals the image-lane `SEEDVR2_REVISION` and both reference the same repo) so the two independent consts can't drift — mirroring the InstantID/PuLID shared-repo sha-agreement tests.
- **3 more fixed-const-repo pins (review follow-up 2):** `krea_convrot_base_revision_is_pinned_commit_not_main` (candle lane), `ltx_bundle_revision_is_pinned_commit_not_main` (macOS lane), and `derived_tokenizer_overlay_revisions_are_pinned_commits_not_main` (asserts every overlay entry's `tokenizer_revision` is 40-hex lowercase); the existing `derived_tokenizer_overlay_targets_only_known_base_repos` table test was updated to the 3-tuple + pinned revisions (incl. Qwen-Image-2512 sharing the same repo/pin).

### Verification
- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p sceneworks-worker --all-targets -- -D warnings` (default lane): clean.
- `cargo clippy -p sceneworks-worker --no-default-features -F backend-candle --all-targets -- -D warnings` (candle lane, on macOS): clean — but note the candle-only `include!`d files are `#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]`-gated, so they do **not** compile on the local macOS host; the candle guards are structurally identical to the MLX guards that pass default-lane clippy, and full candle-lane validation runs on the `server-candle-linux` / parity CI lanes.
- Worker lib tests (default lane): **633 passed / 0 failed**, including all revision-format + shared-repo agreement tests (the two SeedVR2 video tests, the LTX + tokenizer-overlay revision tests). The Krea pin's format test is candle-gated (`cfg(all(not(target_os = "macos"), feature = "backend-candle"))` — matching the const it guards), so it compiles/runs only on the candle lane, not the default macOS lane.

All default-branch SHAs resolved cleanly via `git ls-remote <repo> HEAD`; **none left on `main` for reachability reasons**. The 2nd-review re-sweep of `git grep '"main"' crates/sceneworks-worker/src` confirms every remaining hit is a payload/manifest-DERIVED repo fetch, a default-repo-guard `else`/`_ => "main"` override fallback, a local `refs/main` cache read, or a test assertion — no fixed-const-repo runtime-weight/asset fetch remains on `main`.

References sc-9879.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

