### PR TITLE
fix(worker): follow HF tree pagination in resolve (real empty-download cause) (sc-9909)

### DIFF
--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -345,32 +345,45 @@ impl HuggingFaceSnapshot {
         files: &[String],
     ) -> WorkerResult<Self> {
         let base_url = settings.huggingface_base_url.trim_end_matches('/');
-        let tree_url = format!(
+        // The HF tree API paginates the `expand=1` listing (default limit 50) and returns the next
+        // page as a `Link: <…?cursor=…>; rel="next"` header. A single request therefore sees only the
+        // first ~50 files, so for a multi-tier repo (bf16/q4/q8 subdirs) the later tiers' files fall
+        // past page 1 and go MISSING — a q8 download then resolves zero files and silently produces an
+        // empty cache (sc-9909). Follow `rel="next"` until exhausted so every file is seen. The page
+        // cap is a runaway backstop far above any real repo's file count.
+        let mut next_url = Some(format!(
             "{base_url}/api/models/{}/tree/{}?recursive=1&expand=1",
             quote_path(repo),
             quote_path(revision)
-        );
-        let payload = with_hf_auth(settings, client.get(tree_url))
-            .await
-            .send()
-            .await?
-            .error_for_status()?
-            .json::<Value>()
-            .await?;
-        let entries = if let Some(entries) = payload.as_array() {
-            entries.clone()
-        } else {
-            payload
-                .get("siblings")
-                .and_then(Value::as_array)
-                .cloned()
-                .unwrap_or_default()
-        };
-        let snapshot_files = entries
-            .iter()
-            .filter_map(|entry| snapshot_file_from_entry(base_url, repo, revision, entry))
-            .filter(|file| allow_pattern_matches(&file.path, files))
-            .collect();
+        ));
+        let mut snapshot_files = Vec::new();
+        for _ in 0..10_000 {
+            let Some(url) = next_url.take() else {
+                break;
+            };
+            let response = with_hf_auth(settings, client.get(&url))
+                .await
+                .send()
+                .await?
+                .error_for_status()?;
+            next_url = next_page_url(response.headers());
+            let payload = response.json::<Value>().await?;
+            let entries = if let Some(entries) = payload.as_array() {
+                entries.clone()
+            } else {
+                payload
+                    .get("siblings")
+                    .and_then(Value::as_array)
+                    .cloned()
+                    .unwrap_or_default()
+            };
+            snapshot_files.extend(
+                entries
+                    .iter()
+                    .filter_map(|entry| snapshot_file_from_entry(base_url, repo, revision, entry))
+                    .filter(|file| allow_pattern_matches(&file.path, files)),
+            );
+        }
         Ok(Self {
             files: snapshot_files,
         })
@@ -381,6 +394,35 @@ impl HuggingFaceSnapshot {
             .iter()
             .try_fold(0_u64, |total, file| Some(total.saturating_add(file.size?)))
     }
+}
+
+/// Extract the `rel="next"` target from an RFC 5988 `Link` header, if present. The HF tree API
+/// paginates its `expand=1` listing this way — the header looks like
+/// `<https://…/tree/main?expand=true&recursive=true&limit=50&cursor=…>; rel="next"`. Returns the
+/// absolute next-page URL (the server preserves the `expand`/`recursive` params in it).
+fn next_page_url(headers: &reqwest::header::HeaderMap) -> Option<String> {
+    let link = headers.get(reqwest::header::LINK)?.to_str().ok()?;
+    for part in link.split(',') {
+        let mut segments = part.split(';');
+        let Some(url) = segments.next() else {
+            continue;
+        };
+        let is_next = segments.any(|attribute| {
+            let attribute = attribute.trim();
+            attribute == "rel=\"next\"" || attribute == "rel=next"
+        });
+        if is_next {
+            let url = url
+                .trim()
+                .trim_start_matches('<')
+                .trim_end_matches('>')
+                .trim();
+            if !url.is_empty() {
+                return Some(url.to_owned());
+            }
+        }
+    }
+    None
 }
 
 pub(crate) fn snapshot_file_from_entry(

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -129,6 +129,28 @@ pub(crate) async fn run_model_download_job(
     })?;
     let snapshot =
         HuggingFaceSnapshot::resolve(http_client, settings, repo, revision, &files).await?;
+    // A download that resolves to ZERO files is not a success: the repo/revision has nothing under
+    // the requested filter — e.g. a quant tier whose weights aren't uploaded yet (sc-8513 rollout).
+    // Failing here, instead of downloading nothing and still writing a completion marker, surfaces a
+    // clear error rather than a silent no-op that later reads as an empty/phantom install (sc-9909).
+    if snapshot.files.is_empty() {
+        let scope = if files.is_empty() {
+            String::new()
+        } else {
+            format!(" matching {}", files.join(", "))
+        };
+        fail_job(
+            api,
+            &job.id,
+            &format!("No files to download for {repo}{scope}. This tier may not be published yet."),
+            Some(
+                "The Hugging Face repository/revision matched zero files for the requested filter."
+                    .to_owned(),
+            ),
+        )
+        .await?;
+        return Ok(());
+    }
     if let Some(total_bytes) = snapshot.total_bytes() {
         update_job(
             api,

--- a/crates/sceneworks-worker/src/tests/lora_and_downloads.rs
+++ b/crates/sceneworks-worker/src/tests/lora_and_downloads.rs
@@ -1161,3 +1161,69 @@ async fn model_download_fails_when_the_tier_resolves_no_files() {
     });
     assert!(failed, "expected a failed progress post, got {posts:?}");
 }
+
+/// A tree stub that paginates: page 1 (no cursor) returns bf16/q4 files plus a `Link: rel="next"`
+/// header pointing at page 2; page 2 (cursor=next) returns the q8 file and no further link.
+async fn spawn_paginated_tree_stub() -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("listener binds");
+    let address = listener.local_addr().expect("listener has address");
+    let base = format!("http://{address}");
+    let base_for_handler = base.clone();
+    async fn page(
+        base: String,
+        axum::extract::RawQuery(query): axum::extract::RawQuery,
+    ) -> Response {
+        let on_page_two = query.as_deref().is_some_and(|q| q.contains("cursor=next"));
+        if on_page_two {
+            // The later tier — only visible if pagination is followed.
+            Json(json!([
+                { "type": "file", "path": "q8/unet/model.safetensors", "size": 3_000_000_000u64 }
+            ]))
+            .into_response()
+        } else {
+            let mut response = Json(json!([
+                { "type": "file", "path": "bf16/model_index.json", "size": 600 },
+                { "type": "file", "path": "q4/model_index.json", "size": 600 }
+            ]))
+            .into_response();
+            let link = format!("<{base}/api/models/owner/repo/tree/main?recursive=true&expand=true&limit=50&cursor=next>; rel=\"next\"");
+            response.headers_mut().insert(
+                reqwest::header::LINK,
+                axum::http::HeaderValue::from_str(&link).expect("valid link header"),
+            );
+            response
+        }
+    }
+    let app = Router::new().route(
+        "/api/models/:owner/:repo/tree/:revision",
+        get(move |raw| page(base_for_handler.clone(), raw)),
+    );
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("stub serves");
+    });
+    base
+}
+
+#[tokio::test]
+async fn resolve_follows_tree_pagination_across_pages() {
+    // sc-9909: the HF tree `expand=1` view is paginated (limit 50). A later tier's files land on a
+    // subsequent page, so resolve MUST follow `Link: rel="next"` — otherwise a `q8/*` filter matches
+    // nothing (the q8 files are on page 2) and the tier silently "downloads" empty.
+    let base_url = spawn_paginated_tree_stub().await;
+    let settings = test_settings(base_url, None);
+    let client = reqwest::Client::new();
+
+    let snapshot =
+        HuggingFaceSnapshot::resolve(&client, &settings, "owner/repo", "main", &["q8/*".to_owned()])
+            .await
+            .expect("resolves across pages");
+
+    let paths: Vec<&str> = snapshot.files.iter().map(|file| file.path.as_str()).collect();
+    assert_eq!(
+        paths,
+        vec!["q8/unet/model.safetensors"],
+        "the q8 file from page 2 must be resolved (pagination followed)"
+    );
+}

--- a/crates/sceneworks-worker/src/tests/lora_and_downloads.rs
+++ b/crates/sceneworks-worker/src/tests/lora_and_downloads.rs
@@ -1073,3 +1073,91 @@ async fn download_progress_tick_cancels_from_progress_post_snapshot() {
         "the tick must not GET the job for its cancel decision"
     );
 }
+
+/// A stub whose HF tree resolve returns an EMPTY file list, plus the job/progress/heartbeat routes a
+/// download job touches. Progress POSTs are recorded so the test can assert the job was FAILED.
+async fn spawn_empty_tree_stub() -> (String, std::sync::Arc<std::sync::Mutex<Vec<Value>>>) {
+    use std::sync::{Arc, Mutex};
+    type Posts = Arc<Mutex<Vec<Value>>>;
+    async fn tree_route() -> Response {
+        // No files at this revision under any filter — the unpublished-tier case.
+        Json(json!([])).into_response()
+    }
+    async fn job_route(axum::extract::Path(job_id): axum::extract::Path<String>) -> Response {
+        Json(job_snapshot_json(&job_id, false)).into_response()
+    }
+    async fn progress_route(
+        State(posts): State<Posts>,
+        axum::extract::Path(job_id): axum::extract::Path<String>,
+        Json(body): Json<Value>,
+    ) -> Response {
+        posts.lock().expect("posts lock").push(body);
+        Json(job_snapshot_json(&job_id, false)).into_response()
+    }
+    async fn heartbeat_route(
+        axum::extract::Path(worker_id): axum::extract::Path<String>,
+    ) -> Response {
+        Json(worker_snapshot_json(&worker_id)).into_response()
+    }
+    let posts: Posts = Arc::new(Mutex::new(Vec::new()));
+    let app = Router::new()
+        .route("/api/models/:owner/:repo/tree/:revision", get(tree_route))
+        .route("/api/v1/jobs/:job_id", get(job_route))
+        .route("/api/v1/jobs/:job_id/progress", post(progress_route))
+        .route("/api/v1/workers/:worker_id/heartbeat", post(heartbeat_route))
+        .with_state(posts.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("listener binds");
+    let address = listener.local_addr().expect("listener has address");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("stub serves");
+    });
+    (format!("http://{address}"), posts)
+}
+
+#[tokio::test]
+async fn model_download_fails_when_the_tier_resolves_no_files() {
+    // sc-9909: installing a quant tier whose weights aren't published yet (sc-8513 rollout) resolves
+    // ZERO files. That must FAIL with a clear message rather than silently "succeed" and leave an
+    // empty cache + a stale completion marker.
+    let temp = tempdir().expect("tempdir creates");
+    let (base_url, posts) = spawn_empty_tree_stub().await;
+    let mut settings = test_settings(base_url.clone(), None);
+    settings.api_url = base_url.clone();
+    settings.data_dir = temp.path().to_path_buf();
+    let api = ApiClient::new(&settings);
+    let client = reqwest::Client::new();
+
+    let mut job_json = job_snapshot_json("job-1", false);
+    job_json["type"] = json!("model_download");
+    job_json["payload"] = json!({
+        "modelId": "sdxl",
+        "repo": "SceneWorks/sdxl-base-mlx",
+        "files": ["q8/*"],
+    });
+    let job: JobSnapshot = serde_json::from_value(job_json).expect("job deserializes");
+
+    super::model_jobs::run_model_download_job(&api, &settings, &client, &job)
+        .await
+        .expect("returns Ok — the failure is reported via a progress post, not an Err");
+
+    // The completion marker must NOT have been written for an empty download.
+    let marker = temp
+        .path()
+        .join("models")
+        .join(safe_download_dir("SceneWorks/sdxl-base-mlx"))
+        .join(INSTALL_MARKER);
+    assert!(!marker.exists(), "no completion marker for a zero-file download");
+
+    // A Failed progress post naming the empty tier was recorded.
+    let posts = posts.lock().expect("posts lock");
+    let failed = posts.iter().any(|post| {
+        post.get("status").and_then(Value::as_str) == Some("failed")
+            && post
+                .get("message")
+                .and_then(Value::as_str)
+                .is_some_and(|message| message.contains("No files to download"))
+    });
+    assert!(failed, "expected a failed progress post, got {posts:?}");
+}


### PR DESCRIPTION
## Correction / root cause
My earlier "the quant tiers aren't published" conclusion was **wrong** — the tiers **are** fully uploaded. I'd hit the *same bug the worker has*: the HF tree API's `expand=1` listing is **paginated** (default `limit=50`) and returns the next page via a `Link: <…?cursor=…>; rel="next"` header.

`HuggingFaceSnapshot::resolve` issued a **single** request and ignored the `Link` header, so it only ever saw the first ~50 files of a repo. For a multi-tier repo (bf16/q4/q8 subdirs — e.g. `SceneWorks/sdxl-base-mlx` has **85** files), the later tier's files sort **past page 1** and were invisible. A `q8/*` filter then matched nothing → the tier "downloaded" zero files → empty cache skeleton. That is why installing q8 no-op'd — **not** a content gap.

## Fix
- **`resolve` now follows `Link: rel="next"`** until exhausted, accumulating files across all pages (with a large page-count backstop). The `expand=1` LFS size/digest metadata is preserved.
- Retains a **backstop guard**: if a resolve still yields zero files (a genuinely absent path), the job **fails** with a clear message instead of writing a phantom completion marker.

## Tests
- `resolve_follows_tree_pagination_across_pages` — a `q8/*` file served **only on page 2** is now resolved (fails without the pagination fix).
- `model_download_fails_when_the_tier_resolves_no_files` — the zero-file backstop posts a `failed` status and writes no marker.

`cargo test -p sceneworks-worker` green; fmt + clippy clean.

## Impact
Any repo with >50 files was silently losing everything past the first page — this affects every multi-tier quant model, not just the ones reported. After this lands, re-downloading a previously-empty tier will actually fetch its weights.

Companion: #1195 (empty cache skeleton reads `missing` not `incomplete`).

Follow-up: sc-9912 (the hf-CLI path uses `hf download`, which paginates internally — needs a separate check that it isn't affected).

Shortcut: [sc-9909](https://app.shortcut.com/trefry/story/9909).

🤖 Generated with [Claude Code](https://claude.com/claude-code)