### PR TITLE
feat: Batch Prompt Processing for Image Studio (epic 9952)

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -150,6 +150,14 @@ pub(crate) struct RecipePresetsQuery {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PromptBatchesQuery {
+    pub(crate) project_id: Option<String>,
+    pub(crate) include_archived: Option<bool>,
+    pub(crate) scope: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
 pub(crate) struct EventsQuery {
     pub(crate) ticket: Option<String>,
 }

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -148,9 +148,9 @@ use dto::{
     HostCapabilitiesResponse, ImageJobRequest, InterleaveJobRequest, JobsQuery, LoraImportRequest,
     LorasQuery, ModelConvertRequest, ModelDownloadRequest, ModelImportRequest,
     PersonDetectionJobRequest, PersonTrackCorrectionsRequest, PersonTrackJobRequest,
-    ProjectCreateRequest, PromptRefineRequest, QualityAckBody, ReadinessQuery, RecipePresetsQuery,
-    TimelineCreateRequest, TimelineExportRequest, TimelineSaveRequest, TrainingCaptionJobRequest,
-    VerifyResponse, VideoJobRequest, VqaJobRequest,
+    ProjectCreateRequest, PromptBatchesQuery, PromptRefineRequest, QualityAckBody, ReadinessQuery,
+    RecipePresetsQuery, TimelineCreateRequest, TimelineExportRequest, TimelineSaveRequest,
+    TrainingCaptionJobRequest, VerifyResponse, VideoJobRequest, VqaJobRequest,
 };
 mod manifest;
 use manifest::{
@@ -183,6 +183,11 @@ use recipe_presets::{
     create_recipe_preset, delete_recipe_preset, duplicate_recipe_preset, get_recipe_preset,
     list_recipe_presets, preset_lora_id, preset_lora_weight, preset_prompt, recipe_preset_catalog,
     recipe_preset_catalog_with, recipe_preset_loras, serialize_preset_lora, update_recipe_preset,
+};
+mod prompt_batches;
+use prompt_batches::{
+    create_prompt_batch, delete_prompt_batch, duplicate_prompt_batch, get_prompt_batch,
+    list_prompt_batches, update_prompt_batch,
 };
 mod credentials;
 use credentials::{delete_credential, list_credentials, set_credential};
@@ -1102,6 +1107,20 @@ pub(crate) fn create_app_with_state(
         .route(
             "/api/v1/recipe-presets/:preset_id/duplicate",
             post(duplicate_recipe_preset),
+        )
+        .route(
+            "/api/v1/prompt-batches",
+            get(list_prompt_batches).post(create_prompt_batch),
+        )
+        .route(
+            "/api/v1/prompt-batches/:batch_id",
+            get(get_prompt_batch)
+                .patch(update_prompt_batch)
+                .delete(delete_prompt_batch),
+        )
+        .route(
+            "/api/v1/prompt-batches/:batch_id/duplicate",
+            post(duplicate_prompt_batch),
         )
         .route("/api/v1/jobs", get(list_jobs).post(create_job))
         .route("/api/v1/jobs/claim", post(claim_job))

--- a/apps/rust-api/src/prompt_batches.rs
+++ b/apps/rust-api/src/prompt_batches.rs
@@ -1,0 +1,548 @@
+// Prompt-batch persistence (sc-9954, epic 9952 — Batch Prompt Processing).
+// A prompt batch is a saved, named list of prompt templates plus their variable
+// definitions ({key, values[]}). It is a sibling of a recipe preset — same
+// global/project JSONC-manifest storage and the same scope/write-location model —
+// but deliberately NOT a recipe: it has no model, workflow, or LoRA, so none of the
+// recipe validators apply. Storage: `user.prompt-batches.jsonc` (global) and a
+// per-project `recipes/prompt-batches.jsonc`, mutated through the shared
+// manifest read→merge→save helpers. Generic slug/duplicate helpers are reused from
+// `recipe_presets`; batch-specific shape validation lives here.
+
+use super::*;
+// Generic (non-recipe-specific) helpers reused from the recipe-preset module: slug,
+// duplicate-id/name suffixing, and the shared payload/field validators.
+use super::recipe_presets::{
+    next_duplicate_preset_id, next_duplicate_preset_name, slugify_preset_id, take_string_field,
+    validate_required_string_field,
+};
+
+const MANIFEST_FIELD: &str = "batches";
+
+pub(crate) async fn list_prompt_batches(
+    State(state): State<AppState>,
+    Query(query): Query<PromptBatchesQuery>,
+) -> Result<Json<Vec<Value>>, ApiError> {
+    validate_prompt_batch_query(&query)?;
+    let mut batches = prompt_batch_catalog(&state, query.project_id.as_deref()).await?;
+    if !query.include_archived.unwrap_or(false) {
+        batches.retain(|batch| !prompt_batch_archived(batch));
+    }
+    if let Some(scope) = query.scope.as_deref() {
+        batches.retain(|batch| batch.get("scope").and_then(Value::as_str) == Some(scope));
+    }
+    Ok(Json(batches))
+}
+
+pub(crate) async fn get_prompt_batch(
+    State(state): State<AppState>,
+    Path(batch_id): Path<String>,
+    Query(query): Query<PromptBatchesQuery>,
+) -> Result<Json<Value>, ApiError> {
+    validate_prompt_batch_query(&query)?;
+    let batch = prompt_batch_catalog(&state, query.project_id.as_deref())
+        .await?
+        .into_iter()
+        .find(|batch| batch.get("id").and_then(Value::as_str) == Some(batch_id.as_str()))
+        .filter(|batch| {
+            query.scope.as_deref().map_or(true, |scope| {
+                batch.get("scope").and_then(Value::as_str) == Some(scope)
+            })
+        })
+        .filter(|batch| query.include_archived.unwrap_or(false) || !prompt_batch_archived(batch))
+        .ok_or_else(prompt_batch_not_found)?;
+    Ok(Json(batch))
+}
+
+pub(crate) async fn create_prompt_batch(
+    State(state): State<AppState>,
+    Query(query): Query<PromptBatchesQuery>,
+    ApiJson(payload): ApiJson<Value>,
+) -> Result<(StatusCode, Json<Value>), ApiError> {
+    validate_prompt_batch_query(&query)?;
+    let mut batch = prompt_batch_from_payload(payload)?;
+    let scope = prompt_batch_write_scope(query.scope.as_deref(), prompt_batch_scope(&batch))?;
+    let project_id = prompt_batch_context_project_id(&query, &mut batch);
+    let manifest_path =
+        prompt_batch_write_manifest_path(&state, &scope, project_id.as_deref()).await?;
+    let object = batch
+        .as_object_mut()
+        .ok_or_else(|| ApiError::bad_request("Prompt batch must be an object"))?;
+    let id = object
+        .get("id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .or_else(|| {
+            object
+                .get("name")
+                .and_then(Value::as_str)
+                .map(slugify_preset_id)
+        })
+        .ok_or_else(|| ApiError::bad_request("Prompt batch name is required"))?;
+    object.insert("id".to_owned(), Value::String(id.clone()));
+    let timestamp = now_rfc3339();
+    object
+        .entry("createdAt".to_owned())
+        .or_insert_with(|| Value::String(timestamp.clone()));
+    object.insert("updatedAt".to_owned(), Value::String(timestamp));
+    let batch = mutate_manifest_entries(&state, &manifest_path, MANIFEST_FIELD, |mut entries| {
+        let batch = normalize_prompt_batch_for_write(batch, &scope, true)?;
+        if entries
+            .iter()
+            .any(|entry| entry.get("id").and_then(Value::as_str) == Some(id.as_str()))
+        {
+            return Err(ApiError::bad_request("Prompt batch already exists"));
+        }
+        entries.push(batch.clone());
+        Ok((entries, batch))
+    })
+    .await?;
+    Ok((StatusCode::CREATED, Json(batch)))
+}
+
+pub(crate) async fn update_prompt_batch(
+    State(state): State<AppState>,
+    Path(batch_id): Path<String>,
+    Query(query): Query<PromptBatchesQuery>,
+    ApiJson(payload): ApiJson<Value>,
+) -> Result<Json<Value>, ApiError> {
+    validate_prompt_batch_query(&query)?;
+    let mut patch = prompt_batch_from_payload(payload)?;
+    let project_id = prompt_batch_context_project_id(&query, &mut patch);
+    strip_prompt_batch_write_context(&mut patch);
+    let location = find_prompt_batch_write_location(
+        &state,
+        &batch_id,
+        project_id.as_deref(),
+        query.scope.as_deref(),
+    )
+    .await?;
+    let batch = mutate_manifest_entries(
+        &state,
+        &location.manifest_path,
+        MANIFEST_FIELD,
+        |mut entries| {
+            let Some(index) = entries.iter().position(|entry| {
+                entry.get("id").and_then(Value::as_str) == Some(batch_id.as_str())
+            }) else {
+                return Err(prompt_batch_not_found());
+            };
+            let mut batch = entries[index].clone();
+            merge_object(&mut batch, patch);
+            if let Some(object) = batch.as_object_mut() {
+                object.insert("id".to_owned(), Value::String(batch_id.clone()));
+                object.insert("updatedAt".to_owned(), Value::String(now_rfc3339()));
+            }
+            let batch = normalize_prompt_batch_for_write(batch, &location.scope, false)?;
+            entries[index] = batch.clone();
+            Ok((entries, batch))
+        },
+    )
+    .await?;
+    Ok(Json(batch))
+}
+
+pub(crate) async fn delete_prompt_batch(
+    State(state): State<AppState>,
+    Path(batch_id): Path<String>,
+    Query(query): Query<PromptBatchesQuery>,
+) -> Result<Json<Value>, ApiError> {
+    validate_prompt_batch_query(&query)?;
+    let location = find_prompt_batch_write_location(
+        &state,
+        &batch_id,
+        query.project_id.as_deref(),
+        query.scope.as_deref(),
+    )
+    .await?;
+    let batch = mutate_manifest_entries(
+        &state,
+        &location.manifest_path,
+        MANIFEST_FIELD,
+        |mut entries| {
+            let Some(index) = entries.iter().position(|entry| {
+                entry.get("id").and_then(Value::as_str) == Some(batch_id.as_str())
+            }) else {
+                return Err(prompt_batch_not_found());
+            };
+            let mut batch = entries[index].clone();
+            if let Some(object) = batch.as_object_mut() {
+                object.insert("archived".to_owned(), Value::Bool(true));
+                object.insert("updatedAt".to_owned(), Value::String(now_rfc3339()));
+            }
+            let batch = normalize_prompt_batch_for_write(batch, &location.scope, false)?;
+            entries[index] = batch.clone();
+            Ok((entries, batch))
+        },
+    )
+    .await?;
+    Ok(Json(batch))
+}
+
+pub(crate) async fn duplicate_prompt_batch(
+    State(state): State<AppState>,
+    Path(batch_id): Path<String>,
+    Query(query): Query<PromptBatchesQuery>,
+) -> Result<(StatusCode, Json<Value>), ApiError> {
+    validate_prompt_batch_query(&query)?;
+    let location = find_prompt_batch_write_location(
+        &state,
+        &batch_id,
+        query.project_id.as_deref(),
+        query.scope.as_deref(),
+    )
+    .await?;
+    let batch = mutate_manifest_entries(
+        &state,
+        &location.manifest_path,
+        MANIFEST_FIELD,
+        |mut entries| {
+            let Some(source) = entries
+                .iter()
+                .find(|entry| entry.get("id").and_then(Value::as_str) == Some(batch_id.as_str()))
+                .cloned()
+            else {
+                return Err(prompt_batch_not_found());
+            };
+            let mut duplicate = source;
+            if let Some(object) = duplicate.as_object_mut() {
+                object.remove("manifestPath");
+            }
+            let base_id = duplicate
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or(batch_id.as_str());
+            let duplicate_id = next_duplicate_preset_id(&entries, base_id);
+            let duplicate_name = next_duplicate_preset_name(
+                &entries,
+                duplicate
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or(base_id),
+            );
+            let timestamp = now_rfc3339();
+            if let Some(object) = duplicate.as_object_mut() {
+                object.insert("id".to_owned(), Value::String(duplicate_id));
+                object.insert("name".to_owned(), Value::String(duplicate_name));
+                object.insert("scope".to_owned(), Value::String(location.scope.clone()));
+                object.insert("archived".to_owned(), Value::Bool(false));
+                object.insert("createdAt".to_owned(), Value::String(timestamp.clone()));
+                object.insert("updatedAt".to_owned(), Value::String(timestamp));
+            }
+            let duplicate = normalize_prompt_batch_for_write(duplicate, &location.scope, true)?;
+            entries.push(duplicate.clone());
+            Ok((entries, duplicate))
+        },
+    )
+    .await?;
+    Ok((StatusCode::CREATED, Json(batch)))
+}
+
+pub(crate) async fn prompt_batch_catalog(
+    state: &AppState,
+    project_id: Option<&str>,
+) -> Result<Vec<Value>, ApiError> {
+    let manifest_dir = state.settings.config_dir.join("manifests");
+    let user_manifest = manifest_dir.join("user.prompt-batches.jsonc");
+    let mut batches = load_manifest_entries(state, &user_manifest, MANIFEST_FIELD)
+        .await?
+        .into_iter()
+        .map(|batch| normalize_prompt_batch_entry(batch, "global", &user_manifest))
+        .collect::<Result<Vec<_>, _>>()?;
+    if let Some(project_id) = project_id {
+        let project_path = project_path_for_id(state.clone(), project_id).await?;
+        let project_manifest = project_path.join("recipes").join("prompt-batches.jsonc");
+        let project_batches = load_manifest_entries(state, &project_manifest, MANIFEST_FIELD)
+            .await?
+            .into_iter()
+            .map(|batch| normalize_prompt_batch_entry(batch, "project", &project_manifest))
+            .collect::<Result<Vec<_>, _>>()?;
+        batches = merge_entries_by_id(batches, project_batches);
+    }
+    batches.sort_by(|left, right| {
+        let key = |batch: &Value| {
+            (
+                prompt_batch_scope_order(batch.get("scope").and_then(Value::as_str)),
+                batch
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_lowercase(),
+            )
+        };
+        key(left).cmp(&key(right))
+    });
+    Ok(batches)
+}
+
+fn prompt_batch_scope_order(scope: Option<&str>) -> u8 {
+    match scope {
+        Some("global") => 0,
+        Some("project") => 1,
+        _ => 2,
+    }
+}
+
+fn normalize_prompt_batch_entry(
+    mut batch: Value,
+    scope: &str,
+    manifest_path: &FsPath,
+) -> Result<Value, ApiError> {
+    let object = batch
+        .as_object_mut()
+        .ok_or_else(|| ApiError::internal("Prompt batch manifest entry must be an object"))?;
+    object
+        .entry("scope".to_owned())
+        .or_insert_with(|| Value::String(scope.to_owned()));
+    object
+        .entry("prompts".to_owned())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    object
+        .entry("variables".to_owned())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    object.insert(
+        "manifestPath".to_owned(),
+        Value::String(manifest_path.display().to_string()),
+    );
+    Ok(batch)
+}
+
+fn prompt_batch_archived(batch: &Value) -> bool {
+    batch
+        .get("archived")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn prompt_batch_from_payload(payload: Value) -> Result<Value, ApiError> {
+    match payload {
+        Value::Null => Ok(Value::Object(JsonObject::new())),
+        Value::Object(_) => Ok(payload),
+        _ => Err(ApiError::bad_request(
+            "Prompt batch payload must be an object",
+        )),
+    }
+}
+
+fn prompt_batch_scope(batch: &Value) -> Option<&str> {
+    batch.get("scope").and_then(Value::as_str)
+}
+
+fn prompt_batch_context_project_id(
+    query: &PromptBatchesQuery,
+    payload: &mut Value,
+) -> Option<String> {
+    query
+        .project_id
+        .clone()
+        .or_else(|| take_string_field(payload, "projectId"))
+}
+
+fn strip_prompt_batch_write_context(payload: &mut Value) {
+    if let Some(object) = payload.as_object_mut() {
+        object.remove("projectId");
+        object.remove("scope");
+        object.remove("manifestPath");
+    }
+}
+
+fn prompt_batch_write_scope(
+    query_scope: Option<&str>,
+    payload_scope: Option<&str>,
+) -> Result<String, ApiError> {
+    let scope = query_scope.or(payload_scope).unwrap_or("global").trim();
+    match scope {
+        "global" | "project" => Ok(scope.to_owned()),
+        _ => Err(ApiError::bad_request(
+            "Prompt batch scope must be global or project",
+        )),
+    }
+}
+
+fn validate_prompt_batch_query(query: &PromptBatchesQuery) -> Result<(), ApiError> {
+    if let Some(scope) = query.scope.as_deref() {
+        match scope {
+            "global" | "project" => {}
+            _ => return Err(ApiError::bad_request("Unsupported prompt batch scope")),
+        }
+    }
+    Ok(())
+}
+
+async fn prompt_batch_write_manifest_path(
+    state: &AppState,
+    scope: &str,
+    project_id: Option<&str>,
+) -> Result<PathBuf, ApiError> {
+    match scope {
+        "global" => Ok(state
+            .settings
+            .config_dir
+            .join("manifests")
+            .join("user.prompt-batches.jsonc")),
+        "project" => {
+            let Some(project_id) = project_id else {
+                return Err(ApiError::bad_request(
+                    "Project prompt batches require projectId",
+                ));
+            };
+            let project_path = project_path_for_id(state.clone(), project_id).await?;
+            Ok(project_path.join("recipes").join("prompt-batches.jsonc"))
+        }
+        _ => Err(ApiError::bad_request(
+            "Prompt batch scope must be global or project",
+        )),
+    }
+}
+
+struct PromptBatchWriteLocation {
+    scope: String,
+    manifest_path: PathBuf,
+}
+
+fn prompt_batch_not_found() -> ApiError {
+    ApiError {
+        status: StatusCode::NOT_FOUND,
+        detail: "Prompt batch not found".to_owned(),
+    }
+}
+
+async fn find_prompt_batch_write_location(
+    state: &AppState,
+    batch_id: &str,
+    project_id: Option<&str>,
+    scope: Option<&str>,
+) -> Result<PromptBatchWriteLocation, ApiError> {
+    match scope {
+        Some("global") => {
+            return prompt_batch_location_if_present(state, batch_id, "global", project_id).await
+        }
+        Some("project") => {
+            return prompt_batch_location_if_present(state, batch_id, "project", project_id).await
+        }
+        Some(_) => return Err(ApiError::bad_request("Unsupported prompt batch scope")),
+        None => {}
+    }
+
+    if project_id.is_some() {
+        match prompt_batch_location_if_present(state, batch_id, "project", project_id).await {
+            Ok(location) => return Ok(location),
+            Err(error) if error.status == StatusCode::NOT_FOUND => {}
+            Err(error) => return Err(error),
+        }
+    }
+    prompt_batch_location_if_present(state, batch_id, "global", project_id).await
+}
+
+async fn prompt_batch_location_if_present(
+    state: &AppState,
+    batch_id: &str,
+    scope: &str,
+    project_id: Option<&str>,
+) -> Result<PromptBatchWriteLocation, ApiError> {
+    let manifest_path = prompt_batch_write_manifest_path(state, scope, project_id).await?;
+    let entries = load_manifest_entries(state, &manifest_path, MANIFEST_FIELD).await?;
+    if entries
+        .iter()
+        .any(|entry| entry.get("id").and_then(Value::as_str) == Some(batch_id))
+    {
+        Ok(PromptBatchWriteLocation {
+            scope: scope.to_owned(),
+            manifest_path,
+        })
+    } else {
+        Err(prompt_batch_not_found())
+    }
+}
+
+fn normalize_prompt_batch_for_write(
+    mut batch: Value,
+    scope: &str,
+    require_all: bool,
+) -> Result<Value, ApiError> {
+    let object = batch
+        .as_object_mut()
+        .ok_or_else(|| ApiError::bad_request("Prompt batch must be an object"))?;
+    object.insert("scope".to_owned(), Value::String(scope.to_owned()));
+    validate_prompt_batch_id(object.get("id").and_then(Value::as_str))?;
+    validate_required_string_field(object, "name", require_all, "Prompt batch name is required")?;
+    validate_prompt_batch_prompts(object.get("prompts"))?;
+    validate_prompt_batch_variables(object.get("variables"))?;
+    validate_prompt_batch_last_values(object.get("lastValues"))?;
+    Ok(batch)
+}
+
+fn validate_prompt_batch_id(value: Option<&str>) -> Result<(), ApiError> {
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Err(ApiError::bad_request("Prompt batch id is required"));
+    };
+    let valid = value.chars().enumerate().all(|(index, character)| {
+        character.is_ascii_lowercase()
+            || character.is_ascii_digit()
+            || (index > 0 && matches!(character, '_' | '-'))
+    });
+    if !valid {
+        return Err(ApiError::bad_request(
+            "Prompt batch id must use lowercase letters, numbers, dashes, or underscores",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_prompt_batch_prompts(value: Option<&Value>) -> Result<(), ApiError> {
+    let Some(prompts) = value else {
+        return Ok(());
+    };
+    let items = prompts
+        .as_array()
+        .ok_or_else(|| ApiError::bad_request("Prompt batch prompts must be an array"))?;
+    if items.iter().any(|item| !item.is_string()) {
+        return Err(ApiError::bad_request(
+            "Prompt batch prompts must be an array of strings",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_prompt_batch_variables(value: Option<&Value>) -> Result<(), ApiError> {
+    let Some(variables) = value else {
+        return Ok(());
+    };
+    let items = variables
+        .as_array()
+        .ok_or_else(|| ApiError::bad_request("Prompt batch variables must be an array"))?;
+    for item in items {
+        let object = item
+            .as_object()
+            .ok_or_else(|| ApiError::bad_request("Prompt batch variable must be an object"))?;
+        match object.get("key").and_then(Value::as_str).map(str::trim) {
+            Some(key) if !key.is_empty() => {}
+            _ => {
+                return Err(ApiError::bad_request(
+                    "Prompt batch variable key is required",
+                ))
+            }
+        }
+        if let Some(values) = object.get("values") {
+            let values = values.as_array().ok_or_else(|| {
+                ApiError::bad_request("Prompt batch variable values must be an array")
+            })?;
+            if values.iter().any(|value| !value.is_string()) {
+                return Err(ApiError::bad_request(
+                    "Prompt batch variable values must be an array of strings",
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_prompt_batch_last_values(value: Option<&Value>) -> Result<(), ApiError> {
+    if value.is_some_and(|value| !value.is_object()) {
+        return Err(ApiError::bad_request(
+            "Prompt batch lastValues must be an object",
+        ));
+    }
+    Ok(())
+}

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -8746,6 +8746,174 @@ async fn recipe_preset_crud_routes_persist_global_and_project_presets() {
 }
 
 #[tokio::test]
+async fn prompt_batch_crud_routes_persist_global_and_project_batches() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    // Create a global batch with templated prompts + multi-valued variables.
+    let (status, created) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/prompt-batches",
+        json!({
+            "name": "Character Turnaround",
+            "prompts": [
+                "{{name}} with {{hair}} hair, front view",
+                "{{name}} with {{hair}} hair, profile"
+            ],
+            "variables": [
+                { "key": "name", "values": ["Alice"] },
+                { "key": "hair", "values": ["red", "blue"] }
+            ],
+            "lastValues": { "name": ["Alice"], "hair": ["red", "blue"] }
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(created["id"], "character_turnaround");
+    assert_eq!(created["scope"], "global");
+    assert_eq!(
+        created["prompts"][0],
+        "{{name}} with {{hair}} hair, front view"
+    );
+    assert_eq!(created["variables"][1]["values"][1], "blue");
+    assert!(created["createdAt"].is_string());
+    assert!(created["updatedAt"].is_string());
+
+    let (status, list) = request(app.clone(), "GET", "/api/v1/prompt-batches", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(list.as_array().expect("list array").len(), 1);
+    assert_eq!(list[0]["id"], "character_turnaround");
+
+    let (status, fetched) = request(
+        app.clone(),
+        "GET",
+        "/api/v1/prompt-batches/character_turnaround",
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(fetched["name"], "Character Turnaround");
+
+    // Patch replaces prompts + variables and stamps updatedAt.
+    let (status, updated) = request(
+        app.clone(),
+        "PATCH",
+        "/api/v1/prompt-batches/character_turnaround",
+        json!({
+            "prompts": ["{{name}} smiling"],
+            "variables": [{ "key": "name", "values": ["Bob"] }]
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(updated["prompts"].as_array().expect("prompts").len(), 1);
+    assert_eq!(updated["variables"][0]["values"][0], "Bob");
+
+    // Duplicate carries the current (patched) state under a copied id/name.
+    let (status, duplicated) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/prompt-batches/character_turnaround/duplicate",
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(duplicated["id"], "character_turnaround_copy");
+    assert_eq!(duplicated["name"], "Character Turnaround Copy");
+    assert_eq!(duplicated["prompts"][0], "{{name}} smiling");
+
+    // Non-string variable values are rejected.
+    let (status, bad) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/prompt-batches",
+        json!({ "name": "Bad", "variables": [{ "key": "x", "values": [1, 2] }] }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        bad["detail"],
+        "Prompt batch variable values must be an array of strings"
+    );
+
+    // Read-only-ish scopes are rejected on the query.
+    let (status, _) = request(
+        app.clone(),
+        "GET",
+        "/api/v1/prompt-batches?scope=builtin",
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    // Project-scoped batch lives in the project's own manifest.
+    let (status, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Batch Project" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let project_id = project["id"].as_str().expect("project id").to_owned();
+
+    let (status, project_batch) = request(
+        app.clone(),
+        "POST",
+        &format!("/api/v1/prompt-batches?scope=project&projectId={project_id}"),
+        json!({
+            "name": "Project Batch",
+            "prompts": ["{{subject}} portrait"],
+            "variables": [{ "key": "subject", "values": ["cat"] }]
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(project_batch["scope"], "project");
+
+    // With the project in context, both global and project batches list together.
+    let (status, both) = request(
+        app.clone(),
+        "GET",
+        &format!("/api/v1/prompt-batches?projectId={project_id}"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let ids: Vec<&str> = both
+        .as_array()
+        .expect("both array")
+        .iter()
+        .filter_map(|batch| batch["id"].as_str())
+        .collect();
+    assert!(ids.contains(&"character_turnaround"));
+    assert!(ids.contains(&"project_batch"));
+
+    // Delete soft-archives: hidden from the default list, duplicate survives.
+    let (status, archived) = request(
+        app.clone(),
+        "DELETE",
+        "/api/v1/prompt-batches/character_turnaround",
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(archived["archived"], true);
+
+    let (status, after) = request(app.clone(), "GET", "/api/v1/prompt-batches", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    let remaining: Vec<&str> = after
+        .as_array()
+        .expect("after array")
+        .iter()
+        .filter_map(|batch| batch["id"].as_str())
+        .collect();
+    assert!(!remaining.contains(&"character_turnaround"));
+    assert!(remaining.contains(&"character_turnaround_copy"));
+}
+
+#[tokio::test]
 async fn recipe_preset_accepts_full_studio_snapshot_and_rejects_bad_defaults() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -27,6 +27,7 @@ import { editModelForAsset } from "./presetUtils.js";
 import { sortNewest, sortWorkers, upsertJobNewest } from "./sorters.js";
 import { useCharacters } from "./hooks/useCharacters.js";
 import { usePresets } from "./hooks/usePresets.js";
+import { usePromptBatches } from "./hooks/usePromptBatches.js";
 import { useTraining } from "./hooks/useTraining.js";
 import { useModelsAndLoras } from "./hooks/useModelsAndLoras.js";
 import { usePersonTracks } from "./hooks/usePersonTracks.js";
@@ -461,6 +462,7 @@ export function App() {
   const refreshCharactersRef = useRef(null);
   const refreshLorasRef = useRef(null);
   const refreshPresetsRef = useRef(null);
+  const refreshPromptBatchesRef = useRef(null);
   const refreshTrainingDatasetsRef = useRef(null);
   const refreshPersonTracksRef = useRef(null);
   const refreshTimelinesRef = useRef(null);
@@ -573,6 +575,16 @@ export function App() {
     duplicatePreset,
     deletePreset,
   } = usePresets({ token, activeProject, setError });
+
+  const {
+    promptBatches,
+    setPromptBatches,
+    refreshPromptBatches,
+    createPromptBatch,
+    updatePromptBatch,
+    duplicatePromptBatch,
+    deletePromptBatch,
+  } = usePromptBatches({ token, activeProject, setError });
 
   const {
     trainingDatasets,
@@ -1024,6 +1036,7 @@ export function App() {
     refreshCharactersRef.current?.(activeProject.id, { signal });
     refreshLorasRef.current?.(activeProject.id, { signal });
     refreshPresetsRef.current?.(activeProject.id, { signal });
+    refreshPromptBatchesRef.current?.(activeProject.id, { signal });
     refreshTrainingDatasetsRef.current?.(activeProject.id, { signal });
     refreshPersonTracksRef.current?.(activeProject.id, { signal });
     refreshTimelinesRef.current?.(activeProject.id, { signal });
@@ -1081,6 +1094,7 @@ export function App() {
       presetsResult,
       trainingTargetsResult,
       trainingPresetsResult,
+      promptBatchesResult,
     ] =
       await Promise.all([
         fetchInitial("Projects", "/api/v1/projects", []),
@@ -1091,6 +1105,7 @@ export function App() {
         fetchInitial("Presets", "/api/v1/recipe-presets", [], true),
         fetchInitial("Training targets", "/api/v1/training/targets", { schemaVersion: 1, targets: [] }),
         fetchInitial("Training presets", "/api/v1/training/presets", { schemaVersion: 1, presets: [] }),
+        fetchInitial("Prompt batches", "/api/v1/prompt-batches", [], true),
       ]);
     // Mac UI gating (sc-3486): optional + non-fatal — a fetch failure leaves gating inert.
     fetchInitial("Mac capabilities", "/api/v1/capabilities/mac", DEFAULT_MAC_CAPABILITIES, true)
@@ -1106,6 +1121,7 @@ export function App() {
     setModels(modelsResult.value);
     setLoras(lorasResult.value);
     setPresets(presetsResult.value);
+    setPromptBatches(promptBatchesResult.value);
     setTrainingTargets(trainingTargetsResult.value);
     setTrainingTargetsError(trainingTargetsResult.error);
     setTrainingPresets(trainingPresetsResult.value);
@@ -1176,6 +1192,7 @@ export function App() {
     refreshCharactersRef.current = refreshCharacters;
     refreshLorasRef.current = refreshLoras;
     refreshPresetsRef.current = refreshPresets;
+    refreshPromptBatchesRef.current = refreshPromptBatches;
     refreshTrainingDatasetsRef.current = refreshTrainingDatasets;
     refreshPersonTracksRef.current = refreshPersonTracks;
     refreshTimelinesRef.current = refreshTimelines;
@@ -1938,6 +1955,12 @@ export function App() {
     updatePreset,
     deletePreset,
     duplicatePreset,
+    // Prompt batches (sc-9954, epic 9952)
+    promptBatches,
+    createPromptBatch,
+    updatePromptBatch,
+    deletePromptBatch,
+    duplicatePromptBatch,
     // Auth (sc-4168): pairing token for screens that call apiFetch directly
     // (Image Editor, Logs, Pose Library, useUserPoseLoader). Empty string when
     // the deployment doesn't require auth.
@@ -2011,6 +2034,7 @@ export function App() {
     loras, deleteLora, deleteModel, createModelDownloadJob, createLoraDownloadJob, createModelConvertJob,
     createLoraImportJob, createModelImportJob, requestedGpu, setRequestedGpu,
     presets, createPreset, updatePreset, deletePreset, duplicatePreset, token, authenticated,
+    promptBatches, createPromptBatch, updatePromptBatch, deletePromptBatch, duplicatePromptBatch,
     trainingDatasets, trainingDatasetsProjectId, trainingDatasetsError, loadingTrainingDatasets,
     refreshTrainingDatasets, loadTrainingDataset, loadTrainingDatasetReadiness, setTrainingDatasetItemQualityAck, createTrainingDataset, uploadTrainingDatasetItem,
     updateTrainingDataset, batchRenameTrainingDataset, writeTrainingDatasetCaptionSidecars,

--- a/apps/web/src/components/BatchPromptPanel.jsx
+++ b/apps/web/src/components/BatchPromptPanel.jsx
@@ -1,0 +1,284 @@
+import React, { useMemo, useRef, useState } from "react";
+
+import {
+  cardinality,
+  expandBatch,
+  extractKeys,
+  missingKeys,
+  splitPromptLines,
+} from "../promptBatch.js";
+import { fromPromptBatchImport, serializePromptBatchExport } from "../promptBatchIO.js";
+import { Icon } from "./Icons.jsx";
+
+// Batch authoring panel (sc-9955, epic 9952). Rendered in place of the single-prompt
+// area when Image Studio's Batch mode is on. Owns the prompt-list textarea, the
+// per-variable chip editors, the live preview + total, and the save/load/export/import
+// controls. Pure UI over slice 1's engine (promptBatch.js) and slice 2's persistence
+// (usePromptBatches via callbacks + promptBatchIO for the portable file). The actual
+// fan-out on "Run batch" is wired by the parent (slice 4, sc-9956).
+
+// One variable's chip editor: type a value, Enter/"Add" appends a chip. Values may
+// contain commas ("red, wavy"), so this is a chip list — never a comma split.
+function VariableChips({ label, values, onChange }) {
+  const [draft, setDraft] = useState("");
+  const add = () => {
+    const value = draft.trim();
+    if (!value) return;
+    onChange([...values, value]);
+    setDraft("");
+  };
+  return (
+    <div className="batch-var">
+      <div className="batch-var-head">
+        <code className="batch-var-key">{`{{${label}}}`}</code>
+        <span className="batch-var-count">{values.length === 1 ? "1 value" : `${values.length} values`}</span>
+      </div>
+      <div className="batch-var-chips">
+        {values.map((value, index) => (
+          <span className="batch-chip" key={`${value}-${index}`}>
+            {value}
+            <button
+              aria-label={`Remove ${value}`}
+              className="batch-chip-remove"
+              onClick={() => onChange(values.filter((_, i) => i !== index))}
+              type="button"
+            >
+              ×
+            </button>
+          </span>
+        ))}
+        <input
+          aria-label={`Add a value for ${label}`}
+          className="batch-var-input"
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              add();
+            }
+          }}
+          placeholder={values.length ? "Add another…" : "Type a value, press Enter"}
+          value={draft}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function BatchPromptPanel({
+  promptsText,
+  onPromptsTextChange,
+  variableValues,
+  onVariableValuesChange,
+  count = 1,
+  batches = [],
+  projectId = null,
+  name,
+  onNameChange,
+  scope,
+  onScopeChange,
+  loadedBatchId = null,
+  onSave,
+  onLoad,
+  onDelete,
+  onImport,
+  busy = false,
+  error = "",
+}) {
+  const fileInputRef = useRef(null);
+  const [ioError, setIoError] = useState("");
+
+  const prompts = useMemo(() => splitPromptLines(promptsText), [promptsText]);
+  const keys = useMemo(() => extractKeys(prompts), [prompts]);
+  const variables = useMemo(
+    () => keys.map((key) => ({ key, values: variableValues[key] ?? [] })),
+    [keys, variableValues],
+  );
+  const total = useMemo(() => cardinality(prompts, variables, count), [prompts, variables, count]);
+  const previewPrompt = useMemo(() => expandBatch(prompts, variables)[0]?.prompt ?? "", [prompts, variables]);
+  const missing = useMemo(() => missingKeys(prompts, variables), [prompts, variables]);
+
+  const setKeyValues = (key, values) =>
+    onVariableValuesChange({ ...variableValues, [key]: values });
+
+  const currentExport = () => ({
+    name,
+    prompts,
+    variables,
+    lastValues: Object.fromEntries(variables.map((variable) => [variable.key, variable.values])),
+  });
+
+  const handleExport = () => {
+    setIoError("");
+    const blob = new Blob([serializePromptBatchExport(currentExport())], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    const slug = (name || "prompt-batch").trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+    anchor.download = `${slug || "prompt-batch"}.json`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImportFile = async (event) => {
+    setIoError("");
+    const file = event.target.files?.[0];
+    event.target.value = ""; // allow re-importing the same file
+    if (!file) return;
+    try {
+      const payload = fromPromptBatchImport(await file.text());
+      onImport(payload);
+    } catch (importError) {
+      setIoError(importError.message);
+    }
+  };
+
+  const promptCount = prompts.length;
+  const saveDisabled = busy || !name.trim() || promptCount === 0;
+
+  return (
+    <div className="batch-panel">
+      <div className="batch-panel-main">
+        <label className="batch-field">
+          <span className="batch-field-label">Prompts — one per line</span>
+          <textarea
+            aria-label="Batch prompts"
+            className="batch-prompts"
+            onChange={(event) => onPromptsTextChange(event.target.value)}
+            placeholder={"{{name}} with {{hair}} hair, front view\n{{name}} profile, soft light\n\nUse --- on its own line for multi-line prompts"}
+            value={promptsText}
+          />
+        </label>
+
+        {keys.length > 0 ? (
+          <div className="batch-vars">
+            <span className="batch-field-label">Variables</span>
+            {keys.map((key) => (
+              <VariableChips
+                key={key}
+                label={key}
+                values={variableValues[key] ?? []}
+                onChange={(values) => setKeyValues(key, values)}
+              />
+            ))}
+          </div>
+        ) : (
+          <p className="batch-hint">
+            Add <code>{"{{placeholders}}"}</code> in your prompts (e.g. <code>{"{{name}}"}</code>) to get a value box per
+            variable.
+          </p>
+        )}
+
+        {previewPrompt ? (
+          <div className="batch-preview">
+            <span className="batch-field-label">First prompt preview</span>
+            <p className="batch-preview-text">{previewPrompt}</p>
+          </div>
+        ) : null}
+
+        <div className="batch-total" aria-live="polite">
+          <strong>{total}</strong> {total === 1 ? "image" : "images"}
+          <span className="batch-total-detail">
+            {promptCount} {promptCount === 1 ? "prompt" : "prompts"} × {count} {count === 1 ? "variation" : "variations"}
+            {variables.some((variable) => variable.values.length > 1) ? " × variable values" : ""}
+          </span>
+        </div>
+
+        {missing.length > 0 ? (
+          <p className="batch-warning" role="status">
+            Add at least one value for: {missing.map((key) => `{{${key}}}`).join(", ")}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="batch-panel-side">
+        <div className="batch-save">
+          <span className="batch-field-label">Save this batch</span>
+          <input
+            aria-label="Batch name"
+            className="batch-name"
+            onChange={(event) => onNameChange(event.target.value)}
+            placeholder="Batch name"
+            value={name}
+          />
+          <div className="batch-scope">
+            <label>
+              <input
+                checked={scope === "global"}
+                name="batch-scope"
+                onChange={() => onScopeChange("global")}
+                type="radio"
+              />
+              Global
+            </label>
+            <label className={projectId ? "" : "batch-scope-disabled"}>
+              <input
+                checked={scope === "project"}
+                disabled={!projectId}
+                name="batch-scope"
+                onChange={() => onScopeChange("project")}
+                type="radio"
+              />
+              This project
+            </label>
+          </div>
+          <button className="batch-btn" disabled={saveDisabled} onClick={onSave} type="button">
+            <Icon.Preset size={14} /> {loadedBatchId ? "Update" : "Save"}
+          </button>
+        </div>
+
+        <div className="batch-load">
+          <span className="batch-field-label">Saved batches</span>
+          {batches.length ? (
+            <ul className="batch-list">
+              {batches.map((batch) => (
+                <li className={batch.id === loadedBatchId ? "batch-list-item active" : "batch-list-item"} key={batch.id}>
+                  <button className="batch-list-load" onClick={() => onLoad(batch)} type="button">
+                    <Icon.Folder size={13} /> {batch.name}
+                    <span className="batch-list-scope">{batch.scope}</span>
+                  </button>
+                  <button
+                    aria-label={`Delete ${batch.name}`}
+                    className="batch-list-delete"
+                    onClick={() => onDelete(batch)}
+                    type="button"
+                  >
+                    ×
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="batch-hint">No saved batches yet.</p>
+          )}
+        </div>
+
+        <div className="batch-io">
+          <button className="batch-btn ghost" disabled={promptCount === 0} onClick={handleExport} type="button">
+            Export .json
+          </button>
+          <button className="batch-btn ghost" onClick={() => fileInputRef.current?.click()} type="button">
+            Import .json
+          </button>
+          <input
+            accept="application/json,.json"
+            className="batch-file-input"
+            onChange={handleImportFile}
+            ref={fileInputRef}
+            type="file"
+          />
+        </div>
+
+        {error || ioError ? (
+          <p className="batch-warning" role="alert">
+            {error || ioError}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/BatchPromptPanel.test.jsx
+++ b/apps/web/src/components/BatchPromptPanel.test.jsx
@@ -1,0 +1,125 @@
+import React, { act, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import BatchPromptPanel from "./BatchPromptPanel.jsx";
+
+// React controlled inputs ignore a direct `.value =`; drive them via the native setter.
+function setValue(el, value) {
+  const proto =
+    el instanceof window.HTMLTextAreaElement
+      ? window.HTMLTextAreaElement.prototype
+      : window.HTMLInputElement.prototype;
+  Object.getOwnPropertyDescriptor(proto, "value").set.call(el, value);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+  el.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+// The panel is fully controlled; a tiny stateful harness lets interactions actually
+// update prompts/variables/name the way Image Studio wires them.
+function Harness({ initialPrompts = "", count = 1, batches = [], onSave = vi.fn(), extra = {} }) {
+  const [promptsText, setPromptsText] = useState(initialPrompts);
+  const [variableValues, setVariableValues] = useState({});
+  const [name, setName] = useState("");
+  const [scope, setScope] = useState("global");
+  return (
+    <BatchPromptPanel
+      promptsText={promptsText}
+      onPromptsTextChange={setPromptsText}
+      variableValues={variableValues}
+      onVariableValuesChange={setVariableValues}
+      count={count}
+      batches={batches}
+      projectId={null}
+      name={name}
+      onNameChange={setName}
+      scope={scope}
+      onScopeChange={setScope}
+      onSave={onSave}
+      onLoad={vi.fn()}
+      onDelete={vi.fn()}
+      onImport={vi.fn()}
+      {...extra}
+    />
+  );
+}
+
+describe("BatchPromptPanel (sc-9955)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  const mount = (props) => act(() => root.render(<Harness {...props} />));
+  const varKeys = () => [...document.body.querySelectorAll(".batch-var-key")].map((el) => el.textContent);
+
+  it("renders a chip editor per unique {{key}} referenced in the prompts", () => {
+    mount({ initialPrompts: "{{name}} with {{hair}} hair\n{{name}} smiling" });
+    expect(varKeys()).toEqual(["{{name}}", "{{hair}}"]);
+  });
+
+  it("shows the placeholder hint when there are no variables", () => {
+    mount({ initialPrompts: "a plain prompt" });
+    expect(varKeys()).toEqual([]);
+    expect(document.body.querySelector(".batch-hint").textContent).toContain("placeholders");
+  });
+
+  it("reflects the live total (prompts × variations)", () => {
+    mount({ initialPrompts: "one\ntwo\nthree", count: 4 });
+    expect(document.body.querySelector(".batch-total strong").textContent).toBe("12");
+  });
+
+  it("adds a variable value as a chip on Enter and updates the total", async () => {
+    mount({ initialPrompts: "{{name}} portrait", count: 1 });
+    const input = document.body.querySelector(".batch-var-input");
+    await act(async () => {
+      setValue(input, "Alice");
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+    const chips = [...document.body.querySelectorAll(".batch-chip")].map((el) => el.textContent.replace("×", "").trim());
+    expect(chips).toContain("Alice");
+  });
+
+  it("disables Save until a name is entered", async () => {
+    mount({ initialPrompts: "one" });
+    const saveButton = [...document.body.querySelectorAll(".batch-btn")].find((b) => /Save|Update/.test(b.textContent));
+    expect(saveButton.disabled).toBe(true);
+    const nameInput = document.body.querySelector(".batch-name");
+    await act(async () => setValue(nameInput, "My Batch"));
+    expect(saveButton.disabled).toBe(false);
+  });
+
+  it("previews the first resolved prompt using entered values", async () => {
+    mount({ initialPrompts: "{{name}} portrait" });
+    const input = document.body.querySelector(".batch-var-input");
+    await act(async () => {
+      setValue(input, "Alice");
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+    expect(document.body.querySelector(".batch-preview-text").textContent).toBe("Alice portrait");
+  });
+
+  it("lists saved batches", () => {
+    mount({
+      batches: [
+        { id: "a", name: "Turnaround", scope: "global" },
+        { id: "b", name: "Angles", scope: "project" },
+      ],
+    });
+    expect([...document.body.querySelectorAll(".batch-list-load")].map((el) => el.textContent)).toEqual([
+      expect.stringContaining("Turnaround"),
+      expect.stringContaining("Angles"),
+    ]);
+  });
+});

--- a/apps/web/src/hooks/usePromptBatches.js
+++ b/apps/web/src/hooks/usePromptBatches.js
@@ -1,0 +1,107 @@
+import { useCallback, useState } from "react";
+import { apiFetch, isAbortError } from "../api.js";
+
+// Owns the prompt-batch list plus its scoped refresh/create/update/duplicate/delete
+// mutations (sc-9954, epic 9952). A direct sibling of usePresets — same scoping and
+// error handling — against the /api/v1/prompt-batches routes. Batches carry prompt
+// templates + variable definitions, not a generation recipe, so there is no
+// model/workflow filtering here.
+export function usePromptBatches({ token, activeProject, setError }) {
+  const [promptBatches, setPromptBatches] = useState([]);
+
+  const refreshPromptBatches = useCallback(
+    async (projectId = activeProject?.id, { signal } = {}) => {
+      try {
+        const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
+        const items = await apiFetch(`/api/v1/prompt-batches${query}`, token, { signal });
+        setPromptBatches(items);
+        setError("");
+        return items;
+      } catch (err) {
+        if (isAbortError(err)) return [];
+        setError(err.message);
+        return [];
+      }
+    },
+    [token, activeProject, setError],
+  );
+
+  const batchQuery = useCallback(
+    (scope = null) => {
+      const params = new URLSearchParams();
+      if (scope) {
+        params.set("scope", scope);
+      }
+      if (scope === "project" && activeProject?.id) {
+        params.set("projectId", activeProject.id);
+      }
+      const value = params.toString();
+      return value ? `?${value}` : "";
+    },
+    [activeProject],
+  );
+
+  const createPromptBatch = useCallback(
+    async (payload) => {
+      if (payload.scope === "project" && !activeProject) {
+        throw new Error("Create or open a project first.");
+      }
+      const created = await apiFetch(`/api/v1/prompt-batches${batchQuery(payload.scope)}`, token, {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+      await refreshPromptBatches(activeProject?.id);
+      return created;
+    },
+    [token, activeProject, batchQuery, refreshPromptBatches],
+  );
+
+  const updatePromptBatch = useCallback(
+    async (batchId, payload, scope = payload.scope) => {
+      const updated = await apiFetch(
+        `/api/v1/prompt-batches/${encodeURIComponent(batchId)}${batchQuery(scope)}`,
+        token,
+        { method: "PATCH", body: JSON.stringify(payload) },
+      );
+      await refreshPromptBatches(activeProject?.id);
+      return updated;
+    },
+    [token, activeProject, batchQuery, refreshPromptBatches],
+  );
+
+  const duplicatePromptBatch = useCallback(
+    async (batchId, scope = null) => {
+      const duplicated = await apiFetch(
+        `/api/v1/prompt-batches/${encodeURIComponent(batchId)}/duplicate${batchQuery(scope)}`,
+        token,
+        { method: "POST", body: JSON.stringify({}) },
+      );
+      await refreshPromptBatches(activeProject?.id);
+      return duplicated;
+    },
+    [token, activeProject, batchQuery, refreshPromptBatches],
+  );
+
+  const deletePromptBatch = useCallback(
+    async (batchId, scope = null) => {
+      const archived = await apiFetch(
+        `/api/v1/prompt-batches/${encodeURIComponent(batchId)}${batchQuery(scope)}`,
+        token,
+        { method: "DELETE" },
+      );
+      await refreshPromptBatches(activeProject?.id);
+      return archived;
+    },
+    [token, activeProject, batchQuery, refreshPromptBatches],
+  );
+
+  return {
+    promptBatches,
+    setPromptBatches,
+    refreshPromptBatches,
+    createPromptBatch,
+    updatePromptBatch,
+    duplicatePromptBatch,
+    deletePromptBatch,
+  };
+}

--- a/apps/web/src/promptBatch.js
+++ b/apps/web/src/promptBatch.js
@@ -80,6 +80,31 @@ function promptReferences(prompt, key) {
   return false;
 }
 
+// Turn the authoring textarea into a prompt-template array. Default is one prompt
+// per line (blank lines ignored) — the overwhelmingly common case of pasting a list.
+// For multi-line prompts, a line that is exactly `---` acts as an explicit delimiter;
+// as soon as any `---` line is present the whole text switches to block mode, where
+// each `---`-separated block (trimmed, newlines preserved) is one prompt.
+export function splitPromptLines(text) {
+  if (typeof text !== "string") return [];
+  const lines = text.split(/\r?\n/);
+  if (!lines.some((line) => line.trim() === "---")) {
+    return lines.map((line) => line.trim()).filter((line) => line !== "");
+  }
+  const blocks = [];
+  let current = [];
+  for (const line of lines) {
+    if (line.trim() === "---") {
+      blocks.push(current.join("\n").trim());
+      current = [];
+    } else {
+      current.push(line);
+    }
+  }
+  blocks.push(current.join("\n").trim());
+  return blocks.filter((block) => block !== "");
+}
+
 // Unique {{key}} names referenced across the prompts, trimmed, in first-seen order.
 export function extractKeys(prompts) {
   const seen = new Set();

--- a/apps/web/src/promptBatch.js
+++ b/apps/web/src/promptBatch.js
@@ -1,0 +1,158 @@
+// Prompt-batch template engine (sc-9953, epic 9952 — Batch Prompt Processing).
+// Pure, mode-agnostic logic: pull {{key}} placeholders out of a list of prompt
+// templates, resolve them against a value map, and expand a batch to its concrete
+// prompts via cross-product over multi-valued variables. React/DOM/network-free so
+// the fan-out math is unit-tested in isolation; the authoring UI (slice 3) and the
+// execution fan-out (slice 4) consume these functions.
+//
+// Design notes that the tests pin down:
+//  - A key is `{{name}}`; surrounding whitespace is trimmed so `{{ name }}` ==
+//    `{{name}}`. Any name is allowed (it just can't contain braces).
+//  - Expansion is PER LINE: each prompt fans out only over the variables it
+//    actually references. A variable referenced in some lines but not others (or
+//    in none) does not multiply the lines that omit it into identical duplicate
+//    renders. So cardinality() is a sum over lines, not one global product.
+//  - A referenced key with no usable value is NOT silently dropped: it is skipped
+//    for expansion (its placeholder stays literal) and surfaced via missingKeys()
+//    so the caller (slice 5) can block the run.
+//  - Cross-product ordering is deterministic: prompts vary slowest (outer loop),
+//    then variables in array order, with the LAST variable varying fastest.
+//  - Invariant the tests pin: cardinality(p, v, count) === expandBatch(p, v).length
+//    × count (for a positive integer count). expandBatch's length is the job count;
+//    cardinality is the image count once each job's `count` variations are applied.
+
+// Fresh regex per call — a shared /g regex carries lastIndex state across
+// matchAll/replace and would desync. `[^{}]` can't span across `}}`, so a lazy
+// inner group is enough to isolate one placeholder.
+const keyPattern = () => /\{\{([^{}]+?)\}\}/g;
+
+// Normalize the raw prompt input to a list of non-blank template strings.
+// Whitespace-only entries never produce a render (so "all blank" → 0 downstream).
+function promptList(prompts) {
+  if (!Array.isArray(prompts)) return [];
+  return prompts
+    .map((prompt) => (typeof prompt === "string" ? prompt : ""))
+    .filter((prompt) => prompt.trim() !== "");
+}
+
+// A variable's usable values: trimmed, blanks dropped. Order is preserved and
+// duplicates are kept (a repeat is treated as intent, not silently collapsed).
+function variableValues(variable) {
+  const values = Array.isArray(variable?.values) ? variable.values : [];
+  return values
+    .map((value) => (typeof value === "string" ? value.trim() : ""))
+    .filter((value) => value !== "");
+}
+
+// The variables that actually drive expansion: referenced in the prompts, first
+// entry wins per key, and carrying at least one usable value.
+function effectiveVariables(prompts, variables) {
+  const referenced = new Set(extractKeys(prompts));
+  const list = Array.isArray(variables) ? variables : [];
+  const seen = new Set();
+  const result = [];
+  for (const variable of list) {
+    const key = typeof variable?.key === "string" ? variable.key.trim() : "";
+    if (!key || !referenced.has(key) || seen.has(key)) continue;
+    const values = variableValues(variable);
+    if (values.length === 0) continue; // unfilled — surfaced by missingKeys(), skipped here
+    seen.add(key);
+    result.push({ key, values });
+  }
+  return result;
+}
+
+// Cartesian product of value lists. Empty input → `[[]]` (one empty combination),
+// so a line with no active variables still yields exactly one render. The last
+// list varies fastest, matching the documented ordering.
+function cartesian(lists) {
+  return lists.reduce(
+    (combos, list) => combos.flatMap((combo) => list.map((value) => [...combo, value])),
+    [[]],
+  );
+}
+
+// Whether a single prompt line references a given (already-trimmed) key.
+function promptReferences(prompt, key) {
+  for (const match of prompt.matchAll(keyPattern())) {
+    if (match[1].trim() === key) return true;
+  }
+  return false;
+}
+
+// Unique {{key}} names referenced across the prompts, trimmed, in first-seen order.
+export function extractKeys(prompts) {
+  const seen = new Set();
+  const keys = [];
+  for (const prompt of promptList(prompts)) {
+    for (const match of prompt.matchAll(keyPattern())) {
+      const key = match[1].trim();
+      if (key && !seen.has(key)) {
+        seen.add(key);
+        keys.push(key);
+      }
+    }
+  }
+  return keys;
+}
+
+// Substitute a single value map into one template. Keys absent from the map are
+// left as their literal `{{key}}` placeholder (so an unfilled key stays visible in
+// a preview rather than becoming an empty string).
+export function resolvePrompt(template, valueMap) {
+  if (typeof template !== "string") return "";
+  const map = valueMap ?? {};
+  return template.replace(keyPattern(), (whole, rawKey) => {
+    const key = rawKey.trim();
+    return Object.prototype.hasOwnProperty.call(map, key) ? String(map[key]) : whole;
+  });
+}
+
+// Expand a batch to its concrete prompts. Each prompt line fans out over only the
+// variables it references (their cross-product); a line with none yields exactly
+// one render. Each entry carries the resolved `prompt` plus the `values` map that
+// produced it. Ordering is deterministic (prompts slowest, last variable fastest).
+export function expandBatch(prompts, variables) {
+  const lines = promptList(prompts);
+  const vars = effectiveVariables(prompts, variables);
+  const out = [];
+  for (const prompt of lines) {
+    const lineVars = vars.filter((variable) => promptReferences(prompt, variable.key));
+    const combos = cartesian(lineVars.map((variable) => variable.values));
+    for (const combo of combos) {
+      const values = {};
+      lineVars.forEach((variable, index) => {
+        values[variable.key] = combo[index];
+      });
+      out.push({ prompt: resolvePrompt(prompt, values), values });
+    }
+  }
+  return out;
+}
+
+// Number of images a batch will queue: Σ over prompt lines of Π(value counts of the
+// variables that line references), times `count`. Computed directly from the
+// factors — never materializes the expansion — so it is safe to call live on every
+// keystroke even when the product is enormous.
+export function cardinality(prompts, variables, count = 1) {
+  const lines = promptList(prompts);
+  if (lines.length === 0) return 0;
+  const vars = effectiveVariables(prompts, variables);
+  const jobs = lines.reduce((total, prompt) => {
+    const product = vars.reduce(
+      (acc, variable) => (promptReferences(prompt, variable.key) ? acc * variable.values.length : acc),
+      1,
+    );
+    return total + product;
+  }, 0);
+  const n = Number(count);
+  const multiplier = Number.isFinite(n) && n > 0 ? Math.floor(n) : 1;
+  return jobs * multiplier;
+}
+
+// Referenced keys that have no usable value — the batch cannot run until these are
+// filled. Slice 5 uses this to block the run and name the offending key(s).
+export function missingKeys(prompts, variables) {
+  const filled = new Set(effectiveVariables(prompts, variables).map((variable) => variable.key));
+  return extractKeys(prompts).filter((key) => !filled.has(key));
+}

--- a/apps/web/src/promptBatch.test.js
+++ b/apps/web/src/promptBatch.test.js
@@ -1,6 +1,37 @@
 import { describe, expect, it } from "vitest";
 
-import { cardinality, expandBatch, extractKeys, missingKeys, resolvePrompt } from "./promptBatch.js";
+import {
+  cardinality,
+  expandBatch,
+  extractKeys,
+  missingKeys,
+  resolvePrompt,
+  splitPromptLines,
+} from "./promptBatch.js";
+
+describe("splitPromptLines", () => {
+  it("splits one prompt per line, ignoring blank lines", () => {
+    expect(splitPromptLines("cat\n\n  dog  \nbird\n")).toEqual(["cat", "dog", "bird"]);
+  });
+
+  it("does NOT merge newline-separated lines into one prompt", () => {
+    expect(splitPromptLines("a\nb\nc")).toHaveLength(3);
+  });
+
+  it("switches to block mode when a --- delimiter is present", () => {
+    const text = "line one\nline two\n---\nsecond prompt\n---\nthird";
+    expect(splitPromptLines(text)).toEqual(["line one\nline two", "second prompt", "third"]);
+  });
+
+  it("drops empty blocks and trims each block in delimiter mode", () => {
+    expect(splitPromptLines("---\n  only  \n---")).toEqual(["only"]);
+  });
+
+  it("returns [] for blank or non-string input", () => {
+    expect(splitPromptLines("   \n  ")).toEqual([]);
+    expect(splitPromptLines(null)).toEqual([]);
+  });
+});
 
 describe("extractKeys", () => {
   it("collects unique keys in first-seen order", () => {

--- a/apps/web/src/promptBatch.test.js
+++ b/apps/web/src/promptBatch.test.js
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+
+import { cardinality, expandBatch, extractKeys, missingKeys, resolvePrompt } from "./promptBatch.js";
+
+describe("extractKeys", () => {
+  it("collects unique keys in first-seen order", () => {
+    expect(extractKeys(["{{name}} has {{hair_color}} hair", "{{name}} smiling"])).toEqual([
+      "name",
+      "hair_color",
+    ]);
+  });
+
+  it("trims whitespace so {{ name }} equals {{name}}", () => {
+    expect(extractKeys(["{{ name }} and {{name}}"])).toEqual(["name"]);
+  });
+
+  it("supports arbitrary key names and adjacent placeholders", () => {
+    expect(extractKeys(["{{a}}{{b-2}}{{ c d }}"])).toEqual(["a", "b-2", "c d"]);
+  });
+
+  it("ignores empty and brace-only placeholders", () => {
+    expect(extractKeys(["{{}} {{ }} plain"])).toEqual([]);
+  });
+
+  it("skips blank prompt lines and non-string/garbage input", () => {
+    expect(extractKeys(["  ", "{{x}}", 42, null])).toEqual(["x"]);
+    expect(extractKeys("not an array")).toEqual([]);
+  });
+});
+
+describe("resolvePrompt", () => {
+  it("substitutes provided values, honoring trimmed keys", () => {
+    expect(resolvePrompt("{{ name }} with {{hair_color}} hair", { name: "Alice", hair_color: "red" })).toBe(
+      "Alice with red hair",
+    );
+  });
+
+  it("leaves unknown keys as their literal placeholder", () => {
+    expect(resolvePrompt("{{name}} in {{place}}", { name: "Bob" })).toBe("Bob in {{place}}");
+  });
+
+  it("returns empty string for non-string templates", () => {
+    expect(resolvePrompt(null, { name: "Alice" })).toBe("");
+  });
+});
+
+describe("expandBatch", () => {
+  it("increments a single variable per render", () => {
+    const out = expandBatch(["{{hair_color}} hair"], [{ key: "hair_color", values: ["red", "blue", "blonde"] }]);
+    expect(out.map((entry) => entry.prompt)).toEqual(["red hair", "blue hair", "blonde hair"]);
+  });
+
+  it("cross-products multiple variables (prompts slowest, last variable fastest)", () => {
+    const out = expandBatch(
+      ["{{name}}/{{hair}}"],
+      [
+        { key: "name", values: ["Alice", "Bob"] },
+        { key: "hair", values: ["red", "blue"] },
+      ],
+    );
+    expect(out.map((entry) => entry.prompt)).toEqual([
+      "Alice/red",
+      "Alice/blue",
+      "Bob/red",
+      "Bob/blue",
+    ]);
+    expect(out[0].values).toEqual({ name: "Alice", hair: "red" });
+  });
+
+  it("multiplies the cross-product across every prompt line", () => {
+    const out = expandBatch(
+      ["{{name}} smiling", "{{name}} waving"],
+      [{ key: "name", values: ["Alice", "Bob"] }],
+    );
+    expect(out.map((entry) => entry.prompt)).toEqual([
+      "Alice smiling",
+      "Bob smiling",
+      "Alice waving",
+      "Bob waving",
+    ]);
+  });
+
+  it("ignores an unreferenced variable instead of duplicating renders", () => {
+    const out = expandBatch(["a plain prompt"], [{ key: "mood", values: ["happy", "sad"] }]);
+    expect(out).toEqual([{ prompt: "a plain prompt", values: {} }]);
+  });
+
+  it("skips a referenced variable that has no usable values, keeping the placeholder", () => {
+    const out = expandBatch(["{{name}} in {{place}}"], [
+      { key: "name", values: ["Alice"] },
+      { key: "place", values: ["", "   "] },
+    ]);
+    expect(out).toEqual([{ prompt: "Alice in {{place}}", values: { name: "Alice" } }]);
+  });
+
+  it("trims values and drops blanks before expanding", () => {
+    const out = expandBatch(["{{c}}"], [{ key: "c", values: [" red ", "", "blue"] }]);
+    expect(out.map((entry) => entry.prompt)).toEqual(["red", "blue"]);
+  });
+
+  it("takes the first entry when a key is defined twice", () => {
+    const out = expandBatch(["{{k}}"], [
+      { key: "k", values: ["one"] },
+      { key: "k", values: ["two"] },
+    ]);
+    expect(out.map((entry) => entry.prompt)).toEqual(["one"]);
+  });
+
+  it("returns nothing for an all-blank prompt list", () => {
+    expect(expandBatch(["", "   "], [{ key: "x", values: ["a"] }])).toEqual([]);
+  });
+});
+
+describe("cardinality", () => {
+  it("sums per-line products × count (each line references only {{name}})", () => {
+    const prompts = ["{{name}} smiling", "{{name}} waving", "{{name}} jumping"];
+    const variables = [
+      { key: "name", values: ["Alice", "Bob"] },
+      { key: "hair", values: ["red", "blue"] },
+    ];
+    // {{hair}} is referenced nowhere, so it never multiplies: 3 lines × 2 names × 4 = 24.
+    expect(cardinality(prompts, variables, 4)).toBe(3 * 2 * 4);
+  });
+
+  it("adds up uneven per-line fan-out rather than one global product", () => {
+    const prompts = ["{{name}} with {{hair}} hair", "{{name}} alone"];
+    const variables = [
+      { key: "name", values: ["Alice", "Bob"] },
+      { key: "hair", values: ["red", "blue"] },
+    ];
+    // line 1 fans out name×hair = 4; line 2 fans out name = 2; total 6, not 2×2×2=8.
+    expect(cardinality(prompts, variables, 1)).toBe(4 + 2);
+  });
+
+  it("counts a hair axis once it is referenced", () => {
+    const prompts = ["{{name}} with {{hair}} hair"];
+    const variables = [
+      { key: "name", values: ["Alice", "Bob"] },
+      { key: "hair", values: ["red", "blue", "blonde"] },
+    ];
+    expect(cardinality(prompts, variables, 4)).toBe(1 * 2 * 3 * 4);
+  });
+
+  it("is 0 for an empty or all-blank prompt list", () => {
+    expect(cardinality([], [], 4)).toBe(0);
+    expect(cardinality(["  "], [], 4)).toBe(0);
+  });
+
+  it("treats an unfilled referenced variable as a factor of 1", () => {
+    expect(cardinality(["{{name}} in {{place}}"], [{ key: "name", values: ["Alice"] }], 1)).toBe(1);
+  });
+
+  it("defaults a missing or invalid count to 1", () => {
+    expect(cardinality(["{{name}}"], [{ key: "name", values: ["Alice", "Bob"] }])).toBe(2);
+    expect(cardinality(["{{name}}"], [{ key: "name", values: ["Alice", "Bob"] }], 0)).toBe(2);
+    expect(cardinality(["{{name}}"], [{ key: "name", values: ["Alice", "Bob"] }], "3")).toBe(6);
+  });
+
+  it("equals the expandBatch job count times the variation count (the pinned invariant)", () => {
+    const prompts = ["{{name}}/{{hair}}", "{{name}} alone", "a plain line"];
+    const variables = [
+      { key: "name", values: ["Alice", "Bob"] },
+      { key: "hair", values: ["red", "blue"] },
+    ];
+    const jobs = expandBatch(prompts, variables).length; // 4 + 2 + 1 = 7
+    expect(jobs).toBe(7);
+    expect(cardinality(prompts, variables, 4)).toBe(jobs * 4);
+  });
+
+  it("does not emit duplicate renders for a line missing a batch variable", () => {
+    const out = expandBatch(["{{name}}/{{hair}}", "{{name}} alone"], [
+      { key: "name", values: ["Alice", "Bob"] },
+      { key: "hair", values: ["red", "blue"] },
+    ]);
+    expect(out.map((entry) => entry.prompt)).toEqual([
+      "Alice/red",
+      "Alice/blue",
+      "Bob/red",
+      "Bob/blue",
+      "Alice alone",
+      "Bob alone",
+    ]);
+  });
+});
+
+describe("missingKeys", () => {
+  it("names referenced keys that have no usable value", () => {
+    expect(
+      missingKeys(["{{name}} in {{place}} at {{time}}"], [
+        { key: "name", values: ["Alice"] },
+        { key: "place", values: [""] },
+      ]),
+    ).toEqual(["place", "time"]);
+  });
+
+  it("returns nothing when every referenced key is filled", () => {
+    expect(missingKeys(["{{name}}"], [{ key: "name", values: ["Alice"] }])).toEqual([]);
+  });
+
+  it("ignores unreferenced variables", () => {
+    expect(missingKeys(["plain"], [{ key: "mood", values: [] }])).toEqual([]);
+  });
+});

--- a/apps/web/src/promptBatchIO.js
+++ b/apps/web/src/promptBatchIO.js
@@ -1,0 +1,98 @@
+// Prompt-batch export / import (sc-9954, epic 9952 — Batch Prompt Processing).
+// Server persistence (see apps/rust-api/src/prompt_batches.rs) keeps batches in the
+// user's SceneWorks install; this module is the portable file layer on top so a
+// batch can be shared as a plain .json and re-imported elsewhere (an OSS-friendly
+// "send someone your character-turnaround recipe"). Pure and DOM-free.
+//
+// The export carries only the authored content — name, prompt templates, variable
+// definitions, and remembered defaults — never server-managed fields (id, scope,
+// manifestPath, timestamps, archived), so an import is always a fresh create.
+
+export const PROMPT_BATCH_EXPORT_VERSION = 1;
+const EXPORT_MARKER = "sceneworksPromptBatch";
+
+function normalizePrompts(value) {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry) => typeof entry === "string");
+}
+
+function normalizeVariables(value) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((variable) => {
+      const key = typeof variable?.key === "string" ? variable.key : "";
+      const values = Array.isArray(variable?.values)
+        ? variable.values.filter((entry) => typeof entry === "string")
+        : [];
+      return { key, values };
+    })
+    .filter((variable) => variable.key !== "");
+}
+
+function normalizeLastValues(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const out = {};
+  for (const [key, values] of Object.entries(value)) {
+    if (Array.isArray(values)) {
+      out[key] = values.filter((entry) => typeof entry === "string");
+    }
+  }
+  return Object.keys(out).length ? out : undefined;
+}
+
+// Build the portable export object for a saved (or in-progress) batch. `lastValues`
+// is included only when present so round-trips stay minimal.
+export function toPromptBatchExport(batch) {
+  const exported = {
+    [EXPORT_MARKER]: PROMPT_BATCH_EXPORT_VERSION,
+    name: typeof batch?.name === "string" ? batch.name : "",
+    prompts: normalizePrompts(batch?.prompts),
+    variables: normalizeVariables(batch?.variables),
+  };
+  const lastValues = normalizeLastValues(batch?.lastValues);
+  if (lastValues) {
+    exported.lastValues = lastValues;
+  }
+  return exported;
+}
+
+// Serialize a batch to the pretty-printed JSON string written to disk.
+export function serializePromptBatchExport(batch) {
+  return JSON.stringify(toPromptBatchExport(batch), null, 2);
+}
+
+// Parse + validate an imported batch (a parsed object OR a raw JSON string) into a
+// clean create payload: { name, prompts, variables, lastValues? }. Throws a
+// descriptive Error on malformed input so the caller can surface it to the user.
+export function fromPromptBatchImport(input) {
+  let data = input;
+  if (typeof input === "string") {
+    try {
+      data = JSON.parse(input);
+    } catch {
+      throw new Error("Not a valid JSON file.");
+    }
+  }
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    throw new Error("Prompt batch file must contain a JSON object.");
+  }
+  if (!("prompts" in data) && !(EXPORT_MARKER in data)) {
+    throw new Error("This file is not a SceneWorks prompt batch.");
+  }
+  if ("prompts" in data && !Array.isArray(data.prompts)) {
+    throw new Error("Prompt batch prompts must be an array.");
+  }
+  if ("variables" in data && !Array.isArray(data.variables)) {
+    throw new Error("Prompt batch variables must be an array.");
+  }
+  const payload = {
+    name: typeof data.name === "string" ? data.name.trim() : "",
+    prompts: normalizePrompts(data.prompts),
+    variables: normalizeVariables(data.variables),
+  };
+  const lastValues = normalizeLastValues(data.lastValues);
+  if (lastValues) {
+    payload.lastValues = lastValues;
+  }
+  return payload;
+}

--- a/apps/web/src/promptBatchIO.test.js
+++ b/apps/web/src/promptBatchIO.test.js
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PROMPT_BATCH_EXPORT_VERSION,
+  fromPromptBatchImport,
+  serializePromptBatchExport,
+  toPromptBatchExport,
+} from "./promptBatchIO.js";
+
+const sampleBatch = {
+  id: "character_turnaround",
+  scope: "global",
+  manifestPath: "/home/user/.config/sceneworks/manifests/user.prompt-batches.jsonc",
+  archived: false,
+  createdAt: "2026-07-05T00:00:00Z",
+  updatedAt: "2026-07-05T00:00:00Z",
+  name: "Character Turnaround",
+  prompts: ["{{name}} with {{hair}} hair, front view", "{{name}} profile"],
+  variables: [
+    { key: "name", values: ["Alice"] },
+    { key: "hair", values: ["red", "blue"] },
+  ],
+  lastValues: { name: ["Alice"], hair: ["red", "blue"] },
+};
+
+describe("toPromptBatchExport", () => {
+  it("carries only authored content, never server-managed fields", () => {
+    const exported = toPromptBatchExport(sampleBatch);
+    expect(exported).toEqual({
+      sceneworksPromptBatch: PROMPT_BATCH_EXPORT_VERSION,
+      name: "Character Turnaround",
+      prompts: sampleBatch.prompts,
+      variables: sampleBatch.variables,
+      lastValues: sampleBatch.lastValues,
+    });
+    for (const field of ["id", "scope", "manifestPath", "archived", "createdAt", "updatedAt"]) {
+      expect(exported).not.toHaveProperty(field);
+    }
+  });
+
+  it("omits lastValues when there are none", () => {
+    const exported = toPromptBatchExport({ name: "Plain", prompts: ["a"], variables: [] });
+    expect(exported).not.toHaveProperty("lastValues");
+  });
+});
+
+describe("import round-trip", () => {
+  it("export → serialize → import yields the authored core", () => {
+    const json = serializePromptBatchExport(sampleBatch);
+    const imported = fromPromptBatchImport(json);
+    expect(imported).toEqual({
+      name: "Character Turnaround",
+      prompts: sampleBatch.prompts,
+      variables: sampleBatch.variables,
+      lastValues: sampleBatch.lastValues,
+    });
+  });
+
+  it("accepts an already-parsed object", () => {
+    const imported = fromPromptBatchImport(toPromptBatchExport(sampleBatch));
+    expect(imported.name).toBe("Character Turnaround");
+    expect(imported.prompts).toHaveLength(2);
+  });
+});
+
+describe("fromPromptBatchImport validation", () => {
+  it("rejects non-JSON strings", () => {
+    expect(() => fromPromptBatchImport("{not json")).toThrow(/valid JSON/);
+  });
+
+  it("rejects non-objects", () => {
+    expect(() => fromPromptBatchImport("[1,2,3]")).toThrow(/JSON object/);
+    expect(() => fromPromptBatchImport("42")).toThrow(/JSON object/);
+  });
+
+  it("rejects files that are not prompt batches", () => {
+    expect(() => fromPromptBatchImport({ some: "thing" })).toThrow(/not a SceneWorks prompt batch/);
+  });
+
+  it("rejects a wrong prompts type", () => {
+    expect(() => fromPromptBatchImport({ prompts: "nope" })).toThrow(/prompts must be an array/);
+  });
+
+  it("rejects a wrong variables type", () => {
+    expect(() =>
+      fromPromptBatchImport({ prompts: [], variables: "nope" }),
+    ).toThrow(/variables must be an array/);
+  });
+
+  it("sanitizes junk entries within otherwise-valid arrays", () => {
+    const imported = fromPromptBatchImport({
+      name: "  Messy  ",
+      prompts: ["good", 42, null, "also good"],
+      variables: [
+        { key: "name", values: ["Alice", 7, "Bob"] },
+        { key: "", values: ["dropped"] },
+        { notAKey: true },
+      ],
+    });
+    expect(imported.name).toBe("Messy");
+    expect(imported.prompts).toEqual(["good", "also good"]);
+    expect(imported.variables).toEqual([{ key: "name", values: ["Alice", "Bob"] }]);
+  });
+});

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -9,6 +9,8 @@ import { PoseLibraryPicker } from "../components/PoseLibraryPicker.jsx";
 import { RefinePromptControl } from "../components/RefinePromptControl.jsx";
 import StructuredPromptBuilder from "../components/StructuredPromptBuilder.jsx";
 import ReferenceCaptionPicker from "../components/ReferenceCaptionPicker.jsx";
+import BatchPromptPanel from "../components/BatchPromptPanel.jsx";
+import { cardinality, extractKeys, splitPromptLines } from "../promptBatch.js";
 import {
   emptyCaption,
   orderCaption,
@@ -144,6 +146,13 @@ const DEFAULT_RESOLUTION_OPTIONS = ["768x768", "1024x1024", "1280x720", "720x128
 // character share the text_to_image workflow.
 const IMAGE_MODES = ["text_to_image", "edit_image", "character_image"];
 
+// Join a saved batch's prompts back into the authoring textarea: multi-line prompts
+// round-trip through the `---` delimiter, a flat list joins on newlines.
+function batchTextFromPrompts(prompts) {
+  const list = Array.isArray(prompts) ? prompts : [];
+  return list.join(list.some((prompt) => prompt.includes("\n")) ? "\n---\n" : "\n");
+}
+
 function preferredOption(defaultValue, options) {
   return options.includes(defaultValue) ? defaultValue : options[0] ?? "default";
 }
@@ -250,6 +259,10 @@ export function ImageStudio() {
     setActiveView,
     setPreviewAsset,
     presets = [],
+    promptBatches = [],
+    createPromptBatch,
+    updatePromptBatch,
+    deletePromptBatch,
     requestedGpu,
     selectedAsset,
     setRequestedGpu,
@@ -342,6 +355,95 @@ export function ImageStudio() {
   };
   const suggestions = mode === "character_image" ? characterSuggestions : sceneSuggestions;
   const [count, setCount] = useState(saved.count ?? 4);
+
+  // Batch Prompt Processing (epic 9952). Batch mode is orthogonal to the T2I/Edit/
+  // Character tab — it swaps the single prompt for a list of {{templated}} prompts run
+  // as one batch against the current settings. State persists like the rest of the
+  // studio; the fan-out on "Run batch" is wired in sc-9956 (slice 4).
+  const [batchMode, setBatchMode] = useState(saved.batchMode ?? false);
+  const [batchPromptsText, setBatchPromptsText] = useState(saved.batchPromptsText ?? "");
+  const [batchVariableValues, setBatchVariableValues] = useState(saved.batchVariableValues ?? {});
+  const [batchName, setBatchName] = useState(saved.batchName ?? "");
+  const [batchScope, setBatchScope] = useState(saved.batchScope ?? "global");
+  const [loadedBatchId, setLoadedBatchId] = useState(saved.loadedBatchId ?? null);
+  const [batchError, setBatchError] = useState("");
+  const [batchBusy, setBatchBusy] = useState(false);
+
+  const batchPrompts = useMemo(() => splitPromptLines(batchPromptsText), [batchPromptsText]);
+  const batchVariables = useMemo(
+    () => extractKeys(batchPrompts).map((key) => ({ key, values: batchVariableValues[key] ?? [] })),
+    [batchPrompts, batchVariableValues],
+  );
+  const batchTotal = useMemo(
+    () => cardinality(batchPrompts, batchVariables, count),
+    [batchPrompts, batchVariables, count],
+  );
+
+  const applyBatchContent = useCallback(({ prompts, variables, lastValues, name }) => {
+    setBatchPromptsText(batchTextFromPrompts(prompts));
+    const values = {};
+    for (const variable of variables ?? []) {
+      if (variable?.key) values[variable.key] = Array.isArray(variable.values) ? variable.values : [];
+    }
+    for (const [key, vals] of Object.entries(lastValues ?? {})) {
+      if (!(key in values) && Array.isArray(vals)) values[key] = vals;
+    }
+    setBatchVariableValues(values);
+    if (name !== undefined) setBatchName(name ?? "");
+    setBatchError("");
+  }, []);
+
+  const handleSaveBatch = useCallback(async () => {
+    setBatchBusy(true);
+    setBatchError("");
+    try {
+      const payload = {
+        name: batchName.trim(),
+        scope: batchScope,
+        prompts: batchPrompts,
+        variables: batchVariables,
+        lastValues: Object.fromEntries(batchVariables.map((variable) => [variable.key, variable.values])),
+      };
+      const result = loadedBatchId
+        ? await updatePromptBatch(loadedBatchId, payload, batchScope)
+        : await createPromptBatch(payload);
+      if (result?.id) setLoadedBatchId(result.id);
+    } catch (err) {
+      setBatchError(err.message);
+    } finally {
+      setBatchBusy(false);
+    }
+  }, [batchName, batchScope, batchPrompts, batchVariables, loadedBatchId, updatePromptBatch, createPromptBatch]);
+
+  const handleLoadBatch = useCallback(
+    (batch) => {
+      applyBatchContent(batch);
+      setBatchScope(batch.scope === "project" ? "project" : "global");
+      setLoadedBatchId(batch.id ?? null);
+    },
+    [applyBatchContent],
+  );
+
+  const handleDeleteBatch = useCallback(
+    async (batch) => {
+      setBatchError("");
+      try {
+        await deletePromptBatch(batch.id, batch.scope);
+        setLoadedBatchId((current) => (current === batch.id ? null : current));
+      } catch (err) {
+        setBatchError(err.message);
+      }
+    },
+    [deletePromptBatch],
+  );
+
+  const handleImportBatch = useCallback(
+    (payload) => {
+      applyBatchContent(payload);
+      setLoadedBatchId(null);
+    },
+    [applyBatchContent],
+  );
   const [advancedOpen, setAdvancedOpen] = useState(saved.advancedOpen ?? false);
   const [model, setModel] = useState(saved.model ?? imageModels[0]?.id ?? "z_image_turbo");
   const [seed, setSeed] = useState(saved.seed ?? "");
@@ -1257,6 +1359,12 @@ export function ImageStudio() {
     loraWeights,
     showIncompatibleLoras,
     selectedPresetId,
+    batchMode,
+    batchPromptsText,
+    batchVariableValues,
+    batchName,
+    batchScope,
+    loadedBatchId,
     sampler,
     scheduler,
     schedulerShift,
@@ -1286,6 +1394,11 @@ export function ImageStudio() {
 
   async function submit(event) {
     event.preventDefault();
+    // Batch mode runs through its own "Run batch" action (sc-9956), never the single
+    // Generate submit — guard so a stray Enter in a batch field can't queue one image.
+    if (batchMode) {
+      return;
+    }
     if (submitting) {
       return;
     }
@@ -1509,6 +1622,15 @@ export function ImageStudio() {
                 );
               })}
             </div>
+            <button
+              aria-pressed={batchMode}
+              className={batchMode ? "batch-toggle active" : "batch-toggle"}
+              onClick={() => setBatchMode((on) => !on)}
+              title="Run a list of prompts as one batch with the current settings"
+              type="button"
+            >
+              <Icon.Stars size={13} /> Batch
+            </button>
             <div className="prompt-hero-links">
               <button className="hero-link" onClick={() => setGuideOpen(true)} type="button">
                 <Icon.Book size={14} /> Prompt guide
@@ -1521,6 +1643,33 @@ export function ImageStudio() {
             </div>
           </div>
 
+          {batchMode ? (
+            <div className="prompt-input-row batch">
+              <BatchPromptPanel
+                promptsText={batchPromptsText}
+                onPromptsTextChange={setBatchPromptsText}
+                variableValues={batchVariableValues}
+                onVariableValuesChange={setBatchVariableValues}
+                count={count}
+                batches={promptBatches}
+                projectId={activeProject?.id ?? null}
+                name={batchName}
+                onNameChange={setBatchName}
+                scope={batchScope}
+                onScopeChange={setBatchScope}
+                loadedBatchId={loadedBatchId}
+                onSave={handleSaveBatch}
+                onLoad={handleLoadBatch}
+                onDelete={handleDeleteBatch}
+                onImport={handleImportBatch}
+                busy={batchBusy}
+                error={batchError}
+              />
+              <button className="prompt-cta" disabled title="Batch run lands in sc-9956" type="button">
+                <Icon.Play size={14} /> Run batch · {batchTotal}
+              </button>
+            </div>
+          ) : (
           <div className={`prompt-input-row${structuredPromptModel ? " structured" : ""}`}>
             {structuredPromptModel ? (
               <StructuredPromptBuilder
@@ -1572,6 +1721,7 @@ export function ImageStudio() {
               {submitting ? (expanding ? "Expanding…" : "Queueing…") : "Generate"}
             </button>
           </div>
+          )}
           {/* Auto-expand failure (sc-6501): a structured model couldn't turn the plain-text idea
               into a caption (e.g. the prompt-refiner model isn't installed). We never fall back to
               sending raw plain text, so surface the reason and the path forward. */}

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -147,6 +147,10 @@ const DEFAULT_RESOLUTION_OPTIONS = ["768x768", "1024x1024", "1280x720", "720x128
 // character share the text_to_image workflow.
 const IMAGE_MODES = ["text_to_image", "edit_image", "character_image"];
 
+// Above this many resolved images a batch run needs explicit confirmation, so a stray
+// value or an over-eager cross-product can't silently queue a huge job (sc-9957).
+const BATCH_RENDER_CAP = 100;
+
 // Join a saved batch's prompts back into the authoring textarea: multi-line prompts
 // round-trip through the `---` delimiter, a flat list joins on newlines.
 function batchTextFromPrompts(prompts) {
@@ -372,6 +376,8 @@ export function ImageStudio() {
   // An in-flight / just-finished batch run: { submitting, items: [{ prompt, jobId }] }.
   // Progress + cancel are derived off the live jobs feed, mirroring the asset batch (sc-6112).
   const [batchRun, setBatchRun] = useState(null);
+  // True once a run over BATCH_RENDER_CAP is awaiting the user's explicit confirmation.
+  const [batchConfirmPending, setBatchConfirmPending] = useState(false);
 
   const batchPrompts = useMemo(() => splitPromptLines(batchPromptsText), [batchPromptsText]);
   const batchVariables = useMemo(
@@ -382,6 +388,12 @@ export function ImageStudio() {
     () => cardinality(batchPrompts, batchVariables, count),
     [batchPrompts, batchVariables, count],
   );
+
+  // A pending large-run confirmation is for one specific count — reset it whenever the
+  // batch size changes so the user always re-confirms against the current total.
+  useEffect(() => {
+    setBatchConfirmPending(false);
+  }, [batchTotal]);
 
   const applyBatchContent = useCallback(({ prompts, variables, lastValues, name }) => {
     setBatchPromptsText(batchTextFromPrompts(prompts));
@@ -1651,7 +1663,7 @@ export function ImageStudio() {
   // Fan out one image job per resolved prompt (mirrors the asset batch, sc-6112): each
   // posts independently so the worker runs them serially with its between-image cache
   // release, and progress/cancel read the live jobs feed.
-  async function runBatch() {
+  async function runBatch(confirmed = false) {
     if (batchRun?.submitting || !activeProject) {
       return;
     }
@@ -1659,6 +1671,12 @@ export function ImageStudio() {
     if (!resolved.length) {
       return;
     }
+    // Soft cap: a large run must be confirmed once, showing the exact image count.
+    if (!confirmed && resolved.length * count > BATCH_RENDER_CAP) {
+      setBatchConfirmPending(true);
+      return;
+    }
+    setBatchConfirmPending(false);
     setBatchRun({ submitting: true, items: resolved.map((entry) => ({ prompt: entry.prompt, jobId: null })) });
     const items = [];
     for (const entry of resolved) {
@@ -1801,6 +1819,12 @@ export function ImageStudio() {
                   <p className="batch-warning">
                     Batch mode isn’t available for structured-caption models yet.
                   </p>
+                ) : batchMissingKeys.length > 0 ? (
+                  <p className="batch-warning">
+                    Fill in a value for {batchMissingKeys.map((key) => `{{${key}}}`).join(", ")} to run.
+                  </p>
+                ) : batchTotal === 0 ? (
+                  <p className="batch-hint">Add at least one prompt to run a batch.</p>
                 ) : null}
                 {batchRun ? (
                   <div className="batch-run-progress" aria-live="polite">
@@ -1819,10 +1843,27 @@ export function ImageStudio() {
                     )}
                   </div>
                 ) : null}
-                <button className="prompt-cta" disabled={batchRunDisabled} onClick={runBatch} type="button">
-                  <Icon.Play size={14} />
-                  {batchRun?.submitting ? "Queueing…" : `Run batch · ${batchTotal}`}
-                </button>
+                {batchConfirmPending ? (
+                  <div className="batch-confirm" role="alertdialog">
+                    <span>Queue {batchTotal} images? That’s a large batch.</span>
+                    <button className="prompt-cta" onClick={() => runBatch(true)} type="button">
+                      <Icon.Play size={14} /> Queue {batchTotal}
+                    </button>
+                    <button className="batch-btn ghost" onClick={() => setBatchConfirmPending(false)} type="button">
+                      Cancel
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    className="prompt-cta"
+                    disabled={batchRunDisabled}
+                    onClick={() => runBatch(false)}
+                    type="button"
+                  >
+                    <Icon.Play size={14} />
+                    {batchRun?.submitting ? "Queueing…" : `Run batch · ${batchTotal}`}
+                  </button>
+                )}
               </div>
             </div>
           ) : (

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -10,7 +10,8 @@ import { RefinePromptControl } from "../components/RefinePromptControl.jsx";
 import StructuredPromptBuilder from "../components/StructuredPromptBuilder.jsx";
 import ReferenceCaptionPicker from "../components/ReferenceCaptionPicker.jsx";
 import BatchPromptPanel from "../components/BatchPromptPanel.jsx";
-import { cardinality, extractKeys, splitPromptLines } from "../promptBatch.js";
+import { cardinality, expandBatch, extractKeys, missingKeys, splitPromptLines } from "../promptBatch.js";
+import { batchItemStatus, summarizeBatchProgress } from "../batchOps.js";
 import {
   emptyCaption,
   orderCaption,
@@ -368,6 +369,9 @@ export function ImageStudio() {
   const [loadedBatchId, setLoadedBatchId] = useState(saved.loadedBatchId ?? null);
   const [batchError, setBatchError] = useState("");
   const [batchBusy, setBatchBusy] = useState(false);
+  // An in-flight / just-finished batch run: { submitting, items: [{ prompt, jobId }] }.
+  // Progress + cancel are derived off the live jobs feed, mirroring the asset batch (sc-6112).
+  const [batchRun, setBatchRun] = useState(null);
 
   const batchPrompts = useMemo(() => splitPromptLines(batchPromptsText), [batchPromptsText]);
   const batchVariables = useMemo(
@@ -1570,6 +1574,133 @@ export function ImageStudio() {
     }
   }
 
+  // One image-job request for a single resolved batch prompt. Reuses the current
+  // studio settings (model, loras, upscale, reference/source per mode, and the whole
+  // advanced knob set via the tested buildImageJobAdvanced). Batch deliberately omits
+  // the single-shot pose-library / strict-control conditioning and never sends a
+  // structured caption — each resolved prompt is a plain prompt. `count` still
+  // multiplies within each job (images = jobs × count).
+  const buildBatchJobRequest = (resolvedPrompt) => ({
+    mode,
+    prompt: resolvedPrompt,
+    negativePrompt,
+    model,
+    count,
+    seed: seed === "" ? null : Number(seed),
+    width,
+    height,
+    recipePresetId: selectedPreset?.id ?? null,
+    characterId: mode === "character_image" ? characterId || null : null,
+    characterLookId: mode === "character_image" ? characterLookId || null : null,
+    sourceAssetId: mode === "edit_image" && !multiReference ? sourceAssetId || null : null,
+    referenceAssetIds:
+      mode === "edit_image" && multiReference && referenceAssetIds.length ? referenceAssetIds : undefined,
+    fitMode: mode === "edit_image" ? effectiveFitMode(fitMode, editInpaintCapable) : undefined,
+    referenceAssetId: mode === "character_image" ? referenceAssetId || null : null,
+    loras: selectedLoras.map((lora) => serializeLora(lora, { weight: effectiveLoraWeight(lora) })),
+    ...(upscaleEnabled
+      ? {
+          upscale: {
+            enabled: true,
+            factor: upscaleFactor,
+            engine: upscaleEngine,
+            ...(upscaleEngineHasSoftness(upscaleEngine) ? { softness: upscaleSoftness } : {}),
+          },
+        }
+      : {}),
+    advanced: buildImageJobAdvanced({
+      resolution,
+      sendStructured: false,
+      submitIntent: resolvedPrompt,
+      submitCaption: caption,
+      submitBackend: magicPromptBackend,
+      sampler,
+      scheduler,
+      schedulerShift,
+      stepsOverride,
+      guidanceOverride,
+      guidanceMethod,
+      flashAttn,
+      promptEnhance,
+      enhancePrompt,
+      precisionToggle,
+      bf16Precision,
+      showTierPicker,
+      quantTier,
+      showPidToggle,
+      usePid,
+      mode,
+      referenceAssetId,
+      hideReferenceStrength,
+      ipAdapterScale,
+      identityStructure,
+      controlnetScale,
+      variationStrength,
+      trueCfgScale,
+      viewAngles,
+      viewAngle,
+      posePayload: [],
+      faceRestore,
+      controlActive: false,
+      activeControlMode,
+      controlPassthroughId: null,
+      effectiveControlScale,
+    }),
+  });
+
+  // Fan out one image job per resolved prompt (mirrors the asset batch, sc-6112): each
+  // posts independently so the worker runs them serially with its between-image cache
+  // release, and progress/cancel read the live jobs feed.
+  async function runBatch() {
+    if (batchRun?.submitting || !activeProject) {
+      return;
+    }
+    const resolved = expandBatch(batchPrompts, batchVariables);
+    if (!resolved.length) {
+      return;
+    }
+    setBatchRun({ submitting: true, items: resolved.map((entry) => ({ prompt: entry.prompt, jobId: null })) });
+    const items = [];
+    for (const entry of resolved) {
+      try {
+        const job = await createImageJob(buildBatchJobRequest(entry.prompt));
+        items.push({ prompt: entry.prompt, jobId: job?.id ?? null });
+      } catch {
+        items.push({ prompt: entry.prompt, jobId: null });
+      }
+    }
+    setBatchRun({ submitting: false, items });
+  }
+
+  // Cancel every still-pending job in the current run; completed/failed items are left.
+  function cancelBatchRun() {
+    if (!batchRun) {
+      return;
+    }
+    for (const item of batchRun.items) {
+      if (!item.jobId) {
+        continue;
+      }
+      const status = batchItemStatus(item.jobId, jobs);
+      if (status !== "queued" && status !== "running") {
+        continue;
+      }
+      const job = jobs.find((entry) => entry.id === item.jobId);
+      if (job) {
+        jobAction(job, "cancel");
+      }
+    }
+  }
+
+  const batchRunProgress = batchRun ? summarizeBatchProgress(batchRun.items, jobs) : null;
+  const batchMissingKeys = missingKeys(batchPrompts, batchVariables);
+  const batchRunDisabled =
+    !activeProject ||
+    structuredPromptModel ||
+    batchTotal === 0 ||
+    batchMissingKeys.length > 0 ||
+    Boolean(batchRun?.submitting);
+
   const generateDisabled =
     submitting ||
     !activeProject ||
@@ -1665,9 +1796,34 @@ export function ImageStudio() {
                 busy={batchBusy}
                 error={batchError}
               />
-              <button className="prompt-cta" disabled title="Batch run lands in sc-9956" type="button">
-                <Icon.Play size={14} /> Run batch · {batchTotal}
-              </button>
+              <div className="batch-run">
+                {structuredPromptModel ? (
+                  <p className="batch-warning">
+                    Batch mode isn’t available for structured-caption models yet.
+                  </p>
+                ) : null}
+                {batchRun ? (
+                  <div className="batch-run-progress" aria-live="polite">
+                    <span>
+                      {batchRunProgress.done}/{batchRunProgress.total} done
+                      {batchRunProgress.failed ? ` · ${batchRunProgress.failed} failed` : ""}
+                    </span>
+                    {batchRunProgress.allDone ? (
+                      <button className="batch-btn ghost" onClick={() => setBatchRun(null)} type="button">
+                        Clear
+                      </button>
+                    ) : (
+                      <button className="batch-btn ghost" onClick={cancelBatchRun} type="button">
+                        Cancel remaining
+                      </button>
+                    )}
+                  </div>
+                ) : null}
+                <button className="prompt-cta" disabled={batchRunDisabled} onClick={runBatch} type="button">
+                  <Icon.Play size={14} />
+                  {batchRun?.submitting ? "Queueing…" : `Run batch · ${batchTotal}`}
+                </button>
+              </div>
             </div>
           ) : (
           <div className={`prompt-input-row${structuredPromptModel ? " structured" : ""}`}>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11201,3 +11201,19 @@ details[open] > summary.lora-scope-group-heading::before,
 .batch-list-delete:hover {
   color: var(--danger);
 }
+.batch-run {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-end;
+}
+.batch-run .prompt-cta {
+  min-width: 184px;
+}
+.batch-run-progress {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12.5px;
+  color: var(--text-muted);
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11217,3 +11217,12 @@ details[open] > summary.lora-scope-group-heading::before,
   font-size: 12.5px;
   color: var(--text-muted);
 }
+.batch-confirm {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 10px;
+  font-size: 12.5px;
+  color: var(--text);
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -10897,3 +10897,307 @@ details[open] > summary.lora-scope-group-heading::before,
   font-size: 12px;
   padding: 3px 9px;
 }
+
+/* ── Batch Prompt Processing (epic 9952) ─────────────────────────────────────
+   The Batch toggle sits by the mode tabs; when on, the single prompt is swapped
+   for the two-column authoring panel (prompt list + variables | save/load/io). */
+.batch-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-family: var(--font-ui);
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background var(--t-fast), color var(--t-fast), border-color var(--t-fast);
+}
+.batch-toggle:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+.batch-toggle.active {
+  color: var(--accent-fg);
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.prompt-input-row.batch {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  align-items: stretch;
+}
+.batch-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 264px;
+  gap: 18px;
+}
+@media (max-width: 900px) {
+  .batch-panel {
+    grid-template-columns: 1fr;
+  }
+}
+.batch-panel-main,
+.batch-panel-side {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+.batch-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.batch-field-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+.batch-prompts {
+  min-height: 132px;
+  resize: vertical;
+  font-family: var(--font-ui);
+  font-size: 13.5px;
+  line-height: 1.5;
+  padding: 10px 12px;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+}
+.batch-prompts:focus {
+  outline: 2px solid var(--accent);
+  border-color: var(--accent);
+}
+.batch-vars {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.batch-var {
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: 8px 10px;
+  background: var(--surface-2);
+}
+.batch-var-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+.batch-var-key {
+  font-size: 12.5px;
+  color: var(--accent-strong);
+  font-weight: 600;
+}
+.batch-var-count {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.batch-var-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+.batch-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12.5px;
+  padding: 3px 4px 3px 9px;
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  border-radius: 999px;
+}
+.batch-chip-remove {
+  border: 0;
+  background: none;
+  cursor: pointer;
+  color: inherit;
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 4px;
+  opacity: 0.7;
+}
+.batch-chip-remove:hover {
+  opacity: 1;
+}
+.batch-var-input {
+  flex: 1;
+  min-width: 110px;
+  font-family: var(--font-ui);
+  font-size: 12.5px;
+  padding: 5px 8px;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+}
+.batch-var-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.batch-hint {
+  font-size: 12.5px;
+  color: var(--text-muted);
+}
+.batch-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.batch-preview-text {
+  font-size: 13px;
+  color: var(--text);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: 8px 10px;
+  white-space: pre-wrap;
+}
+.batch-total {
+  font-size: 14px;
+  color: var(--text);
+}
+.batch-total strong {
+  font-size: 18px;
+  color: var(--accent-strong);
+}
+.batch-total-detail {
+  display: block;
+  font-size: 11.5px;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+.batch-warning {
+  font-size: 12.5px;
+  color: var(--warn);
+}
+.batch-save,
+.batch-load {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.batch-name {
+  width: 100%;
+  font-family: var(--font-ui);
+  font-size: 13px;
+  padding: 7px 10px;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+}
+.batch-scope {
+  display: flex;
+  gap: 14px;
+  font-size: 12.5px;
+  color: var(--text-muted);
+}
+.batch-scope label {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  cursor: pointer;
+}
+.batch-scope-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.batch-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 600;
+  padding: 8px 12px;
+  border-radius: var(--r-sm);
+  border: 0;
+  cursor: pointer;
+  background: var(--accent);
+  color: var(--accent-fg);
+}
+.batch-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.batch-btn.ghost {
+  background: var(--surface-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+.batch-io {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+}
+.batch-io .batch-btn {
+  flex: 1;
+}
+.batch-file-input {
+  display: none;
+}
+.batch-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 184px;
+  overflow-y: auto;
+}
+.batch-list-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.batch-list-load {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12.5px;
+  padding: 6px 8px;
+  text-align: left;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  color: var(--text);
+  cursor: pointer;
+}
+.batch-list-item.active .batch-list-load {
+  border-color: var(--accent);
+}
+.batch-list-scope {
+  margin-left: auto;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-muted);
+}
+.batch-list-delete {
+  border: 0;
+  background: none;
+  color: var(--text-muted);
+  font-size: 15px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 2px 6px;
+}
+.batch-list-delete:hover {
+  color: var(--danger);
+}


### PR DESCRIPTION
## Summary

Adds **Batch Prompt Processing** to Image Studio (epic [9952](https://app.shortcut.com/trefry/epic/9952)): supply a list of `{{templated}}` prompts and run them as one batch against the current studio settings. Works across all three modes (Text / Edit / With character).

A **Batch** toggle sits by the mode tabs; when on, the single prompt box becomes a prompt-list textarea plus a value chip-editor per unique `{{key}}`, with a live image-count total and a first-prompt preview. Multi-valued variables fan out as a per-line cross-product. Batches are savable/loadable (server-persisted, global or per-project) and exportable/importable as portable JSON. Run enqueues one image job per resolved prompt with aggregated done/total progress and cancel.

## Why storage vs authoring are separated

Batches persist as JSON (server-side, shareable via export), but nobody types JSON — the UI is the friendly authoring layer. Persistence is a **sibling entity** to recipe presets (not an extension of them): a batch has no model/workflow/LoRA, so the recipe validators don't apply.

## Slices (one commit each)

| Story | Commit | What |
|-------|--------|------|
| [sc-9953](https://app.shortcut.com/trefry/story/9953) | template engine | `promptBatch.js`: parse `{{key}}`, resolve, **per-line** cross-product, cardinality |
| [sc-9954](https://app.shortcut.com/trefry/story/9954) | persistence | `apps/rust-api/src/prompt_batches.rs` + `/api/v1/prompt-batches` (global + per-project JSONC), `usePromptBatches` hook, `promptBatchIO` export/import |
| [sc-9955](https://app.shortcut.com/trefry/story/9955) | authoring UI | `BatchPromptPanel.jsx` + Batch-mode toggle in `ImageStudio.jsx` |
| [sc-9956](https://app.shortcut.com/trefry/story/9956) | run | fan-out (one job per resolved prompt) + aggregated cancelable progress |
| [sc-9957](https://app.shortcut.com/trefry/story/9957) | guardrails | 100-image soft cap w/ confirmation + unfilled-variable / empty-batch blocking |

## Design notes for reviewers

- **Per-line cross-product**, not one global product: each prompt line fans out only over the variables *it* references, so mixed prompts don't produce duplicate identical renders. `cardinality` is a sum over lines; invariant `cardinality(p,v,count) === expandBatch(p,v).length × count` keeps the live total honest and feeds the cap. All engine logic is pure + unit-tested.
- Backend mirrors `recipe_presets.rs` (shared manifest read→merge→save helpers, slug/duplicate reuse); delete soft-archives; project scope overrides global by id.
- Run reuses the asset-batch fan-out pattern (`assetBatch.jsx` / `batchOps.js` `summarizeBatchProgress`). `count` multiplies within each job (images = jobs × count).
- Authoring format: one prompt per line; `---` on its own line for multi-line prompts.

## Scope / deferred (tracked, not dropped)

- Batch **omits** structured-caption models (guarded off — plain prompts are OOD there) and the single-shot pose/strict-control conditioning → [sc-9980](https://app.shortcut.com/trefry/story/9980) (Backlog).
- **Zip/lockstep** variable pairing (alternative to cross-product) → [sc-9958](https://app.shortcut.com/trefry/story/9958) (Backlog).

## Validation

- **189** rust-api tests (new CRUD/validation/scope test) · `cargo fmt` + `clippy -D warnings` clean.
- **1243** web vitest (52 new across the batch modules — engine, IO round-trip, real-DOM panel test) · ESLint 0 errors · production build clean.
- **Not** visually QA'd in a live browser: the studio is gated behind the running Rust backend + a downloaded image model, which wasn't available in the working environment. The panel is covered by a real-DOM component test and uses existing design tokens; a local eyeball on layout is worth a reviewer's time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)