### PR TITLE
chore(worker): bump mlx-gen + candle-gen pins for SANA caption fix (sc-9927)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -495,7 +495,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -510,7 +510,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -524,7 +524,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -577,7 +577,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -605,7 +605,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -615,7 +615,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -630,7 +630,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -645,7 +645,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -660,7 +660,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-gen",
  "image",
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -700,7 +700,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -714,7 +714,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -757,7 +757,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -788,7 +788,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -812,7 +812,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8db956db49a2b8ce79569285df61fc74adc6f160#8db956db49a2b8ce79569285df61fc74adc6f160"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -3623,7 +3623,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3636,7 +3636,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "image",
  "inventory",
@@ -3650,7 +3650,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "image",
  "inventory",
@@ -3664,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3678,7 +3678,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3689,7 +3689,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3698,7 +3698,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3707,7 +3707,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3721,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3734,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3747,7 +3747,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3759,7 +3759,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3769,7 +3769,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "image",
  "inventory",
@@ -3782,7 +3782,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "image",
  "inventory",
@@ -3796,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "image",
  "inventory",
@@ -3810,7 +3810,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "image",
  "inventory",
@@ -3822,7 +3822,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3845,7 +3845,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3857,7 +3857,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3866,7 +3866,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3875,7 +3875,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3885,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3897,7 +3897,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "image",
  "inventory",
@@ -3912,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "image",
  "inventory",
@@ -3926,7 +3926,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3949,7 +3949,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3960,7 +3960,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "image",
  "inventory",
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "image",
  "inventory",
@@ -5740,7 +5740,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b520a0e753e1a75e6c7d791212c5d2660a1a733a#b520a0e753e1a75e6c7d791212c5d2660a1a733a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
 dependencies = [
  "core-llm",
  "inventory",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -485,7 +485,7 @@ sceneworks-core = { path = "../sceneworks-core" }
 # candle-gen pin below moves to 7c43ec8f IN LOCKSTEP (candle-gen #301: consumes `text_encoder` in the
 # LTX provider AND re-pins candle-gen's own gen-core 330d339 -> b520a0e7) so `--features backend-candle`
 # resolves the SINGLE gen-core rev b520a0e7. mlx-rs + mlx-llm pins unchanged.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -837,7 +837,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -853,23 +853,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -877,7 +877,7 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
 # mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
 # mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
@@ -885,59 +885,59 @@ mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e
 # conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
 # DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
 # generator-cache load path drives.
-mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -946,19 +946,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -967,7 +967,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -975,7 +975,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -986,7 +986,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -997,7 +997,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -1019,7 +1019,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -1030,7 +1030,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b52
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -1062,7 +1062,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520a0e753e1a75e6c7d791212c5d2660a1a733a" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1461,15 +1461,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b520
 # pin is UNCHANGED at b520a0e7 (= this worker's mlx-gen pin), so `--features backend-candle --target all`
 # still resolves the SINGLE gen-core rev b520a0e7 (the skew gate) — no testkit reconcile. ALL candle-gen-*
 # rev lines move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1477,17 +1477,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1497,7 +1497,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1505,21 +1505,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1528,17 +1528,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1547,7 +1547,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1580,7 +1580,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1589,12 +1589,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1602,7 +1602,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db95
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1611,7 +1611,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1619,7 +1619,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1633,7 +1633,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1660,7 +1660,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1671,7 +1671,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8db956db49a2b8ce79569285df61fc74adc6f160", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with


### PR DESCRIPTION
## Summary
Pulls the **sc-9927 SANA caption fix** into the worker. Base SANA-1600M produced colorful noise (short prompts) / over-saturated stylized images. Two caption-path bugs vs the diffusers reference, both fixed in [SceneWorks/mlx-gen#651](https://github.com/SceneWorks/mlx-gen/pull/651) (merged):
1. `attn2` cross-attention dropped the caption **padding mask** (short prompts are mostly PAD → noise).
2. Prompts weren't **lowercased** (diffusers `_text_preprocessing` does `.lower().strip()`; SANA is conditioned on lowercased captions).

## Pin changes
- `mlx-gen` + `sceneworks-gen-core`: `b520a0e` → **`ccd852c`** (= b520a0e + *only* this fix; minimal, no other model changes).
- `candle-gen`: `8db956db` → **`199b56f`** (gen-core re-pinned to ccd852c in lockstep; candle-gen is CUDA-only with no code change — needed so the backend-candle build resolves one gen-core).

## Verification
- `check-gen-core-skew.sh` passes on **both** default (mlx) and `--features backend-candle` — exactly one `sceneworks-gen-core` (ccd852c).
- Fix verified end-to-end on real weights (Metal): original-case prompts now render photorealistically.
- gen-core content is byte-identical to b520a0e; only the SANA caption path changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)