### PR TITLE
feat(worker): host + wire Wan2.2 T2V-A14B bf16/Q8/Q4 quant-matrix tiers (sc-9942, epic 8506)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -4776,17 +4776,52 @@
       // from the SceneWorks HF org (sc-5607, epic 5594; replaces the third-party AITRADER mirror);
       // Windows/Linux load the diffusers/GGUF layout via the torch wan_video adapter.
       "downloads": [
+        // macOS quant matrix (sc-9942, epic 8506): each tier is a SEPARATE user-selectable artifact
+        // tagged with a `variant`; `q4` (default) installs when no tier is chosen. Unlike LTX there
+        // is NO shared coRequisite — every tier subdir is fully self-contained (both MoE experts +
+        // UMT5 T5 + z16 VAE + tokenizer + config.json), so the dense T5/VAE repeat per tier (epic
+        // decision #3: storage is a non-issue; keeps the load path a single self-contained dir with
+        // no engine change). The worker fetches a toggled-but-not-downloaded tier on demand
+        // (ensure_wan_t2v_14b_tier_present, video_jobs.rs), so advanced.mlxQuantize works without a
+        // pre-pick. The legacy flat root files stay hosted for already-shipped workers that resolve
+        // the repo root; a new worker only ever resolves the tier subdirs (cleanup follow-up sc-9977).
+        // estimatedSizeBytes/footprint are backfilled with the exact hosted subdir sizes post-build.
         {
           "provider": "huggingface",
           "repo": "SceneWorks/wan2.2-t2v-a14b-mlx",
-          "files": [],
+          "variant": "q4",
+          "default": true,
+          "files": ["q4/*"],
           "platforms": ["macos"],
-          "estimatedSizeBytes": 69040469369
+          "estimatedSizeBytes": 28644241134,
+          "footprint": { "diskSizeBytes": 28644241134, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/wan2.2-t2v-a14b-mlx",
+          "variant": "q8",
+          "files": ["q8/*"],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 42695163382,
+          "footprint": { "diskSizeBytes": 42695163382, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/wan2.2-t2v-a14b-mlx",
+          "variant": "bf16",
+          "files": ["bf16/*"],
+          "platforms": ["macos"],
+          // Dense bf16 tier (sc-9942): both experts bf16 (~28.58 GB each) + T5 (~11.36 GB) + VAE +
+          // tokenizer — the same content as the legacy flat root, hosted under bf16/ for the uniform
+          // tier layout. Exact on-disk size of the built bf16/ subdir.
+          "estimatedSizeBytes": 69040469649,
+          "footprint": { "diskSizeBytes": 69040469649, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
           "files": [],
+          "default": true,
           "platforms": ["windows", "linux"],
           "estimatedSizeBytes": 72000000000
         }
@@ -4844,12 +4879,15 @@
       },
       "mlx": {
         // Turnkey pre-converted dual-expert MLX snapshot on the SceneWorks HF org (sc-5607,
-        // epic 5594) — replaces the third-party AITRADER/Wan2.2-T2V-A14B-mlx-bf16 mirror. Dense
-        // bf16, self-contained (high/low-noise experts + UMT5 encoder + z16 VAE + tokenizer),
-        // downloaded on first use. The worker resolves env override (SCENEWORKS_MLX_WAN14B_T2V_DIR)
-        // → local <data>/models/mlx/wan_2_2_t2v_14b → this snapshot. Source Wan-AI/Wan2.2-T2V-A14B
-        // is Apache-2.0; converter "wan_t2v_14b" emits bf16 (Q4/Q8 at load). The lightx2v 4-step
-        // Lightning LoRA is downloaded on demand by MlxVideoAdapter at generation time.
+        // epic 5594) — replaces the third-party AITRADER/Wan2.2-T2V-A14B-mlx-bf16 mirror. As of the
+        // quant matrix (sc-9942, epic 8506) it ships pre-built q4/q8/bf16 tier subdirs (each
+        // self-contained: high/low-noise experts + UMT5 encoder + z16 VAE + tokenizer + config.json,
+        // the quant baked in via config.json so nothing quantizes at load). The worker resolves env
+        // override (SCENEWORKS_MLX_WAN14B_T2V_DIR) → local <data>/models/mlx/wan_2_2_t2v_14b → the
+        // requested tier subdir of this snapshot (wan_t2v_14b_tier_subdir; both MoE experts live in
+        // one subdir), loading with no install-time convert peak. Source Wan-AI/Wan2.2-T2V-A14B is
+        // Apache-2.0; converter "wan_t2v_14b" (mlx-gen-wan convert_t2v_14b) builds each tier. The
+        // lightx2v 4-step Lightning LoRA is downloaded on demand by MlxVideoAdapter at gen time.
         "minMemoryGb": 133,
         "repo": "SceneWorks/wan2.2-t2v-a14b-mlx",
         // macOS curated menu (sc-7296): the full curated fold-in over the A14B native flow σ

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -269,6 +269,13 @@ mod sana_mlx_smoke;
 // manifest footprint fields.
 #[cfg(all(test, target_os = "macos"))]
 mod footprint_measure;
+// On-device build helper for the Wan2.2 T2V-A14B quant matrix (sc-9942, epic 8506). Test-only +
+// macOS-only; an #[ignore]d helper that drives `mlx_gen_wan::convert::convert_t2v_14b` once per tier
+// (bf16/q8/q4) against the native checkpoint to produce the self-contained hosted tier subdirs, then
+// copies the tokenizer the converter omits. Run one-off to build the artifacts for
+// `SceneWorks/wan2.2-t2v-a14b-mlx`; not exercised in CI (needs the ~126GB native weights).
+#[cfg(all(test, target_os = "macos"))]
+mod wan_t2v_14b_tier_build;
 // The DWPose skeleton rasterizer is consumed only by the macOS Z-Image strict-pose
 // control path; on Mac AND the off-Mac candle DWPose lane (sc-5496) it backs the
 // `pose_jobs` skeleton render; on a candle-disabled box off Mac it still builds +

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -732,3 +732,85 @@ fn sana_sprint_manifest_entry_gates_correctly() {
         "sana-sprint UI description carries the NVIDIA non-commercial notice"
     );
 }
+
+/// sc-9942 (epic 8506): the Wan2.2 T2V-A14B builtin entry ships the macOS quant matrix as per-tier
+/// installable artifacts — `q4` (default) + `q8` + `bf16`, each a self-contained SceneWorks HF
+/// download tagged with a `variant` and carrying an `estimatedSizeBytes` + `footprint` (sc-8508). The
+/// video load path (`video_jobs::wan_t2v_14b_tier_subdir`) descends into the chosen tier, so a drift
+/// that drops a tier or its size would break the download UI + the RAM→tier suggestion — assert the
+/// shape here so it fails CI.
+#[test]
+fn wan_t2v_14b_manifest_ships_the_quant_matrix() {
+    let entry = builtin_model_entry("wan_2_2_t2v_14b");
+    assert_eq!(
+        entry.get("family").and_then(Value::as_str),
+        Some("wan-video"),
+        "wan T2V-14B family"
+    );
+    assert_eq!(
+        entry.get("type").and_then(Value::as_str),
+        Some("video"),
+        "wan T2V-14B is a video model"
+    );
+    let downloads = entry
+        .get("downloads")
+        .and_then(Value::as_array)
+        .expect("wan T2V-14B downloads");
+    // The macOS tiers, in order, from the SceneWorks quant-matrix repo.
+    let macos: Vec<&Value> = downloads
+        .iter()
+        .filter(|d| {
+            d.get("platforms")
+                .and_then(Value::as_array)
+                .map(|p| p.iter().any(|x| x.as_str() == Some("macos")))
+                .unwrap_or(false)
+        })
+        .collect();
+    let variants: Vec<&str> = macos
+        .iter()
+        .filter_map(|d| d.get("variant").and_then(Value::as_str))
+        .collect();
+    assert_eq!(
+        variants,
+        vec!["q4", "q8", "bf16"],
+        "wan T2V-14B ships the q4/q8/bf16 tier matrix on macOS"
+    );
+    for tier in &macos {
+        let variant = tier.get("variant").and_then(Value::as_str).unwrap();
+        assert_eq!(
+            tier.get("repo").and_then(Value::as_str),
+            Some("SceneWorks/wan2.2-t2v-a14b-mlx"),
+            "{variant} tier hosts on the SceneWorks quant-matrix repo"
+        );
+        let files: Vec<String> = tier
+            .get("files")
+            .and_then(Value::as_array)
+            .map(|f| f.iter().filter_map(Value::as_str).map(String::from).collect())
+            .unwrap_or_default();
+        assert_eq!(
+            files,
+            vec![format!("{variant}/*")],
+            "{variant} tier installs only its own subdir"
+        );
+        assert!(
+            tier.get("estimatedSizeBytes")
+                .and_then(Value::as_u64)
+                .is_some_and(|b| b > 0),
+            "{variant} tier declares a nonzero estimatedSizeBytes"
+        );
+        assert!(
+            tier.get("footprint")
+                .and_then(|f| f.get("diskSizeBytes"))
+                .and_then(Value::as_u64)
+                .is_some_and(|b| b > 0),
+            "{variant} tier declares a footprint.diskSizeBytes"
+        );
+    }
+    // Exactly one macOS default, and it is the lean q4 tier (the big bf16 is a deliberate opt-in).
+    let defaults: Vec<&str> = macos
+        .iter()
+        .filter(|d| d.get("default").and_then(Value::as_bool) == Some(true))
+        .filter_map(|d| d.get("variant").and_then(Value::as_str))
+        .collect();
+    assert_eq!(defaults, vec!["q4"], "the macOS default tier is q4");
+}

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -2779,6 +2779,149 @@ fn local_mlx_dir(settings: &Settings, env: &str, local_id: &str) -> Option<PathB
         .find(|dir| dir.join("config.json").is_file())
 }
 
+/// The turnkey SceneWorks Wan2.2 **T2V-A14B** MLX repo (sc-9942, epic 8506). Hosts the quant matrix
+/// as self-contained tier subdirs `q4/` (default) + `q8/` + `bf16/`, each a COMPLETE dual-expert
+/// snapshot (both MoE experts + UMT5 T5 encoder + z16 VAE + tokenizer + `config.json`). This replaces
+/// the flat dense-bf16 layout (which quantized at LOAD, staging the full bf16 experts first); the
+/// worker now descends into the chosen tier so a pre-packed snapshot loads with no install-time
+/// convert peak. The flat root files are kept for back-compat with already-shipped workers that
+/// resolve the repo root (a cleanup story drops them once those age out); a new worker only ever
+/// resolves the tier subdirs.
+#[cfg(target_os = "macos")]
+const WAN_T2V_14B_REPO: &str = "SceneWorks/wan2.2-t2v-a14b-mlx";
+
+/// Pinned revision for [`WAN_T2V_14B_REPO`] (mirrors [`LTX_BUNDLE_REVISION`], sc-9879). The repo is a
+/// hard-coded const — no manifest/payload override reaches the on-demand `q8/*` + `bf16/*` fetches —
+/// so pulling the mutable `main` branch would let an upstream re-push silently swap a checkpoint we
+/// load. Pin the exact commit that adds the `q4/`/`q8/`/`bf16/` tier subdirs for defense-in-depth
+/// (the `hf` CLI still verifies each file's own hash on download). This is the commit that added the
+/// `q4/`/`q8/`/`bf16/` tier subdirs (sc-9942).
+#[cfg(target_os = "macos")]
+const WAN_T2V_14B_REVISION: &str = "991eb255c544bbb2e1f1e07da4355c2f0a5337b7";
+
+/// Parse `advanced.mlxQuantize` (int or numeric string) for the Wan A14B tier selector, if present.
+#[cfg(target_os = "macos")]
+fn wan_quant_bits(request: &VideoRequest) -> Option<i64> {
+    request
+        .advanced
+        .get("mlxQuantize")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()))
+}
+
+/// The Wan2.2 T2V-A14B tier search order for a request — preferred tier first, then the
+/// always-smaller fallback tiers so a repo missing the preferred subdir still loads (mirrors
+/// [`ltx_bundle_tier_order`]): `mlxQuantize <= 0` ⇒ `bf16`, `>= 8` ⇒ `q8`, else the `q4` default.
+/// `bf16` is only ever tried when explicitly requested, so a default job never pulls the huge dense
+/// tier by accident.
+#[cfg(target_os = "macos")]
+fn wan_t2v_14b_tier_order(request: &VideoRequest) -> &'static [&'static str] {
+    match wan_quant_bits(request) {
+        Some(b) if b <= 0 => &["bf16", "q8", "q4"],
+        Some(b) if b >= 8 => &["q8", "q4"],
+        _ => &["q4", "q8"],
+    }
+}
+
+/// Whether `dir` is a COMPLETE self-contained Wan2.2 A14B tier snapshot: both MoE experts + the T5
+/// encoder + VAE + tokenizer + `config.json`. A partially-downloaded tier fails this so
+/// [`wan_t2v_14b_tier_subdir`] falls through to a smaller complete tier rather than half-loading.
+#[cfg(target_os = "macos")]
+fn wan_a14b_tier_is_complete(dir: &Path) -> bool {
+    [
+        "high_noise_model.safetensors",
+        "low_noise_model.safetensors",
+        "t5_encoder.safetensors",
+        "vae.safetensors",
+        "tokenizer.json",
+        "config.json",
+    ]
+    .iter()
+    .all(|file| dir.join(file).is_file())
+}
+
+/// Descend a resolved Wan2.2 T2V-A14B repo `root` into the requested quant tier subdir (sc-9942,
+/// epic 8506), mirroring [`ltx_bundle_subdir`]. Returns the first COMPLETE tier in
+/// [`wan_t2v_14b_tier_order`] (both experts live in the SAME subdir, so one resolution covers the
+/// full MoE), or `None` when the repo has no complete tier subdir — a legacy flat snapshot, where the
+/// caller keeps the root + load-time quant.
+#[cfg(target_os = "macos")]
+fn wan_t2v_14b_tier_subdir(root: &Path, request: &VideoRequest) -> Option<PathBuf> {
+    wan_t2v_14b_tier_order(request)
+        .iter()
+        .map(|tier| root.join(tier))
+        .find(|dir| wan_a14b_tier_is_complete(dir))
+}
+
+/// Resolve the Wan2.2 T2V-A14B `(model_dir, load-time quant)` for a generation, descending into the
+/// quant-matrix tier subdir when the turnkey ships them (sc-9942). A pre-packed tier's `config.json`
+/// is authoritative — [`WanTransformer::from_weights`] builds the experts at the stored bits and
+/// `resolve_load_time_quant` rejects a conflicting `spec.quantize` as a hard error — so a resolved
+/// tier loads with `quant = None`: `mlxQuantize` selects WHICH tier, never a load-time requant (the
+/// `bf16/` tier is dense, so `None` ⇒ dense too). A legacy flat snapshot (no tier subdirs) keeps
+/// today's behavior: load the root and quantize at load per [`resolve_wan_quant`].
+#[cfg(target_os = "macos")]
+fn resolve_wan_t2v_14b_dir_and_quant(
+    settings: &Settings,
+    request: &VideoRequest,
+    engine_id: &'static str,
+) -> WorkerResult<(PathBuf, Option<Quant>)> {
+    let root = resolve_wan_model_dir(settings, &request.model, engine_id)?;
+    match wan_t2v_14b_tier_subdir(&root, request) {
+        Some(tier) => Ok((tier, None)),
+        None => Ok((root, resolve_wan_quant(request))),
+    }
+}
+
+/// On-demand fetch of a non-default Wan2.2 T2V-A14B tier subdir (sc-9942, mirrors
+/// [`ensure_ltx_q8_present`] / [`ensure_ltx_bf16_present`]). The macOS default download is the lean
+/// `q4/` tier; a job that opts into a heavier tier (`mlxQuantize <= 0` ⇒ `bf16`, `>= 8` ⇒ `q8`) pulls
+/// just that subdir from the FIXED [`WAN_T2V_14B_REVISION`] the first time it is requested so
+/// [`wan_t2v_14b_tier_subdir`] can resolve it. No-op for a non-T2V-14B model, a `q4` (default) job,
+/// when the repo snapshot isn't downloaded yet (resolve surfaces the clear error), or when the tier
+/// is already complete. Fails loud on a real download error — fast, before any compute; a missing
+/// `hf` CLI leaves the tier absent so resolve gracefully falls back to a smaller complete tier.
+#[cfg(target_os = "macos")]
+async fn ensure_wan_t2v_14b_tier_present(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+) -> WorkerResult<()> {
+    if request.model != "wan_2_2_t2v_14b" {
+        return Ok(());
+    }
+    let tier = match wan_quant_bits(request) {
+        Some(b) if b <= 0 => "bf16",
+        Some(b) if b >= 8 => "q8",
+        // q4 default — ships with the base install, nothing to fetch on demand.
+        _ => return Ok(()),
+    };
+    let Some(root) = huggingface_snapshot_dir(&settings.data_dir, WAN_T2V_14B_REPO) else {
+        return Ok(());
+    };
+    if wan_a14b_tier_is_complete(&root.join(tier)) {
+        return Ok(());
+    }
+    let scratch = settings
+        .data_dir
+        .join("cache")
+        .join(format!(".wan-t2v-14b-{tier}-fetch-{}", job.id));
+    tokio::fs::create_dir_all(&scratch).await?;
+    let files = vec![format!("{tier}/*")];
+    let result = crate::model_jobs::download_model_with_hf_cli(
+        api,
+        settings,
+        job,
+        WAN_T2V_14B_REPO,
+        WAN_T2V_14B_REVISION,
+        &files,
+        &scratch,
+    )
+    .await;
+    let _ = tokio::fs::remove_dir_all(&scratch).await;
+    result.map(|_| ())
+}
+
 /// The 4-step Lightning distill LoRA pair (high/low) for an A14B MoE model
 /// (`lightx2v/Wan2.2-Lightning`, the rank-64 Seko distill). The subdir is architecture-specific:
 /// T2V-A14B (V1.1) and I2V-A14B (V1) ship distinct LoRAs that are NOT cross-compatible (sc-4997).
@@ -4891,12 +5034,27 @@ async fn generate_wan(
         }
         _ => resolve_wan_conditioning(settings, request, project_path, engine_id)?,
     };
+    // T2V-A14B quant matrix (sc-9942, epic 8506): the macOS default install is the lean q4 tier; a
+    // q8/bf16 job fetches that subdir on demand before resolving. No-op for the 5B/I2V models, a q4
+    // job, or an already-present tier.
+    ensure_wan_t2v_14b_tier_present(api, settings, job, request).await?;
+    // Descend into the chosen quant-matrix tier subdir when the T2V-A14B turnkey ships them; a
+    // pre-packed tier loads with quant=None (config.json is authoritative). The 5B/I2V models and a
+    // legacy flat T2V snapshot keep the root + load-time quant.
+    let (model_dir, quant) = if engine_id == "wan2_2_t2v_14b" {
+        resolve_wan_t2v_14b_dir_and_quant(settings, request, engine_id)?
+    } else {
+        (
+            resolve_wan_model_dir(settings, &request.model, engine_id)?,
+            resolve_wan_quant(request),
+        )
+    };
     let input = VideoGenInput {
         sampler: None,
         scheduler: None,
         engine_id,
-        model_dir: resolve_wan_model_dir(settings, &request.model, engine_id)?,
-        quant: resolve_wan_quant(request),
+        model_dir,
+        quant,
         adapters: resolve_wan_adapters(settings, request, engine_id)?,
         conditioning,
         prompt: request.prompt.clone(),
@@ -9304,6 +9462,109 @@ mod tests {
         assert_eq!(resolve_wan_quant(&absent), None);
     }
 
+    /// Write the six files that make a Wan2.2 A14B tier subdir COMPLETE
+    /// ([`wan_a14b_tier_is_complete`]), so [`wan_t2v_14b_tier_subdir`] treats it as present.
+    #[cfg(target_os = "macos")]
+    fn write_complete_wan_tier(root: &Path, tier: &str) {
+        let dir = root.join(tier);
+        std::fs::create_dir_all(&dir).unwrap();
+        for file in [
+            "high_noise_model.safetensors",
+            "low_noise_model.safetensors",
+            "t5_encoder.safetensors",
+            "vae.safetensors",
+            "tokenizer.json",
+            "config.json",
+        ] {
+            std::fs::write(dir.join(file), b"x").unwrap();
+        }
+    }
+
+    /// `mlxQuantize` selects the preferred T2V-A14B tier, then falls back to the always-smaller
+    /// present tiers (bf16 is only ever tried when explicitly requested).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn wan_t2v_14b_tier_order_prefers_then_falls_back() {
+        let bf16 = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 0 } }));
+        assert_eq!(wan_t2v_14b_tier_order(&bf16), &["bf16", "q8", "q4"]);
+        let q8 = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 8 } }));
+        assert_eq!(wan_t2v_14b_tier_order(&q8), &["q8", "q4"]);
+        let q4 = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 4 } }));
+        assert_eq!(wan_t2v_14b_tier_order(&q4), &["q4", "q8"]);
+        // Absent knob defaults to the lean q4 tier; bf16 is never in a default job's search path.
+        let absent = request(json!({ "projectId": "p" }));
+        assert_eq!(wan_t2v_14b_tier_order(&absent), &["q4", "q8"]);
+    }
+
+    /// [`wan_t2v_14b_tier_subdir`] resolves the requested tier, falls back to a smaller COMPLETE
+    /// tier, ignores a partially-downloaded one, and returns `None` for a legacy flat root.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn wan_t2v_14b_tier_subdir_resolves_and_falls_back() {
+        let root = std::env::temp_dir().join(format!("sw_wan_tier_{}", Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&root).unwrap();
+        // Legacy flat root (no tier subdirs) → None (caller keeps root + load-time quant).
+        let q8_req = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 8 } }));
+        assert_eq!(wan_t2v_14b_tier_subdir(&root, &q8_req), None);
+
+        // Only q4 present: a q8 request falls back to the smaller complete q4 tier.
+        write_complete_wan_tier(&root, "q4");
+        assert_eq!(
+            wan_t2v_14b_tier_subdir(&root, &q8_req),
+            Some(root.join("q4"))
+        );
+
+        // A partial q8 (missing a file) is skipped, still falling back to q4.
+        std::fs::create_dir_all(root.join("q8")).unwrap();
+        std::fs::write(root.join("q8").join("config.json"), b"x").unwrap();
+        assert_eq!(
+            wan_t2v_14b_tier_subdir(&root, &q8_req),
+            Some(root.join("q4"))
+        );
+
+        // Completed q8 now wins for a q8 request; a default job still prefers q4.
+        write_complete_wan_tier(&root, "q8");
+        assert_eq!(
+            wan_t2v_14b_tier_subdir(&root, &q8_req),
+            Some(root.join("q8"))
+        );
+        let default_req = request(json!({ "projectId": "p" }));
+        assert_eq!(
+            wan_t2v_14b_tier_subdir(&root, &default_req),
+            Some(root.join("q4"))
+        );
+
+        // bf16 request with no bf16 tier falls back to q8 (never silently to a default).
+        let bf16_req = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 0 } }));
+        assert_eq!(
+            wan_t2v_14b_tier_subdir(&root, &bf16_req),
+            Some(root.join("q8"))
+        );
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// The T2V-A14B tier repo must pin an exact commit (not the mutable `main`) so an upstream
+    /// re-push can't swap a checkpoint the on-demand fetch loads (mirrors the LTX/SeedVR2 pins).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn wan_t2v_14b_revision_is_pinned_commit_not_main() {
+        assert_ne!(
+            WAN_T2V_14B_REVISION, "main",
+            "the T2V-A14B tier repo must pin a fixed revision before release"
+        );
+        assert_eq!(
+            WAN_T2V_14B_REVISION.len(),
+            40,
+            "a pinned HF revision is a 40-char commit sha"
+        );
+        assert!(
+            WAN_T2V_14B_REVISION
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+            "the pinned revision must be lowercase hex"
+        );
+    }
+
     /// The `.high_noise.safetensors` → `.low_noise.safetensors` sibling convention
     /// (case-insensitive; only fires when the sibling file exists).
     #[cfg(target_os = "macos")]
@@ -9624,6 +9885,114 @@ mod tests {
             .frames
             .iter()
             .all(|f| f.pixels.len() == (f.width * f.height * 3) as usize));
+    }
+
+    /// Real in-process load+generate verification for the Wan2.2 T2V-A14B quant-matrix tiers
+    /// (sc-9942, epic 8506). For each tier subdir present under `$SCENEWORKS_WAN_T2V_14B_TIER_OUT`
+    /// (`bf16/`/`q8/`/`q4/`, e.g. the wan_t2v_14b_tier_build output), loads the tier through the SAME
+    /// engine path a job uses (`run_video_generation`, `quant: None` — the pre-packed config.json is
+    /// authoritative) and denoises a tiny 5-frame clip, asserting the frames come back RGB8-sized and
+    /// NON-degenerate (real pixel variance, so a broken packed load surfaces instead of silent noise).
+    /// This is the on-device evidence that every hosted tier loads packed with no install-time convert
+    /// peak. Runs a few CFG steps WITHOUT the Lightning distill so it is self-contained (no LoRA
+    /// download); output is a coherence check, not a quality bar. `#[ignore]` — needs the built tiers
+    /// (~28–69 GB each) + a big-memory Mac; the cache limit is capped so loading bf16 then q8 then q4
+    /// in one process does not accumulate residue (sc-5567).
+    ///
+    /// ```sh
+    /// export SCENEWORKS_WAN_T2V_14B_TIER_OUT=<tier-out-root>   # holds bf16/ q8/ q4/
+    /// cargo test -p sceneworks-worker --release --lib wan_t2v_14b_tier_real_weights -- --ignored --nocapture
+    /// ```
+    #[cfg(target_os = "macos")]
+    #[ignore = "loads the built Wan2.2 T2V-A14B tiers; run manually on a Mac where they are present"]
+    #[test]
+    fn wan_t2v_14b_tier_real_weights() {
+        let Some(root) = std::env::var_os("SCENEWORKS_WAN_T2V_14B_TIER_OUT").map(PathBuf::from)
+        else {
+            eprintln!(
+                "skipping wan_t2v_14b_tier_real_weights: set SCENEWORKS_WAN_T2V_14B_TIER_OUT"
+            );
+            return;
+        };
+        // Cap the buffer cache so three sequential heavy loads release between tiers (sc-5567).
+        mlx_rs::memory::set_cache_limit(0);
+        let mut verified = 0;
+        for tier in ["bf16", "q8", "q4"] {
+            let dir = root.join(tier);
+            if !wan_a14b_tier_is_complete(&dir) {
+                eprintln!("skipping {tier}: {} is not a complete tier", dir.display());
+                continue;
+            }
+            eprintln!("verifying {tier} tier → {}", dir.display());
+            let input = VideoGenInput {
+                sampler: None,
+                scheduler: None,
+                engine_id: "wan2_2_t2v_14b",
+                model_dir: dir.clone(),
+                // Pre-packed tier: config.json carries the quant; the engine reconstructs the experts
+                // packed and rejects a conflicting override, so load with None (the worker path does
+                // the same in resolve_wan_t2v_14b_dir_and_quant).
+                quant: None,
+                prompt: "a calm ocean wave at sunset, cinematic".to_owned(),
+                // A few CFG steps WITHOUT the Lightning distill — enough to exercise the packed
+                // experts + VAE decode and produce non-degenerate frames for a load check.
+                width: 256,
+                height: 256,
+                frames: 5,
+                fps: 16,
+                steps: Some(6),
+                guidance: Some(5.0),
+                seed: 7,
+                ..VideoGenInput::default()
+            };
+            let cancel = CancelFlag::new();
+            let mut steps = 0u32;
+            let mut on_progress = |progress: Progress| {
+                if let Progress::Step { .. } = progress {
+                    steps += 1;
+                }
+            };
+            let decoded = run_video_generation(input, &cancel, &mut on_progress)
+                .unwrap_or_else(|e| panic!("{tier} tier T2V generation failed: {e:?}"));
+            // The engine's temporal VAE fixes the decoded frame count (a 5-latent-frame request
+            // decodes to 8 RGB frames for the A14B); assert a real multi-frame clip, not an exact
+            // count.
+            assert!(
+                decoded.frames.len() > 1,
+                "{tier}: got {} frames, expected a multi-frame clip",
+                decoded.frames.len()
+            );
+            assert!(steps > 0, "{tier}: denoise progress streamed");
+            assert!(
+                decoded
+                    .frames
+                    .iter()
+                    .all(|f| f.pixels.len() == (f.width * f.height * 3) as usize),
+                "{tier}: frames are RGB8-sized"
+            );
+            // Non-degenerate: a broken packed load tends to decode to a flat/NaN frame. Require real
+            // spatial variance in the first frame.
+            let f0 = &decoded.frames[0];
+            let mean = f0.pixels.iter().map(|&p| p as f64).sum::<f64>() / f0.pixels.len() as f64;
+            let var = f0
+                .pixels
+                .iter()
+                .map(|&p| (p as f64 - mean).powi(2))
+                .sum::<f64>()
+                / f0.pixels.len() as f64;
+            assert!(
+                var.sqrt() > 3.0,
+                "{tier}: frame 0 looks degenerate (std {:.2}) — packed load likely broken",
+                var.sqrt()
+            );
+            mlx_rs::memory::clear_cache();
+            verified += 1;
+        }
+        assert!(
+            verified > 0,
+            "no tier subdirs found under SCENEWORKS_WAN_T2V_14B_TIER_OUT"
+        );
+        eprintln!("verified {verified} tier(s)");
     }
 
     /// Real-weight image→video fit smoke (sc-6139): proves the Crop/Pad pre-fit reaches the

--- a/crates/sceneworks-worker/src/wan_t2v_14b_tier_build.rs
+++ b/crates/sceneworks-worker/src/wan_t2v_14b_tier_build.rs
@@ -1,0 +1,163 @@
+//! On-device build helper for the Wan2.2 T2V-A14B quant matrix (sc-9942, epic 8506).
+//!
+//! Produces the three hosted tier subdirs — `bf16/` + `q8/` + `q4/` — from the native
+//! `Wan-AI/Wan2.2-T2V-A14B` checkpoint by driving the SAME byte-parity-validated converter the
+//! turnkey uses (`mlx_gen_wan::convert::convert_t2v_14b`), once per tier with the matching quant.
+//! Each tier is a COMPLETE self-contained dual-expert snapshot (both MoE experts, the UMT5 T5, the
+//! z16 VAE and `config.json` with the quant baked in); this helper additionally copies the
+//! `tokenizer.json` the converter does not emit into every tier so the load path
+//! (`video_jobs::wan_a14b_tier_is_complete`) treats each as present.
+//!
+//! This is an `#[ignore]`d test, not part of CI — it needs the ~126 GB native fp32 checkpoint on
+//! disk and takes minutes per tier on an Apple-Silicon Mac. Run one-off to produce the artifacts,
+//! then `hf upload` the `bf16/`/`q8/`/`q4/` subdirs to `SceneWorks/wan2.2-t2v-a14b-mlx`.
+//!
+//! ```sh
+//! # Native checkpoint (high_noise_model/ + low_noise_model/ + models_t5_umt5-xxl-enc-bf16.pth +
+//! # Wan2.1_VAE.pth), e.g. `hf download Wan-AI/Wan2.2-T2V-A14B --local-dir <native>`:
+//! export SCENEWORKS_WAN_T2V_14B_NATIVE_DIR=<native>
+//! export SCENEWORKS_WAN_T2V_14B_TIER_OUT=<out-root>          # bf16/ q8/ q4/ written here
+//! # tokenizer.json to copy into each tier (the converter does not emit it). Defaults to
+//! # <native>/tokenizer.json, then the cached SceneWorks/wan2.2-t2v-a14b-mlx turnkey's tokenizer.json.
+//! export SCENEWORKS_WAN_T2V_14B_TOKENIZER=<path/to/tokenizer.json>   # optional
+//! cargo test -p sceneworks-worker --release wan_t2v_14b_build_tiers -- --ignored --nocapture
+//! ```
+//!
+//! Each tier prints a `[[TIER]] {json}` line (tier, dir, diskSizeBytes) so the manifest
+//! `estimatedSizeBytes`/`footprint.diskSizeBytes` can be backfilled with the exact hosted sizes.
+
+use std::path::{Path, PathBuf};
+
+/// The three tiers to build: `(subdir, Option<(bits, group_size)>)`. bf16 is dense (`None`); q8/q4
+/// pack the Linear-DiT experts at group 64 — the canonical Wan group (mflux/reference default; the
+/// same group `WanModelConfig::from_config_json` assumes and the load path reconstructs).
+const TIERS: &[(&str, Option<(i32, i32)>)] =
+    &[("bf16", None), ("q8", Some((8, 64))), ("q4", Some((4, 64)))];
+
+/// Recursively sum the byte size of every file under `dir` (the on-disk size of a built tier).
+fn dir_size_bytes(dir: &Path) -> u64 {
+    let mut total = 0;
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            total += dir_size_bytes(&path);
+        } else if let Ok(meta) = path.metadata() {
+            total += meta.len();
+        }
+    }
+    total
+}
+
+/// Resolve the `tokenizer.json` to copy into each tier: the explicit env override, then
+/// `<native>/tokenizer.json`, then the cached `SceneWorks/wan2.2-t2v-a14b-mlx` turnkey's
+/// `tokenizer.json` under the HF hub cache. Panics with actionable guidance if none is found — the
+/// tier is incomplete without it.
+fn resolve_tokenizer(native_dir: &Path) -> PathBuf {
+    if let Ok(explicit) = std::env::var("SCENEWORKS_WAN_T2V_14B_TOKENIZER") {
+        let path = PathBuf::from(explicit.trim());
+        assert!(
+            path.is_file(),
+            "SCENEWORKS_WAN_T2V_14B_TOKENIZER={} is not a file",
+            path.display()
+        );
+        return path;
+    }
+    let beside = native_dir.join("tokenizer.json");
+    if beside.is_file() {
+        return beside;
+    }
+    // Cached turnkey: ~/.cache/huggingface/hub/models--SceneWorks--wan2.2-t2v-a14b-mlx/snapshots/*/tokenizer.json
+    if let Some(home) = std::env::var_os("HOME") {
+        let snapshots = PathBuf::from(home)
+            .join(".cache/huggingface/hub")
+            .join("models--SceneWorks--wan2.2-t2v-a14b-mlx")
+            .join("snapshots");
+        if let Ok(entries) = std::fs::read_dir(&snapshots) {
+            for entry in entries.flatten() {
+                let candidate = entry.path().join("tokenizer.json");
+                if candidate.is_file() {
+                    return candidate;
+                }
+            }
+        }
+    }
+    panic!(
+        "no tokenizer.json found — set SCENEWORKS_WAN_T2V_14B_TOKENIZER, place one at {}, or cache \
+         the SceneWorks/wan2.2-t2v-a14b-mlx turnkey (hf download … --include tokenizer.json)",
+        beside.display()
+    );
+}
+
+/// Build all three Wan2.2 T2V-A14B tier subdirs from the native checkpoint. `#[ignore]`d — run
+/// on-device with the env vars above; not exercised in CI (needs the native weights).
+#[test]
+#[ignore = "on-device tier build: needs the ~126GB native Wan2.2-T2V-A14B checkpoint + minutes/tier"]
+fn wan_t2v_14b_build_tiers() {
+    let native_dir = PathBuf::from(
+        std::env::var("SCENEWORKS_WAN_T2V_14B_NATIVE_DIR")
+            .expect("set SCENEWORKS_WAN_T2V_14B_NATIVE_DIR to the native checkpoint dir"),
+    );
+    assert!(
+        native_dir.join("high_noise_model").is_dir() && native_dir.join("low_noise_model").is_dir(),
+        "{} is not a native Wan2.2 A14B checkpoint (expected high_noise_model/ + low_noise_model/ \
+         subdirs, models_t5_umt5-xxl-enc-bf16.pth, Wan2.1_VAE.pth)",
+        native_dir.display()
+    );
+    let out_root = PathBuf::from(
+        std::env::var("SCENEWORKS_WAN_T2V_14B_TIER_OUT")
+            .expect("set SCENEWORKS_WAN_T2V_14B_TIER_OUT to the output root for bf16/ q8/ q4/"),
+    );
+    let tokenizer = resolve_tokenizer(&native_dir);
+    std::fs::create_dir_all(&out_root).unwrap();
+
+    // The converter loads each expert as a full fp32 buffer (~57 GB) then casts to bf16; at MLX's
+    // default cache limit the freed fp32 buffers are RETAINED as cache, so after both experts the
+    // residue (~114 GB) plus the T5 f32 load OOM-SIGKILLs the process on a 128 GB box (sc-5567 batch
+    // pattern). Cap the buffer cache to 0 so freed buffers return to the OS immediately between
+    // stages — a build-time realloc-cost trade the generation hot path deliberately avoids.
+    mlx_rs::memory::set_cache_limit(0);
+
+    for (tier, quant) in TIERS {
+        let out_dir = out_root.join(tier);
+        eprintln!(
+            "building {tier} tier → {} (quant={:?})",
+            out_dir.display(),
+            quant
+        );
+        mlx_gen_wan::convert::convert_t2v_14b(&native_dir, &out_dir, *quant)
+            .unwrap_or_else(|e| panic!("convert_t2v_14b {tier} failed: {e:?}"));
+        // Release any retained buffers before the next (heavier) tier so residue never accumulates.
+        mlx_rs::memory::clear_cache();
+        // The converter does not emit tokenizer.json; copy it so the tier is complete for the load
+        // path (video_jobs::wan_a14b_tier_is_complete).
+        std::fs::copy(&tokenizer, out_dir.join("tokenizer.json"))
+            .unwrap_or_else(|e| panic!("copy tokenizer.json into {tier} failed: {e:?}"));
+        // Sanity: the six files the load path requires must all exist.
+        for file in [
+            "high_noise_model.safetensors",
+            "low_noise_model.safetensors",
+            "t5_encoder.safetensors",
+            "vae.safetensors",
+            "tokenizer.json",
+            "config.json",
+        ] {
+            assert!(
+                out_dir.join(file).is_file(),
+                "built {tier} tier is missing {file}"
+            );
+        }
+        let size = dir_size_bytes(&out_dir);
+        // Machine-readable line for backfilling the manifest sizes.
+        eprintln!(
+            "[[TIER]] {{\"tier\":\"{tier}\",\"dir\":\"{}\",\"diskSizeBytes\":{size}}}",
+            out_dir.display()
+        );
+    }
+    eprintln!(
+        "done — upload the tier subdirs:\n  hf upload SceneWorks/wan2.2-t2v-a14b-mlx {} --include 'bf16/*' 'q8/*' 'q4/*'",
+        out_root.display()
+    );
+}


### PR DESCRIPTION
## What & why

Brings **Wan2.2 T2V-A14B** into the catalog-wide quant matrix (epic 8506). It previously shipped a **flat dense-bf16** turnkey and quantized **at load** (staging the full bf16 experts first). `SceneWorks/wan2.2-t2v-a14b-mlx` now hosts self-contained **`q4/` (default) + `q8/` + `bf16/`** tier subdirs — each a complete dual-expert snapshot (both MoE experts + UMT5 T5 + z16 VAE + tokenizer + `config.json`, the quant baked into `config.json`) — so a tier loads with **no install-time convert peak**.

## Changes
- **`video_jobs.rs`**: `wan_t2v_14b_tier_subdir` descends into the requested tier subdir (both experts live in one dir → one resolution covers the MoE). A pre-packed tier loads with `quant=None` because `config.json` is authoritative (`resolve_load_time_quant` makes a conflicting `spec.quantize` a *hard error*). `ensure_wan_t2v_14b_tier_present` fetches a toggled `q8`/`bf16` on demand from a **pinned revision** (mirrors the LTX pattern). A legacy flat snapshot still loads with load-time quant.
- **manifest**: per-variant `q4`/`q8`/`bf16` macOS downloads with exact hosted sizes + `footprint` blocks (q4 28.6 GB / q8 42.7 GB / bf16 69.0 GB); `q4` is the lean default. The legacy flat root is kept for back-compat with already-shipped workers (cleanup tracked in **sc-9977**).
- **build + verify** (on-device, `#[ignore]`): `wan_t2v_14b_tier_build` runs `convert_t2v_14b` ×3 into the tier subdirs; `wan_t2v_14b_tier_real_weights` loads each tier packed and generates a clip.
- unit + manifest gate tests.

## Verification
- Tiers built from the native `Wan-AI/Wan2.2-T2V-A14B` checkpoint, uploaded to `SceneWorks/wan2.2-t2v-a14b-mlx` (commit `991eb25`), and **verified on-device**: each of q4/q8/bf16 loads packed and generates a non-degenerate clip.
- `cargo clippy -p sceneworks-worker --all-targets -- -D warnings` clean; `cargo fmt --check` clean; new unit + manifest tests pass.

All new worker code is `#[cfg(target_os = "macos")]`, so the candle/Windows lane is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)