### PR TITLE
fix(rust-api): don't flag a valid single-quant install as incomplete (sc-9907)

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -938,17 +938,44 @@ fn install_state_for(
             .join("models")
             .join(safe_download_dir(&download_context.repo));
         let cache_path = huggingface_repo_cache_path(data_dir, &download_context.repo);
-        let cache_health = cache_path
-            .as_ref()
-            .map(|path| huggingface_cache_health(path, &download_context.files));
-        let cache_installed = cache_health.as_ref().is_some_and(|health| health.installed);
-        let cache_incomplete = cache_health
-            .as_ref()
-            .is_some_and(|health| health.incomplete);
-        let mut missing_required_files = cache_health
-            .as_ref()
-            .map(|health| health.missing_files.clone())
-            .unwrap_or_default();
+        // Quant-matrix models (sc-8506/8508): the top-level install state aggregates across ALL
+        // selectable tiers, not just the default one. A model that offers bf16/q8/q4 counts as
+        // installed when ANY tier is fully present, and is only "incomplete" when a tier is genuinely
+        // torn (partially downloaded) AND no complete tier exists. Installing a single valid tier —
+        // even a non-default one — must never surface as an incomplete/repairable cache (sc-9907),
+        // because that rendered a false "Cached files are incomplete" warning + Fix button on a
+        // perfectly good install. Single-variant models keep the default-tier contract below.
+        let (cache_installed, cache_incomplete, mut missing_required_files) =
+            if model_has_variant_matrix(model) {
+                let variants = model_variant_states(model, data_dir);
+                let any_installed = variants.iter().any(|variant| variant.installed);
+                // Only a torn tier (some-but-not-all files present) with no complete sibling is a real
+                // repair candidate; a validly absent tier is "missing", not "incomplete".
+                let torn = variants
+                    .iter()
+                    .find(|variant| variant.cache_incomplete && !variant.installed);
+                let incomplete = !any_installed && torn.is_some();
+                let missing = if any_installed {
+                    Vec::new()
+                } else {
+                    torn.map(|variant| variant.missing_required_files.clone())
+                        .unwrap_or_default()
+                };
+                (any_installed, incomplete, missing)
+            } else {
+                let cache_health = cache_path
+                    .as_ref()
+                    .map(|path| huggingface_cache_health(path, &download_context.files));
+                let installed = cache_health.as_ref().is_some_and(|health| health.installed);
+                let incomplete = cache_health
+                    .as_ref()
+                    .is_some_and(|health| health.incomplete);
+                let missing = cache_health
+                    .as_ref()
+                    .map(|health| health.missing_files.clone())
+                    .unwrap_or_default();
+                (installed, incomplete, missing)
+            };
         let managed_installed = model_is_installed(&managed_path);
         let primary_installed = managed_installed || cache_installed;
         let installed_path = if cache_installed || cache_incomplete {
@@ -1720,8 +1747,24 @@ fn huggingface_filtered_cache_health(
         .cloned()
         .collect::<Vec<_>>();
     if missing.is_empty() {
+        // Every expected file/pattern is present — fully installed.
         HuggingFaceCacheHealth::installed()
+    } else if missing.len() == files.len() {
+        // NONE of this filter's expected files are present: the tier is cleanly absent, not torn.
+        // A quant-matrix model keeps every tier in ONE shared repo cache (bf16/, q8/, q4/ subdirs),
+        // so downloading one tier populates the repo snapshot the OTHER tiers' filters also probe.
+        // Reporting a not-downloaded tier as `incomplete` is what surfaced a false "Cached files are
+        // incomplete" warning + Fix button for a perfectly valid single-quant install (sc-9907).
+        // "You didn't download this tier" (missing) must stay distinct from "this tier is
+        // half-downloaded" (incomplete) so nothing upstream raises a spurious repair prompt.
+        HuggingFaceCacheHealth {
+            installed: false,
+            incomplete: false,
+            missing_files: missing,
+        }
     } else {
+        // Some — but not all — expected files are present: a genuinely torn download a re-fetch
+        // should repair.
         HuggingFaceCacheHealth::missing(missing)
     }
 }

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -7287,6 +7287,119 @@ fn turbo_cache_health_flags_missing_lora_only_when_listed_explicitly() {
     );
 }
 
+#[test]
+fn filtered_cache_health_reports_absent_filter_as_missing_not_incomplete() {
+    // sc-9907: a filter whose files are ENTIRELY absent is cleanly missing, not torn. Only a
+    // partially-present filter (some files there, some gone) counts as incomplete/repairable.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let repo_root = temp_dir.path().join("models--SceneWorks--z-image-turbo-mlx");
+    let snapshot = repo_root.join("snapshots/abc123");
+    std::fs::create_dir_all(snapshot.join("q8")).expect("q8 creates");
+    std::fs::create_dir_all(repo_root.join("refs")).expect("refs creates");
+    std::fs::write(repo_root.join("refs/main"), "abc123").expect("ref writes");
+    // Only the q8 tier is on disk.
+    std::fs::write(snapshot.join("q8/model_index.json"), "{}").expect("q8 file writes");
+
+    // The q4 tier is entirely absent → missing, but NOT incomplete (no false repair prompt).
+    let q4 = super::models::huggingface_cache_health(&repo_root, &["q4/*".to_owned()]);
+    assert!(
+        !q4.installed && !q4.incomplete,
+        "an entirely-absent tier is missing, not incomplete: {q4:?}"
+    );
+
+    // The q8 tier is present → installed.
+    let q8 = super::models::huggingface_cache_health(&repo_root, &["q8/*".to_owned()]);
+    assert!(q8.installed && !q8.incomplete, "downloaded tier is installed");
+}
+
+#[tokio::test]
+async fn quant_matrix_model_with_single_tier_reads_installed_not_incomplete() {
+    // sc-9907: a quant-matrix model keeps every tier in ONE shared repo cache. Downloading a single
+    // valid tier (here q8, NOT the default q4) previously tripped the top-level default-tier check
+    // and surfaced a false "Cached files are incomplete" + Fix button. The card must read installed,
+    // never incomplete/repairable, and the per-tier states must show q8 installed / q4+bf16 missing.
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"
+            {
+              "schemaVersion": 1,
+              "models": [{
+                "id": "z_image_turbo",
+                "name": "Z-Image Turbo",
+                "type": "image",
+                "family": "z-image",
+                "downloads": [
+                  { "provider": "huggingface", "repo": "SceneWorks/z-image-turbo-mlx", "variant": "q4", "default": true, "files": ["q4/*"] },
+                  { "provider": "huggingface", "repo": "SceneWorks/z-image-turbo-mlx", "variant": "q8", "files": ["q8/*"] },
+                  { "provider": "huggingface", "repo": "SceneWorks/z-image-turbo-mlx", "variant": "bf16", "files": ["bf16/*"] }
+                ]
+              }]
+            }
+            "#,
+    )
+    .expect("builtin models writes");
+    for file in [
+        "user.models.jsonc",
+        "builtin.loras.jsonc",
+        "user.loras.jsonc",
+        "builtin.recipe-presets.jsonc",
+        "user.recipe-presets.jsonc",
+    ] {
+        let key = if file.contains("preset") {
+            "presets"
+        } else if file.contains("lora") {
+            "loras"
+        } else {
+            "models"
+        };
+        std::fs::write(
+            config_dir.join(file),
+            format!(r#"{{ "schemaVersion": 1, "{key}": [] }}"#),
+        )
+        .expect("empty manifest writes");
+    }
+    // Only the non-default q8 tier is on disk in the shared repo snapshot.
+    let snapshot = temp_dir
+        .path()
+        .join("data/cache/huggingface/hub/models--SceneWorks--z-image-turbo-mlx/snapshots/abc123");
+    std::fs::create_dir_all(snapshot.join("q8")).expect("q8 dir creates");
+    std::fs::write(snapshot.join("q8/model_index.json"), "{}").expect("q8 file writes");
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (status, models) = request(app, "GET", "/api/v1/models", Value::Null).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(models[0]["id"], "z_image_turbo");
+    assert_eq!(models[0]["hasVariantMatrix"], true);
+    // Top-level card reads installed — a single valid tier is a complete install, not a repair.
+    assert_eq!(models[0]["installState"], "installed");
+    assert_eq!(models[0]["cacheState"], "complete");
+    assert_eq!(models[0]["repairAvailable"], false);
+    assert_eq!(models[0]["missingRequiredFiles"], json!([]));
+
+    // Per-tier truth: q8 installed; q4 (default) and bf16 cleanly missing, NOT incomplete.
+    let variants = models[0]["variants"].as_array().expect("variants array");
+    let state_of = |name: &str| {
+        variants
+            .iter()
+            .find(|variant| variant["variant"] == name)
+            .unwrap_or_else(|| panic!("variant {name} present"))
+            .clone()
+    };
+    let q8 = state_of("q8");
+    assert_eq!(q8["installState"], "installed");
+    assert_eq!(q8["cacheState"], "complete");
+    for absent in ["q4", "bf16"] {
+        let tier = state_of(absent);
+        assert_eq!(tier["installState"], "missing", "{absent} installState");
+        assert_eq!(tier["cacheState"], "missing", "{absent} cacheState");
+    }
+}
+
 #[cfg(windows)]
 fn create_test_symlink_file(
     target: &std::path::Path,

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -7292,7 +7292,9 @@ fn filtered_cache_health_reports_absent_filter_as_missing_not_incomplete() {
     // sc-9907: a filter whose files are ENTIRELY absent is cleanly missing, not torn. Only a
     // partially-present filter (some files there, some gone) counts as incomplete/repairable.
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
-    let repo_root = temp_dir.path().join("models--SceneWorks--z-image-turbo-mlx");
+    let repo_root = temp_dir
+        .path()
+        .join("models--SceneWorks--z-image-turbo-mlx");
     let snapshot = repo_root.join("snapshots/abc123");
     std::fs::create_dir_all(snapshot.join("q8")).expect("q8 creates");
     std::fs::create_dir_all(repo_root.join("refs")).expect("refs creates");
@@ -7309,7 +7311,10 @@ fn filtered_cache_health_reports_absent_filter_as_missing_not_incomplete() {
 
     // The q8 tier is present → installed.
     let q8 = super::models::huggingface_cache_health(&repo_root, &["q8/*".to_owned()]);
-    assert!(q8.installed && !q8.incomplete, "downloaded tier is installed");
+    assert!(
+        q8.installed && !q8.incomplete,
+        "downloaded tier is installed"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem
For a quant-matrix model — where bf16/Q8/Q4 tiers are hosted as subdirs of **one shared HF repo** (e.g. `SceneWorks/z-image-turbo-mlx` with `files: ["q4/*"]`, `["q8/*"]`, `["bf16/*"]`, q4 = `default:true`) — downloading only **one** tier (especially a non-default one like Q8) made the Model Manager card show a false `incomplete` badge, the warning **"Cached files are incomplete: …"**, and a **Fix** button. Downloading a single quant is a completely valid, complete install; this made it look broken.

## Root cause (`apps/rust-api/src/models.rs`)
Two compounding defects:
1. **`huggingface_filtered_cache_health`** returned `HuggingFaceCacheHealth::missing` (which hard-codes `incomplete: true`) whenever *any* expected pattern was absent — conflating *entirely absent* with *torn/partial*. Because all tiers share one repo snapshot, a downloaded Q8 populated the snapshot the Q4 filter also probes, so the not-downloaded Q4 tier registered as `incomplete`.
2. **`install_state_for`** computed the top-level `installState` / `cacheState` / `repairAvailable` / `missingRequiredFiles` against the **default variant only**. So a matrix model with Q8 installed but not the default Q4 reported the default tier's absence as the whole model's cache state.

These flow to `cacheState:"incomplete"` + `repairAvailable:true`, which the frontend (`apps/web/src/screens/ModelManagerScreen.jsx:871`) turns into the false warning + Fix button.

## Fix
- `huggingface_filtered_cache_health` is now three-state: **all** patterns present → installed; **none** present → missing (`incomplete:false`); **some** present → incomplete (a genuinely torn download, still a real repair candidate).
- `install_state_for` aggregates the top-level state across **all** tiers for `model_has_variant_matrix(model)` — installed when any tier is fully present; incomplete only when a tier is genuinely torn *and* no complete tier exists. Single-variant models keep the existing default-tier contract.
- **No frontend change** — it derives the warning from the now-correct backend fields.

## Tests
- `filtered_cache_health_reports_absent_filter_as_missing_not_incomplete` (unit)
- `quant_matrix_model_with_single_tier_reads_installed_not_incomplete` (catalog: Q8-only → top-level installed/complete/no-repair; per-tier Q8 installed, Q4+bf16 missing not incomplete)
- Genuine torn downloads still flag incomplete — guarded by the existing `turbo_cache_health_flags_missing_lora_only_when_listed_explicitly`.

Full `sceneworks-rust-api` lib suite green (187 passed); `npm run rust:check` (fmt + clippy + build) clean.

Shortcut: [sc-9907](https://app.shortcut.com/trefry/story/9907) (epic 8506).

🤖 Generated with [Claude Code](https://claude.com/claude-code)