### PR TITLE
feat(web): per-prompt [WxH] resolution directive in batch prompts (sc-10063)

### DIFF
--- a/apps/web/src/components/BatchPromptPanel.jsx
+++ b/apps/web/src/components/BatchPromptPanel.jsx
@@ -6,6 +6,7 @@ import {
   firstResolvedPrompt,
   linkedGroupIssues,
   missingKeys,
+  parsePromptResolution,
   splitPromptLines,
 } from "../promptBatch.js";
 import { fromPromptBatchImport, serializePromptBatchExport } from "../promptBatchIO.js";
@@ -108,8 +109,14 @@ export default function BatchPromptPanel({
   );
   const total = useMemo(() => cardinality(prompts, variables, count), [prompts, variables, count]);
   // firstResolvedPrompt (not expandBatch()[0]) so the live preview never materializes the
-  // whole expansion, which inline alternation can make enormous.
-  const previewPrompt = useMemo(() => firstResolvedPrompt(prompts, variables), [prompts, variables]);
+  // whole expansion, which inline alternation can make enormous. Strip any leading [WxH]
+  // directive for display and surface the size as a badge (sc-10063).
+  const preview = useMemo(
+    () => parsePromptResolution(firstResolvedPrompt(prompts, variables)),
+    [prompts, variables],
+  );
+  const previewPrompt = preview.prompt;
+  const previewResolution = preview.resolution;
   const missing = useMemo(() => missingKeys(prompts, variables), [prompts, variables]);
   const groupIssues = useMemo(() => linkedGroupIssues(prompts), [prompts]);
   const hasPlaceholders = useMemo(() => prompts.some((prompt) => /\{\{[^{}]+\}\}/.test(prompt)), [prompts]);
@@ -165,7 +172,7 @@ export default function BatchPromptPanel({
             aria-label="Batch prompts"
             className="batch-prompts"
             onChange={(event) => onPromptsTextChange(event.target.value)}
-            placeholder={"{{name}} with {{hair}} hair, front view\n{{name}} in a {{red|blue|green}} coat\n{{p:he|she|they}} adjusts {{p:his|her|their}} scarf\n\nUse --- on its own line for multi-line prompts"}
+            placeholder={"{{name}} with {{hair}} hair, front view\n{{name}} in a {{red|blue|green}} coat\n[832x1216] {{name}} full-body portrait\n\nStart a line with [WxH] for a per-prompt size · use --- for multi-line prompts"}
             value={promptsText}
           />
         </label>
@@ -194,9 +201,16 @@ export default function BatchPromptPanel({
           </p>
         )}
 
-        {previewPrompt ? (
+        {previewPrompt || previewResolution ? (
           <div className="batch-preview">
-            <span className="batch-field-label">First prompt preview</span>
+            <span className="batch-field-label">
+              First prompt preview
+              {previewResolution ? (
+                <span className="batch-preview-res">
+                  {previewResolution.width}×{previewResolution.height}
+                </span>
+              ) : null}
+            </span>
             <p className="batch-preview-text">{previewPrompt}</p>
           </div>
         ) : null}

--- a/apps/web/src/components/BatchPromptPanel.test.jsx
+++ b/apps/web/src/components/BatchPromptPanel.test.jsx
@@ -125,6 +125,12 @@ describe("BatchPromptPanel (sc-9955)", () => {
     expect(document.body.querySelector(".batch-preview-text").textContent).toBe("Alice portrait");
   });
 
+  it("strips a leading [WxH] from the preview and shows it as a size badge", () => {
+    mount({ initialPrompts: "[832x1216] a full-body portrait" });
+    expect(document.body.querySelector(".batch-preview-text").textContent).toBe("a full-body portrait");
+    expect(document.body.querySelector(".batch-preview-res").textContent).toBe("832×1216");
+  });
+
   it("lists saved batches", () => {
     mount({
       batches: [

--- a/apps/web/src/promptBatch.js
+++ b/apps/web/src/promptBatch.js
@@ -244,6 +244,22 @@ export function firstResolvedPrompt(prompts, variables) {
   ).prompt;
 }
 
+// A prompt line may start with a `[WxH]` directive to render that prompt at its own size,
+// overriding the studio Aspect (sc-10063): `[832x1216] a full-body portrait`. Only a numeric
+// `[W x H]` at the very start counts — `[cinematic] …` stays part of the prompt. Returns the
+// stripped `prompt` and the parsed `{width,height}` (or null when absent). Range is NOT checked
+// here (the caller validates against the backend 256–4096 bounds).
+const RESOLUTION_DIRECTIVE = /^\s*\[\s*(\d{2,5})\s*[x×X]\s*(\d{2,5})\s*\]\s*/;
+export function parsePromptResolution(text) {
+  if (typeof text !== "string") return { prompt: "", resolution: null };
+  const match = RESOLUTION_DIRECTIVE.exec(text);
+  if (!match) return { prompt: text, resolution: null };
+  return {
+    prompt: text.slice(match[0].length),
+    resolution: { width: Number(match[1]), height: Number(match[2]) },
+  };
+}
+
 // Number of images a batch will queue: Σ over lines of Π(axis sizes), times `count`.
 // Computed from the factors — never materializes the expansion — so it is safe to call
 // live on every keystroke even when the product is enormous.

--- a/apps/web/src/promptBatch.test.js
+++ b/apps/web/src/promptBatch.test.js
@@ -7,6 +7,7 @@ import {
   firstResolvedPrompt,
   linkedGroupIssues,
   missingKeys,
+  parsePromptResolution,
   resolvePrompt,
   splitPromptLines,
 } from "./promptBatch.js";
@@ -342,5 +343,42 @@ describe("firstResolvedPrompt", () => {
 
   it("leaves an unfilled named key literal", () => {
     expect(firstResolvedPrompt(["{{name}} {{a|b}}"], [])).toBe("{{name}} a");
+  });
+});
+
+describe("parsePromptResolution", () => {
+  it("strips a leading [WxH] and returns the parsed size", () => {
+    expect(parsePromptResolution("[832x1216] a portrait")).toEqual({
+      prompt: "a portrait",
+      resolution: { width: 832, height: 1216 },
+    });
+  });
+
+  it("accepts x / X / × separators and surrounding whitespace", () => {
+    expect(parsePromptResolution("[ 1024 X 768 ]  wide").resolution).toEqual({ width: 1024, height: 768 });
+    expect(parsePromptResolution("[512×512] sq").resolution).toEqual({ width: 512, height: 512 });
+  });
+
+  it("returns null resolution when there is no directive", () => {
+    expect(parsePromptResolution("just a prompt")).toEqual({ prompt: "just a prompt", resolution: null });
+  });
+
+  it("only triggers on a numeric bracket — [cinematic] stays part of the prompt", () => {
+    expect(parsePromptResolution("[cinematic] a cat")).toEqual({
+      prompt: "[cinematic] a cat",
+      resolution: null,
+    });
+  });
+
+  it("only strips a LEADING directive, not one mid-prompt", () => {
+    expect(parsePromptResolution("a cat [1024x1024]").resolution).toBeNull();
+  });
+
+  it("parses out-of-range values (the caller range-checks)", () => {
+    expect(parsePromptResolution("[10x10] tiny").resolution).toEqual({ width: 10, height: 10 });
+  });
+
+  it("handles non-string input", () => {
+    expect(parsePromptResolution(null)).toEqual({ prompt: "", resolution: null });
   });
 });

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -16,9 +16,14 @@ import {
   extractKeys,
   linkedGroupIssues,
   missingKeys,
+  parsePromptResolution,
   splitPromptLines,
 } from "../promptBatch.js";
-import { resolveEffectiveDimensions } from "../resolutionOverride.js";
+import {
+  MAX_IMAGE_DIMENSION,
+  MIN_IMAGE_DIMENSION,
+  resolveEffectiveDimensions,
+} from "../resolutionOverride.js";
 import { batchItemStatus, summarizeBatchRun } from "../batchOps.js";
 import {
   emptyCaption,
@@ -1644,8 +1649,9 @@ export function ImageStudio() {
     model,
     count: posePayload.length ? 1 : count,
     seed: seed === "" ? null : Number(seed),
-    width,
-    height,
+    // A per-prompt [WxH] directive (sc-10063) overrides the studio resolution for this job.
+    width: opts.resolution?.width ?? width,
+    height: opts.resolution?.height ?? height,
     recipePresetId: selectedPreset?.id ?? null,
     characterId: mode === "character_image" ? characterId || null : null,
     characterLookId: mode === "character_image" ? characterLookId || null : null,
@@ -1667,7 +1673,7 @@ export function ImageStudio() {
         }
       : {}),
     advanced: buildImageJobAdvanced({
-      resolution,
+      resolution: opts.resolution ? `${opts.resolution.width}x${opts.resolution.height}` : resolution,
       sendStructured: opts.sendStructured ?? false,
       submitIntent: resolvedPrompt,
       submitCaption: opts.submitCaption ?? caption,
@@ -1739,29 +1745,33 @@ export function ImageStudio() {
         break;
       }
       const entry = resolved[i];
+      // Strip a leading [WxH] directive (sc-10063): the model gets the clean prompt, the job
+      // gets that per-prompt resolution.
+      const { prompt: cleanPrompt, resolution } = parsePromptResolution(entry.prompt);
       try {
         let request;
         if (structuredPromptModel) {
           // Structured-caption models (Ideogram 4) reject raw plain text, so auto-expand each
           // resolved prompt into a JSON caption first (sc-9980) — N sequential refine calls.
           // A prompt that fails to expand fails only that item; the rest continue.
-          const expanded = await onMagicExpand(entry.prompt);
+          const expanded = await onMagicExpand(cleanPrompt);
           if (!validateCaption(expanded).ok) {
             throw new Error("Auto-generated caption was invalid.");
           }
-          request = buildBatchJobRequest(entry.prompt, {
+          request = buildBatchJobRequest(cleanPrompt, {
             promptToSend: serializeCaption(expanded),
             sendStructured: true,
             submitCaption: expanded,
             submitBackend: PROMPT_REFINE_MODEL_ID,
+            resolution,
           });
         } else {
-          request = buildBatchJobRequest(entry.prompt);
+          request = buildBatchJobRequest(cleanPrompt, { resolution });
         }
         const job = await createImageJob(request);
-        items[i] = { prompt: entry.prompt, jobId: job?.id ?? null, error: !job?.id };
+        items[i] = { prompt: cleanPrompt, jobId: job?.id ?? null, error: !job?.id };
       } catch {
-        items[i] = { prompt: entry.prompt, jobId: null, error: true };
+        items[i] = { prompt: cleanPrompt, jobId: null, error: true };
       }
       setBatchRun({ submitting: true, items: items.map((item) => ({ ...item })) });
     }
@@ -1793,6 +1803,18 @@ export function ImageStudio() {
   const batchRunProgress = batchRun ? summarizeBatchRun(batchRun.items, jobs) : null;
   const batchMissingKeys = missingKeys(batchPrompts, batchVariables);
   const batchGroupIssues = linkedGroupIssues(batchPrompts);
+  // Prompt lines whose leading [WxH] directive (sc-10063) is out of the backend 256–4096
+  // range — block the run and name the offending size.
+  const batchResolutionIssues = batchPrompts
+    .map((line) => parsePromptResolution(line).resolution)
+    .filter(
+      (res) =>
+        res &&
+        (res.width < MIN_IMAGE_DIMENSION ||
+          res.width > MAX_IMAGE_DIMENSION ||
+          res.height < MIN_IMAGE_DIMENSION ||
+          res.height > MAX_IMAGE_DIMENSION),
+    );
   // A structured-caption model can batch, but only if the prompt-refiner is available to
   // auto-write a caption per resolved prompt (sc-9980).
   const batchStructuredExpandBlocked =
@@ -1803,6 +1825,7 @@ export function ImageStudio() {
     batchTotal === 0 ||
     batchMissingKeys.length > 0 ||
     batchGroupIssues.length > 0 ||
+    batchResolutionIssues.length > 0 ||
     Boolean(batchRun?.submitting);
 
   const generateDisabled =
@@ -1914,6 +1937,11 @@ export function ImageStudio() {
                   <p className="batch-warning">
                     Give each {batchGroupIssues.map((issue) => `{{${issue.label}:…}}`).join(", ")} the same number of
                     options to run.
+                  </p>
+                ) : batchResolutionIssues.length > 0 ? (
+                  <p className="batch-warning">
+                    A prompt&rsquo;s [{batchResolutionIssues[0].width}×{batchResolutionIssues[0].height}] size is out of
+                    range — each side must be {MIN_IMAGE_DIMENSION}–{MAX_IMAGE_DIMENSION}.
                   </p>
                 ) : batchTotal === 0 ? (
                   <p className="batch-hint">Add at least one prompt to run a batch.</p>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11066,6 +11066,17 @@ details[open] > summary.lora-scope-group-heading::before,
   padding: 8px 10px;
   white-space: pre-wrap;
 }
+.batch-preview-res {
+  margin-left: 8px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: normal;
+  text-transform: none;
+  color: var(--accent-strong);
+  background: var(--accent-soft);
+  border-radius: 999px;
+  padding: 1px 7px;
+}
 .batch-total {
   font-size: 14px;
   color: var(--text);


### PR DESCRIPTION
## Summary

Lets a batch prompt line start with a `[WxH]` directive to render **that** prompt at its own size, overriding the studio Aspect ([epic 9952](https://app.shortcut.com/trefry/epic/9952), [sc-10063](https://app.shortcut.com/trefry/story/10063)). Mix sizes in one batch:

```
[832x1216] {{name}} full-body portrait
[1216x832] {{name}} wide establishing shot
{{name}} close-up            ← no directive → studio resolution
```

## Syntax

A leading `[<width>x<height>]` (separator `x` / `X` / `×`, optional whitespace) at the **start** of a line. Only a numeric `[W x H]` triggers it — `[cinematic] …` stays part of the prompt. The directive is stripped from the prompt sent to the model; variables / inline / linked placeholders on the rest of the line work as usual.

## Behavior

- Per-prompt `[WxH]` overrides the studio width/height (and any Advanced Width/Height override) for that prompt's job(s) only.
- Range **256–4096** per side (mirrors `resolveEffectiveDimensions` / backend `validate_dimension`). An out-of-range `[WxH]` **blocks the run** with a clear message, like the missing-key / linked-group guards.
- Resolution isn't an axis, so cardinality / total / cap are unaffected.

## Implementation

- `promptBatch.js`: pure `parsePromptResolution(text)` → `{ prompt (stripped), resolution: {width,height}|null }`. `expandBatch`'s return shape is **unchanged** (callers apply the parse) to avoid test churn.
- `ImageStudio.jsx`: `buildBatchJobRequest` takes an optional `resolution` override → top-level width/height + `advanced.resolution`; `runBatch` strips the directive (structured-caption expansion gets the clean prompt) and applies the per-prompt size; `batchResolutionIssues` blocks + explains on an out-of-range directive.
- `BatchPromptPanel.jsx`: preview strips the directive and shows the size as a badge; textarea placeholder documents the syntax.

## Validation

**1281** web vitest (8 new — 7 `parsePromptResolution` cases + a panel strip/badge test) · ESLint 0 errors · production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)