### PR TITLE
fix(rust-api): empty HF cache skeleton reads as missing, not incomplete (sc-9909)

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -976,7 +976,13 @@ fn install_state_for(
                     .unwrap_or_default();
                 (installed, incomplete, missing)
             };
-        let managed_installed = model_is_installed(&managed_path);
+        // A quant-matrix model's top-level state is the aggregate of its tier-aware variant states
+        // computed above (cache_installed = "any tier installed"). The repo-level managed marker must
+        // NOT independently mark it installed (sc-9909): a stale .sceneworks-download-complete.json
+        // left by an empty download would otherwise read the whole model as installed while every tier
+        // reads missing. Single-variant models keep the repo-level managed contract.
+        let managed_installed =
+            !model_has_variant_matrix(model) && model_is_installed(&managed_path);
         let primary_installed = managed_installed || cache_installed;
         let installed_path = if cache_installed || cache_incomplete {
             cache_path.clone()
@@ -1724,7 +1730,17 @@ pub(crate) fn huggingface_cache_health(
     }
     let snapshots = huggingface_snapshot_dirs(repo_root);
     if snapshots.is_empty() {
-        return HuggingFaceCacheHealth::missing(vec!["snapshots/<revision>".to_owned()]);
+        // The repo cache dir exists but holds no snapshot revision at all — an empty skeleton
+        // (bare refs/blobs, e.g. a download that resolved zero files against an unpublished tier, or
+        // a cache whose weights were pruned). Nothing is partially there, so this is MISSING, not a
+        // repairable "incomplete": reporting incomplete surfaced a confusing "Cached files are
+        // incomplete: snapshots/<revision>" banner for a tier that simply was never downloaded
+        // (sc-9909). incomplete:false keeps it a clean not-installed state.
+        return HuggingFaceCacheHealth {
+            installed: false,
+            incomplete: false,
+            missing_files: vec!["snapshots/<revision>".to_owned()],
+        };
     }
     if !files.is_empty() {
         return huggingface_filtered_cache_health(&snapshots, files);

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -7417,6 +7417,95 @@ async fn quant_matrix_model_with_single_tier_reads_installed_not_incomplete() {
     }
 }
 
+#[tokio::test]
+async fn quant_matrix_empty_cache_skeleton_reads_missing_not_incomplete() {
+    // sc-9909: a tier that isn't published upstream resolves ZERO files, leaving an empty HF cache
+    // skeleton (bare blobs/, no snapshots) PLUS a stale repo-level completion marker. That must read
+    // as a clean not-installed model — NOT a false "installed" (from the marker) and NOT the confusing
+    // "Cached files are incomplete: snapshots/<revision>" repair banner.
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"
+            {
+              "schemaVersion": 1,
+              "models": [{
+                "id": "sdxl",
+                "name": "SDXL",
+                "type": "image",
+                "family": "sdxl",
+                "downloads": [
+                  { "provider": "huggingface", "repo": "SceneWorks/sdxl-base-mlx", "variant": "q4", "default": true, "files": ["q4/*"] },
+                  { "provider": "huggingface", "repo": "SceneWorks/sdxl-base-mlx", "variant": "q8", "files": ["q8/*"] },
+                  { "provider": "huggingface", "repo": "SceneWorks/sdxl-base-mlx", "variant": "bf16", "files": ["bf16/*"] }
+                ]
+              }]
+            }
+            "#,
+    )
+    .expect("builtin models writes");
+    for file in [
+        "user.models.jsonc",
+        "builtin.loras.jsonc",
+        "user.loras.jsonc",
+        "builtin.recipe-presets.jsonc",
+        "user.recipe-presets.jsonc",
+    ] {
+        let key = if file.contains("preset") {
+            "presets"
+        } else if file.contains("lora") {
+            "loras"
+        } else {
+            "models"
+        };
+        std::fs::write(
+            config_dir.join(file),
+            format!(r#"{{ "schemaVersion": 1, "{key}": [] }}"#),
+        )
+        .expect("empty manifest writes");
+    }
+    // Empty HF cache skeleton: the repo dir exists (bare blobs/) but has NO snapshot revision.
+    let repo_root = temp_dir
+        .path()
+        .join("data/cache/huggingface/hub/models--SceneWorks--sdxl-base-mlx");
+    std::fs::create_dir_all(repo_root.join("blobs")).expect("blobs dir creates");
+    // ...plus a stale repo-level completion marker in the app-managed dir.
+    let managed = temp_dir
+        .path()
+        .join("data/models/SceneWorks__sdxl-base-mlx");
+    std::fs::create_dir_all(&managed).expect("managed dir creates");
+    std::fs::write(
+        managed.join(".sceneworks-download-complete.json"),
+        r#"{ "repo": "SceneWorks/sdxl-base-mlx" }"#,
+    )
+    .expect("marker writes");
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (status, models) = request(app, "GET", "/api/v1/models", Value::Null).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(models[0]["id"], "sdxl");
+    // Clean not-installed — no phantom "installed" from the marker, no incomplete/repair banner.
+    assert_eq!(models[0]["installState"], "missing");
+    assert_eq!(models[0]["cacheState"], "missing");
+    assert_eq!(models[0]["repairAvailable"], false);
+    for variant in models[0]["variants"].as_array().expect("variants array") {
+        assert_eq!(
+            variant["installState"], "missing",
+            "{} installState",
+            variant["variant"]
+        );
+        assert_eq!(
+            variant["cacheState"], "missing",
+            "{} cacheState",
+            variant["variant"]
+        );
+    }
+}
+
 #[cfg(windows)]
 fn create_test_symlink_file(
     target: &std::path::Path,


### PR DESCRIPTION
Re-lands a commit dropped when #1194 squash-merged with a stale PR head. Same sc-9909 theme.

## Note on root cause (corrected)
The empty caches that motivated this were caused by a **worker bug** (HF tree `resolve` not following `Link: rel="next"` pagination, so files past the first ~50 were invisible → a tier "downloaded" zero files). That's fixed in **#1196**. My earlier "tiers aren't published" claim was wrong — the tiers are fully uploaded.

This PR is the **display-side robustness** half, still correct independent of the cause:
- `huggingface_cache_health`: a repo dir that exists but has **no snapshot revision** now reads `missing` (`incomplete: false`) instead of a repairable `incomplete: snapshots/<revision>`. An empty skeleton isn't partially-there, so there's nothing to repair.
- `install_state_for`: a quant-matrix model's top-level state derives **solely** from its tier-aware variant aggregate; it no longer OR's in the repo-level managed marker (a stale marker from an empty download no longer reads the whole model as installed while every tier reads missing).

Net: any empty/torn cache reads as a clean not-installed state rather than a confusing banner + phantom badge. With #1196 landed, re-downloading fills the cache properly.

Test: `quant_matrix_empty_cache_skeleton_reads_missing_not_incomplete`. 188 green; fmt + clippy clean.

Shortcut: [sc-9909](https://app.shortcut.com/trefry/story/9909).

🤖 Generated with [Claude Code](https://claude.com/claude-code)