### PR TITLE
fix(web): batch variable values commit live, not on Enter (sc-9991)

### DIFF
--- a/apps/web/src/components/BatchPromptPanel.jsx
+++ b/apps/web/src/components/BatchPromptPanel.jsx
@@ -17,49 +17,60 @@ import { Icon } from "./Icons.jsx";
 // (usePromptBatches via callbacks + promptBatchIO for the portable file). The actual
 // fan-out on "Run batch" is wired by the parent (slice 4, sc-9956).
 
-// One variable's chip editor: type a value, Enter/"Add" appends a chip. Values may
-// contain commas ("red, wavy"), so this is a chip list — never a comma split.
+// One variable's value editor: an auto-expanding list of inputs. A typed value counts
+// LIVE (no "press Enter to commit" step — that stranded a typed value as 0 values); a
+// trailing empty box always sits at the end, so more values appear as you type. Each is
+// its own input (not a comma split) so a value may contain commas ("red, wavy"). Empty
+// values are ignored everywhere by the engine and stripped from the saved payload.
 function VariableChips({ label, values, onChange }) {
-  const [draft, setDraft] = useState("");
-  const add = () => {
-    const value = draft.trim();
-    if (!value) return;
-    onChange([...values, value]);
-    setDraft("");
+  const list = Array.isArray(values) ? values : [];
+  // Ensure exactly one trailing empty slot to type the next value into.
+  const slots = list.length && list[list.length - 1].trim() === "" ? list : [...list, ""];
+  const filled = list.filter((value) => value.trim() !== "").length;
+
+  const setAt = (index, value) => {
+    const next = [...slots];
+    next[index] = value;
+    onChange(next);
   };
+  const removeAt = (index) => onChange(slots.filter((_, i) => i !== index));
+
   return (
     <div className="batch-var">
       <div className="batch-var-head">
         <code className="batch-var-key">{`{{${label}}}`}</code>
-        <span className="batch-var-count">{values.length === 1 ? "1 value" : `${values.length} values`}</span>
+        <span className="batch-var-count">{filled === 1 ? "1 value" : `${filled} values`}</span>
       </div>
-      <div className="batch-var-chips">
-        {values.map((value, index) => (
-          <span className="batch-chip" key={`${value}-${index}`}>
-            {value}
-            <button
-              aria-label={`Remove ${value}`}
-              className="batch-chip-remove"
-              onClick={() => onChange(values.filter((_, i) => i !== index))}
-              type="button"
-            >
-              ×
-            </button>
-          </span>
+      <div className="batch-var-values">
+        {slots.map((value, index) => (
+          <div className="batch-value" key={index}>
+            <input
+              aria-label={`Value ${index + 1} for ${label}`}
+              className="batch-var-input"
+              onChange={(event) => setAt(index, event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                } else if (event.key === "Backspace" && value === "" && slots.length > 1) {
+                  event.preventDefault();
+                  removeAt(index);
+                }
+              }}
+              placeholder={index === 0 ? "Type a value" : "Another value"}
+              value={value}
+            />
+            {value.trim() !== "" ? (
+              <button
+                aria-label={`Remove ${value}`}
+                className="batch-value-remove"
+                onClick={() => removeAt(index)}
+                type="button"
+              >
+                ×
+              </button>
+            ) : null}
+          </div>
         ))}
-        <input
-          aria-label={`Add a value for ${label}`}
-          className="batch-var-input"
-          onChange={(event) => setDraft(event.target.value)}
-          onKeyDown={(event) => {
-            if (event.key === "Enter") {
-              event.preventDefault();
-              add();
-            }
-          }}
-          placeholder={values.length ? "Add another…" : "Type a value, press Enter"}
-          value={draft}
-        />
       </div>
     </div>
   );

--- a/apps/web/src/components/BatchPromptPanel.test.jsx
+++ b/apps/web/src/components/BatchPromptPanel.test.jsx
@@ -80,15 +80,20 @@ describe("BatchPromptPanel (sc-9955)", () => {
     expect(document.body.querySelector(".batch-total strong").textContent).toBe("12");
   });
 
-  it("adds a variable value as a chip on Enter and updates the total", async () => {
+  it("commits a typed value live, without pressing Enter", async () => {
     mount({ initialPrompts: "{{name}} portrait", count: 1 });
-    const input = document.body.querySelector(".batch-var-input");
-    await act(async () => {
-      setValue(input, "Alice");
-      input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
-    });
-    const chips = [...document.body.querySelectorAll(".batch-chip")].map((el) => el.textContent.replace("×", "").trim());
-    expect(chips).toContain("Alice");
+    await act(async () => setValue(document.body.querySelector(".batch-var-input"), "Alice"));
+    expect(document.body.querySelector(".batch-var-count").textContent).toBe("1 value");
+  });
+
+  it("auto-expands to accept multiple values as you type", async () => {
+    mount({ initialPrompts: "{{c}}" });
+    const inputs = () => [...document.body.querySelectorAll(".batch-var-input")];
+    expect(inputs()).toHaveLength(1);
+    await act(async () => setValue(inputs()[0], "red"));
+    expect(inputs()).toHaveLength(2); // a fresh trailing box appears
+    await act(async () => setValue(inputs()[1], "blue"));
+    expect(document.body.querySelector(".batch-var-count").textContent).toBe("2 values");
   });
 
   it("disables Save until a name is entered", async () => {
@@ -100,13 +105,9 @@ describe("BatchPromptPanel (sc-9955)", () => {
     expect(saveButton.disabled).toBe(false);
   });
 
-  it("previews the first resolved prompt using entered values", async () => {
+  it("previews the first resolved prompt from a live-typed value", async () => {
     mount({ initialPrompts: "{{name}} portrait" });
-    const input = document.body.querySelector(".batch-var-input");
-    await act(async () => {
-      setValue(input, "Alice");
-      input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
-    });
+    await act(async () => setValue(document.body.querySelector(".batch-var-input"), "Alice"));
     expect(document.body.querySelector(".batch-preview-text").textContent).toBe("Alice portrait");
   });
 

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -381,7 +381,13 @@ export function ImageStudio() {
 
   const batchPrompts = useMemo(() => splitPromptLines(batchPromptsText), [batchPromptsText]);
   const batchVariables = useMemo(
-    () => extractKeys(batchPrompts).map((key) => ({ key, values: batchVariableValues[key] ?? [] })),
+    () =>
+      extractKeys(batchPrompts).map((key) => ({
+        key,
+        // The value editor keeps a trailing empty slot; drop blanks so saved batches
+        // and the run payload carry only real values (the engine ignores them anyway).
+        values: (batchVariableValues[key] ?? []).filter((value) => value.trim() !== ""),
+      })),
     [batchPrompts, batchVariableValues],
   );
   const batchTotal = useMemo(

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11003,41 +11003,22 @@ details[open] > summary.lora-scope-group-heading::before,
   font-size: 11px;
   color: var(--text-muted);
 }
-.batch-var-chips {
+.batch-var-values {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 6px;
+}
+.batch-value {
+  display: flex;
   align-items: center;
-}
-.batch-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 12.5px;
-  padding: 3px 4px 3px 9px;
-  background: var(--accent-soft);
-  color: var(--accent-strong);
-  border-radius: 999px;
-}
-.batch-chip-remove {
-  border: 0;
-  background: none;
-  cursor: pointer;
-  color: inherit;
-  font-size: 14px;
-  line-height: 1;
-  padding: 0 4px;
-  opacity: 0.7;
-}
-.batch-chip-remove:hover {
-  opacity: 1;
+  gap: 6px;
 }
 .batch-var-input {
   flex: 1;
-  min-width: 110px;
+  min-width: 0;
   font-family: var(--font-ui);
   font-size: 12.5px;
-  padding: 5px 8px;
+  padding: 6px 9px;
   background: var(--surface);
   color: var(--text);
   border: 1px solid var(--border);
@@ -11046,6 +11027,18 @@ details[open] > summary.lora-scope-group-heading::before,
 .batch-var-input:focus {
   outline: none;
   border-color: var(--accent);
+}
+.batch-value-remove {
+  border: 0;
+  background: none;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 15px;
+  line-height: 1;
+  padding: 2px 6px;
+}
+.batch-value-remove:hover {
+  color: var(--danger);
 }
 .batch-hint {
   font-size: 12.5px;


### PR DESCRIPTION
## Summary

Fixes a v1 bug ([sc-9991](https://app.shortcut.com/trefry/story/9991)) in Batch Prompt Processing ([epic 9952](https://app.shortcut.com/trefry/epic/9952)): the variable **value editor required pressing Enter** to commit each value into a chip, so a typed-but-uncommitted value counted as **0 values**.

User-reported symptom: after filling every field, each still showed "0 values", the first-prompt preview stayed literal (`{{name}}` unresolved), the "Add at least one value for …" validation never cleared, and **Run batch stayed disabled** — the batch couldn't run.

## Fix

Replace the type-then-Enter chip model with an **auto-expanding list of value inputs**:
- A typed value counts **immediately** — no Enter step. Single values just work.
- A trailing empty box always sits at the end, so more value boxes appear as you type (multi-value still supported).
- Backspace on an empty box removes it.
- Empty values are ignored by the engine and now also filtered when `ImageStudio` builds `batchVariables`, so saved batches and run payloads carry only real values.

## Files

- `apps/web/src/components/BatchPromptPanel.jsx` — `VariableChips` rewritten to live-commit.
- `apps/web/src/styles.css` — chip styles → stacked value-input styles.
- `apps/web/src/screens/ImageStudio.jsx` — filter empty values when building `batchVariables`.
- `apps/web/src/components/BatchPromptPanel.test.jsx` — the Enter-to-add tests → live-commit + a new auto-expand test.

## Validation

1244 web vitest (the panel test now pins the exact reported scenario: typing a value → count reads "1 value" + preview resolves) · ESLint 0 errors · production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)