### PR TITLE
fix(core): route candle Q8/Q4 tier-select for krea/ideogram/boogu (sc-9983, epic 9083)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3344,6 +3344,19 @@ mod candle_routing_tests {
                 image_request_candle_eligible(model, &object(json!({ "prompt": "an aurora" }))),
                 "{model} plain txt2img must be candle-eligible"
             );
+            // sc-9607/sc-9983: a Q8/Q4 tier-select stays on candle (ideogram is in CANDLE_QUANT_MODELS —
+            // the packed q4/q8 turnkeys load off-Mac; the `mlxQuantize` value picks the subdir).
+            for bits in [8, 4] {
+                assert!(
+                    image_request_candle_eligible(
+                        model,
+                        &object(
+                            json!({ "prompt": "an aurora", "advanced": { "mlxQuantize": bits } })
+                        )
+                    ),
+                    "{model} Q{bits} tier-select should stay on candle"
+                );
+            }
             // Edit shapes → the bespoke dispatcher branch (img2img, inpaint, outpaint all need a source).
             for payload in [
                 json!({ "model": model, "mode": "edit_image", "sourceAssetId": "a" }),
@@ -3422,11 +3435,32 @@ mod candle_routing_tests {
         assert!(!boogu_edit_candle_eligible(&object(json!({
             "model": "boogu_image_edit", "mode": "edit_image", "referenceAssetIds": []
         }))));
-        // bf16-only: a deliberate Q8/Q4 quant request defers (boogu is not in CANDLE_QUANT_LORA_MODELS).
-        assert!(!image_request_candle_eligible(
-            "boogu_image",
-            &object(json!({ "prompt": "x", "advanced": { "mlxQuantize": 8 } }))
-        ));
+        // sc-9607/sc-9983: a Q8/Q4 tier-select now STAYS on candle (boogu is in CANDLE_QUANT_MODELS — the
+        // packed q4/q8 turnkeys load off-Mac, the `mlxQuantize` value picks the subdir). A LoRA still
+        // defers (boogu advertises no inference LoRA on candle).
+        for model in ["boogu_image", "boogu_image_turbo", "boogu_image_edit"] {
+            assert!(
+                image_request_candle_eligible(
+                    model,
+                    &object(json!({ "prompt": "x", "advanced": { "mlxQuantize": 8 } }))
+                ),
+                "{model} Q8 tier-select should stay on candle"
+            );
+            assert!(
+                image_request_candle_eligible(
+                    model,
+                    &object(json!({ "prompt": "x", "advanced": { "mlxQuantize": 4 } }))
+                ),
+                "{model} Q4 tier-select should stay on candle"
+            );
+            assert!(
+                !image_request_candle_eligible(
+                    model,
+                    &object(json!({ "loras": [{ "name": "x", "path": "/x.safetensors" }] }))
+                ),
+                "{model} with a LoRA must defer to torch (no candle inference LoRA)"
+            );
+        }
     }
 
     #[test]
@@ -3551,13 +3585,14 @@ mod candle_routing_tests {
     }
 
     #[test]
-    fn krea_lora_stays_on_candle_but_quant_and_conditioning_defer() {
-        // sc-7836 (epic 7565 P4): the candle `candle-gen-krea` descriptor advertises
-        // supports_lora/supports_lokr: true (it merges a `krea_2_raw`-trained adapter at Turbo
-        // inference) but `supported_quants: &[]`, so — the inverse of SD3.5 — a LoRA stays on the candle
-        // lane while an explicit quant request (and every conditioning shape) defers to the Python torch
-        // worker. Regression guard for the missed router un-gate: before this, a Krea LoRA hit the
-        // no-torch-fallback candle gap instead of routing to candle.
+    fn krea_lora_and_quant_stay_on_candle_but_conditioning_defers() {
+        // sc-7836 (epic 7565 P4) + sc-9607/sc-9983 (epic 9083): the candle `candle-gen-krea` descriptor
+        // advertises supports_lora/supports_lokr: true (it merges a `krea_2_raw`-trained adapter at Turbo
+        // inference) AND, since sc-9607, `supported_quants: [Q4, Q8]` (a no-op on the already-packed q4/q8
+        // turnkey subdir), so BOTH a LoRA and a Q8/Q4 tier-select stay on the candle lane (Krea is in
+        // CANDLE_QUANT_LORA_MODELS). Only the conditioning shapes (edit/reference/mask/pose) defer to the
+        // Python torch worker. Regression guard for the two missed router un-gates: before sc-7836 a Krea
+        // LoRA, and before sc-9983 a Krea Q8/Q4, each hit the no-torch-fallback candle gap off-Mac.
         let model = "krea_2_turbo";
         // Plain txt2img is eligible.
         assert!(
@@ -3572,14 +3607,14 @@ mod candle_routing_tests {
             ),
             "{model} with a LoRA should stay on candle"
         );
-        // Q8 / Q4 requests defer (Krea's candle provider is dense bf16 only).
+        // sc-9607/sc-9983: a Q8 / Q4 tier-select now STAYS on candle (the packed turnkey loads off-Mac).
         for bits in [8, 4] {
             assert!(
-                !image_request_candle_eligible(
+                image_request_candle_eligible(
                     model,
                     &object(json!({ "advanced": { "mlxQuantize": bits } }))
                 ),
-                "{model} Q{bits} request must fall back to torch (no candle quant lane)"
+                "{model} Q{bits} tier-select should stay on candle"
             );
         }
         // Every conditioning shape defers (txt2img + LoRA only).

--- a/crates/sceneworks-core/src/jobs_store/routing/candle.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/candle.rs
@@ -256,11 +256,12 @@ pub(crate) fn image_request_candle_eligible(model: &str, payload: &Map<String, V
     {
         return false;
     }
-    // Lens / Lens-Turbo advertise Q4/Q8 + LoRA/LoKr, so a quant request OR a LoRA stays on the candle
-    // lane for them. SD3.5 (sc-7880) advertises Q4/Q8 but NOT inference LoRA (quant stays, LoRA defers);
-    // Krea 2 Turbo (sc-7836) is the inverse — inference LoRA/LoKr but NOT quant (LoRA stays, quant
-    // defers). Every other candle family advertises neither and defers both. The two capabilities are
-    // decoupled: `supports_lora` and `supports_quant` each consult the both-set plus their own list.
+    // Lens / Lens-Turbo and Krea 2 Turbo advertise Q4/Q8 + LoRA/LoKr, so a quant request OR a LoRA stays
+    // on the candle lane for them (Krea gained Q4/Q8 in sc-9607, joining Lens in the both-set — sc-9983).
+    // SD3.5 (sc-7880) and the Ideogram/Boogu packed families (sc-9607) advertise Q4/Q8 but NOT inference
+    // LoRA (quant stays, LoRA defers). Every other candle family advertises neither and defers both. The
+    // two capabilities are decoupled: `supports_lora` and `supports_quant` each consult the both-set plus
+    // their own list.
     let supports_lora =
         CANDLE_QUANT_LORA_MODELS.contains(&model) || CANDLE_LORA_MODELS.contains(&model);
     let supports_quant =
@@ -287,7 +288,10 @@ pub(crate) fn image_request_candle_eligible(model: &str, payload: &Map<String, V
     // On-the-fly quantization (`advanced.mlxQuantize` > 0) → torch UNLESS the family advertises quant.
     // The sc-3675/sc-5096 candle providers advertise `supported_quants: &[]` (dense bf16/fp16 only), so
     // an explicit quant request can't be honored — route to Python rather than silently running dense
-    // (sc-5099). Lens (sc-5126) + SD3.5 (sc-7880) advertise Q4/Q8, so their quant requests stay here.
+    // (sc-5099). Lens (sc-5126), SD3.5 (sc-7880), Krea (sc-9607/sc-9983), and the Ideogram/Boogu packed
+    // families (sc-9607) advertise Q4/Q8, so their quant requests stay on candle. For the packed families
+    // the `mlxQuantize` value is a turnkey tier-SELECT (which pre-quantized q4/q8 subdir to load), a no-op
+    // on the loader rather than a runtime quantize — but the gate is the same: quant-capable → stay.
     if !supports_quant && candle_request_wants_quant(payload) {
         return false;
     }

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -599,18 +599,25 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
     ModelCaps::new("bernini_image", true, false, false, false, false),
     // Ideogram 4 + Turbo (epic 4725 MLX; sc-6597 candle): 9.3B flow DiT + Qwen3-VL-8B TE. T2I + edit on
     // MLX (sc-6303); candle serves txt2img + the in-lane edit path (sc-6598) via the generic stream.
-    ModelCaps::new("ideogram_4", true, true, false, false, false),
-    ModelCaps::new("ideogram_4_turbo", true, true, false, false, false),
+    // Candle advertises Q4/Q8 (sc-9607 flipped `supported_quants: [Q4, Q8]`, dropping the loader's
+    // `spec.quantize` reject — a no-op on the already-packed q4/q8 turnkey), so `candle_quant` is set
+    // (sc-9983 — the routing half of sc-9607, previously missed): a tier-select `mlxQuantize` stays on
+    // candle. No inference LoRA on candle, so NOT quant/lora-exempt.
+    ModelCaps::new("ideogram_4", true, true, true, false, false),
+    ModelCaps::new("ideogram_4_turbo", true, true, true, false, false),
     // Boogu-Image-0.1 (epic 6387 MLX; sc-7524 candle): ~10.3B flow DiT + Qwen3-VL-8B + FLUX.1 VAE. Base +
-    // Turbo are txt2img; Edit adds the instruction image-edit path. bf16-only on candle (the provider
-    // rejects on-the-fly quant), so deliberately NOT quant/lora-exempt.
-    ModelCaps::new("boogu_image", true, true, false, false, false),
-    ModelCaps::new("boogu_image_turbo", true, true, false, false, false),
-    ModelCaps::new("boogu_image_edit", true, true, false, false, false),
+    // Turbo are txt2img; Edit adds the instruction image-edit path. Candle advertises Q4/Q8 (sc-9607
+    // flipped `supported_quants: [Q4, Q8]`, the packed-tier no-op), so `candle_quant` is set (sc-9983 —
+    // the routing half of sc-9607). No inference LoRA on candle, so NOT quant/lora-exempt.
+    ModelCaps::new("boogu_image", true, true, true, false, false),
+    ModelCaps::new("boogu_image_turbo", true, true, true, false, false),
+    ModelCaps::new("boogu_image_edit", true, true, true, false, false),
     // Krea 2 Turbo (epic 7565 / sc-7572 MLX; sc-7581 candle): 12B rectified-flow DiT, TDM-distilled
-    // CFG-free. Candle advertises inference LoRA/LoKr but NOT on-the-fly quant (`supported_quants: &[]`),
-    // so `candle_lora` is set (sc-7836 — merges a `krea_2_raw`-trained adapter at Turbo inference).
-    ModelCaps::new("krea_2_turbo", true, true, false, true, false),
+    // CFG-free. Candle advertises inference LoRA/LoKr (sc-7836 — merges a `krea_2_raw`-trained adapter at
+    // Turbo inference) AND, since sc-9607, on-the-fly Q4/Q8 (`supported_quants: [Q4, Q8]`, a no-op on the
+    // already-packed q4/q8 turnkey), so `candle_quant_lora` is set (sc-9983 — the routing half of sc-9607,
+    // moving Krea from `candle_lora` to BOTH): a tier-select `mlxQuantize` AND a LoRA both stay on candle.
+    ModelCaps::new("krea_2_turbo", true, true, false, false, true),
     // Stable Diffusion 3.5 Large / Large Turbo / Medium (epic 7841 / sc-7871 MLX; sc-7880 candle):
     // pure txt2img. Candle advertises Q4/Q8 (sc-7879) but NOT inference LoRA (`supports_lora: false`), so
     // `candle_quant` is set — an explicit quant request stays on candle while a LoRA still defers to torch.
@@ -703,24 +710,28 @@ derive_model_list! {
 
 derive_model_list! {
     /// The candle image families that advertise on-the-fly Q4/Q8 quant AND LoRA/LoKr adapters — Lens /
-    /// Lens-Turbo (derived from [`IMAGE_MODEL_CAPS`]`.candle_quant_lora`, sc-9495). For these a LoRA or an
-    /// explicit quant request does NOT force the job to torch. Subset of [`CANDLE_ROUTED_MODELS`].
+    /// Lens-Turbo and Krea 2 Turbo (derived from [`IMAGE_MODEL_CAPS`]`.candle_quant_lora`, sc-9495; Krea
+    /// added sc-9983 once sc-9607 flipped its `supported_quants`). For these a LoRA or an explicit quant
+    /// request does NOT force the job to torch. Subset of [`CANDLE_ROUTED_MODELS`].
     pub(crate) CANDLE_QUANT_LORA_MODELS, IMAGE_MODEL_CAPS, candle_quant_lora
 }
 
 derive_model_list! {
     /// The candle image families that advertise on-the-fly Q4/Q8 quant but NOT inference LoRA — Stable
-    /// Diffusion 3.5 (derived from [`IMAGE_MODEL_CAPS`]`.candle_quant`, sc-9495). Quant stays on candle;
-    /// a LoRA still defers to torch. Disjoint from [`CANDLE_QUANT_LORA_MODELS`]; both are consulted by the
-    /// gate. Subset of [`CANDLE_ROUTED_MODELS`].
+    /// Diffusion 3.5, Ideogram 4 (+Turbo), and Boogu (Base/Turbo/Edit) (derived from
+    /// [`IMAGE_MODEL_CAPS`]`.candle_quant`, sc-9495; the ideogram/boogu packed families added sc-9983 once
+    /// sc-9607 flipped their `supported_quants`). Quant stays on candle; a LoRA still defers to torch.
+    /// Disjoint from [`CANDLE_QUANT_LORA_MODELS`]; both are consulted by the gate. Subset of
+    /// [`CANDLE_ROUTED_MODELS`].
     pub(crate) CANDLE_QUANT_MODELS, IMAGE_MODEL_CAPS, candle_quant
 }
 
 derive_model_list! {
-    /// The candle image families that advertise inference LoRA/LoKr but NOT on-the-fly quant — Krea 2
-    /// Turbo (derived from [`IMAGE_MODEL_CAPS`]`.candle_lora`, sc-9495). A LoRA stays on candle; an explicit
-    /// quant request still defers to torch. The mirror of [`CANDLE_QUANT_MODELS`]; both plus
-    /// [`CANDLE_QUANT_LORA_MODELS`] are disjoint and all consulted by the gate. Subset of
+    /// The candle image families that advertise inference LoRA/LoKr but NOT on-the-fly quant (derived from
+    /// [`IMAGE_MODEL_CAPS`]`.candle_lora`, sc-9495). Currently EMPTY: Krea 2 Turbo was the sole member until
+    /// sc-9983 moved it to [`CANDLE_QUANT_LORA_MODELS`] (sc-9607 gave it Q4/Q8 too). Kept as the vocabulary
+    /// for the next candle family that advertises LoRA but not quant. The mirror of [`CANDLE_QUANT_MODELS`];
+    /// both plus [`CANDLE_QUANT_LORA_MODELS`] are disjoint and all consulted by the gate. Subset of
     /// [`CANDLE_ROUTED_MODELS`].
     pub(crate) CANDLE_LORA_MODELS, IMAGE_MODEL_CAPS, candle_lora
 }
@@ -920,12 +931,25 @@ mod tests {
         "sd3_5_medium",
     ];
 
-    const EXPECTED_CANDLE_QUANT_LORA_MODELS: &[&str] = &["lens", "lens_turbo"];
+    // sc-9983: Krea joins Lens as a BOTH-quant-and-LoRA candle family (sc-9607 flipped its
+    // `supported_quants` to [Q4, Q8]; it already advertised inference LoRA via sc-7836).
+    const EXPECTED_CANDLE_QUANT_LORA_MODELS: &[&str] = &["lens", "lens_turbo", "krea_2_turbo"];
 
-    const EXPECTED_CANDLE_QUANT_MODELS: &[&str] =
-        &["sd3_5_large", "sd3_5_large_turbo", "sd3_5_medium"];
+    // sc-9983: ideogram/boogu join SD3.5 as quant-only candle families (sc-9607 flipped their
+    // `supported_quants` to [Q4, Q8]; no inference LoRA on candle).
+    const EXPECTED_CANDLE_QUANT_MODELS: &[&str] = &[
+        "sd3_5_large",
+        "sd3_5_large_turbo",
+        "sd3_5_medium",
+        "ideogram_4",
+        "ideogram_4_turbo",
+        "boogu_image",
+        "boogu_image_turbo",
+        "boogu_image_edit",
+    ];
 
-    const EXPECTED_CANDLE_LORA_MODELS: &[&str] = &["krea_2_turbo"];
+    // sc-9983: Krea moved to CANDLE_QUANT_LORA_MODELS (BOTH), so the LoRA-only list is now empty.
+    const EXPECTED_CANDLE_LORA_MODELS: &[&str] = &[];
 
     const EXPECTED_CANDLE_VIDEO_ROUTED_MODELS: &[&str] = &[
         "wan_2_2",


### PR DESCRIPTION
## Problem

Selecting **Q8/Q4 for Krea 2 Turbo** text-to-image off-Mac fails with:

> `candle_unsupported: conditioned shape on a txt2img candle family (krea_2_turbo) … the requested … quant shape has no candle lane for it off-Mac. [epic 5480]`

## Root cause — half-landed sc-9607 (engine wired, router half missed)

sc-9607 (candle-gen #333, worker pin `a02e72f`) flipped `supported_quants: [Q4, Q8]` on the **ideogram / boogu / krea** descriptors and dropped each loader's `spec.quantize` reject (a no-op on the already-packed q4/q8 turnkey subdir). The manifest hosts the per-tier turnkeys off-Mac and a full candle `vramGbByTier` gate, and the worker's A-B quant toggle was wired to engage.

But the SceneWorks routing capability table (`IMAGE_MODEL_CAPS`) was **never flipped** — all three families still had `candle_quant=false`, so `image_request_candle_eligible` rejected any `advanced.mlxQuantize > 0` job (the studio tier picker sends `mlxQuantize`: `q8→8`, `q4→4`). Off-Mac there is no torch worker, so the job stranded and enforce-failed `candle_unsupported`. This is the "engine wired, router half missed" bug the catalog file itself warns about (chroma sc-5576, krea sc-7836).

## Fix

One row per family in `IMAGE_MODEL_CAPS` + the membership-parity snapshot constants:

| family | before | after |
|---|---|---|
| `krea_2_turbo` | `candle_lora` | `candle_quant_lora` (BOTH quant + inference LoRA) |
| `ideogram_4`, `ideogram_4_turbo` | — | `candle_quant` (quant only) |
| `boogu_image`, `boogu_image_turbo`, `boogu_image_edit` | — | `candle_quant` (quant only) |

For the packed families the `mlxQuantize` value is a turnkey tier-**select** (which pre-quantized subdir to load), not a runtime quantize — but the gate is the same: quant-capable → stay on candle. Also refreshes the derived-list/gate doc comments and the ideogram/boogu/krea candle-routing unit tests (a Q8/Q4 tier-select now stays on candle; a LoRA still defers for the quant-only families).

## Validation

- `cargo test -p sceneworks-core` — **378 pass** (incl. `routed_model_lists_match_snapshot` + superset invariants).
- `cargo fmt` + `cargo clippy` clean.
- **Follow-up:** GPU-val an actual off-Mac Q8 Krea + Q8 Ideogram generation (In Review pending that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)