### PR TITLE
fix(rust-api): quant tier install state must be per-tier, not repo-marker (sc-9909)

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1131,10 +1131,14 @@ fn model_variant_states(model: &Value, data_dir: &FsPath) -> Vec<ModelVariantSta
                 .as_ref()
                 .map(|health| health.missing_files.clone())
                 .unwrap_or_default();
-            // The managed dir mirrors the default-download install path; a variant that is present
-            // there (a directly-downloaded turnkey) counts as installed too.
+            // The managed dir mirrors the default-download install path; a variant present there (a
+            // directly-downloaded turnkey) counts as installed too — but the check must be TIER-aware.
+            // A quant-matrix repo writes ONE repo-level completion marker no matter which tier was
+            // fetched, so keying a per-tier "installed" on the bare marker made EVERY tier report
+            // installed after any single tier's download (sc-9909). Require the tier's own files to
+            // actually exist under the managed dir, not just the marker.
             let managed_path = data_dir.join("models").join(safe_download_dir(&repo));
-            let managed_installed = model_is_installed(&managed_path);
+            let managed_installed = managed_tier_installed(&managed_path, &files);
             let installed_path = if installed || cache_incomplete {
                 cache_path
             } else if managed_installed {
@@ -1159,6 +1163,23 @@ fn model_variant_states(model: &Value, data_dir: &FsPath) -> Vec<ModelVariantSta
             }
         })
         .collect()
+}
+
+// Whether a tier's OWN artifacts live in the app-managed turnkey dir (data/models/<repo>), as opposed
+// to the shared HF cache. The repo-level completion marker (.sceneworks-download-complete.json) alone
+// does NOT certify a tier: a quant-matrix repo writes exactly one marker regardless of which tier was
+// downloaded, so a bare-marker check reported every tier of a repo installed after any single tier's
+// fetch (sc-9909). Require BOTH the marker AND — for a tier that declares a `files` filter — that the
+// tier's files actually exist under the managed dir. A single-variant turnkey (empty `files`) is
+// certified by the marker alone, preserving the pre-matrix contract.
+fn managed_tier_installed(managed_path: &FsPath, files: &[String]) -> bool {
+    if !model_is_installed(managed_path) {
+        return false;
+    }
+    files.is_empty()
+        || files
+            .iter()
+            .all(|pattern| snapshot_contains_pattern(managed_path, pattern))
 }
 
 // The on-disk size a `downloads[].footprint.diskSizeBytes` declares, if any — the tier-scoped

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -7373,6 +7373,18 @@ async fn quant_matrix_model_with_single_tier_reads_installed_not_incomplete() {
         .join("data/cache/huggingface/hub/models--SceneWorks--z-image-turbo-mlx/snapshots/abc123");
     std::fs::create_dir_all(snapshot.join("q8")).expect("q8 dir creates");
     std::fs::write(snapshot.join("q8/model_index.json"), "{}").expect("q8 file writes");
+    // sc-9909: the real download flow ALSO writes a repo-level completion marker into the app-managed
+    // dir (data/models/<repo>). It is tier-agnostic (one marker per repo, no matter which tier was
+    // fetched), so the per-tier state must NOT treat its presence as "every tier installed".
+    let managed = temp_dir
+        .path()
+        .join("data/models/SceneWorks__z-image-turbo-mlx");
+    std::fs::create_dir_all(&managed).expect("managed dir creates");
+    std::fs::write(
+        managed.join(".sceneworks-download-complete.json"),
+        r#"{ "repo": "SceneWorks/z-image-turbo-mlx" }"#,
+    )
+    .expect("marker writes");
 
     let app = create_app(test_settings(&temp_dir)).expect("app creates");
     let (status, models) = request(app, "GET", "/api/v1/models", Value::Null).await;


### PR DESCRIPTION
## Problem
Follow-up to #1193 (sc-9907). After that fix removed the false *"incomplete + Fix"*, the Model Manager showed **all three tiers (q4/q8/bf16) as installed** for quant-matrix models even when only **one** tier was downloaded.

Verified live against the running app (`GET /api/v1/models`): e.g. `flux2_klein_9b` has only `q4` in the HF cache, yet `q8` and `bf16` reported `installed/complete` with `installedPath = data/models/SceneWorks__flux2-klein-9b-mlx`.

## Root cause (`apps/rust-api/src/models.rs`, `model_variant_states`)
Per-tier `installed` was `cache_health.installed || managed_installed`, where `managed_installed = model_is_installed(&managed_path)` checks the **repo-level** app-managed dir `data/models/<repo>`. The download flow writes a repo-level completion marker `.sceneworks-download-complete.json` there — **one marker per repo**, tier-agnostic (it records only repo/modelId/jobId/completedAt). So once any tier is downloaded, the marker exists and every tier OR's to `installed = true`.

sc-9907's *absent-tier → missing* change is what made this fully visible: those tiers flipped from `cacheState: incomplete` to `complete`.

## Fix
New `managed_tier_installed(managed_path, files)`: the managed dir only certifies a tier when the marker is present **AND** — for a tier with a `files` filter — the tier's own files actually exist under the managed dir. A quant tier whose files live only in the HF cache (or nowhere) no longer inherits the repo marker. Single-variant turnkey (empty `files`) is still certified by the marker alone, preserving the pre-matrix contract.

## Tests
`quant_matrix_model_with_single_tier_reads_installed_not_incomplete` now also writes the repo-level managed marker (the realistic on-disk state) and asserts the un-downloaded tiers stay `missing`/`missing` while the downloaded tier reads `installed`/`complete`. **Fails without this fix.**

Full `sceneworks-rust-api` lib suite green (187 passed); fmt + clippy + build clean.

## Known follow-up (separate, filed)
The coarse `<tier>/*` glob still marks a tier installed when it holds ≥1 file, so a *partially* downloaded tier (e.g. z-image-turbo q8 present but missing `transformer/` + `vae/`) reads installed. Tracked as **[sc-9910](https://app.shortcut.com/trefry/story/9910)** — needs per-tier required-file patterns in the manifest.

Shortcut: [sc-9909](https://app.shortcut.com/trefry/story/9909) (epic 8506).

🤖 Generated with [Claude Code](https://claude.com/claude-code)