### PR TITLE
feat(worker): host + wire Wan2.2 TI2V-5B bf16/Q8/Q4 quant-matrix tiers (sc-9941, epic 8506)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -4848,17 +4848,54 @@
       // SceneWorks HF org (sc-5599, epic 5594); Windows/Linux load the diffusers layout via the
       // torch wan_video adapter. The API serves only the entry matching the running OS.
       "downloads": [
+        // macOS quant matrix (sc-9941, epic 8506): each tier is a SEPARATE user-selectable artifact
+        // tagged with a `variant`; `q4` (default) installs when no tier is chosen. Each tier subdir is
+        // fully self-contained (the single-expert DiT `model.safetensors` + UMT5 T5 + z16 VAE +
+        // tokenizer + config.json with the quant baked in), so the dense T5/VAE repeat per tier (epic
+        // decision #3: storage is a non-issue; keeps the load path a single self-contained dir with no
+        // engine change). The worker fetches a toggled-but-not-downloaded tier on demand
+        // (ensure_wan_tier_present, video_jobs.rs), so advanced.mlxQuantize works without a pre-pick.
+        // The legacy flat root files stay hosted for already-shipped workers that resolve the repo
+        // root; a new worker only ever resolves the tier subdirs (cleanup follow-up sc-9977).
+        // estimatedSizeBytes/footprint are backfilled with the exact hosted subdir sizes post-build.
         {
           "provider": "huggingface",
           "repo": "SceneWorks/wan2.2-ti2v-5b-mlx",
-          "files": [],
+          "variant": "q4",
+          "default": true,
+          "files": ["q4/*"],
           "platforms": ["macos"],
-          "estimatedSizeBytes": 24197123156
+          // The dense UMT5 T5 (~11.4 GB) + z16 VAE (~2.8 GB) are shared bf16 in every tier, so the q4
+          // DiT (~2.9 GB) makes this only modestly smaller than q8/bf16 (same shape as SD3.5).
+          "estimatedSizeBytes": 17142889289,
+          "footprint": { "diskSizeBytes": 17142889289, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/wan2.2-ti2v-5b-mlx",
+          "variant": "q8",
+          "files": ["q8/*"],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 19596557565,
+          "footprint": { "diskSizeBytes": 19596557565, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/wan2.2-ti2v-5b-mlx",
+          "variant": "bf16",
+          "files": ["bf16/*"],
+          "platforms": ["macos"],
+          // Dense bf16 tier (sc-9941): the same content as the legacy flat root (single-expert DiT +
+          // T5 + VAE + tokenizer), hosted under bf16/ for the uniform tier layout. Exact on-disk size
+          // of the built bf16/ subdir.
+          "estimatedSizeBytes": 24197122980,
+          "footprint": { "diskSizeBytes": 24197122980, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "Wan-AI/Wan2.2-TI2V-5B-Diffusers",
           "files": [],
+          "default": true,
           "platforms": ["windows", "linux"],
           "estimatedSizeBytes": 34203021834
         }
@@ -4912,12 +4949,14 @@
         }
       },
       "mlx": {
-        // Turnkey pre-converted MLX snapshot on the SceneWorks HF org (sc-5599, epic 5594):
-        // dense bf16, self-contained (DiT + UMT5 encoder + VAE + tokenizer), downloaded on
-        // first use — no in-app conversion. The worker still resolves env override
-        // (SCENEWORKS_MLX_WAN5B_DIR) → local <data>/models/mlx/wan_2_2 (a local conversion
-        // supersedes) → this turnkey snapshot. Source Wan-AI/Wan2.2-TI2V-5B is Apache-2.0;
-        // converter "wan_ti2v_5b" emits bf16 (Q4/Q8 applied at load, not baked in).
+        // Turnkey pre-converted MLX snapshot on the SceneWorks HF org (sc-5599, epic 5594),
+        // self-contained (single-expert DiT + UMT5 encoder + VAE + tokenizer). As of the quant matrix
+        // (sc-9941, epic 8506) it ships pre-built q4/q8/bf16 tier subdirs (the quant baked into each
+        // tier's config.json so nothing quantizes at load). The worker resolves env override
+        // (SCENEWORKS_MLX_WAN5B_DIR) → local <data>/models/mlx/wan_2_2 (a local conversion supersedes)
+        // → the requested tier subdir of this snapshot (wan_tier_subdir), loading with no install-time
+        // convert peak. Source Wan-AI/Wan2.2-TI2V-5B is Apache-2.0; converter "wan_ti2v_5b" builds the
+        // bf16 tier and the q8/q4 tiers are derived from it (quantize_wan_transformer, group 64).
         "minMemoryGb": 45,
         "repo": "SceneWorks/wan2.2-ti2v-5b-mlx",
         // macOS curated menu (sc-7296): mlx Wan adopts the unified framework over its native

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -283,6 +283,14 @@ mod wan_t2v_14b_tier_build;
 // `SceneWorks/wan2.2-i2v-a14b-mlx`; not exercised in CI (needs the ~126GB native weights).
 #[cfg(all(test, target_os = "macos"))]
 mod wan_i2v_14b_tier_build;
+// On-device build helper for the Wan2.2 TI2V-5B quant matrix (sc-9941, epic 8506). The single-expert
+// sibling of the A14B helpers: drives `mlx_gen_wan::convert::convert_ti2v_5b` for the dense bf16 tier,
+// then derives the q8/q4 tiers worker-side (load the bf16 `model.safetensors` →
+// `quantize_wan_transformer` → save + reuse the shared dense T5/VAE/tokenizer + a `config.json` quant
+// patch) — byte-identical to an inline convert, no mlx-gen change. Run one-off to build the artifacts
+// for `SceneWorks/wan2.2-ti2v-5b-mlx`; not exercised in CI (needs the native checkpoint).
+#[cfg(all(test, target_os = "macos"))]
+mod wan_ti2v_5b_tier_build;
 // The DWPose skeleton rasterizer is consumed only by the macOS Z-Image strict-pose
 // control path; on Mac AND the off-Mac candle DWPose lane (sc-5496) it backs the
 // `pose_jobs` skeleton render; on a candle-disabled box off Mac it still builds +

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -741,7 +741,7 @@ fn sana_sprint_manifest_entry_gates_correctly() {
 /// sc-9942 (epic 8506): the Wan2.2 T2V-A14B builtin entry ships the macOS quant matrix as per-tier
 /// installable artifacts — `q4` (default) + `q8` + `bf16`, each a self-contained SceneWorks HF
 /// download tagged with a `variant` and carrying an `estimatedSizeBytes` + `footprint` (sc-8508). The
-/// video load path (`video_jobs::wan_a14b_tier_subdir`) descends into the chosen tier, so a drift
+/// video load path (`video_jobs::wan_tier_subdir`) descends into the chosen tier, so a drift
 /// that drops a tier or its size would break the download UI + the RAM→tier suggestion — assert the
 /// shape here so it fails CI.
 #[test]
@@ -823,7 +823,7 @@ fn wan_t2v_14b_manifest_ships_the_quant_matrix() {
 /// sc-9943 (epic 8506): the Wan2.2 I2V-A14B builtin entry ships the SAME macOS quant matrix as its
 /// T2V sibling — per-tier `q4` (default) + `q8` + `bf16` self-contained SceneWorks HF downloads
 /// tagged with a `variant`, each with an `estimatedSizeBytes` + `footprint` (sc-8508). The video load
-/// path (`video_jobs::wan_a14b_tier_subdir`) descends into the chosen tier for BOTH A14B models, so a
+/// path (`video_jobs::wan_tier_subdir`) descends into the chosen tier for BOTH A14B models, so a
 /// drift that drops an I2V tier or its size would break the download UI + the RAM→tier suggestion —
 /// assert the shape here so it fails CI.
 #[test]
@@ -868,6 +868,88 @@ fn wan_i2v_14b_manifest_ships_the_quant_matrix() {
             tier.get("repo").and_then(Value::as_str),
             Some("SceneWorks/wan2.2-i2v-a14b-mlx"),
             "{variant} tier hosts on the SceneWorks I2V quant-matrix repo"
+        );
+        let files: Vec<String> = tier
+            .get("files")
+            .and_then(Value::as_array)
+            .map(|f| f.iter().filter_map(Value::as_str).map(String::from).collect())
+            .unwrap_or_default();
+        assert_eq!(
+            files,
+            vec![format!("{variant}/*")],
+            "{variant} tier installs only its own subdir"
+        );
+        assert!(
+            tier.get("estimatedSizeBytes")
+                .and_then(Value::as_u64)
+                .is_some_and(|b| b > 0),
+            "{variant} tier declares a nonzero estimatedSizeBytes"
+        );
+        assert!(
+            tier.get("footprint")
+                .and_then(|f| f.get("diskSizeBytes"))
+                .and_then(Value::as_u64)
+                .is_some_and(|b| b > 0),
+            "{variant} tier declares a footprint.diskSizeBytes"
+        );
+    }
+    // Exactly one macOS default, and it is the lean q4 tier (the big bf16 is a deliberate opt-in).
+    let defaults: Vec<&str> = macos
+        .iter()
+        .filter(|d| d.get("default").and_then(Value::as_bool) == Some(true))
+        .filter_map(|d| d.get("variant").and_then(Value::as_str))
+        .collect();
+    assert_eq!(defaults, vec!["q4"], "the macOS default tier is q4");
+}
+
+/// sc-9941 (epic 8506): the single-expert Wan2.2 TI2V-5B builtin entry (`wan_2_2`) ships the SAME
+/// macOS quant matrix as its A14B siblings — per-tier `q4` (default) + `q8` + `bf16` self-contained
+/// SceneWorks HF downloads tagged with a `variant`, each with an `estimatedSizeBytes` + `footprint`
+/// (sc-8508). The video load path (`video_jobs::wan_tier_subdir`) descends into the chosen tier, so a
+/// drift that drops a tier or its size would break the download UI + the RAM→tier suggestion — assert
+/// the shape here so it fails CI.
+#[test]
+fn wan_ti2v_5b_manifest_ships_the_quant_matrix() {
+    let entry = builtin_model_entry("wan_2_2");
+    assert_eq!(
+        entry.get("family").and_then(Value::as_str),
+        Some("wan-video"),
+        "wan TI2V-5B family"
+    );
+    assert_eq!(
+        entry.get("type").and_then(Value::as_str),
+        Some("video"),
+        "wan TI2V-5B is a video model"
+    );
+    let downloads = entry
+        .get("downloads")
+        .and_then(Value::as_array)
+        .expect("wan TI2V-5B downloads");
+    // The macOS tiers, in order, from the SceneWorks quant-matrix repo.
+    let macos: Vec<&Value> = downloads
+        .iter()
+        .filter(|d| {
+            d.get("platforms")
+                .and_then(Value::as_array)
+                .map(|p| p.iter().any(|x| x.as_str() == Some("macos")))
+                .unwrap_or(false)
+        })
+        .collect();
+    let variants: Vec<&str> = macos
+        .iter()
+        .filter_map(|d| d.get("variant").and_then(Value::as_str))
+        .collect();
+    assert_eq!(
+        variants,
+        vec!["q4", "q8", "bf16"],
+        "wan TI2V-5B ships the q4/q8/bf16 tier matrix on macOS"
+    );
+    for tier in &macos {
+        let variant = tier.get("variant").and_then(Value::as_str).unwrap();
+        assert_eq!(
+            tier.get("repo").and_then(Value::as_str),
+            Some("SceneWorks/wan2.2-ti2v-5b-mlx"),
+            "{variant} tier hosts on the SceneWorks TI2V-5B quant-matrix repo"
         );
         let files: Vec<String> = tier
             .get("files")

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -2815,20 +2815,73 @@ const WAN_I2V_14B_REPO: &str = "SceneWorks/wan2.2-i2v-a14b-mlx";
 #[cfg(target_os = "macos")]
 const WAN_I2V_14B_REVISION: &str = "c6c786170031eccc3a1fac0f98f1ad4ff988271e";
 
-/// Map an A14B dual-expert MoE video model id to its `(quant-matrix repo, pinned revision)` for the
-/// on-demand tier fetch, or `None` for a non-A14B model. The T2V (sc-9942) and I2V (sc-9943) A14B
-/// turnkeys host the SAME self-contained `q4/`/`q8/`/`bf16/` tier layout (epic 8506); only the repo +
-/// pinned commit differ, so the whole tier-resolve/fetch path is shared and keyed only here.
+/// The turnkey SceneWorks Wan2.2 **TI2V-5B** MLX repo (sc-9941, epic 8506). The single-expert sibling
+/// of the A14B repos: same self-contained `q4/`/`q8/`/`bf16/` tier layout, but ONE transformer
+/// (`model.safetensors`) rather than the dual `high/low_noise_model` MoE experts (still + UMT5 T5 +
+/// z16 VAE + tokenizer + `config.json`). The worker descends into the chosen tier so a pre-packed
+/// snapshot loads with no install-time convert peak; the legacy flat root files stay for
+/// already-shipped workers (cleanup sc-9977).
 #[cfg(target_os = "macos")]
-fn wan_a14b_tier_repo(model: &str) -> Option<(&'static str, &'static str)> {
+const WAN_TI2V_5B_REPO: &str = "SceneWorks/wan2.2-ti2v-5b-mlx";
+
+/// Pinned revision for [`WAN_TI2V_5B_REPO`] (mirrors [`WAN_T2V_14B_REVISION`]). The commit that adds
+/// the `q4/`/`q8/`/`bf16/` tier subdirs to the TI2V-5B repo (sc-9941); pinning the exact commit (not
+/// the mutable `main`) stops an upstream re-push from silently swapping a checkpoint the on-demand
+/// `q8/*` + `bf16/*` fetch loads (the `hf` CLI still verifies each file's own hash on download).
+#[cfg(target_os = "macos")]
+const WAN_TI2V_5B_REVISION: &str = "bb1b055249614cf9d7cf4373fbdbc184b77dee88";
+
+/// The files that make an **A14B** (dual-expert MoE) Wan tier subdir COMPLETE: both experts + the T5
+/// encoder + VAE + tokenizer + `config.json`.
+#[cfg(target_os = "macos")]
+const WAN_A14B_TIER_FILES: &[&str] = &[
+    "high_noise_model.safetensors",
+    "low_noise_model.safetensors",
+    "t5_encoder.safetensors",
+    "vae.safetensors",
+    "tokenizer.json",
+    "config.json",
+];
+
+/// The files that make a **TI2V-5B** (single-expert) Wan tier subdir COMPLETE: the one transformer
+/// (`model.safetensors`) + the T5 encoder + VAE + tokenizer + `config.json`.
+#[cfg(target_os = "macos")]
+const WAN_TI2V_5B_TIER_FILES: &[&str] = &[
+    "model.safetensors",
+    "t5_encoder.safetensors",
+    "vae.safetensors",
+    "tokenizer.json",
+    "config.json",
+];
+
+/// The tier-completeness file set for a Wan quant-matrix model: the single-expert TI2V-5B ships one
+/// `model.safetensors`, the A14B MoE models ship the two `high/low_noise_model.safetensors` experts.
+#[cfg(target_os = "macos")]
+fn wan_tier_files(model: &str) -> &'static [&'static str] {
+    if model == "wan_2_2" {
+        WAN_TI2V_5B_TIER_FILES
+    } else {
+        WAN_A14B_TIER_FILES
+    }
+}
+
+/// Map a Wan quant-matrix video model id to its `(quant-matrix repo, pinned revision)` for the
+/// on-demand tier fetch, or `None` for a model with no hosted tier matrix. The TI2V-5B (sc-9941),
+/// T2V-A14B (sc-9942) and I2V-A14B (sc-9943) turnkeys host the SAME self-contained
+/// `q4/`/`q8/`/`bf16/` tier layout (epic 8506); only the repo + pinned commit (and the single- vs
+/// dual-expert file set, see [`wan_tier_files`]) differ, so the whole tier-resolve/fetch path is
+/// shared and keyed only here. `request.model` is `"wan_2_2"` for the TI2V-5B engine.
+#[cfg(target_os = "macos")]
+fn wan_tier_repo(model: &str) -> Option<(&'static str, &'static str)> {
     match model {
+        "wan_2_2" => Some((WAN_TI2V_5B_REPO, WAN_TI2V_5B_REVISION)),
         "wan_2_2_t2v_14b" => Some((WAN_T2V_14B_REPO, WAN_T2V_14B_REVISION)),
         "wan_2_2_i2v_14b" => Some((WAN_I2V_14B_REPO, WAN_I2V_14B_REVISION)),
         _ => None,
     }
 }
 
-/// Parse `advanced.mlxQuantize` (int or numeric string) for the Wan A14B tier selector, if present.
+/// Parse `advanced.mlxQuantize` (int or numeric string) for the Wan quant-matrix tier selector.
 #[cfg(target_os = "macos")]
 fn wan_quant_bits(request: &VideoRequest) -> Option<i64> {
     request
@@ -2837,13 +2890,13 @@ fn wan_quant_bits(request: &VideoRequest) -> Option<i64> {
         .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()))
 }
 
-/// The Wan2.2 A14B (T2V + I2V) tier search order for a request — preferred tier first, then the
+/// The Wan2.2 quant-matrix tier search order for a request — preferred tier first, then the
 /// always-smaller fallback tiers so a repo missing the preferred subdir still loads (mirrors
 /// [`ltx_bundle_tier_order`]): `mlxQuantize <= 0` ⇒ `bf16`, `>= 8` ⇒ `q8`, else the `q4` default.
 /// `bf16` is only ever tried when explicitly requested, so a default job never pulls the huge dense
 /// tier by accident.
 #[cfg(target_os = "macos")]
-fn wan_a14b_tier_order(request: &VideoRequest) -> &'static [&'static str] {
+fn wan_tier_order(request: &VideoRequest) -> &'static [&'static str] {
     match wan_quant_bits(request) {
         Some(b) if b <= 0 => &["bf16", "q8", "q4"],
         Some(b) if b >= 8 => &["q8", "q4"],
@@ -2851,73 +2904,69 @@ fn wan_a14b_tier_order(request: &VideoRequest) -> &'static [&'static str] {
     }
 }
 
-/// Whether `dir` is a COMPLETE self-contained Wan2.2 A14B tier snapshot: both MoE experts + the T5
-/// encoder + VAE + tokenizer + `config.json`. A partially-downloaded tier fails this so
-/// [`wan_a14b_tier_subdir`] falls through to a smaller complete tier rather than half-loading.
+/// Whether `dir` is a COMPLETE self-contained Wan2.2 tier snapshot, given the model's expected tier
+/// file set (`files`, from [`wan_tier_files`]): the transformer(s), the T5 encoder, VAE, tokenizer,
+/// and `config.json`. A partially-downloaded tier fails this so [`wan_tier_subdir`] falls through to
+/// a smaller complete tier rather than half-loading.
 #[cfg(target_os = "macos")]
-fn wan_a14b_tier_is_complete(dir: &Path) -> bool {
-    [
-        "high_noise_model.safetensors",
-        "low_noise_model.safetensors",
-        "t5_encoder.safetensors",
-        "vae.safetensors",
-        "tokenizer.json",
-        "config.json",
-    ]
-    .iter()
-    .all(|file| dir.join(file).is_file())
+fn wan_tier_is_complete(dir: &Path, files: &[&str]) -> bool {
+    files.iter().all(|file| dir.join(file).is_file())
 }
 
-/// Descend a resolved Wan2.2 A14B repo `root` into the requested quant tier subdir (sc-9942/sc-9943,
-/// epic 8506), mirroring [`ltx_bundle_subdir`]. Returns the first COMPLETE tier in
-/// [`wan_a14b_tier_order`] (both experts live in the SAME subdir, so one resolution covers the full
-/// MoE), or `None` when the repo has no complete tier subdir — a legacy flat snapshot, where the
-/// caller keeps the root + load-time quant.
+/// Descend a resolved Wan2.2 quant-matrix repo `root` into the requested quant tier subdir
+/// (sc-9941 TI2V-5B / sc-9942 T2V / sc-9943 I2V, epic 8506), mirroring [`ltx_bundle_subdir`]. Returns
+/// the first COMPLETE tier in [`wan_tier_order`] (all of a model's weights — one transformer for the
+/// 5B, both experts for the A14B — live in the SAME subdir, so one resolution covers the model), or
+/// `None` when the repo has no complete tier subdir — a legacy flat snapshot, where the caller keeps
+/// the root + load-time quant.
 #[cfg(target_os = "macos")]
-fn wan_a14b_tier_subdir(root: &Path, request: &VideoRequest) -> Option<PathBuf> {
-    wan_a14b_tier_order(request)
+fn wan_tier_subdir(root: &Path, request: &VideoRequest) -> Option<PathBuf> {
+    let files = wan_tier_files(&request.model);
+    wan_tier_order(request)
         .iter()
         .map(|tier| root.join(tier))
-        .find(|dir| wan_a14b_tier_is_complete(dir))
+        .find(|dir| wan_tier_is_complete(dir, files))
 }
 
-/// Resolve the Wan2.2 A14B `(model_dir, load-time quant)` for a generation, descending into the
-/// quant-matrix tier subdir when the turnkey ships them (sc-9942 T2V / sc-9943 I2V). A pre-packed
+/// Resolve the Wan2.2 `(model_dir, load-time quant)` for a generation, descending into the
+/// quant-matrix tier subdir when the turnkey ships them (sc-9941 TI2V-5B / sc-9942 T2V / sc-9943 I2V).
+/// A pre-packed
 /// tier's `config.json` is authoritative — [`WanTransformer::from_weights`] builds the experts at the
 /// stored bits and `resolve_load_time_quant` rejects a conflicting `spec.quantize` as a hard error —
 /// so a resolved tier loads with `quant = None`: `mlxQuantize` selects WHICH tier, never a load-time
 /// requant (the `bf16/` tier is dense, so `None` ⇒ dense too). A legacy flat snapshot (no tier
 /// subdirs) keeps today's behavior: load the root and quantize at load per [`resolve_wan_quant`].
 #[cfg(target_os = "macos")]
-fn resolve_wan_a14b_dir_and_quant(
+fn resolve_wan_tier_dir_and_quant(
     settings: &Settings,
     request: &VideoRequest,
     engine_id: &'static str,
 ) -> WorkerResult<(PathBuf, Option<Quant>)> {
     let root = resolve_wan_model_dir(settings, &request.model, engine_id)?;
-    match wan_a14b_tier_subdir(&root, request) {
+    match wan_tier_subdir(&root, request) {
         Some(tier) => Ok((tier, None)),
         None => Ok((root, resolve_wan_quant(request))),
     }
 }
 
-/// On-demand fetch of a non-default Wan2.2 A14B tier subdir (sc-9942 T2V / sc-9943 I2V, mirrors
-/// [`ensure_ltx_q8_present`] / [`ensure_ltx_bf16_present`]). The macOS default download is the lean
-/// `q4/` tier; a job that opts into a heavier tier (`mlxQuantize <= 0` ⇒ `bf16`, `>= 8` ⇒ `q8`) pulls
-/// just that subdir from that model's FIXED [`wan_a14b_tier_repo`] revision the first time it is
-/// requested so [`wan_a14b_tier_subdir`] can resolve it. No-op for a non-A14B model, a `q4` (default)
+/// On-demand fetch of a non-default Wan2.2 quant-matrix tier subdir (sc-9941 TI2V-5B / sc-9942 T2V /
+/// sc-9943 I2V, mirrors [`ensure_ltx_q8_present`] / [`ensure_ltx_bf16_present`]). The macOS default
+/// download is the lean `q4/` tier; a job that opts into a heavier tier (`mlxQuantize <= 0` ⇒ `bf16`,
+/// `>= 8` ⇒ `q8`) pulls just that subdir from that model's FIXED [`wan_tier_repo`] revision the first
+/// time it is requested so [`wan_tier_subdir`] can resolve it. No-op for a model with no hosted tier
+/// matrix, a `q4` (default)
 /// job, when the repo snapshot isn't downloaded yet (resolve surfaces the clear error), or when the
 /// tier is already complete. Fails loud on a real download error — fast, before any compute; a
 /// missing `hf` CLI leaves the tier absent so resolve gracefully falls back to a smaller complete
 /// tier.
 #[cfg(target_os = "macos")]
-async fn ensure_wan_a14b_tier_present(
+async fn ensure_wan_tier_present(
     api: &ApiClient,
     settings: &Settings,
     job: &JobSnapshot,
     request: &VideoRequest,
 ) -> WorkerResult<()> {
-    let Some((repo, revision)) = wan_a14b_tier_repo(&request.model) else {
+    let Some((repo, revision)) = wan_tier_repo(&request.model) else {
         return Ok(());
     };
     let tier = match wan_quant_bits(request) {
@@ -2929,13 +2978,13 @@ async fn ensure_wan_a14b_tier_present(
     let Some(root) = huggingface_snapshot_dir(&settings.data_dir, repo) else {
         return Ok(());
     };
-    if wan_a14b_tier_is_complete(&root.join(tier)) {
+    if wan_tier_is_complete(&root.join(tier), wan_tier_files(&request.model)) {
         return Ok(());
     }
     let scratch = settings
         .data_dir
         .join("cache")
-        .join(format!(".wan-a14b-{tier}-fetch-{}", job.id));
+        .join(format!(".wan-tier-{tier}-fetch-{}", job.id));
     tokio::fs::create_dir_all(&scratch).await?;
     let files = vec![format!("{tier}/*")];
     let result = crate::model_jobs::download_model_with_hf_cli(
@@ -5058,15 +5107,15 @@ async fn generate_wan(
         }
         _ => resolve_wan_conditioning(settings, request, project_path, engine_id)?,
     };
-    // A14B quant matrix (sc-9942 T2V / sc-9943 I2V, epic 8506): the macOS default install is the lean
-    // q4 tier; a q8/bf16 job fetches that subdir on demand before resolving. No-op for the 5B model, a
-    // q4 job, or an already-present tier.
-    ensure_wan_a14b_tier_present(api, settings, job, request).await?;
-    // Descend into the chosen quant-matrix tier subdir when the A14B turnkey ships them; a pre-packed
-    // tier loads with quant=None (config.json is authoritative). The 5B model and a legacy flat A14B
-    // snapshot keep the root + load-time quant.
-    let (model_dir, quant) = if engine_id == "wan2_2_t2v_14b" || engine_id == "wan2_2_i2v_14b" {
-        resolve_wan_a14b_dir_and_quant(settings, request, engine_id)?
+    // Wan quant matrix (sc-9941 TI2V-5B / sc-9942 T2V / sc-9943 I2V, epic 8506): the macOS default
+    // install is the lean q4 tier; a q8/bf16 job fetches that subdir on demand before resolving. No-op
+    // for a model with no hosted tier matrix, a q4 job, or an already-present tier.
+    ensure_wan_tier_present(api, settings, job, request).await?;
+    // Descend into the chosen quant-matrix tier subdir when the turnkey ships them; a pre-packed tier
+    // loads with quant=None (config.json is authoritative). A legacy flat snapshot (or a model with no
+    // hosted matrix) keeps the root + load-time quant.
+    let (model_dir, quant) = if wan_tier_repo(&request.model).is_some() {
+        resolve_wan_tier_dir_and_quant(settings, request, engine_id)?
     } else {
         (
             resolve_wan_model_dir(settings, &request.model, engine_id)?,
@@ -9490,7 +9539,7 @@ mod tests {
     }
 
     /// Write the six files that make a Wan2.2 A14B tier subdir COMPLETE
-    /// ([`wan_a14b_tier_is_complete`]), so [`wan_a14b_tier_subdir`] treats it as present.
+    /// ([`wan_tier_is_complete`]), so [`wan_tier_subdir`] treats it as present.
     #[cfg(target_os = "macos")]
     fn write_complete_wan_tier(root: &Path, tier: &str) {
         let dir = root.join(tier);
@@ -9511,66 +9560,65 @@ mod tests {
     /// present tiers (bf16 is only ever tried when explicitly requested).
     #[cfg(target_os = "macos")]
     #[test]
-    fn wan_a14b_tier_order_prefers_then_falls_back() {
+    fn wan_tier_order_prefers_then_falls_back() {
         let bf16 = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 0 } }));
-        assert_eq!(wan_a14b_tier_order(&bf16), &["bf16", "q8", "q4"]);
+        assert_eq!(wan_tier_order(&bf16), &["bf16", "q8", "q4"]);
         let q8 = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 8 } }));
-        assert_eq!(wan_a14b_tier_order(&q8), &["q8", "q4"]);
+        assert_eq!(wan_tier_order(&q8), &["q8", "q4"]);
         let q4 = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 4 } }));
-        assert_eq!(wan_a14b_tier_order(&q4), &["q4", "q8"]);
+        assert_eq!(wan_tier_order(&q4), &["q4", "q8"]);
         // Absent knob defaults to the lean q4 tier; bf16 is never in a default job's search path.
         let absent = request(json!({ "projectId": "p" }));
-        assert_eq!(wan_a14b_tier_order(&absent), &["q4", "q8"]);
+        assert_eq!(wan_tier_order(&absent), &["q4", "q8"]);
     }
 
-    /// [`wan_a14b_tier_subdir`] resolves the requested tier, falls back to a smaller COMPLETE
+    /// [`wan_tier_subdir`] resolves the requested tier, falls back to a smaller COMPLETE
     /// tier, ignores a partially-downloaded one, and returns `None` for a legacy flat root.
     #[cfg(target_os = "macos")]
     #[test]
-    fn wan_a14b_tier_subdir_resolves_and_falls_back() {
+    fn wan_tier_subdir_resolves_and_falls_back() {
         let root = std::env::temp_dir().join(format!("sw_wan_tier_{}", Uuid::new_v4().simple()));
         std::fs::create_dir_all(&root).unwrap();
         // Legacy flat root (no tier subdirs) → None (caller keeps root + load-time quant).
         let q8_req = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 8 } }));
-        assert_eq!(wan_a14b_tier_subdir(&root, &q8_req), None);
+        assert_eq!(wan_tier_subdir(&root, &q8_req), None);
 
         // Only q4 present: a q8 request falls back to the smaller complete q4 tier.
         write_complete_wan_tier(&root, "q4");
-        assert_eq!(wan_a14b_tier_subdir(&root, &q8_req), Some(root.join("q4")));
+        assert_eq!(wan_tier_subdir(&root, &q8_req), Some(root.join("q4")));
 
         // A partial q8 (missing a file) is skipped, still falling back to q4.
         std::fs::create_dir_all(root.join("q8")).unwrap();
         std::fs::write(root.join("q8").join("config.json"), b"x").unwrap();
-        assert_eq!(wan_a14b_tier_subdir(&root, &q8_req), Some(root.join("q4")));
+        assert_eq!(wan_tier_subdir(&root, &q8_req), Some(root.join("q4")));
 
         // Completed q8 now wins for a q8 request; a default job still prefers q4.
         write_complete_wan_tier(&root, "q8");
-        assert_eq!(wan_a14b_tier_subdir(&root, &q8_req), Some(root.join("q8")));
+        assert_eq!(wan_tier_subdir(&root, &q8_req), Some(root.join("q8")));
         let default_req = request(json!({ "projectId": "p" }));
-        assert_eq!(
-            wan_a14b_tier_subdir(&root, &default_req),
-            Some(root.join("q4"))
-        );
+        assert_eq!(wan_tier_subdir(&root, &default_req), Some(root.join("q4")));
 
         // bf16 request with no bf16 tier falls back to q8 (never silently to a default).
         let bf16_req = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 0 } }));
-        assert_eq!(
-            wan_a14b_tier_subdir(&root, &bf16_req),
-            Some(root.join("q8"))
-        );
+        assert_eq!(wan_tier_subdir(&root, &bf16_req), Some(root.join("q8")));
         std::fs::remove_dir_all(&root).ok();
     }
 
-    /// Both A14B tier repos (T2V sc-9942 / I2V sc-9943) must pin an exact commit (not the mutable
-    /// `main`) so an upstream re-push can't swap a checkpoint the on-demand fetch loads (mirrors the
-    /// LTX/SeedVR2 pins). `wan_a14b_tier_repo` also routes each model id to its own repo+revision.
+    /// Every Wan quant-matrix tier repo (TI2V-5B sc-9941 / T2V sc-9942 / I2V sc-9943) must pin an
+    /// exact commit (not the mutable `main`) so an upstream re-push can't swap a checkpoint the
+    /// on-demand fetch loads (mirrors the LTX/SeedVR2 pins). `wan_tier_repo` also routes each model id
+    /// to its own repo+revision.
     #[cfg(target_os = "macos")]
     #[test]
-    fn wan_a14b_tier_revisions_are_pinned_commits_not_main() {
-        for (label, revision) in [("T2V", WAN_T2V_14B_REVISION), ("I2V", WAN_I2V_14B_REVISION)] {
+    fn wan_tier_revisions_are_pinned_commits_not_main() {
+        for (label, revision) in [
+            ("TI2V-5B", WAN_TI2V_5B_REVISION),
+            ("T2V", WAN_T2V_14B_REVISION),
+            ("I2V", WAN_I2V_14B_REVISION),
+        ] {
             assert_ne!(
                 revision, "main",
-                "the {label}-A14B tier repo must pin a fixed revision before release"
+                "the {label} tier repo must pin a fixed revision before release"
             );
             assert_eq!(
                 revision.len(),
@@ -9584,16 +9632,44 @@ mod tests {
                 "the pinned {label} revision must be lowercase hex"
             );
         }
-        // Each A14B model id routes to its own repo + revision; a non-A14B model has no tier repo.
+        // Each quant-matrix model id routes to its own repo + revision (the 5B engine's request.model
+        // is `wan_2_2`); a model with no hosted matrix has no tier repo.
         assert_eq!(
-            wan_a14b_tier_repo("wan_2_2_t2v_14b"),
+            wan_tier_repo("wan_2_2"),
+            Some((WAN_TI2V_5B_REPO, WAN_TI2V_5B_REVISION))
+        );
+        assert_eq!(
+            wan_tier_repo("wan_2_2_t2v_14b"),
             Some((WAN_T2V_14B_REPO, WAN_T2V_14B_REVISION))
         );
         assert_eq!(
-            wan_a14b_tier_repo("wan_2_2_i2v_14b"),
+            wan_tier_repo("wan_2_2_i2v_14b"),
             Some((WAN_I2V_14B_REPO, WAN_I2V_14B_REVISION))
         );
-        assert_eq!(wan_a14b_tier_repo("wan_2_2"), None);
+        assert_eq!(wan_tier_repo("bernini"), None);
+    }
+
+    /// The single-expert TI2V-5B tier (sc-9941) is COMPLETE with one `model.safetensors` (not the
+    /// A14B two-expert set), and `wan_tier_subdir` resolves it for the `wan_2_2` model id.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn wan_tier_ti2v_5b_single_expert_completeness() {
+        assert_eq!(wan_tier_files("wan_2_2"), WAN_TI2V_5B_TIER_FILES);
+        assert_eq!(wan_tier_files("wan_2_2_t2v_14b"), WAN_A14B_TIER_FILES);
+
+        let root = std::env::temp_dir().join(format!("sw_wan5b_{}", Uuid::new_v4().simple()));
+        let dir = root.join("q4");
+        std::fs::create_dir_all(&dir).unwrap();
+        for file in WAN_TI2V_5B_TIER_FILES {
+            std::fs::write(dir.join(file), b"x").unwrap();
+        }
+        // Complete for the 5B (single transformer) but NOT for the A14B set (missing the experts).
+        assert!(wan_tier_is_complete(&dir, WAN_TI2V_5B_TIER_FILES));
+        assert!(!wan_tier_is_complete(&dir, WAN_A14B_TIER_FILES));
+
+        let req = request(json!({ "projectId": "p", "model": "wan_2_2" }));
+        assert_eq!(wan_tier_subdir(&root, &req), Some(dir));
+        std::fs::remove_dir_all(&root).ok();
     }
 
     /// The `.high_noise.safetensors` → `.low_noise.safetensors` sibling convention
@@ -9950,7 +10026,7 @@ mod tests {
         let mut verified = 0;
         for tier in ["bf16", "q8", "q4"] {
             let dir = root.join(tier);
-            if !wan_a14b_tier_is_complete(&dir) {
+            if !wan_tier_is_complete(&dir, WAN_A14B_TIER_FILES) {
                 eprintln!("skipping {tier}: {} is not a complete tier", dir.display());
                 continue;
             }
@@ -9962,7 +10038,7 @@ mod tests {
                 model_dir: dir.clone(),
                 // Pre-packed tier: config.json carries the quant; the engine reconstructs the experts
                 // packed and rejects a conflicting override, so load with None (the worker path does
-                // the same in resolve_wan_a14b_dir_and_quant).
+                // the same in resolve_wan_tier_dir_and_quant).
                 quant: None,
                 prompt: "a calm ocean wave at sunset, cinematic".to_owned(),
                 // A few CFG steps WITHOUT the Lightning distill — enough to exercise the packed
@@ -10022,6 +10098,109 @@ mod tests {
         assert!(
             verified > 0,
             "no tier subdirs found under SCENEWORKS_WAN_T2V_14B_TIER_OUT"
+        );
+        eprintln!("verified {verified} tier(s)");
+    }
+
+    /// Real in-process load+generate verification for the Wan2.2 **TI2V-5B** quant-matrix tiers
+    /// (sc-9941, epic 8506) — the single-expert sibling of [`wan_t2v_14b_tier_real_weights`]. For each
+    /// tier subdir present under `$SCENEWORKS_WAN_TI2V_5B_TIER_OUT` (`bf16/`/`q8/`/`q4/`, the
+    /// wan_ti2v_5b_tier_build output), loads the tier through the SAME engine path a job uses
+    /// (`run_video_generation`, `quant: None` — the pre-packed config.json is authoritative) and
+    /// denoises a tiny text-to-video clip, asserting the frames come back RGB8-sized and NON-degenerate
+    /// (real pixel variance, so a broken packed load surfaces instead of silent noise). This is the
+    /// on-device evidence that every hosted 5B tier loads packed (single `model.safetensors`
+    /// transformer) with no install-time convert peak. Runs a few CFG steps so it is self-contained;
+    /// output is a coherence check, not a quality bar. `#[ignore]` — needs the built tiers + a Metal
+    /// device; the cache limit is capped so loading bf16 then q8 then q4 in one process does not
+    /// accumulate residue (sc-5567).
+    ///
+    /// ```sh
+    /// export SCENEWORKS_WAN_TI2V_5B_TIER_OUT=<tier-out-root>   # holds bf16/ q8/ q4/
+    /// cargo test -p sceneworks-worker --release --lib wan_ti2v_5b_tier_real_weights -- --ignored --nocapture
+    /// ```
+    #[cfg(target_os = "macos")]
+    #[ignore = "loads the built Wan2.2 TI2V-5B tiers; run manually on a Mac where they are present"]
+    #[test]
+    fn wan_ti2v_5b_tier_real_weights() {
+        let Some(root) = std::env::var_os("SCENEWORKS_WAN_TI2V_5B_TIER_OUT").map(PathBuf::from)
+        else {
+            eprintln!(
+                "skipping wan_ti2v_5b_tier_real_weights: set SCENEWORKS_WAN_TI2V_5B_TIER_OUT"
+            );
+            return;
+        };
+        // Cap the buffer cache so three sequential loads release between tiers (sc-5567).
+        mlx_rs::memory::set_cache_limit(0);
+        let mut verified = 0;
+        for tier in ["bf16", "q8", "q4"] {
+            let dir = root.join(tier);
+            if !wan_tier_is_complete(&dir, WAN_TI2V_5B_TIER_FILES) {
+                eprintln!("skipping {tier}: {} is not a complete tier", dir.display());
+                continue;
+            }
+            eprintln!("verifying {tier} tier → {}", dir.display());
+            let input = VideoGenInput {
+                sampler: None,
+                scheduler: None,
+                engine_id: "wan2_2_ti2v_5b",
+                model_dir: dir.clone(),
+                // Pre-packed tier: config.json carries the quant; the engine reconstructs the
+                // transformer packed and rejects a conflicting override, so load with None (the worker
+                // path does the same in resolve_wan_tier_dir_and_quant).
+                quant: None,
+                prompt: "a calm ocean wave at sunset, cinematic".to_owned(),
+                width: 256,
+                height: 256,
+                frames: 5,
+                fps: 24,
+                steps: Some(8),
+                seed: 7,
+                ..VideoGenInput::default()
+            };
+            let cancel = CancelFlag::new();
+            let mut steps = 0u32;
+            let mut on_progress = |progress: Progress| {
+                if let Progress::Step { .. } = progress {
+                    steps += 1;
+                }
+            };
+            let decoded = run_video_generation(input, &cancel, &mut on_progress)
+                .unwrap_or_else(|e| panic!("{tier} tier TI2V-5B generation failed: {e:?}"));
+            assert!(
+                decoded.frames.len() > 1,
+                "{tier}: got {} frames, expected a multi-frame clip",
+                decoded.frames.len()
+            );
+            assert!(steps > 0, "{tier}: denoise progress streamed");
+            assert!(
+                decoded
+                    .frames
+                    .iter()
+                    .all(|f| f.pixels.len() == (f.width * f.height * 3) as usize),
+                "{tier}: frames are RGB8-sized"
+            );
+            // Non-degenerate: a broken packed load tends to decode to a flat/NaN frame. Require real
+            // spatial variance in the first frame.
+            let f0 = &decoded.frames[0];
+            let mean = f0.pixels.iter().map(|&p| p as f64).sum::<f64>() / f0.pixels.len() as f64;
+            let var = f0
+                .pixels
+                .iter()
+                .map(|&p| (p as f64 - mean).powi(2))
+                .sum::<f64>()
+                / f0.pixels.len() as f64;
+            assert!(
+                var.sqrt() > 3.0,
+                "{tier}: frame 0 looks degenerate (std {:.2}) — packed load likely broken",
+                var.sqrt()
+            );
+            mlx_rs::memory::clear_cache();
+            verified += 1;
+        }
+        assert!(
+            verified > 0,
+            "no tier subdirs found under SCENEWORKS_WAN_TI2V_5B_TIER_OUT"
         );
         eprintln!("verified {verified} tier(s)");
     }
@@ -10088,7 +10267,7 @@ mod tests {
         let mut verified = 0;
         for tier in ["bf16", "q8", "q4"] {
             let dir = root.join(tier);
-            if !wan_a14b_tier_is_complete(&dir) {
+            if !wan_tier_is_complete(&dir, WAN_A14B_TIER_FILES) {
                 eprintln!("skipping {tier}: {} is not a complete tier", dir.display());
                 continue;
             }
@@ -10100,7 +10279,7 @@ mod tests {
                 model_dir: dir.clone(),
                 // Pre-packed tier: config.json carries the quant; the engine reconstructs the experts
                 // packed and rejects a conflicting override, so load with None (the worker path does
-                // the same in resolve_wan_a14b_dir_and_quant).
+                // the same in resolve_wan_tier_dir_and_quant).
                 quant: None,
                 // The I2V-defining input: a source frame the engine VAE-encodes into its channel-concat
                 // conditioning (the in_dim-36 path). Without it the I2V engine errors, so this also

--- a/crates/sceneworks-worker/src/wan_i2v_14b_tier_build.rs
+++ b/crates/sceneworks-worker/src/wan_i2v_14b_tier_build.rs
@@ -6,7 +6,7 @@
 //! per tier with the matching quant. Each tier is a COMPLETE self-contained dual-expert snapshot
 //! (both MoE experts at `in_dim` 36 image-concat conditioning, the UMT5 T5, the z16 VAE and
 //! `config.json` with the quant baked in); this helper additionally copies the `tokenizer.json` the
-//! converter does not emit into every tier so the load path (`video_jobs::wan_a14b_tier_is_complete`)
+//! converter does not emit into every tier so the load path (`video_jobs::wan_tier_is_complete`)
 //! treats each as present.
 //!
 //! This is an `#[ignore]`d test, not part of CI — it needs the ~126 GB native checkpoint on disk and
@@ -140,7 +140,7 @@ fn wan_i2v_14b_build_tiers() {
         // Release any retained buffers before the next (heavier) tier so residue never accumulates.
         mlx_rs::memory::clear_cache();
         // The converter does not emit tokenizer.json; copy it so the tier is complete for the load
-        // path (video_jobs::wan_a14b_tier_is_complete).
+        // path (video_jobs::wan_tier_is_complete).
         std::fs::copy(&tokenizer, out_dir.join("tokenizer.json"))
             .unwrap_or_else(|e| panic!("copy tokenizer.json into {tier} failed: {e:?}"));
         // Sanity: the six files the load path requires must all exist.

--- a/crates/sceneworks-worker/src/wan_t2v_14b_tier_build.rs
+++ b/crates/sceneworks-worker/src/wan_t2v_14b_tier_build.rs
@@ -6,7 +6,7 @@
 //! Each tier is a COMPLETE self-contained dual-expert snapshot (both MoE experts, the UMT5 T5, the
 //! z16 VAE and `config.json` with the quant baked in); this helper additionally copies the
 //! `tokenizer.json` the converter does not emit into every tier so the load path
-//! (`video_jobs::wan_a14b_tier_is_complete`) treats each as present.
+//! (`video_jobs::wan_tier_is_complete`) treats each as present.
 //!
 //! This is an `#[ignore]`d test, not part of CI — it needs the ~126 GB native fp32 checkpoint on
 //! disk and takes minutes per tier on an Apple-Silicon Mac. Run one-off to produce the artifacts,
@@ -132,7 +132,7 @@ fn wan_t2v_14b_build_tiers() {
         // Release any retained buffers before the next (heavier) tier so residue never accumulates.
         mlx_rs::memory::clear_cache();
         // The converter does not emit tokenizer.json; copy it so the tier is complete for the load
-        // path (video_jobs::wan_a14b_tier_is_complete).
+        // path (video_jobs::wan_tier_is_complete).
         std::fs::copy(&tokenizer, out_dir.join("tokenizer.json"))
             .unwrap_or_else(|e| panic!("copy tokenizer.json into {tier} failed: {e:?}"));
         // Sanity: the six files the load path requires must all exist.

--- a/crates/sceneworks-worker/src/wan_ti2v_5b_tier_build.rs
+++ b/crates/sceneworks-worker/src/wan_ti2v_5b_tier_build.rs
@@ -1,0 +1,248 @@
+//! On-device build helper for the Wan2.2 TI2V-5B quant matrix (sc-9941, epic 8506).
+//!
+//! The single-expert sibling of `wan_t2v_14b_tier_build` / `wan_i2v_14b_tier_build`. Produces the
+//! three hosted tier subdirs — `bf16/` + `q8/` + `q4/` — for `SceneWorks/wan2.2-ti2v-5b-mlx`:
+//!
+//! - `bf16/`: the dense converter output. Drives the SAME byte-parity-validated converter the turnkey
+//!   uses (`mlx_gen_wan::convert::convert_ti2v_5b`) → one transformer (`model.safetensors`) + the UMT5
+//!   T5 encoder + the z16 VAE + `config.json`; this helper then copies the `tokenizer.json` the
+//!   converter does not emit.
+//! - `q8/` + `q4/`: derived **worker-side** from the bf16 tier with NO mlx-gen change — load the bf16
+//!   `model.safetensors`, quantize the DiT Linears via the public
+//!   `mlx_gen_wan::convert::quantize_wan_transformer` (group 64, the canonical Wan group), save, reuse
+//!   the shared dense T5/VAE/tokenizer, and patch `config.json` with the `{bits, group_size}` block.
+//!   This is byte-identical to what an inline `convert_ti2v_5b(quantize)` would emit (the converter's
+//!   transformer path is exactly `sanitize → cast bf16 → quantize_wan_transformer`, and the config
+//!   patch is what `WanModelConfig::to_json()` writes), so a resolved tier loads packed with
+//!   `config.json` authoritative and no install-time convert peak.
+//!
+//! This is an `#[ignore]`d test, not part of CI — it needs the native `Wan-AI/Wan2.2-TI2V-5B`
+//! checkpoint on disk (transformer `diffusion_pytorch_model-*.safetensors` shards +
+//! `models_t5_umt5-xxl-enc-bf16.pth` + `Wan2.2_VAE.pth`) and takes minutes per tier on an
+//! Apple-Silicon Mac. Run one-off to produce the artifacts, then `hf upload` the `bf16/`/`q8/`/`q4/`
+//! subdirs to `SceneWorks/wan2.2-ti2v-5b-mlx`.
+//!
+//! ```sh
+//! # Native checkpoint, e.g. `hf download Wan-AI/Wan2.2-TI2V-5B --local-dir <native>`:
+//! export SCENEWORKS_WAN_TI2V_5B_NATIVE_DIR=<native>
+//! export SCENEWORKS_WAN_TI2V_5B_TIER_OUT=<out-root>          # bf16/ q8/ q4/ written here
+//! # tokenizer.json to copy into each tier (the converter does not emit it). Defaults to
+//! # <native>/tokenizer.json, then <native>/google/umt5-xxl/tokenizer.json, then the cached
+//! # SceneWorks/wan2.2-ti2v-5b-mlx turnkey's tokenizer.json.
+//! export SCENEWORKS_WAN_TI2V_5B_TOKENIZER=<path/to/tokenizer.json>   # optional
+//! cargo test -p sceneworks-worker --release wan_ti2v_5b_build_tiers -- --ignored --nocapture
+//! ```
+//!
+//! Each tier prints a `[[TIER]] {json}` line (tier, dir, diskSizeBytes) so the manifest
+//! `estimatedSizeBytes`/`footprint.diskSizeBytes` can be backfilled with the exact hosted sizes.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use mlx_rs::Array;
+
+/// The five files that make a TI2V-5B tier subdir COMPLETE for the load path
+/// (`video_jobs::wan_tier_is_complete` with `WAN_TI2V_5B_TIER_FILES`): one transformer + the shared
+/// dense T5/VAE + tokenizer + `config.json`.
+const TIER_FILES: &[&str] = &[
+    "model.safetensors",
+    "t5_encoder.safetensors",
+    "vae.safetensors",
+    "tokenizer.json",
+    "config.json",
+];
+
+/// The two quantized tiers to derive from the bf16 output: `(subdir, bits)`. Group 64 (the canonical
+/// Wan/mflux default the load path `WanModelConfig::from_config_json` assumes and reconstructs).
+const QUANT_TIERS: &[(&str, i32)] = &[("q8", 8), ("q4", 4)];
+
+/// The Wan transformer quant group size (mflux/reference default; matches the A14B tiers).
+const GROUP_SIZE: i32 = 64;
+
+/// Recursively sum the byte size of every file under `dir` (the on-disk size of a built tier).
+fn dir_size_bytes(dir: &Path) -> u64 {
+    let mut total = 0;
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            total += dir_size_bytes(&path);
+        } else if let Ok(meta) = path.metadata() {
+            total += meta.len();
+        }
+    }
+    total
+}
+
+/// Resolve the `tokenizer.json` to copy into each tier: the explicit env override, then
+/// `<native>/tokenizer.json`, then the native `google/umt5-xxl/tokenizer.json` (where the upstream
+/// checkpoint ships the UMT5 tokenizer), then the cached `SceneWorks/wan2.2-ti2v-5b-mlx` turnkey's
+/// `tokenizer.json` under the HF hub cache. Panics with actionable guidance if none is found — the
+/// tier is incomplete without it.
+fn resolve_tokenizer(native_dir: &Path) -> PathBuf {
+    if let Ok(explicit) = std::env::var("SCENEWORKS_WAN_TI2V_5B_TOKENIZER") {
+        let path = PathBuf::from(explicit.trim());
+        assert!(
+            path.is_file(),
+            "SCENEWORKS_WAN_TI2V_5B_TOKENIZER={} is not a file",
+            path.display()
+        );
+        return path;
+    }
+    let beside = native_dir.join("tokenizer.json");
+    if beside.is_file() {
+        return beside;
+    }
+    let native_umt5 = native_dir.join("google/umt5-xxl/tokenizer.json");
+    if native_umt5.is_file() {
+        return native_umt5;
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        let snapshots = PathBuf::from(home)
+            .join(".cache/huggingface/hub")
+            .join("models--SceneWorks--wan2.2-ti2v-5b-mlx")
+            .join("snapshots");
+        if let Ok(entries) = std::fs::read_dir(&snapshots) {
+            for entry in entries.flatten() {
+                let candidate = entry.path().join("tokenizer.json");
+                if candidate.is_file() {
+                    return candidate;
+                }
+            }
+        }
+    }
+    panic!(
+        "no tokenizer.json found — set SCENEWORKS_WAN_TI2V_5B_TOKENIZER, place one at {}, or cache \
+         the SceneWorks/wan2.2-ti2v-5b-mlx turnkey (hf download … --include tokenizer.json)",
+        beside.display()
+    );
+}
+
+/// Assert the five load-path files exist in a built `tier` dir.
+fn assert_tier_complete(out_dir: &Path, tier: &str) {
+    for file in TIER_FILES {
+        assert!(
+            out_dir.join(file).is_file(),
+            "built {tier} tier is missing {file}"
+        );
+    }
+}
+
+/// Print the machine-readable `[[TIER]]` line for backfilling the manifest sizes.
+fn report_tier(tier: &str, out_dir: &Path) {
+    let size = dir_size_bytes(out_dir);
+    eprintln!(
+        "[[TIER]] {{\"tier\":\"{tier}\",\"dir\":\"{}\",\"diskSizeBytes\":{size}}}",
+        out_dir.display()
+    );
+}
+
+/// Derive a quantized tier (`q8`/`q4`) from the already-built dense `bf16/` tier: quantize the DiT
+/// transformer worker-side, reuse the shared dense T5/VAE/tokenizer, and patch `config.json` with the
+/// `{bits, group_size}` block the load path reads as authoritative. Byte-identical to an inline
+/// `convert_ti2v_5b(Some((bits, GROUP_SIZE)))`.
+fn build_quant_tier(bf16_dir: &Path, out_dir: &Path, tier: &str, bits: i32) {
+    std::fs::create_dir_all(out_dir).unwrap();
+
+    // 1. Transformer — load the dense bf16 `model.safetensors`, quantize the same Linear set the
+    //    converter's `convert_expert` would (attn q/k/v/o + FFN fc1/fc2), and save the packed triple.
+    let dense: HashMap<String, Array> = Array::load_safetensors(bf16_dir.join("model.safetensors"))
+        .unwrap_or_else(|e| panic!("load bf16 model.safetensors for {tier}: {e:?}"));
+    let packed = mlx_gen_wan::convert::quantize_wan_transformer(dense, bits, GROUP_SIZE)
+        .unwrap_or_else(|e| panic!("quantize_wan_transformer {tier}: {e:?}"));
+    // Materialize before writing (lazy MLX graph, mirrors mlx-gen-wan's save_map).
+    mlx_rs::transforms::eval(packed.values().collect::<Vec<_>>())
+        .unwrap_or_else(|e| panic!("eval packed {tier}: {e:?}"));
+    Array::save_safetensors(
+        packed.iter().map(|(k, v)| (k.as_str(), v)),
+        None::<&HashMap<String, String>>,
+        out_dir.join("model.safetensors"),
+    )
+    .unwrap_or_else(|e| panic!("save packed model.safetensors for {tier}: {e:?}"));
+    drop(packed);
+    mlx_rs::memory::clear_cache();
+
+    // 2. Shared dense components — the T5/VAE/tokenizer are identical across tiers (only the DiT is
+    //    quantized), so copy them from the bf16 tier rather than re-converting the heavy .pth sources.
+    for file in [
+        "t5_encoder.safetensors",
+        "vae.safetensors",
+        "tokenizer.json",
+    ] {
+        std::fs::copy(bf16_dir.join(file), out_dir.join(file))
+            .unwrap_or_else(|e| panic!("copy {file} into {tier}: {e:?}"));
+    }
+
+    // 3. config.json — take the dense config and add the quantization manifest the load path reads
+    //    (`{"bits": bits, "group_size": 64}`, exactly what `WanModelConfig::to_json()` emits).
+    let text = std::fs::read_to_string(bf16_dir.join("config.json"))
+        .unwrap_or_else(|e| panic!("read bf16 config.json for {tier}: {e:?}"));
+    let mut config: serde_json::Value =
+        serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse bf16 config.json: {e:?}"));
+    config["quantization"] = serde_json::json!({ "bits": bits, "group_size": GROUP_SIZE });
+    std::fs::write(
+        out_dir.join("config.json"),
+        serde_json::to_string_pretty(&config).unwrap(),
+    )
+    .unwrap_or_else(|e| panic!("write {tier} config.json: {e:?}"));
+
+    assert_tier_complete(out_dir, tier);
+    report_tier(tier, out_dir);
+}
+
+/// Build all three Wan2.2 TI2V-5B tier subdirs (bf16 via the converter, q8/q4 derived from it).
+/// `#[ignore]`d — run on-device with the env vars above; not exercised in CI (needs the native
+/// weights).
+#[test]
+#[ignore = "on-device tier build: needs the native Wan2.2-TI2V-5B checkpoint + minutes/tier"]
+fn wan_ti2v_5b_build_tiers() {
+    let native_dir = PathBuf::from(
+        std::env::var("SCENEWORKS_WAN_TI2V_5B_NATIVE_DIR")
+            .expect("set SCENEWORKS_WAN_TI2V_5B_NATIVE_DIR to the native checkpoint dir"),
+    );
+    assert!(
+        native_dir.join("models_t5_umt5-xxl-enc-bf16.pth").is_file(),
+        "{} is not a native Wan2.2 TI2V-5B checkpoint (expected the transformer \
+         diffusion_pytorch_model-*.safetensors shards, models_t5_umt5-xxl-enc-bf16.pth, \
+         Wan2.2_VAE.pth)",
+        native_dir.display()
+    );
+    let out_root = PathBuf::from(
+        std::env::var("SCENEWORKS_WAN_TI2V_5B_TIER_OUT")
+            .expect("set SCENEWORKS_WAN_TI2V_5B_TIER_OUT to the output root for bf16/ q8/ q4/"),
+    );
+    let tokenizer = resolve_tokenizer(&native_dir);
+    std::fs::create_dir_all(&out_root).unwrap();
+
+    // The converter loads the T5 (.pth) and transformer as full buffers; at MLX's default cache limit
+    // the freed buffers are RETAINED as cache. Cap the buffer cache to 0 so freed buffers return to
+    // the OS immediately between stages (sc-5567 batch pattern) — a build-time realloc-cost trade the
+    // generation hot path deliberately avoids.
+    mlx_rs::memory::set_cache_limit(0);
+
+    // 1. Dense bf16 tier via the byte-parity-validated converter, then copy the tokenizer it omits.
+    let bf16_dir = out_root.join("bf16");
+    eprintln!("building bf16 tier → {}", bf16_dir.display());
+    mlx_gen_wan::convert::convert_ti2v_5b(&native_dir, &bf16_dir)
+        .unwrap_or_else(|e| panic!("convert_ti2v_5b bf16 failed: {e:?}"));
+    mlx_rs::memory::clear_cache();
+    std::fs::copy(&tokenizer, bf16_dir.join("tokenizer.json"))
+        .unwrap_or_else(|e| panic!("copy tokenizer.json into bf16 failed: {e:?}"));
+    assert_tier_complete(&bf16_dir, "bf16");
+    report_tier("bf16", &bf16_dir);
+
+    // 2. q8/q4 derived from the bf16 tier (worker-side quantize; no re-convert of the heavy sources).
+    for (tier, bits) in QUANT_TIERS {
+        let out_dir = out_root.join(tier);
+        eprintln!("building {tier} tier → {} (bits={bits})", out_dir.display());
+        build_quant_tier(&bf16_dir, &out_dir, tier, *bits);
+        mlx_rs::memory::clear_cache();
+    }
+
+    eprintln!(
+        "done — upload the tier subdirs:\n  hf upload SceneWorks/wan2.2-ti2v-5b-mlx {} --include 'bf16/*' 'q8/*' 'q4/*'",
+        out_root.display()
+    );
+}


### PR DESCRIPTION
## What

Brings the single-expert **Wan2.2 TI2V-5B** (`wan_2_2`) to the catalog-wide quant matrix (epic 8506) — the sibling of the A14B **T2V** (#1204) and **I2V** (#1211) work. macOS now installs a lean **q4** tier by default and can toggle **q8**/**bf16** on demand, each a self-contained pre-packed snapshot that loads with **no install-time convert peak**.

## Scope decision

**Full q4/q8/bf16 matrix** (epic locked decision #1 = full matrix for every model). TI2V-5B is the lightest Wan model, so there's no per-frame-quality reason for the LTX bf16-only carve-out. Same choice as the two A14B siblings.

## How

- **`video_jobs.rs`** — generalized the `wan_a14b_*` video-lane tier machinery → `wan_tier_*`, now serving all three Wan quant-matrix models. Model-aware `wan_tier_files` distinguishes the single-expert 5B (`model.safetensors`) from the A14B two-expert set; `wan_tier_repo("wan_2_2")` routes to the pinned `SceneWorks/wan2.2-ti2v-5b-mlx`. `generate_wan` sends any model with a hosted tier repo through the resolver (pre-packed → `quant=None`, config.json authoritative; legacy flat root → load-time quant).
- **No mlx-gen change.** The bf16 tier is the `convert_ti2v_5b` output; q8/q4 are derived worker-side (load bf16 `model.safetensors` → public `quantize_wan_transformer` group 64 → save + reuse the shared dense T5/VAE/tokenizer + a `config.json` `{bits, group_size}` patch). Byte-identical to an inline `convert_ti2v_5b(quantize)` — so no pin bump, no candle-gen lockstep. New `wan_ti2v_5b_tier_build.rs` build helper.
- **Manifest** — per-tier macOS downloads (q4 default / q8 / bf16) with exact hosted sizes + footprint; mlx-block comment updated.
- **Tests** — new `wan_ti2v_5b_manifest_ships_the_quant_matrix` gate test; new `wan_ti2v_5b_tier_real_weights` on-device verify smoke; the pinned-commit guard now covers the 5B.

## Hosting + verification

Hosted on `SceneWorks/wan2.2-ti2v-5b-mlx` (q4/q8/bf16 subdirs, public/ungated Apache-2.0), pinned `@bb1b055249614cf9d7cf4373fbdbc184b77dee88`. Exact sizes: q4 17,142,889,289 / q8 19,596,557,565 / bf16 24,197,122,980 (the dense T5 ~11.4 GB + VAE ~2.8 GB are shared across tiers, so q4/q8 aren't much smaller than bf16 — same shape as SD3.5). All three tiers **verified on-device**: load packed + generate a non-degenerate clip. Legacy flat root kept for already-shipped workers (cleanup sc-9977).

## Test evidence

- Worker `cargo test -p sceneworks-worker --lib`: **644 passed, 0 failed, 145 ignored**.
- `cargo fmt --all --check` clean; `cargo clippy -p sceneworks-worker --all-targets` clean.
- On-device `wan_ti2v_5b_tier_real_weights`: **verified 3 tier(s)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)