### PR TITLE
fix(worker): provision mandatory Wan2.2 A14B Lightning distill LoRA (sc-10030)

### DIFF
--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -11907,6 +11907,81 @@ fn builtin_manifest_registers_the_wan_vace_fun_model() {
 }
 
 #[test]
+fn builtin_manifest_registers_wan_a14b_lightning_corequisite() {
+    // sc-10030 (epic 8506): both A14B MoE video models bake the 4-step lightx2v Lightning distill as a
+    // MANDATORY dependency (wan_sampling forces 4-step/CFG-off; resolve_wan_adapters always applies the
+    // high/low pair). It must install as a macOS `coRequisite` so the model manager provisions it and
+    // install_state gates on it — without this the model errors "not downloaded — fetch it via the
+    // model manager" with no way to fetch it. The subdir is per-architecture and NOT cross-compatible.
+    let manifest_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../config/manifests/builtin.models.jsonc");
+    let raw = std::fs::read_to_string(&manifest_path).expect("read builtin.models.jsonc");
+    let manifest: Value =
+        serde_json::from_str(&strip_jsonc_comments(&raw)).expect("parse builtin.models.jsonc");
+    let models = manifest["models"].as_array().expect("models array");
+
+    // (engine id, expected per-architecture Lightning subdir prefix)
+    let cases = [
+        (
+            "wan_2_2_t2v_14b",
+            "Wan2.2-T2V-A14B-4steps-lora-rank64-Seko-V1.1",
+        ),
+        (
+            "wan_2_2_i2v_14b",
+            "Wan2.2-I2V-A14B-4steps-lora-rank64-Seko-V1",
+        ),
+    ];
+    for (model_id, subdir) in cases {
+        let model = models
+            .iter()
+            .find(|entry| entry["id"] == model_id)
+            .unwrap_or_else(|| panic!("{model_id} is registered in the catalog"));
+        let downloads = model["downloads"].as_array().expect("downloads array");
+        let lightning = downloads
+            .iter()
+            .find(|download| download["coRequisite"] == Value::Bool(true))
+            .unwrap_or_else(|| panic!("{model_id} declares a Lightning coRequisite"));
+        assert_eq!(lightning["provider"], "huggingface");
+        assert_eq!(
+            lightning["repo"], "lightx2v/Wan2.2-Lightning",
+            "{model_id} coRequisite points at the lightx2v Lightning repo"
+        );
+        // macOS-only (the native MLX path is Mac; Windows/Linux use the torch adapter).
+        let platforms: Vec<&str> = lightning["platforms"]
+            .as_array()
+            .expect("coRequisite platforms array")
+            .iter()
+            .filter_map(Value::as_str)
+            .collect();
+        assert_eq!(
+            platforms,
+            vec!["macos"],
+            "{model_id} Lightning is macOS-only"
+        );
+        // Exactly the per-architecture high/low pair — nothing cross-compatible, no preview assets.
+        let files: Vec<&str> = lightning["files"]
+            .as_array()
+            .expect("coRequisite files array")
+            .iter()
+            .filter_map(Value::as_str)
+            .collect();
+        assert_eq!(
+            files,
+            vec![
+                format!("{subdir}/high_noise_model.safetensors").as_str(),
+                format!("{subdir}/low_noise_model.safetensors").as_str(),
+            ],
+            "{model_id} fetches exactly its per-architecture Lightning pair"
+        );
+        // A coRequisite is never a selectable quant tier.
+        assert!(
+            lightning.get("variant").is_none(),
+            "{model_id} Lightning coRequisite is not a quant tier"
+        );
+    }
+}
+
+#[test]
 fn builtin_manifest_registers_the_joycaption_model() {
     // sc-5620: the native captioner (caption_jobs.rs, the training_caption job) resolves an
     // already-cached HF snapshot via the same resolve_app_managed_model_dir seam and does NOT

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -4959,15 +4959,36 @@
       // Windows/Linux load the diffusers/GGUF layout via the torch wan_video adapter.
       "downloads": [
         // macOS quant matrix (sc-9942, epic 8506): each tier is a SEPARATE user-selectable artifact
-        // tagged with a `variant`; `q4` (default) installs when no tier is chosen. Unlike LTX there
-        // is NO shared coRequisite — every tier subdir is fully self-contained (both MoE experts +
-        // UMT5 T5 + z16 VAE + tokenizer + config.json), so the dense T5/VAE repeat per tier (epic
-        // decision #3: storage is a non-issue; keeps the load path a single self-contained dir with
-        // no engine change). The worker fetches a toggled-but-not-downloaded tier on demand
-        // (ensure_wan_t2v_14b_tier_present, video_jobs.rs), so advanced.mlxQuantize works without a
-        // pre-pick. The legacy flat root files stay hosted for already-shipped workers that resolve
-        // the repo root; a new worker only ever resolves the tier subdirs (cleanup follow-up sc-9977).
-        // estimatedSizeBytes/footprint are backfilled with the exact hosted subdir sizes post-build.
+        // tagged with a `variant`; `q4` (default) installs when no tier is chosen. Unlike LTX the
+        // TIER subdirs carry no shared TE/VAE coRequisite — every tier subdir is fully self-contained
+        // (both MoE experts + UMT5 T5 + z16 VAE + tokenizer + config.json), so the dense T5/VAE repeat
+        // per tier (epic decision #3: storage is a non-issue; keeps the load path a single
+        // self-contained dir with no engine change). The worker fetches a toggled-but-not-downloaded
+        // tier on demand (ensure_wan_a14b_tier_present, video_jobs.rs), so advanced.mlxQuantize works
+        // without a pre-pick. The legacy flat root files stay hosted for already-shipped workers that
+        // resolve the repo root; a new worker only ever resolves the tier subdirs (cleanup follow-up
+        // sc-9977). estimatedSizeBytes/footprint are backfilled with the exact hosted subdir sizes
+        // post-build.
+        //
+        // The 4-step Lightning distill LoRA (lightx2v/Wan2.2-Lightning) IS a `coRequisite` (sc-10030):
+        // the A14B MoE recipe bakes it as MANDATORY (wan_sampling forces 4 steps / CFG-off and
+        // resolve_wan_adapters always applies the high/low pair), so the model cannot generate without
+        // it. It lives in a separate upstream repo under a per-architecture subdir (T2V ⇒ Seko-V1.1,
+        // NOT cross-compatible with I2V), installs alongside whichever tier(s) the user picks, and
+        // gates install_state. Mirrors the PiD/LTX gemma coRequisite precedent (sc-9696). The worker
+        // also self-heals an already-installed pre-coRequisite worker via ensure_wan_lightning_present
+        // (video_jobs.rs) at gen time.
+        {
+          "provider": "huggingface",
+          "repo": "lightx2v/Wan2.2-Lightning",
+          "coRequisite": true,
+          "files": [
+            "Wan2.2-T2V-A14B-4steps-lora-rank64-Seko-V1.1/high_noise_model.safetensors",
+            "Wan2.2-T2V-A14B-4steps-lora-rank64-Seko-V1.1/low_noise_model.safetensors"
+          ],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 2453954848
+        },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/wan2.2-t2v-a14b-mlx",
@@ -5069,7 +5090,8 @@
         // requested tier subdir of this snapshot (wan_t2v_14b_tier_subdir; both MoE experts live in
         // one subdir), loading with no install-time convert peak. Source Wan-AI/Wan2.2-T2V-A14B is
         // Apache-2.0; converter "wan_t2v_14b" (mlx-gen-wan convert_t2v_14b) builds each tier. The
-        // lightx2v 4-step Lightning LoRA is downloaded on demand by MlxVideoAdapter at gen time.
+        // mandatory lightx2v 4-step Lightning distill LoRA installs as a `coRequisite` above (sc-10030;
+        // ensure_wan_lightning_present also self-heals a pre-coRequisite worker at gen time).
         "minMemoryGb": 133,
         "repo": "SceneWorks/wan2.2-t2v-a14b-mlx",
         // macOS curated menu (sc-7296): the full curated fold-in over the A14B native flow σ
@@ -5117,6 +5139,24 @@
         // already-shipped workers that resolve the repo root; a new worker only ever resolves the tier
         // subdirs (cleanup follow-up sc-9977). estimatedSizeBytes/footprint are the exact hosted
         // subdir sizes measured from the on-device build.
+        //
+        // Mandatory 4-step Lightning distill LoRA as a `coRequisite` (sc-10030): the I2V-A14B recipe
+        // bakes it (wan_sampling forces 4 steps / CFG-off; resolve_wan_adapters always applies the
+        // high/low pair), so the model cannot generate without it. Per-architecture subdir (I2V ⇒
+        // Seko-V1, NOT cross-compatible with the T2V Seko-V1.1 LoRA). Same upstream repo as T2V's
+        // coRequisite; each model tracks only its own subdir files. See the T2V entry + sc-9696 for
+        // the coRequisite pattern; ensure_wan_lightning_present self-heals a pre-coRequisite worker.
+        {
+          "provider": "huggingface",
+          "repo": "lightx2v/Wan2.2-Lightning",
+          "coRequisite": true,
+          "files": [
+            "Wan2.2-I2V-A14B-4steps-lora-rank64-Seko-V1/high_noise_model.safetensors",
+            "Wan2.2-I2V-A14B-4steps-lora-rank64-Seko-V1/low_noise_model.safetensors"
+          ],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 2453954848
+        },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/wan2.2-i2v-a14b-mlx",

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -765,10 +765,15 @@ fn wan_t2v_14b_manifest_ships_the_quant_matrix() {
     let macos: Vec<&Value> = downloads
         .iter()
         .filter(|d| {
-            d.get("platforms")
+            let is_macos = d
+                .get("platforms")
                 .and_then(Value::as_array)
                 .map(|p| p.iter().any(|x| x.as_str() == Some("macos")))
-                .unwrap_or(false)
+                .unwrap_or(false);
+            // The Lightning coRequisite (sc-10030) is a macOS download too, but it is a mandatory
+            // dependency, not a selectable quant tier — exclude it from the tier assertions.
+            let is_corequisite = d.get("coRequisite").and_then(Value::as_bool) == Some(true);
+            is_macos && !is_corequisite
         })
         .collect();
     let variants: Vec<&str> = macos
@@ -847,10 +852,15 @@ fn wan_i2v_14b_manifest_ships_the_quant_matrix() {
     let macos: Vec<&Value> = downloads
         .iter()
         .filter(|d| {
-            d.get("platforms")
+            let is_macos = d
+                .get("platforms")
                 .and_then(Value::as_array)
                 .map(|p| p.iter().any(|x| x.as_str() == Some("macos")))
-                .unwrap_or(false)
+                .unwrap_or(false);
+            // The Lightning coRequisite (sc-10030) is a macOS download too, but it is a mandatory
+            // dependency, not a selectable quant tier — exclude it from the tier assertions.
+            let is_corequisite = d.get("coRequisite").and_then(Value::as_bool) == Some(true);
+            is_macos && !is_corequisite
         })
         .collect();
     let variants: Vec<&str> = macos

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -2946,6 +2946,57 @@ async fn ensure_wan_a14b_tier_present(
     result.map(|_| ())
 }
 
+/// On-demand fetch of the mandatory 4-step Lightning distill LoRA pair (`lightx2v/Wan2.2-Lightning`)
+/// for the A14B MoE models (sc-10030). Normally the pair installs as a manifest `coRequisite`
+/// alongside the model (sc-9696), but a worker that installed the model BEFORE the coRequisite was
+/// added has the tiers without the LoRA — and [`resolve_wan_adapters`] then hard-errors because the
+/// distill is mandatory (`wan_sampling` forces 4-step / CFG-off). This self-heals that case: it pulls
+/// just the per-architecture high/low pair the first time a gen needs it (twin of
+/// [`ensure_wan_a14b_tier_present`] / the candle `ensure_qwen_lightning_lora_cached`). No-op for a
+/// non-A14B engine, when the pair is already cached, or when the `hf` CLI is absent (resolve then
+/// surfaces the clear "fetch it via the model manager" error). Fails loud on a real download error —
+/// fast, before any compute.
+#[cfg(target_os = "macos")]
+async fn ensure_wan_lightning_present(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    engine_id: &str,
+) -> WorkerResult<()> {
+    // Per-architecture subdir (NOT cross-compatible, sc-4997); must match `resolve_lightning_loras`.
+    let subdir = match engine_id {
+        "wan2_2_t2v_14b" => "Wan2.2-T2V-A14B-4steps-lora-rank64-Seko-V1.1",
+        "wan2_2_i2v_14b" => "Wan2.2-I2V-A14B-4steps-lora-rank64-Seko-V1",
+        // Only the A14B MoE models bake Lightning — every other engine needs nothing here.
+        _ => return Ok(()),
+    };
+    const REPO: &str = "lightx2v/Wan2.2-Lightning";
+    // Fast path: both halves already materialized in the hub cache (the common case after install).
+    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, REPO) {
+        let base = snapshot.join(subdir);
+        if base.join("high_noise_model.safetensors").is_file()
+            && base.join("low_noise_model.safetensors").is_file()
+        {
+            return Ok(());
+        }
+    }
+    let scratch = settings
+        .data_dir
+        .join("cache")
+        .join(format!(".wan-lightning-fetch-{}", job.id));
+    tokio::fs::create_dir_all(&scratch).await?;
+    let files = vec![
+        format!("{subdir}/high_noise_model.safetensors"),
+        format!("{subdir}/low_noise_model.safetensors"),
+    ];
+    let result = crate::model_jobs::download_model_with_hf_cli(
+        api, settings, job, REPO, "main", &files, &scratch,
+    )
+    .await;
+    let _ = tokio::fs::remove_dir_all(&scratch).await;
+    result.map(|_| ())
+}
+
 /// The 4-step Lightning distill LoRA pair (high/low) for an A14B MoE model
 /// (`lightx2v/Wan2.2-Lightning`, the rank-64 Seko distill). The subdir is architecture-specific:
 /// T2V-A14B (V1.1) and I2V-A14B (V1) ship distinct LoRAs that are NOT cross-compatible (sc-4997).
@@ -5062,6 +5113,11 @@ async fn generate_wan(
     // q4 tier; a q8/bf16 job fetches that subdir on demand before resolving. No-op for the 5B model, a
     // q4 job, or an already-present tier.
     ensure_wan_a14b_tier_present(api, settings, job, request).await?;
+    // The A14B MoE recipe bakes a MANDATORY Lightning distill LoRA (sc-10030). It normally installs as
+    // a manifest coRequisite, but self-heal a worker that installed the model before the coRequisite
+    // existed so resolve_wan_adapters below doesn't dead-end. No-op for the 5B model or an already-
+    // cached pair.
+    ensure_wan_lightning_present(api, settings, job, engine_id).await?;
     // Descend into the chosen quant-matrix tier subdir when the A14B turnkey ships them; a pre-packed
     // tier loads with quant=None (config.json is authoritative). The 5B model and a legacy flat A14B
     // snapshot keep the root + load-time quant.


### PR DESCRIPTION
## Problem

Both Wan2.2 A14B video models (**T2V** `wan2_2_t2v_14b` and **I2V** `wan2_2_i2v_14b`) are **unusable on macOS**. Every generation fails with:

> `wan2_2_t2v_14b: the Lightning distill LoRA (lightx2v/Wan2.2-Lightning) is not downloaded — fetch it via the model manager`

…and there is no way to fetch it via the model manager.

## Root cause

The A14B MoE recipe bakes the 4-step Lightning distill as **mandatory** — `wan_sampling` forces 4-step / CFG-off, and `resolve_wan_adapters` unconditionally applies the high/low pair for the A14B engines, calling `resolve_lightning_loras`, which hard-errors when `lightx2v/Wan2.2-Lightning` is absent.

Nothing provisioned it:
- The manifest entries declared **no `coRequisite`** and no standalone download for the LoRA, so the model manager never offered it.
- Unlike the Qwen Lightning path (`ensure_qwen_lightning_lora_cached`), the Wan path had **no on-demand fetch**.

The manifest comment still claimed *"downloaded on demand by MlxVideoAdapter at gen time"* — that was the retired **Python** `MlxVideoAdapter` (epic 8283). The Python→Rust port dropped the on-demand fetch, and the quant-matrix rollout (sc-9942 / sc-9943) never added a co-requisite. The on-device smoke tests deliberately run **without** the Lightning distill, so this shipped green.

## Fix

1. **`config/manifests/builtin.models.jsonc`** — add a macOS `coRequisite` download for `lightx2v/Wan2.2-Lightning` to both A14B entries, each fetching exactly its per-architecture high/low pair (precise file lists, not a `<subdir>/*` glob, so the preview mp4 + Comfy JSONs aren't pulled):
   - T2V → `Wan2.2-T2V-A14B-4steps-lora-rank64-Seko-V1.1/{high,low}_noise_model.safetensors`
   - I2V → `Wan2.2-I2V-A14B-4steps-lora-rank64-Seko-V1/{high,low}_noise_model.safetensors`

   The subdirs are per-architecture and **not** cross-compatible. Installs alongside the model and gates `install_state`, mirroring the PiD/LTX gemma co-requisite precedent (sc-9696). `estimatedSizeBytes` = 2,453,954,848 (2 × 1.227 GB, exact from the HF tree API). Also corrected the stale on-demand comment.
2. **`crates/sceneworks-worker/src/video_jobs.rs`** — add `ensure_wan_lightning_present` (twin of `ensure_wan_a14b_tier_present` / candle `ensure_qwen_lightning_lora_cached`), called in `generate_wan` after the tier ensure. Self-heals a worker that installed the model **before** the co-requisite existed by pulling just the per-arch pair via the `hf` CLI on first gen. No-op for the 5B model, an already-cached pair, or a missing `hf` CLI (resolve then surfaces the clear error).
3. **`apps/rust-api/src/tests.rs`** — `builtin_manifest_registers_wan_a14b_lightning_corequisite` guards the manifest shape for both models.

## Verification

- `cargo check -p sceneworks-worker` ✅
- `cargo test -p sceneworks-rust-api --lib` → 189 passed (incl. `model_and_lora_routes_match_manifest_behavior`, which loads the real manifest) + the new test ✅
- `cargo fmt --all -- --check` ✅
- `cargo clippy -p sceneworks-rust-api -p sceneworks-worker --all-targets -- -D warnings` → exit 0 ✅

### ⚠️ Pending (could not run in this environment)

On-device end-to-end: the install path fetches the ~2.4 GB LoRA and a **real (non-smoke)** T2V **and** I2V generation completes. The existing on-device smoke tests deliberately skip the Lightning distill, so they do **not** cover this — a real gen should be run before merge.

Story: [sc-10030](https://app.shortcut.com/trefry/story/10030) (epic 8506; relates to sc-9942 / sc-9943).

🤖 Generated with [Claude Code](https://claude.com/claude-code)