### PR TITLE
feat: SenseNova-U1 Infographic V2 as a coexisting model (epic 9959, sc-9960/9962)

### DIFF
--- a/apps/web/public/prompt-guides/sensenova-u1-8b-infographic-v2.md
+++ b/apps/web/public/prompt-guides/sensenova-u1-8b-infographic-v2.md
@@ -1,0 +1,76 @@
+# SenseNova-U1 8B Infographic V2 Prompt Guide
+
+## Best For
+
+Information-dense visual content: infographics, posters, presentations, comics, resumes, and knowledge illustrations where dense small-text, precise layout, and visual hierarchy all matter. V2 refines the base model with sharper small-text edges, more stable complex layouts, better overall aesthetics, and a fix for the black-background issue. It also handles the same unified surface as the base — image editing, wardrobe-preserving Character Studio, VQA, and Document Studio (interleaved text+image).
+
+## Prompt Shape
+
+Use a structured design brief:
+
+`purpose + subject/content + layout + visual hierarchy + exact text + style + camera/composition + details`
+
+Short prompts under-constrain the model, especially for infographics. Expand simple ideas into a clear layout and content plan.
+
+## Build The Prompt
+
+### Subject
+
+State the topic and main visual subject. For informational images, define the message the viewer should understand.
+
+Good: `an infographic explaining how urban rain gardens reduce street flooding`
+
+### Details
+
+For dense layouts, specify sections, labels, icons, charts, captions, and reading order. Keep every required text string exact and in quotes. V2 renders small labels and dense tables more crisply — you can push more text per panel than with the base model, but still bound each section clearly.
+
+### Style
+
+Name the design language:
+
+- `clean educational infographic`
+- `flat vector poster`
+- `arXiv-style technical page`
+- `presentation slide`
+- `comic explainer`
+
+### Layout And Composition
+
+For design layouts, use layout terms:
+
+- `two-column layout`
+- `four-card grid`
+- `large title at the top`
+- `central diagram with callout labels`
+- `clear margins and no overlapping text`
+
+### Text And Typography
+
+V2 is tuned for dense text, but it still needs exact instructions. Include font feel, relative size, alignment, and hierarchy. Quote every string you want rendered verbatim.
+
+### Backgrounds
+
+V2 fixes the base model's black-background failure mode, but it is still worth naming the background you want (`white background`, `soft gradient`, `light paper texture`) so the palette stays intentional.
+
+### Editing
+
+For edits, say what to preserve first, then what to change. Keep the edit instruction concrete and ordered.
+
+### Avoid
+
+- Vague one-line prompts for infographics or posters — they under-constrain the layout.
+- Approximate or unquoted text; always quote the exact strings you want rendered.
+- Conflicting or overlapping layout instructions (e.g. "centered" and "left-aligned" for the same element).
+- Cramming too many competing sections into one image; fewer, clearly bounded sections render more reliably.
+- Generic quality tags like `masterpiece` or `best quality`; describe concrete content and structure instead.
+
+## Example Prompts
+
+`Create a vertical educational infographic titled "RAIN GARDENS AT WORK". Use a clean flat vector style with a blue and green palette on a white background. Top section: a city street with rain falling. Middle section: a cutaway soil diagram with arrows labeled "runoff", "plant roots", and "filtered water". Bottom section: three benefit cards reading "Less flooding", "Cleaner rivers", and "More habitat". Large readable sans-serif text, crisp small labels, clear margins, no overlapping elements.`
+
+`A one-page resume layout for "Jordan Lee, Product Designer" on a light background. Left sidebar with "Contact", "Skills", and "Education" headers in small bold caps; right column with "Experience" entries in a clean two-line-per-role format. Muted navy accent color, generous whitespace, sharp legible body text.`
+
+## Sources
+
+- [SenseNova-U1 Infographic V2 model card](https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic-V2)
+- [SenseNova-U1 prompt enhancement doc](https://huggingface.co/sensenova/SenseNova-U1-8B-MoT/blob/main/docs/prompt_enhancement.md)

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1120,6 +1120,94 @@
       }
     },
     {
+      // SenseNova-U1-8B-MoT-Infographic-V2 (epic 9959): a coexisting checkpoint refresh of the SAME
+      // NEO-unify architecture as `sensenova_u1_8b` (identical config.json + tensor namespace — verified
+      // byte-for-byte), specialized for infographic generation with sharper dense small-text, more stable
+      // complex layouts, better aesthetics, and a black-background fix. Because the architecture is
+      // unchanged, it rides the EXISTING `sensenova_u1_8b` engine (engines.rs ModelRow engine_id) with no
+      // engine change — only a new hosted quant-matrix re-host + this catalog entry. Not `recommended`
+      // yet (pending on-device A/B vs V1). Full capability surface, identical to V1.
+      "id": "sensenova_u1_8b_infographic_v2",
+      "name": "SenseNova-U1 8B Infographic V2",
+      "family": "sensenova-u1",
+      "type": "image",
+      "adapter": "sensenova_u1",
+      "capabilities": ["text_to_image", "edit_image", "character_image", "vqa", "interleave"],
+      "downloads": [
+        // SceneWorks pre-built MLX quant-matrix turnkey (epic 9959, S1): a public/ungated re-host of
+        // sensenova/SenseNova-U1-8B-MoT-Infographic-V2 built with the same `prequantize_turnkey` harness
+        // as the base. Per-tier subdirs (each a complete from_snapshot tree: packed/dense backbone +
+        // tokenizer + config): q4/ (default), q8/, bf16/. Byte sizes are EXACT on-disk measurements of
+        // the hosted repo per subdir.
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/sensenova-u1-8b-infographic-v2-mlx",
+          "variant": "q4",
+          "default": true,
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 11824526363,
+          "footprint": { "diskSizeBytes": 11824526363, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/sensenova-u1-8b-infographic-v2-mlx",
+          "variant": "q8",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 19927923905,
+          "footprint": { "diskSizeBytes": 19927923905, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/sensenova-u1-8b-infographic-v2-mlx",
+          "variant": "bf16",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 35121744859,
+          "footprint": { "diskSizeBytes": 35121744859, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/SceneWorks/sensenova-u1-8b-infographic-v2-mlx"
+      },
+      "gated": false,
+      "defaults": {
+        "resolution": "2048x2048",
+        "steps": 50,
+        "guidanceScale": 4.0,
+        "count": 1,
+        "sampler": "default",
+        "scheduler": "shift",
+        "schedulerShift": 3.0
+      },
+      "limits": {
+        "resolutions": ["2048x2048", "2720x1536", "2496x1664", "2368x1760", "1536x2720", "1664x2496", "1760x2368"],
+        "count": [1, 2, 4],
+        "samplers": ["default"],
+        "schedulers": ["default"]
+      },
+      "loraCompatibility": {
+        "families": ["sensenova-u1"],
+        "types": []
+      },
+      "mlx": {
+        "quantize": 4,
+        "standardTierLayout": true
+      },
+      "ui": {
+        "label": "SenseNova-U1 8B Infographic V2",
+        "description": "Infographic-specialized variant of SenseNova-U1 (NEO-unify, ~16B), a coexisting checkpoint refresh of the base 8B model. Tuned for information-dense visual content — posters, presentations, comics, resumes, knowledge illustrations — with sharper dense small-text, more stable complex layouts, improved aesthetics, and a fix for the black-background issue. Same unified surface as the base: text-to-image, instruction editing, wardrobe-preserving Character Studio, VQA, and Document Studio (interleaved text+image). Heavy: ~35GB bf16, ~50 steps; runs on large-VRAM GPUs and 96GB+ Apple Silicon (MPS).",
+        "recommendedFor": ["text_to_image", "edit_image", "character_image"],
+        "variationStrength": { "label": "Reference strength", "default": 1.5, "min": 0.5, "max": 4.0, "step": 0.1 },
+        "promptGuide": {
+          "title": "SenseNova-U1 8B Infographic V2 Prompt Guide",
+          "path": "/prompt-guides/sensenova-u1-8b-infographic-v2.md",
+          "sources": [
+            { "label": "SenseNova-U1 Infographic V2 model card", "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic-V2" },
+            { "label": "SenseNova-U1 prompt enhancement doc", "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT/blob/main/docs/prompt_enhancement.md" }
+          ]
+        }
+      }
+    },
+    {
       "id": "sensenova_u1_8b_fast",
       "name": "SenseNova-U1 8B Fast",
       "family": "sensenova-u1",

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -583,6 +583,16 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
     ModelCaps::new("chroma1_flash", true, true, false, false, false),
     // SenseNova-U1 (epic 3180 / sc-3900 MLX; sc-5576 candle). Pure txt2img on candle.
     ModelCaps::new("sensenova_u1_8b", true, true, false, false, false),
+    // Infographic-V2 (epic 9959): coexisting checkpoint refresh of the SAME NEO-unify engine as the
+    // base id — routes identically (MLX full surface; candle pure txt2img).
+    ModelCaps::new(
+        "sensenova_u1_8b_infographic_v2",
+        true,
+        true,
+        false,
+        false,
+        false,
+    ),
     ModelCaps::new("sensenova_u1_8b_fast", true, true, false, false, false),
     // Kolors (epic 3090): full surface on the Rust `kolors` engine (SDXL-family U-Net + ChatGLM3);
     // candle serves txt2img + bespoke IP/pose lanes (sc-5488/sc-5489).
@@ -871,6 +881,7 @@ mod tests {
         "chroma1_flash",
         "sensenova_u1_8b",
         "sensenova_u1_8b_fast",
+        "sensenova_u1_8b_infographic_v2",
         "kolors",
         "lens",
         "lens_turbo",
@@ -908,6 +919,7 @@ mod tests {
         "chroma1_flash",
         "kolors",
         "sensenova_u1_8b",
+        "sensenova_u1_8b_infographic_v2",
         "sensenova_u1_8b_fast",
         "ideogram_4",
         "ideogram_4_turbo",

--- a/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
@@ -63,7 +63,9 @@ pub(crate) fn image_request_mlx_eligible(model: &str, payload: &Map<String, Valu
         "instantid_realvisxl" => instantid_mlx_eligible(payload),
         "pulid_flux_dev" => pulid_flux_mlx_eligible(payload),
         "chroma1_hd" | "chroma1_base" | "chroma1_flash" => chroma_mlx_eligible(payload),
-        "sensenova_u1_8b" | "sensenova_u1_8b_fast" => sensenova_mlx_eligible(payload),
+        "sensenova_u1_8b" | "sensenova_u1_8b_infographic_v2" | "sensenova_u1_8b_fast" => {
+            sensenova_mlx_eligible(payload)
+        }
         "kolors" => kolors_mlx_eligible(payload),
         "lens" | "lens_turbo" => lens_mlx_eligible(payload),
         "bernini_image" => bernini_image_mlx_eligible(payload),

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -360,6 +360,18 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
         adapter_label: "mlx_sensenova",
     },
     ModelRow {
+        // Infographic-V2 (epic 9959): coexisting checkpoint refresh of the base NEO-unify model.
+        // Its config + tensor layout are byte-identical to the base, so it rides the SAME engine
+        // (`engine_id: "sensenova_u1_8b"`) with no engine change — only a distinct SceneWorks
+        // quant-matrix re-host (q4/q8/bf16 packed tiers, epic 9959 S1). Same defaults as the base.
+        sceneworks_id: "sensenova_u1_8b_infographic_v2",
+        engine_id: "sensenova_u1_8b",
+        default_repo: "SceneWorks/sensenova-u1-8b-infographic-v2-mlx",
+        default_steps: 50,
+        default_guidance: 4.0,
+        adapter_label: "mlx_sensenova",
+    },
+    ModelRow {
         sceneworks_id: "sensenova_u1_8b_fast",
         engine_id: "sensenova_u1_8b_fast",
         // sc-8775: SceneWorks MLX quant-matrix re-host of the *distilled* variant — q4/q8/bf16 packed

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1669,7 +1669,10 @@ fn is_flux_model(model: &str) -> bool {
 /// `mlx-gen-sensenova` engine (sc-3900).
 #[cfg(target_os = "macos")]
 fn is_sensenova_model(model: &str) -> bool {
-    matches!(model, "sensenova_u1_8b" | "sensenova_u1_8b_fast")
+    matches!(
+        model,
+        "sensenova_u1_8b" | "sensenova_u1_8b_infographic_v2" | "sensenova_u1_8b_fast"
+    )
 }
 
 /// Stage the engine's IP-Adapter dir contract from the two cached HF snapshots:
@@ -3225,6 +3228,7 @@ fn is_candle_engine(model: &str) -> bool {
             | "lens_turbo"
             | "kolors"
             | "sensenova_u1_8b"
+            | "sensenova_u1_8b_infographic_v2"
             | "sensenova_u1_8b_fast"
             | "ideogram_4"
             | "ideogram_4_turbo"
@@ -3273,7 +3277,9 @@ fn candle_adapter_label(model: &str) -> &'static str {
         "chroma1_hd" | "chroma1_base" | "chroma1_flash" => "candle_chroma",
         "lens" | "lens_turbo" => "candle_lens",
         "kolors" => "candle_kolors",
-        "sensenova_u1_8b" | "sensenova_u1_8b_fast" => "candle_sensenova",
+        "sensenova_u1_8b" | "sensenova_u1_8b_infographic_v2" | "sensenova_u1_8b_fast" => {
+            "candle_sensenova"
+        }
         "ideogram_4" | "ideogram_4_turbo" => "candle_ideogram",
         "boogu_image" | "boogu_image_turbo" | "boogu_image_edit" => "candle_boogu",
         "krea_2_turbo" => "candle_krea",

--- a/crates/sceneworks-worker/src/sensenova_jobs.rs
+++ b/crates/sceneworks-worker/src/sensenova_jobs.rs
@@ -1561,6 +1561,88 @@ mod tests {
         );
     }
 
+    /// sc-9960 (epic 9959) S0 engine-load de-risk: prove the NEW `Infographic-V2` checkpoint
+    /// (`sensenova/SenseNova-U1-8B-MoT-Infographic-V2`, ~33GB dense bf16) loads and runs on the
+    /// CURRENTLY pinned `mlx-gen-sensenova` with NO engine change. Static analysis already showed
+    /// V2's `config.json` is byte-identical to V1's and its tensor namespace adds nothing new, so
+    /// this is expected to be a no-op like the LTX-2.3 dense tier — but S0's AC requires an actual
+    /// render + VQA, not just the static diff. Exercises the full stack in one shot: config +
+    /// sharded weight load + tokenizer (V2 ships slow-only vocab.json/merges.txt, no tokenizer.json —
+    /// a `load_tokenizer` failure here means a derived-tokenizer overlay is an S1 conversion step,
+    /// NOT an architecture problem), the understanding path (VQA), and the generation path
+    /// (interleave decode + non-degenerate render check). Run on demand:
+    /// `cargo test -p sceneworks-worker --lib -- --ignored sensenova_v2_infographic_real_weights`.
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "needs real SenseNova-U1-8B-MoT-Infographic-V2 weights (~33GB) + Metal device"]
+    fn sensenova_v2_infographic_real_weights_load_render_vqa() {
+        let snapshot = hf_snapshot("models--sensenova--SenseNova-U1-8B-MoT-Infographic-V2");
+        let (model, tokenizer) =
+            load_sensenova_model(&snapshot).expect("load V2 model on the current pinned engine");
+
+        // Understanding path: VQA over a synthetic image must return non-empty text post think-strip.
+        let image = gradient_image(512, 512);
+        let pixel_values = image_to_chw01(&image, 256 * 256, 768 * 768).expect("preprocess");
+        let answer = model
+            .vqa(
+                &tokenizer,
+                "What colors appear in this image?",
+                std::slice::from_ref(&pixel_values),
+                64,
+                Sampler::Greedy,
+                None,
+            )
+            .expect("V2 vqa");
+        let answer = strip_reasoning(&answer);
+        assert!(
+            !answer.is_empty(),
+            "V2 VQA answer should be non-empty: {answer:?}"
+        );
+
+        // Generation path: the PRIMARY t2i render (what the Infographic-V2 checkpoint is tuned for).
+        // 512² + 16 steps for speed (production is 2048²/50); we only assert the decode is a real,
+        // non-degenerate image, not infographic quality (that's S4 on-device validation).
+        let opts = T2iOptions {
+            cfg_scale: 4.0,
+            img_cfg_scale: 1.0,
+            num_steps: 16,
+            timestep_shift: 3.0,
+            seed: 42,
+            think_mode: false,
+            ..Default::default()
+        };
+        let out = model
+            .generate(
+                &tokenizer,
+                "an infographic poster about the water cycle, clean vector style",
+                512,
+                512,
+                &opts,
+                None,
+                None,
+            )
+            .expect("V2 t2i generate");
+        let decoded = decoded_to_image(&out.image).expect("decode");
+        assert_eq!(
+            decoded.pixels.len(),
+            (decoded.width * decoded.height * 3) as usize
+        );
+        // Non-degenerate check: a NaN/all-black/flat decode collapses the per-pixel std toward 0.
+        let n = decoded.pixels.len() as f64;
+        let mean = decoded.pixels.iter().map(|&p| p as f64).sum::<f64>() / n;
+        let std = (decoded
+            .pixels
+            .iter()
+            .map(|&p| (p as f64 - mean).powi(2))
+            .sum::<f64>()
+            / n)
+            .sqrt();
+        assert!(
+            std > 10.0,
+            "V2 render looks degenerate (std {std:.2}, mean {mean:.2}) — possible NaN / all-black / flat decode"
+        );
+    }
+
     /// sc-8771 on-device verify (MLX, epic 8506 Group-B): drive the ACTUAL packed worker seam against
     /// the downloaded SceneWorks/sensenova-u1-8b-mlx **q4** turnkey tier. SenseNova-U1 is a unified MoT
     /// (no separate TE/VAE) whose whole backbone packs into a flat `q4/model.safetensors`; the worker's

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -348,6 +348,9 @@ fn model_table_rows_resolve_and_flags_match_descriptor() {
         ("chroma1_base", false, true),
         ("chroma1_flash", false, true),
         ("sensenova_u1_8b", true, false),
+        // Infographic-V2 (epic 9959): rides the base `sensenova_u1_8b` engine id, so its descriptor
+        // flags are identical to the base (guidance true, negative false).
+        ("sensenova_u1_8b_infographic_v2", true, false),
         ("sensenova_u1_8b_fast", true, false),
         // Lens / Lens-Turbo (epic 3164 / sc-5105): the `mlx-gen-lens` descriptor advertises the
         // norm-rescaled CFG path (`supports_guidance=true`) + a negative prompt


### PR DESCRIPTION
Adds **SenseNova-U1-8B-MoT-Infographic-V2** as a new, coexisting model alongside the existing `sensenova_u1_8b` (V1 unchanged). Part of epic [sc-9959](https://app.shortcut.com/trefry/epic/9959).

## What & why

V2 is a **checkpoint refresh of the same `neo_chat`/NEO-unify architecture** as the base — its `config.json` is byte-identical and its tensor namespace adds zero new/renamed tensors (verified statically and by a real-weight load+render+VQA on the pinned engine). So it rides the **existing `sensenova_u1_8b` engine with no engine change** — only a distinct SceneWorks quant-matrix re-host + this catalog wiring. It ships the **full capability surface identical to V1**: `text_to_image`, `edit_image`, `character_image`, `vqa`, `interleave` (VQA + Document Studio are the point of SenseNova, so they are not gated).

Tiers are hosted at [`SceneWorks/sensenova-u1-8b-infographic-v2-mlx`](https://huggingface.co/SceneWorks/sensenova-u1-8b-infographic-v2-mlx) (public, Apache-2.0): q4 (default) 11.82 GB / q8 19.93 GB / bf16 35.12 GB — all remote-verified.

Not marked `recommended` yet — pending on-device A/B vs V1 (epic story S4).

## Changes

- **sc-9960** — `#[ignore]` engine-load de-risk test in `sensenova_jobs.rs` (loads V2 on the pinned engine; VQA + primary T2I render with a non-degenerate check).
- **sc-9962** — catalog wiring:
  - manifest entry `sensenova_u1_8b_infographic_v2` (per-tier q4/q8/bf16 variant matrix with exact hosted bytes, `standardTierLayout`, full caps) + a dedicated prompt guide
  - `catalog.rs` `ModelCaps` (auto-derives the MLX/candle routed lists) + the two EXPECTED test mirrors
  - `mlx.rs` sensenova eligibility, `is_sensenova_model`, candle txt2img match + `candle_adapter_label`
  - `engines.rs` `ModelRow` — `engine_id: "sensenova_u1_8b"` (same engine) + the V2 repo; plus the exhaustive `MODEL_TABLE` descriptor-parity expectation

## Verification

All green, including after merging `origin/main` (the SANA rollout #1202 + candle tier-select #1203 touched the same structures — additive, auto-merged clean, re-verified):
`scripts/check-scaffold.mjs` · `npm run rust:check` (fmt / clippy `-D warnings` / full `cargo test` / build) · candle parity (`--no-default-features -F backend-candle --all-targets`) · web vitest.

Remaining in the epic: S3 (fast 8-step tier — conditional) and S4 (on-device full-surface A/B validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)