### PR TITLE
feat(worker): PuLID-FLUX MLX consumes the SceneWorks/flux1-dev-mlx tier backbone (sc-9947)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -4530,21 +4530,63 @@
       // alone so it appears solely in the "With character" picker. License: FLUX.1
       // [dev] NC (same posture as the flux_dev built-in).
       "capabilities": ["character_image"],
+      // Per-platform backbone source (sc-9947, epic 8506), mirroring LTX's sc-5608 split:
+      //   - macOS (MLX): the SAME ungated `SceneWorks/flux1-dev-mlx` quant-matrix turnkey the base
+      //     `flux_dev` built-in consumes — self-contained q4/ (default) + q8/ + bf16/ subdirs, each a
+      //     complete from_snapshot tree (packed transformer + CLIP + T5 + VAE + tokenizers). The
+      //     `mlx-gen-pulid` loader delegates its FLUX.1-dev backbone to `mlx_gen_flux::load_flux1`, which
+      //     packed-detects the tier subdir — so PuLID loads the SELECTED packed tier with NO install-time
+      //     convert peak and NO upstream BFL gate. The PuLID adapter / EVA / face stack stay f32 and are
+      //     fetched on demand (mirrors Kolors/InstantID).
+      //   - Windows/Linux (candle): unchanged — the bespoke `candle_gen_pulid::PulidFlux` loader still
+      //     reads the upstream BFL dense layout (`flux1-dev.safetensors` + `ae.safetensors`); its packed
+      //     quant-matrix consumption is a separate epic-9083 slice. So Windows/Linux keep the gated BFL
+      //     download (resolved via the `PULID_CANDLE_FLUX_REPO` const, NOT this manifest `repo`).
       "downloads": [
         {
-          // FLUX.1-dev base (BFL flow + VAE + T5 + CLIP-L); the worker loads the
-          // BFL flux1-dev.safetensors + ae.safetensors directly via the vendored
-          // BFL flow loader (skip the diffusers transformer shards). NC + gated;
-          // the PuLID-FLUX adapter weights (~1.5GB) and the QuanSun EVA-CLIP-L
-          // checkpoint (~1.6GB) are fetched on demand (mirrors Kolors/InstantID).
+          "provider": "huggingface",
+          "repo": "SceneWorks/flux1-dev-mlx",
+          "variant": "q4",
+          "default": true,
+          "files": ["q4/*"],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 9617334683,
+          "footprint": { "diskSizeBytes": 9617334683, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/flux1-dev-mlx",
+          "variant": "q8",
+          "files": ["q8/*"],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 18010071290,
+          "footprint": { "diskSizeBytes": 18010071290, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/flux1-dev-mlx",
+          "variant": "bf16",
+          "files": ["bf16/*"],
+          "platforms": ["macos"],
+          "estimatedSizeBytes": 33746402173,
+          "footprint": { "diskSizeBytes": 33746402173, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          // Windows/Linux candle: the BFL flow + VAE + T5 + CLIP-L; the candle `PulidFlux` loads the
+          // BFL flux1-dev.safetensors + ae.safetensors directly via the vendored flow loader. NC + gated;
+          // the PuLID-FLUX adapter (~1.5GB) + EVA-CLIP-L (~1.6GB) are fetched on demand.
           "provider": "huggingface",
           "repo": "black-forest-labs/FLUX.1-dev",
           "files": [],
+          "default": true,
+          "platforms": ["windows", "linux"],
           "estimatedSizeBytes": 33500000000
         }
       ],
       "paths": {
-        "model": "${HF_CACHE}/black-forest-labs/FLUX.1-dev"
+        // macOS install/display path (the MLX turnkey); Windows/Linux candle resolves the BFL snapshot
+        // via its own const, not this field (mirrors LTX's per-platform paths.model).
+        "model": "${HF_CACHE}/SceneWorks/flux1-dev-mlx"
       },
       "defaults": {
         // sc-2012 spike: 30 steps at guidance 4.0; id_weight=1.0,
@@ -4571,15 +4613,19 @@
       },
       // Native MLX path (sc-3344): PuLID-FLUX runs on the Rust `mlx-gen-pulid` engine — the
       // FLUX.1-dev backbone + the f32 EVA/IDFormer/CA conditioning — retiring the torch MPS path
-      // that drove the old 64 GB gate (an 85.3 GB peak on MPS bf16, sc-2012). Q8 is the default:
-      // near-lossless for identity (engine sc-3076 — Q8 ArcFace 0.6841 ≈ bf16 0.68; the conditioning
-      // stays f32 either way) and far lighter. minMemoryGb mirrors the native `flux_dev` sibling
-      // (42, a measured Q8 FLUX.1-dev gate) plus the ~1.6 GB f32 EVA tower + CA overhead. Q4
-      // (`advanced.mlxQuantize: 4`) drops the backbone to ~6.5 GB for tighter hosts; dense bf16
-      // (`mlxQuantize: 0`) is the sc-2012-exact identity at a higher floor.
+      // that drove the old 64 GB gate (an 85.3 GB peak on MPS bf16, sc-2012). As of sc-9947 the
+      // backbone loads from the `SceneWorks/flux1-dev-mlx` quant-matrix turnkey (see `downloads`):
+      // the worker resolves the SELECTED q4/q8/bf16 tier subdir (`standard_tier_subdir`) and the
+      // packed weights load directly — no install-time convert peak. `quantize: 4` is the DEFAULT
+      // tier (matching the turnkey's `q4` default + the base `flux_dev` sibling): near-lossless for
+      // identity (engine sc-3076 — Q4 ArcFace 0.6835 / Q8 0.6841 ≈ bf16 0.68; the conditioning stays
+      // f32 either way) and the lightest floor (~6.5 GB backbone). Q8 (`advanced.mlxQuantize: 8`) and
+      // dense bf16 (`mlxQuantize: 0`, the sc-2012-exact identity) are user-selectable. minMemoryGb
+      // stays conservative (the measured Q8 `flux_dev` gate + the ~1.6 GB f32 EVA tower + CA overhead);
+      // a follow-up re-measures the now-lighter q4 default on-device.
       "mlx": {
         "minMemoryGb": 44,
-        "quantize": 8
+        "quantize": 4
       },
       "loraCompatibility": {
         // FLUX-family backbone, so flux LoRAs apply (sc-1927: declare a real
@@ -4589,7 +4635,7 @@
       },
       "ui": {
         "label": "PuLID-FLUX (FLUX.1 [dev])",
-        "description": "Identity-preserving FLUX character generation: holds a person's face from a single reference image while the prompt drives scene, pose, and wardrobe. Built on FLUX.1-dev with PuLID's IDFormer cross-attention adapter — the sc-2012 spike measured 0.8016 ArcFace cosine vs reference at id_weight=1.0 / start-cfg=4 (above the InstantID-SDXL no-restore baseline; no face-restoration pass needed). Pick a character with an approved reference image, then raise Variations to explore takes. ~30 steps at guidance 4.0; ~85 GB peak unified memory at 1024². Needs the PuLID-FLUX adapter (~1.5GB) + EVA-CLIP-L (~1.6GB) + antelopev2 face pack, fetched on first use. License: FLUX.1 [dev] non-commercial (gated).",
+        "description": "Identity-preserving FLUX character generation: holds a person's face from a single reference image while the prompt drives scene, pose, and wardrobe. Built on FLUX.1-dev with PuLID's IDFormer cross-attention adapter — the sc-2012 spike measured 0.8016 ArcFace cosine vs reference at id_weight=1.0 / start-cfg=4 (above the InstantID-SDXL no-restore baseline; no face-restoration pass needed). Pick a character with an approved reference image, then raise Variations to explore takes. ~30 steps at guidance 4.0. On Apple Silicon the FLUX.1-dev backbone loads from the ungated SceneWorks quant-matrix rehost at a user-selectable tier (q4 default / q8 / bf16) — the identity conditioning stays full-precision, so even q4 holds the face (ArcFace ~0.68). Needs the PuLID-FLUX adapter (~1.5GB) + EVA-CLIP-L (~1.6GB) + antelopev2 face pack, fetched on first use. License: FLUX.1 [dev] non-commercial.",
         "recommendedFor": ["character_image"],
         // PuLID identity tuning surfaced in the character-image picker. The
         // reference-strength slider drives idWeight (PuLID's identity-strength

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -525,6 +525,13 @@ const STANDARD_TIER_MODELS: &[&str] = &[
     // weights, bf16 resolves to Quant::None). Replaces the gated BFL download + install-time quantize.
     "flux_schnell",
     "flux_dev",
+    // PuLID-FLUX (sc-9947, epic 8506): the MLX lane's FLUX.1-dev backbone now loads from the SAME
+    // `SceneWorks/flux1-dev-mlx` q4/q8/bf16 turnkey as base `flux_dev` (its bespoke `pulid.rs` resolver
+    // calls `standard_tier_subdir` directly; `mlx-gen-pulid` delegates the backbone to `load_flux1`, which
+    // packed-detects the tier). Registering it here makes `uses_standard_tier_layout` true for that
+    // resolver. The candle (Windows/Linux) PuLID lane keeps the upstream dense BFL backbone and never
+    // reaches the base tier path, so this is inert there (epic-9083 covers the candle packed lane).
+    "pulid_flux_dev",
     // Lens / Lens-Turbo (sc-9092, epic 9083 gap #3): the SceneWorks re-hosted `SceneWorks/lens-mlx` /
     // `SceneWorks/lens-turbo-mlx` turnkeys are standard q4/q8/bf16 tiers (their manifests already flag
     // `mlx.standardTierLayout: true`, so `uses_standard_tier_layout` was already true via the manifest —

--- a/crates/sceneworks-worker/src/image_jobs/pulid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid.rs
@@ -18,9 +18,15 @@
 const PULID_MODEL: &str = "pulid_flux_dev";
 /// The mlx-gen registry id the worker loads through `gen_core::load`.
 const PULID_ENGINE_ID: &str = "pulid_flux";
-/// FLUX.1-dev backbone repo when the manifest omits `repo` (the torch `pulid_flux_dev`
-/// MODEL_TARGETS default). NC-gated — same posture as the base `flux_dev` built-in.
-const PULID_FLUX_REPO: &str = "black-forest-labs/FLUX.1-dev";
+/// FLUX.1-dev backbone repo for the MLX path (sc-9947): the SAME ungated `SceneWorks/flux1-dev-mlx`
+/// quant-matrix turnkey the base `flux_dev` built-in consumes — self-contained q4/q8/bf16 tier subdirs,
+/// packed-detected by `mlx_gen_flux::load_flux1` (which `mlx-gen-pulid` delegates the backbone to). This
+/// de-gates PuLID on macOS (no HF token / license-accept, the sc-8669 `flux_dev` precedent) and drops the
+/// install-time convert peak (the packed tier loads directly). The candle (Windows/Linux) lane keeps the
+/// upstream gated dense BFL layout via its own `PULID_CANDLE_FLUX_REPO` const — its packed consumption is a
+/// separate epic-9083 slice — so this const is the MLX-only lever, NOT a shared manifest `repo` (which both
+/// resolvers would read).
+const PULID_FLUX_REPO: &str = "SceneWorks/flux1-dev-mlx";
 /// The PuLID-FLUX adapter checkpoint (IDFormer + PerceiverAttention CA blocks). Public repo,
 /// downloaded directly (the torch path used the same `guozinan/PuLID` / `v0.9.1` weight).
 const PULID_ADAPTER_REPO: &str = "guozinan/PuLID";
@@ -52,10 +58,13 @@ const PULID_MAX_SEQUENCE_LENGTH: u32 = 128;
 /// recipe; mirrors `mlx_instantid` for the InstantID path).
 const PULID_ADAPTER_LABEL: &str = "mlx_pulid_flux";
 
-/// Resolve the FLUX.1-dev backbone snapshot for PuLID-FLUX: an explicit `modelPath` dir wins,
-/// else the HF cache snapshot for the manifest `repo` (default FLUX.1-dev). `None` means the
-/// base is not present, so the job is not MLX-runnable (it stays on the torch path until the
-/// retirement slice removes it). Mirrors `resolve_instantid_sdxl_base`.
+/// Resolve the FLUX.1-dev backbone snapshot for PuLID-FLUX: an explicit `modelPath` dir wins (a
+/// pre-staged complete FLUX dir — used as-is, never tier-resolved), else the HF cache snapshot for the
+/// manifest `repo` (default `SceneWorks/flux1-dev-mlx`, sc-9947). For the quant-matrix turnkey that root
+/// holds `q4/`/`q8/`/`bf16/` tier subdirs, so pick the SELECTED tier via `standard_tier_subdir` — the SAME
+/// resolver the base `flux_dev` MLX lane uses — exactly as `mlx_gen_flux::load_flux1` (which
+/// `mlx-gen-pulid` delegates the backbone to) packed-loads it. `None` means the base is not present, so the
+/// job is not MLX-runnable. Mirrors `resolve_instantid_sdxl_base` + `base::snapshot_dir_for_request`.
 fn resolve_pulid_flux_base(
     request: &ImageRequest,
     settings: &Settings,
@@ -78,7 +87,16 @@ fn resolve_pulid_flux_base(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or(PULID_FLUX_REPO);
-    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
+    let root = huggingface_snapshot_dir(&settings.data_dir, repo);
+    // Quant-matrix turnkey (sc-9947): descend into the selected q4/q8/bf16 tier subdir. A non-turnkey
+    // `repo`/root (no tier subdirs) falls through to the root untouched inside `standard_tier_subdir`.
+    Ok(root.map(|root| {
+        if uses_standard_tier_layout(request) {
+            standard_tier_subdir(&root, request)
+        } else {
+            root
+        }
+    }))
 }
 
 /// True when this is a native-MLX-eligible PuLID-FLUX job: the production model in
@@ -126,32 +144,6 @@ fn pulid_timestep_to_start_cfg(request: &ImageRequest) -> u32 {
         PULID_DEFAULT_TIMESTEP_TO_START_CFG,
         0..=20,
     )
-}
-
-/// Resolve PuLID quantization. **Dense (bf16) is the default** — the torch-parity production
-/// baseline (64 GB-tier; ArcFace cosine ~0.80 @1024²/30-step). Q8/Q4 only on an explicit
-/// `advanced.mlxQuantize` / manifest opt-in, which materially lowers the RAM floor (the FLUX.1-dev
-/// backbone 23.8 → 12 → 6.5 GB; the PuLID conditioning stays f32 either way, so identity is
-/// near-lossless — engine e2e Q8 0.6841 / Q4 0.6835 vs bf16 0.68 @512²). Returns the engine
-/// `Quant` + the recipe bit count.
-fn pulid_quant(request: &ImageRequest) -> (Option<Quant>, Option<i64>) {
-    let raw = request
-        .advanced
-        .get("mlxQuantize")
-        .and_then(quant_int)
-        .or_else(|| {
-            request
-                .model_manifest_entry
-                .get("mlx")
-                .and_then(|mlx| mlx.get("quantize"))
-                .and_then(quant_int)
-        });
-    match raw {
-        Some(bits) if bits > 0 && bits <= 4 => (Some(Quant::Q4), Some(4)),
-        Some(bits) if bits > 4 => (Some(Quant::Q8), Some(8)),
-        // None / 0 / negative → dense bf16 (the default + the validated torch-parity envelope).
-        _ => (None, None),
-    }
 }
 
 /// The resolved engine weight inputs: the three files/dirs the engine reads from its env-var seam.
@@ -316,7 +308,20 @@ async fn generate_pulid_flux_stream(
     let guidance = pulid_guidance(request);
     let id_weight = pulid_id_weight(request);
     let start_cfg = pulid_timestep_to_start_cfg(request);
-    let (quant, recipe_bits) = pulid_quant(request);
+    // Quant-matrix backbone (sc-9947): the FLUX.1-dev backbone always supports quant, so resolve the
+    // request quant the SAME way the base `flux_dev` MLX lane does and reconcile it against the tier
+    // subdir actually resolved (`flux_base`) — record the precision that ran + emit `quant_tier_downgraded`
+    // on a genuine fallback (requested tier absent). On an already-packed q4/q8 tier the load quant is a
+    // harmless no-op; the bf16 tier resolves to `None`. The PuLID conditioning (EVA/IDFormer/CA) stays f32
+    // in every case — `load_flux1` quantizes only the backbone linears (sc-3076).
+    let (quant, recipe_bits) = reconcile_resolved_tier_quant(
+        resolve_quant(request),
+        &flux_base,
+        true,
+        &request.model,
+        &job.id,
+        backend,
+    );
     // Curated unified-sampler selection (epic 7114, sc-7432): PuLID-FLUX delegates its denoise to the
     // FLUX backbone, which honors a curated solver/scheduler on the `GenerationRequest` (#537). Read +
     // N3-normalize against the shared curated menu (an unknown name drops to the engine default + emits


### PR DESCRIPTION
## sc-9947 (epic 8506 — catalog-wide quant matrix)

Split out of sc-8513. PuLID-FLUX was **not** quant-matrixed by inheritance: its MLX lane loaded the dense **upstream gated** `black-forest-labs/FLUX.1-dev` snapshot ROOT and applied load-time quant (an install-time convert peak), rather than consuming the hosted **ungated** `SceneWorks/flux1-dev-mlx` q4/q8/bf16 tiers the base `flux_dev` built-in already uses.

### What changed
- **Manifest `pulid_flux_dev`** — per-platform `downloads` (mirrors LTX's sc-5608 split): macOS pulls the `SceneWorks/flux1-dev-mlx` **q4 (default) / q8 / bf16** tiers (ungated, packed); Windows/Linux keep the gated dense BFL download. `paths.model` → the turnkey; `mlx.quantize` 8→4 to match the q4 default tier + the base sibling. `ui.description` updated.
- **`pulid.rs` (macOS MLX)** — `PULID_FLUX_REPO` → `SceneWorks/flux1-dev-mlx`; `resolve_pulid_flux_base` descends into the selected tier subdir via `standard_tier_subdir`; quant now flows through the shared `resolve_quant` + `reconcile_resolved_tier_quant` (records the tier that ran, warns/emits on a genuine fallback) instead of the bespoke `pulid_quant`.
- **`base.rs`** — register `pulid_flux_dev` in `STANDARD_TIER_MODELS` so `uses_standard_tier_layout` is true for the resolver.

### Work-item #3 (VERIFY packed-detect) — ✅ no engine change needed
`mlx-gen-pulid::load_pulid_flux` delegates its FLUX.1-dev backbone to `mlx_gen_flux::load_flux1` — the **same** packed-detecting loader the base `flux_dev` MLX lane uses on these exact tiers. So the selected packed tier loads directly (no install-time convert peak), the q4/q8 load-quant is a harmless no-op on already-packed weights, bf16 resolves to `None`, and the PuLID adapter / EVA / IDFormer / CA conditioning stays f32.

### Scope: MLX only
The candle (Windows/Linux) PuLID lane keeps the upstream **dense BFL** backbone via its own `PULID_CANDLE_FLUX_REPO` const. `candle_gen_pulid`'s bespoke `PulidFlux::load` reads the single-file BFL layout and does **not** reuse `candle_gen_flux`'s packed pipeline (nor does the sibling candle FLUX IP-adapter lane) — so teaching it to consume the packed tiers is genuine candle-gen engine work, a separate **epic-9083** slice. No candle behavior change here (byte-identical BFL const + per-platform download). InstantID (sc-9965) is the exact MLX sibling on the RealVisXL backbone.

### Validation
- Manifest parses via `check-scaffold.mjs` + the real Rust loader (`sceneworks-core` builtin-manifest tests pass).
- The web tier picker surfaces q4/q8/bf16 for PuLID on macOS automatically (manifest `downloads[].variant`); single-tier BFL on Windows.
- ⚠️ MLX `pulid.rs` is `cfg(target_os = "macos")` and **cannot compile on the Windows dev box**; the change mirrors the proven base `flux_dev` path exactly. Parity CI (macOS) compiles + tests it.
- ⏳ **On-device q4 + bf16 ArcFace sanity** (acceptance #4) needs Apple Silicon — a Mac follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)