### PR TITLE
fix(web): make Image Studio prompt-tool panels match the design

### DIFF
--- a/apps/web/src/App.refinePrompt.test.jsx
+++ b/apps/web/src/App.refinePrompt.test.jsx
@@ -55,18 +55,14 @@ describe("refine my prompt (sc-2041)", () => {
       );
     });
 
-    // Prompt tools (UI-refinement 1b): the "Refine my prompt" tile toggles the panel open;
-    // the actual refine runs from the RefinePromptControl button revealed inside it.
+    // Prompt tools (UI-refinement 1b): selecting the "Refine my prompt" tile opens its panel and
+    // auto-runs the refine (autoStart) — no separate trigger button, the panel goes straight to
+    // the suggested rewrite.
     const refineTile = [...document.body.querySelectorAll(".prompt-tool")].find((button) =>
       button.textContent.includes("Refine my prompt"),
     );
     await act(async () => {
       refineTile.click();
-    });
-    await settle();
-    const refine = document.body.querySelector(".refine-button");
-    await act(async () => {
-      refine.click();
     });
     await settle();
 

--- a/apps/web/src/components/RefinePromptControl.jsx
+++ b/apps/web/src/components/RefinePromptControl.jsx
@@ -39,8 +39,17 @@ export function RefinePromptControl({
   onApply,
   refineModel,
   onDownloadRefineModel,
+  // When true (the Image Studio prompt-tools tile), run the refine as soon as the control
+  // mounts and hide the standalone trigger button — the tile is the trigger, so the panel
+  // goes straight to the suggested rewrite. Default off keeps the inline button for callers
+  // that render this control persistently (e.g. Video Studio).
+  autoStart = false,
 }) {
-  const [status, setStatus] = useState("idle"); // idle | loading | review | error
+  // Start in "loading" when we'll auto-run on mount, so the trigger button never flashes before
+  // the effect fires (the effect below actually kicks off the refine).
+  const [status, setStatus] = useState(() =>
+    autoStart && (prompt ?? "").trim() && typeof refinePrompt === "function" ? "loading" : "idle",
+  ); // idle | loading | review | error
   const [refined, setRefined] = useState("");
   const [error, setError] = useState("");
   const [downloadRequested, setDownloadRequested] = useState(false);
@@ -69,6 +78,15 @@ export function RefinePromptControl({
     },
     [],
   );
+
+  // Auto-run once on mount when the control opens as a prompt-tool tile (autoStart). Guard on a
+  // non-empty prompt + a usable refine fn so an empty composer just shows the idle button instead.
+  useEffect(() => {
+    if (autoStart && trimmed && typeof refinePrompt === "function") {
+      handleRefine();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   async function handleRefine() {
     refineControllerRef.current?.abort();
@@ -131,9 +149,18 @@ export function RefinePromptControl({
 
   return (
     <div className="refine-control">
-      <button className="hero-link refine-button" disabled={disabled} onClick={handleRefine} type="button">
-        <Icon.Wand size={14} /> {busy ? "Refining…" : "Refine my prompt"}
-      </button>
+      {/* With autoStart the tile is the trigger, so hide the button while refining/reviewing —
+          it reappears (as a re-run) only once the user keeps the original or an error needs a retry. */}
+      {autoStart && (status === "loading" || status === "review") ? null : (
+        <button className="hero-link refine-button" disabled={disabled} onClick={handleRefine} type="button">
+          <Icon.Wand size={14} /> {busy ? "Refining…" : "Refine my prompt"}
+        </button>
+      )}
+      {autoStart && status === "loading" ? (
+        <p className="refine-status">
+          <Icon.Wand size={14} /> Refining…
+        </p>
+      ) : null}
 
       {status === "error" && modelMissing ? (
         <div className="refine-missing-model" role="alert">

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -1656,7 +1656,7 @@ export function ImageStudio() {
                       referenceCharacters={characters}
                       importAsset={importAsset}
                       projectId={activeProject?.id ?? ""}
-                      hint="Start from a reference image — the captioner reads it into a detailed prompt you can edit. The image is only used to write the prompt; it isn’t sent to generation."
+                      hint="The image is only used to write the prompt — it isn’t sent to generation."
                       buttonLabel="✨ Describe image"
                       busyLabel="Describing…"
                       emptyMessage="The image did not produce a usable description. Try another reference."
@@ -1675,6 +1675,7 @@ export function ImageStudio() {
                 {refineActive ? (
                   <div className="prompt-tool-panel">
                     <RefinePromptControl
+                      autoStart
                       guidePath={promptGuide.path}
                       modelId={model}
                       onApply={setPromptFromUser}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1697,8 +1697,62 @@ label {
   color: var(--text-muted);
 }
 
+/* The inline panel a prompt-tool tile reveals (UI-refinement 1b) — a bordered surface-2 card.
+   It wraps the reused ReferenceCaptionPicker / RefinePromptControl, so normalize their internal
+   spacing and flatten the refine-review so it's not a card inside a card. */
 .prompt-tool-panel {
   margin-top: 2px;
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+}
+
+.prompt-tool-panel .structured-reference,
+.prompt-tool-panel .refine-control {
+  display: grid;
+  gap: 10px;
+}
+
+/* Flatten the nested review card — the panel already provides the surface + border. */
+.prompt-tool-panel .refine-review {
+  padding: 0;
+  border: 0;
+  background: none;
+}
+
+/* Primary "Describe image" action reads as accent inside the panel (matches the design). Scoped
+   to the reference flow so the refine Apply/Keep buttons keep their neutral treatment. */
+.prompt-tool-panel .structured-reference .secondary-action {
+  background: var(--accent);
+  color: var(--accent-fg);
+  border-color: transparent;
+}
+
+.prompt-tool-panel .structured-reference .secondary-action:hover:not(:disabled) {
+  background: var(--accent-strong);
+}
+
+/* Apply (the primary action in the rewrite review) reads as accent; Keep original stays neutral. */
+.prompt-tool-panel .refine-review-actions .secondary-action:first-child {
+  background: var(--accent);
+  color: var(--accent-fg);
+  border-color: transparent;
+}
+
+.prompt-tool-panel .refine-review-actions .secondary-action:first-child:hover:not(:disabled) {
+  background: var(--accent-strong);
+}
+
+.refine-status {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12.5px;
+  color: var(--text-muted);
 }
 
 /* Settings bar (UI-refinement 2b): the everyday knobs (Model / Aspect / Variations, then a


### PR DESCRIPTION
Follow-up to #1197 / #1198. The "Start from an image" and "Refine my prompt" tiles revealed their reused components with loose, uncontained styling (and a redundant "Refine my prompt" trigger button duplicating the tile), so the panels didn't match the design.

## Changes
- **`.prompt-tool-panel` is now the design's bordered `surface-2` card** — the reused `ReferenceCaptionPicker` / `RefinePromptControl` are contained, their internal spacing normalized, and the nested refine-review is flattened (no card-in-card). Primary **Describe** / **Apply** actions read as accent.
- **`RefinePromptControl` gains an opt-in `autoStart`** — the Image Studio tile runs the refine on open and hides the standalone trigger, so the panel goes straight to "Refining…" → the suggested rewrite (matching the design). Default off keeps the inline button for Video Studio's persistent usage.
- Shortened the reference-image hint to the design's one-liner.

## Verification
- `vitest`: green (refine test updated to the auto-start flow; 47 shown in the affected suites); `eslint`: 0 errors; `vite build`: succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)