### PR TITLE
feat: PiD 2K/4K output tier — selectable, catalog-wide (sc-10054, sc-10055)

### DIFF
--- a/apps/web/src/components/CharacterAdvancedOptions.jsx
+++ b/apps/web/src/components/CharacterAdvancedOptions.jsx
@@ -72,6 +72,11 @@ export function useCharacterAdvancedOptions(
   // when the model is PiD-eligible AND its checkpoint is installed (showPidToggle), so a stale `true`
   // on a non-eligible model is inert — same gating discipline as ImageStudio.
   const [usePid, setUsePid] = React.useState(false);
+  // PiD output tier (sc-10054): PiD super-resolves the base render 4×, so this picks the output size —
+  // "4k" (~4096px, the default) or "2k" (~2048px, faster + less GPU memory). Rides `advanced.pidTarget`,
+  // emitted only when the toggle is shown+on AND "2k" is picked ("4k" is the worker default). Mirrors
+  // Image Studio.
+  const [pidTarget, setPidTarget] = React.useState("4k");
   const showPidToggle = pidToggleVisible(model, catalog);
 
   // Reset the model-derived tuning whenever the backbone changes so a value from a
@@ -117,6 +122,11 @@ export function useCharacterAdvancedOptions(
     // super-resolve; mirrors Image Studio. A stale `true` on a hidden toggle stays inert.
     if (showPidToggle && usePid) {
       advanced.usePid = true;
+      // PiD output tier (sc-10054): "4k" is the worker default, so only "2k" is emitted — keeps existing
+      // usePid recipes byte-identical.
+      if (pidTarget === "2k") {
+        advanced.pidTarget = "2k";
+      }
     }
     return advanced;
   }
@@ -144,6 +154,8 @@ export function useCharacterAdvancedOptions(
     setNegativePrompt,
     usePid,
     setUsePid,
+    pidTarget,
+    setPidTarget,
     showPidToggle,
     model,
     identityStructure,
@@ -184,6 +196,8 @@ export function CharacterAdvancedOptions({ state }) {
     setNegativePrompt,
     usePid,
     setUsePid,
+    pidTarget,
+    setPidTarget,
     showPidToggle,
     model,
     identityStructure,
@@ -311,17 +325,34 @@ export function CharacterAdvancedOptions({ state }) {
             <textarea onChange={(event) => setNegativePrompt(event.target.value)} rows={3} value={negativePrompt} />
           </label>
           {showPidToggle ? (
-            <label
-              className="checkline pid-decoder-toggle"
-              title="Decode this generation through NVIDIA's PiD pixel-diffusion decoder instead of the model's VAE: it decodes and super-resolves in one pass, so output comes out at 2K/4K (sharper detail, but slower and more memory). Non-commercial use only — PiD output is licensed for research/evaluation, unlike the rest of the pipeline. Off = the model's native VAE at the selected resolution."
-            >
-              <input
-                checked={usePid}
-                onChange={(event) => setUsePid(event.target.checked)}
-                type="checkbox"
-              />
-              PiD decoder · 2K/4K <span className="badge badge-nc">Non-Commercial</span>
-            </label>
+            <>
+              <label
+                className="checkline pid-decoder-toggle"
+                title="Decode this generation through NVIDIA's PiD pixel-diffusion decoder instead of the model's VAE: it decodes and super-resolves in one pass to 2K or 4K (pick the tier at right — sharper detail, but slower and more memory). Non-commercial use only — PiD output is licensed for research/evaluation, unlike the rest of the pipeline. Off = the model's native VAE at the selected resolution."
+              >
+                <input
+                  checked={usePid}
+                  onChange={(event) => setUsePid(event.target.checked)}
+                  type="checkbox"
+                />
+                PiD decoder <span className="badge badge-nc">Non-Commercial</span>
+              </label>
+              {usePid ? (
+                <label
+                  className="pid-target-select"
+                  title="PiD super-resolves the base render 4×, so this sets the output size: 4K (~4096px, max detail) or 2K (~2048px, faster and less GPU memory). Both are super-resolved from the model's latent."
+                >
+                  Output
+                  <select
+                    onChange={(event) => setPidTarget(event.target.value)}
+                    value={pidTarget}
+                  >
+                    <option value="4k">4K · max detail</option>
+                    <option value="2k">2K · faster</option>
+                  </select>
+                </label>
+              ) : null}
+            </>
           ) : null}
         </div>
       ) : null}

--- a/apps/web/src/imageJobAdvanced.js
+++ b/apps/web/src/imageJobAdvanced.js
@@ -42,6 +42,7 @@ export function buildImageJobAdvanced(state) {
     // PiD decoder (epic 7840).
     showPidToggle,
     usePid,
+    pidTarget,
     // Character-reference knobs.
     mode,
     referenceAssetId,
@@ -146,6 +147,10 @@ export function buildImageJobAdvanced(state) {
     // rawAdapterSettings — that recorded `usePid:true` is the output's non-commercial
     // marker. The worker independently no-ops to the native VAE if the checkpoint is gone.
     ...(showPidToggle && usePid ? { usePid: true } : {}),
+    // PiD output tier (sc-10054): PiD super-resolves the base render 4×, so the tier sets the output
+    // size by capping the effective base. Emit `pidTarget:"2k"` only when the PiD toggle is shown+on AND
+    // 2K is picked; "4k" is the worker default, so omitting it keeps existing usePid recipes byte-identical.
+    ...(showPidToggle && usePid && pidTarget === "2k" ? { pidTarget: "2k" } : {}),
     // IP-Adapter / InstantID reference strength only applies when a character
     // reference is attached AND the model uses the IP-Adapter knob; Qwen's
     // edit pipeline ignores this scalar (hideReferenceStrength gates it out).

--- a/apps/web/src/imageJobAdvanced.test.js
+++ b/apps/web/src/imageJobAdvanced.test.js
@@ -163,6 +163,24 @@ describe("buildImageJobAdvanced", () => {
     expect(buildImageJobAdvanced(offState({ showPidToggle: true, usePid: true })).usePid).toBe(true);
   });
 
+  it("emits pidTarget only for a shown+on PiD toggle set to 2k (4k is the worker default)", () => {
+    // 2K → emitted alongside usePid.
+    const twoK = buildImageJobAdvanced(offState({ showPidToggle: true, usePid: true, pidTarget: "2k" }));
+    expect(twoK.pidTarget).toBe("2k");
+    expect(twoK.usePid).toBe(true);
+    // 4K (default) → omitted, keeping existing usePid recipes byte-identical.
+    expect(buildImageJobAdvanced(offState({ showPidToggle: true, usePid: true, pidTarget: "4k" }))).not.toHaveProperty(
+      "pidTarget",
+    );
+    // 2K but PiD off / toggle hidden → never emitted (can't shrink a native-VAE gen).
+    expect(buildImageJobAdvanced(offState({ showPidToggle: true, usePid: false, pidTarget: "2k" }))).not.toHaveProperty(
+      "pidTarget",
+    );
+    expect(buildImageJobAdvanced(offState({ showPidToggle: false, usePid: true, pidTarget: "2k" }))).not.toHaveProperty(
+      "pidTarget",
+    );
+  });
+
   it("embeds a structured-prompt recipe only for structured submissions", () => {
     expect(buildImageJobAdvanced(offState({ sendStructured: false }))).not.toHaveProperty("structuredPrompt");
     const structured = buildImageJobAdvanced(

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -432,6 +432,11 @@ export function ImageStudio() {
   // toggle only renders + emits when the model is PiD-eligible AND its checkpoint is installed
   // (showPidToggle), so a stale `true` on a non-eligible model is inert — mirrors bf16Precision.
   const [usePid, setUsePid] = useState(saved.usePid ?? false);
+  // PiD output tier (epic 7840, sc-10054): PiD always super-resolves the base latent 4×, so this picks
+  // the effective base — "4k" keeps the requested base (~4096 output, the pre-tier behavior), "2k" caps
+  // it (~2048 output, faster + less GPU memory). Sticky pref, default "4k". Rides `advanced.pidTarget`
+  // (emitted only when the PiD toggle is shown+on AND "2k" is picked — "4k" is the worker default).
+  const [pidTarget, setPidTarget] = useState(saved.pidTarget === "2k" ? "2k" : "4k");
   const [faceRestore, setFaceRestore] = useState(false);
   // User-created poses (reserved global project) join the built-in library in both
   // the picker and the id→keypoints resolver below, so saved poses can generate.
@@ -1267,6 +1272,7 @@ export function ImageStudio() {
     enhancePrompt,
     bf16Precision,
     usePid,
+    pidTarget,
     lastUsedTiers,
   });
 
@@ -1433,6 +1439,7 @@ export function ImageStudio() {
           quantTier,
           showPidToggle,
           usePid,
+          pidTarget,
           mode,
           referenceAssetId,
           hideReferenceStrength,
@@ -2144,18 +2151,35 @@ export function ImageStudio() {
                   </label>
                 ) : null}
                 {showPidToggle ? (
-                  <label
-                    className="checkline pid-decoder-toggle"
-                    title="Decode this generation through NVIDIA's PiD pixel-diffusion decoder instead of the model's VAE: it decodes and super-resolves in one pass, so output comes out at 2K/4K (sharper detail, but slower and more memory). Non-commercial use only — PiD output is licensed for research/evaluation, unlike the rest of the pipeline. Off = the model's native VAE at the selected resolution."
-                  >
-                    <input
-                      checked={usePid}
-                      disabled={upscaleEnabled}
-                      onChange={(event) => setUsePid(event.target.checked)}
-                      type="checkbox"
-                    />
-                    PiD decoder · 2K/4K <span className="badge badge-nc">Non-Commercial</span>
-                  </label>
+                  <>
+                    <label
+                      className="checkline pid-decoder-toggle"
+                      title="Decode this generation through NVIDIA's PiD pixel-diffusion decoder instead of the model's VAE: it decodes and super-resolves in one pass to 2K or 4K (pick the tier at right — sharper detail, but slower and more memory). Non-commercial use only — PiD output is licensed for research/evaluation, unlike the rest of the pipeline. Off = the model's native VAE at the selected resolution."
+                    >
+                      <input
+                        checked={usePid}
+                        disabled={upscaleEnabled}
+                        onChange={(event) => setUsePid(event.target.checked)}
+                        type="checkbox"
+                      />
+                      PiD decoder <span className="badge badge-nc">Non-Commercial</span>
+                    </label>
+                    {usePid ? (
+                      <label
+                        className="pid-target-select"
+                        title="PiD super-resolves the base render 4×, so this sets the output size: 4K (~4096px, max detail) or 2K (~2048px, faster and less GPU memory). Both are super-resolved from the model's latent."
+                      >
+                        Output
+                        <select
+                          onChange={(event) => setPidTarget(event.target.value)}
+                          value={pidTarget}
+                        >
+                          <option value="4k">4K · max detail</option>
+                          <option value="2k">2K · faster</option>
+                        </select>
+                      </label>
+                    ) : null}
+                  </>
                 ) : null}
                 <label
                   className="checkline upscale-toggle"

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -1387,6 +1387,44 @@ describe("ImageStudio PiD decoder toggle (sc-7851)", () => {
     await click(generateButton());
     expect(createImageJob.mock.calls[1][0].advanced.usePid).toBe(true);
   });
+
+  const pidTargetSelect = () => document.body.querySelector(".pid-target-select select");
+
+  it("reveals the 2K/4K output selector only when PiD is on (default 4K)", async () => {
+    await render(baseContext({ imageModels: [PID_QWEN], models: [PID_QWEN, PID_CKPT("installed")] }));
+    await openAdvanced();
+    await act(async () => {});
+    // Off → no selector.
+    expect(pidTargetSelect()).toBeFalsy();
+    // On → selector appears, defaulting to 4k.
+    await act(async () => pidLabel().querySelector('input[type="checkbox"]').click());
+    expect(pidTargetSelect()).toBeTruthy();
+    expect(pidTargetSelect().value).toBe("4k");
+  });
+
+  it("emits advanced.pidTarget:'2k' only when 2K is picked (4K default omits it)", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    await render(
+      baseContext({ createImageJob, imageModels: [PID_QWEN], models: [PID_QWEN, PID_CKPT("installed")] }),
+    );
+    await openAdvanced();
+    await act(async () => {});
+    await act(async () => pidLabel().querySelector('input[type="checkbox"]').click());
+
+    // Default 4K → usePid but no pidTarget.
+    await click(generateButton());
+    expect(createImageJob.mock.calls[0][0].advanced.usePid).toBe(true);
+    expect(createImageJob.mock.calls[0][0].advanced).not.toHaveProperty("pidTarget");
+
+    // Pick 2K → pidTarget:"2k" rides advanced.
+    await act(async () => {
+      const select = pidTargetSelect();
+      select.value = "2k";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await click(generateButton());
+    expect(createImageJob.mock.calls[1][0].advanced.pidTarget).toBe("2k");
+  });
 });
 
 describe("ImageStudio strict-control panel (epic 8236, sc-8245)", () => {

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -3034,6 +3034,10 @@ async fn generate_stream(
     // the native VAE. `use_pid` and `spec.pid` stay in lockstep (the engine rejects a mismatch).
     let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
     let use_pid = pid_weights.is_some();
+    // PiD output tier (sc-10054): PiD super-resolves the base latent by a fixed 4×, so the effective
+    // base picks whether the output lands on ~2K or ~4K. `4k`/native leave the requested dims untouched;
+    // `2k` caps the base (also lowering the F-013 decode peak). Rebind before `generate_one`.
+    let (width, height) = pid_effective_dims(width, height, use_pid, pid_output_tier(request));
     let mut spec = load_spec(weights_dir, quant, adapters, flux_ip_dir);
     if let Some(pid) = pid_weights {
         spec = spec.with_pid(pid.checkpoint, pid.gemma);
@@ -3527,6 +3531,9 @@ async fn generate_candle_stream(
         resolve_pid_weights(request, &settings.data_dir, &request.model)?
     };
     let use_pid = pid_weights.is_some();
+    // PiD output tier (sc-10054): 2K caps the effective base so PiD's fixed 4× lands on ~2048 (default
+    // 4K/native leaves the requested dims untouched). Rebind before `generate_one`.
+    let (width, height) = pid_effective_dims(width, height, use_pid, pid_output_tier(request));
     let mut spec = load_spec(weights_dir, quant, adapters, None);
     if let Some(pid) = pid_weights {
         spec = spec.with_pid(pid.checkpoint, pid.gemma);

--- a/crates/sceneworks-worker/src/image_jobs/candle_strict_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/candle_strict_control.rs
@@ -48,6 +48,14 @@ trait CandleStrictControl: Send + 'static {
     /// The short `start_gen_stream` tag (`zimage_control` / `flux2_control` / `qwen_control`).
     fn stream_tag(&self) -> &'static str;
 
+    /// The output base dimensions for this generation: the geometry the control map (pose skeleton /
+    /// canny / depth) is rendered at, and the size the provider generates. Normally the request's W×H;
+    /// a PiD `2k` output tier (sc-10054) caps them so PiD's fixed 4× lands on ~2048. These MUST equal the
+    /// provider's stored `width`/`height` (used inside `generate_one`), or the control map and the latent
+    /// misalign — so each impl returns exactly those fields.
+    fn out_width(&self) -> u32;
+    fn out_height(&self) -> u32;
+
     /// Load the provider on the blocking thread (download already happened in the async preamble).
     fn load(&self) -> WorkerResult<Self::Model>;
 
@@ -114,7 +122,9 @@ async fn run_candle_strict_control<P: CandleStrictControl>(
     let poses = parse_poses(request);
     let pose_count = poses.len();
 
-    let (width, height) = (request.width, request.height);
+    // Render the control map + generate at the provider's output dims (normally the request's W×H; a PiD
+    // 2K output tier caps them — sc-10054). The provider's stored dims and these are the same value.
+    let (width, height) = (provider.out_width(), provider.out_height());
     let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
     // One shared seed across the pose set (the MLX `_generate_pose_set` convention) so noise-derived
     // attributes (hair, wardrobe, lighting) stay constant while only the pose changes. `resolve_seed`

--- a/crates/sceneworks-worker/src/image_jobs/flux1_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux1_control_candle.rs
@@ -242,6 +242,14 @@ impl CandleStrictControl for Flux1StrictControl {
         "flux1_control"
     }
 
+    fn out_width(&self) -> u32 {
+        self.width
+    }
+
+    fn out_height(&self) -> u32 {
+        self.height
+    }
+
     fn load(&self) -> WorkerResult<Self::Model> {
         let paths = Flux1ControlPaths {
             flux_base: self.base.clone(),

--- a/crates/sceneworks-worker/src/image_jobs/flux2_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_control_candle.rs
@@ -248,6 +248,14 @@ impl CandleStrictControl for Flux2StrictControl {
         "flux2_control"
     }
 
+    fn out_width(&self) -> u32 {
+        self.width
+    }
+
+    fn out_height(&self) -> u32 {
+        self.height
+    }
+
     fn load(&self) -> WorkerResult<Self::Model> {
         let paths = Flux2ControlPaths {
             root: self.base.clone(),
@@ -337,6 +345,12 @@ async fn generate_candle_flux2_control_stream(
     // Per-generation PiD decode (epic 7840, sc-8044): resolve the `flux2` PiD student + Gemma when
     // `advanced.usePid` is set and the snapshots are cached; else `None` → native FLUX.2 VAE.
     let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
+    let use_pid = pid_weights.is_some();
+    // PiD output tier (sc-10054): 2K caps the effective base so PiD's fixed 4× lands on ~2048 (default
+    // 4K/native leaves the requested dims untouched). The shared driver renders the control map at these
+    // same dims (via `out_width`/`out_height`), keeping control + latent aligned.
+    let (width, height) =
+        pid_effective_dims(request.width, request.height, use_pid, pid_output_tier(request));
     let mut raw_settings = flux2_control_candle_raw_settings(
         request,
         &repo,
@@ -347,15 +361,15 @@ async fn generate_candle_flux2_control_stream(
         pose_count,
     );
     // Mark PiD output on the sidecar (NSCLv1 NC flows to PiD output); record whether PiD actually ran.
-    raw_settings.insert("usePid".to_owned(), Value::Bool(pid_weights.is_some()));
+    raw_settings.insert("usePid".to_owned(), Value::Bool(use_pid));
 
     let provider = Flux2StrictControl {
         base,
         control,
         quant,
         prompt: request.prompt.clone(),
-        width: request.width,
-        height: request.height,
+        width,
+        height,
         steps,
         guidance,
         control_scale,

--- a/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
@@ -237,7 +237,13 @@ async fn generate_candle_flux2_edit_stream(
         ));
     }
     let is_dev = is_flux2_edit_candle_dev(&request.model);
-    let (width, height) = (request.width, request.height);
+    // Per-generation PiD decode (epic 7840, sc-8044) + output tier (sc-10054), resolved BEFORE the
+    // references are loaded/fit so a 2K tier sizes the effective base and the edit references land at THAT
+    // base (references + latent stay aligned). `use_pid`/`with_pid` stay paired below.
+    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
+    let use_pid = pid_weights.is_some();
+    let (width, height) =
+        pid_effective_dims(request.width, request.height, use_pid, pid_output_tier(request));
     let references = load_flux2_edit_references(request, project_path, settings, width, height)?;
 
     // dev (32B) loads Q4 (manifest `mlx.quantize: 4` → `resolve_quant`); klein loads dense. The dev
@@ -266,11 +272,8 @@ async fn generate_candle_flux2_edit_stream(
         },
     );
     let repo = flux2_edit_candle_repo(request);
-    // Per-generation PiD decode (epic 7840, sc-8044): resolve the `flux2` PiD student + Gemma when
-    // `advanced.usePid` is set and the snapshots are cached; else `None` → native FLUX.2 VAE. `use_pid`
-    // and the engine's `with_pid` load stay in lockstep (the engine rejects a mismatch).
-    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
-    let use_pid = pid_weights.is_some();
+    // `pid_weights`/`use_pid`/`width`/`height` were resolved above (ahead of the reference fit) so the
+    // PiD output tier (sc-10054) could size the effective base; `use_pid`/`with_pid` stay in lockstep.
     let mut raw_settings =
         flux2_edit_candle_raw_settings(request, &repo, steps, guidance, quant_bits, references.len());
     // Mark PiD output on the sidecar (NSCLv1 NC flows to PiD output); record whether PiD actually ran.

--- a/crates/sceneworks-worker/src/image_jobs/instantid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/instantid.rs
@@ -673,6 +673,15 @@ async fn generate_instantid_stream(
     // Per-image work items: (seed, prompt, action). Pose + angle sets share one seed (only the
     // pose changes across the set — noise-derived attributes stay constant); single identity is
     // per-seed at the reference's natural pose.
+    //
+    // PiD output tier (sc-10054): when PiD runs, 2K caps the effective base so its fixed 4× lands on
+    // ~2048 (default 4K/native leaves the requested dims untouched). The skeleton/keypoints render at
+    // this same base, so control + latent stay aligned. Gated to the PiD-capable face backends (where
+    // `use_pid` + the helpers exist); the no-face build keeps the requested dims verbatim.
+    #[cfg(any(target_os = "macos", all(not(target_os = "macos"), feature = "backend-candle")))]
+    let (width, height) =
+        pid_effective_dims(request.width, request.height, use_pid, pid_output_tier(request));
+    #[cfg(not(any(target_os = "macos", all(not(target_os = "macos"), feature = "backend-candle"))))]
     let (width, height) = (request.width, request.height);
     let work: Vec<(i64, String, InstantIdAction)> = match &mode {
         InstantIdMode::PoseSet(_) => {

--- a/crates/sceneworks-worker/src/image_jobs/kolors_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_control.rs
@@ -239,6 +239,14 @@ impl CandleStrictControl for KolorsStrictControl {
         "kolors_control"
     }
 
+    fn out_width(&self) -> u32 {
+        self.width
+    }
+
+    fn out_height(&self) -> u32 {
+        self.height
+    }
+
     fn load(&self) -> WorkerResult<Self::Model> {
         let paths = KolorsControlPaths {
             kolors_base: self.kolors_base.clone(),
@@ -349,18 +357,24 @@ async fn generate_candle_kolors_control_stream(
     // Per-generation PiD decode (epic 7840, sc-8044): resolve the `sdxl` PiD student + Gemma when
     // `advanced.usePid` is set and the snapshots are cached; else `None` → native SDXL VAE.
     let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
+    let use_pid = pid_weights.is_some();
+    // PiD output tier (sc-10054): 2K caps the effective base so PiD's fixed 4× lands on ~2048 (default
+    // 4K/native leaves the requested dims untouched). The shared driver renders the control map at these
+    // same dims (via `out_width`/`out_height`), keeping control + latent aligned.
+    let (width, height) =
+        pid_effective_dims(request.width, request.height, use_pid, pid_output_tier(request));
     let mut raw_settings =
         kolors_control_raw_settings(request, &repo, steps, guidance, control_scale, pose_count);
     // Mark PiD output on the sidecar (NSCLv1 NC flows to PiD output); record whether PiD actually ran.
-    raw_settings.insert("usePid".to_owned(), Value::Bool(pid_weights.is_some()));
+    raw_settings.insert("usePid".to_owned(), Value::Bool(use_pid));
 
     let provider = KolorsStrictControl {
         kolors_base,
         controlnet,
         prompt: request.prompt.clone(),
         negative: request.negative_prompt.clone(),
-        width: request.width,
-        height: request.height,
+        width,
+        height,
         steps,
         guidance,
         control_scale,

--- a/crates/sceneworks-worker/src/image_jobs/pid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pid.rs
@@ -87,6 +87,65 @@ fn pid_backbone_for(model: &str) -> Option<&'static str> {
     }
 }
 
+/// PiD super-resolves the sampler latent by a FIXED 4× (`mlx_gen_pid` `sr_scale`, baked into every
+/// released student), so the *output* image is always `effective_base × 4`. There is no engine knob for
+/// the factor — the only lever on the output resolution is the base fed to the decode. `advanced.pidTarget`
+/// (opt-in, opaque pass-through like `usePid`) picks which tier that base×4 lands on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PidOutputTier {
+    /// ~2048-px-ceiling output: the effective base long side is capped to 512 (×4 = 2048). Lower
+    /// pixel-space decode peak (F-013 memory-relief valve).
+    Res2k,
+    /// `base × 4` at the requested base, untouched — the default and the byte-identical pre-sc-10054
+    /// behavior (a typical 1024 base → 4096 output).
+    Res4k,
+}
+
+/// PiD's fixed spatial super-resolution factor (`mlx_gen_pid` `sr_scale`). Output pixels = base × this.
+const PID_SR_SCALE: u32 = 4;
+/// Base-dimension granularity for the 2K tier. Every PiD-eligible engine requires the base width/height
+/// to be a multiple of at least 16 (`mlx-gen-flux` `model.rs` validates `is_multiple_of(16)`; the flux2
+/// packed latent is coarser). Snap the down-scaled 2K base to 32 so it stays legal for ALL backbones.
+const PID_DIM_MULTIPLE: u32 = 32;
+
+/// Resolve the requested PiD output tier from `advanced.pidTarget` (sc-10054). Default + any
+/// unrecognized value → `Res4k` (today's full-resolution behavior); only an explicit `"2k"` opts down.
+fn pid_output_tier(request: &ImageRequest) -> PidOutputTier {
+    match request
+        .advanced
+        .get("pidTarget")
+        .and_then(Value::as_str)
+        .map(str::trim)
+    {
+        Some(tier) if tier.eq_ignore_ascii_case("2k") => PidOutputTier::Res2k,
+        _ => PidOutputTier::Res4k,
+    }
+}
+
+/// The effective base (pre-super-resolve) dimensions to hand the engine so PiD's `base × 4` output lands
+/// on `tier`. Only reshapes when PiD actually runs (`use_pid`) AND the caller asked for `2k`; otherwise
+/// returns the request dims unchanged (the byte-identical default path — so a stray `pidTarget` on a
+/// non-PiD generation can never shrink a native-VAE image). For `2k`, scales the requested aspect down
+/// so the longer output side is ~2048 (base long side ≤ 512), snapping each side to `PID_DIM_MULTIPLE`
+/// (min 256). Never upscales: a base already at/under the 2K ceiling is left as-is.
+fn pid_effective_dims(width: u32, height: u32, use_pid: bool, tier: PidOutputTier) -> (u32, u32) {
+    if !use_pid || tier == PidOutputTier::Res4k {
+        return (width, height);
+    }
+    let base_cap = 2048 / PID_SR_SCALE; // 512: max base long side for a ~2K output
+    let longest = width.max(height);
+    if longest <= base_cap {
+        return (width, height);
+    }
+    let scale = f64::from(base_cap) / f64::from(longest);
+    let snap = |v: u32| {
+        let scaled = (f64::from(v) * scale).round();
+        let rounded = (scaled / f64::from(PID_DIM_MULTIPLE)).round() as u32 * PID_DIM_MULTIPLE;
+        rounded.max(256)
+    };
+    (snap(width), snap(height))
+}
+
 /// True when the request opted into the PiD decoder via `advanced.usePid` (an opaque pass-through bool,
 /// like `mlxQuantize` / `schedulerShift` — no top-level `ImageRequest` field, so zero contract-snapshot
 /// drift). Accepts a JSON bool or the string `"true"`.
@@ -217,6 +276,88 @@ mod pid_tests {
         // No PiD backbone → silently ignored (SenseNova is autoregressive, no VAE latent).
         assert_eq!(pid_backbone_for("sensenova_u1_8b"), None);
         assert_eq!(pid_backbone_for("bernini_image"), None);
+    }
+
+    #[test]
+    fn pid_output_tier_defaults_to_4k_and_reads_2k() {
+        // Default (no key) + explicit 4k + garbage → Res4k; only "2k" (case-insensitive) → Res2k.
+        assert_eq!(
+            pid_output_tier(&request("qwen_image", json!({}))),
+            PidOutputTier::Res4k
+        );
+        assert_eq!(
+            pid_output_tier(&request("qwen_image", json!({ "pidTarget": "4k" }))),
+            PidOutputTier::Res4k
+        );
+        assert_eq!(
+            pid_output_tier(&request("qwen_image", json!({ "pidTarget": "8k" }))),
+            PidOutputTier::Res4k
+        );
+        assert_eq!(
+            pid_output_tier(&request("qwen_image", json!({ "pidTarget": "2K" }))),
+            PidOutputTier::Res2k
+        );
+    }
+
+    #[test]
+    fn pid_effective_dims_passthrough_unless_2k_and_pid() {
+        // Non-PiD, or 4k tier → request dims untouched (byte-identical default; no shrink of a native
+        // VAE image even if pidTarget leaks in).
+        assert_eq!(
+            pid_effective_dims(1024, 1024, false, PidOutputTier::Res2k),
+            (1024, 1024)
+        );
+        assert_eq!(
+            pid_effective_dims(1024, 1024, true, PidOutputTier::Res4k),
+            (1024, 1024)
+        );
+    }
+
+    #[test]
+    fn pid_effective_dims_2k_caps_base_to_512_long_side() {
+        // 1024² base → 512² (×4 = 2048² output). Aspect preserved, snapped to /32.
+        assert_eq!(
+            pid_effective_dims(1024, 1024, true, PidOutputTier::Res2k),
+            (512, 512)
+        );
+        // 16:9 (1024×576) → longest 1024 halves to 512; 576→288 (both /32) → 2048×1152 output.
+        assert_eq!(
+            pid_effective_dims(1024, 576, true, PidOutputTier::Res2k),
+            (512, 288)
+        );
+        // Portrait mirror.
+        assert_eq!(
+            pid_effective_dims(576, 1024, true, PidOutputTier::Res2k),
+            (288, 512)
+        );
+        // A base already at/under the 2K ceiling is left as-is (never upscaled).
+        assert_eq!(
+            pid_effective_dims(512, 512, true, PidOutputTier::Res2k),
+            (512, 512)
+        );
+        assert_eq!(
+            pid_effective_dims(384, 256, true, PidOutputTier::Res2k),
+            (384, 256)
+        );
+    }
+
+    #[test]
+    fn pid_effective_dims_2k_stays_dimension_legal() {
+        // Every reshaped side must remain a multiple of 16 (the strictest engine requirement) and ≥256,
+        // across a spread of requested bases — else the engine rejects the base (mlx-gen-flux model.rs).
+        for (w, h) in [
+            (4096u32, 4096u32),
+            (2048, 1024),
+            (1536, 1024),
+            (1024, 768),
+            (2048, 512),
+            (4096, 256),
+        ] {
+            let (ew, eh) = pid_effective_dims(w, h, true, PidOutputTier::Res2k);
+            assert!(ew.is_multiple_of(16) && eh.is_multiple_of(16), "{ew}x{eh} not /16");
+            assert!(ew >= 256 && eh >= 256, "{ew}x{eh} below min");
+            assert!(ew.max(eh) <= 512, "{ew}x{eh} base long side exceeds 2K cap");
+        }
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/image_jobs/pid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pid.rs
@@ -92,7 +92,7 @@ fn pid_backbone_for(model: &str) -> Option<&'static str> {
 /// the factor — the only lever on the output resolution is the base fed to the decode. `advanced.pidTarget`
 /// (opt-in, opaque pass-through like `usePid`) picks which tier that base×4 lands on.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PidOutputTier {
+pub(crate) enum PidOutputTier {
     /// ~2048-px-ceiling output: the effective base long side is capped to 512 (×4 = 2048). Lower
     /// pixel-space decode peak (F-013 memory-relief valve).
     Res2k,
@@ -110,7 +110,7 @@ const PID_DIM_MULTIPLE: u32 = 32;
 
 /// Resolve the requested PiD output tier from `advanced.pidTarget` (sc-10054). Default + any
 /// unrecognized value → `Res4k` (today's full-resolution behavior); only an explicit `"2k"` opts down.
-fn pid_output_tier(request: &ImageRequest) -> PidOutputTier {
+pub(crate) fn pid_output_tier(request: &ImageRequest) -> PidOutputTier {
     match request
         .advanced
         .get("pidTarget")
@@ -128,7 +128,12 @@ fn pid_output_tier(request: &ImageRequest) -> PidOutputTier {
 /// non-PiD generation can never shrink a native-VAE image). For `2k`, scales the requested aspect down
 /// so the longer output side is ~2048 (base long side ≤ 512), snapping each side to `PID_DIM_MULTIPLE`
 /// (min 256). Never upscales: a base already at/under the 2K ceiling is left as-is.
-fn pid_effective_dims(width: u32, height: u32, use_pid: bool, tier: PidOutputTier) -> (u32, u32) {
+pub(crate) fn pid_effective_dims(
+    width: u32,
+    height: u32,
+    use_pid: bool,
+    tier: PidOutputTier,
+) -> (u32, u32) {
     if !use_pid || tier == PidOutputTier::Res4k {
         return (width, height);
     }

--- a/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
@@ -339,7 +339,10 @@ async fn generate_candle_pulid_stream(
     raw_settings.insert("usePid".to_owned(), Value::Bool(use_pid));
 
     // Per-image work items: (seed, prompt) — `request.count` images at the reference identity.
-    let (width, height) = (request.width, request.height);
+    // PiD output tier (sc-10054): 2K caps the effective base so PiD's fixed 4× lands on ~2048 (default
+    // 4K/native leaves the requested dims untouched).
+    let (width, height) =
+        pid_effective_dims(request.width, request.height, use_pid, pid_output_tier(request));
     let work: Vec<(i64, String)> = (0..request.count as usize)
         .map(|index| (resolve_seed(request, index), request.prompt.clone()))
         .collect();

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -257,14 +257,19 @@ async fn generate_qwen_control_stream(
     .await;
 
     let prompt = request.prompt.clone();
-    let (width, height) = (request.width, request.height);
-    let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
-    let adapter_count = adapters.len();
     // Per-generation PiD decode (epic 7840, sc-7849): the strict-pose control engine shares the
     // `qwenimage` latent space, so route its decode through PiD when `advanced.usePid` is set and the
-    // snapshots are cached; otherwise native VAE. `use_pid` and `spec.pid` stay in lockstep.
+    // snapshots are cached; otherwise native VAE. `use_pid` and `spec.pid` stay in lockstep. Resolved
+    // before the dims so the PiD output tier (sc-10054) can size the base — the pose skeleton is
+    // rendered at that same base, so control + latent stay aligned.
     let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
     let use_pid = pid_weights.is_some();
+    // PiD output tier (sc-10054): 2K caps the effective base so PiD's fixed 4× lands on ~2048 (default
+    // 4K/native leaves the requested dims untouched).
+    let (width, height) =
+        pid_effective_dims(request.width, request.height, use_pid, pid_output_tier(request));
+    let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
+    let adapter_count = adapters.len();
     let mut spec = qwen_control_spec(weights_dir, control_weights, quant, adapters);
     if let Some(pid) = pid_weights {
         spec = spec.with_pid(pid.checkpoint, pid.gemma);
@@ -694,15 +699,21 @@ async fn generate_qwen_edit_stream(
             "Qwen-Image-Edit requires a reference image".to_owned(),
         ));
     }
-    // sc-3030 fit_image: pre-fit the Image-Edit source to the output W×H (crop / pad /
+    // Per-generation PiD decode (epic 7840, sc-7849) + output tier (sc-10054). Resolved here, ahead of
+    // the source pre-fit and generation, so a 2K tier sizes the effective base and the Image-Edit source
+    // is fit to THAT base — source and latent stay in lockstep. `use_pid`/`spec.pid` stay paired below.
+    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
+    let use_pid = pid_weights.is_some();
+    let (width, height) =
+        pid_effective_dims(request.width, request.height, use_pid, pid_output_tier(request));
+
+    // sc-3030 fit_image: pre-fit the Image-Edit source to the (effective) output W×H (crop / pad /
     // outpaint→pad) so an off-aspect edit doesn't stretch. Character-Studio references
     // stay native (the `should_fit_edit_source` gate excludes them).
     if should_fit_edit_source(request) {
         references = references
             .into_iter()
-            .map(|reference| {
-                fit_engine_image(reference, request.width, request.height, &request.fit_mode)
-            })
+            .map(|reference| fit_engine_image(reference, width, height, &request.fit_mode))
             .collect::<WorkerResult<Vec<_>>>()?;
     }
 
@@ -758,14 +769,10 @@ async fn generate_qwen_edit_stream(
     let likeness_source = (score_likeness && face_stack_dir.is_some()).then(|| references[0].clone());
     let likeness_source_ref = reference_ids.first().cloned();
 
-    let (width, height) = (request.width, request.height);
+    // `width`/`height`, `pid_weights`, and `use_pid` were resolved above (ahead of the source pre-fit)
+    // so the PiD output tier could size the effective base; reuse them here for the skeleton + spec.
     let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
     let adapter_count = adapters.len();
-    // Per-generation PiD decode (epic 7840, sc-7849): Qwen-Image-Edit shares the `qwenimage` latent
-    // space, so route its decode through PiD when `advanced.usePid` is set and the snapshots are
-    // cached; otherwise native VAE. `use_pid` and `spec.pid` stay in lockstep.
-    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
-    let use_pid = pid_weights.is_some();
     let mut spec = load_spec(weights_dir, quant, adapters, None);
     if let Some(pid) = pid_weights {
         spec = spec.with_pid(pid.checkpoint, pid.gemma);

--- a/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
@@ -266,6 +266,14 @@ impl CandleStrictControl for QwenStrictControl {
         "qwen_control"
     }
 
+    fn out_width(&self) -> u32 {
+        self.width
+    }
+
+    fn out_height(&self) -> u32 {
+        self.height
+    }
+
     fn load(&self) -> WorkerResult<Self::Model> {
         let paths = QwenFunControlPaths {
             qwen_base: self.qwen_base.clone(),

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
@@ -195,7 +195,13 @@ async fn generate_candle_sdxl_edit_stream(
             "SDXL edit requires edit_image mode + a source image".to_owned(),
         )
     })?;
-    let (width, height) = (request.width, request.height);
+    // Per-generation PiD decode (epic 7840, sc-8044) + output tier (sc-10054), resolved BEFORE the
+    // source/mask fit so a 2K tier sizes the effective base and the edit source + mask are fit to THAT
+    // base (source, mask, and latent stay aligned). `use_pid`/`with_pid` stay paired at the load below.
+    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
+    let use_pid = pid_weights.is_some();
+    let (width, height) =
+        pid_effective_dims(request.width, request.height, use_pid, pid_output_tier(request));
     let source = load_sdxl_edit_source(request, project_path, settings)?;
 
     let is_inpaint = matches!(
@@ -278,15 +284,10 @@ async fn generate_candle_sdxl_edit_stream(
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| sdxl_edit_candle_default_repo(&request.model))
         .to_owned();
-    // Per-generation PiD decode (epic 7840, sc-8044): resolve the `sdxl` PiD student + Gemma when
-    // `advanced.usePid` is set and the snapshots are cached; else `None` → native VAE. SDXL edit composes
-    // the SDXL VAE, so it shares the one `sdxl` student. The inpaint/outpaint mask blend runs in latent
-    // space and ends in a single decode, so PiD sees the same final latent as the VAE path — the output
-    // is just 2K/4K. `use_pid` and the engine's `with_pid` load stay in lockstep (the engine rejects a
-    // mismatch).
-    let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
-    let use_pid = pid_weights.is_some();
-
+    // `pid_weights`/`use_pid`/`width`/`height` were resolved above (ahead of the source+mask fit) so the
+    // PiD output tier (sc-10054) could size the effective base. SDXL edit composes the SDXL VAE, so it
+    // shares the one `sdxl` student; the inpaint/outpaint mask blend ends in a single decode, so PiD sees
+    // the same final latent as the VAE path — the output is just the tier's 2K/4K.
     let mut raw_settings =
         sdxl_edit_candle_raw_settings(request, &repo, steps, guidance, strength, mode_tag);
     // Mark PiD output on the sidecar (epic 7840): the NSCLv1 non-commercial restriction flows to PiD-

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
@@ -299,7 +299,10 @@ async fn generate_candle_sdxl_ipadapter_stream(
     raw_settings.insert("usePid".to_owned(), Value::Bool(use_pid));
 
     // Per-image work items: (seed, prompt) — `request.count` images at the reference identity.
-    let (width, height) = (request.width, request.height);
+    // PiD output tier (sc-10054): 2K caps the effective base so PiD's fixed 4× lands on ~2048 (default
+    // 4K/native leaves the requested dims untouched).
+    let (width, height) =
+        pid_effective_dims(request.width, request.height, use_pid, pid_output_tier(request));
     let work: Vec<(i64, String)> = (0..request.count as usize)
         .map(|index| (resolve_seed(request, index), request.prompt.clone()))
         .collect();

--- a/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
@@ -305,6 +305,14 @@ impl CandleStrictControl for ZImageStrictControl {
         "zimage_control"
     }
 
+    fn out_width(&self) -> u32 {
+        self.width
+    }
+
+    fn out_height(&self) -> u32 {
+        self.height
+    }
+
     fn load(&self) -> WorkerResult<Self::Model> {
         let paths = ZImageControlPaths {
             snapshot: self.snapshot.clone(),
@@ -413,6 +421,12 @@ async fn generate_candle_zimage_control_stream(
     // Per-generation PiD decode (epic 7840, sc-8044): resolve the `zimage-turbo`/`flux` PiD student + Gemma
     // when `advanced.usePid` is set and the snapshots are cached; else `None` → native Z-Image VAE.
     let pid_weights = resolve_pid_weights(request, &settings.data_dir, &request.model)?;
+    let use_pid = pid_weights.is_some();
+    // PiD output tier (sc-10054): 2K caps the effective base so PiD's fixed 4× lands on ~2048 (default
+    // 4K/native leaves the requested dims untouched). The shared driver renders the control map at these
+    // same dims (via `out_width`/`out_height`), keeping control + latent aligned.
+    let (width, height) =
+        pid_effective_dims(request.width, request.height, use_pid, pid_output_tier(request));
     let mut raw_settings = zimage_control_raw_settings(
         request,
         &repo,
@@ -423,14 +437,14 @@ async fn generate_candle_zimage_control_stream(
         guidance,
     );
     // Mark PiD output on the sidecar (NSCLv1 NC flows to PiD output); record whether PiD actually ran.
-    raw_settings.insert("usePid".to_owned(), Value::Bool(pid_weights.is_some()));
+    raw_settings.insert("usePid".to_owned(), Value::Bool(use_pid));
 
     let provider = ZImageStrictControl {
         snapshot: base,
         controlnet,
         prompt: request.prompt.clone(),
-        width: request.width,
-        height: request.height,
+        width,
+        height,
         steps,
         control_scale,
         is_base,

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -252,6 +252,13 @@ mod lens_base_q4_mlx_smoke;
 // never quantizes its T5, so no denseTextEncoderTier). hd/flash share this crate + layout.
 #[cfg(all(test, target_os = "macos"))]
 mod chroma1_base_q4_mlx_smoke;
+// Real-weight MLX smoke for the PiD 2K/4K output tier (epic 7840, sc-10054). Test-only + macOS-only;
+// drives the REAL `pid_output_tier` + `pid_effective_dims` mapping then renders z_image_turbo through
+// `gen_core::load(...).with_pid(pid_flux, gemma)` + `use_pid`, asserting `pidTarget:"2k"` yields a 2048²
+// image (base 512 × 4) and `"4k"` yields 4096² (base 1024 × 4) — the on-device evidence that the tier
+// mapping actually changes the output resolution on real weights.
+#[cfg(all(test, target_os = "macos"))]
+mod pid_tier_mlx_smoke;
 // On-device per-tier memory-footprint measurement harness (sc-8516, epic 8506). Test-only + macOS-only;
 // #[ignore]d real-weight smokes that drive `gen_core::load(id)` + ONE generation while sampling the MLX
 // process-global memory counters (mlx_rs::memory::{reset_peak_memory, get_active_memory, get_peak_memory})

--- a/crates/sceneworks-worker/src/pid_tier_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/pid_tier_mlx_smoke.rs
@@ -1,0 +1,189 @@
+//! Local real-weight MLX smoke for the **PiD 2K/4K output tier** (epic 7840, sc-10054). `#[ignore]`d —
+//! run by hand on an Apple-Silicon Mac. It is the on-device evidence that the sc-10054 base-resolution
+//! mapping actually yields a 2K image at `pidTarget:"2k"` and a 4K image at `"4k"`, on real weights.
+//!
+//! What it proves end-to-end: PiD super-resolves the sampler latent by a FIXED 4×, so the only lever on
+//! output size is the base fed to the decode. The worker translates `advanced.pidTarget` into that base
+//! via `pid_output_tier` + `pid_effective_dims` (the REAL functions, called here — not a re-derivation).
+//! For a 1024² request: `"4k"` keeps base 1024 → 4096² output; `"2k"` caps base to 512 → 2048² output.
+//! Rendering through the same `gen_core::load(...).with_pid(...)` + `GenerationRequest.use_pid` seam the
+//! worker lanes use confirms the engine emits exactly `effective_base × 4`.
+//!
+//! Uses `z_image_turbo` (8-step distilled, CFG-free — the fastest PiD-eligible MLX model) whose FLUX.1
+//! latent space decodes through the `pid-flux` student (Z-Image aliases `pid_flux`; there is no dedicated
+//! `pid_zimage`). All three snapshots (z-image-turbo-mlx bf16 + NC pid-flux + gemma-2-2b-it) auto-resolve
+//! from the HF cache; override with env if needed.
+//! ```text
+//! # optional: PID_TIER_BASE=/path/to/z-image-turbo-mlx (root containing bf16/, or the bf16/ dir)
+//! # optional: PID_TIER_CKPT=/path/to/pid_flux_2kto4k.safetensors  PID_TIER_GEMMA=/path/to/gemma-2-2b-it
+//! # optional: PID_TIER_STEPS=8  PID_TIER_OUT=/tmp/pid_tier_smoke  PID_TIER_PROMPT="..."
+//! cargo test -p sceneworks-worker --release pid_tier_mlx_gpu_smoke -- --ignored --nocapture
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use gen_core::{GenerationOutput, GenerationRequest, Image, LoadSpec, WeightsSource};
+use sceneworks_core::image_request::ImageRequest;
+use serde_json::json;
+
+use super::image_jobs::{pid_effective_dims, pid_output_tier};
+use super::smoke_support::{env_or, image_std, save_png, DEGENERATE_STD_FLOOR_DEFAULT};
+
+/// Find the newest snapshot dir of a cached `SceneWorks/<repo>` HF model whose `probe` relative path
+/// exists, or `None` if the repo/tier isn't pulled.
+fn cached_snapshot(repo_dir: &str, probe: &str) -> Option<PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+    let snapshots = PathBuf::from(home)
+        .join(".cache/huggingface/hub")
+        .join(repo_dir)
+        .join("snapshots");
+    std::fs::read_dir(&snapshots)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|dir| dir.join(probe).exists())
+}
+
+/// Resolve the z-image-turbo-mlx engine root: prefer `<root>/bf16` (the tiered turnkey layout), else the
+/// root itself if it already carries the engine (`transformer/`).
+fn resolve_base_dir(root: &Path) -> PathBuf {
+    let bf16 = root.join("bf16");
+    if bf16.join("transformer").is_dir() {
+        return bf16;
+    }
+    assert!(
+        root.join("transformer").is_dir(),
+        "PID_TIER_BASE must be a z-image-turbo-mlx turnkey root (containing bf16/) or a bf16/ engine dir \
+         with transformer/; neither found under {}",
+        root.display()
+    );
+    root.to_path_buf()
+}
+
+/// Render one image through the z_image_turbo MLX generator with the PiD decoder attached (`use_pid`),
+/// at the given base `w`×`h`. The PiD student super-resolves the decode 4×, so the returned image is
+/// `w*4`×`h*4`.
+fn render_pid(spec: &LoadSpec, w: u32, h: u32, steps: u32, prompt: &str) -> Image {
+    let generator =
+        gen_core::load("z_image_turbo", spec).expect("load mlx z_image_turbo generator");
+    let req = GenerationRequest {
+        prompt: prompt.to_owned(),
+        width: w,
+        height: h,
+        count: 1,
+        seed: Some(42),
+        steps: Some(steps),
+        use_pid: true,
+        ..Default::default()
+    };
+    let mut last = String::new();
+    let output = generator
+        .generate(&req, &mut |p| {
+            let s = format!("{p:?}");
+            if s != last {
+                println!("[progress] {s}");
+                last = s;
+            }
+        })
+        .expect("z_image_turbo PiD generate");
+    match output {
+        GenerationOutput::Images(mut images) => images.pop().expect("engine returned no image"),
+        other => panic!("expected Images output, got {other:?}"),
+    }
+}
+
+/// Build the `ImageRequest` a `pidTarget` job carries, so the tier resolution below runs the REAL parse
+/// (`advanced.pidTarget` → `PidOutputTier`) and not a hand-rolled copy.
+fn request_with_tier(tier: &str) -> ImageRequest {
+    ImageRequest::from_payload(
+        json!({
+            "model": "z_image_turbo",
+            "width": 1024,
+            "height": 1024,
+            "advanced": { "usePid": true, "pidTarget": tier },
+        })
+        .as_object()
+        .unwrap(),
+    )
+}
+
+#[test]
+#[ignore = "real-weight MLX smoke; needs SceneWorks/{z-image-turbo-mlx bf16, pid-flux, gemma-2-2b-it} cached + an Apple-Silicon Mac"]
+fn pid_tier_mlx_gpu_smoke() {
+    let base_root = match std::env::var("PID_TIER_BASE") {
+        Ok(p) if !p.trim().is_empty() => PathBuf::from(p.trim()),
+        _ => cached_snapshot("models--SceneWorks--z-image-turbo-mlx", "bf16/transformer")
+            .unwrap_or_else(|| {
+                panic!("no cached SceneWorks/z-image-turbo-mlx bf16 tier; set PID_TIER_BASE")
+            }),
+    };
+    let base_dir = resolve_base_dir(&base_root);
+    let ckpt = match std::env::var("PID_TIER_CKPT") {
+        Ok(p) if !p.trim().is_empty() => PathBuf::from(p.trim()),
+        _ => cached_snapshot(
+            "models--SceneWorks--pid-flux",
+            "pid_flux_2kto4k.safetensors",
+        )
+        .map(|d| d.join("pid_flux_2kto4k.safetensors"))
+        .unwrap_or_else(|| panic!("no cached SceneWorks/pid-flux; set PID_TIER_CKPT")),
+    };
+    let gemma = match std::env::var("PID_TIER_GEMMA") {
+        Ok(p) if !p.trim().is_empty() => PathBuf::from(p.trim()),
+        _ => cached_snapshot("models--SceneWorks--gemma-2-2b-it", "config.json")
+            .unwrap_or_else(|| panic!("no cached SceneWorks/gemma-2-2b-it; set PID_TIER_GEMMA")),
+    };
+    let out_dir = PathBuf::from(env_or("PID_TIER_OUT", "/tmp/pid_tier_smoke"));
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+    let steps: u32 = env_or("PID_TIER_STEPS", "8")
+        .parse()
+        .expect("PID_TIER_STEPS");
+    let prompt = env_or(
+        "PID_TIER_PROMPT",
+        "a serene mountain lake at golden hour, crisp reflections, highly detailed",
+    );
+
+    let spec = LoadSpec::new(WeightsSource::Dir(base_dir.clone())).with_pid(
+        WeightsSource::File(ckpt.clone()),
+        WeightsSource::Dir(gemma.clone()),
+    );
+
+    // Drive the REAL sc-10054 mapping for each tier: a 1024² request → effective base → base×4 output.
+    for (tier, expected_out) in [("2k", 2048u32), ("4k", 4096u32)] {
+        let req = request_with_tier(tier);
+        let (bw, bh) = pid_effective_dims(req.width, req.height, true, pid_output_tier(&req));
+        println!(
+            "[smoke] pidTarget={tier}: 1024x1024 request -> effective base {bw}x{bh} -> expect {expected_out}x{expected_out} out"
+        );
+        assert_eq!(
+            (bw, bh),
+            (expected_out / 4, expected_out / 4),
+            "sc-10054 mapping produced the wrong effective base for pidTarget={tier}"
+        );
+
+        let img = render_pid(&spec, bw, bh, steps, &prompt);
+        let std = image_std(&img);
+        let png = out_dir.join(format!("pid_{tier}_{}x{}.png", img.width, img.height));
+        save_png(&img, &png);
+        println!(
+            "[smoke] pidTarget={tier}: rendered {}x{} std {:.2} -> {}",
+            img.width,
+            img.height,
+            std,
+            png.display()
+        );
+        assert_eq!(
+            (img.width, img.height),
+            (expected_out, expected_out),
+            "PiD output for pidTarget={tier} must be effective_base x4 ({expected_out}); got {}x{}",
+            img.width,
+            img.height
+        );
+        assert!(
+            std > DEGENERATE_STD_FLOOR_DEFAULT,
+            "PiD {tier} render looks degenerate (std {std:.2}) — check pid-flux + gemma snapshots"
+        );
+    }
+    println!(
+        "[smoke] DONE: sc-10054 tier mapping verified on real weights — 2k -> 2048² and 4k -> 4096² via pid_flux"
+    );
+}


### PR DESCRIPTION
## What & why
PiD was advertised as "2K/4K" but effectively only ever produced 4K, because PiD super-resolves the latent by a **fixed 4×** — so output = `base × 4`, and the base is almost always 1024 (→4096). This adds a real, user-selectable **2K / 4K output tier** across the whole PiD-eligible catalog, with **no new weights**.

Closes the "give the user options for both" ask under epic 7840 (Option A). Option B (dedicated `2k`-tuned flux/flux2 checkpoints) remains as sc-10056–10058.

## How
- **Worker (sc-10054):** new `advanced.pidTarget` (`2k`|`4k`, default `4k`) → `pid_output_tier` + `pid_effective_dims` map it to the effective base. `4k` leaves the requested dims untouched (**byte-identical** to today); `2k` caps the base long side to 512 (~2048 output), aspect-preserved, `/32`-snapped, only-downscale. Lowering the base also lowers the F-013 pixel-space decode peak, so **2K doubles as a memory-relief valve**. Rides the opaque `advanced` map → zero rust-api contract-snapshot drift.
  - Wired into **all 12 PiD lanes** (MLX + candle t2i, Qwen control/edit, InstantID, sdxl-ipadapter, pulid, sdxl-edit, flux2-edit, and the 3 candle strict-control lanes via a new `out_width`/`out_height` on the `CandleStrictControl` trait so the control skeleton renders at the effective base, aligned with the latent). Edit/control lanes hoist the PiD resolution above their source pre-fit.
- **Web (sc-10055):** the descriptive "PiD decoder · 2K/4K" copy becomes a real **Output: 4K / 2K** selector (Image Studio + Character Studio), shown only when the eligibility-gated PiD toggle is on. Emits `pidTarget:"2k"` only when 2K is picked — omitting `4k` keeps existing `usePid` recipes byte-identical.

## Verification
- **On-device (Apple-Silicon Mac, real weights)** — `pid_tier_mlx_smoke.rs` drives the *actual* mapping + renders z_image_turbo through pid-flux:
  - `pidTarget=2k` → base 512 → **rendered 2048×2048** (std 65.88), coherent
  - `pidTarget=4k` → base 1024 → **rendered 4096×4096** (std 65.59), coherent
- Worker unit tests: **10/10** `pid_tests` (4 new tier tests)
- Candle parity `cargo check --no-default-features -F backend-candle --all-targets`: clean
- `cargo clippy -p sceneworks-worker --all-targets -- -D warnings`: clean · `cargo fmt --check`: clean
- Web: **1197/1197** vitest (new pidTarget emission + selector tests) · `eslint src`: 0 errors

## Notes
- Merged `origin/main` (not rebased); one trivial `lib.rs` smoke-registration conflict resolved (kept both `pid_tier_mlx_smoke` + `sana_mlx_smoke`).
- Commits: worker mapping · web selector · on-device smoke · merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)