### PR TITLE
feat(web): custom Width/Height resolution override in Image Studio Advanced (sc-10012)

### DIFF
--- a/apps/web/src/resolutionOverride.js
+++ b/apps/web/src/resolutionOverride.js
@@ -1,0 +1,28 @@
+// Advanced resolution override (Image Studio): a custom Width/Height lets the user
+// experiment beyond a model's pre-declared Aspect options (e.g. Krea 2 up to 4K). A
+// non-empty override wins for that axis; an empty ("") field falls back to the Aspect
+// dropdown value, mirroring the Steps/Guidance overrides. Kept pure + unit-testable so
+// the submit path stays focused on orchestration.
+
+// Backend cap: rust-api validate_dimension enforces 256–4096 per side (lib.rs).
+export const MIN_IMAGE_DIMENSION = 256;
+export const MAX_IMAGE_DIMENSION = 4096;
+
+// Resolve the effective width/height sent to the worker from the Aspect dropdown string
+// ("1024x1024") and the optional per-axis overrides. Returns { width, height, invalid },
+// where `invalid` is true when either effective side falls outside the backend range.
+export function resolveEffectiveDimensions({ resolution, widthOverride, heightOverride }) {
+  const [dropdownWidth, dropdownHeight] = String(resolution ?? "")
+    .split("x")
+    .map((value) => Number(value));
+  const width = widthOverride !== "" && widthOverride != null ? Number(widthOverride) : dropdownWidth;
+  const height = heightOverride !== "" && heightOverride != null ? Number(heightOverride) : dropdownHeight;
+  const invalid = !(
+    inRange(width) && inRange(height)
+  );
+  return { width, height, invalid };
+}
+
+function inRange(value) {
+  return Number.isFinite(value) && value >= MIN_IMAGE_DIMENSION && value <= MAX_IMAGE_DIMENSION;
+}

--- a/apps/web/src/resolutionOverride.test.js
+++ b/apps/web/src/resolutionOverride.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_IMAGE_DIMENSION,
+  MIN_IMAGE_DIMENSION,
+  resolveEffectiveDimensions,
+} from "./resolutionOverride.js";
+
+describe("resolveEffectiveDimensions", () => {
+  it("uses the Aspect dropdown when no override is set", () => {
+    expect(
+      resolveEffectiveDimensions({ resolution: "1024x1024", widthOverride: "", heightOverride: "" }),
+    ).toEqual({ width: 1024, height: 1024, invalid: false });
+  });
+
+  it("overrides only the axis whose field is filled (per-axis)", () => {
+    expect(
+      resolveEffectiveDimensions({ resolution: "1024x768", widthOverride: "2048", heightOverride: "" }),
+    ).toEqual({ width: 2048, height: 768, invalid: false });
+    expect(
+      resolveEffectiveDimensions({ resolution: "1024x768", widthOverride: "", heightOverride: "2048" }),
+    ).toEqual({ width: 1024, height: 2048, invalid: false });
+  });
+
+  it("overrides both axes when both fields are filled (Krea 2 up to 4K)", () => {
+    expect(
+      resolveEffectiveDimensions({ resolution: "1024x1024", widthOverride: "4096", heightOverride: "4096" }),
+    ).toEqual({ width: 4096, height: 4096, invalid: false });
+  });
+
+  it("accepts the exact backend bounds", () => {
+    expect(
+      resolveEffectiveDimensions({
+        resolution: "1024x1024",
+        widthOverride: String(MIN_IMAGE_DIMENSION),
+        heightOverride: String(MAX_IMAGE_DIMENSION),
+      }),
+    ).toEqual({ width: MIN_IMAGE_DIMENSION, height: MAX_IMAGE_DIMENSION, invalid: false });
+  });
+
+  it("flags an override above the 4096 cap as invalid", () => {
+    const result = resolveEffectiveDimensions({
+      resolution: "1024x1024",
+      widthOverride: "5000",
+      heightOverride: "",
+    });
+    expect(result).toMatchObject({ width: 5000, height: 1024, invalid: true });
+  });
+
+  it("flags an override below the 256 floor as invalid", () => {
+    const result = resolveEffectiveDimensions({
+      resolution: "1024x1024",
+      widthOverride: "",
+      heightOverride: "64",
+    });
+    expect(result).toMatchObject({ width: 1024, height: 64, invalid: true });
+  });
+
+  it("treats null overrides like an empty field", () => {
+    expect(
+      resolveEffectiveDimensions({ resolution: "768x1280", widthOverride: null, heightOverride: null }),
+    ).toEqual({ width: 768, height: 1280, invalid: false });
+  });
+});

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -11,6 +11,7 @@ import StructuredPromptBuilder from "../components/StructuredPromptBuilder.jsx";
 import ReferenceCaptionPicker from "../components/ReferenceCaptionPicker.jsx";
 import BatchPromptPanel from "../components/BatchPromptPanel.jsx";
 import { cardinality, expandBatch, extractKeys, missingKeys, splitPromptLines } from "../promptBatch.js";
+import { resolveEffectiveDimensions } from "../resolutionOverride.js";
 import { batchItemStatus, summarizeBatchProgress } from "../batchOps.js";
 import {
   emptyCaption,
@@ -518,6 +519,12 @@ export function ImageStudio() {
   // clear the override.
   const [stepsOverride, setStepsOverride] = useState(saved.steps ?? "");
   const [guidanceOverride, setGuidanceOverride] = useState(saved.guidanceScale ?? "");
+  // Advanced resolution override: a custom Width/Height to experiment beyond the model's
+  // pre-declared Aspect options (e.g. Krea 2 up to 4K). "" = "use the Aspect dropdown" for
+  // that axis, mirroring the Steps/Guidance overrides. Effective dims are derived below and
+  // ride the existing top-level width/height payload; the backend caps each at 256–4096.
+  const [widthOverride, setWidthOverride] = useState(saved.widthOverride ?? "");
+  const [heightOverride, setHeightOverride] = useState(saved.heightOverride ?? "");
   // Flash attention (sc-3674): fused attention on the candle (Windows/CUDA) SDXL backend — faster +
   // less VRAM. Per-payload (sent in `advanced.flashAttn`); the worker honors it only on candle, and
   // ignores it on every other backend. Default on. Sticky pref (persisted), not model-reset.
@@ -1182,7 +1189,16 @@ export function ImageStudio() {
       setUpscaleSoftness(upscale.softness);
     }
   }, [launchRequest?.id]);
-  const [width, height] = resolution.split("x").map((value) => Number(value));
+  const [dropdownWidth, dropdownHeight] = resolution.split("x").map((value) => Number(value));
+  // A non-empty Width/Height override wins for that axis; empty falls back to the Aspect
+  // dropdown. The resulting dims flow through the existing top-level width/height payload,
+  // so submit() and the batch builder need no further change. Logic lives in the pure,
+  // unit-tested resolveEffectiveDimensions helper.
+  const { width, height, invalid: dimensionsInvalid } = resolveEffectiveDimensions({
+    resolution,
+    widthOverride,
+    heightOverride,
+  });
 
   // Magic-prompt expansion (sc-5997): expand the plain-text idea into an editable caption via the
   // native utility model (same backend as Refine), recording which model drafted it. Returns the
@@ -1361,6 +1377,8 @@ export function ImageStudio() {
     seed,
     negativePrompt,
     resolution,
+    widthOverride,
+    heightOverride,
     fitMode,
     referenceAssetIds,
     ipAdapterScale,
@@ -1416,6 +1434,10 @@ export function ImageStudio() {
       return;
     }
     if (submitting) {
+      return;
+    }
+    if (dimensionsInvalid) {
+      setSubmitError("Width and height must each be between 256 and 4096.");
       return;
     }
     setSubmitting(true);
@@ -1671,6 +1693,11 @@ export function ImageStudio() {
     if (!resolved.length) {
       return;
     }
+    if (dimensionsInvalid) {
+      setBatchError("Width and height must each be between 256 and 4096.");
+      return;
+    }
+    setBatchError("");
     // Soft cap: a large run must be confirmed once, showing the exact image count.
     if (!confirmed && resolved.length * count > BATCH_RENDER_CAP) {
       setBatchConfirmPending(true);
@@ -2349,6 +2376,31 @@ export function ImageStudio() {
                   Seed
                   <input onChange={(event) => setSeed(event.target.value)} placeholder="Random" type="number" value={seed} />
                 </label>
+                <label>
+                  Width override
+                  <input
+                    min="256"
+                    max="4096"
+                    onChange={(event) => setWidthOverride(event.target.value)}
+                    placeholder={String(dropdownWidth)}
+                    type="number"
+                    value={widthOverride}
+                  />
+                </label>
+                <label>
+                  Height override
+                  <input
+                    min="256"
+                    max="4096"
+                    onChange={(event) => setHeightOverride(event.target.value)}
+                    placeholder={String(dropdownHeight)}
+                    type="number"
+                    value={heightOverride}
+                  />
+                </label>
+                <span className="field-hint">
+                  Custom size overrides the Aspect dropdown (256–4096 per side; leave blank to use it).
+                </span>
                 {showSamplerPicker ? (
                   <label>
                     Sampler


### PR DESCRIPTION
## Summary
Adds a **resolution override** to the Image Studio **Advanced** panel: two number inputs, **Width** and **Height**. When filled they override the resolution chosen in the "Aspect" dropdown; when empty the dropdown is used exactly as before. Prompted by Krea 2 rendering up to ~4K given enough steps — the manifest's pre-declared Aspect options don't reach that — but exposed for **all image models** since the cap is enforced backend-wide.

Shortcut: [sc-10012](https://app.shortcut.com/trefry/story/10012) (epic [9992](https://app.shortcut.com/trefry/epic/9992) — Krea 2 Raw T2I generation surface).

## Behavior
- **Per-axis, independent:** a non-empty field overrides that axis; empty falls back to the Aspect dropdown value — mirroring the existing Steps/Guidance overrides where `""` = "use the default".
- Placeholders show the current dropdown-derived baseline so the user sees what they're overriding.
- **Sticky pref** persisted via `useStudioSettingsWriter` (survives reload/project switch), like the other advanced knobs.
- Range **256–4096** per side, matching the backend `validate_dimension` cap (`MAX_IMAGE_DIMENSION = 4096`). Out-of-range surfaces a friendly inline error on submit and on batch run instead of a raw API rejection.

## Why frontend-only
The image-job API already accepts arbitrary `width`/`height` and validates 256–4096. The override just feeds the existing top-level `width`/`height` payload fields — no rust-api or worker change.

## Recipe round-trip
Handled for free: `recipeResolution` already reconstructs the resolution string from stored width/height, so a job generated with an override reloads with the correct effective dims. `buildImageJobAdvanced` / `imageJobAdvanced.js` and its test are untouched.

## Files
- `apps/web/src/resolutionOverride.js` (new) — pure `resolveEffectiveDimensions({resolution, widthOverride, heightOverride})` → `{width, height, invalid}`.
- `apps/web/src/resolutionOverride.test.js` (new) — 7 focused tests.
- `apps/web/src/screens/ImageStudio.jsx` — state, derivation via the helper, UI inputs, sticky persistence, submit + batch guards.

## Known interaction (acceptable v1)
The override is a sticky pref (like flashAttn), not recipe-reset. If an override is active and a recipe with different dims is loaded, the override still wins for that axis. Consistent with the other advanced knobs; recipe-load clearing can be added later if faithful reproduction is preferred.

## Verification
- eslint: 0 errors (only pre-existing `exhaustive-deps` warnings).
- Full web vitest suite: **1251 passed** (post-merge with origin/main).
- Render-mount check: Image Studio route mounts with zero console errors.
- Full e2e generate-at-4096 + payload inspection not runnable in the dev sandbox (no rust-api/worker/Krea 2 model); covered deterministically by the unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)