### PR TITLE
feat(worker): Krea 2 Turbo reference-guided generation / img2img (sc-8591)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -2265,6 +2265,39 @@ fn resolve_identity_init(
     Ok(Some((image, strength)))
 }
 
+/// Resolve the **Krea 2 Turbo img2img** init (epic 8588 slice A, sc-8591): `Some((reference, strength))`
+/// from a `referenceAssetId` + `advanced.strength`, or `None` when no reference asset is supplied (the
+/// lane then falls back to plain txt2img). `strength` is the full-range 0.0–1.0 reference-fidelity
+/// slider (default 0.5); the worker does NOT clamp beyond `[0, 1]` — the usable band is model-specific
+/// (A0/sc-8589 mapped Krea Turbo's sweet spot at ~0.35–0.65, but that is guidance, not a hard clamp).
+/// The single `Conditioning::Reference` this produces is routed by the engine to
+/// `generate_turbo_img2img` (sc-10135), whose `preprocess_init_image` LANCZOS-resizes the reference to
+/// the output W×H — so, like Z-Image's [`resolve_identity_init`], the reference is fed raw (the
+/// `edit_image`-only [`should_fit_edit_source`] crop/pad-fit never applies to Krea's t2i-only surface).
+#[cfg(target_os = "macos")]
+fn resolve_krea_img2img_init(
+    request: &ImageRequest,
+    settings: &Settings,
+    project_path: &Path,
+) -> WorkerResult<Option<(Image, f32)>> {
+    let Some(asset_id) = request
+        .reference_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    else {
+        return Ok(None);
+    };
+    let image = load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        asset_id,
+        project_path,
+    )?;
+    let strength = advanced::f32_clamped(&request.advanced, "strength", 0.5, 0.0..=1.0);
+    Ok(Some((image, strength)))
+}
+
 /// The source identity reference (decoded image + its asset id) a strict-control pose set scores its
 /// finished poses against (epic 4406, sc-4410), or `None` when the job carries no identity reference.
 ///
@@ -2856,6 +2889,16 @@ fn resolve_generic_lane_conditioning(
             }),
             None => Ok(LaneConditioning::default()),
         }
+    } else if request.model == "krea_2_turbo" && has_reference {
+        // Krea 2 Turbo reference-guided generation = img2img latent-init (epic 8588 slice A, sc-8591):
+        // a `referenceAssetId` + `advanced.strength` seeds the CFG-free Turbo denoise from the
+        // VAE-encoded reference. Text-only model (no `edit_image` mode), so the reference is optional
+        // within plain t2i; the engine routes the single `Conditioning::Reference` to
+        // `generate_turbo_img2img` (sc-10135). Candle parity is sc-10134.
+        Ok(LaneConditioning {
+            identity_init: resolve_krea_img2img_init(request, settings, project_path)?,
+            ..Default::default()
+        })
     } else {
         // Boogu instruction edit resolves its (1..5) references separately into `boogu_refs` below —
         // it uses the `MultiReference`-capable path, not the single `identity_init` reference.

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -4511,14 +4511,21 @@ fn generic_lane_conditioning_defaults_when_no_reference() {
     // The generic MLX lane's per-family conditioning resolver (sc-8828, F-026): a plain t2i job (no
     // reference, no edit source) resolves to the all-`None` default for every family that reaches the
     // generic lane — the Z-Image arm (via `resolve_zimage_identity_init` returning `None`), the Kolors
-    // arm, and the final Boogu/plain fall-through. No disk access; just proves the dispatch order picks
-    // the right arm and each yields the empty conditioning when its reference precondition is absent.
+    // arm, the Krea img2img arm (sc-8591, gated on `has_reference`), and the final Boogu/plain
+    // fall-through. No disk access; just proves the dispatch order picks the right arm and each yields
+    // the empty conditioning when its reference precondition is absent.
     let dir = tempfile::tempdir().unwrap();
     let mut settings = Settings::from_env();
     settings.data_dir = dir.path().to_path_buf();
     let project_path = dir.path();
 
-    for model in ["z_image_turbo", "kolors", "sdxl", "flux_dev"] {
+    for model in [
+        "z_image_turbo",
+        "kolors",
+        "sdxl",
+        "flux_dev",
+        "krea_2_turbo",
+    ] {
         let req = request(json!({
             "projectId": "p", "model": model, "count": 1,
         }));


### PR DESCRIPTION
## What
Wire **Krea 2 Turbo reference-guided generation** (img2img latent-init) into the worker — epic 8588 slice A, A2. A `krea_2_turbo` text-to-image job that carries a `referenceAssetId` + `advanced.strength` now seeds the CFG-free Turbo denoise from the VAE-encoded reference.

## How
- `resolve_generic_lane_conditioning` (base.rs) gains a `krea_2_turbo && has_reference` arm that resolves `resolve_krea_img2img_init` → a single `Conditioning::Reference { image, strength }`. The engine routes that to `generate_turbo_img2img` (mlx-gen sc-10135, already merged + pinned via sc-10145/#1239).
- `strength` = the full **0.0–1.0** reference-fidelity slider, default **0.5**, **no clamp** beyond `[0,1]` (the usable band is model-specific — A0/sc-8589 mapped Krea Turbo's sweet spot at ~0.35–0.65, but that's guidance, not a hard clamp).
- Mirrors the Z-Image identity-init pattern; the reference is fed raw (the `edit_image`-only `should_fit_edit_source` crop/pad never applies to Krea's t2i-only surface, and the engine LANCZOS-resizes to the output dims).

## Not needed / deferred
- **No DTO/schema/contract changes** — `referenceAssetId` + `advanced.strength` already exist; `strength` is validated by `f32_clamped(0.0..=1.0)`.
- **candle parity** → sc-10134. **Frontend reference+strength UI + capability advertisement** → A3 (sc-8593). This PR is backend-only and inert until A3 sends a reference for Krea.

## Tests
- Extended `generic_lane_conditioning_defaults_when_no_reference` to cover `krea_2_turbo` (the new arm no-ops to plain t2i without a reference). The reference-present img2img behavior is validated end-to-end by the engine real-weight test (sc-8589 A0) + the Generator routing unit tests (sc-10135); the worker resolver is a thin reference-loader mirroring `resolve_identity_init` (whose I/O path is likewise not unit-tested, per convention).
- `cargo test -p sceneworks-worker --lib` green; clippy 0 warnings; fmt clean.

Epic **8588**. Follows sc-8590/#664, sc-10135/#666, sc-10145/#1239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)