### PR TITLE
fix(desktop): discover the API port from JSON stdout, not just logfmt

### DIFF
--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -283,17 +283,22 @@ fn parse_listening_port(line: &str) -> Option<u16> {
     if !line.contains("api_listening") {
         return None;
     }
-    // Read the port from the `address=` field specifically (not any bare host:port
-    // elsewhere on the line), for either the loopback or the LAN bind host.
-    let rest = line.split("address=").nth(1)?;
+    // Read the port from the `address` field specifically (not any bare host:port
+    // elsewhere on the line — a peer addr, a health probe). The packaged sidecar logs
+    // JSON to its piped stdout (`"address":"127.0.0.1:PORT"`), while a TTY/dev stdout
+    // logs the pretty/logfmt form (`address=127.0.0.1:PORT`). Anchor on the field name
+    // and read the first bind marker that follows, so BOTH formats resolve the port —
+    // keying only on `address=` (F-127, sc-8929) silently broke the JSON path, which is
+    // the default packaged loopback launch, stranding window-gating until the 30 s
+    // timeout ("The local API did not start in time.").
+    let rest = line.split("address").nth(1)?;
     for marker in ["127.0.0.1:", "0.0.0.0:"] {
-        if let Some(addr) = rest.strip_prefix(marker) {
-            if let Ok(port) = addr
+        if let Some(index) = rest.find(marker) {
+            let digits: String = rest[index + marker.len()..]
                 .chars()
                 .take_while(char::is_ascii_digit)
-                .collect::<String>()
-                .parse()
-            {
+                .collect();
+            if let Ok(port) = digits.parse() {
                 return Some(port);
             }
         }
@@ -1790,6 +1795,36 @@ mod bind_tests {
                 "2026-07-04 event=api_listening address=127.0.0.1:41234 msg=\"listening\""
             ),
             Some(41234)
+        );
+    }
+
+    /// The packaged sidecar's stdout is a pipe, so the API logs JSON
+    /// (`"address":"HOST:PORT"`), not the logfmt `address=HOST:PORT` a TTY/dev run
+    /// emits. Keying only on `address=` (the sc-8929 regression) failed to discover
+    /// the port on a default loopback launch, so window-gating dead-polled until the
+    /// 30 s timeout. Parse the real JSON envelope the desktop reader actually sees.
+    #[test]
+    fn parse_listening_port_handles_json_stdout() {
+        // Loopback (OS-assigned) — the default packaged first-run path.
+        assert_eq!(
+            parse_listening_port(
+                r#"{"message":"SceneWorks Rust API listening","event":"api_listening","address":"127.0.0.1:60294","level":"info","reportedAt":"2026-07-04T15:20:19Z"}"#
+            ),
+            Some(60294)
+        );
+        // LAN (0.0.0.0/fixed) JSON envelope parses too.
+        assert_eq!(
+            parse_listening_port(
+                r#"{"event":"api_listening","address":"0.0.0.0:8787","level":"info"}"#
+            ),
+            Some(8787)
+        );
+        // A JSON line that is NOT the listening event contributes no port.
+        assert_eq!(
+            parse_listening_port(
+                r#"{"event":"utility_worker_inprocess","apiUrl":"http://127.0.0.1:60294"}"#
+            ),
+            None
         );
     }
 }


### PR DESCRIPTION
## Problem

A fresh install (or any launch with **remote access off**, i.e. the default loopback mode) hangs on **"Starting the local engine…"** and then fails with **"The local API did not start in time."** Retry and app-restart reproduce it every time.

## Root cause

The API sidecar is spawned with its stdout attached to a pipe, so `observability::resolve_format()` selects **JSON**, and the listening line is:

```json
{"message":"SceneWorks Rust API listening","event":"api_listening","address":"127.0.0.1:60294","level":"info",...}
```

`parse_listening_port` (setup.rs) was keyed on the **logfmt** form via `line.split("address=")` — introduced by `fb2e0570` (sc-8929 / F-127). `address=` never appears in a JSON line, so the parser returns `None`, `Managed.api_port` is never populated, and `gate_window` polls a never-known port until the 30 s deadline fires the error. The API itself is healthy and listening the whole time.

Why it wasn't caught earlier:
- **LAN mode** (remote access on) seeds the **fixed** port directly in `spawn_api`, bypassing the parser — so anyone testing with remote access enabled never hit it.
- `tauri dev` runs on a **TTY**, so `resolve_format()` picks the **pretty** (logfmt-ish `address=…`) format the old parser handled.
- The unit tests used logfmt sample strings, so they passed against a format production never emits.

Only a **packaged, loopback, fresh-install** launch exposes it — exactly the scenario reported.

## Fix

Anchor on the `address` field and read the first bind marker that follows, resolving the port from **both** the JSON (packaged) and logfmt/pretty (TTY/dev) forms. Keeps F-127's intent (only trust the `api_listening` line; ignore an incidental host:port elsewhere).

## Testing

- Extracted the pure parser and ran all pre-existing logfmt cases + the real JSON envelope (loopback + LAN + a non-listening JSON line) via `rustc --test` — all pass.
- Added `parse_listening_port_handles_json_stdout` as an in-tree regression test.
- `cargo fmt -p sceneworks-desktop -- --check` clean. (Full `cargo build -p sceneworks-desktop` can't run in a git worktree without the staged `sceneworks-api` sidecar resource; CI builds it with the sidecar present.)

## Note on already-installed builds

v0.5.1 in the field is still affected. Immediate workaround without rebuilding — launch so the sidecar logs pretty (`address=…`) instead of JSON:

```
SCENEWORKS_LOG_FORMAT=pretty /Applications/SceneWorks.app/Contents/MacOS/sceneworks-desktop
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)