### PR TITLE
feat(worker): candle PuLID-FLUX consumes the flux1-dev-mlx packed tiers (sc-10103, epic 9083)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -4558,26 +4558,24 @@
       // alone so it appears solely in the "With character" picker. License: FLUX.1
       // [dev] NC (same posture as the flux_dev built-in).
       "capabilities": ["character_image"],
-      // Per-platform backbone source (sc-9947, epic 8506), mirroring LTX's sc-5608 split:
-      //   - macOS (MLX): the SAME ungated `SceneWorks/flux1-dev-mlx` quant-matrix turnkey the base
-      //     `flux_dev` built-in consumes — self-contained q4/ (default) + q8/ + bf16/ subdirs, each a
-      //     complete from_snapshot tree (packed transformer + CLIP + T5 + VAE + tokenizers). The
-      //     `mlx-gen-pulid` loader delegates its FLUX.1-dev backbone to `mlx_gen_flux::load_flux1`, which
-      //     packed-detects the tier subdir — so PuLID loads the SELECTED packed tier with NO install-time
-      //     convert peak and NO upstream BFL gate. The PuLID adapter / EVA / face stack stay f32 and are
-      //     fetched on demand (mirrors Kolors/InstantID).
-      //   - Windows/Linux (candle): unchanged — the bespoke `candle_gen_pulid::PulidFlux` loader still
-      //     reads the upstream BFL dense layout (`flux1-dev.safetensors` + `ae.safetensors`); its packed
-      //     quant-matrix consumption is a separate epic-9083 slice. So Windows/Linux keep the gated BFL
-      //     download (resolved via the `PULID_CANDLE_FLUX_REPO` const, NOT this manifest `repo`).
+      // Backbone source (sc-9947 macOS + sc-10103 candle; epics 8506/9083): the SAME ungated
+      // `SceneWorks/flux1-dev-mlx` quant-matrix turnkey the base `flux_dev` built-in consumes —
+      // self-contained q4/ (default) + q8/ + bf16/ subdirs, each a complete from_snapshot tree (packed
+      // transformer + CLIP + T5 + VAE + tokenizers). BOTH lanes packed-detect the SELECTED tier subdir:
+      // macOS via `mlx_gen_pulid` → `mlx_gen_flux::load_flux1` (sc-9947), Windows/Linux via
+      // `candle_gen_pulid`'s `FluxRefBackbone` → the base FLUX `Pipeline::load_components` (sc-10103).
+      // So PuLID loads the SELECTED packed tier on every platform with NO install-time convert peak and
+      // NO upstream BFL gate — replacing the sc-9947 Windows/Linux BFL fallback. The PuLID adapter / EVA /
+      // face stack stay f32 and are fetched on demand (mirrors Kolors/InstantID).
       "downloads": [
+        // Per-tier subdirs (q4/ default, q8/, bf16/), each a complete from_snapshot tree; sizes shared
+        // with `flux_dev` (same repo). All-platforms (the candle lane now reads the turnkey too, sc-10103).
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux1-dev-mlx",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
-          "platforms": ["macos"],
           "estimatedSizeBytes": 9617334683,
           "footprint": { "diskSizeBytes": 9617334683, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
@@ -4586,7 +4584,6 @@
           "repo": "SceneWorks/flux1-dev-mlx",
           "variant": "q8",
           "files": ["q8/*"],
-          "platforms": ["macos"],
           "estimatedSizeBytes": 18010071290,
           "footprint": { "diskSizeBytes": 18010071290, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
@@ -4595,25 +4592,11 @@
           "repo": "SceneWorks/flux1-dev-mlx",
           "variant": "bf16",
           "files": ["bf16/*"],
-          "platforms": ["macos"],
           "estimatedSizeBytes": 33746402173,
           "footprint": { "diskSizeBytes": 33746402173, "residentMemoryBytes": null, "peakMemoryBytes": null }
-        },
-        {
-          // Windows/Linux candle: the BFL flow + VAE + T5 + CLIP-L; the candle `PulidFlux` loads the
-          // BFL flux1-dev.safetensors + ae.safetensors directly via the vendored flow loader. NC + gated;
-          // the PuLID-FLUX adapter (~1.5GB) + EVA-CLIP-L (~1.6GB) are fetched on demand.
-          "provider": "huggingface",
-          "repo": "black-forest-labs/FLUX.1-dev",
-          "files": [],
-          "default": true,
-          "platforms": ["windows", "linux"],
-          "estimatedSizeBytes": 33500000000
         }
       ],
       "paths": {
-        // macOS install/display path (the MLX turnkey); Windows/Linux candle resolves the BFL snapshot
-        // via its own const, not this field (mirrors LTX's per-platform paths.model).
         "model": "${HF_CACHE}/SceneWorks/flux1-dev-mlx"
       },
       "defaults": {
@@ -4655,6 +4638,12 @@
         "minMemoryGb": 44,
         "quantize": 4
       },
+      // sc-10103 (epic 9083): the backbone now rides the ungated `SceneWorks/flux1-dev-mlx` re-host
+      // (FLUX.1 [dev] Non-Commercial License redistributed with LICENSE + NOTICE) — no HF token /
+      // license-accept gate, matching the base `flux_dev` built-in. `licenseUrl` points at the NC
+      // license for the Models-screen banner.
+      "gated": false,
+      "licenseUrl": "https://huggingface.co/SceneWorks/flux1-dev-mlx/blob/main/LICENSE.md",
       "loraCompatibility": {
         // FLUX-family backbone, so flux LoRAs apply (sc-1927: declare a real
         // family rather than empty, which would match every LoRA).
@@ -4663,7 +4652,7 @@
       },
       "ui": {
         "label": "PuLID-FLUX (FLUX.1 [dev])",
-        "description": "Identity-preserving FLUX character generation: holds a person's face from a single reference image while the prompt drives scene, pose, and wardrobe. Built on FLUX.1-dev with PuLID's IDFormer cross-attention adapter — the sc-2012 spike measured 0.8016 ArcFace cosine vs reference at id_weight=1.0 / start-cfg=4 (above the InstantID-SDXL no-restore baseline; no face-restoration pass needed). Pick a character with an approved reference image, then raise Variations to explore takes. ~30 steps at guidance 4.0. On Apple Silicon the FLUX.1-dev backbone loads from the ungated SceneWorks quant-matrix rehost at a user-selectable tier (q4 default / q8 / bf16) — the identity conditioning stays full-precision, so even q4 holds the face (ArcFace ~0.68). Needs the PuLID-FLUX adapter (~1.5GB) + EVA-CLIP-L (~1.6GB) + antelopev2 face pack, fetched on first use. License: FLUX.1 [dev] non-commercial.",
+        "description": "Identity-preserving FLUX character generation: holds a person's face from a single reference image while the prompt drives scene, pose, and wardrobe. Built on FLUX.1-dev with PuLID's IDFormer cross-attention adapter — the sc-2012 spike measured 0.8016 ArcFace cosine vs reference at id_weight=1.0 / start-cfg=4 (above the InstantID-SDXL no-restore baseline; no face-restoration pass needed). Pick a character with an approved reference image, then raise Variations to explore takes. ~30 steps at guidance 4.0. The FLUX.1-dev backbone loads from the ungated SceneWorks quant-matrix re-host at a user-selectable tier (q4 default / q8 / bf16) on every platform — no Hugging Face token needed; the identity conditioning stays full-precision, so even q4 holds the face (ArcFace ~0.68). Needs the PuLID-FLUX adapter (~1.5GB) + EVA-CLIP-L (~1.6GB) + antelopev2 face pack, fetched on first use. License: FLUX.1 [dev] non-commercial.",
         "recommendedFor": ["character_image"],
         // PuLID identity tuning surfaced in the character-image picker. The
         // reference-strength slider drives idWeight (PuLID's identity-strength

--- a/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
@@ -16,8 +16,13 @@
 
 /// SceneWorks model id for native PuLID-FLUX (FLUX.1-dev backbone + PuLID injection).
 const PULID_CANDLE_MODEL: &str = "pulid_flux_dev";
-/// FLUX.1-dev backbone repo when the manifest omits `repo` (the same default the MLX route uses).
-const PULID_CANDLE_FLUX_REPO: &str = "black-forest-labs/FLUX.1-dev";
+/// FLUX.1-dev backbone repo when the manifest omits `repo`. As of sc-10103 (epic 9083) this is the
+/// ungated `SceneWorks/flux1-dev-mlx` quant-matrix turnkey — the SAME repo `flux_dev` uses — so the
+/// candle PuLID lane consumes the packed q4/q8 + bf16 tiers instead of the gated dense BFL checkpoint
+/// (the candle twin of the MLX repoint, sc-9947). The tier subdir is resolved by
+/// [`resolve_pulid_candle_base`] via [`standard_tier_subdir`]; `candle_gen_pulid`'s `FluxRefBackbone`
+/// packed-detects whichever tier landed.
+const PULID_CANDLE_FLUX_REPO: &str = "SceneWorks/flux1-dev-mlx";
 /// The PuLID-FLUX adapter (IDFormer + the 20 PerceiverAttention CA blocks). Public repo.
 const PULID_CANDLE_ADAPTER_REPO: &str = "guozinan/PuLID";
 const PULID_CANDLE_ADAPTER_FILE: &str = "pulid_flux_v0.9.1.safetensors";
@@ -63,9 +68,13 @@ const PULID_CANDLE_DEFAULT_ID_WEIGHT: f32 = 1.0;
 const PULID_CANDLE_ENGINE: &str = "candle_pulid_flux";
 
 /// Resolve the FLUX.1-dev backbone snapshot for candle PuLID-FLUX: an explicit `modelPath` dir
-/// (advanced or manifest) wins, else the HF cache snapshot for the manifest `repo` (default
-/// FLUX.1-dev). `None` means the base is not present locally, so the job is not candle-runnable (falls
-/// through to torch). Mirrors `resolve_flux_ipadapter_base` / the MLX `resolve_pulid_flux_base`.
+/// (advanced or manifest) wins (used verbatim — an app-managed override picks its own layout), else the
+/// HF cache snapshot for the manifest `repo` (default `SceneWorks/flux1-dev-mlx`) descended into the
+/// selected quant-matrix **tier subdir** via [`standard_tier_subdir`] (sc-10103): `bf16/` when the
+/// request opts out of quant, `q8/` for Q8, else `q4/`. `candle_gen_pulid`'s `FluxRefBackbone`
+/// packed-detects whichever tier landed (or a dense BFL snapshot for a legacy `modelPath`). `None` means
+/// the base is not present locally, so the job is not candle-runnable (falls through to torch). Mirrors
+/// `resolve_flux_ipadapter_base` / the MLX `resolve_pulid_flux_base`.
 fn resolve_pulid_candle_base(
     request: &ImageRequest,
     settings: &Settings,
@@ -88,7 +97,8 @@ fn resolve_pulid_candle_base(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or(PULID_CANDLE_FLUX_REPO);
-    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo)
+        .map(|root| standard_tier_subdir(&root, request)))
 }
 
 /// True when this is a candle-eligible PuLID-FLUX job: the `pulid_flux_dev` model in `character_image`


### PR DESCRIPTION
## What

Makes the **candle (Windows/CUDA)** PuLID-FLUX lane consume the ungated `SceneWorks/flux1-dev-mlx` q4/q8/bf16 turnkey tiers — the candle follow-up to sc-9947 (which moved the **MLX** lane onto the same turnkey and deferred candle to epic 9083).

- `image_jobs/pulid_candle.rs`:
  - `PULID_CANDLE_FLUX_REPO` → `SceneWorks/flux1-dev-mlx` (the SAME repo `flux_dev` uses), replacing the gated dense BFL `black-forest-labs/FLUX.1-dev` checkpoint.
  - `resolve_pulid_candle_base` now descends into the selected quant-tier subdir via `standard_tier_subdir` (bf16 / q8 / q4). The app-managed `modelPath` override is still honored verbatim ahead of it.
- `config/manifests/builtin.models.jsonc` `pulid_flux_dev`:
  - `downloads` → the q4 (default) / q8 / bf16 turnkey tier variants (same repo + sizes as `flux_dev`), **all-platforms** — supersedes sc-9947's macOS-only per-platform split (#1231).
  - `paths.model` → `${HF_CACHE}/SceneWorks/flux1-dev-mlx`; `gated: false` + `licenseUrl` → the SceneWorks re-host; description reworded (no HF token needed).

## Why

`candle_gen_pulid::PulidFlux::load` read the gated dense BFL single-file layout with no packed-detect, so it couldn't read the diffusers-layout turnkey tiers even at bf16. The engine work to fix that lives in the paired **candle-gen** PR (new `FluxRefBackbone` + `PackedFluxDit` injector seam); this PR is the worker/manifest half.

## Stacked dependency (read before merging)

This is functional **only** with the candle-gen pin bump. Sequencing to keep a single gen-core rev (the skew gate):
1. Land #1232 (`claude/pid-worker-repin`: worker → mlx-gen `5c28c20` + candle-gen `536c2ef`).
2. Merge the candle-gen PuLID PR (`FluxRefBackbone` + `PackedFluxDit::forward_injected`).
3. Follow-up commit here bumps **only** `candle-gen*` to the merged rev (mlx-gen already at `5c28c20`).

The pin bump is deliberately **omitted** from this PR so it stays on one gen-core rev. At the current pin the worker compiles (`PulidFlux`'s worker-facing API is unchanged), but PuLID won't read the new tiers until the bump.

## Validation

- `cargo test -p sceneworks-core` green (manifest parses, PuLID candle routing unchanged).
- candle-gen side: `cargo test -p candle-gen-flux -p candle-gen-pulid` green, clippy clean (in the paired PR).
- ⏳ GPU-val (q4 + bf16 ArcFace on 2× RTX PRO 6000) pending the pin bump + tier download.

Shortcut: sc-10103 (epic 9083).

🤖 Generated with [Claude Code](https://claude.com/claude-code)