### PR TITLE
feat: Krea 2 Raw as a Mac generation model + unify LoRA training onto the turnkey (epic 9992)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -473,7 +473,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da)",
+ "sceneworks-gen-core",
  "serde_json",
  "thiserror 2.0.18",
 ]
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -495,7 +495,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -510,7 +510,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -524,7 +524,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -577,7 +577,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -605,7 +605,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -615,7 +615,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -630,7 +630,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -645,7 +645,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -660,7 +660,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-gen",
  "image",
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -700,7 +700,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -714,7 +714,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -757,7 +757,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -788,7 +788,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -812,7 +812,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=08c8053d3d96d6d8433dd50101ffe2142bb741a1#08c8053d3d96d6d8433dd50101ffe2142bb741a1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=171a5dd841072ca063550970360c09497eab8907#171a5dd841072ca063550970360c09497eab8907"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -3628,7 +3628,7 @@ dependencies = [
  "inventory",
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14)",
+ "sceneworks-gen-core",
  "serde_json",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
@@ -5752,19 +5752,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sceneworks-gen-core"
-version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
-dependencies = [
- "core-llm",
- "inventory",
- "safetensors 0.4.5",
- "serde_json",
- "thiserror 2.0.18",
- "tokenizers 0.21.4",
-]
-
-[[package]]
 name = "sceneworks-image-quality"
 version = "0.2.0"
 dependencies = [
@@ -5886,7 +5873,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14)",
+ "sceneworks-gen-core",
  "sceneworks-image-quality",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,7 +473,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da)",
  "serde_json",
  "thiserror 2.0.18",
 ]
@@ -3623,12 +3623,12 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14)",
  "serde_json",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
@@ -3637,7 +3637,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "image",
  "inventory",
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "image",
  "inventory",
@@ -3665,7 +3665,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3679,7 +3679,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3690,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3699,7 +3699,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3708,7 +3708,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3722,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3735,7 +3735,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3748,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3760,7 +3760,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3770,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "image",
  "inventory",
@@ -3783,7 +3783,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "image",
  "inventory",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "image",
  "inventory",
@@ -3811,7 +3811,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "image",
  "inventory",
@@ -3823,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3834,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3867,7 +3867,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3876,7 +3876,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3898,7 +3898,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "image",
  "inventory",
@@ -3913,7 +3913,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "image",
  "inventory",
@@ -3927,7 +3927,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3938,7 +3938,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3950,7 +3950,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3961,7 +3961,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "image",
  "inventory",
@@ -3975,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
 dependencies = [
  "image",
  "inventory",
@@ -5741,6 +5741,19 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+dependencies = [
+ "core-llm",
+ "inventory",
+ "safetensors 0.4.5",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokenizers 0.21.4",
+]
+
+[[package]]
+name = "sceneworks-gen-core"
+version = "0.1.0"
 source = "git+https://github.com/michaeltrefry/mlx-gen?rev=dad872b2bd537ccd17075c16cad38b3674f418da#dad872b2bd537ccd17075c16cad38b3674f418da"
 dependencies = [
  "core-llm",
@@ -5873,7 +5886,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14)",
  "sceneworks-image-quality",
  "serde",
  "serde_json",

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -1,6 +1,8 @@
 use super::auth::{loopback_trusted, requires_token};
 use super::events::{EventHub, EventMessage};
-use super::training::{insufficient_disk_space, resolve_base_model_path};
+use super::training::{
+    insufficient_disk_space, resolve_base_model_path, training_base_model_installed,
+};
 use super::workers::person_readiness_from_workers;
 use super::{
     create_app, create_app_with_state, huggingface_repo_cache_path, inject_converted_model_path,
@@ -11736,6 +11738,57 @@ fn resolve_base_model_path_descends_into_hf_snapshot() {
             .join("tokenizer.json")
             .is_file(),
         "the component tree must be reachable from the resolved path"
+    );
+}
+
+#[test]
+fn tiered_turnkey_base_trains_on_bf16_tier() {
+    // epic 9992 Krea 2 Raw (Path 1): SceneWorks/krea-2-raw-mlx ships bf16/ q8/ q4/ tier subdirs with NO
+    // component tree at the snapshot root. Training reads the DENSE bf16 tier; a repo with only the q8
+    // GENERATION tier installed is NOT training-ready (no dense weights to LoRA-train on).
+    let temp = tempfile::tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+
+    let target = super::builtin_training_targets()
+        .targets
+        .into_iter()
+        .find(|t| t.base_model == "krea_2_raw")
+        .expect("krea_2_raw target");
+    assert_eq!(
+        target.base_model_repo.as_deref(),
+        Some("SceneWorks/krea-2-raw-mlx"),
+        "Path 1: training shares the generation turnkey re-host"
+    );
+    let repo = target.base_model_repo.clone().expect("repo set");
+
+    let repo_root = huggingface_repo_cache_path(&data_dir, &repo).expect("repo cache path");
+    let revision = "abc123";
+    let snapshot = repo_root.join("snapshots").join(revision);
+    // Only the q8 GENERATION tier installed so far (no bf16 dense weights).
+    std::fs::create_dir_all(snapshot.join("q8").join("transformer")).expect("q8 tree");
+    std::fs::create_dir_all(repo_root.join("refs")).expect("create refs");
+    std::fs::write(repo_root.join("refs").join("main"), revision).expect("write refs/main");
+
+    // The resolver points training at the bf16 tier (whether or not it is present yet).
+    let resolved = resolve_base_model_path(&target, &data_dir);
+    assert_eq!(
+        resolved,
+        snapshot.join("bf16").display().to_string(),
+        "training must read the dense bf16 tier of a tiered turnkey"
+    );
+    // q8-only → NOT training-ready (the run-gate blocks it).
+    assert!(
+        !training_base_model_installed(&data_dir, &target),
+        "a q8-only tiered turnkey is not training-ready"
+    );
+
+    // Install the dense bf16 component tree → training-ready.
+    std::fs::create_dir_all(snapshot.join("bf16").join("transformer")).expect("bf16 transformer");
+    std::fs::create_dir_all(snapshot.join("bf16").join("text_encoder")).expect("bf16 te");
+    std::fs::create_dir_all(snapshot.join("bf16").join("vae")).expect("bf16 vae");
+    assert!(
+        training_base_model_installed(&data_dir, &target),
+        "bf16 tier present → training-ready"
     );
 }
 

--- a/apps/rust-api/src/training.rs
+++ b/apps/rust-api/src/training.rs
@@ -1431,7 +1431,7 @@ pub(crate) fn resolve_base_model_path(target: &TrainingTarget, data_dir: &FsPath
             // root, exactly as inference does. Fall back to the cache root when no snapshot is
             // materialized yet (the path need not exist at dry-run time).
             if let Some(snapshot) = huggingface_snapshot_dirs(&cache_path).into_iter().next() {
-                return snapshot.display().to_string();
+                return tiered_turnkey_train_dir(snapshot).display().to_string();
             }
             return cache_path.display().to_string();
         }
@@ -1441,6 +1441,37 @@ pub(crate) fn resolve_base_model_path(target: &TrainingTarget, data_dir: &FsPath
         .join(safe_download_dir(&target.base_model))
         .display()
         .to_string()
+}
+
+/// Whether a resolved HF snapshot is a tiered-turnkey re-host (epic 9992): tier subdirs (`bf16/ q8/
+/// q4/`) with NO flat component tree at the root. A flat diffusers snapshot (z-image / lens / the
+/// retired `krea/Krea-2-Raw` tree) has `transformer/` at the root and is NOT tiered.
+fn snapshot_is_tiered_turnkey(snapshot: &FsPath) -> bool {
+    !snapshot.join("transformer").is_dir()
+        && (snapshot.join("bf16").is_dir()
+            || snapshot.join("q8").is_dir()
+            || snapshot.join("q4").is_dir())
+}
+
+/// Whether a `bf16/` tier holds the dense component tree the trainer needs (`transformer/`,
+/// `text_encoder/`, `vae/`). The repo-level completion marker does NOT certify a tier (sc-9909), so
+/// check the actual dirs.
+fn bf16_component_tree_present(bf16: &FsPath) -> bool {
+    bf16.join("transformer").is_dir()
+        && bf16.join("text_encoder").is_dir()
+        && bf16.join("vae").is_dir()
+}
+
+/// For a tiered-turnkey re-host (epic 9992 Krea 2 Raw: `SceneWorks/krea-2-raw-mlx` ships `bf16/ q8/ q4/`
+/// tier subdirs), training reads the DENSE `bf16/` tier — the trainer needs the full-precision base, and
+/// the bf16 tier is byte-identical to the retired `krea/Krea-2-Raw` diffusers tree. A flat diffusers
+/// snapshot (transformer/ at the root) is returned unchanged, so this is backward-compatible. Mirrors
+/// how generation resolves a tier subdir via `krea_model_subdir`.
+fn tiered_turnkey_train_dir(snapshot: std::path::PathBuf) -> std::path::PathBuf {
+    if snapshot_is_tiered_turnkey(&snapshot) {
+        return snapshot.join("bf16");
+    }
+    snapshot
 }
 
 /// GPU selection for a training job, read from the config's advanced bag (the
@@ -1544,6 +1575,15 @@ pub(crate) fn training_base_model_installed(data_dir: &FsPath, target: &Training
         .filter(|repo| !repo.is_empty())
     {
         if let Some(cache_path) = huggingface_repo_cache_path(data_dir, repo) {
+            // Tiered-turnkey re-host (epic 9992 Krea 2 Raw): training reads the DENSE `bf16/` tier, but
+            // generation may have installed only the q8 default. The repo-level completion marker does
+            // NOT certify a tier (sc-9909), so require the bf16 component tree specifically — otherwise
+            // the run-gate would green-light training on a repo that has no dense weights to train.
+            if let Some(snapshot) = huggingface_snapshot_dirs(&cache_path).into_iter().next() {
+                if snapshot_is_tiered_turnkey(&snapshot) {
+                    return bf16_component_tree_present(&snapshot.join("bf16"));
+                }
+            }
             if models::huggingface_cache_health(&cache_path, &[]).installed {
                 return true;
             }

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useAppContext } from "../context/AppContext.js";
 import { ModelAvailabilityGate } from "../components/ModelAvailabilityGate.jsx";
-import { downloadOffersFor } from "../modelEligibility.js";
 import { DEFAULT_MAC_CAPABILITIES, macTrainingKernelBlocked } from "../macGating.js";
 import { API_BASE_URL, isAbortError } from "../api.js";
 import { assetCanRenderAsImage } from "../components/assetMedia.jsx";
@@ -508,19 +507,39 @@ export function TrainingStudio({ mode = "training" } = {}) {
   // install reads the true state). Only gated when targets exist but every trainable base is
   // missing — a target-registry error keeps its own "registry unavailable" message.
   const usableTrainingTargets = trainingTargets.filter((target) => !macTargetBlocked(target));
+  // A training base that is a quant-matrix re-host (epic 9992 Krea 2 Raw) is trained on its DENSE `bf16`
+  // tier — generation may have installed only the q8 default, but LoRA training needs the full-precision
+  // weights. Readiness + the install offer therefore track the `bf16` variant when present; a non-matrix
+  // base (z-image / sdxl / lens) has no such variant and uses its default tier.
+  const trainingBaseTier = (base) =>
+    base?.variants?.some((variant) => variant.variant === "bf16") ? "bf16" : undefined;
+  const trainingBaseState = (base) => {
+    const tier = trainingBaseTier(base);
+    if (tier) {
+      return base.variants.find((variant) => variant.variant === tier)?.installState ?? "missing";
+    }
+    return base.installState;
+  };
   const trainingBaseMissing = (target) => {
     const base = models.find((item) => item.id === target?.baseModel);
-    return Boolean(base) && base.installState === "missing";
+    return Boolean(base) && trainingBaseState(base) === "missing";
   };
   const trainingReady =
     usableTrainingTargets.length === 0 ||
     usableTrainingTargets.some((target) => !trainingBaseMissing(target));
   const trainingBaseIds = new Set(usableTrainingTargets.map((target) => target.baseModel).filter(Boolean));
   const trainingOffers = useMemo(
-    () => downloadOffersFor(models, (item) => trainingBaseIds.has(item.id), macCapabilities),
+    () =>
+      (models ?? []).filter(
+        (item) => trainingBaseIds.has(item.id) && trainingBaseState(item) === "missing",
+      ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [models, macCapabilities, [...trainingBaseIds].join("|")],
   );
+  // Install the DENSE bf16 tier for a quant-matrix training base (else the default tier). Mirrors the
+  // Models-page tier picker's `createModelDownloadJob(model, { variant })` (sc-8509).
+  const installTrainingBase = (model, options = {}) =>
+    createModelDownloadJob(model, { variant: trainingBaseTier(model), ...options });
   const trainingDownloadJobs = useMemo(
     () => (jobs ?? []).filter((job) => job.type === "model_download"),
     [jobs],
@@ -1434,7 +1453,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
       description="LoRA training needs a downloaded base model (e.g. Z-Image-Turbo or SDXL). Download one to get started."
       offers={trainingOffers}
       downloadJobs={trainingDownloadJobs}
-      onDownload={createModelDownloadJob}
+      onDownload={installTrainingBase}
       onOpenModels={() => setActiveView("Models")}
       onOpenQueue={() => setActiveView("Queue")}
     >

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2404,56 +2404,136 @@
     },
     {
       "id": "krea_2_raw",
-      // Krea 2 Raw (epic 7565 P3, sc-8613) — the UNDISTILLED 12B single-stream DiT that Krea 2 LoRAs
-      // train on; the trained adapter applies back at Krea 2 Turbo inference by family match (the Lens /
-      // Z-Image train-on-base → infer-on-Turbo pattern). This is a training-base DEPENDENCY, not an
-      // inference model: there is no `krea_2_raw` generator (only `krea_2_turbo` is routed), so it is
-      // `utility` (empty capabilities) and never appears in the Image Studio picker. The id MUST equal
-      // the training target's `base_model` (`krea_2_raw`, core training.rs) — the Training UI matches
-      // the base by `item.id === target.baseModel` (TrainingStudio.jsx) and offers this for download
-      // when it's missing.
+      // Krea 2 Raw (epic 9992) — the UNDISTILLED 12B single-stream DiT, now a first-class text-to-image
+      // GENERATION model (TRUE classifier-free guidance: a real guidance scale + optional negative
+      // prompt, 52 steps, resolution-dynamic mu) alongside the distilled CFG-free Krea 2 Turbo — the
+      // Boogu base/turbo precedent. Same gen_core engine code (the `krea_2_raw` descriptor /
+      // KreaPipeline::generate_base, mlx-gen #656); loads the packed Q8 (default) / Q4 / bf16 turnkey
+      // subdir (`krea_model_subdir`) from `SceneWorks/krea-2-raw-mlx` (sc-9995).
       //
-      // Cataloging it lets Model Manager install the base into the HF cache the trainer reads via
-      // `training_base_model_installed` (apps/rust-api training.rs) — closing the "Base model
-      // 'krea_2_raw' is not installed. Install it from the model catalog" dead-end (the bare repo was
-      // never catalogued, unlike every other trainable family's base). Cross-platform as of sc-8614:
-      // `krea_lora` now also routes to the candle (Windows/Linux CUDA) trainer
-      // (CANDLE_ROUTED_TRAINING_KERNELS includes it; MLX_ONLY_TRAINING_KERNELS keeps it off torch), and
-      // BOTH the MLX and candle trainers read the same `krea/Krea-2-Raw` diffusers tree — so a single
-      // whole-repo download serves every platform (no MLX-turnkey vs candle split like Krea 2 Turbo).
-      // Ungated public diffusers tree, Krea 2 Community License (non-commercial).
+      // PATH 1 (epic 9992): this ONE entry is BOTH the generation model AND the LoRA-training base. The
+      // id MUST equal the training target's `base_model` (`krea_2_raw`, core training.rs); the Training
+      // UI matches the base by `item.id === target.baseModel` (TrainingStudio.jsx) and offers this
+      // turnkey for download when missing. The trainer reads the DENSE `bf16/` tier of the SAME repo
+      // (apps/rust-api `resolve_base_model_path` descends into `bf16/` for a tiered turnkey), so training
+      // + generation share one download — no separate diffusers tree. The bf16 tier is byte-identical to
+      // the retired `krea/Krea-2-Raw` diffusers base, so training behavior is unchanged.
+      //
+      // MAC-FIRST (epic 9992): `mlx-gen-krea` registers the `krea_2_raw` GENERATOR; the candle
+      // (Windows/Linux) generator is not wired yet (sc-9994 / P2), so `krea_2_raw` is candle_routed=false
+      // in the routing table and GENERATION is Mac-only until then. The tier downloads stay all-platform
+      // because the candle TRAINER trains cross-platform off the same `bf16/` tier (CANDLE_ROUTED_TRAINING
+      // _KERNELS includes `krea_lora`). Krea 2 Community License (non-commercial OK; the re-host carries
+      // the license + "Krea" name prefix + attribution).
       "autoDownload": false,
-      "name": "Krea 2 Raw (LoRA training base)",
+      "name": "Krea 2 Raw",
       "family": "krea_2",
-      "type": "utility",
+      "type": "image",
       "adapter": "mlx_krea",
-      "capabilities": [],
+      // Routing (not this flag) drives availability: `krea_2_raw` is mlx-routed; candle generation lands
+      // in P2 (sc-9994). All-platform downloads so the candle trainer can install the bf16 tier off-Mac.
+      "macOnly": false,
       "downloads": [
         {
+          // Q8 `q8/` subdir of the SceneWorks/krea-2-raw-mlx turnkey (sc-9995). Each quant subdir is a
+          // complete `from_snapshot`-loadable root (transformer/ text_encoder/ vae/ tokenizer/ scheduler/
+          // model_index.json). MEASURED q8 download 20,554,619,432 B. q8 is the shipped default.
           "provider": "huggingface",
-          "repo": "krea/Krea-2-Raw",
-          "files": [],
+          "repo": "SceneWorks/krea-2-raw-mlx",
+          "variant": "q8",
+          "default": true,
+          "files": [
+            "q8/transformer/*",
+            "q8/text_encoder/*",
+            "q8/vae/*",
+            "q8/tokenizer/*",
+            "q8/scheduler/*",
+            "q8/model_index.json"
+          ],
           "platforms": ["macos", "windows", "linux"],
-          "estimatedSizeBytes": 40000000000
+          "estimatedSizeBytes": 20554619432
+        },
+        {
+          // Q4 `q4/` subdir — the lighter quant tier, selectable via advanced mlxQuantize<=4. Same
+          // complete-root shape as q8. MEASURED 12,488,709,625 B.
+          "provider": "huggingface",
+          "repo": "SceneWorks/krea-2-raw-mlx",
+          "variant": "q4",
+          "files": [
+            "q4/transformer/*",
+            "q4/text_encoder/*",
+            "q4/vae/*",
+            "q4/tokenizer/*",
+            "q4/scheduler/*",
+            "q4/model_index.json"
+          ],
+          "platforms": ["macos", "windows", "linux"],
+          "estimatedSizeBytes": 12488709625
+        },
+        {
+          // bf16 `bf16/` subdir — the dense max-fidelity tier (SHARDED transformer; krea's loader takes
+          // the dense base with no quantize, Quant::None). Selectable via advanced mlxQuantize<=0. This
+          // tier is ALSO the Krea 2 LoRA training base (the trainer reads `bf16/`). MEASURED 35,678,121,657 B.
+          "provider": "huggingface",
+          "repo": "SceneWorks/krea-2-raw-mlx",
+          "variant": "bf16",
+          "files": [
+            "bf16/transformer/*",
+            "bf16/text_encoder/*",
+            "bf16/vae/*",
+            "bf16/tokenizer/*",
+            "bf16/scheduler/*",
+            "bf16/model_index.json"
+          ],
+          "platforms": ["macos", "windows", "linux"],
+          "estimatedSizeBytes": 35678121657
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/krea/Krea-2-Raw"
+        "model": "${HF_CACHE}/SceneWorks/krea-2-raw-mlx"
       },
-      "defaults": {},
-      "limits": {},
+      "defaults": {
+        // Raw: undistilled base, TRUE CFG (the engine forwards a real guidance value + negative prompt),
+        // resolution-dynamic mu. Reference Raw preset (sc-7566 spike): 52 steps / guidance 3.5.
+        "resolution": "1024x1024",
+        "steps": 52,
+        "guidanceScale": 3.5,
+        "count": 1,
+        "sampler": "default",
+        "scheduler": "default"
+      },
+      "limits": {
+        "resolutions": ["1024x1024", "768x1024", "1024x768", "1280x720", "720x1280", "1536x1536"],
+        "count": [1, 2, 4],
+        // Raw routes the per-generation sampler/scheduler knobs through the unified framework, exactly
+        // like Turbo — the `krea_2_raw` descriptor advertises curated_sampler_names()/
+        // curated_scheduler_names(); the engines.rs drift guard checks this manifest list is a subset.
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
+      },
       "loraCompatibility": {
-        // A LoRA trained here records `family: krea_2` / `baseModel: krea_2_raw` and applies at Krea 2
-        // Turbo inference (family match, no base-model gating — lora_family.rs). Mirrors the Krea 2 Turbo
-        // entry's `families: [krea_2]`.
+        // Krea LoRAs (family krea_2) apply at Raw inference too (family match, no base-model gating —
+        // lora_family.rs), and Raw's bf16 tier is their training base. `types` lists what trains here.
         "families": ["krea_2"],
         "types": ["character", "style"]
       },
+      "mlx": {
+        // Pre-quantized Q8 turnkey (`q8/` subdir) is the default. Raw runs TRUE CFG (two DiT forwards per
+        // step) at 52 steps — slower than the distilled Turbo, but the resident weights (≈ Turbo's)
+        // dominate the peak, so minMemoryGb 48 covers Q8 with headroom (the bf16 dense tier needs more —
+        // the per-tier picker gates it). Mirrors Krea 2 Turbo's mlx block.
+        "minMemoryGb": 48,
+        "quantize": 8,
+        "repo": "SceneWorks/krea-2-raw-mlx"
+      },
       "licenseUrl": "https://www.krea.ai/krea-2-licensing",
       "ui": {
-        "label": "Krea 2 Raw (training base)",
-        "description": "Undistilled Krea 2 12B DiT — the LoRA training base for Krea 2 (epic 7565). Train a LoRA here and it applies at Krea 2 Turbo inference; this is not a generation model itself. Trains on Apple Silicon (native MLX) or Windows/Linux NVIDIA (candle/CUDA) (~40 GB download). Krea 2 Community License (non-commercial).",
-        "recommendedFor": [],
+        "label": "Krea 2 Raw",
+        "description": "Krea 2 Raw — Krea AI's undistilled 12B single-stream rectified-flow DiT with a Qwen3-VL-4B text encoder, native MLX (Apple Silicon). The full-fidelity, TRUE classifier-free-guidance counterpart to the fast CFG-free Krea 2 Turbo: run ~52 steps with a real guidance scale (~3.5) and an optional negative prompt for the highest quality and the most control. Pre-quantized Q8 (~20.5 GB download, default); the dense bf16 tier doubles as the Krea 2 LoRA training base. Krea 2 Community License (non-commercial). Needs a 48 GB-class Mac. (Windows/Linux generation lands with the candle engine — epic 9992 P2.)",
+        "recommendedFor": ["text_to_image"],
+        // PiD decoder (epic 7840, qwenimage latent space — Krea 2 Raw reuses the Qwen VAE, like Turbo) —
+        // optional per-generation VAE replacement, decode + 2K/4K SR; NC output. See `qwen_image`.
+        "pid": { "checkpointId": "pid_qwenimage" },
         "promptGuide": {
           "title": "Krea 2 Prompt Guide",
           "path": "/prompt-guides/krea-2.md",

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -637,6 +637,14 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
     // already-packed q4/q8 turnkey), so `candle_quant_lora` is set (sc-9983 — the routing half of sc-9607,
     // moving Krea from `candle_lora` to BOTH): a tier-select `mlxQuantize` AND a LoRA both stay on candle.
     ModelCaps::new("krea_2_turbo", true, true, false, false, true),
+    // Krea 2 Raw (epic 9992) — the undistilled 12B DiT exposed as a full-CFG generation model (52 steps /
+    // guidance 3.5 + negative prompt), alongside the distilled Turbo (the Boogu base/turbo precedent).
+    // MLX-first: `mlx-gen-krea` registers the `krea_2_raw` generator (PR #656). Candle is NOT wired yet
+    // (`candle-gen-krea` has no `krea_2_raw` generator until epic 9992 P2 / sc-9994), so candle_routed is
+    // false — this flips to `(true, true, false, false, true)` (mirroring Turbo) when the candle engine
+    // lands. `krea_2_raw` is ALSO the LoRA-training base id (Path 1 unify); training routes via the
+    // trainer registry, independent of this image-caps row.
+    ModelCaps::new("krea_2_raw", true, false, false, false, false),
     // Stable Diffusion 3.5 Large / Large Turbo / Medium (epic 7841 / sc-7871 MLX; sc-7880 candle):
     // pure txt2img. Candle advertises Q4/Q8 (sc-7879) but NOT inference LoRA (`supports_lora: false`), so
     // `candle_quant` is set — an explicit quant request stays on candle while a LoRA still defers to torch.
@@ -913,6 +921,7 @@ mod tests {
         "boogu_image_turbo",
         "boogu_image_edit",
         "krea_2_turbo",
+        "krea_2_raw",
         "sd3_5_large",
         "sd3_5_large_turbo",
         "sd3_5_medium",

--- a/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
@@ -72,7 +72,7 @@ pub(crate) fn image_request_mlx_eligible(model: &str, payload: &Map<String, Valu
         "bernini_image" => bernini_image_mlx_eligible(payload),
         "ideogram_4" | "ideogram_4_turbo" => ideogram_mlx_eligible(payload),
         "boogu_image" | "boogu_image_turbo" | "boogu_image_edit" => boogu_mlx_eligible(payload),
-        "krea_2_turbo" => krea_mlx_eligible(payload),
+        "krea_2_turbo" | "krea_2_raw" => krea_mlx_eligible(payload),
         "sd3_5_large" | "sd3_5_large_turbo" | "sd3_5_medium" => sd3_5_mlx_eligible(payload),
         "sana_1600m" | "sana_sprint_1600m" => sana_mlx_eligible(payload),
         // Every model in MLX_ROUTED_MODELS must have an arm.
@@ -423,9 +423,10 @@ pub(crate) fn boogu_mlx_eligible(payload: &Map<String, Value>) -> bool {
     true
 }
 
-/// Krea 2 Turbo (epic 7565 / sc-7572) MLX-eligibility. The native `mlx-gen-krea`
-/// engine serves the Turbo text-to-image surface only; `edit_image` has no source/reference
-/// path, so reject that defensive shape the same way Lens does.
+/// Krea 2 Turbo (epic 7565 / sc-7572) + Krea 2 Raw (epic 9992) MLX-eligibility. The native
+/// `mlx-gen-krea` engine serves the text-to-image surface only for both variants (distilled Turbo +
+/// full-CFG Raw); `edit_image` has no source/reference path, so reject that defensive shape the same way
+/// Lens does.
 pub(crate) fn krea_mlx_eligible(payload: &Map<String, Value>) -> bool {
     payload.get("mode").and_then(Value::as_str) != Some("edit_image")
 }

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -1232,11 +1232,15 @@ fn lens_turbo_lora_target() -> TrainingTarget {
 /// mlx-only markers are therefore omitted (matching the candle-capable z-image/lens targets);
 /// `MacTrainingSupport::supported_kernels` already lists `krea_lora` and is inert off-Mac.
 ///
-/// `base_model_repo` points the plan's `baseModelPath` at the ungated public `krea/Krea-2-Raw`
-/// diffusers tree (Krea 2 Community License), independent of the served `krea_2_turbo` model. The
-/// single-stream DiT uses separate `to_q`/`to_k`/`to_v` attention projections plus the joint-attention
-/// output projection (`to_out` is an `nn.ModuleList([Linear, Identity])`, so the trainable Linear is
-/// `to_out.0`), matching the engine trainer's `DEFAULT_TARGET_MODULES`.
+/// `base_model_repo` points the plan's `baseModelPath` at the `SceneWorks/krea-2-raw-mlx` turnkey — the
+/// SAME re-host that serves `krea_2_raw` GENERATION (epic 9992 Path 1). Training reads the DENSE `bf16/`
+/// tier (`resolve_base_model_path` descends into it for a tiered turnkey), which is byte-identical to the
+/// retired `krea/Krea-2-Raw` diffusers tree (the turnkey's bf16 tier was built from those exact files),
+/// so training behavior is unchanged — but generation + training now share one download instead of two.
+/// Krea 2 Community License. The single-stream DiT uses separate `to_q`/`to_k`/`to_v` attention
+/// projections plus the joint-attention output projection (`to_out` is an `nn.ModuleList([Linear,
+/// Identity])`, so the trainable Linear is `to_out.0`), matching the engine trainer's
+/// `DEFAULT_TARGET_MODULES`.
 fn krea_raw_lora_target() -> TrainingTarget {
     TrainingTarget {
         id: "krea_2_raw_lora".to_owned(),
@@ -1245,7 +1249,7 @@ fn krea_raw_lora_target() -> TrainingTarget {
         output_kind: TrainingOutputKind::Lora,
         family: "krea_2".to_owned(),
         base_model: "krea_2_raw".to_owned(),
-        base_model_repo: Some("krea/Krea-2-Raw".to_owned()),
+        base_model_repo: Some("SceneWorks/krea-2-raw-mlx".to_owned()),
         kernel: "krea_lora".to_owned(),
         defaults: TrainingConfig {
             rank: 16,

--- a/crates/sceneworks-core/tests/training_contracts.rs
+++ b/crates/sceneworks-core/tests/training_contracts.rs
@@ -315,7 +315,12 @@ fn builtin_registry_exposes_krea_target() {
     assert_eq!(target.family, "krea_2");
     assert_eq!(target.base_model, "krea_2_raw");
     assert_eq!(target.kernel, "krea_lora");
-    assert_eq!(target.base_model_repo.as_deref(), Some("krea/Krea-2-Raw"));
+    // Path 1 (epic 9992): training shares the generation turnkey re-host; the trainer reads its dense
+    // `bf16/` tier (rust-api resolve_base_model_path descends into it).
+    assert_eq!(
+        target.base_model_repo.as_deref(),
+        Some("SceneWorks/krea-2-raw-mlx")
+    );
     // Single-stream DiT attention modules (separate q/k/v + the joint-attention output
     // projection `to_out.0`), matching the engine trainer's default target set.
     assert_eq!(

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1461,15 +1461,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495b
 # pin is UNCHANGED at b520a0e7 (= this worker's mlx-gen pin), so `--features backend-candle --target all`
 # still resolves the SINGLE gen-core rev b520a0e7 (the skew gate) — no testkit reconcile. ALL candle-gen-*
 # rev lines move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1477,17 +1477,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1497,7 +1497,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1505,21 +1505,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1528,17 +1528,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1547,7 +1547,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1580,7 +1580,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1589,12 +1589,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1602,7 +1602,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c80
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1611,7 +1611,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1619,7 +1619,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1633,7 +1633,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1660,7 +1660,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1671,7 +1671,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "08c8053d3d96d6d8433dd50101ffe2142bb741a1", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "171a5dd841072ca063550970360c09497eab8907", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -485,7 +485,7 @@ sceneworks-core = { path = "../sceneworks-core" }
 # candle-gen pin below moves to 7c43ec8f IN LOCKSTEP (candle-gen #301: consumes `text_encoder` in the
 # LTX provider AND re-pins candle-gen's own gen-core 330d339 -> b520a0e7) so `--features backend-candle`
 # resolves the SINGLE gen-core rev b520a0e7. mlx-rs + mlx-llm pins unchanged.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -837,7 +837,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -853,23 +853,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd5
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -877,7 +877,7 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
 # mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
 # mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
@@ -885,59 +885,59 @@ mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b
 # conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
 # DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
 # generator-cache load path drives.
-mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -946,19 +946,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -967,7 +967,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad87
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -975,7 +975,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "d
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -986,7 +986,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad8
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -997,7 +997,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad87
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -1019,7 +1019,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -1030,7 +1030,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -1062,7 +1062,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "dad872b2bd537ccd17075c16cad38b3674f418da" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -493,6 +493,19 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
         default_guidance: 0.0,
         adapter_label: "mlx_krea",
     },
+    // Krea 2 Raw (epic 9992) — native MLX, the undistilled 12B DiT run with TRUE classifier-free guidance
+    // (the `krea_2_raw` descriptor advertises supports_guidance + supports_negative_prompt, unlike the
+    // CFG-free Turbo). 52 steps / guidance 3.5. Loads the packed bf16 / Q8 (default) / Q4 turnkey subdir
+    // (`SceneWorks/krea-2-raw-mlx`, the same `krea_model_subdir` resolver as Turbo). Shares the Krea
+    // pipeline with Turbo (arch-identical); the `krea_2_raw` id is also the LoRA-training base (Path 1).
+    ModelRow {
+        sceneworks_id: "krea_2_raw",
+        engine_id: "krea_2_raw",
+        default_repo: "SceneWorks/krea-2-raw-mlx",
+        default_steps: 52,
+        default_guidance: 3.5,
+        adapter_label: "mlx_krea",
+    },
     // Stable Diffusion 3.5 Large (epic 7841 / sc-7871) — native MLX, gated. 8B MMDiT + triple text
     // encoder (CLIP-L + CLIP-G + T5-XXL) + 16-ch VAE. True-CFG flagship: 28 steps / guidance 3.5 +
     // negative prompt (the `sd3_5_large` descriptor advertises supports_guidance + supports_negative

--- a/crates/sceneworks-worker/src/image_jobs/pid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pid.rs
@@ -55,7 +55,8 @@ fn pid_backbone_for(model: &str) -> Option<&'static str> {
         | "qwen_image_edit_2509"
         | "qwen_image_edit_2511"
         | "qwen_image_edit_2511_lightning"
-        | "krea_2_turbo" => Some("qwenimage"),
+        | "krea_2_turbo"
+        | "krea_2_raw" => Some("qwenimage"),
         // flux (sc-7846): FLUX.1, Boogu-Image, Chroma, and Z-Image — Z-Image is in the FLUX.1 VAE latent
         // space (PiD's zimage tags alias the flux checkpoint), not the qwenimage space.
         "flux_dev"
@@ -198,6 +199,7 @@ mod pid_tests {
         assert_eq!(pid_backbone_for("qwen_image"), Some("qwenimage"));
         assert_eq!(pid_backbone_for("qwen_image_edit"), Some("qwenimage"));
         assert_eq!(pid_backbone_for("krea_2_turbo"), Some("qwenimage"));
+        assert_eq!(pid_backbone_for("krea_2_raw"), Some("qwenimage"));
         // flux (sc-7846) — incl. Z-Image, which is in the FLUX.1 VAE latent space.
         assert_eq!(pid_backbone_for("flux_dev"), Some("flux"));
         assert_eq!(pid_backbone_for("boogu_image_turbo"), Some("flux"));

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -374,6 +374,10 @@ fn model_table_rows_resolve_and_flags_match_descriptor() {
         // (supports_guidance=false) with no user negative prompt (supports_negative_prompt=false) — the
         // z_image_turbo / boogu_image_turbo distilled-turbo pattern.
         ("krea_2_turbo", false, false),
+        // Krea 2 Raw (epic 9992): the UNDISTILLED base run with TRUE CFG — supports_guidance=true +
+        // supports_negative_prompt=true (unlike the CFG-free distilled Turbo). The Boogu-base pattern,
+        // but Raw ALSO accepts a user negative prompt (the reference `sample()` takes `negative_prompts`).
+        ("krea_2_raw", true, true),
         // SD3.5 Large (epic 7841 / sc-7871): true-CFG MMDiT flagship — supports_guidance=true +
         // supports_negative_prompt=true (the `sd3_5_large` descriptor advertises supports_true_cfg).
         ("sd3_5_large", true, true),

--- a/tests/fixtures/rust_migration_contracts/training/target-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/target-registry.json
@@ -405,7 +405,7 @@
       "outputKind": "lora",
       "family": "krea_2",
       "baseModel": "krea_2_raw",
-      "baseModelRepo": "krea/Krea-2-Raw",
+      "baseModelRepo": "SceneWorks/krea-2-raw-mlx",
       "kernel": "krea_lora",
       "defaults": {
         "rank": 16,


### PR DESCRIPTION
Epic [9992](https://app.shortcut.com/trefry/epic/9992) — expose **Krea 2 Raw** (the undistilled 12B DiT) as a first-class text-to-image generation model, **Mac-first**. The engine (mlx-gen #656) + rehosted weights (`SceneWorks/krea-2-raw-mlx`, live) already landed; this is the SceneWorks wiring so Raw generates in Image Studio on Mac. Windows/Linux (candle) is the fast-follow tracked in [sc-9994](https://app.shortcut.com/trefry/story/9994).

## sc-9999 — routing + worker (mac-first)
- Bump the worker mlx-gen pin `dad872b → 495bb19` (#656). gen-core is byte-identical across the range, so no candle lockstep / skew change. This also activates the merged sc-9989 LTX trainer fix that was waiting on a pin bump.
- `catalog.rs`: `ModelCaps::new("krea_2_raw", true, false, …)` — mlx-routed; candle stays off until sc-9994 (then flips to Turbo's `(true,true,false,false,true)`). mlx eligibility + `EXPECTED_MLX_ROUTED_MODELS` updated.
- Worker `MODEL_TABLE`: `krea_2_raw` ModelRow (SceneWorks/krea-2-raw-mlx, 52 steps, guidance 3.5).

## sc-10003 — manifest (generation surface)
- Flip `krea_2_raw` `utility → image`: bf16/q8/q4 turnkey tiers (q8 default, all-platform), 52-step/CFG-3.5 defaults, curated sampler menu, PiD, prompt guide. Appears in the Image Studio picker on Mac.

## sc-9997 — Path 1: unify training onto the turnkey bf16
Training + generation now share ONE re-host. The turnkey `bf16/` tier is byte-identical to the retired `krea/Krea-2-Raw` diffusers base, so training behavior is unchanged.
- core: `krea_raw_lora_target` → `SceneWorks/krea-2-raw-mlx`.
- rust-api `resolve_base_model_path` descends into `bf16/` for a tiered turnkey; `training_base_model_installed` requires the `bf16/` component tree (gen may have installed only q8, which has no dense weights to train on — the run-gate blocks that). New `tiered_turnkey_base_trains_on_bf16_tier` test.
- web TrainingStudio: base readiness + "install base" target the `bf16` variant for a quant-matrix base (`createModelDownloadJob({ variant })`); non-matrix bases unchanged.

## Verification
core (386) · rust-api models/training (+ new tiered-turnkey test) · worker engines incl. the `manifest_menu_is_subset_of_descriptor` drift guard — all green. fmt + clippy clean on the changed crates. Real `generate_base` CFG render on the q8 tier verified during the rehost (sc-9995). Web vitest + candle parity lane run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)