### PR TITLE
feat(worker): wire SANA + SANA-Sprint into the bf16/Q8/Q4 quant matrix (sc-8513)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -495,7 +495,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -510,7 +510,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -524,7 +524,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -577,7 +577,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -605,7 +605,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -615,7 +615,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -630,7 +630,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -645,7 +645,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -660,7 +660,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-gen",
  "image",
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -700,7 +700,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -714,7 +714,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -757,7 +757,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -788,7 +788,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -812,7 +812,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=199b56fff6f13bdd54fbf4553be88c3861508b3c#199b56fff6f13bdd54fbf4553be88c3861508b3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=418b8a4190e61ed8bc19c21679508aba4a0dfda9#418b8a4190e61ed8bc19c21679508aba4a0dfda9"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -3623,12 +3623,13 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
  "sceneworks-gen-core",
+ "serde_json",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
 ]
@@ -3636,7 +3637,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "image",
  "inventory",
@@ -3650,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "image",
  "inventory",
@@ -3664,7 +3665,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3678,7 +3679,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3689,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3698,7 +3699,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3707,7 +3708,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3721,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3734,7 +3735,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3747,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3759,7 +3760,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3769,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "image",
  "inventory",
@@ -3782,7 +3783,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "image",
  "inventory",
@@ -3796,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "image",
  "inventory",
@@ -3810,7 +3811,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "image",
  "inventory",
@@ -3822,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3833,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3845,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3857,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3866,7 +3867,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3875,7 +3876,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3885,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3897,7 +3898,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "image",
  "inventory",
@@ -3912,7 +3913,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "image",
  "inventory",
@@ -3926,7 +3927,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3937,7 +3938,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3949,7 +3950,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3960,7 +3961,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "image",
  "inventory",
@@ -3974,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "image",
  "inventory",
@@ -4305,7 +4306,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5740,7 +5741,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ccd852cc7028aae47881f5707d31b5e1e24eef78#ccd852cc7028aae47881f5707d31b5e1e24eef78"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f#6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f"
 dependencies = [
  "core-llm",
  "inventory",
@@ -8163,7 +8164,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -3526,21 +3526,42 @@
       "capabilities": ["text_to_image"],
       "macOnly": true,
       "downloads": [
+        // SceneWorks pre-built MLX quant-matrix turnkey (sc-8489/sc-8513, epic 8506): per-tier
+        // subdirs (q4/ default, q8/, bf16/), each a complete `SanaPipeline::from_snapshot`-loadable
+        // tree — `transformer/` (the Linear-DiT trunk, packed q4/q8 else dense bf16), `vae/` (the 32×
+        // DC-AE f32 decoder, dense in EVERY tier), and `text_encoder/` (the gemma-2-2b-it CHI caption
+        // encoder — `gemma-2-2b-it.safetensors` packed q4/q8 else dense + `tokenizer.json`, sourced
+        // from the SceneWorks/gemma-2-2b-it mirror so the TE weights are NOT duplicated). Un-gated
+        // (the mirror carries the NVIDIA non-commercial NOTICE). mlx-gen #653 packs the transformer +
+        // Gemma-2 TE offline and packed-detects on load (NO install-time quantize). This is the
+        // shared group-64 affine tier, NOT the (unported) 2-bit SANA quant. Sizes measured on-disk.
         {
-          // Pre-converted MLX snapshot on the SceneWorks HF org (sc-8489): ONE
-          // `SanaPipeline::from_snapshot`-loadable root — `transformer/` (the Linear-DiT trunk),
-          // `vae/` (the 32× DC-AE f32 decoder), and `text_encoder/` (the gemma-2-2b-it CHI caption
-          // encoder — `gemma-2-2b-it.safetensors` + `tokenizer.json`, sourced from the
-          // SceneWorks/gemma-2-2b-it mirror so the TE weights are NOT duplicated as a separate
-          // catalog dependency). Un-gated (the mirror carries the NVIDIA non-commercial NOTICE).
-          // Dense bf16 (no quant subdir — the 2-bit SANA quant is intentionally NOT ported).
-          // estimatedSizeBytes is the measured mirror total (transformer F16 3.21GB + DC-AE F32
-          // 1.25GB + merged gemma-2-2b-it TE BF16 5.23GB + license/notice), sc-8604.
           "provider": "huggingface",
           "repo": "SceneWorks/Sana_1600M_1024px_mlx",
-          "files": ["transformer/*", "vae/*", "text_encoder/*"],
+          "variant": "q4",
+          "default": true,
+          "files": ["q4/*"],
           "platforms": ["macos"],
-          "estimatedSizeBytes": 9704269924
+          "estimatedSizeBytes": 5574343362,
+          "footprint": { "diskSizeBytes": 5574343362, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Sana_1600M_1024px_mlx",
+          "variant": "q8",
+          "files": ["q8/*"],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 7010863702,
+          "footprint": { "diskSizeBytes": 7010863702, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Sana_1600M_1024px_mlx",
+          "variant": "bf16",
+          "files": ["bf16/*"],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 9704258849,
+          "footprint": { "diskSizeBytes": 9704258849, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
@@ -3576,16 +3597,18 @@
         "types": []
       },
       "mlx": {
-        // Dense bf16 snapshot (no runtime quant — the 2-bit SANA quant is NOT ported; the load path
-        // rejects a quantize override). minMemoryGb 24: the 1.6B Linear-DiT trunk + the ~2.6B gemma
-        // TE + DC-AE decode, a comfortably small footprint relative to the SD3.5 / Boogu flagships.
+        // Quant-matrix turnkey (sc-8489/sc-8513): default q4 (`standard_tier_subdir` resolves the
+        // `q4/` subdir; q8/bf16 selectable via advanced.mlxQuantize). The transformer + Gemma-2 TE are
+        // pre-packed and packed-detected on load (no install-time quantize peak). minMemoryGb 24: the
+        // 1.6B Linear-DiT trunk + the ~2.6B gemma TE + DC-AE decode, comfortably small.
         "minMemoryGb": 24,
+        "quantize": 4,
         "repo": "SceneWorks/Sana_1600M_1024px_mlx"
       },
       "licenseUrl": "https://huggingface.co/Efficient-Large-Model/Sana_1600M_1024px",
       "ui": {
         "label": "SANA 1600M",
-        "description": "NVIDIA SANA 1600M — an efficient Linear-DiT text-to-image model, ported natively to MLX (Apple Silicon only). A 1.6B linear-attention transformer (deep compression 32× DC-AE autoencoder + a gemma-2 instruction text encoder) for fast 1024×1024 generation with true classifier-free guidance and negative prompts. Runs ~20 steps at guidance 4.5 (flow-match Euler, shift 3.0). Dense bf16 (no quantization). Distributed under the NVIDIA Open Model License (non-commercial): generations are for non-commercial / research use only. The SceneWorks mirror is un-gated and carries the upstream license + notice. Runs comfortably on a 24 GB-class Mac.",
+        "description": "NVIDIA SANA 1600M — an efficient Linear-DiT text-to-image model, ported natively to MLX (Apple Silicon only). A 1.6B linear-attention transformer (deep compression 32× DC-AE autoencoder + a gemma-2 instruction text encoder) for fast 1024×1024 generation with true classifier-free guidance and negative prompts. Runs ~20 steps at guidance 4.5 (flow-match Euler, shift 3.0). Ships q4 (default) / q8 / bf16 quant tiers — pick per available RAM; each loads pre-packed with no conversion peak. Distributed under the NVIDIA Open Model License (non-commercial): generations are for non-commercial / research use only. The SceneWorks mirror is un-gated and carries the upstream license + notice. Runs comfortably on a 24 GB-class Mac.",
         "recommendedFor": ["text_to_image"],
         "promptGuide": {
           "title": "SANA Prompt Guide",
@@ -3624,20 +3647,41 @@
       "capabilities": ["text_to_image"],
       "macOnly": true,
       "downloads": [
+        // SceneWorks pre-built MLX quant-matrix turnkey (sc-8490/sc-8513, epic 8506): per-tier subdirs
+        // (q4/ default, q8/, bf16/), each a complete `SanaPipeline::new_sprint`-loadable tree —
+        // `transformer/` (the Sprint Linear-DiT trunk, packed q4/q8 else dense bf16), `vae/` (the 32×
+        // DC-AE f32 decoder, dense in EVERY tier), and `text_encoder/` (the gemma-2-2b-it CHI caption
+        // encoder — packed q4/q8 else dense + `tokenizer.json`, from the SceneWorks/gemma-2-2b-it
+        // mirror, NOT duplicated). Un-gated (NVIDIA non-commercial NOTICE). mlx-gen #653 packs the
+        // transformer + Gemma-2 TE offline and packed-detects on load (no install-time quantize). This
+        // is the shared group-64 affine tier, NOT the (unported) 2-bit SANA quant. Sizes measured.
         {
-          // Pre-converted MLX snapshot on the SceneWorks HF org (sc-8490): ONE
-          // `SanaPipeline::new_sprint`-loadable root — `transformer/` (the Linear-DiT trunk, Sprint
-          // weights), `vae/` (the 32× DC-AE f32 decoder), and `text_encoder/` (the gemma-2-2b-it CHI
-          // caption encoder — `gemma-2-2b-it.safetensors` + `tokenizer.json`, sourced from the
-          // SceneWorks/gemma-2-2b-it mirror so the TE weights are NOT duplicated as a separate catalog
-          // dependency). Un-gated (the mirror carries the NVIDIA non-commercial NOTICE). Dense bf16 (no
-          // quant subdir). estimatedSizeBytes is the measured mirror total (transformer BF16 3.22GB +
-          // DC-AE F32 1.25GB + merged gemma-2-2b-it TE BF16 5.23GB + license/notice), sc-8607.
           "provider": "huggingface",
           "repo": "SceneWorks/Sana_Sprint_1.6B_1024px_mlx",
-          "files": ["transformer/*", "vae/*", "text_encoder/*"],
+          "variant": "q4",
+          "default": true,
+          "files": ["q4/*"],
           "platforms": ["macos"],
-          "estimatedSizeBytes": 9715830101
+          "estimatedSizeBytes": 5577866495,
+          "footprint": { "diskSizeBytes": 5577866495, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Sana_Sprint_1.6B_1024px_mlx",
+          "variant": "q8",
+          "files": ["q8/*"],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 7017182259,
+          "footprint": { "diskSizeBytes": 7017182259, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Sana_Sprint_1.6B_1024px_mlx",
+          "variant": "bf16",
+          "files": ["bf16/*"],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 9715818241,
+          "footprint": { "diskSizeBytes": 9715818241, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
@@ -3675,15 +3719,18 @@
         "types": []
       },
       "mlx": {
-        // Dense bf16 snapshot (no runtime quant — the 2-bit SANA quant is NOT ported). minMemoryGb 24:
-        // the 1.6B Linear-DiT trunk + the ~2.6B gemma TE + DC-AE decode, a comfortably small footprint.
+        // Quant-matrix turnkey (sc-8490/sc-8513): default q4 (`standard_tier_subdir` resolves `q4/`;
+        // q8/bf16 selectable via advanced.mlxQuantize). Transformer + Gemma-2 TE pre-packed +
+        // packed-detected on load (no install-time quantize peak). minMemoryGb 24: the 1.6B Linear-DiT
+        // trunk + the ~2.6B gemma TE + DC-AE decode, a comfortably small footprint.
         "minMemoryGb": 24,
+        "quantize": 4,
         "repo": "SceneWorks/Sana_Sprint_1.6B_1024px_mlx"
       },
       "licenseUrl": "https://huggingface.co/Efficient-Large-Model/Sana_Sprint_1.6B_1024px",
       "ui": {
         "label": "SANA-Sprint 1.6B",
-        "description": "NVIDIA SANA-Sprint 1.6B — the few-step distillation of SANA, ported natively to MLX (Apple Silicon only). The same 1.6B linear-attention transformer (deep compression 32× DC-AE autoencoder + a gemma-2 instruction text encoder) as base SANA, distilled for ~2-step CFG-free generation via a continuous-time consistency (SCM) sampler and a guidance-embedding trunk — so it generates a 1024×1024 image in a couple of steps with no negative prompt. Dense bf16 (no quantization). Distributed under the NVIDIA Open Model License (non-commercial): generations are for non-commercial / research use only. The SceneWorks mirror is un-gated and carries the upstream license + notice. Runs comfortably on a 24 GB-class Mac.",
+        "description": "NVIDIA SANA-Sprint 1.6B — the few-step distillation of SANA, ported natively to MLX (Apple Silicon only). The same 1.6B linear-attention transformer (deep compression 32× DC-AE autoencoder + a gemma-2 instruction text encoder) as base SANA, distilled for ~2-step CFG-free generation via a continuous-time consistency (SCM) sampler and a guidance-embedding trunk — so it generates a 1024×1024 image in a couple of steps with no negative prompt. Ships q4 (default) / q8 / bf16 quant tiers — pick per available RAM; each loads pre-packed with no conversion peak. Distributed under the NVIDIA Open Model License (non-commercial): generations are for non-commercial / research use only. The SceneWorks mirror is un-gated and carries the upstream license + notice. Runs comfortably on a 24 GB-class Mac.",
         "recommendedFor": ["text_to_image"],
         "promptGuide": {
           "title": "SANA Prompt Guide",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -485,7 +485,7 @@ sceneworks-core = { path = "../sceneworks-core" }
 # candle-gen pin below moves to 7c43ec8f IN LOCKSTEP (candle-gen #301: consumes `text_encoder` in the
 # LTX provider AND re-pins candle-gen's own gen-core 330d339 -> b520a0e7) so `--features backend-candle`
 # resolves the SINGLE gen-core rev b520a0e7. mlx-rs + mlx-llm pins unchanged.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -837,7 +837,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -853,23 +853,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc702
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -877,7 +877,7 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
 # mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
 # mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
@@ -885,59 +885,59 @@ mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852c
 # conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
 # DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
 # generator-cache load path drives.
-mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -946,19 +946,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -967,7 +967,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd85
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -975,7 +975,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -986,7 +986,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd8
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -997,7 +997,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd85
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -1019,7 +1019,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -1030,7 +1030,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -1062,7 +1062,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd852cc7028aae47881f5707d31b5e1e24eef78" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6b3cbc306e9cbeb91d2e22caa3a8e6f40855d46f" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1461,15 +1461,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ccd8
 # pin is UNCHANGED at b520a0e7 (= this worker's mlx-gen pin), so `--features backend-candle --target all`
 # still resolves the SINGLE gen-core rev b520a0e7 (the skew gate) — no testkit reconcile. ALL candle-gen-*
 # rev lines move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1477,17 +1477,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1497,7 +1497,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1505,21 +1505,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1528,17 +1528,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1547,7 +1547,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1580,7 +1580,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1589,12 +1589,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1602,7 +1602,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b5
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1611,7 +1611,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1619,7 +1619,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1633,7 +1633,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1660,7 +1660,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1671,7 +1671,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "199b56fff6f13bdd54fbf4553be88c3861508b3c", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "418b8a4190e61ed8bc19c21679508aba4a0dfda9", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -523,8 +523,9 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     // the latter bundling the SceneWorks/gemma-2-2b-it TE so the load path resolves one snapshot dir —
     // SanaTextEncoder::from_snapshot reads `<dir>/text_encoder/gemma-2-2b-it.safetensors` + tokenizer.json).
     // Generator self-registers via the shared force-link (`use mlx_gen_sana as _;` in image_jobs.rs);
-    // reaches the generic MODEL_TABLE / `generate_stream` path. No runtime quant (the 2-bit quant is NOT
-    // ported); ships dense bf16. 32× DC-AE divisor → width/height must be multiples of 32.
+    // reaches the generic MODEL_TABLE / `generate_stream` path. Quant matrix (sc-8489/sc-8513): ships
+    // pre-packed q4/q8/bf16 tiers (transformer + Gemma-2 TE packed, DC-AE VAE dense), packed-detected
+    // on load — NOT the (unported) 2-bit SANA quant. 32× DC-AE divisor → W/H must be multiples of 32.
     ModelRow {
         sceneworks_id: "sana_1600m",
         engine_id: "sana_1600m",
@@ -541,8 +542,9 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     // ~2 steps (the `sana_sprint_1600m` descriptor advertises NO supports_true_cfg / supports_negative).
     // Loads the un-gated `SceneWorks/Sana_Sprint_1.6B_1024px_mlx` MLX snapshot (same transformer/ vae/
     // text_encoder/ layout as base SANA; the text_encoder/ bundles the SceneWorks/gemma-2-2b-it TE so it is
-    // NOT duplicated). Dense bf16 (no quant). 32× DC-AE divisor → width/height multiples of 32. NVIDIA
-    // non-commercial (NSCLv1) — the re-host carries the upstream LICENSE + NOTICE.
+    // NOT duplicated). Quant matrix (sc-8490/sc-8513): pre-packed q4/q8/bf16 tiers, packed-detected on
+    // load. 32× DC-AE divisor → width/height multiples of 32. NVIDIA non-commercial (NSCLv1) — the
+    // re-host carries the upstream LICENSE + NOTICE.
     ModelRow {
         sceneworks_id: "sana_sprint_1600m",
         engine_id: "sana_sprint_1600m",

--- a/crates/sceneworks-worker/src/flux1_control_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/flux1_control_mlx_smoke.rs
@@ -179,7 +179,7 @@ fn flux1_dev_control_mlx_smoke() {
             kind => vec![Conditioning::Control {
                 image: control_map.clone(),
                 kind,
-                scale: control_scale,
+                scale: Some(control_scale),
             }],
         };
         let image = render(&*generator, &prompt, w, h, steps, guidance, conditioning);

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -537,6 +537,16 @@ const STANDARD_TIER_MODELS: &[&str] = &[
     // q4-default / per-variant / q8-default layouts) and are NOT registered here.
     "lens",
     "lens_turbo",
+    // SANA + SANA-Sprint (sc-8489/sc-8513, epic 8506): the `SceneWorks/Sana_1600M_1024px_mlx` /
+    // `Sana_Sprint_1.6B_1024px_mlx` turnkeys ship standard q4/q8/bf16 tiers. mlx-gen #653 packs the
+    // Linear-DiT transformer + the Gemma-2 CHI TE and packed-detects on load; the DC-AE VAE stays
+    // dense in every tier. Like flux1/qwen (and UNLIKE the dense-TE klein class) the q4/q8 load-quant
+    // is a harmless no-op on the already-packed weights and bf16 resolves to Quant::None — so these do
+    // NOT need a DENSE_TE_TIER_MODELS guard. The SANA descriptor now advertises supported_quants
+    // Q4/Q8 (mlx-gen #654), so `supports_quant()` is true and they flow through the same
+    // resolve_quant + reconcile path as every other matrix model (no more no-quant special case).
+    "sana_1600m",
+    "sana_sprint_1600m",
 ];
 
 /// Standard-tier models whose text encoder ships DENSE bf16 in EVERY tier (epic 8506, sc-8711:
@@ -2866,12 +2876,13 @@ async fn generate_stream(
     } else {
         model.backend()
     };
-    // Descriptor-gated quant (mirrors the candle lane below): the generic MLX families all advertise
-    // Q4/Q8 (`supported_quants`) and tolerate the Q8 default (a real quant on a dense convert, a no-op on
-    // an already-packed turnkey). SANA (sc-8489) is the lone exception — its descriptor advertises
-    // `supported_quants: &[]` and its `load` REJECTS any `spec.quantize`, so resolve no quant for it and
-    // let it load dense bf16. Every pre-existing family keeps `supports_quant() == true`, so their
-    // resolved quant is byte-identical.
+    // Descriptor-gated quant (mirrors the candle lane below): the MLX families advertise Q4/Q8
+    // (`supported_quants`) and tolerate the Q8 default (a real quant on a dense convert, a no-op on an
+    // already-packed turnkey). SANA joined this set in mlx-gen #654 (sc-8489): its descriptor now
+    // advertises Q4/Q8 and its `load` ACCEPTS an advisory `spec.quantize` (the pre-quantized tier is
+    // packed-detected from disk, #653), so it flows through the normal resolve_quant path like every
+    // other matrix model. The `else` arm stays for any future engine that genuinely advertises no
+    // quant — such a model loads dense.
     let (quant, quant_bits) = if model.supports_quant() {
         resolve_quant(request)
     } else {
@@ -2882,8 +2893,8 @@ async fn generate_stream(
     // REQUEST — so a bf16 pick with only `q4/` present would render Q4 while the recipe records dense,
     // lying to the epic 8506 quant A/B workflow. Reconcile against the tier subdir actually resolved:
     // record the precision that ran + `warn!`/emit `quant_tier_downgraded` on a real fallback. SANA
-    // (no quant support) has no tier subdir, so `tier_quant_from_resolved_dir` returns `None` and this
-    // is a no-op for it.
+    // (sc-8489) now ships standard q4/q8/bf16 turnkey tiers and advertises Q4/Q8, so it reconciles here
+    // exactly like the other matrix models.
     //
     // sc-9362 (F-018 follow-up): dense-TE turnkeys (FLUX.2-klein) always derive `(None, None)` from
     // `resolve_quant` (the load quant must stay `None` so the dense bf16 TE is never re-quantized),

--- a/crates/sceneworks-worker/src/image_jobs/detail.rs
+++ b/crates/sceneworks-worker/src/image_jobs/detail.rs
@@ -104,7 +104,8 @@ fn detail_refine_tile(
             Conditioning::Control {
                 image: tile,
                 kind: ControlKind::Other("tile".to_owned()),
-                scale: params.cn_scale,
+                // gen-core drift (sc-9940): scale is now Option<f32>; explicit tile-CN scale → Some.
+                scale: Some(params.cn_scale),
             },
         ],
         cancel: cancel.clone(),

--- a/crates/sceneworks-worker/src/image_jobs/kolors.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors.rs
@@ -226,7 +226,8 @@ fn kolors_control_generate_one(
         Conditioning::Control {
             image: control,
             kind: ControlKind::Pose,
-            scale: control_scale,
+            // gen-core drift (sc-9940): scale is now Option<f32>; explicit control scale → Some.
+            scale: Some(control_scale),
         },
         Conditioning::Reference {
             image: reference.clone(),

--- a/crates/sceneworks-worker/src/image_jobs/strict_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/strict_control.rs
@@ -430,7 +430,9 @@ fn build_control_conditioning(
         kind => vec![Conditioning::Control {
             image: control,
             kind,
-            scale,
+            // gen-core drift (sc-9940): Conditioning::Control.scale is now Option<f32> (None = engine
+            // default). This lane always has an explicit control scale → Some.
+            scale: Some(scale),
         }],
     };
     if let Some((image, strength)) = identity_init {

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -2310,7 +2310,7 @@ fn kolors_real_weights_pose_generates_one_image() {
             Conditioning::Control {
                 image: skeleton,
                 kind: ControlKind::Pose,
-                scale: 0.7,
+                scale: Some(0.7),
             },
             Conditioning::Reference {
                 image: reference,
@@ -6644,7 +6644,8 @@ fn build_control_conditioning_matches_legacy_shape() {
         Conditioning::Control { image, kind, scale } => {
             assert_eq!(image.pixels, control.pixels);
             assert_eq!(*kind, ControlKind::Pose);
-            assert!((*scale - 0.9).abs() < 1e-6);
+            // gen-core drift (sc-9940): scale is now Option<f32>.
+            assert!((scale.expect("control scale") - 0.9).abs() < 1e-6);
         }
         other => panic!("expected Control, got {other:?}"),
     }

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -252,6 +252,15 @@ mod lens_base_q4_mlx_smoke;
 // never quantizes its T5, so no denseTextEncoderTier). hd/flash share this crate + layout.
 #[cfg(all(test, target_os = "macos"))]
 mod chroma1_base_q4_mlx_smoke;
+// Real-weight MLX smoke for the SANA quant-matrix lane (sc-8489/sc-8513, epic 8506). macOS-only;
+// drives `gen_core::load("sana_1600m"|"sana_sprint_1600m")` with a per-tier LoadSpec against the
+// packed q4/q8 + dense bf16 turnkey subdirs. On-device evidence that the SceneWorks/Sana_*_mlx
+// pre-quantized turnkeys load through the worker packed path (`STANDARD_TIER_MODELS` →
+// `standard_tier_subdir` resolves the tier) and render non-degenerate at EVERY downloaded tier. SANA
+// packs the Linear-DiT transformer + Gemma-2 CHI TE per-tier (DC-AE VAE dense); q4/q8 are a no-op on
+// the already-packed weights (packed-detected) and bf16 loads dense (Quant::None).
+#[cfg(all(test, target_os = "macos"))]
+mod sana_mlx_smoke;
 // On-device per-tier memory-footprint measurement harness (sc-8516, epic 8506). Test-only + macOS-only;
 // #[ignore]d real-weight smokes that drive `gen_core::load(id)` + ONE generation while sampling the MLX
 // process-global memory counters (mlx_rs::memory::{reset_peak_memory, get_active_memory, get_peak_memory})

--- a/crates/sceneworks-worker/src/sana_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/sana_mlx_smoke.rs
@@ -1,0 +1,204 @@
+//! Local real-weight MLX smoke for the SANA **quant-matrix** worker lane (sc-8489/sc-8513, epic 8506
+//! Group-B). `#[ignore]`d — run by hand on an Apple-Silicon Mac. It drives the real native-MLX
+//! `sana_1600m` + `sana_sprint_1600m` engines via `gen_core::load(id)` with a per-tier `LoadSpec`
+//! pointed at the packed/dense turnkey subdir — the exact runtime seam `generate_stream` uses (minus
+//! the API/job plumbing) when the router routes a SANA MLX job (`standard_tier_subdir` → the
+//! `q4/`|`q8/`|`bf16/` subdir; `resolve_quant` → `Quant::Q4`|`Quant::Q8`|`None`).
+//!
+//! Purpose: on-device evidence that the `SceneWorks/Sana_1600M_1024px_mlx` /
+//! `SceneWorks/Sana_Sprint_1.6B_1024px_mlx` pre-quantized turnkeys load through the worker packed
+//! path (`STANDARD_TIER_MODELS` → `standard_tier_subdir` resolves the tier) and render a
+//! non-degenerate image at EVERY downloaded tier. SANA packs the Linear-DiT transformer + the Gemma-2
+//! CHI text encoder per-tier (the DC-AE VAE stays dense); the q4/q8 load-quant is a harmless no-op on
+//! the already-packed weights (packed-detected from `{base}.scales`) and bf16 loads dense
+//! (`Quant::None`), so this covers both the packed and dense load mechanisms.
+//!
+//! Setup — point at the published turnkeys (the worker defaults). With the tier subdirs in the HF
+//! cache the smoke auto-resolves each cached snapshot's `q4/`|`q8/`|`bf16/` subdir and verifies every
+//! tier it finds (a partial download verifies whatever is present). Pull them via the manifest, e.g.
+//! ```text
+//! hf download SceneWorks/Sana_1600M_1024px_mlx      --include 'q4/*' 'q8/*' 'bf16/*'
+//! hf download SceneWorks/Sana_Sprint_1.6B_1024px_mlx --include 'q4/*' 'q8/*' 'bf16/*'
+//! cargo test -p sceneworks-worker --release sana_mlx_gpu_smoke -- --ignored --nocapture
+//! ```
+//! Optional overrides: `SANA_W`/`SANA_H` (default 512, a 32-multiple within the DC-AE 256..1024
+//! envelope), `SANA_OUT_DIR` (default `/tmp/sana_mlx_smoke`).
+
+use std::path::PathBuf;
+
+use gen_core::{GenerationOutput, GenerationRequest, LoadSpec, Quant, WeightsSource};
+
+use super::smoke_support::{
+    env_or, image_mean, image_std, is_all_zero, save_png, DEGENERATE_STD_FLOOR_DEFAULT,
+};
+
+/// A SANA model to smoke: its registry id, its cache repo folder, and its per-render recipe. Base is
+/// true-CFG 20-step guidance 4.5; Sprint is the CFG-free ~2-step SCM distillation.
+struct SanaModel {
+    id: &'static str,
+    repo_folder: &'static str,
+    steps: u32,
+    guidance: f32,
+}
+
+const MODELS: &[SanaModel] = &[
+    SanaModel {
+        id: "sana_1600m",
+        repo_folder: "models--SceneWorks--Sana_1600M_1024px_mlx",
+        steps: 20,
+        guidance: 4.5,
+    },
+    SanaModel {
+        id: "sana_sprint_1600m",
+        repo_folder: "models--SceneWorks--Sana_Sprint_1.6B_1024px_mlx",
+        steps: 2,
+        guidance: 4.5,
+    },
+];
+
+/// The three matrix tiers + the load `Quant` each maps to — mirroring `image_jobs::base`'s
+/// `standard_tier_subdir` (subdir) + `resolve_quant` (load quant): q4→Q4, q8→Q8, bf16→dense/None.
+const TIERS: &[(&str, Option<Quant>)] = &[
+    ("q4", Some(Quant::Q4)),
+    ("q8", Some(Quant::Q8)),
+    ("bf16", None),
+];
+
+/// The cached snapshot dir for `repo_folder` that carries a loadable `<tier>/transformer/` — SANA
+/// turnkeys pack the backbone under `transformer/diffusion_pytorch_model.safetensors`. `None` if the
+/// repo isn't cached at all.
+fn cached_snapshot(repo_folder: &str) -> Option<PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+    let snapshots = PathBuf::from(home)
+        .join(".cache/huggingface/hub")
+        .join(repo_folder)
+        .join("snapshots");
+    std::fs::read_dir(&snapshots)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|dir| {
+            TIERS.iter().any(|(t, _)| {
+                dir.join(t)
+                    .join("transformer/diffusion_pytorch_model.safetensors")
+                    .is_file()
+            })
+        })
+}
+
+#[test]
+#[ignore = "real-weight MLX smoke; needs the SceneWorks SANA q4/q8/bf16 turnkeys cached + an Apple-Silicon Mac"]
+fn sana_mlx_gpu_smoke() {
+    let out_dir = PathBuf::from(env_or("SANA_OUT_DIR", "/tmp/sana_mlx_smoke"));
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+    let w: u32 = env_or("SANA_W", "512").parse().expect("SANA_W");
+    let h: u32 = env_or("SANA_H", "512").parse().expect("SANA_H");
+    let prompt =
+        "a photorealistic portrait of a red fox sitting in a sunlit autumn forest, sharp focus";
+
+    // Verified (model, tier) pairs — the run must cover at least one so a stale/empty cache fails loud.
+    let mut verified: Vec<String> = Vec::new();
+
+    for model in MODELS {
+        let Some(snapshot) = cached_snapshot(model.repo_folder) else {
+            println!(
+                "[smoke] {} — no cached tiers found ({}); skipping (pull via `hf download`)",
+                model.id, model.repo_folder
+            );
+            continue;
+        };
+        for (tier, quant) in TIERS {
+            let tier_dir = snapshot.join(tier);
+            if !tier_dir
+                .join("transformer/diffusion_pytorch_model.safetensors")
+                .is_file()
+            {
+                println!("[smoke] {} {tier} not downloaded — skipping", model.id);
+                continue;
+            }
+
+            // Same seam as the worker MLX path: registry load of the SANA generator (force-linked via
+            // `use mlx_gen_sana as _;`) + a `LoadSpec` pointed at the tier subdir. Packed tiers
+            // (q4/q8) carry `.scales` and auto-detect; bf16 loads dense. `with_quant` mirrors
+            // `resolve_quant` (advisory post-#653 — the on-disk tier dictates the real precision).
+            let mut spec = LoadSpec::new(WeightsSource::Dir(tier_dir.clone()));
+            if let Some(q) = quant {
+                spec = spec.with_quant(*q);
+            }
+            println!(
+                "[smoke] loading {} ({tier}) from {} ...",
+                model.id,
+                tier_dir.display()
+            );
+            let generator =
+                gen_core::load(model.id, &spec).expect("load mlx sana generator for tier");
+
+            let req = GenerationRequest {
+                prompt: prompt.to_owned(),
+                width: w,
+                height: h,
+                count: 1,
+                seed: Some(42),
+                steps: Some(model.steps),
+                guidance: Some(model.guidance),
+                ..Default::default()
+            };
+            println!(
+                "[smoke] rendering {}x{} @ {} steps ({}) ...",
+                w, h, model.steps, model.id
+            );
+            let output = generator
+                .generate(&req, &mut |_p| {})
+                .expect("sana generate");
+            let image = match output {
+                GenerationOutput::Images(mut images) => {
+                    images.pop().expect("engine returned no image")
+                }
+                other => panic!("expected Images output, got {other:?}"),
+            };
+
+            let mean = image_mean(&image);
+            let std = image_std(&image);
+            let all_zero = is_all_zero(&image);
+            let png = out_dir.join(format!("{}_{tier}.png", model.id));
+            save_png(&image, &png);
+            println!(
+                "[smoke] {} {tier} {}x{} mean {:.2} std {:.2} all_zero={} -> {}",
+                model.id,
+                image.width,
+                image.height,
+                mean,
+                std,
+                all_zero,
+                png.display()
+            );
+            assert_eq!(
+                (image.width, image.height),
+                (w, h),
+                "{} {tier} returned the wrong dimensions",
+                model.id
+            );
+            assert!(
+                !all_zero,
+                "{} {tier} decode is ALL-ZERO — a broken packed/dense load or decode",
+                model.id
+            );
+            assert!(
+                std > DEGENERATE_STD_FLOOR_DEFAULT,
+                "{} {tier} render looks degenerate (std {std:.2}) — possible NaN / all-black / flat decode",
+                model.id
+            );
+            verified.push(format!("{}:{tier}", model.id));
+        }
+    }
+
+    assert!(
+        !verified.is_empty(),
+        "no SANA tiers were verified — download the SceneWorks/Sana_*_mlx q4/q8/bf16 turnkeys first \
+         (hf download SceneWorks/Sana_1600M_1024px_mlx --include 'q4/*' 'q8/*' 'bf16/*')"
+    );
+    println!(
+        "[smoke] DONE: SANA quant-matrix renders coherent through the worker packed lane for [{}]",
+        verified.join(", ")
+    );
+}

--- a/crates/sceneworks-worker/src/sensenova_jobs.rs
+++ b/crates/sceneworks-worker/src/sensenova_jobs.rs
@@ -1056,13 +1056,15 @@ fn load_sensenova_model(weights_dir: &Path) -> WorkerResult<(T2iModel, TextToken
 fn image_to_chw01(img: &Image, min_pixels: i64, max_pixels: i64) -> WorkerResult<Array> {
     let (in_w, in_h) = (img.width as i32, img.height as i32);
     let (out_h, out_w) = smart_resize(in_h, in_w, 32, min_pixels, max_pixels);
+    // gen-core drift (sc-9940): imageops::resize_*_u8 became fallible.
     let hwc = resize_bicubic_u8(
         &img.pixels,
         in_h as usize,
         in_w as usize,
         out_h as usize,
         out_w as usize,
-    );
+    )
+    .map_err(|error| WorkerError::InvalidPayload(format!("image resize: {error}")))?;
     let hwc = Array::from_slice(&hwc, &[out_h, out_w, 3]);
     let chw = hwc
         .transpose_axes(&[2, 0, 1])

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -583,12 +583,29 @@ fn sana_manifest_entry_gates_correctly() {
         repo, "SceneWorks/Sana_1600M_1024px_mlx",
         "sana downloads from the un-gated SceneWorks/* MLX mirror, got {repo:?}"
     );
-    // Dense bf16: NO `mlx.quantize` (the SANA `load` rejects any `spec.quantize`; the worker resolves
-    // no quant for it via the `supports_quant()` gate). minMemoryGb drives the admit/hide gate.
+    // Quant matrix (sc-8489/sc-8513): the q4/q8/bf16 turnkey tiers are packed-detected on load, so the
+    // descriptor advertises Q4/Q8 and the manifest defaults to the packed q4 tier (`mlx.quantize: 4`;
+    // `standard_tier_subdir` resolves `q4/`). minMemoryGb drives the admit/hide gate.
     let mlx = entry.get("mlx").expect("sana mlx block");
-    assert!(
-        mlx.get("quantize").is_none(),
-        "sana ships dense bf16 — no mlx.quantize"
+    assert_eq!(
+        mlx.get("quantize").and_then(Value::as_u64),
+        Some(4),
+        "sana defaults to the packed q4 tier"
+    );
+    // Per-tier variants present (q4 default + q8 + bf16), each its own installable artifact (sc-8508).
+    let variants: Vec<&str> = entry
+        .get("downloads")
+        .and_then(Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(|d| d.get("variant").and_then(Value::as_str))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert_eq!(
+        variants,
+        vec!["q4", "q8", "bf16"],
+        "sana ships the q4/q8/bf16 tier matrix"
     );
     assert!(
         mlx.get("minMemoryGb").and_then(Value::as_u64).is_some(),
@@ -621,8 +638,8 @@ fn sana_manifest_entry_gates_correctly() {
 
 /// sc-8490: the SANA-Sprint builtin entry gates exactly like base SANA — `sana` family, text_to_image
 /// only (CFG-free few-step distillation, no edit/reference surface), un-gated `SceneWorks/*` MLX
-/// re-host carrying the NVIDIA non-commercial notice, dense bf16 (no mlx.quantize), and the SANA LoRA
-/// family reserved. The few-step default (2 steps) is asserted so a manifest drift to the base 20-step
+/// re-host carrying the NVIDIA non-commercial notice, the q4/q8/bf16 quant matrix (default q4), and the
+/// SANA LoRA family reserved. The few-step default (2 steps) is asserted so a manifest drift to the base 20-step
 /// loop fails CI. Descriptor-derived guidance/negative/backend flags are covered by
 /// `model_table_rows_resolve_and_flags_match_descriptor`.
 #[test]
@@ -667,11 +684,26 @@ fn sana_sprint_manifest_entry_gates_correctly() {
         Some(2),
         "sana-sprint is a few-step (2-step) distillation"
     );
-    // Dense bf16: NO `mlx.quantize`.
+    // Quant matrix (sc-8490/sc-8513): default q4 (`mlx.quantize: 4`); q4/q8/bf16 tiers packed-detected.
     let mlx = entry.get("mlx").expect("sana-sprint mlx block");
-    assert!(
-        mlx.get("quantize").is_none(),
-        "sana-sprint ships dense bf16 — no mlx.quantize"
+    assert_eq!(
+        mlx.get("quantize").and_then(Value::as_u64),
+        Some(4),
+        "sana-sprint defaults to the packed q4 tier"
+    );
+    let variants: Vec<&str> = entry
+        .get("downloads")
+        .and_then(Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(|d| d.get("variant").and_then(Value::as_str))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert_eq!(
+        variants,
+        vec!["q4", "q8", "bf16"],
+        "sana-sprint ships the q4/q8/bf16 tier matrix"
     );
     assert!(
         mlx.get("minMemoryGb").and_then(Value::as_u64).is_some(),

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -504,6 +504,10 @@ fn map_training_config(config: &sceneworks_core::training::TrainingConfig) -> Tr
         sample_every: advanced_u32(advanced, "sampleEvery", 0),
         sample_steps: advanced_u32(advanced, "sampleSteps", 20),
         sample_guidance_scale: advanced_f32(advanced, "sampleGuidanceScale", 1.0),
+        // Mid-schedule resume (gen-core sc-9560 / F-125): not yet surfaced on the SceneWorks
+        // training path — default `false` preserves the current from-scratch behavior. Wiring the
+        // resume toggle from the plan's `advanced` bag is a separate training-feature story.
+        resume: false,
         // sc-8671 — the engine renders one preview per prompt, capped at `sampleCount` (default 4 =
         // the historical fixed `[:4]` cap). The UI always supplies `samplePrompts` (prefilled from the
         // trigger phrase); an absent/empty pool ⇒ no previews, exactly as before (sampling is gated by
@@ -2399,6 +2403,7 @@ mod tests {
             sample_prompts: Vec::new(),
             sample_steps: 20,
             sample_guidance_scale: 1.0,
+            resume: false,
         };
         let request = TrainingRequest {
             items: vec![TrainingItem {
@@ -2503,6 +2508,7 @@ mod tests {
             sample_prompts: Vec::new(),
             sample_steps: 20,
             sample_guidance_scale: 1.0,
+            resume: false,
         };
         let request = TrainingRequest {
             items: vec![TrainingItem {
@@ -2610,6 +2616,7 @@ mod tests {
             sample_prompts: Vec::new(),
             sample_steps: 20,
             sample_guidance_scale: 1.0,
+            resume: false,
         };
         let request = TrainingRequest {
             items: vec![TrainingItem {
@@ -2756,6 +2763,7 @@ mod tests {
             sample_prompts: Vec::new(),
             sample_steps: 20,
             sample_guidance_scale: 1.0,
+            resume: false,
         };
         let request = TrainingRequest {
             items: vec![TrainingItem {


### PR DESCRIPTION
Wires SANA-1.6B + SANA-Sprint into the catalog-wide quant matrix (epic 8506), the last in-scope model for **sc-8513** (the remaining tail — wan ×3, scail2, bernini, kolors, pulid — was split into sc-9941…sc-9947). Both models now ship pre-quantized **q4/q8/bf16** turnkey tiers on the SceneWorks HF org and load them directly (no install-time convert peak).

## Upstream (already merged)
- mlx-gen **#653** — packed-load Q4/Q8 + prequantize convert (packs the Linear-DiT transformer + Gemma-2 CHI TE; DC-AE VAE dense; packed-detects on load).
- mlx-gen **#654** (`6b3cbc3`) — both SANA descriptors advertise `supported_quants: [Q4, Q8]`.
- candle-gen **#348** (`418b8a4`) — gen-core re-pin to `6b3cbc3` (byte-identical; keeps the worker's backend-candle lane on one gen-core rev).
- Tiers hosted: `SceneWorks/Sana_1600M_1024px_mlx` (q4 5.57 / q8 7.01 / bf16 9.70 GB) + `SceneWorks/Sana_Sprint_1.6B_1024px_mlx` (q4 5.58 / q8 7.02 / bf16 9.72 GB).

## Pins
Bump mlx-gen `ccd852c → 6b3cbc3` and candle-gen `199b56f → 418b8a4`. gen-core skew gate green (exactly one gen-core rev on the backend-candle graph); `core-llm` pin unchanged.

## SANA wiring
- `base.rs`: `sana_1600m` + `sana_sprint_1600m` → `STANDARD_TIER_MODELS`. Transformer + TE packed per-tier (like flux1/qwen, **not** dense-TE): q4/q8 load-quant is a harmless no-op on the packed weights, bf16 → `Quant::None`. Now that SANA advertises `supported_quants`, it flows through the normal `resolve_quant` + `reconcile_resolved_tier_quant` path (accurate recipe + downgrade telemetry) — the old no-quant special-case comments are corrected.
- `builtin.models.jsonc`: both entries → per-tier q4(default)/q8/bf16 downloads with measured sizes + `footprint`, `mlx.quantize: 4`, updated UI/comments.
- `engines.rs`: refreshed both SANA row comments (dense bf16 → quant matrix).
- `gpu_and_manifest.rs`: SANA manifest-gate tests now assert the q4 default + the q4/q8/bf16 matrix.

## gen-core drift adaptation (forced by the pin jump off the old `b520a0e` base; mirrors candle-gen #347)
The worker's mlx-gen pin was parked on the old gen-core base; jumping to `6b3cbc3` pulls in the merged gen-core API drift the worker must adapt to:
- `Conditioning::Control.scale` is now `Option<f32>` → `Some(...)` at the 3 explicit-scale control sites (strict_control / kolors / detail) + 2 control tests.
- `imageops::resize_*_u8` became fallible → `map_err` + `?` in the sensenova image preprocess.
- `TrainingConfig` gained `resume: bool` (gen-core sc-9560) → `resume: false` (from-scratch behavior preserved; wiring the resume toggle is a separate training story).

## Verification
- **On-device (Apple Silicon):** new `sana_mlx_smoke.rs` (`#[ignore]`) loads + renders **every tier of both models** through the `gen_core::load` seam — `sana_1600m` q4/q8/bf16 (std ~69) + `sana_sprint_1600m` q4/q8/bf16 (std ~74), all non-degenerate, correct dims.
- fmt + workspace `clippy --all-targets -D warnings` clean; candle parity lane (`--no-default-features -F backend-candle --all-targets`) compiles; worker lib **636** tests pass.

Closes the SANA slice of sc-8513 (InstantID done-by-inheritance verify remains before the story closes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)