### PR TITLE
feat(bernini): quant matrix tiers (bf16/Q8/Q4) hosted + wired (sc-9945, epic 8506)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -495,7 +495,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -510,7 +510,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -524,7 +524,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -577,7 +577,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -605,7 +605,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -615,7 +615,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -630,7 +630,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -645,7 +645,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -660,7 +660,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-gen",
  "image",
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -700,7 +700,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -714,7 +714,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -757,7 +757,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -788,7 +788,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -812,7 +812,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=a4f2b4d4d35825e38f662e9ab47f29ca17fe8192#a4f2b4d4d35825e38f662e9ab47f29ca17fe8192"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3f217342e017655e3f604aa0752a3640f9500ad8#3f217342e017655e3f604aa0752a3640f9500ad8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -3623,7 +3623,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3637,7 +3637,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "image",
  "inventory",
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "image",
  "inventory",
@@ -3665,7 +3665,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3679,7 +3679,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3690,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3699,7 +3699,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3708,7 +3708,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3722,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3735,7 +3735,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3748,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3760,7 +3760,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3770,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "image",
  "inventory",
@@ -3783,7 +3783,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "image",
  "inventory",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "image",
  "inventory",
@@ -3811,7 +3811,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "image",
  "inventory",
@@ -3823,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3834,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3867,7 +3867,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3876,7 +3876,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3898,7 +3898,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "image",
  "inventory",
@@ -3913,7 +3913,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "image",
  "inventory",
@@ -3927,7 +3927,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3938,7 +3938,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3950,7 +3950,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3961,7 +3961,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "image",
  "inventory",
@@ -3975,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "image",
  "inventory",
@@ -5741,7 +5741,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=495bb19437452a66a0a13d9ba37767f7aec84d14#495bb19437452a66a0a13d9ba37767f7aec84d14"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4f425de53007a81a119f2982e28e8f115e82ae03#4f425de53007a81a119f2982e28e8f115e82ae03"
 dependencies = [
  "core-llm",
  "inventory",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -5553,17 +5553,49 @@
         "ads2v"
       ],
       "downloads": [
+        // Bernini quant matrix (sc-9945, epic 8506): self-contained q4/ (default) + q8/ + bf16/ tier
+        // subdirs on SceneWorks/bernini-mlx. Each tier is a COMPLETE composite snapshot — the Qwen2.5-VL
+        // planner (backbone packed q4/q8, vision tower + connector + clip-diff dense) + both Wan renderer
+        // experts (packed q4/q8) + the shared dense T5/VAE/tokenizer + config sidecars. Pre-packed tiers
+        // load with no dense-staging peak (the flat layout staged ~82 GiB bf16 then quantized at load).
+        // The dense T5 repeats per tier (epic decision #3: storage non-issue; keeps the load path a
+        // single self-contained dir). The worker fetches a toggled-but-not-downloaded tier on demand
+        // (ensure_bernini_tier_present, video_jobs.rs), so advanced.mlxQuantize works without a pre-pick.
+        // The legacy flat root files stay hosted for already-shipped workers that resolve the repo root;
+        // a new worker only ever resolves the tier subdirs. Shared by bernini + bernini_image (one repo,
+        // HF cache dedupes). estimatedSizeBytes/footprint are measured from the built tiers.
         {
           "provider": "huggingface",
           "repo": "SceneWorks/bernini-mlx",
-          "files": [],
+          "variant": "q4",
+          "default": true,
+          "files": ["q4/*"],
           "platforms": ["macos"],
-          // Pre-converted MLX snapshot (planner + dual-expert renderer + stock
-          // Wan2.2 UMT5/VAE/tokenizer), bf16 ≈ 82 GiB (lean — the diffusers-format
-          // t5_text_encoder/t5_tokenizer/vae/scheduler dirs the engine never loads
-          // are excluded). Self-contained — no Wan base or diffusers source needed
-          // at runtime. Q4 default / Q8 opt-in applied at load.
-          "estimatedSizeBytes": 88046829568
+          // ~35.2 GiB measured (experts + planner backbone at 4-bit; dense T5/VAE/vision shared).
+          "estimatedSizeBytes": 37815703819,
+          "footprint": { "diskSizeBytes": 37815703819, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/bernini-mlx",
+          "variant": "q8",
+          "files": ["q8/*"],
+          "platforms": ["macos"],
+          // ~51.3 GiB measured (experts + planner backbone at 8-bit; dense T5/VAE/vision shared).
+          "estimatedSizeBytes": 55129270617,
+          "footprint": { "diskSizeBytes": 55129270617, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/bernini-mlx",
+          "variant": "bf16",
+          "files": ["bf16/*"],
+          "platforms": ["macos"],
+          // Dense bf16 tier: the same content as the legacy flat root (lean ≈ 82 GiB — the diffusers-format
+          // t5_text_encoder/t5_tokenizer/vae/scheduler dirs the engine never loads are excluded), hosted
+          // under bf16/ for the uniform tier layout (~81.6 GiB measured).
+          "estimatedSizeBytes": 87591990679,
+          "footprint": { "diskSizeBytes": 87591990679, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
@@ -5653,15 +5685,37 @@
       "adapter": "bernini",
       "capabilities": ["text_to_image", "edit_image"],
       "downloads": [
+        // Bernini quant matrix (sc-9945, epic 8506) — the SAME q4/ (default) + q8/ + bf16/ tier subdirs
+        // on SceneWorks/bernini-mlx the video `bernini` id uses (one repo, HF cache dedupes even with
+        // both ids installed). Per-tier layout + on-demand fetch (ensure_bernini_tier_present) mirror the
+        // video entry; the image lane resolves through the same tier machinery. estimatedSizeBytes/footprint are measured from the built tiers.
         {
           "provider": "huggingface",
           "repo": "SceneWorks/bernini-mlx",
-          "files": [],
+          "variant": "q4",
+          "default": true,
+          "files": ["q4/*"],
           "platforms": ["macos"],
-          // Same pre-converted MLX snapshot the video `bernini` id uses (planner + dual-expert
-          // renderer + stock Wan2.2 UMT5/VAE/tokenizer), bf16 ≈ 82 GiB. Shared HF repo — the
-          // cache stores it once even with both ids installed.
-          "estimatedSizeBytes": 88046829568
+          "estimatedSizeBytes": 37815703819,
+          "footprint": { "diskSizeBytes": 37815703819, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/bernini-mlx",
+          "variant": "q8",
+          "files": ["q8/*"],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 55129270617,
+          "footprint": { "diskSizeBytes": 55129270617, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/bernini-mlx",
+          "variant": "bf16",
+          "files": ["bf16/*"],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 87591990679,
+          "footprint": { "diskSizeBytes": 87591990679, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -485,7 +485,18 @@ sceneworks-core = { path = "../sceneworks-core" }
 # candle-gen pin below moves to 7c43ec8f IN LOCKSTEP (candle-gen #301: consumes `text_encoder` in the
 # LTX provider AND re-pins candle-gen's own gen-core 330d339 -> b520a0e7) so `--features backend-candle`
 # resolves the SINGLE gen-core rev b520a0e7. mlx-rs + mlx-llm pins unchanged.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+# Rev 495bb19 -> 4f425de (sc-9945, epic 8506): the Bernini pre-packable planner quant tier — mlx-gen
+# #658 adds `mlx_gen_bernini::convert::quantize_qwen_planner_backbone` (pub) + a packed-aware
+# `Qwen25VlText` loader (`QwenVlTextConfig.quantization`), so a hosted Bernini q4/q8 tier loads its
+# Qwen2.5-VL planner packed (the dual-Wan renderer already did). Bumps EVERY mlx-gen crate + gen-core
+# 495bb19 -> 4f425de in lockstep. `git diff 495bb19..4f425de -- gen-core/ gen-core-testkit/` is EMPTY
+# (mlx-gen-bernini-only change), so the worker import surface is unchanged. The candle-gen pin below
+# moves to 3f21734 IN LOCKSTEP (candle-gen #355: re-pins candle-gen's own gen-core 495bb19 -> 4f425de,
+# byte-identical) so `--features backend-candle` resolves the SINGLE gen-core rev 4f425de. mlx-rs +
+# mlx-llm pins unchanged. mlx-gen #658 MERGE-committed (main 91ba8b9), so 4f425de is durable + reachable
+# from main; the pin deliberately stays at 4f425de (495bb19 + ONLY the bernini delta) rather than
+# flipping to main HEAD, which has since merged the UNRELATED kolors quant (#659) this must not drag in.
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -837,7 +848,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -853,23 +864,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb194374
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -877,7 +888,7 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb1
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
 # mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
 # mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
@@ -885,59 +896,59 @@ mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19
 # conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
 # DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
 # generator-cache load path drives.
-mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -946,19 +957,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb1
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -967,7 +978,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -975,7 +986,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -986,7 +997,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495b
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -997,7 +1008,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -1019,7 +1030,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb1
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -1030,7 +1041,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -1062,7 +1073,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495bb19437452a66a0a13d9ba37767f7aec84d14" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4f425de53007a81a119f2982e28e8f115e82ae03" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1472,15 +1483,21 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "495b
 # this worker's `sceneworks-gen-core` + `mlx-gen*` pin (the epic-9992 krea lockstep, PR #656) — so
 # `--features backend-candle --target all` still resolves the SINGLE gen-core rev `495bb19` (skew gate
 # green, no testkit reconcile). ALL candle-gen-* move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+# Bumped `a4f2b4d` -> `3f21734` (sc-9945, epic 8506): lockstep with the worker's mlx-gen re-pin to
+# `4f425de` (mlx-gen #658 Bernini planner packed tier). candle-gen #355 re-pins candle-gen's OWN gen-core
+# `495bb19` -> `4f425de` (byte-identical — mlx-gen-bernini-only change candle does not link), so
+# `--features backend-candle --target all` resolves the SINGLE gen-core rev `4f425de` (skew gate green,
+# no testkit reconcile). ALL candle-gen-* move together. candle-gen #355 MERGE-committed (main ec2f344),
+# so `3f21734` is durable + reachable from candle-gen main — the pin stays at it (the minimal re-pin).
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1488,17 +1505,17 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1508,7 +1525,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1516,21 +1533,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1539,17 +1556,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1558,7 +1575,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1591,7 +1608,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1600,12 +1617,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1613,7 +1630,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1622,7 +1639,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1630,7 +1647,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1644,7 +1661,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1671,7 +1688,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1682,7 +1699,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a4f2b4d4d35825e38f662e9ab47f29ca17fe8192", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3f217342e017655e3f604aa0752a3640f9500ad8", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/bernini_tier_build.rs
+++ b/crates/sceneworks-worker/src/bernini_tier_build.rs
@@ -1,0 +1,286 @@
+//! On-device build helper for the Bernini quant matrix (sc-9945, epic 8506).
+//!
+//! Bernini is a COMPOSITE — a Qwen2.5-VL-7B semantic planner + a dual-expert Wan2.2-A14B renderer —
+//! so its tiers pack THREE weight files (the planner LLM backbone + both renderer experts) and leave
+//! everything else (the vision tower, connector, clip-diff flow head, T5, VAE) dense, exactly matching
+//! the sc-5146 load-time quant policy. Produces the three hosted tier subdirs — `bf16/` + `q8/` +
+//! `q4/` — for `SceneWorks/bernini-mlx`.
+//!
+//! Unlike the Wan tier builders (which convert from a native checkpoint), ALL three Bernini tiers are
+//! derived **worker-side from the already-hosted lean bf16 snapshot** — the ~82 GiB self-contained
+//! MLX snapshot the turnkey `bernini` / `bernini_image` ids ship today (the diffusers-format
+//! `t5_text_encoder`/`t5_tokenizer`/`vae`/`scheduler` dirs the engine never loads are already
+//! excluded). This avoids re-downloading the ~168 GB raw `ByteDance/Bernini-Diffusers` package + a
+//! base-Wan snapshot, and guarantees the tiers are byte-parity with what ships today:
+//!
+//! - `bf16/`: a verbatim copy of the lean bf16 snapshot.
+//! - `q8/` + `q4/`: derived from the bf16 tier with NO extra convert — the three packable files are
+//!   quantized worker-side (group 64), the dense remainder is copied, and the two config sidecars get
+//!   the `{bits, group_size}` block the load path reads as authoritative:
+//!     * `qwen2_5_vl.safetensors` → `mlx_gen_bernini::convert::quantize_qwen_planner_backbone`
+//!       (packs the LLM backbone attention + SwiGLU linears; vision tower + embeddings + norms stay
+//!       dense) + patch `qwen2_5_vl_config.json` `quantization`.
+//!     * `high_noise_model.safetensors` + `low_noise_model.safetensors` →
+//!       `mlx_gen_wan::convert::quantize_wan_transformer` (the same public helper the Wan tiers use) +
+//!       patch the renderer `config.json` `quantization`.
+//!
+//! A resolved tier then loads packed with the config sidecars authoritative and `quant = None` — no
+//! install-time convert peak, no dense-staging of the ~56 GB experts.
+//!
+//! This is an `#[ignore]`d test, not part of CI — it needs the lean bf16 `SceneWorks/bernini-mlx`
+//! snapshot on disk and takes minutes per tier on an Apple-Silicon Mac. Run one-off to produce the
+//! artifacts, then `hf upload` the `bf16/`/`q8/`/`q4/` subdirs to `SceneWorks/bernini-mlx`.
+//!
+//! ```sh
+//! # The lean bf16 snapshot, e.g. `hf download SceneWorks/bernini-mlx --local-dir <bf16>` (or point
+//! # at the cached HF snapshot dir). Auto-resolves the cached turnkey when the var is unset.
+//! export SCENEWORKS_BERNINI_BF16_DIR=<bf16-snapshot>
+//! export SCENEWORKS_BERNINI_TIER_OUT=<out-root>            # bf16/ q8/ q4/ written here
+//! cargo test -p sceneworks-worker --release bernini_build_tiers -- --ignored --nocapture
+//! ```
+//!
+//! Each tier prints a `[[TIER]] {json}` line (tier, dir, diskSizeBytes) so the manifest
+//! `estimatedSizeBytes`/`footprint.diskSizeBytes` can be backfilled with the exact hosted sizes.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use mlx_rs::Array;
+
+/// The runtime files that make a Bernini tier subdir COMPLETE for the load path (mirrors
+/// `video_jobs::BERNINI_TIER_FILES`): the planner components + both renderer experts + the shared
+/// dense T5/VAE + tokenizer + the config sidecars + the planner's `mllm/tokenizer.json`.
+const TIER_FILES: &[&str] = &[
+    "qwen2_5_vl.safetensors",
+    "qwen2_5_vl_config.json",
+    "connector.safetensors",
+    "vit_decoder.safetensors",
+    "mask_tokens.safetensors",
+    "bernini_planner.json",
+    "high_noise_model.safetensors",
+    "low_noise_model.safetensors",
+    "t5_encoder.safetensors",
+    "vae.safetensors",
+    "tokenizer.json",
+    "config.json",
+    "bernini_renderer.json",
+    "mllm/tokenizer.json",
+];
+
+/// The two quantized tiers to derive from the bf16 tier: `(subdir, bits)`.
+const QUANT_TIERS: &[(&str, i32)] = &[("q8", 8), ("q4", 4)];
+
+/// The quant group size — the canonical mflux/reference default the load path
+/// (`WanModelConfig::from_config_json` / `QwenVlTextConfig::from_config_json`) reconstructs. Matches
+/// the Wan A14B renderer experts, so the two halves pack at the same group.
+const GROUP_SIZE: i32 = 64;
+
+/// The three weight files a tier PACKS (planner backbone + both renderer experts). Everything else in
+/// the snapshot is copied dense.
+const PLANNER_WEIGHTS: &str = "qwen2_5_vl.safetensors";
+const RENDERER_EXPERTS: &[&str] = &[
+    "high_noise_model.safetensors",
+    "low_noise_model.safetensors",
+];
+
+/// The config sidecars a quant tier patches with the `{bits, group_size}` block the load path reads as
+/// authoritative: the planner config gates `Qwen25VlText::from_weights` packed-load; the renderer
+/// config gates `WanTransformer::from_weights`.
+const PLANNER_CONFIG: &str = "qwen2_5_vl_config.json";
+const RENDERER_CONFIG: &str = "config.json";
+
+/// Recursively sum the byte size of every file under `dir` (the on-disk size of a built tier).
+fn dir_size_bytes(dir: &Path) -> u64 {
+    let mut total = 0;
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            total += dir_size_bytes(&path);
+        } else if let Ok(meta) = path.metadata() {
+            total += meta.len();
+        }
+    }
+    total
+}
+
+/// Recursively copy a directory tree (following symlinks to real files, like the HF cache blobs).
+fn copy_tree(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap_or_else(|e| panic!("mkdir {}: {e:?}", dst.display()));
+    for entry in std::fs::read_dir(src)
+        .unwrap_or_else(|e| panic!("read_dir {}: {e:?}", src.display()))
+        .flatten()
+    {
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if std::fs::symlink_metadata(&from)
+            .map(|m| m.is_dir())
+            .unwrap_or(false)
+        {
+            copy_tree(&from, &to);
+        } else {
+            std::fs::copy(&from, &to)
+                .unwrap_or_else(|e| panic!("copy {} → {}: {e:?}", from.display(), to.display()));
+        }
+    }
+}
+
+/// Assert every load-path file exists in a built `tier` dir.
+fn assert_tier_complete(out_dir: &Path, tier: &str) {
+    for file in TIER_FILES {
+        assert!(
+            out_dir.join(file).is_file(),
+            "built {tier} tier is missing {file}"
+        );
+    }
+}
+
+/// Print the machine-readable `[[TIER]]` line for backfilling the manifest sizes.
+fn report_tier(tier: &str, out_dir: &Path) {
+    let size = dir_size_bytes(out_dir);
+    eprintln!(
+        "[[TIER]] {{\"tier\":\"{tier}\",\"dir\":\"{}\",\"diskSizeBytes\":{size}}}",
+        out_dir.display()
+    );
+}
+
+/// Load a bf16 safetensors map, apply `quantize` to it, materialize, and save to `out`.
+fn quantize_file(
+    bf16_file: &Path,
+    out_file: &Path,
+    quantize: impl FnOnce(HashMap<String, Array>) -> mlx_gen::Result<HashMap<String, Array>>,
+) {
+    let dense: HashMap<String, Array> = Array::load_safetensors(bf16_file)
+        .unwrap_or_else(|e| panic!("load {}: {e:?}", bf16_file.display()));
+    let packed =
+        quantize(dense).unwrap_or_else(|e| panic!("quantize {}: {e:?}", bf16_file.display()));
+    mlx_rs::transforms::eval(packed.values().collect::<Vec<_>>())
+        .unwrap_or_else(|e| panic!("eval packed {}: {e:?}", out_file.display()));
+    Array::save_safetensors(
+        packed.iter().map(|(k, v)| (k.as_str(), v)),
+        None::<&HashMap<String, String>>,
+        out_file,
+    )
+    .unwrap_or_else(|e| panic!("save {}: {e:?}", out_file.display()));
+    drop(packed);
+    mlx_rs::memory::clear_cache();
+}
+
+/// Add the `{"bits", "group_size"}` quantization block to a JSON config in place.
+fn patch_config_quant(config_file: &Path, bits: i32) {
+    let text = std::fs::read_to_string(config_file)
+        .unwrap_or_else(|e| panic!("read {}: {e:?}", config_file.display()));
+    let mut config: serde_json::Value = serde_json::from_str(&text)
+        .unwrap_or_else(|e| panic!("parse {}: {e:?}", config_file.display()));
+    config["quantization"] = serde_json::json!({ "bits": bits, "group_size": GROUP_SIZE });
+    std::fs::write(config_file, serde_json::to_string_pretty(&config).unwrap())
+        .unwrap_or_else(|e| panic!("write {}: {e:?}", config_file.display()));
+}
+
+/// Derive a quantized tier (`q8`/`q4`) from the already-built dense `bf16/` tier: copy the whole tier,
+/// then overwrite the three packable weight files with their quantized packs and patch the two config
+/// sidecars. Byte-identical to what an inline convert with `quantize = Some((bits, GROUP_SIZE))` would
+/// emit (the planner packs the same backbone linears `Qwen25VlText::quantize` would; the experts run
+/// the same `quantize_wan_transformer` the renderer assembler runs).
+fn build_quant_tier(bf16_dir: &Path, out_dir: &Path, tier: &str, bits: i32) {
+    // 1. Copy the full bf16 tier (dense remainder: connector, vit_decoder, mask_tokens, T5, VAE,
+    //    tokenizer, sidecars, mllm/). The three packable files are overwritten below.
+    copy_tree(bf16_dir, out_dir);
+
+    // 2. Planner backbone — pack the LLM attention + SwiGLU linears (vision/embeddings/norms stay
+    //    dense) and patch the planner config so `Qwen25VlText::from_weights` loads the packs.
+    quantize_file(
+        &bf16_dir.join(PLANNER_WEIGHTS),
+        &out_dir.join(PLANNER_WEIGHTS),
+        |m| mlx_gen_bernini::convert::quantize_qwen_planner_backbone(m, bits, GROUP_SIZE),
+    );
+    patch_config_quant(&out_dir.join(PLANNER_CONFIG), bits);
+
+    // 3. Renderer experts — pack both dual-expert DiTs and patch the renderer config so
+    //    `WanTransformer::from_weights` loads them packed.
+    for expert in RENDERER_EXPERTS {
+        quantize_file(&bf16_dir.join(expert), &out_dir.join(expert), |m| {
+            mlx_gen_wan::convert::quantize_wan_transformer(m, bits, GROUP_SIZE)
+        });
+    }
+    patch_config_quant(&out_dir.join(RENDERER_CONFIG), bits);
+
+    assert_tier_complete(out_dir, tier);
+    report_tier(tier, out_dir);
+}
+
+/// Resolve the source lean bf16 snapshot: the explicit env override, else the cached
+/// `SceneWorks/bernini-mlx` turnkey under the HF hub cache. Panics with actionable guidance if none is
+/// found (the tiers are derived from it).
+fn resolve_bf16_source() -> PathBuf {
+    if let Ok(explicit) = std::env::var("SCENEWORKS_BERNINI_BF16_DIR") {
+        let path = PathBuf::from(explicit.trim());
+        assert!(
+            path.join("qwen2_5_vl.safetensors").is_file(),
+            "SCENEWORKS_BERNINI_BF16_DIR={} is not a Bernini bf16 snapshot (no qwen2_5_vl.safetensors)",
+            path.display()
+        );
+        return path;
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        let snapshots = PathBuf::from(home)
+            .join(".cache/huggingface/hub")
+            .join("models--SceneWorks--bernini-mlx")
+            .join("snapshots");
+        if let Ok(entries) = std::fs::read_dir(&snapshots) {
+            for entry in entries.flatten() {
+                if entry.path().join("qwen2_5_vl.safetensors").is_file() {
+                    return entry.path();
+                }
+            }
+        }
+    }
+    panic!(
+        "no Bernini bf16 snapshot found — set SCENEWORKS_BERNINI_BF16_DIR or cache the turnkey \
+         (hf download SceneWorks/bernini-mlx --local-dir <bf16>)"
+    );
+}
+
+/// Build all three Bernini tier subdirs (bf16 = copy of the lean snapshot; q8/q4 derived from it).
+/// `#[ignore]`d — run on-device with the env vars above; not exercised in CI (needs the ~82 GiB
+/// snapshot + minutes/tier).
+#[test]
+#[ignore = "on-device tier build: needs the lean SceneWorks/bernini-mlx bf16 snapshot + minutes/tier"]
+fn bernini_build_tiers() {
+    let bf16_source = resolve_bf16_source();
+    let out_root = PathBuf::from(
+        std::env::var("SCENEWORKS_BERNINI_TIER_OUT")
+            .expect("set SCENEWORKS_BERNINI_TIER_OUT to the output root for bf16/ q8/ q4/"),
+    );
+    std::fs::create_dir_all(&out_root).unwrap();
+
+    // Cap the MLX buffer cache to 0 so freed buffers return to the OS immediately between the heavy
+    // per-file loads (sc-5567 batch pattern) — a build-time realloc-cost trade the generation hot path
+    // deliberately avoids.
+    mlx_rs::memory::set_cache_limit(0);
+
+    // 1. bf16 tier = verbatim copy of the lean snapshot.
+    let bf16_dir = out_root.join("bf16");
+    eprintln!(
+        "building bf16 tier → {} (copy of lean snapshot)",
+        bf16_dir.display()
+    );
+    copy_tree(&bf16_source, &bf16_dir);
+    assert_tier_complete(&bf16_dir, "bf16");
+    report_tier("bf16", &bf16_dir);
+
+    // 2. q8/q4 derived from the bf16 tier (worker-side quantize of the three packable files).
+    for (tier, bits) in QUANT_TIERS {
+        let out_dir = out_root.join(tier);
+        eprintln!("building {tier} tier → {} (bits={bits})", out_dir.display());
+        build_quant_tier(&bf16_dir, &out_dir, tier, *bits);
+        mlx_rs::memory::clear_cache();
+    }
+
+    eprintln!(
+        "done — upload the tier subdirs:\n  hf upload SceneWorks/bernini-mlx {} --include 'bf16/*' 'q8/*' 'q4/*'",
+        out_root.display()
+    );
+}

--- a/crates/sceneworks-worker/src/image_jobs/bernini.rs
+++ b/crates/sceneworks-worker/src/image_jobs/bernini.rs
@@ -166,13 +166,24 @@ async fn generate_bernini_image_stream(
     let model = mlx_model(&request.model)
         .ok_or_else(|| WorkerError::InvalidPayload("not an MLX-backed model".to_owned()))?;
     let engine_id = model.engine_id();
-    let weights_dir = crate::video_jobs::resolve_bernini_model_dir(settings)?;
     let backend = if model.backend().is_empty() {
         backend
     } else {
         model.backend()
     };
     let (quant, quant_bits) = resolve_bernini_image_quant(request);
+    // sc-9945: raw `mlxQuantize` bits for the quant-matrix tier selector (distinct from `quant_bits`,
+    // which is `None` for BOTH bf16 and the q4 default — the tier order must tell `<= 0` bf16 apart).
+    // Fetch the requested tier subdir (q8/bf16) if not the shipped q4 default, then descend into it: a
+    // pre-packed tier loads with `quant = None` (config sidecars authoritative); a legacy flat snapshot
+    // keeps load-time quant (`quant` above).
+    let tier_bits = request
+        .advanced
+        .get("mlxQuantize")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()));
+    crate::video_jobs::ensure_bernini_tier_present(api, settings, job, tier_bits).await?;
+    let (weights_dir, quant) =
+        crate::video_jobs::resolve_bernini_tier_dir_and_quant(settings, tier_bits, quant)?;
     let steps = resolve_steps(request, &model);
     // Standard guidance family: `guidance` carries the CFG scale (engine `omega_txt`); the negative
     // prompt is forwarded (descriptor advertises both). No true-CFG.

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -291,6 +291,13 @@ mod wan_i2v_14b_tier_build;
 // for `SceneWorks/wan2.2-ti2v-5b-mlx`; not exercised in CI (needs the native checkpoint).
 #[cfg(all(test, target_os = "macos"))]
 mod wan_ti2v_5b_tier_build;
+// On-device build helper for the Bernini quant matrix (sc-9945, epic 8506). Composite model: derives
+// all three tiers (bf16/q8/q4) worker-side from the already-hosted lean bf16 snapshot — copy the dense
+// remainder, quantize the planner backbone (`mlx_gen_bernini::convert::quantize_qwen_planner_backbone`)
+// + both renderer experts (`mlx_gen_wan::convert::quantize_wan_transformer`), patch the two config
+// sidecars. Run one-off to build the artifacts for `SceneWorks/bernini-mlx`; not exercised in CI.
+#[cfg(all(test, target_os = "macos"))]
+mod bernini_tier_build;
 // The DWPose skeleton rasterizer is consumed only by the macOS Z-Image strict-pose
 // control path; on Mac AND the off-Mac candle DWPose lane (sc-5496) it backs the
 // `pose_jobs` skeleton render; on a candle-disabled box off Mac it still builds +

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -997,3 +997,81 @@ fn wan_ti2v_5b_manifest_ships_the_quant_matrix() {
         .collect();
     assert_eq!(defaults, vec!["q4"], "the macOS default tier is q4");
 }
+
+/// sc-9945 (epic 8506): BOTH Bernini catalog ids — the `bernini` video id and the `bernini_image`
+/// still-image companion — ship the same macOS quant matrix (per-tier `q4` default + `q8` + `bf16`
+/// self-contained SceneWorks HF downloads, each `variant`-tagged with an `estimatedSizeBytes` +
+/// `footprint`, all from the shared `SceneWorks/bernini-mlx` repo). Both load paths descend into the
+/// chosen tier (`video_jobs::bernini_tier_subdir`), so a drift that drops a tier, its size, or lets the
+/// two ids diverge would break the download UI + the RAM→tier suggestion — assert the shape here.
+#[test]
+fn bernini_manifest_ships_the_quant_matrix() {
+    for (id, ty) in [("bernini", "video"), ("bernini_image", "image")] {
+        let entry = builtin_model_entry(id);
+        assert_eq!(
+            entry.get("family").and_then(Value::as_str),
+            Some("bernini"),
+            "{id} family"
+        );
+        assert_eq!(entry.get("type").and_then(Value::as_str), Some(ty), "{id} type");
+        let downloads = entry
+            .get("downloads")
+            .and_then(Value::as_array)
+            .unwrap_or_else(|| panic!("{id} downloads"));
+        let macos: Vec<&Value> = downloads
+            .iter()
+            .filter(|d| {
+                d.get("platforms")
+                    .and_then(Value::as_array)
+                    .map(|p| p.iter().any(|x| x.as_str() == Some("macos")))
+                    .unwrap_or(false)
+            })
+            .collect();
+        let variants: Vec<&str> = macos
+            .iter()
+            .filter_map(|d| d.get("variant").and_then(Value::as_str))
+            .collect();
+        assert_eq!(
+            variants,
+            vec!["q4", "q8", "bf16"],
+            "{id} ships the q4/q8/bf16 tier matrix on macOS"
+        );
+        for tier in &macos {
+            let variant = tier.get("variant").and_then(Value::as_str).unwrap();
+            assert_eq!(
+                tier.get("repo").and_then(Value::as_str),
+                Some("SceneWorks/bernini-mlx"),
+                "{id} {variant} tier hosts on the shared SceneWorks Bernini repo"
+            );
+            let files: Vec<String> = tier
+                .get("files")
+                .and_then(Value::as_array)
+                .map(|f| f.iter().filter_map(Value::as_str).map(String::from).collect())
+                .unwrap_or_default();
+            assert_eq!(
+                files,
+                vec![format!("{variant}/*")],
+                "{id} {variant} tier installs only its own subdir"
+            );
+            assert!(
+                tier.get("estimatedSizeBytes")
+                    .and_then(Value::as_u64)
+                    .is_some_and(|b| b > 0),
+                "{id} {variant} tier declares a nonzero estimatedSizeBytes"
+            );
+            assert!(
+                tier.get("footprint")
+                    .and_then(|f| f.get("diskSizeBytes"))
+                    .and_then(Value::as_u64)
+                    .is_some_and(|b| b > 0),
+                "{id} {variant} tier declares a footprint.diskSizeBytes"
+            );
+        }
+        let defaults: Vec<&str> = macos
+            .iter()
+            .filter(|d| d.get("default").and_then(Value::as_bool) == Some(true))
+            .filter_map(|d| d.get("variant").and_then(Value::as_str))
+            .collect();
+        assert_eq!(defaults, vec!["q4"], "{id} macOS default tier is q4");
+    }
+}

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -5260,6 +5260,165 @@ fn resolve_bernini_quant(request: &VideoRequest) -> Option<Quant> {
     resolve_mlx_dense_quant(request)
 }
 
+// --- Bernini quant-matrix tiers (sc-9945, epic 8506) ---------------------------------------------
+// The composite sibling of the Wan quant-matrix tiers. `SceneWorks/bernini-mlx` hosts self-contained
+// `q4/` (default) + `q8/` + `bf16/` tier subdirs, each a COMPLETE composite snapshot (the Qwen2.5-VL
+// planner components + both Wan renderer experts + the shared dense T5/VAE/tokenizer + config
+// sidecars). The legacy flat dense-bf16 layout quantized at LOAD, staging the ~56 GB experts + ~14 GB
+// planner backbone as bf16 first; a pre-packed tier loads with no dense-staging peak. Both the video
+// (`bernini`) and image (`bernini_image`) load paths resolve through the same tier machinery. The flat
+// root files stay for already-shipped workers; a new worker resolves the tier subdirs. Mirrors the
+// `wan_tier_*` helpers, but keyed on raw `mlxQuantize` bits so it serves the image lane too.
+
+/// The turnkey SceneWorks Bernini MLX repo (sc-9945). Hosts the `q4/`/`q8/`/`bf16/` tier subdirs.
+#[cfg(target_os = "macos")]
+const BERNINI_REPO: &str = "SceneWorks/bernini-mlx";
+
+/// Pinned revision for [`BERNINI_REPO`] — the commit that adds the `q4/`/`q8/`/`bf16/` tier subdirs
+/// (sc-9945). Pinning the exact commit (not the mutable `main`) stops an upstream re-push from silently
+/// swapping a checkpoint the on-demand `q8/*` + `bf16/*` fetch loads (the `hf` CLI still verifies each
+/// file's own hash on download). This is the commit that added the `q4/`/`q8/`/`bf16/` tier subdirs
+/// (sc-9945), with the exact hosted sizes: q4 37,815,703,819 / q8 55,129,270,617 / bf16 87,591,990,679.
+#[cfg(target_os = "macos")]
+const BERNINI_REVISION: &str = "533d688f16c8f33dc832890c1e16c11921a2019a";
+
+/// The runtime files that make a Bernini tier subdir COMPLETE for the load path: the planner
+/// components + both renderer experts + the shared dense T5/VAE + tokenizer + config sidecars + the
+/// planner's `mllm/tokenizer.json` (mirrors `bernini_tier_build::TIER_FILES`). The three packable
+/// weights (`qwen2_5_vl.safetensors`, `high/low_noise_model.safetensors`) are present in every tier;
+/// only their contents differ (packed vs dense).
+#[cfg(target_os = "macos")]
+const BERNINI_TIER_FILES: &[&str] = &[
+    "qwen2_5_vl.safetensors",
+    "qwen2_5_vl_config.json",
+    "connector.safetensors",
+    "vit_decoder.safetensors",
+    "mask_tokens.safetensors",
+    "bernini_planner.json",
+    "high_noise_model.safetensors",
+    "low_noise_model.safetensors",
+    "t5_encoder.safetensors",
+    "vae.safetensors",
+    "tokenizer.json",
+    "config.json",
+    "bernini_renderer.json",
+    "mllm/tokenizer.json",
+];
+
+/// The Bernini quant-matrix tier search order for a request — preferred tier first, then the
+/// always-smaller fallback tiers so a repo missing the preferred subdir still loads (mirrors
+/// [`wan_tier_order`]): `mlxQuantize <= 0` ⇒ `bf16`, `>= 8` ⇒ `q8`, else the `q4` default. `bf16` is
+/// only ever tried when explicitly requested, so a default job never pulls the huge dense tier.
+#[cfg(target_os = "macos")]
+fn bernini_tier_order(bits: Option<i64>) -> &'static [&'static str] {
+    match bits {
+        Some(b) if b <= 0 => &["bf16", "q8", "q4"],
+        Some(b) if b >= 8 => &["q8", "q4"],
+        _ => &["q4", "q8"],
+    }
+}
+
+/// Whether `dir` is a COMPLETE self-contained Bernini tier snapshot (all [`BERNINI_TIER_FILES`]). A
+/// partially-downloaded tier fails this so [`bernini_tier_subdir`] falls through to a smaller complete
+/// tier rather than half-loading.
+#[cfg(target_os = "macos")]
+fn bernini_tier_is_complete(dir: &Path) -> bool {
+    BERNINI_TIER_FILES
+        .iter()
+        .all(|file| dir.join(file).is_file())
+}
+
+/// Descend a resolved Bernini repo `root` into the requested quant tier subdir (sc-9945), mirroring
+/// [`wan_tier_subdir`]. Returns the first COMPLETE tier in [`bernini_tier_order`], or `None` when the
+/// repo has no complete tier subdir — a legacy flat snapshot, where the caller keeps the root +
+/// load-time quant.
+#[cfg(target_os = "macos")]
+fn bernini_tier_subdir(root: &Path, bits: Option<i64>) -> Option<PathBuf> {
+    bernini_tier_order(bits)
+        .iter()
+        .map(|tier| root.join(tier))
+        .find(|dir| bernini_tier_is_complete(dir))
+}
+
+/// Resolve the Bernini `(model_dir, load-time quant)` for a generation, descending into the
+/// quant-matrix tier subdir when the turnkey ships them (sc-9945). A pre-packed tier's config sidecars
+/// are authoritative — the planner (`Qwen25VlText::from_weights`, via the `quantization` block) and
+/// both renderer experts (`WanTransformer::from_weights`) build packed — so a resolved tier loads with
+/// `quant = None`: `mlxQuantize` selects WHICH tier, never a load-time requant (the `bf16/` tier is
+/// dense, so `None` ⇒ dense too). A legacy flat snapshot (no tier subdirs) keeps today's behavior: load
+/// the root and quantize at load per `legacy_quant`. Shared by the video + image lanes (each passes its
+/// own parsed `bits` + `legacy_quant`).
+#[cfg(target_os = "macos")]
+pub(crate) fn resolve_bernini_tier_dir_and_quant(
+    settings: &Settings,
+    bits: Option<i64>,
+    legacy_quant: Option<Quant>,
+) -> WorkerResult<(PathBuf, Option<Quant>)> {
+    let root = resolve_bernini_model_dir(settings)?;
+    match bernini_tier_subdir(&root, bits) {
+        Some(tier) => Ok((tier, None)),
+        None => Ok((root, legacy_quant)),
+    }
+}
+
+/// Parse `advanced.mlxQuantize` (int or numeric string) for the Bernini tier selector — the raw bits
+/// the tier order keys on (the video lane's twin of the image lane's `resolve_bernini_image_quant`
+/// bits). `resolve_bernini_quant` maps the same value to a `Quant`; this keeps the tier selection and
+/// the legacy load-time quant in sync off one source.
+#[cfg(target_os = "macos")]
+fn bernini_quant_bits(request: &VideoRequest) -> Option<i64> {
+    request
+        .advanced
+        .get("mlxQuantize")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()))
+}
+
+/// On-demand fetch of a non-default Bernini quant-matrix tier subdir (sc-9945, mirrors
+/// [`ensure_wan_tier_present`]). The macOS default download is the lean `q4/` tier; a job that opts into
+/// a heavier tier (`mlxQuantize <= 0` ⇒ `bf16`, `>= 8` ⇒ `q8`) pulls just that subdir from the FIXED
+/// [`BERNINI_REVISION`] the first time it is requested so [`bernini_tier_subdir`] can resolve it. No-op
+/// for a `q4` (default) job, when the repo snapshot isn't downloaded yet (resolve surfaces the clear
+/// error), or when the tier is already complete. Fails loud on a real download error — fast, before any
+/// compute; a missing `hf` CLI leaves the tier absent so resolve falls back to a smaller complete tier.
+#[cfg(target_os = "macos")]
+pub(crate) async fn ensure_bernini_tier_present(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    bits: Option<i64>,
+) -> WorkerResult<()> {
+    let tier = match bits {
+        Some(b) if b <= 0 => "bf16",
+        Some(b) if b >= 8 => "q8",
+        // q4 default — ships with the base install, nothing to fetch on demand.
+        _ => return Ok(()),
+    };
+    let Some(root) = huggingface_snapshot_dir(&settings.data_dir, BERNINI_REPO) else {
+        return Ok(());
+    };
+    if bernini_tier_is_complete(&root.join(tier)) {
+        return Ok(());
+    }
+    let scratch = settings
+        .data_dir
+        .join("cache")
+        .join(format!(".bernini-tier-{tier}-fetch-{}", job.id));
+    tokio::fs::create_dir_all(&scratch).await?;
+    let files = vec![format!("{tier}/*")];
+    let result = crate::model_jobs::download_model_with_hf_cli(
+        api,
+        settings,
+        job,
+        BERNINI_REPO,
+        BERNINI_REVISION,
+        &files,
+        &scratch,
+    )
+    .await;
+    let _ = tokio::fs::remove_dir_all(&scratch).await;
+    result.map(|_| ())
+}
+
 /// Raw-settings recorded on a real MLX Bernini asset (mirrors `wan_raw_settings`).
 #[cfg(target_os = "macos")]
 fn bernini_raw_settings(request: &VideoRequest) -> Value {
@@ -5417,12 +5576,19 @@ async fn generate_bernini(
     let negative_prompt = non_empty_negative_prompt(request);
     let conditioning =
         resolve_bernini_conditioning(api, settings, job, request, project_path).await?;
+    // sc-9945: fetch the requested quant tier subdir (q8/bf16) if it isn't the shipped q4 default, then
+    // descend into it — a pre-packed tier loads with `quant = None` (config sidecars authoritative); a
+    // legacy flat snapshot keeps load-time quant.
+    let bits = bernini_quant_bits(request);
+    ensure_bernini_tier_present(api, settings, job, bits).await?;
+    let (model_dir, quant) =
+        resolve_bernini_tier_dir_and_quant(settings, bits, resolve_bernini_quant(request))?;
     let input = VideoGenInput {
         sampler: None,
         scheduler: None,
         engine_id,
-        model_dir: resolve_bernini_model_dir(settings)?,
-        quant: resolve_bernini_quant(request),
+        model_dir,
+        quant,
         conditioning,
         prompt: request.prompt.clone(),
         negative_prompt,
@@ -9703,6 +9869,62 @@ mod tests {
             Some((WAN_I2V_14B_REPO, WAN_I2V_14B_REVISION))
         );
         assert_eq!(wan_tier_repo("bernini"), None);
+    }
+
+    /// sc-9945: the Bernini quant-matrix repo must pin an exact commit (not the mutable `main`) so an
+    /// upstream re-push can't swap a checkpoint the on-demand tier fetch loads. INTENTIONALLY red until
+    /// the tiers are hosted and `BERNINI_REVISION` is pinned to the real commit (mirrors sc-9941's flow).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn bernini_tier_revision_is_pinned_commit_not_main() {
+        assert_ne!(
+            BERNINI_REVISION, "main",
+            "the Bernini tier repo must pin a fixed revision before release"
+        );
+        assert_eq!(
+            BERNINI_REVISION.len(),
+            40,
+            "a pinned HF revision is a 40-char commit sha"
+        );
+        assert!(
+            BERNINI_REVISION
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+            "the pinned Bernini revision must be lowercase hex"
+        );
+    }
+
+    /// sc-9945: a COMPLETE Bernini tier (all [`BERNINI_TIER_FILES`], incl. the planner's nested
+    /// `mllm/tokenizer.json`) resolves for the requested quant, and a missing preferred tier falls
+    /// through to the next smaller complete tier — never silently to the wrong one. Composite: the three
+    /// packable weights live in the SAME tier subdir as the dense remainder, so one resolution covers
+    /// both the planner and the renderer.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn bernini_tier_subdir_resolves_complete_tier() {
+        let root = std::env::temp_dir().join(format!("bernini-tier-test-{}", std::process::id()));
+        std::fs::remove_dir_all(&root).ok();
+        let make_tier = |tier: &str| {
+            for file in BERNINI_TIER_FILES {
+                let path = root.join(tier).join(file);
+                std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+                std::fs::write(&path, b"x").unwrap();
+            }
+        };
+        make_tier("q4");
+        make_tier("q8");
+
+        // Default (no bits) → q4.
+        assert_eq!(bernini_tier_subdir(&root, None), Some(root.join("q4")));
+        // Q8 (bits >= 8) → q8.
+        assert_eq!(bernini_tier_subdir(&root, Some(8)), Some(root.join("q8")));
+        // bf16 (bits <= 0) with no bf16 tier falls back to q8 (never silently to a default).
+        assert_eq!(bernini_tier_subdir(&root, Some(0)), Some(root.join("q8")));
+        // An incomplete tier (missing the nested planner tokenizer) is not resolved.
+        std::fs::remove_file(root.join("q8").join("mllm/tokenizer.json")).unwrap();
+        assert_eq!(bernini_tier_subdir(&root, Some(8)), Some(root.join("q4")));
+
+        std::fs::remove_dir_all(&root).ok();
     }
 
     /// The single-expert TI2V-5B tier (sc-9941) is COMPLETE with one `model.safetensors` (not the


### PR DESCRIPTION
## What
Brings **Bernini** to the catalog-wide quant matrix (epic 8506) — the last heavy tail model. Both catalog ids (`bernini` video + `bernini_image` still) now resolve self-contained `q4/` (default) / `q8/` / `bf16/` tier subdirs on `SceneWorks/bernini-mlx`, loading pre-packed with **no dense-staging peak** (the flat layout staged the ~56 GB experts + ~14 GB planner backbone as bf16, then quantized at load).

## The composite twist
Unlike the three Wan quant-matrix siblings (#1204/#1211/#1216, which needed **zero** mlx-gen change), Bernini is a composite — a Qwen2.5-VL planner + a dual-expert Wan renderer. The renderer already loaded pre-packed, but the **planner loader was not packed-aware**, so pre-packing it required an mlx-gen change:
- mlx-gen SceneWorks/mlx-gen#658 (merged) — `quantize_qwen_planner_backbone` + a packed-aware `Qwen25VlText` loader.
- candle-gen SceneWorks/candle-gen#355 (merged) — gen-core lockstep re-pin (byte-identical) so the worker's `--features backend-candle` skew gate resolves a single gen-core rev.

## Worker changes
- **Pins:** every `mlx-gen*` + `sceneworks-gen-core` → `4f425de` (mlx-gen #658, the bernini delta only — deliberately not main HEAD, which has merged the unrelated kolors #659); all `candle-gen*` → `3f21734` (candle-gen #355). Skew gate verified single-rev.
- **`video_jobs.rs`:** `bernini_tier_*` machinery mirroring `wan_tier_*` — repo/rev consts, the composite completeness file set (planner components + both experts + shared dense T5/VAE + config sidecars + `mllm/tokenizer.json`), tier order/subdir resolve, on-demand fetch. `resolve_bernini_tier_dir_and_quant` returns `quant=None` for a packed tier (config sidecars authoritative), root + load-time quant for a legacy flat snapshot. Keyed on raw `mlxQuantize` bits so the image lane shares it.
- **Wired on BOTH load paths:** `generate_bernini` (video) + `generate_bernini_image_stream` (image). The image lane parses raw tier bits (its `quant_bits` is `None` for both bf16 and the q4 default, which the tier order must tell apart).
- **`bernini_tier_build.rs`** (`#[ignore]` on-device): derives all three tiers worker-side from the lean bf16 snapshot — quantize the planner backbone + both experts, copy the dense remainder, patch the two config sidecars.
- **Manifest:** per-tier `q4`(default)/`q8`/`bf16` downloads + footprint for both ids, with **exact hosted sizes** (q4 37,815,703,819 / q8 55,129,270,617 / bf16 87,591,990,679).

## Hosted + verified on-device
Tiers built + uploaded to `SceneWorks/bernini-mlx` @ **`533d688f16c8f33dc832890c1e16c11921a2019a`** (pinned, ungated). Each tier verified through the real `gen_core::load("bernini")` seam:
- **q4 / q8 / bf16** — all load packed + generate a non-degenerate 512² image.
- **q4 video** — loads packed + generates a clip (video lane).

## Checks
`cargo test -p sceneworks-worker --lib` = **647 passed / 0 failed / 146 ignored** (incl. the now-green pinned-commit guard + the `bernini_manifest_ships_the_quant_matrix` gate for both ids). `cargo fmt --check` ✅ · `cargo clippy --lib --tests` ✅ · gen-core skew gate resolves a single rev under `--features backend-candle`.

Legacy flat-root cleanup tracked separately (analog of sc-9977 for the Wan tiers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)