### PR TITLE
feat(web): implement SceneWorks UI Refinement design handoff

### DIFF
--- a/apps/web/src/App.imageGeneration.test.jsx
+++ b/apps/web/src/App.imageGeneration.test.jsx
@@ -615,25 +615,45 @@ describe("SceneWorks app shell", () => {
       [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Advanced").click();
     });
 
+    // Add-on-demand LoRA picker (UI-refinement 3b): open the "Add LoRA" dropdown and click a
+    // compatible row to add each LoRA. built_in (scope "builtin") doesn't count toward the
+    // four-user cap, so we can add it plus four user LoRAs.
+    const addLora = async (name) => {
+      await act(async () => {
+        [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Add LoRA").click();
+      });
+      await act(async () => {
+        [...document.body.querySelectorAll(".lora-pick-row")]
+          .find((button) => button.textContent.includes(name))
+          .click();
+      });
+    };
+    await addLora("Built In");
+    await addLora("Global Style");
+    await addLora("Project Mira");
+    await addLora("Third User");
+    await addLora("Fourth User");
+
     expect(container.textContent).toContain("Built In");
-    const checkboxes = [...document.body.querySelectorAll('.lora-choice input[type="checkbox"]')];
+
+    // At the four-user cap, the fifth user LoRA's Add row is disabled in the dropdown.
     await act(async () => {
-      checkboxes[0].click();
-      checkboxes[1].click();
-      checkboxes[2].click();
-      checkboxes[3].click();
-      checkboxes[4].click();
+      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Add LoRA").click();
     });
+    const fifthRow = [...document.body.querySelectorAll(".lora-pick-row")].find((button) =>
+      button.textContent.includes("Fifth User"),
+    );
+    expect(fifthRow.disabled).toBe(true);
 
-    // built_in is scope "builtin" and doesn't count toward the user cap, so four
-    // user LoRAs are selected here; the fifth user LoRA is disabled at the cap.
-    expect(checkboxes[5].disabled).toBe(true);
-
+    // The Show-incompatible toggle reveals incompatible LoRAs in the same dropdown.
     await act(async () => {
       document.body.querySelector('.lora-picker .checkline input[type="checkbox"]').click();
     });
-
-    expect(container.textContent).toContain("Qwen Only");
+    expect(
+      [...document.body.querySelectorAll(".lora-pick-row")].some((button) =>
+        button.textContent.includes("Qwen Only"),
+      ),
+    ).toBe(true);
     expect(container.textContent).not.toContain("Missing LoRA");
 
     await act(async () => {
@@ -686,8 +706,12 @@ describe("SceneWorks app shell", () => {
     await act(async () => {
       [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Advanced").click();
     });
+    // Open the Add-LoRA dropdown to inspect which LoRAs the model offers as compatible.
+    await act(async () => {
+      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Add LoRA").click();
+    });
 
-    const loraNames = [...document.body.querySelectorAll(".lora-choice strong")].map((node) => node.textContent);
+    const loraNames = [...document.body.querySelectorAll(".lora-pick-row strong")].map((node) => node.textContent);
     // A kolors-family model must not offer a z-image LoRA as compatible.
     expect(loraNames).toContain("Kolors Style");
     expect(loraNames).not.toContain("Z Style");
@@ -721,11 +745,17 @@ describe("SceneWorks app shell", () => {
     await act(async () => {
       [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Advanced").click();
     });
+    // Reveal the incompatible LoRA in the dropdown, then add it via its Add row.
     await act(async () => {
       document.body.querySelector('.lora-picker .checkline input[type="checkbox"]').click();
     });
     await act(async () => {
-      document.body.querySelector('.lora-choice input[type="checkbox"]').click();
+      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Add LoRA").click();
+    });
+    await act(async () => {
+      [...document.body.querySelectorAll(".lora-pick-row")]
+        .find((button) => button.textContent.includes("Qwen Only"))
+        .click();
     });
 
     const generate = [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Generate");
@@ -988,12 +1018,12 @@ describe("SceneWorks app shell", () => {
     });
     await settle();
 
-    // Primary preset controls are surfaced in the rail (no longer behind Advanced),
-    // alongside the hero-mounted prompt + preset chip strip.
-    const railLabels = [...document.body.querySelectorAll(".preset-rail > label, .preset-rail .preset-rail-row label")].map(
+    // Primary generation controls sit in the settings bar under the composer (UI-refinement 2b),
+    // no longer in a right-hand rail; power-user knobs stay behind Advanced.
+    const settingsLabels = [...document.body.querySelectorAll(".settings-bar label")].map(
       (label) => label.childNodes[0]?.textContent.trim(),
     );
-    expect(railLabels).toEqual(expect.arrayContaining(["Model", "Variations", "Aspect"]));
+    expect(settingsLabels).toEqual(expect.arrayContaining(["Model", "Variations", "Aspect"]));
     expect(document.body.querySelector(".prompt-input")).not.toBeNull();
     expect(document.body.querySelector(".preset-chips").textContent).toContain("None");
     // sc-5875: a fresh studio defaults to None, so the preset's count (2) is NOT
@@ -1626,7 +1656,7 @@ describe("SceneWorks app shell", () => {
     const sceneSuggestions = [...document.body.querySelectorAll(".suggestion")].map((button) => button.textContent).join("|");
 
     await act(async () => {
-      [...document.body.querySelectorAll(".segmented-control button")].find((button) => button.textContent === "With character").click();
+      [...document.body.querySelectorAll(".mode-tabs button")].find((button) => button.textContent === "With character").click();
     });
     await settle();
 
@@ -1728,7 +1758,7 @@ describe("SceneWorks app shell", () => {
 
     await changeField(document.body.querySelector(".prompt-input"), "my own deliberate scene");
     await act(async () => {
-      [...document.body.querySelectorAll(".segmented-control button")].find((button) => button.textContent === "With character").click();
+      [...document.body.querySelectorAll(".mode-tabs button")].find((button) => button.textContent === "With character").click();
     });
     await changeField(field(container, "Character"), "char-1");
     await settle();
@@ -2070,20 +2100,25 @@ describe("SceneWorks app shell", () => {
     });
     await settle();
 
-    // Only the ltx-video LoRA is compatible; the z-image one is filtered out.
-    expect(container.textContent).toContain("LTX Style");
-    expect(container.textContent).not.toContain("Z Glow");
-
-    const loraCheckbox = document.body.querySelector(".lora-choice-list input[type=checkbox]");
+    // Add-on-demand LoRA picker (UI-refinement 3b): open the dropdown. Only the ltx-video LoRA is
+    // compatible; the z-image one is filtered out.
     await act(async () => {
-      loraCheckbox.click();
+      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Add LoRA").click();
+    });
+    const pickNames = [...document.body.querySelectorAll(".lora-pick-row strong")].map((node) => node.textContent);
+    expect(pickNames).toContain("LTX Style");
+    expect(pickNames).not.toContain("Z Glow");
+
+    // Adding a LoRA drops in a slot with its weight slider, defaulting to the LoRA weight (0.8).
+    await act(async () => {
+      [...document.body.querySelectorAll(".lora-pick-row")]
+        .find((button) => button.textContent.includes("LTX Style"))
+        .click();
     });
     await settle();
-
-    // Selecting a LoRA reveals its weight slider, defaulting to the LoRA weight (0.8).
-    const weightSlider = document.body.querySelector(".lora-weight-row input[type=range]");
+    const weightSlider = document.body.querySelector(".lora-slot-weight input[type=range]");
     expect(weightSlider).toBeTruthy();
-    expect(document.body.querySelector(".lora-weight-value").textContent).toBe("0.80");
+    expect(document.body.querySelector(".lora-slot-weight-value").textContent).toBe("0.80");
     await changeField(weightSlider, "0.5");
 
     const generate = [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Render clip");
@@ -2241,7 +2276,7 @@ describe("SceneWorks app shell", () => {
     await settle();
 
     await act(async () => {
-      [...document.body.querySelectorAll(".segmented-control button")].find((button) => button.textContent === "Edit").click();
+      [...document.body.querySelectorAll(".mode-tabs button")].find((button) => button.textContent === "Edit").click();
     });
     await settle();
 

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -2083,21 +2083,27 @@ export function App() {
           </div>
           <span className="topbar-spacer" />
           <div className="topbar-status">
-            <span className={health?.status === "ok" ? "status-pill" : "status-pill warning"}>
+            {/* Status collapses to one summary pill (UI-refinement 1d): API health · workers · GPU.
+                Clicking through opens the Queue, where the per-worker/job detail lives. */}
+            <button
+              className={health?.status === "ok" ? "status-pill status-summary" : "status-pill status-summary warning"}
+              onClick={() => setActiveView("Queue")}
+              title="Workers and GPU activity — open the Queue for detail"
+              type="button"
+            >
               <StatusDot ok={health?.status === "ok"} />
-              {health?.status === "ok" ? "API ready" : "API offline"}
-            </span>
-            <span className="status-pill">
-              <span className={visibleWorkers.length ? "dot" : "dot idle"} />
-              {visibleWorkers.length ? `${visibleWorkers.length} worker${visibleWorkers.length === 1 ? "" : "s"}` : "No workers"}
-            </span>
-            <span className="status-pill">
-              {gpuOptions.length > 1 ? `${gpuOptions.length - 1} GPU slot${gpuOptions.length === 2 ? "" : "s"}` : "GPU auto"}
-            </span>
+              {health?.status === "ok" ? "Ready" : "API offline"}
+              <span className="status-summary-sep">·</span>
+              {visibleWorkers.length} worker{visibleWorkers.length === 1 ? "" : "s"}
+              <span className="status-summary-sep">·</span>
+              {gpuOptions.length > 1 ? `${gpuOptions.length - 1} GPU` : "GPU auto"}
+              <Icon.ChevDown className="status-summary-caret" size={13} />
+            </button>
             <button className="queue-chip" onClick={() => setActiveView("Queue")} type="button">
               Queue {queueCounts.active}
             </button>
           </div>
+          <span className="topbar-divider" aria-hidden="true" />
           <button className="icon-btn" title="Notifications" type="button">
             <Icon.Bell />
           </button>

--- a/apps/web/src/App.models.test.jsx
+++ b/apps/web/src/App.models.test.jsx
@@ -847,7 +847,7 @@ describe("SceneWorks app shell", () => {
     });
 
     await act(async () => {
-      document.body.querySelector(".model-card .danger-action").click();
+      document.body.querySelector(".model-row .danger-action").click();
     });
 
     expect(confirm).toHaveBeenCalledWith(expect.stringContaining('Delete model "Z-Image Turbo"?'));

--- a/apps/web/src/App.refinePrompt.test.jsx
+++ b/apps/web/src/App.refinePrompt.test.jsx
@@ -55,7 +55,16 @@ describe("refine my prompt (sc-2041)", () => {
       );
     });
 
-    const refine = [...document.body.querySelectorAll("button")].find((button) => button.textContent.includes("Refine my prompt"));
+    // Prompt tools (UI-refinement 1b): the "Refine my prompt" tile toggles the panel open;
+    // the actual refine runs from the RefinePromptControl button revealed inside it.
+    const refineTile = [...document.body.querySelectorAll(".prompt-tool")].find((button) =>
+      button.textContent.includes("Refine my prompt"),
+    );
+    await act(async () => {
+      refineTile.click();
+    });
+    await settle();
+    const refine = document.body.querySelector(".refine-button");
     await act(async () => {
       refine.click();
     });

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -519,12 +519,12 @@ export function CharacterStudio() {
           <div className="empty-panel">No characters yet — use “New character” to start.</div>
         ) : (
           <section className="character-detail">
-            <div className="segmented-control character-tabs" role="tablist" aria-label="Character workspace">
+            <div className="mode-tabs character-tabs" role="tablist" aria-label="Character workspace">
               {CHARACTER_TABS.map(([id, label]) => (
                 <button
                   aria-controls={activeTab === id ? `character-panel-${id}` : undefined}
                   aria-selected={activeTab === id}
-                  className={activeTab === id ? "active" : ""}
+                  className={activeTab === id ? "mode-tab active" : "mode-tab"}
                   id={`character-tab-${id}`}
                   key={id}
                   onClick={() => setActiveTab(id)}

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -451,6 +451,15 @@ export function ImageStudio() {
   const [expanding, setExpanding] = useState(false);
   const [submitError, setSubmitError] = useState("");
   const [guideOpen, setGuideOpen] = useState(false);
+  // Prompt tools (epic UI-refinement): which inline prompt-tool panel is open —
+  // null | "describe" (reference-image caption) | "refine" (rewrite my prompt).
+  // Replaces the always-rendered ReferenceCaptionPicker + RefinePromptControl pair
+  // with two toggle tiles; only one panel opens at a time.
+  const [promptTool, setPromptTool] = useState(null);
+  const togglePromptTool = useCallback(
+    (tool) => setPromptTool((current) => (current === tool ? null : tool)),
+    [],
+  );
   const editImageAssets = useMemo(
     () =>
       assets.filter(
@@ -1471,17 +1480,20 @@ export function ImageStudio() {
       <form className="studio-shell" onSubmit={submit}>
         <div className="surface-header hero studio-prompt-hero">
           <div className="prompt-hero-top">
-            <div className="segmented-control" role="tablist" aria-label="Image mode">
+            <div className="mode-tabs" role="tablist" aria-label="Image mode">
               {[
                 ["text_to_image", "Text"],
                 ["edit_image", "Edit"],
                 ["character_image", "With character"],
               ].map(([value, label]) => {
                 const macBlock = macModeTabBlock(value);
+                const active = mode === value;
                 return (
                   <button
-                    className={mode === value ? "active" : ""}
+                    className={active ? "mode-tab active" : "mode-tab"}
                     key={value}
+                    role="tab"
+                    aria-selected={active}
                     onClick={() => handleModeChange(value)}
                     type="button"
                     disabled={Boolean(macBlock)}
@@ -1565,72 +1577,114 @@ export function ImageStudio() {
             </p>
           ) : null}
 
-          {/* Reference-image → plain-text prompt (epic 8203, sc-8208). For NON-structured t2i models,
-              offer the same "start from a reference image" affordance Ideogram has — but it fills the
-              plain prompt box with a description (prose, or booru tags for `captionStyle:"tags"` models).
-              Gated to text-to-image only; the section is hidden unless the macOS-first captioner is
-              platform-eligible (ready, or an install offer exists — both false off-Mac, so it stays
-              hidden there, matching the Ideogram surface). C1: captioning-only, never sent to generation. */}
-          {!structuredPromptModel &&
-          mode === "text_to_image" &&
-          typeof imageDescribe === "function" &&
-          (visionCaptionReady || visionCaptionOffers.length > 0) ? (
-            <ReferenceCaptionPicker
-              onCaption={onImageDescribe}
-              onApply={(text) => setPromptFromUser(text)}
-              onReferenceImageLoaded={onReferenceImageLoaded}
-              referenceAssets={editImageAssets}
-              referenceCharacters={characters}
-              importAsset={importAsset}
-              projectId={activeProject?.id ?? ""}
-              hint="Start from a reference image — the captioner reads it into a detailed prompt you can edit. The image is only used to write the prompt; it isn’t sent to generation."
-              buttonLabel="✨ Describe image"
-              busyLabel="Describing…"
-              emptyMessage="The image did not produce a usable description. Try another reference."
-              errorFallback="Could not describe the image."
-              gateDescription="Download the vision captioner to turn a reference image into a prompt. It runs locally on the native worker; the image is only used to write the prompt."
-              visionCaptionReady={visionCaptionReady}
-              visionCaptionOffers={visionCaptionOffers}
-              visionCaptionDownloadJobs={modelDownloadJobs}
-              onDownloadModel={createModelDownloadJob}
-              onOpenModels={() => setActiveView("Models")}
-              onOpenQueue={onOpenQueue}
-              onCancelJob={onCancelJob}
-            />
-          ) : null}
-
-          {/* Plain-text refine + scene suggestions only make sense for free-text
-              prompts; structured models get the builder + (later) magic-prompt. */}
+          {/* Scene suggestions sit directly under the prompt (UI-refinement 4a). Free-text
+              prompts only; structured models get the builder + (later) magic-prompt. */}
           {structuredPromptModel ? null : (
-            <>
-              <RefinePromptControl
-                guidePath={promptGuide.path}
-                modelId={model}
-                onApply={setPromptFromUser}
-                prompt={prompt}
-                refinePrompt={refinePrompt}
-                refineModel={refineModel}
-                onDownloadRefineModel={refineModel ? () => createModelDownloadJob(refineModel) : undefined}
-                workflow="image"
-              />
-
-              <div className="suggestion-row">
-                <span className="suggestion-row-label">Try:</span>
-                {suggestions.map((suggestion) => (
-                  <button
-                    className="suggestion"
-                    key={suggestion}
-                    onClick={() => setPromptFromUser(suggestion)}
-                    type="button"
-                  >
-                    <Icon.Sparkle size={11} />
-                    {suggestion}
-                  </button>
-                ))}
-              </div>
-            </>
+            <div className="suggestion-row">
+              <span className="suggestion-row-label">Try:</span>
+              {suggestions.map((suggestion) => (
+                <button
+                  className="suggestion"
+                  key={suggestion}
+                  onClick={() => setPromptFromUser(suggestion)}
+                  type="button"
+                >
+                  <Icon.Sparkle size={11} />
+                  {suggestion}
+                </button>
+              ))}
+            </div>
           )}
-        </div>
+
+          {/* Prompt tools (UI-refinement 1b): one framed strip of two equally-weighted toggle
+              tiles that replace the disjointed ReferenceCaptionPicker card + lone Refine link.
+              Tile A wraps the reference-image → plain-text describe flow (epic 8203, sc-8208):
+              gated to text-to-image and hidden unless the macOS-first captioner is platform-
+              eligible (ready, or an install offer exists — both false off-Mac). C1: captioning-
+              only, never sent to generation. Tile B wraps RefinePromptControl (sc-2041). Only
+              one panel opens at a time; both are free-text only (structured models excluded). */}
+          {structuredPromptModel ? null : (() => {
+            const describeAvailable =
+              mode === "text_to_image" &&
+              typeof imageDescribe === "function" &&
+              (visionCaptionReady || visionCaptionOffers.length > 0);
+            const describeActive = describeAvailable && promptTool === "describe";
+            const refineActive = promptTool === "refine";
+            return (
+              <div className="prompt-tools">
+                <div className="prompt-tools-head">
+                  <span className="prompt-tools-title">Prompt tools</span>
+                  <span className="hairline" />
+                </div>
+                <div className="prompt-tools-tiles">
+                  {describeAvailable ? (
+                    <button
+                      type="button"
+                      className={describeActive ? "prompt-tool active" : "prompt-tool"}
+                      aria-pressed={describeActive}
+                      onClick={() => togglePromptTool("describe")}
+                    >
+                      <span className="prompt-tool-title">
+                        <Icon.Image size={15} /> Start from an image
+                      </span>
+                      <span className="prompt-tool-desc">Caption a reference into an editable prompt</span>
+                    </button>
+                  ) : null}
+                  <button
+                    type="button"
+                    className={refineActive ? "prompt-tool active" : "prompt-tool"}
+                    aria-pressed={refineActive}
+                    onClick={() => togglePromptTool("refine")}
+                  >
+                    <span className="prompt-tool-title">
+                      <Icon.Wand size={15} /> Refine my prompt
+                    </span>
+                    <span className="prompt-tool-desc">Rewrite what you typed for clarity &amp; detail</span>
+                  </button>
+                </div>
+                {describeActive ? (
+                  <div className="prompt-tool-panel">
+                    <ReferenceCaptionPicker
+                      onCaption={onImageDescribe}
+                      onApply={(text) => setPromptFromUser(text)}
+                      onReferenceImageLoaded={onReferenceImageLoaded}
+                      referenceAssets={editImageAssets}
+                      referenceCharacters={characters}
+                      importAsset={importAsset}
+                      projectId={activeProject?.id ?? ""}
+                      hint="Start from a reference image — the captioner reads it into a detailed prompt you can edit. The image is only used to write the prompt; it isn’t sent to generation."
+                      buttonLabel="✨ Describe image"
+                      busyLabel="Describing…"
+                      emptyMessage="The image did not produce a usable description. Try another reference."
+                      errorFallback="Could not describe the image."
+                      gateDescription="Download the vision captioner to turn a reference image into a prompt. It runs locally on the native worker; the image is only used to write the prompt."
+                      visionCaptionReady={visionCaptionReady}
+                      visionCaptionOffers={visionCaptionOffers}
+                      visionCaptionDownloadJobs={modelDownloadJobs}
+                      onDownloadModel={createModelDownloadJob}
+                      onOpenModels={() => setActiveView("Models")}
+                      onOpenQueue={onOpenQueue}
+                      onCancelJob={onCancelJob}
+                    />
+                  </div>
+                ) : null}
+                {refineActive ? (
+                  <div className="prompt-tool-panel">
+                    <RefinePromptControl
+                      guidePath={promptGuide.path}
+                      modelId={model}
+                      onApply={setPromptFromUser}
+                      prompt={prompt}
+                      refinePrompt={refinePrompt}
+                      refineModel={refineModel}
+                      onDownloadRefineModel={refineModel ? () => createModelDownloadJob(refineModel) : undefined}
+                      workflow="image"
+                    />
+                  </div>
+                ) : null}
+              </div>
+            );
+          })()}
 
         {mode === "edit_image" || mode === "character_image" ? (
           <div className="studio-source-band">
@@ -1861,80 +1915,37 @@ export function ImageStudio() {
           </div>
         ) : null}
 
-        <div className="studio-results">
-          <section className="review-panel">
-            <div className="review-panel-head">
-              <h2>Latest batch</h2>
-              <span className="kbd-hint">
-                <kbd>⌘</kbd>
-                <kbd>↵</kbd>
-                to generate
-              </span>
-            </div>
-            {localJobGroups.length ? (
-              <div className="worker-progress-card-stack local-job-stack">
-                {localJobGroups.map(({ job, completedAssets, expectedCount }) => (
-                  <WorkerProgressCard
-                    key={job.id}
-                    job={job}
-                    thumbnailsVariant="image-grid"
-                    thumbnailAssets={completedAssets}
-                    expectedThumbnailCount={expectedCount}
-                    onThumbnailClick={(asset) => onPreview(asset, completedAssets)}
-                    onCancel={onCancelJob}
-                    onOpenQueue={onOpenQueue}
-                  />
-                ))}
-              </div>
-            ) : null}
-            {latestAssets.length ? (
-              <div className="recent-assets">
-                {localJobGroups.length ? <h3 className="recent-assets__title">Recent Assets</h3> : null}
-                <div className="review-grid">
-                  {latestAssets.map((asset) => (
-                    <AssetCard
-                      asset={asset}
-                      deleteAsset={deleteAsset}
-                      key={asset.id}
-                      onPreview={(previewed) => onPreview(previewed, latestAssets)}
-                      purgeAsset={purgeAsset}
-                      updateAssetStatus={updateAssetStatus}
-                    />
+          {/* Generation settings (UI-refinement 2b): the everyday knobs — Model, Aspect,
+              Variations, Style preset — sit in a bar directly under the composer instead of a
+              detached right rail. Power-user knobs fold into Advanced below; the results area
+              reclaims the full width (single-column .studio-results). */}
+          <div className="settings-bar">
+            <div className="settings-bar-row">
+              <label className="settings-field settings-field-model">
+                Model
+                <select onChange={(event) => setModel(event.target.value)} value={model}>
+                  {pickerModels.map((item) => (
+                    <option key={item.id} value={item.id}>
+                      {item.name}
+                    </option>
                   ))}
-                </div>
-              </div>
-            ) : localJobGroups.length ? null : (
-              <div className="empty-panel">No fresh image batch</div>
-            )}
-          </section>
-
-          <section className="studio-controls preset-rail">
-            <div className="preset-rail-head">
-              <h3>Preset</h3>
-              <span className="preset-rail-model-tag">{selectedModel?.name ?? "—"}</span>
+                </select>
+              </label>
+              <label className="settings-field settings-field-aspect">
+                Aspect
+                <select onChange={(event) => setResolution(event.target.value)} value={resolution}>
+                  {resolutionOptions.map((option) => (
+                    <option key={option} value={option}>{formatResolutionLabel(option)}</option>
+                  ))}
+                </select>
+              </label>
+              <label className="settings-field settings-field-count">
+                Variations
+                <input min="1" max="8" onChange={(event) => setCount(Number(event.target.value))} type="number" value={count} />
+              </label>
             </div>
-
-            <label>
-              Model
-              <select onChange={(event) => setModel(event.target.value)} value={model}>
-                {pickerModels.map((item) => (
-                  <option key={item.id} value={item.id}>
-                    {item.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-            {macActiveModeBlock ? <p className="mac-gating-note">{macActiveModeBlock.text}</p> : null}
-            {macHiddenImageModels.length ? (
-              <p className="mac-gating-note">
-                {macHiddenImageModels.length} model
-                {macHiddenImageModels.length === 1 ? "" : "s"} unavailable on Mac (Rust/MLX only) —
-                see Models for details.
-              </p>
-            ) : null}
-
-            <div className="style-preset-strip">
-              <span className="style-preset-label">Style preset</span>
+            <div className="settings-bar-styles">
+              <span className="settings-bar-label">Style preset</span>
               <div className="preset-chips">
                 <button
                   className={!selectedPreset ? "preset-chip active" : "preset-chip"}
@@ -1955,45 +1966,28 @@ export function ImageStudio() {
                 ))}
               </div>
             </div>
+          </div>
 
-            <SavePresetPanel
-              presetName={presetName}
-              setPresetName={setPresetName}
-              savingPreset={savingPreset}
-              presetSaveMessage={presetSaveMessage}
-              setPresetSaveMessage={setPresetSaveMessage}
-              onSave={handleSaveAsPreset}
-              presetScope={presetScope}
-              setPresetScope={setPresetScope}
-              activeProject={activeProject}
-            />
+          {macActiveModeBlock ? <p className="mac-gating-note">{macActiveModeBlock.text}</p> : null}
+          {macHiddenImageModels.length ? (
+            <p className="mac-gating-note">
+              {macHiddenImageModels.length} model
+              {macHiddenImageModels.length === 1 ? "" : "s"} unavailable on Mac (Rust/MLX only) —
+              see Models for details.
+            </p>
+          ) : null}
 
-            <div className="control-grid preset-rail-row">
-              <label>
-                Variations
-                <input min="1" max="8" onChange={(event) => setCount(Number(event.target.value))} type="number" value={count} />
-              </label>
-              <label>
-                Aspect
-                <select onChange={(event) => setResolution(event.target.value)} value={resolution}>
-                  {resolutionOptions.map((option) => (
-                    <option key={option} value={option}>{formatResolutionLabel(option)}</option>
-                  ))}
-                </select>
-              </label>
-            </div>
+          <PresetGuidanceStrip
+            selectedPreset={selectedPreset}
+            presetPromptParts={presetPromptParts}
+            presetLoraDetails={presetLoraDetails}
+            noPresetHint="Generation uses only the prompt, model, and visible preset settings."
+          />
 
-            <PresetGuidanceStrip
-              selectedPreset={selectedPreset}
-              presetPromptParts={presetPromptParts}
-              presetLoraDetails={presetLoraDetails}
-              noPresetHint="Generation uses only the prompt, model, and visible preset settings."
-            />
-
-            <button className="advanced-toggle" onClick={() => setAdvancedOpen((value) => !value)} type="button">
-              <Icon.ChevDown className={advancedOpen ? "chev-rotate open" : "chev-rotate"} size={14} />
-              {advancedOpen ? "Hide advanced" : "Advanced"}
-            </button>
+          <button className="advanced-toggle" onClick={() => setAdvancedOpen((value) => !value)} type="button">
+            <Icon.ChevDown className={advancedOpen ? "chev-rotate open" : "chev-rotate"} size={14} />
+            {advancedOpen ? "Hide advanced" : "Advanced"}
+          </button>
 
             {advancedOpen ? (
               <div className="advanced-panel">
@@ -2226,15 +2220,75 @@ export function ImageStudio() {
                   setLoraWeight={setLoraWeight}
                   loraEmptyMessage={loraEmptyMessage}
                 />
+                {/* Save-as-preset folds into Advanced with the rest of the power-user
+                    knobs (UI-refinement 2b). */}
+                <SavePresetPanel
+                  presetName={presetName}
+                  setPresetName={setPresetName}
+                  savingPreset={savingPreset}
+                  presetSaveMessage={presetSaveMessage}
+                  setPresetSaveMessage={setPresetSaveMessage}
+                  onSave={handleSaveAsPreset}
+                  presetScope={presetScope}
+                  setPresetScope={setPresetScope}
+                  activeProject={activeProject}
+                />
               </div>
             ) : null}
 
-            <PresetValidationWarnings presetValidationResult={presetValidationResult} selectedModel={selectedModel} />
-            {selectedLoraValidationResult.incompatible.length ? (
-              <p className="inline-warning">
-                Generate is blocked because these selected LoRAs are incompatible with {selectedModel?.name ?? "the selected model"}: {selectedLoraValidationResult.incompatible.join(", ")}.
-              </p>
+          <PresetValidationWarnings presetValidationResult={presetValidationResult} selectedModel={selectedModel} />
+          {selectedLoraValidationResult.incompatible.length ? (
+            <p className="inline-warning">
+              Generate is blocked because these selected LoRAs are incompatible with {selectedModel?.name ?? "the selected model"}: {selectedLoraValidationResult.incompatible.join(", ")}.
+            </p>
+          ) : null}
+        </div>
+
+        <div className="studio-results">
+          <section className="review-panel">
+            <div className="review-panel-head">
+              <h2>Latest batch</h2>
+              <span className="kbd-hint">
+                <kbd>⌘</kbd>
+                <kbd>↵</kbd>
+                to generate
+              </span>
+            </div>
+            {localJobGroups.length ? (
+              <div className="worker-progress-card-stack local-job-stack">
+                {localJobGroups.map(({ job, completedAssets, expectedCount }) => (
+                  <WorkerProgressCard
+                    key={job.id}
+                    job={job}
+                    thumbnailsVariant="image-grid"
+                    thumbnailAssets={completedAssets}
+                    expectedThumbnailCount={expectedCount}
+                    onThumbnailClick={(asset) => onPreview(asset, completedAssets)}
+                    onCancel={onCancelJob}
+                    onOpenQueue={onOpenQueue}
+                  />
+                ))}
+              </div>
             ) : null}
+            {latestAssets.length ? (
+              <div className="recent-assets">
+                {localJobGroups.length ? <h3 className="recent-assets__title">Recent Assets</h3> : null}
+                <div className="review-grid">
+                  {latestAssets.map((asset) => (
+                    <AssetCard
+                      asset={asset}
+                      deleteAsset={deleteAsset}
+                      key={asset.id}
+                      onPreview={(previewed) => onPreview(previewed, latestAssets)}
+                      purgeAsset={purgeAsset}
+                      updateAssetStatus={updateAssetStatus}
+                    />
+                  ))}
+                </div>
+              </div>
+            ) : localJobGroups.length ? null : (
+              <div className="empty-panel">No fresh image batch</div>
+            )}
           </section>
         </div>
       </form>

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -105,6 +105,8 @@ describe("ImageStudio Save as Preset", () => {
     const context = baseContext();
     await render(context);
 
+    // Save-as-preset now lives inside the Advanced panel (UI-refinement 2b).
+    await click([...document.body.querySelectorAll("button")].find((b) => b.textContent === "Advanced"));
     const input = nameInput(container);
     expect(input).toBeTruthy();
     await act(async () => setInput(input, "Atrium Look"));
@@ -140,6 +142,7 @@ describe("ImageStudio Save as Preset", () => {
     });
     await render(context);
 
+    await click([...document.body.querySelectorAll("button")].find((b) => b.textContent === "Advanced"));
     await act(async () => setInput(nameInput(container), "Atrium Look"));
     await click(saveButton(container));
 
@@ -385,7 +388,7 @@ describe("ImageStudio edit source picker", () => {
 
   async function openEditSourcePicker(context) {
     await render(context);
-    await click([...document.body.querySelectorAll(".segmented-control button")].find((button) => button.textContent === "Edit"));
+    await click([...document.body.querySelectorAll(".mode-tabs button")].find((button) => button.textContent === "Edit"));
     await click([...document.body.querySelectorAll(".asset-picker-head button")].find((button) => button.textContent === "Select image"));
     return document.body.querySelector('[role="dialog"]');
   }
@@ -531,7 +534,7 @@ describe("ImageStudio edit source picker", () => {
         selectedAsset: null,
       }),
     );
-    await click([...document.body.querySelectorAll(".segmented-control button")].find((button) => button.textContent === "Edit"));
+    await click([...document.body.querySelectorAll(".mode-tabs button")].find((button) => button.textContent === "Edit"));
 
     // The multi-image picker ("Select images") replaces the single source picker ("Select image").
     const headButtons = () => [...document.body.querySelectorAll(".asset-picker-head button")];
@@ -620,7 +623,7 @@ describe("ImageStudio model picker capability gating", () => {
 
   const modelOptionValues = () => [...field(container, "Model").options].map((option) => option.value);
   const modeButton = (label) =>
-    [...document.body.querySelectorAll(".segmented-control button")].find((button) => button.textContent === label);
+    [...document.body.querySelectorAll(".mode-tabs button")].find((button) => button.textContent === label);
 
   it("Text tab lists only text_to_image models, excluding edit-only and character-only (sc-5549)", async () => {
     await render(baseContext({ imageModels: [EDIT_ONLY, T2I, VARIATIONS, CHARACTER_ONLY] }));

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -531,6 +531,21 @@ export function ModelManagerScreen() {
   const [modelFileInputKey, setModelFileInputKey] = useState(0);
   const [deletingItem, setDeletingItem] = useState("");
   const [deleteMessage, setDeleteMessage] = useState({ tone: "neutral", text: "" });
+  // Expandable model rows (UI-refinement 1c): each model is a collapsed row (name · family ·
+  // status · size) that expands to reveal capabilities, description, repo/MLX and actions —
+  // the same rhythm as the LoRA rows. Rows needing attention (an active download/convert, an
+  // incomplete cache) auto-expand.
+  const [expandedModels, setExpandedModels] = useState(() => new Set());
+  const toggleModel = (id) =>
+    setExpandedModels((current) => {
+      const next = new Set(current);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
   // Read the host's memory so MLX models can be gated against their memory tier.
   // Desktop reads it from the Tauri GPU probe; a remote LAN browser reads the
   // auth-protected REST signal (epic 4484 story 9). `isDesktop`/`tauriInvoke` come
@@ -895,25 +910,37 @@ export function ModelManagerScreen() {
     // Quant-matrix models (sc-8509): render the per-tier download panel with a RAM-based suggestion
     // + multi-select instead of the single Download button. Single-variant models are unchanged.
     const hasTierMatrix = model.hasVariantMatrix === true && orderedMatrixVariants(model).length > 0;
+    const autoOpen =
+      Boolean(localDownloadJob) || incomplete || Boolean(convertJob) || Boolean(failedConvert) || Boolean(failedDownload);
+    const open = expandedModels.has(model.id) || autoOpen;
+    const firstCapability = capabilities.length ? capabilityLabel(capabilities[0]) : null;
+    const familyMeta = [model.family ?? "unassociated", firstCapability].filter(Boolean).join(" · ");
     return (
-      <article className="model-card" key={model.id}>
-        <div>
-          <p className="eyebrow">{model.family ?? "unassociated"}</p>
-          <h3>{model.name}</h3>
-        </div>
-        <span className={incomplete ? "status-badge warning" : installed ? "status-badge installed" : "status-badge"}>
-          {incomplete ? "incomplete" : installed ? "installed" : "missing"}
-        </span>
-        {unassociated ? (
-          <span className="status-badge warning" title="Set this model's family in user.models.jsonc before using it for generation.">
-            needs family
+      <div className="model-row" key={model.id}>
+        <button className="model-row-summary" type="button" aria-expanded={open} onClick={() => toggleModel(model.id)}>
+          <span className={open ? "model-row-caret open" : "model-row-caret"} aria-hidden="true">
+            ▶
           </span>
-        ) : null}
-        {macModelBlock(model, macCapabilities) ? (
-          <span className="status-badge warning" title={macModelBlock(model, macCapabilities).text}>
-            not on Mac
+          <span className="model-row-heading">
+            <strong>{model.name}</strong>
+            <small>{familyMeta}</small>
           </span>
-        ) : null}
+          <span className={incomplete ? "status-badge warning" : installed ? "status-badge installed" : "status-badge"}>
+            {incomplete ? "incomplete" : installed ? "installed" : "missing"}
+          </span>
+          {unassociated ? (
+            <span className="status-badge warning" title="Set this model's family in user.models.jsonc before using it for generation.">
+              needs family
+            </span>
+          ) : null}
+          {macModelBlock(model, macCapabilities) ? (
+            <span className="status-badge warning" title={macModelBlock(model, macCapabilities).text}>
+              not on Mac
+            </span>
+          ) : null}
+          <span className="model-row-size">{downloadSize}</span>
+        </button>
+        <div className="model-row-body" hidden={!open}>
         {capabilities.length ? (
           <ul className="model-capabilities">
             {capabilities.map((capability) => (
@@ -1047,7 +1074,8 @@ export function ModelManagerScreen() {
             {model.removable === false ? "Protected" : deletingItem === deleteKey ? "Deleting" : "Delete"}
           </button>
         </div>
-      </article>
+        </div>
+      </div>
     );
   }
 

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -538,7 +538,7 @@ describe("ModelManagerScreen type-grouped layout", () => {
     // Each group holds exactly its own type's card.
     const groups = container.querySelectorAll(".model-type-group");
     expect(groups.length).toBe(3);
-    expect(groups[0].querySelectorAll(".model-card").length).toBe(1);
+    expect(groups[0].querySelectorAll(".model-row").length).toBe(1);
     expect(groups[0].textContent).toContain("Z-Image-Turbo");
     expect(groups[1].textContent).toContain("Wan T2V");
     expect(groups[2].textContent).toContain("Real-ESRGAN");
@@ -559,13 +559,13 @@ describe("ModelManagerScreen type-grouped layout", () => {
     const imageGroup = container.querySelector(".model-type-group");
     const recommendedGrid = imageGroup.querySelector(".model-subgroup .model-grid");
     expect(imageGroup.textContent).toContain("Recommended Models");
-    expect(recommendedGrid.querySelectorAll(".model-card").length).toBe(1);
+    expect(recommendedGrid.querySelectorAll(".model-row").length).toBe(1);
     expect(recommendedGrid.textContent).toContain("Z-Image-Turbo");
     const additional = imageGroup.querySelector(".model-subgroup-additional");
     expect(additional.tagName).toBe("DETAILS");
     expect(additional.open).toBe(false); // collapsed by default to cut clutter
     expect(additional.textContent).toContain("Additional Supported Models");
-    expect(additional.querySelectorAll(".model-card").length).toBe(1);
+    expect(additional.querySelectorAll(".model-row").length).toBe(1);
     expect(additional.textContent).toContain("FLUX.1 [dev]");
   });
 
@@ -574,7 +574,7 @@ describe("ModelManagerScreen type-grouped layout", () => {
     const imageGroup = container.querySelector(".model-type-group");
     expect(imageGroup.textContent).not.toContain("Recommended Models");
     expect(imageGroup.querySelector(".model-subgroup-additional")).toBeNull();
-    expect(imageGroup.querySelectorAll(".model-card").length).toBe(1);
+    expect(imageGroup.querySelectorAll(".model-row").length).toBe(1);
   });
 
   it("describes each model's capabilities as chips on the card", async () => {

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -864,15 +864,18 @@ export function VideoStudio() {
       <form className="studio-shell" onSubmit={submit}>
         <div className="surface-header hero studio-prompt-hero video-prompt-hero">
           <div className="prompt-hero-top">
-            <div className="segmented-control mode-control" role="tablist" aria-label="Video mode">
+            <div className="mode-tabs mode-control" role="tablist" aria-label="Video mode">
               {modeOptions.map(([value, label]) => {
                 // Disabled only when no available model serves this mode on Mac — and never the
                 // active tab, so the user can always switch away (sc-5716).
                 const blocked = value !== mode && macModeTabBlocked(value);
+                const active = mode === value;
                 return (
                   <button
-                    className={mode === value ? "active" : ""}
+                    className={active ? "mode-tab active" : "mode-tab"}
                     key={value}
+                    role="tab"
+                    aria-selected={active}
                     onClick={() => setMode(value)}
                     type="button"
                     disabled={blocked}

--- a/apps/web/src/screens/generationStudio.jsx
+++ b/apps/web/src/screens/generationStudio.jsx
@@ -459,11 +459,31 @@ export function LoraPickerSection({
   setLoraWeight,
   loraEmptyMessage,
 }) {
+  // Add-on-demand picker (UI-refinement 3b): only the LoRAs you've added render as
+  // slots; everything else lives behind the "Add LoRA" dropdown. This replaces the
+  // checkbox-per-LoRA wall so a large library no longer floods the panel. "Show
+  // incompatible" now filters the dropdown (through compatibleLoras) instead of an
+  // always-visible list. Slot styles (.lora-stack/.lora-slot/.lora-add/
+  // .lora-picker-panel/.lora-pick-row) already live in styles.css.
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const availableLoras = compatibleLoras.filter((lora) => !selectedLoraIds.includes(lora.id));
+  const atUserLimit = userSelectedLoraCount >= MAX_USER_JOB_LORAS;
+  const loraMeta = (lora) => {
+    const scope = lora.scope ?? "global";
+    return lora.family ? `${scope} · ${lora.family}` : scope;
+  };
+
   return (
     <section className="lora-picker" aria-label="LoRA selection">
       <div>
         <strong>LoRAs</strong>
-        <span>{selectedLoras.length ? `${selectedLoras.length} selected` : selectedModel ? "Installed and compatible" : "Choose a model"}</span>
+        <span>
+          {selectedLoras.length
+            ? `${selectedLoras.length} selected`
+            : selectedModel
+              ? "Installed and compatible"
+              : "Choose a model"}
+        </span>
       </div>
       <label className="checkline">
         <input
@@ -473,49 +493,92 @@ export function LoraPickerSection({
         />
         Show incompatible
       </label>
-      {compatibleLoras.length ? (
-        <div className="lora-choice-list">
-          {compatibleLoras.map((lora) => {
-            const checked = selectedLoraIds.includes(lora.id);
-            const userLimitReached = lora.scope !== "builtin" && !checked && userSelectedLoraCount >= MAX_USER_JOB_LORAS;
-            const weight = effectiveLoraWeight(lora);
-            return (
-              <div className="lora-choice-item" key={lora.id}>
-                <label className={checked ? "lora-choice active" : "lora-choice"}>
-                  <input
-                    checked={checked}
-                    disabled={userLimitReached}
-                    onChange={() => toggleLora(lora)}
-                    type="checkbox"
-                  />
-                  <span>
-                    <strong>{lora.name ?? lora.id}</strong>
-                    <small>
-                      {lora.scope ?? "global"} {lora.family ? `| ${lora.family}` : ""}
-                    </small>
-                  </span>
-                </label>
-                {checked ? (
-                  <div className="lora-weight-row">
-                    <span>Weight</span>
-                    <input
-                      aria-label={`${lora.name ?? lora.id} weight`}
-                      max="2"
-                      min="0"
-                      onChange={(event) => setLoraWeight(lora.id, Number(event.target.value))}
-                      step="0.05"
-                      type="range"
-                      value={weight}
-                    />
-                    <span className="lora-weight-value">{weight.toFixed(2)}</span>
-                  </div>
-                ) : null}
-              </div>
-            );
-          })}
-        </div>
-      ) : (
+
+      {!selectedLoras.length && !availableLoras.length ? (
         <div className="empty-panel compact-panel">{loraEmptyMessage}</div>
+      ) : (
+        <>
+          {selectedLoras.length ? (
+            <div className="lora-stack">
+              {selectedLoras.map((lora) => {
+                const weight = effectiveLoraWeight(lora);
+                return (
+                  <div className="lora-slot" key={lora.id}>
+                    <div className="lora-slot-head">
+                      <span className="lora-slot-meta">
+                        <strong>{lora.name ?? lora.id}</strong>
+                        <small>{loraMeta(lora)}</small>
+                      </span>
+                      <button
+                        aria-label={`Remove ${lora.name ?? lora.id}`}
+                        className="lora-slot-remove"
+                        onClick={() => toggleLora(lora)}
+                        title="Remove"
+                        type="button"
+                      >
+                        ×
+                      </button>
+                    </div>
+                    <div className="lora-slot-weight">
+                      <label>
+                        <span>Weight</span>
+                        <span className="lora-slot-weight-value">{weight.toFixed(2)}</span>
+                      </label>
+                      <input
+                        aria-label={`${lora.name ?? lora.id} weight`}
+                        max="2"
+                        min="0"
+                        onChange={(event) => setLoraWeight(lora.id, Number(event.target.value))}
+                        step="0.05"
+                        type="range"
+                        value={weight}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : null}
+
+          <button
+            className="lora-add"
+            data-count={`· ${availableLoras.length} available`}
+            disabled={!availableLoras.length}
+            onClick={() => setPickerOpen((open) => !open)}
+            type="button"
+          >
+            <Icon.Plus size={15} />
+            <span>Add LoRA</span>
+          </button>
+
+          {pickerOpen && availableLoras.length ? (
+            <div className="lora-picker-panel">
+              <div className="lora-picker-list">
+                {availableLoras.map((lora) => {
+                  const disabled = lora.scope !== "builtin" && atUserLimit;
+                  return (
+                    <button
+                      className="lora-pick-row"
+                      disabled={disabled}
+                      key={lora.id}
+                      onClick={() => {
+                        toggleLora(lora);
+                        setPickerOpen(false);
+                      }}
+                      type="button"
+                    >
+                      <span className="lora-slot-meta">
+                        <strong>{lora.name ?? lora.id}</strong>
+                        <small>{loraMeta(lora)}</small>
+                      </span>
+                      <span className="lora-pick-add">{disabled ? "Limit reached" : "Add"}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ) : null}
+        </>
       )}
     </section>
   );

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -862,6 +862,36 @@ button:focus-visible {
   color: var(--text);
 }
 
+/* One summary status pill (UI-refinement 1d) — a clickable button that folds API health,
+   worker count and GPU count into a single chip with a chevron. */
+.topbar-status button.status-summary {
+  gap: 6px;
+  font-family: var(--font-ui);
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.topbar-status button.status-summary:hover {
+  background: var(--surface-hover);
+}
+
+.status-summary-sep {
+  color: var(--text-faint);
+}
+
+.status-summary-caret {
+  opacity: 0.5;
+  margin-left: 2px;
+}
+
+/* Divider between the system-status group and the personal controls (bell · accent · theme). */
+.topbar-divider {
+  flex: 0 0 auto;
+  width: 1px;
+  height: 22px;
+  background: var(--border);
+}
+
 .queue-chip {
   display: inline-flex;
   align-items: center;
@@ -1554,6 +1584,196 @@ label {
   flex-wrap: wrap;
 }
 
+/* Mode tabs (UI-refinement 1a): flat underline tabs replacing the segmented pill for the
+   Text / Edit / With-character switch. A shared class so Video/Character studios can adopt
+   the same treatment. Sits on a shared 1px baseline; the active tab carries a 2px accent
+   underline + heavier weight. */
+.mode-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  border-bottom: 1px solid var(--border);
+}
+
+.mode-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: 0;
+  padding: 11px 2px;
+  margin-right: 26px;
+  margin-bottom: -1px;
+  font-family: var(--font-ui);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-muted);
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: color var(--t-fast);
+}
+
+.mode-tab:hover:not(:disabled) {
+  color: var(--text);
+}
+
+.mode-tab.active {
+  color: var(--text);
+  font-weight: 700;
+  border-bottom-color: var(--accent);
+}
+
+.mode-tab:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* Prompt tools (UI-refinement 1b): one framed strip of two equally-weighted toggle tiles;
+   the active tile lights up in accent and reveals its panel inline below. */
+.prompt-tools {
+  display: grid;
+  gap: 8px;
+}
+
+.prompt-tools-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.prompt-tools-title {
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.prompt-tools-head .hairline {
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+.prompt-tools-tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.prompt-tool {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  text-align: left;
+  padding: 12px 14px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  cursor: pointer;
+  transition: border-color var(--t-fast), background var(--t-fast);
+}
+
+.prompt-tool:hover {
+  border-color: var(--border-strong);
+}
+
+.prompt-tool.active {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.prompt-tool-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.prompt-tool-desc {
+  font-size: 11.5px;
+  line-height: 1.4;
+  color: var(--text-muted);
+}
+
+.prompt-tool-panel {
+  margin-top: 2px;
+}
+
+/* Settings bar (UI-refinement 2b): the everyday knobs (Model / Aspect / Variations, then a
+   Style-preset row) in a bordered strip directly under the composer. Advanced holds the
+   power-user knobs. */
+.settings-bar {
+  display: grid;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+}
+
+.settings-bar-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  align-items: flex-end;
+}
+
+.settings-field {
+  display: grid;
+  gap: 5px;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.settings-field-model {
+  flex: 2 1 200px;
+  min-width: 160px;
+}
+
+.settings-field-aspect {
+  flex: 1 1 130px;
+  min-width: 120px;
+}
+
+.settings-field-count {
+  flex: 0 1 96px;
+  min-width: 82px;
+}
+
+.settings-field select,
+.settings-field input {
+  width: 100%;
+  height: 36px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: 8px 10px;
+  color: var(--text);
+  font: 400 13px var(--font-ui);
+  letter-spacing: normal;
+  text-transform: none;
+}
+
+.settings-bar-styles {
+  display: grid;
+  gap: 7px;
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
+}
+
+.settings-bar-label {
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
 .refine-control {
   display: grid;
   gap: 8px;
@@ -2142,17 +2362,13 @@ label {
 }
 
 /* ---------- Studio results: latest batch + preset rail ---------- */
+/* Single column (UI-refinement 2b): the generation settings moved into the composer, so the
+   results area reclaims the full width the preset rail used to take. */
 .studio-results {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+  grid-template-columns: 1fr;
   gap: 16px;
   align-items: start;
-}
-
-@media (max-width: 1100px) {
-  .studio-results {
-    grid-template-columns: 1fr;
-  }
 }
 
 /* Document Studio (interleaved text-image) — sc-1607/1608. The screen wraps in
@@ -4188,10 +4404,12 @@ label {
 }
 
 /* ---------- Model + LoRA panels ---------- */
+/* Model catalog is a single-column list of expandable rows (UI-refinement 1c), the same
+   rhythm as the LoRA rows — no longer a dense card grid. */
 .model-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-  gap: var(--gap-3);
+  grid-template-columns: 1fr;
+  gap: 8px;
 }
 
 /* Type-grouped model sections (Image / Video / Utility) + family-grouped LoRAs. */
@@ -4348,7 +4566,7 @@ details[open] > summary.lora-scope-group-heading::before,
   font-variant-numeric: tabular-nums;
 }
 
-.model-card,
+.model-row,
 .lora-panel,
 .lora-row,
 .preset-list,
@@ -4417,43 +4635,109 @@ details[open] > summary.lora-scope-group-heading::before,
   white-space: nowrap;
 }
 
-.model-card {
+/* Expandable model rows (UI-refinement 1c): a collapsed summary line (caret · name ·
+   family/capability · status · size) over an expandable body of details + actions. */
+.model-row {
+  overflow: hidden;
+}
+
+.model-row-summary {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 11px 14px;
+  background: none;
+  border: 0;
+  text-align: left;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.model-row-summary:hover {
+  background: var(--surface-hover);
+}
+
+.model-row-caret {
+  flex: 0 0 auto;
+  width: 10px;
+  font-size: 10px;
+  color: var(--text-faint);
+  transition: transform var(--t-fast);
+}
+
+.model-row-caret.open {
+  transform: rotate(90deg);
+}
+
+.model-row-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.model-row-heading strong {
+  font-size: 13.5px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.model-row-heading small {
+  font-size: 11.5px;
+  color: var(--text-muted);
+}
+
+.model-row-size {
+  flex: 0 0 auto;
+  min-width: 64px;
+  text-align: right;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.model-row-body {
   display: grid;
   gap: 12px;
   align-content: start;
-  padding: 14px;
+  padding: 12px 16px 14px 36px;
+  border-top: 1px solid var(--border);
 }
 
-.model-card h3,
-.model-card p,
-.model-card dl {
+.model-row-body[hidden] {
+  display: none;
+}
+
+.model-row-body h3,
+.model-row-body p,
+.model-row-body dl {
   margin: 0;
 }
 
-.model-card h3 {
-  font-size: 15px;
-  font-weight: 600;
-}
-
-.model-card p {
+.model-row-body p {
   color: var(--text-muted);
   line-height: 1.5;
   font-size: 13px;
 }
 
-.model-card dl {
+.model-row-body dl {
   display: grid;
   gap: 8px;
 }
 
-.model-card dt {
+.model-row-body dt {
   color: var(--text-faint);
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
 
-.model-card dd {
+.model-row-body dd {
   margin: 0;
   font-family: var(--font-mono);
   font-size: 12px;
@@ -5459,10 +5743,21 @@ details[open] > summary.lora-scope-group-heading::before,
 }
 
 .lora-slot-meta {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
   min-width: 0;
+}
+
+.lora-slot-meta strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lora-slot-meta small {
+  font-size: 11px;
+  color: var(--text-muted);
 }
 
 .lora-slot-remove {
@@ -5580,12 +5875,37 @@ details[open] > summary.lora-scope-group-heading::before,
   transition: border-color var(--t-fast);
 }
 
-.lora-pick-row:hover {
+.lora-pick-row:hover:not(:disabled) {
   border-color: var(--accent);
+  background: var(--surface-hover);
+}
+
+.lora-pick-row:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .lora-pick-row strong {
   font-weight: 600;
+}
+
+/* Accent "Add" affordance on the right of each dropdown row (UI-refinement 3b). */
+.lora-pick-add {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--accent);
+  white-space: nowrap;
+}
+
+.lora-pick-row:disabled .lora-pick-add {
+  color: var(--text-faint);
+}
+
+/* Mono weight readout in an added LoRA slot's Weight header row. */
+.lora-slot-weight-value {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text);
 }
 
 .lora-pick-empty {


### PR DESCRIPTION
Recreates the claude.ai/design **SceneWorks UI Refinement** handoff in the `apps/web` React + `styles.css` vocabulary — reusing existing components, class names, and OKLCH tokens; no ported inline styles.

## Refinements
1. **Mode tabs** — segmented pill → flat underline tabs (new `.mode-tabs`/`.mode-tab`), reused across **Image, Video & Character** studios for consistency.
2. **Prompt tools** — the disjointed "Describe image" card + lone "Refine my prompt" link → one framed strip of two equally-weighted toggle tiles that reveal the **reused** `ReferenceCaptionPicker` / `RefinePromptControl` flows inline. `Try:` chips moved directly under the prompt.
3. **Settings into composer** — Model / Aspect / Variations + Style-preset moved out of the right-hand preset rail into a `.settings-bar` under the prompt; power-user knobs (and Save-as-preset) fold into **Advanced**; rail removed; `.studio-results` reclaims full width (single column).
4. **LoRA picker** — the checkbox wall → add-on-demand `.lora-slot` stack + "Add LoRA · N available" dropdown, wiring the `.lora-slot`/`.lora-add`/`.lora-picker-panel` CSS that already existed. `LoraPickerSection` is shared, so **Video Studio** gets the same treatment.
5. **Model Manager** *(reference refinement)* — dense card grid → single-column expandable rows (`.model-row`; body kept in the DOM via `hidden`).
6. **Topbar** *(reference refinement)* — three status pills → one summary pill (`● Ready · N workers · M GPU` + chevron) + 1px divider + grouped bell / accent / theme.

## Verification
- `vitest`: **92 files, 1193 tests pass.** Tests coupled to the old markup were updated to the refined flows (mode-tab queries, LoRA add-on-demand in Image **and** Video, preset-save now opens Advanced, refine opens the tile then triggers, `.model-card`→`.model-row`).
- `eslint src`: **0 errors** (pre-existing `exhaustive-deps` warnings only).
- `vite build`: **succeeds.**

## Notes
- Not rendered live: Image Studio sits behind `ModelAvailabilityGate`, so a dev server can't show the composer without a backend + seeded model. Verification is via the test suite + build.
- One deliberate deviation from the mock: LoRA weight slider kept at the app-wide `max=2` (mock shows an illustrative `1.5`) to avoid visually clipping existing presets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)