### PR TITLE
fix(web): zoom the full-res image in the fullscreen viewer, not the fit-sized bitmap

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -8070,8 +8070,16 @@ details[open] > summary.lora-scope-group-heading::before,
   cursor: grabbing;
 }
 
+/* Do NOT add `will-change: transform` here. It promotes the wrapper to a
+   compositor layer whose backing store is rasterized once at the fit (layout)
+   size; the zoom `scale()` then GPU-stretches that low-res texture, so zooming
+   in pixelates the full-resolution image (it never resamples from the decoded
+   source). Leaving the transform un-hinted lets the compositor re-rasterize the
+   static scaled layer at on-screen resolution — sharp up to the image's native
+   pixels. Pan is driven by per-pointermove React state, not a CSS animation, so
+   the hint bought no smoothness anyway. */
 .preview-zoom-inner {
-  will-change: transform;
+  transform-origin: 0 0;
 }
 
 .preview-zoom-inner img {


### PR DESCRIPTION
## What

The fullscreen image viewer (`FullscreenPreview` in `apps/web/src/components/assetPanels.jsx`) zoomed a blurry, pixelated image once you passed ~100%, even though the full-resolution image was loaded the whole time.

## Why

Zoom is applied as a CSS `transform: scale()` on the `.preview-zoom-inner` wrapper, and that wrapper carried `will-change: transform`. That hint promotes the wrapper to its own compositor layer whose backing store is rasterized **once at the fit (layout) size**. The `scale()` then just GPU-stretches that fit-resolution texture — it never resamples from the full-resolution decoded `<img>`. So every zoom step magnified the fit-sized bitmap and pixelated.

(The Image Editor doesn't have this bug because it renders on a Konva `<canvas>` that redraws from the source at each scale.)

## Fix

Remove `will-change: transform` from `.preview-zoom-inner` (with a comment explaining why it must not come back). Without the raster-scale pin, the compositor re-rasterizes the *static* scaled layer at on-screen resolution, resampling from the decoded source — sharp up to the image's native pixels.

Deliberately minimal:
- JS zoom/pan geometry (`transform: translate() scale()`), the zoom math, and container sizing are all untouched.
- A layout-driven resize of the `<img>` itself would have been the "obvious" alternative but blows out the windowed stage height (that stage has no fixed height — the image defines it).
- Pan is driven by per-`pointermove` React state, not a CSS animation, so the hint bought no smoothness to lose.

## Reviewer notes / testing

- CSS-only change; the JS `.style.transform` string is unchanged, so the existing assertion in `assetPanels.contextMenu.test.jsx` ("Zoom In / Zoom Out / Fit drive the view transform") stays green.
- I could not run vitest locally in this worktree (no `node_modules` installed). Worth a quick visual confirm: open a high-res asset in the fullscreen preview and zoom in — it should stay sharp up to native resolution instead of pixelating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)