### PR TITLE
feat(krea): route Krea 2 Raw generation off-Mac (candle/CUDA) + pin bump (sc-9994, epic 9992)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -495,7 +495,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -510,7 +510,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -524,7 +524,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -577,7 +577,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -605,7 +605,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -615,7 +615,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -630,7 +630,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -645,7 +645,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -660,7 +660,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-gen",
  "image",
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -700,7 +700,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -714,7 +714,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -757,7 +757,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -788,7 +788,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -812,7 +812,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4919ba5c8bf2c6d7c51e6655601e95eea978f3c#e4919ba5c8bf2c6d7c51e6655601e95eea978f3c"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2419,19 +2419,20 @@
       // + generation share one download — no separate diffusers tree. The bf16 tier is byte-identical to
       // the retired `krea/Krea-2-Raw` diffusers base, so training behavior is unchanged.
       //
-      // MAC-FIRST (epic 9992): `mlx-gen-krea` registers the `krea_2_raw` GENERATOR; the candle
-      // (Windows/Linux) generator is not wired yet (sc-9994 / P2), so `krea_2_raw` is candle_routed=false
-      // in the routing table and GENERATION is Mac-only until then. The tier downloads stay all-platform
-      // because the candle TRAINER trains cross-platform off the same `bf16/` tier (CANDLE_ROUTED_TRAINING
-      // _KERNELS includes `krea_lora`). Krea 2 Community License (non-commercial OK; the re-host carries
-      // the license + "Krea" name prefix + attribution).
+      // ALL-PLATFORM (epic 9992): both backends register the `krea_2_raw` GENERATOR — `mlx-gen-krea`
+      // (macOS) + `candle-gen-krea` (Windows/Linux CUDA, sc-9994 / candle-gen #350), so `krea_2_raw` is
+      // candle_routed=true (`candle_quant_lora`, mirroring Turbo) and GENERATION runs on all three
+      // platforms. The tier downloads are all-platform for both generation AND the candle TRAINER (which
+      // trains cross-platform off the same `bf16/` tier — CANDLE_ROUTED_TRAINING_KERNELS includes
+      // `krea_lora`). Krea 2 Community License (non-commercial OK; the re-host carries the license +
+      // "Krea" name prefix + attribution).
       "autoDownload": false,
       "name": "Krea 2 Raw",
       "family": "krea_2",
       "type": "image",
       "adapter": "mlx_krea",
-      // Routing (not this flag) drives availability: `krea_2_raw` is mlx-routed; candle generation lands
-      // in P2 (sc-9994). All-platform downloads so the candle trainer can install the bf16 tier off-Mac.
+      // Routing (not this flag) drives availability: `krea_2_raw` is BOTH mlx- and candle-routed
+      // (sc-9994). All-platform downloads serve generation on all three platforms + the candle trainer.
       "macOnly": false,
       "downloads": [
         {
@@ -2526,10 +2527,23 @@
         "quantize": 8,
         "repo": "SceneWorks/krea-2-raw-mlx"
       },
+      // candle/CUDA VRAM gate (sc-9994, epic 9992). Raw shares Turbo's resident surface (the 12B
+      // single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE), and the resident weights dominate the peak.
+      // q8 MEASURED @1024² on an RTX PRO 6000 (Blackwell sm_120) via the nvidia-smi peak monitor: 33.4 GB
+      // overall-peak — a ~2.4 GB bump over Turbo's estimated q8 31 GB, consistent with Raw's TRUE CFG (two
+      // SEQUENTIAL DiT forwards/step + the extra encoded uncond context; not 2× — the forwards don't
+      // co-reside). q4/bf16 ESTIMATED from the measured q8 using Turbo's inter-tier gaps (q8−q4 ≈ 4.6,
+      // bf16−q8 ≈ 13). No `int8-convrot` tier (that checkpoint is Turbo-only, sc-9300). minMemoryGb 32
+      // gates visibility (the default q8 tier needs 33.4, so a 32 GB card falls to q4 via the per-tier pick).
+      "candle": {
+        "minMemoryGb": 32,
+        "vramGbByTier": { "q4": 28.8, "q8": 33.4, "bf16": 46.4 },
+        "measured": false
+      },
       "licenseUrl": "https://www.krea.ai/krea-2-licensing",
       "ui": {
         "label": "Krea 2 Raw",
-        "description": "Krea 2 Raw — Krea AI's undistilled 12B single-stream rectified-flow DiT with a Qwen3-VL-4B text encoder, native MLX (Apple Silicon). The full-fidelity, TRUE classifier-free-guidance counterpart to the fast CFG-free Krea 2 Turbo: run ~52 steps with a real guidance scale (~3.5) and an optional negative prompt for the highest quality and the most control. Pre-quantized Q8 (~20.5 GB download, default); the dense bf16 tier doubles as the Krea 2 LoRA training base. Krea 2 Community License (non-commercial). Needs a 48 GB-class Mac. (Windows/Linux generation lands with the candle engine — epic 9992 P2.)",
+        "description": "Krea 2 Raw — Krea AI's undistilled 12B single-stream rectified-flow DiT with a Qwen3-VL-4B text encoder, native MLX (Apple Silicon). The full-fidelity, TRUE classifier-free-guidance counterpart to the fast CFG-free Krea 2 Turbo: run ~52 steps with a real guidance scale (~3.5) and an optional negative prompt for the highest quality and the most control. Pre-quantized Q8 (~20.5 GB download, default); the dense bf16 tier doubles as the Krea 2 LoRA training base. Krea 2 Community License (non-commercial). Runs on Apple Silicon (MLX) and Windows/Linux NVIDIA GPUs (candle/CUDA, sc-9994); needs a 48 GB-class Mac or a ~32 GB-class CUDA GPU.",
         "recommendedFor": ["text_to_image"],
         // PiD decoder (epic 7840, qwenimage latent space — Krea 2 Raw reuses the Qwen VAE, like Turbo) —
         // optional per-generation VAE replacement, decode + 2K/4K SR; NC output. See `qwen_image`.

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -639,12 +639,14 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
     ModelCaps::new("krea_2_turbo", true, true, false, false, true),
     // Krea 2 Raw (epic 9992) — the undistilled 12B DiT exposed as a full-CFG generation model (52 steps /
     // guidance 3.5 + negative prompt), alongside the distilled Turbo (the Boogu base/turbo precedent).
-    // MLX-first: `mlx-gen-krea` registers the `krea_2_raw` generator (PR #656). Candle is NOT wired yet
-    // (`candle-gen-krea` has no `krea_2_raw` generator until epic 9992 P2 / sc-9994), so candle_routed is
-    // false — this flips to `(true, true, false, false, true)` (mirroring Turbo) when the candle engine
-    // lands. `krea_2_raw` is ALSO the LoRA-training base id (Path 1 unify); training routes via the
-    // trainer registry, independent of this image-caps row.
-    ModelCaps::new("krea_2_raw", true, false, false, false, false),
+    // Both backends wired: `mlx-gen-krea` (PR #656) + `candle-gen-krea` (sc-9994, candle-gen #350 —
+    // `render_base`, two DiT forwards/step, the reference `sampling.py:129` CFG combine). Candle
+    // advertises inference LoRA/LoKr (the shared Krea merge, sc-7836) AND on-the-fly Q4/Q8 (a no-op on
+    // the already-packed q4/q8 turnkey, sc-9607), so `candle_quant_lora` is set — mirroring `krea_2_turbo`
+    // exactly (Raw + Turbo share the arch / loader; only the DiT weights differ). `krea_2_raw` is ALSO the
+    // LoRA-training base id (Path 1 unify); training routes via the trainer registry, independent of this
+    // image-caps row.
+    ModelCaps::new("krea_2_raw", true, true, false, false, true),
     // Stable Diffusion 3.5 Large / Large Turbo / Medium (epic 7841 / sc-7871 MLX; sc-7880 candle):
     // pure txt2img. Candle advertises Q4/Q8 (sc-7879) but NOT inference LoRA (`supports_lora: false`), so
     // `candle_quant` is set — an explicit quant request stays on candle while a LoRA still defers to torch.
@@ -958,14 +960,17 @@ mod tests {
         "boogu_image_turbo",
         "boogu_image_edit",
         "krea_2_turbo",
+        "krea_2_raw",
         "sd3_5_large",
         "sd3_5_large_turbo",
         "sd3_5_medium",
     ];
 
     // sc-9983: Krea joins Lens as a BOTH-quant-and-LoRA candle family (sc-9607 flipped its
-    // `supported_quants` to [Q4, Q8]; it already advertised inference LoRA via sc-7836).
-    const EXPECTED_CANDLE_QUANT_LORA_MODELS: &[&str] = &["lens", "lens_turbo", "krea_2_turbo"];
+    // `supported_quants` to [Q4, Q8]; it already advertised inference LoRA via sc-7836). sc-9994 adds the
+    // Raw variant (candle-gen #350) with the same both-set advertisement.
+    const EXPECTED_CANDLE_QUANT_LORA_MODELS: &[&str] =
+        &["lens", "lens_turbo", "krea_2_turbo", "krea_2_raw"];
 
     // sc-9983: ideogram/boogu join SD3.5 as quant-only candle families (sc-9607 flipped their
     // `supported_quants` to [Q4, Q8]; no inference LoRA on candle).

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1461,15 +1461,26 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495b
 # pin is UNCHANGED at b520a0e7 (= this worker's mlx-gen pin), so `--features backend-candle --target all`
 # still resolves the SINGLE gen-core rev b520a0e7 (the skew gate) — no testkit reconcile. ALL candle-gen-*
 # rev lines move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
+# Bumped `e4919ba` -> `a4f2b4d` (sc-9994, epic 9992): candle-gen main HEAD carrying #350 — the Krea 2 Raw
+# full-CFG candle generator (`candle-gen-krea` registers `krea_2_raw` alongside `krea_2_turbo`:
+# `render_base`, two DiT forwards/step, the reference `sampling.py:129` CFG combine + the sc-10009-twin
+# trainer-preview fix). This is the candle half of the routing flip above (`ModelCaps krea_2_raw` →
+# `(true, true, false, false, true)`). The prior `e4919ba` (PR #1218 durability re-pin) IS candle-gen
+# #352 and is an ancestor of `a4f2b4d`, so this is a clean forward move; the range adds #350 plus #351
+# (qwen-image VAE decode-tail tiling above 1536², sc-10023) and #353 (candle-gen-wan packed-load seam,
+# sc-10025). candle-gen's OWN gen-core stays mlx-gen `495bb19` (set by #352, unchanged since) — EXACTLY
+# this worker's `sceneworks-gen-core` + `mlx-gen*` pin (the epic-9992 krea lockstep, PR #656) — so
+# `--features backend-candle --target all` still resolves the SINGLE gen-core rev `495bb19` (skew gate
+# green, no testkit reconcile). ALL candle-gen-* move together.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1477,17 +1488,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1497,7 +1508,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1505,21 +1516,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1528,17 +1539,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1547,7 +1558,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1580,7 +1591,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1589,12 +1600,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1602,7 +1613,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1611,7 +1622,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1619,7 +1630,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1633,7 +1644,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1660,7 +1671,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1671,7 +1682,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4919ba5c8bf2c6d7c51e6655601e95eea978f3c", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with


### PR DESCRIPTION
Flip **Krea 2 Raw** (`krea_2_raw`) from Mac-only generation to **all-platform** now that the candle engine has landed (candle-gen [#350](https://github.com/SceneWorks/candle-gen/pull/350), sc-9994). This is the SceneWorks half of **epic 9992 P2** — it rides on top of the Mac vertical (#1215) which added the base `krea_2_raw` generation surface.

## Changes
- **`routing/catalog.rs`** — flip the `ModelCaps` row `krea_2_raw` `(true, false, false, false, false)` → `(true, true, false, false, true)` (candle_routed + candle_quant_lora, mirroring `krea_2_turbo` exactly — Raw + Turbo share the arch/loader). Add `"krea_2_raw"` to `EXPECTED_CANDLE_ROUTED_MODELS` + `EXPECTED_CANDLE_QUANT_LORA_MODELS`. No `candle.rs` arm needed — pure-t2i routes via the generic `image_request_candle_eligible` gate (which rejects `edit_image` family-wide), exactly like `krea_2_turbo`.
- **`sceneworks-worker/Cargo.toml`** — bump all `candle-gen*` pins `171a5dd` → `a4f2b4d` (candle-gen main HEAD carrying #350). The range also carries #351 (qwen-image VAE decode-tail tiling >1536², sc-10023), #353 (candle-gen-wan packed seam, sc-10025), and #352 which re-pinned candle-gen's own gen-core to mlx-gen `495bb19` — **exactly this worker's `sceneworks-gen-core` + `mlx-gen*` pin**, so `--features backend-candle` still resolves the single gen-core rev `495bb19` (skew gate green).
- **`config/manifests/builtin.models.jsonc`** — refresh the `krea_2_raw` comments/UI (candle now wired, all-platform) and add the `candle` VRAM gate block. `type: image` / `macOnly: false` / all-3 `platforms` were already set by the Mac vertical.

## VRAM (candle) — q8 MEASURED
`vramGbByTier: { q4: 28.8, q8: 33.4, bf16: 46.4 }`, `minMemoryGb: 32`. **q8 measured at 33.4 GB overall-peak** @1024² on an RTX PRO 6000 (Blackwell sm_120) via the nvidia-smi peak monitor (~2.4 GB over Turbo's q8 estimate, consistent with Raw's TRUE-CFG two sequential forwards + extra uncond context). q4/bf16 estimated from the measured q8 using Turbo's inter-tier gaps.

## Validation
- `cargo test -p sceneworks-core jobs_store::routing` — 4/4 pass incl. `routed_model_lists_match_snapshot` (derived candle lists == EXPECTED) + `quant_and_lora_models_are_candle_routed_supersets`.
- `node scripts/check-scaffold.mjs` — passed.
- gen-core skew: `cargo tree -p sceneworks-worker --features backend-candle -i sceneworks-gen-core` resolves the **single** rev `495bb19`.
- `cargo check -p sceneworks-worker --no-default-features -F backend-candle --all-targets` — the parity lane (worker compiles + force-links the bumped candle-gen).
- Engine already GPU-validated in candle-gen #350: coherent Raw CFG render + guidance A/B on the RTX PRO 6000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
