### PR TITLE
feat: SenseNova-U1 Infographic-V2 fast (8-step) tier + V2 VQA-routing fix (epic 9959, sc-9963)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1328,6 +1328,100 @@
       }
     },
     {
+      // Infographic-V2 8-step distilled variant (epic 9959, sc-9963). The V1 8-step distill LoRA
+      // (sensenova/SenseNova-U1-8B-MoT-LoRAs) merges cleanly onto V2 (296/296 gen-path targets) and
+      // renders coherent 8-step infographics — validated on-device. Pre-merged + packed per tier
+      // (distill_merged.json marker → load_fast skips the load-time merge), riding the existing
+      // sensenova_u1_8b_fast engine. T2I / edit / character only (no VQA / interleave), 8 steps / cfg 1.0.
+      "id": "sensenova_u1_8b_infographic_v2_fast",
+      "name": "SenseNova-U1 8B Infographic V2 Fast",
+      "family": "sensenova-u1",
+      "type": "image",
+      "adapter": "sensenova_u1",
+      "capabilities": ["text_to_image", "edit_image", "character_image"],
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/sensenova-u1-8b-infographic-v2-fast-mlx",
+          "variant": "q4",
+          "default": true,
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 11824526409,
+          "footprint": { "diskSizeBytes": 11824526409, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/sensenova-u1-8b-infographic-v2-fast-mlx",
+          "variant": "q8",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 19927924235,
+          "footprint": { "diskSizeBytes": 19927924235, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/sensenova-u1-8b-infographic-v2-fast-mlx",
+          "variant": "bf16",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 35121633249,
+          "footprint": { "diskSizeBytes": 35121633249, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/SceneWorks/sensenova-u1-8b-infographic-v2-fast-mlx"
+      },
+      "gated": false,
+      "defaults": {
+        "resolution": "2048x2048",
+        "steps": 8,
+        "guidanceScale": 1.0,
+        "count": 1,
+        "sampler": "default",
+        "scheduler": "shift",
+        "schedulerShift": 3.0
+      },
+      "limits": {
+        "resolutions": ["2048x2048", "2720x1536", "2496x1664", "2368x1760", "1536x2720", "1664x2496", "1760x2368"],
+        "count": [1, 2, 4],
+        "samplers": ["default"],
+        "schedulers": ["default"]
+      },
+      "loraCompatibility": {
+        "families": ["sensenova-u1"],
+        "types": []
+      },
+      "mlx": {
+        "quantize": 4,
+        "standardTierLayout": true
+      },
+      "ui": {
+        "label": "SenseNova-U1 8B Infographic V2 Fast",
+        "description": "8-step distilled SenseNova-U1 Infographic V2 — ~5–6× faster infographic/poster text-to-image, editing, and Character Studio reference at a small quality trade-off. Same infographic strengths as the V2 base (dense small-text, stable layouts, black-background fix) at 8 steps / cfg 1.0. Ships as its own pre-built quant-matrix (q4 default / q8 / bf16), each a self-contained tier with the 8-step distill LoRA already merged in — no separate LoRA download. Use the V2 base for max-quality dense-text work.",
+        "recommendedFor": ["text_to_image", "edit_image", "character_image"],
+        "variationStrength": { "label": "Reference strength", "default": 1.5, "min": 0.5, "max": 4.0, "step": 0.1 },
+        "viewAngles": [
+          { "id": "three_quarter_left", "label": "Three-quarter left" },
+          { "id": "three_quarter_right", "label": "Three-quarter right" },
+          { "id": "left_profile", "label": "Left profile" },
+          { "id": "right_profile", "label": "Right profile" },
+          { "id": "up", "label": "Looking up" },
+          { "id": "down", "label": "Looking down" },
+          { "id": "up_left", "label": "Up · left" },
+          { "id": "up_right", "label": "Up · right" },
+          { "id": "down_left", "label": "Down · left" },
+          { "id": "down_right", "label": "Down · right" },
+          { "id": "front", "label": "Front" }
+        ],
+        "promptGuide": {
+          "title": "SenseNova-U1 8B Infographic V2 Fast Prompt Guide",
+          "path": "/prompt-guides/sensenova-u1-8b-infographic-v2.md",
+          "sources": [
+            { "label": "SenseNova-U1 Infographic V2 model card", "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Infographic-V2" },
+            { "label": "SenseNova-U1 prompt enhancement doc", "url": "https://huggingface.co/sensenova/SenseNova-U1-8B-MoT/blob/main/docs/prompt_enhancement.md" }
+          ]
+        }
+      }
+    },
+    {
       "id": "flux_schnell",
       "name": "FLUX.1 [schnell]",
       "family": "flux",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -4783,6 +4783,23 @@ mod candle_routing_tests {
                 json!({ "model": "sensenova_u1_8b_fast", "prompt": "a short illustrated story" })
             )
         ));
+        // Infographic-V2 base advertises the SAME understanding surface (epic 9959): the eligibility
+        // list must include its id, else V2 VQA / Document-Studio jobs never route to the in-process
+        // worker (regression guard for the sc-9963 fix).
+        assert!(worker_supports_job(
+            &candle,
+            &understanding_job(
+                "image_vqa",
+                json!({ "model": "sensenova_u1_8b_infographic_v2", "question": "what is this?", "sourceAssetId": "a1" })
+            )
+        ));
+        assert!(worker_supports_job(
+            &candle,
+            &understanding_job(
+                "image_interleave",
+                json!({ "model": "sensenova_u1_8b_infographic_v2", "prompt": "an illustrated explainer" })
+            )
+        ));
         // Refuses a non-SenseNova understanding job → falls back to the Python torch worker.
         assert!(!worker_supports_job(
             &candle,

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -594,6 +594,15 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
         false,
     ),
     ModelCaps::new("sensenova_u1_8b_fast", true, true, false, false, false),
+    // Infographic-V2 8-step distilled variant (epic 9959): same fast engine, routes like the base fast.
+    ModelCaps::new(
+        "sensenova_u1_8b_infographic_v2_fast",
+        true,
+        true,
+        false,
+        false,
+        false,
+    ),
     // Kolors (epic 3090): full surface on the Rust `kolors` engine (SDXL-family U-Net + ChatGLM3);
     // candle serves txt2img + bespoke IP/pose lanes (sc-5488/sc-5489).
     ModelCaps::new("kolors", true, true, false, false, false),
@@ -893,6 +902,7 @@ mod tests {
         "sensenova_u1_8b",
         "sensenova_u1_8b_fast",
         "sensenova_u1_8b_infographic_v2",
+        "sensenova_u1_8b_infographic_v2_fast",
         "kolors",
         "lens",
         "lens_turbo",
@@ -932,6 +942,7 @@ mod tests {
         "sensenova_u1_8b",
         "sensenova_u1_8b_infographic_v2",
         "sensenova_u1_8b_fast",
+        "sensenova_u1_8b_infographic_v2_fast",
         "ideogram_4",
         "ideogram_4_turbo",
         "boogu_image",

--- a/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
@@ -63,9 +63,10 @@ pub(crate) fn image_request_mlx_eligible(model: &str, payload: &Map<String, Valu
         "instantid_realvisxl" => instantid_mlx_eligible(payload),
         "pulid_flux_dev" => pulid_flux_mlx_eligible(payload),
         "chroma1_hd" | "chroma1_base" | "chroma1_flash" => chroma_mlx_eligible(payload),
-        "sensenova_u1_8b" | "sensenova_u1_8b_infographic_v2" | "sensenova_u1_8b_fast" => {
-            sensenova_mlx_eligible(payload)
-        }
+        "sensenova_u1_8b"
+        | "sensenova_u1_8b_infographic_v2"
+        | "sensenova_u1_8b_fast"
+        | "sensenova_u1_8b_infographic_v2_fast" => sensenova_mlx_eligible(payload),
         "kolors" => kolors_mlx_eligible(payload),
         "lens" | "lens_turbo" => lens_mlx_eligible(payload),
         "bernini_image" => bernini_image_mlx_eligible(payload),
@@ -123,7 +124,17 @@ pub(crate) fn understanding_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or("sensenova_u1_8b");
-    matches!(model, "sensenova_u1_8b" | "sensenova_u1_8b_fast")
+    // All SenseNova-U1 ids (base + Infographic-V2 + distilled) serve the understanding surface via
+    // the same in-process T2iModel. V2 base advertises vqa/interleave; the `_fast` ids don't (their
+    // manifests omit those caps, so a VQA/interleave job is never created for them) but are listed for
+    // parity with the base+fast pattern — harmless.
+    matches!(
+        model,
+        "sensenova_u1_8b"
+            | "sensenova_u1_8b_infographic_v2"
+            | "sensenova_u1_8b_fast"
+            | "sensenova_u1_8b_infographic_v2_fast"
+    )
 }
 
 /// SDXL MLX-routing conditions. sc-3026 brought txt2img + LoRA; sc-3060 (epic 3041) adds the

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -384,6 +384,18 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
         default_guidance: 1.0,
         adapter_label: "mlx_sensenova",
     },
+    ModelRow {
+        // Infographic-V2 8-step distilled variant (epic 9959, sc-9963): the V1 distill LoRA merges
+        // cleanly onto V2 (296/296 gen-path targets) and renders coherent 8-step infographics. Same
+        // pre-merged + packed layout as the base fast (distill_merged.json marker → load_fast skip),
+        // so it rides the SAME `sensenova_u1_8b_fast` engine id — only the re-host repo differs.
+        sceneworks_id: "sensenova_u1_8b_infographic_v2_fast",
+        engine_id: "sensenova_u1_8b_fast",
+        default_repo: "SceneWorks/sensenova-u1-8b-infographic-v2-fast-mlx",
+        default_steps: 8,
+        default_guidance: 1.0,
+        adapter_label: "mlx_sensenova",
+    },
     // Microsoft Lens / Lens-Turbo (epic 3164 engine / sc-5105 cutover) — gpt-oss-20b MoE text
     // encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE. Pure **T2I** (the descriptor advertises
     // no conditioning — no img2img / ControlNet / IP), so both ids ride the base [`generate_stream`]

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1681,7 +1681,10 @@ fn is_flux_model(model: &str) -> bool {
 fn is_sensenova_model(model: &str) -> bool {
     matches!(
         model,
-        "sensenova_u1_8b" | "sensenova_u1_8b_infographic_v2" | "sensenova_u1_8b_fast"
+        "sensenova_u1_8b"
+            | "sensenova_u1_8b_infographic_v2"
+            | "sensenova_u1_8b_fast"
+            | "sensenova_u1_8b_infographic_v2_fast"
     )
 }
 
@@ -3241,6 +3244,7 @@ fn is_candle_engine(model: &str) -> bool {
             | "sensenova_u1_8b"
             | "sensenova_u1_8b_infographic_v2"
             | "sensenova_u1_8b_fast"
+            | "sensenova_u1_8b_infographic_v2_fast"
             | "ideogram_4"
             | "ideogram_4_turbo"
             // Boogu-Image-0.1 (sc-7524, epic 6831): Base + Turbo (txt2img) and the Edit checkpoint, all
@@ -3288,9 +3292,10 @@ fn candle_adapter_label(model: &str) -> &'static str {
         "chroma1_hd" | "chroma1_base" | "chroma1_flash" => "candle_chroma",
         "lens" | "lens_turbo" => "candle_lens",
         "kolors" => "candle_kolors",
-        "sensenova_u1_8b" | "sensenova_u1_8b_infographic_v2" | "sensenova_u1_8b_fast" => {
-            "candle_sensenova"
-        }
+        "sensenova_u1_8b"
+        | "sensenova_u1_8b_infographic_v2"
+        | "sensenova_u1_8b_fast"
+        | "sensenova_u1_8b_infographic_v2_fast" => "candle_sensenova",
         "ideogram_4" | "ideogram_4_turbo" => "candle_ideogram",
         "boogu_image" | "boogu_image_turbo" | "boogu_image_edit" => "candle_boogu",
         "krea_2_turbo" => "candle_krea",

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -352,6 +352,8 @@ fn model_table_rows_resolve_and_flags_match_descriptor() {
         // flags are identical to the base (guidance true, negative false).
         ("sensenova_u1_8b_infographic_v2", true, false),
         ("sensenova_u1_8b_fast", true, false),
+        // Infographic-V2 fast (epic 9959): rides the base `sensenova_u1_8b_fast` engine id → same flags.
+        ("sensenova_u1_8b_infographic_v2_fast", true, false),
         // Lens / Lens-Turbo (epic 3164 / sc-5105): the `mlx-gen-lens` descriptor advertises the
         // norm-rescaled CFG path (`supports_guidance=true`) + a negative prompt
         // (`supports_negative_prompt=true`) — a standard guidance family (NOT true-CFG), so the worker


### PR DESCRIPTION
Adds the **8-step distilled `SenseNova-U1 8B Infographic V2 Fast`** variant, coexisting with the V2 base (merged in #1206). Part of epic [sc-9959](https://app.shortcut.com/trefry/epic/9959).

## Viability (the S3 question)

The V1 8-step distill LoRA (`sensenova/SenseNova-U1-8B-MoT-LoRAs`) **merges cleanly onto the V2 checkpoint** — full coverage (296/296 gen-path targets) — and renders **coherent 8-step infographics**, verified on-device (a legible "THE WATER CYCLE" poster with labeled stages). So the fast tier is real, not a no-op.

Tiers hosted at [`SceneWorks/sensenova-u1-8b-infographic-v2-fast-mlx`](https://huggingface.co/SceneWorks/sensenova-u1-8b-infographic-v2-fast-mlx) (public, Apache-2.0): q4 (default) 11.82 GB / q8 19.93 GB / bf16 35.12 GB — LoRA pre-merged + packed per tier with a `distill_merged.json` marker, all remote-verified. Ships **t2i / edit / character only** (no VQA/interleave, matching the base fast), 8 steps / cfg 1.0.

## Changes

- manifest entry `sensenova_u1_8b_infographic_v2_fast` (per-tier q4/q8/bf16 with exact hosted bytes, `standardTierLayout`, reuses the V2 base prompt guide)
- catalog `ModelCaps` + EXPECTED mirrors; mlx eligibility; `engines.rs` `ModelRow` with `engine_id: "sensenova_u1_8b_fast"` (the same distilled engine — `load_fast` marker-skip) + the exhaustive `MODEL_TABLE` expectation; `base.rs` `is_sensenova_model` / candle match / adapter label

## Bugfix folded in (found while wiring)

`understanding_job_is_mlx_eligible` did **not** include the V2 base id `sensenova_u1_8b_infographic_v2`, so **V2 VQA / Document-Studio jobs would not route to the in-process worker** — a gap from the V2-base PR (#1206) that its test didn't catch (it only exercised the base id). Fixed to include both V2 ids, with a regression test in the candle-understanding routing test.

## Verification

All green: `check-scaffold.mjs` · `npm run rust:check` (fmt / clippy `-D warnings` / full `cargo test` / build) · candle parity (`--no-default-features -F backend-candle --all-targets`) · core routing tests incl. the new V2-understanding regression assertion.

Closes the code for epic 9959. Remaining: S4 — your on-device A/B of V2 base vs V1 across all five modes (also decides whether V2 gets flagged `recommended`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)