### PR TITLE
feat(web): Lightning fast-4-step toggle for Wan A14B video studio (sc-10048, epic 10043)

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -46,6 +46,13 @@ export const PROMPT_REFINE_MODEL_ID = "prompt_refine_anubis_8b";
 // this id to look up install state and offer a download in the caption dialog when missing.
 export const JOY_CAPTION_MODEL_ID = "joycaption_beta_one";
 
+// Wan2.2 A14B MoE video engines (T2V + I2V). These two dual-expert models honor the
+// Lightning fast-4-step toggle (sc-10047/sc-10048, epic 10043) — the worker derives the
+// 4-step/CFG-off recipe from `advanced.lightning` for them and ignores it for the dense
+// 5B (wan_2_2) and non-Wan engines, so the UI only surfaces the toggle for these ids.
+// (Mirrors ModelManagerScreen's WAN_MOE_BASE_MODELS, which is the LoRA-pairing subset.)
+export const WAN_A14B_LIGHTNING_MODEL_IDS = new Set(["wan_2_2_t2v_14b", "wan_2_2_i2v_14b"]);
+
 // Vision captioner (epic 8102, sc-8107/8108). Turns an uploaded reference image into a structured
 // Ideogram-style JSON caption (style + grounded composition) for Ideogram 4 text-to-image variations.
 // As with PROMPT_REFINE_MODEL_ID, the native worker resolves the model by its HF repo string (carried

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -69,7 +69,7 @@ import { ReplacePersonPanel } from "./ReplacePersonPanel.jsx";
 import { useAppContext } from "../context/AppContext.js";
 import { ModelAvailabilityGate } from "../components/ModelAvailabilityGate.jsx";
 import { downloadOffersFor, videoModelUsable } from "../modelEligibility.js";
-import { PROMPT_REFINE_MODEL_ID } from "../constants.js";
+import { PROMPT_REFINE_MODEL_ID, WAN_A14B_LIGHTNING_MODEL_IDS } from "../constants.js";
 import {
   DEFAULT_MAC_CAPABILITIES,
   macAvailableModels,
@@ -236,6 +236,12 @@ export function VideoStudio() {
   const [schedulerShift, setSchedulerShift] = useState(saved.schedulerShift ?? 3.0);
   const [stepsOverride, setStepsOverride] = useState(saved.steps ?? "");
   const [guidanceOverride, setGuidanceOverride] = useState(saved.guidanceScale ?? "");
+  // Lightning fast-4-step toggle for Wan2.2 A14B MoE (T2V + I2V) — epic 10043, sc-10048.
+  // Default ON: the worker (sc-10047) reads `advanced.lightning` and, when on, derives the
+  // 4-step / CFG-off distilled recipe; when off it honors the user's steps/guidance (or the
+  // native multi-step CFG default). Only the two A14B engines honor it (see showLightning),
+  // so the dense 5B and non-Wan models never see the control. Persisted per-workspace.
+  const [lightning, setLightning] = useState(saved.lightning ?? true);
   // LTX-2.3 native guidance knobs (epic 1753 sc-1769). The native ltx-core
   // path has no diffusers scheduler to swap — these three values (cfg + STG +
   // rescale) drive its sealed MultiModalGuiderParams instead.
@@ -286,6 +292,12 @@ export function VideoStudio() {
   // per-platform default (Q8_0 on MPS, Q4_K_M on CUDA).
   const quantVariants = Object.entries(selectedModel?.quantization?.variants ?? {});
   const supportsQuantization = quantVariants.length > 0;
+  // Lightning is only meaningful for the two Wan2.2 A14B MoE engines (T2V + I2V); the dense
+  // 5B and every non-Wan engine ignore `advanced.lightning`, so hide the control there
+  // (sc-10048, epic 10043). When it's shown and on, the worker governs steps/guidance with the
+  // 4-step recipe, so the manual Steps/Guidance inputs are disabled to reflect that.
+  const showLightning = WAN_A14B_LIGHTNING_MODEL_IDS.has(selectedModel?.id);
+  const lightningActive = showLightning && lightning;
   const implementedMode = [
     "image_to_video",
     "text_to_video",
@@ -575,6 +587,7 @@ export function VideoStudio() {
     schedulerShift,
     steps: stepsOverride,
     guidanceScale: guidanceOverride,
+    lightning,
     videoCfgGuidanceScale: ltxVideoCfg,
     videoStgGuidanceScale: ltxVideoStg,
     videoRescaleScale: ltxVideoRescale,
@@ -777,10 +790,16 @@ export function VideoStudio() {
           Number.isFinite(Number(schedulerShift))
             ? { schedulerShift: Number(schedulerShift) }
             : {}),
-          ...(stepsOverride !== "" && Number.isFinite(Number(stepsOverride))
+          // Lightning fast-4-step toggle for Wan2.2 A14B MoE (sc-10048, epic 10043). Only the two
+          // A14B engines honor it; emit the explicit bool for them (worker sc-10047 reads
+          // `advanced.lightning`: absent → defaults on, false → off). When on the worker derives
+          // the 4-step/CFG-off recipe, so we suppress the manual steps/guidance overrides below to
+          // keep the payload consistent with the recipe the UI is reflecting.
+          ...(showLightning ? { lightning } : {}),
+          ...(!lightningActive && stepsOverride !== "" && Number.isFinite(Number(stepsOverride))
             ? { steps: Number(stepsOverride) }
             : {}),
-          ...(guidanceOverride !== "" && Number.isFinite(Number(guidanceOverride))
+          ...(!lightningActive && guidanceOverride !== "" && Number.isFinite(Number(guidanceOverride))
             ? { guidanceScale: Number(guidanceOverride) }
             : {}),
           // LTX native guidance knobs (epic 1753 sc-1769). Only emitted for
@@ -1381,6 +1400,23 @@ export function VideoStudio() {
 
               {advancedOpen ? (
                 <div className="advanced-panel">
+                  {showLightning ? (
+                    <div className="lightning-toggle">
+                      <label className="checkline">
+                        <input
+                          checked={lightning}
+                          onChange={(event) => setLightning(event.target.checked)}
+                          type="checkbox"
+                        />
+                        Lightning (fast 4-step)
+                      </label>
+                      <p className="helper-copy">
+                        {lightning
+                          ? "On: ~10× faster, 4 steps, CFG off, small quality trade-off. Steps and guidance are governed by the recipe."
+                          : "Off: full multi-step quality with CFG (slower). Use the Steps and Guidance controls below."}
+                      </p>
+                    </div>
+                  ) : null}
                   {model === ltxVideoModelId ? (
                     <>
                       <label>
@@ -1547,10 +1583,12 @@ export function VideoStudio() {
                     <input
                       min="1"
                       max="80"
+                      disabled={lightningActive}
                       onChange={(event) => setStepsOverride(event.target.value)}
-                      placeholder={String(stepsDefaultFromModel(selectedModel) ?? "")}
+                      placeholder={lightningActive ? "4 (Lightning)" : String(stepsDefaultFromModel(selectedModel) ?? "")}
+                      title={lightningActive ? "Governed by Lightning (fast 4-step). Turn Lightning off to set steps." : undefined}
                       type="number"
-                      value={stepsOverride}
+                      value={lightningActive ? "" : stepsOverride}
                     />
                   </label>
                   <label>
@@ -1558,14 +1596,16 @@ export function VideoStudio() {
                     <input
                       min="0"
                       max="30"
+                      disabled={lightningActive}
                       onChange={(event) => setGuidanceOverride(event.target.value)}
-                      placeholder={(() => {
+                      placeholder={lightningActive ? "off (Lightning)" : (() => {
                         const value = guidanceDefaultFromModel(selectedModel);
                         return value == null ? "" : String(value);
                       })()}
                       step="0.1"
+                      title={lightningActive ? "Governed by Lightning (fast 4-step). Turn Lightning off to set guidance." : undefined}
                       type="number"
-                      value={guidanceOverride}
+                      value={lightningActive ? "" : guidanceOverride}
                     />
                   </label>
                   <label>

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -836,3 +836,174 @@ describe("VideoStudio Mac mode gating (sc-5716)", () => {
     );
   });
 });
+
+// Lightning fast-4-step toggle for Wan2.2 A14B MoE (T2V + I2V) — epic 10043, sc-10048.
+// Renders default-on for the two A14B engines only; maps to advanced.lightning; when on it
+// governs (disables) the manual steps/guidance controls.
+describe("VideoStudio Lightning toggle (sc-10048)", () => {
+  let container;
+  let root;
+
+  // The two A14B MoE engines that honor advanced.lightning (constants.js WAN_A14B_LIGHTNING_MODEL_IDS).
+  const WAN_T2V_14B = {
+    id: "wan_2_2_t2v_14b",
+    name: "Wan2.2 14B (T2V)",
+    type: "video",
+    family: "wan-video",
+    capabilities: ["text_to_video"],
+    defaults: { duration: 5, resolution: "832x480", fps: 16 },
+    limits: { durations: [3, 4, 5], fps: [16], resolutions: ["832x480", "480x832"] },
+    quantization: {},
+    loraCompatibility: {},
+    ui: {},
+  };
+  const WAN_I2V_14B = {
+    ...WAN_T2V_14B,
+    id: "wan_2_2_i2v_14b",
+    name: "Wan2.2 14B (I2V)",
+    capabilities: ["image_to_video", "text_to_video"],
+  };
+  // Dense 5B (single-expert) — ignores advanced.lightning, so no toggle.
+  const WAN_5B = {
+    ...WAN_T2V_14B,
+    id: "wan_2_2",
+    name: "Wan 2.2 (5B)",
+    capabilities: ["text_to_video"],
+  };
+  // A non-Wan engine (LTX) — no toggle.
+  const NON_WAN = {
+    id: "ltx_2_3",
+    name: "LTX 2.3",
+    type: "video",
+    family: "ltx-video",
+    capabilities: ["text_to_video"],
+    defaults: { duration: 6, resolution: "768x512", fps: 25 },
+    limits: {},
+    quantization: {},
+    loraCompatibility: {},
+    ui: {},
+  };
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <VideoStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  // Open the Advanced panel where the toggle + steps/guidance live.
+  const openAdvanced = async () => {
+    await click(buttonWithText(container, "Advanced"));
+  };
+  const lightningLabel = () =>
+    [...container.querySelectorAll(".lightning-toggle label")].find((el) =>
+      el.textContent.includes("Lightning"),
+    );
+  const lightningCheckbox = () => lightningLabel()?.querySelector('input[type="checkbox"]');
+  const labeledInput = (label) =>
+    [...container.querySelectorAll("label")]
+      .find((el) => el.textContent.trim().startsWith(label))
+      ?.querySelector("input");
+
+  it("renders default-on for Wan A14B T2V", async () => {
+    const context = baseContext({ videoModels: [WAN_T2V_14B] });
+    await render(context);
+    await openAdvanced();
+
+    const box = lightningCheckbox();
+    expect(box).toBeTruthy();
+    expect(box.checked).toBe(true);
+  });
+
+  it("renders default-on for Wan A14B I2V", async () => {
+    const context = baseContext({ videoModels: [WAN_I2V_14B] });
+    await render(context);
+    await openAdvanced();
+
+    const box = lightningCheckbox();
+    expect(box).toBeTruthy();
+    expect(box.checked).toBe(true);
+  });
+
+  it("is not rendered for the dense Wan 5B", async () => {
+    const context = baseContext({ videoModels: [WAN_5B] });
+    await render(context);
+    await openAdvanced();
+
+    expect(lightningCheckbox()).toBeFalsy();
+  });
+
+  it("is not rendered for a non-Wan engine", async () => {
+    const context = baseContext({ videoModels: [NON_WAN] });
+    await render(context);
+    await openAdvanced();
+
+    expect(lightningCheckbox()).toBeFalsy();
+  });
+
+  it("sends advanced.lightning = true by default for Wan A14B T2V", async () => {
+    const context = baseContext({ videoModels: [WAN_T2V_14B] });
+    await render(context);
+
+    await click(buttonWithText(container, "Render clip"));
+    expect(context.createVideoJob).toHaveBeenCalledTimes(1);
+    const payload = context.createVideoJob.mock.calls[0][0];
+    expect(payload.model).toBe("wan_2_2_t2v_14b");
+    expect(payload.advanced.lightning).toBe(true);
+    // On → the worker governs steps/guidance, so the UI suppresses the overrides.
+    expect(payload.advanced.steps).toBeUndefined();
+    expect(payload.advanced.guidanceScale).toBeUndefined();
+  });
+
+  it("sends advanced.lightning = false when the toggle is turned off", async () => {
+    const context = baseContext({ videoModels: [WAN_T2V_14B] });
+    await render(context);
+    await openAdvanced();
+
+    await act(async () => lightningCheckbox().click());
+    expect(lightningCheckbox().checked).toBe(false);
+
+    await click(buttonWithText(container, "Render clip"));
+    const payload = context.createVideoJob.mock.calls[0][0];
+    expect(payload.advanced.lightning).toBe(false);
+  });
+
+  it("disables the manual steps/guidance controls while Lightning is on and re-enables them off", async () => {
+    const context = baseContext({ videoModels: [WAN_T2V_14B] });
+    await render(context);
+    await openAdvanced();
+
+    // On (default): governed by the recipe.
+    expect(labeledInput("Steps").disabled).toBe(true);
+    expect(labeledInput("Guidance").disabled).toBe(true);
+
+    // Off: the user's steps/guidance controls become active.
+    await act(async () => lightningCheckbox().click());
+    expect(labeledInput("Steps").disabled).toBe(false);
+    expect(labeledInput("Guidance").disabled).toBe(false);
+  });
+
+  it("does not emit advanced.lightning for a non-Wan engine", async () => {
+    const context = baseContext({ videoModels: [NON_WAN] });
+    await render(context);
+
+    await click(buttonWithText(container, "Render clip"));
+    const payload = context.createVideoJob.mock.calls[0][0];
+    expect(payload.advanced.lightning).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What changed

Surfaces the **Lightning (fast 4-step)** toggle in the Video Studio for the two Wan2.2 **A14B MoE** engines (T2V + I2V), completing the user-facing surface of the epic's Lightning toggle (engine sc-10044/45, worker sc-10047).

- **New shared constant** `WAN_A14B_LIGHTNING_MODEL_IDS` = `{wan_2_2_t2v_14b, wan_2_2_i2v_14b}` in `apps/web/src/constants.js` (mirrors ModelManagerScreen's `WAN_MOE_BASE_MODELS`). The toggle renders **only** for those ids.
- **Default-ON** control in the Advanced panel with the story's helper copy:
  - on = ~10× faster, 4 steps, CFG off, small quality trade-off
  - off = full multi-step quality with CFG (slower)
- **Maps to `advanced.lightning`** (worker sc-10047 reads the free-form `advanced` map): explicit bool emitted for A14B (`true` by default, `false` when off); **omitted** for the dense 5B (`wan_2_2`) and non-Wan engines that ignore the flag.
- **Recipe reflection**: when Lightning is on, the worker derives the 4-step/CFG-off recipe, so the manual **Steps** and **Guidance** inputs are disabled (with an explanatory `title`) and their overrides are suppressed from the payload; when off, those controls are active as before. Placeholders indicate `4 (Lightning)` / `off (Lightning)`.
- Persisted per-workspace via the existing studio settings writer.

## Scope vs acceptance criteria

- [x] Toggle renders default-on for Wan T2V/I2V (A14B); hidden/absent for 5B and non-Wan.
- [x] Flipping it changes the submitted request (`advanced.lightning`; steps/guidance governed by the recipe).
- [x] Vitest coverage for the toggle → request-payload mapping.

Note: the story targets "A14B (T2V + I2V)". The VACE-Fun A14B control model (`wan_2_2_vace_fun_14b`, replace_person only) is intentionally not included — the story scopes to the two T2V/I2V generation engines. If the worker later honors Lightning for VACE-Fun too, adding its id to the shared set is a one-line change.

## Tests

Added a `VideoStudio Lightning toggle (sc-10048)` describe block (7 tests):
- renders default-on for A14B T2V and A14B I2V
- not rendered for the dense 5B and for a non-Wan engine
- default submit → `advanced.lightning === true` (steps/guidance omitted)
- flipped off → `advanced.lightning === false`
- steps/guidance disabled while on, re-enabled when off
- non-Wan engine → `advanced.lightning` omitted

## Verification

- `vitest run` (apps/web) full suite: **1292 passed / 96 files** (29 in VideoStudio, incl. 7 new).
- `eslint` on changed files: **0 errors** (3 pre-existing `react-hooks/exhaustive-deps` warnings on untouched effects at lines 425/443/465).
- Web-only change; no Rust/contract touched.

Closes sc-10048.

🤖 Generated with [Claude Code](https://claude.com/claude-code)