### PR TITLE
fix(web): collapse the Text-to-Image "Structure control" panel by default

### DIFF
--- a/apps/web/src/components/ControlPanel.jsx
+++ b/apps/web/src/components/ControlPanel.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { PoseLibraryPicker } from "./PoseLibraryPicker.jsx";
 import { ImageEditSourcePickerField } from "./AssetPicker.jsx";
 
@@ -49,6 +49,9 @@ export function ControlPanel({
   onControlScaleChange,
 }) {
   const modes = Array.isArray(supportedModes) ? supportedModes : [];
+  // Collapsed by default (this is a large, optional section); the user opts in when they want to
+  // lock structure to a reference.
+  const [open, setOpen] = useState(false);
   if (!modes.length) {
     return null;
   }
@@ -56,82 +59,115 @@ export function ControlPanel({
   const scaleCfg = controlScaleConfig ?? {};
 
   return (
-    <div className="control-panel">
-      <div className="control-panel-head">
-        <span className="control-panel-label">Structure control</span>
-        <span className="muted">Lock the output's pose, edges, or depth to a reference.</span>
-      </div>
+    <div className={`control-panel${open ? " open" : " collapsed"}`}>
+      <button
+        aria-expanded={open}
+        className="control-panel-head"
+        onClick={() => setOpen((prev) => !prev)}
+        type="button"
+      >
+        <span className="control-panel-caret" aria-hidden="true">
+          {open ? "▾" : "▸"}
+        </span>
+        <span className="control-panel-headings">
+          <span className="control-panel-label">Structure control</span>
+          <span className="muted">
+            Lock the output's pose, edges, or depth to a reference.
+          </span>
+        </span>
+      </button>
 
-      <div className="control-mode-tabs" role="tablist" aria-label="Control type">
-        {modes.map((mode) => (
-          <button
-            aria-pressed={mode === activeMode}
-            className={mode === activeMode ? "control-mode-tab active" : "control-mode-tab"}
-            key={mode}
-            onClick={() => onControlModeChange?.(mode)}
-            role="tab"
-            type="button"
+      {open ? (
+        <>
+          <div
+            className="control-mode-tabs"
+            role="tablist"
+            aria-label="Control type"
           >
-            {MODE_LABELS[mode] ?? mode}
-          </button>
-        ))}
-      </div>
-
-      {activeMode === "pose" ? (
-        poseBlockText ? (
-          <p className="mac-gating-note">{poseBlockText}</p>
-        ) : (
-          <div className="control-pose-section">
-            <PoseLibraryPicker
-              loadUserPoses={loadUserPoses}
-              onClear={onClearPoses}
-              onToggle={onTogglePose}
-              selectedIds={selectedPoseIds}
-            />
-            <p className="muted">Selecting poses generates one image per pose (overrides Variations).</p>
+            {modes.map((mode) => (
+              <button
+                aria-pressed={mode === activeMode}
+                className={
+                  mode === activeMode
+                    ? "control-mode-tab active"
+                    : "control-mode-tab"
+                }
+                key={mode}
+                onClick={() => onControlModeChange?.(mode)}
+                role="tab"
+                type="button"
+              >
+                {MODE_LABELS[mode] ?? mode}
+              </button>
+            ))}
           </div>
-        )
-      ) : (
-        <div className="control-image-section">
-          <ImageEditSourcePickerField
-            assets={controlImageAssets}
-            buttonLabel="Select image"
-            characters={characters}
-            emptyLabel={`No ${activeMode} control image selected`}
-            importAsset={importAsset}
-            label={activeMode === "canny" ? "Edge/canny source" : "Depth source"}
-            onChange={onControlImageChange}
-            projectId={projectId}
-            value={controlImageAssetId}
-          />
-          <label className="checkline">
-            <input
-              checked={Boolean(controlImagePassthrough)}
-              onChange={(event) => onControlImagePassthroughChange?.(event.target.checked)}
-              type="checkbox"
-            />
-            Use this image as the control map directly (skip preprocessing)
-          </label>
-          <p className="muted">
-            {controlImagePassthrough
-              ? `Your image is fed in verbatim as the ${activeMode} map — supply an already-prepared ${activeMode} map.`
-              : `The worker auto-derives the ${activeMode} map from your image before generating.`}
-          </p>
-        </div>
-      )}
 
-      <label className="reference-strength control-scale">
-        {scaleCfg.label ?? "Control strength"}
-        <input
-          max={scaleCfg.max ?? 2}
-          min={scaleCfg.min ?? 0}
-          onChange={(event) => onControlScaleChange?.(Number(event.target.value))}
-          step={scaleCfg.step ?? 0.05}
-          type="range"
-          value={controlScale}
-        />
-        <span>{Number(controlScale).toFixed(2)}</span>
-      </label>
+          {activeMode === "pose" ? (
+            poseBlockText ? (
+              <p className="mac-gating-note">{poseBlockText}</p>
+            ) : (
+              <div className="control-pose-section">
+                <PoseLibraryPicker
+                  loadUserPoses={loadUserPoses}
+                  onClear={onClearPoses}
+                  onToggle={onTogglePose}
+                  selectedIds={selectedPoseIds}
+                />
+                <p className="muted">
+                  Selecting poses generates one image per pose (overrides
+                  Variations).
+                </p>
+              </div>
+            )
+          ) : (
+            <div className="control-image-section">
+              <ImageEditSourcePickerField
+                assets={controlImageAssets}
+                buttonLabel="Select image"
+                characters={characters}
+                emptyLabel={`No ${activeMode} control image selected`}
+                importAsset={importAsset}
+                label={
+                  activeMode === "canny" ? "Edge/canny source" : "Depth source"
+                }
+                onChange={onControlImageChange}
+                projectId={projectId}
+                value={controlImageAssetId}
+              />
+              <label className="checkline">
+                <input
+                  checked={Boolean(controlImagePassthrough)}
+                  onChange={(event) =>
+                    onControlImagePassthroughChange?.(event.target.checked)
+                  }
+                  type="checkbox"
+                />
+                Use this image as the control map directly (skip preprocessing)
+              </label>
+              <p className="muted">
+                {controlImagePassthrough
+                  ? `Your image is fed in verbatim as the ${activeMode} map — supply an already-prepared ${activeMode} map.`
+                  : `The worker auto-derives the ${activeMode} map from your image before generating.`}
+              </p>
+            </div>
+          )}
+
+          <label className="reference-strength control-scale">
+            {scaleCfg.label ?? "Control strength"}
+            <input
+              max={scaleCfg.max ?? 2}
+              min={scaleCfg.min ?? 0}
+              onChange={(event) =>
+                onControlScaleChange?.(Number(event.target.value))
+              }
+              step={scaleCfg.step ?? 0.05}
+              type="range"
+              value={controlScale}
+            />
+            <span>{Number(controlScale).toFixed(2)}</span>
+          </label>
+        </>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/ControlPanel.test.jsx
+++ b/apps/web/src/components/ControlPanel.test.jsx
@@ -8,7 +8,15 @@ import { ControlPanel } from "./ControlPanel.jsx";
 // gating + the canny/depth upload toggle. The picker itself is covered by PoseLibraryPicker tests.
 vi.mock("../poseLibrary.js", () => ({
   usePoseLibrary: () => ({
-    poses: [{ id: "p1", label: "Standing", category: "Basics", keypoints: [], preview: "p1.png" }],
+    poses: [
+      {
+        id: "p1",
+        label: "Standing",
+        category: "Basics",
+        keypoints: [],
+        preview: "p1.png",
+      },
+    ],
     categories: ["Basics"],
     loading: false,
     error: null,
@@ -18,7 +26,9 @@ vi.mock("../poseLibrary.js", () => ({
 // The source picker opens a modal on click; for the panel test we only need its presence/label and the
 // onChange seam, so stub it to a lightweight control surfacing the same props.
 vi.mock("./AssetPicker.jsx", () => ({
-  ImageEditSourcePickerField: ({ label }) => <div data-testid="control-image-picker">{label}</div>,
+  ImageEditSourcePickerField: ({ label }) => (
+    <div data-testid="control-image-picker">{label}</div>
+  ),
 }));
 
 describe("ControlPanel (sc-8245 gating + toggle)", () => {
@@ -42,11 +52,30 @@ describe("ControlPanel (sc-8245 gating + toggle)", () => {
     await act(async () => root.render(ui));
   }
 
+  // The panel is collapsed by default (large, optional section); clicking the head expands it so the
+  // gated inner content (tabs, pose/upload, slider) mounts. Most tests below assert on that content, so
+  // they render then expand.
+  async function expand() {
+    const head = container.querySelector(".control-panel-head");
+    await act(async () => {
+      head.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+  }
+
+  async function renderExpanded(ui) {
+    await render(ui);
+    await expand();
+  }
+
   const tabLabels = () =>
-    [...container.querySelectorAll(".control-mode-tab")].map((b) => b.textContent.trim());
+    [...container.querySelectorAll(".control-mode-tab")].map((b) =>
+      b.textContent.trim(),
+    );
 
   const tabByLabel = (label) =>
-    [...container.querySelectorAll(".control-mode-tab")].find((b) => b.textContent.trim() === label);
+    [...container.querySelectorAll(".control-mode-tab")].find(
+      (b) => b.textContent.trim() === label,
+    );
 
   function baseProps(overrides = {}) {
     return {
@@ -66,20 +95,49 @@ describe("ControlPanel (sc-8245 gating + toggle)", () => {
       importAsset: vi.fn(),
       projectId: "proj_1",
       characters: [],
-      controlScaleConfig: { label: "Control strength", default: 0.9, min: 0, max: 2, step: 0.05 },
+      controlScaleConfig: {
+        label: "Control strength",
+        default: 0.9,
+        min: 0,
+        max: 2,
+        step: 0.05,
+      },
       controlScale: 0.9,
       onControlScaleChange: vi.fn(),
       ...overrides,
     };
   }
 
-  it("shows all three tabs when the backbone supports pose+canny+depth", async () => {
+  it("is collapsed by default and expands on clicking the head", async () => {
     await render(<ControlPanel {...baseProps()} />);
+    // Collapsed: the header is present but the gated inner content is not mounted.
+    const head = container.querySelector(".control-panel-head");
+    expect(head).not.toBeNull();
+    expect(head.getAttribute("aria-expanded")).toBe("false");
+    expect(tabLabels()).toEqual([]);
+    expect(container.querySelector(".control-mode-tabs")).toBeNull();
+
+    await expand();
+    expect(head.getAttribute("aria-expanded")).toBe("true");
+    expect(tabLabels()).toEqual(["Pose", "Canny", "Depth"]);
+
+    // Clicking again collapses it back.
+    await expand();
+    expect(head.getAttribute("aria-expanded")).toBe("false");
+    expect(tabLabels()).toEqual([]);
+  });
+
+  it("shows all three tabs when the backbone supports pose+canny+depth", async () => {
+    await renderExpanded(<ControlPanel {...baseProps()} />);
     expect(tabLabels()).toEqual(["Pose", "Canny", "Depth"]);
   });
 
   it("shows only the pose tab for a pose-only backbone", async () => {
-    await render(<ControlPanel {...baseProps({ supportedModes: ["pose"], controlMode: "pose" })} />);
+    await renderExpanded(
+      <ControlPanel
+        {...baseProps({ supportedModes: ["pose"], controlMode: "pose" })}
+      />,
+    );
     expect(tabLabels()).toEqual(["Pose"]);
   });
 
@@ -89,14 +147,22 @@ describe("ControlPanel (sc-8245 gating + toggle)", () => {
   });
 
   it("pose mode shows the pose library, not the control-image upload", async () => {
-    await render(<ControlPanel {...baseProps({ controlMode: "pose" })} />);
+    await renderExpanded(
+      <ControlPanel {...baseProps({ controlMode: "pose" })} />,
+    );
     expect(container.querySelector(".pose-library")).not.toBeNull();
-    expect(container.querySelector('[data-testid="control-image-picker"]')).toBeNull();
+    expect(
+      container.querySelector('[data-testid="control-image-picker"]'),
+    ).toBeNull();
   });
 
   it("canny/depth mode shows the control-image upload + the preprocess toggle", async () => {
-    await render(<ControlPanel {...baseProps({ controlMode: "canny" })} />);
-    expect(container.querySelector('[data-testid="control-image-picker"]')).not.toBeNull();
+    await renderExpanded(
+      <ControlPanel {...baseProps({ controlMode: "canny" })} />,
+    );
+    expect(
+      container.querySelector('[data-testid="control-image-picker"]'),
+    ).not.toBeNull();
     const toggle = container.querySelector('input[type="checkbox"]');
     expect(toggle).not.toBeNull();
     expect(toggle.checked).toBe(false); // preprocess (derive) by default
@@ -104,9 +170,12 @@ describe("ControlPanel (sc-8245 gating + toggle)", () => {
 
   it("the preprocess/use-as-is toggle reports its checked state", async () => {
     const onControlImagePassthroughChange = vi.fn();
-    await render(
+    await renderExpanded(
       <ControlPanel
-        {...baseProps({ controlMode: "depth", onControlImagePassthroughChange })}
+        {...baseProps({
+          controlMode: "depth",
+          onControlImagePassthroughChange,
+        })}
       />,
     );
     const toggle = container.querySelector('input[type="checkbox"]');
@@ -119,22 +188,32 @@ describe("ControlPanel (sc-8245 gating + toggle)", () => {
 
   it("falls back to the first supported mode when the active pick is unsupported", async () => {
     // controlMode is a stranded "canny" but the backbone only supports pose → pose renders.
-    await render(<ControlPanel {...baseProps({ supportedModes: ["pose"], controlMode: "canny" })} />);
+    await renderExpanded(
+      <ControlPanel
+        {...baseProps({ supportedModes: ["pose"], controlMode: "canny" })}
+      />,
+    );
     expect(tabLabels()).toEqual(["Pose"]);
     expect(container.querySelector(".pose-library")).not.toBeNull();
   });
 
   it("clicking a mode tab calls onControlModeChange", async () => {
     const onControlModeChange = vi.fn();
-    await render(<ControlPanel {...baseProps({ onControlModeChange })} />);
+    await renderExpanded(
+      <ControlPanel {...baseProps({ onControlModeChange })} />,
+    );
     await act(async () => {
-      tabByLabel("Depth").dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      tabByLabel("Depth").dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
     });
     expect(onControlModeChange).toHaveBeenCalledWith("depth");
   });
 
   it("binds the control-scale slider to controlScale + its config range", async () => {
-    await render(<ControlPanel {...baseProps({ controlScale: 1.25 })} />);
+    await renderExpanded(
+      <ControlPanel {...baseProps({ controlScale: 1.25 })} />,
+    );
     const slider = container.querySelector('input[type="range"]');
     expect(slider).not.toBeNull();
     expect(slider.value).toBe("1.25");

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -1483,16 +1483,21 @@ describe("ImageStudio strict-control panel (epic 8236, sc-8245)", () => {
     [...document.body.querySelectorAll(".control-mode-tab")].map((b) => b.textContent.trim());
   const controlTabByLabel = (label) =>
     [...document.body.querySelectorAll(".control-mode-tab")].find((b) => b.textContent.trim() === label);
+  // The structure-control panel is collapsed by default; expand it so the gated inner content
+  // (mode tabs, control-image upload, slider) mounts before the assertions below.
+  const expandControlPanel = async () => click(document.body.querySelector(".control-panel-head"));
   const generate = async () =>
     click([...document.body.querySelectorAll("button")].find((b) => b.textContent === "Generate"));
 
   it("gates the picker to the backbone's supported modes (all three)", async () => {
     await render(baseContext({ imageModels: [FULL_CONTROL] }));
+    await expandControlPanel();
     expect(controlTabs()).toEqual(["Pose", "Canny", "Depth"]);
   });
 
   it("shows only the pose tab for a pose-only backbone", async () => {
     await render(baseContext({ imageModels: [POSE_ONLY] }));
+    await expandControlPanel();
     expect(controlTabs()).toEqual(["Pose"]);
   });
 
@@ -1503,6 +1508,7 @@ describe("ImageStudio strict-control panel (epic 8236, sc-8245)", () => {
 
   it("re-gates and resets an unsupported mode when the backbone switches", async () => {
     await render(baseContext({ imageModels: [FULL_CONTROL, POSE_ONLY] }));
+    await expandControlPanel();
     // Pick canny on the multi-mode backbone.
     await click(controlTabByLabel("Canny"));
     expect(controlTabByLabel("Canny").getAttribute("aria-pressed")).toBe("true");
@@ -1517,6 +1523,7 @@ describe("ImageStudio strict-control panel (epic 8236, sc-8245)", () => {
     const createImageJob = vi.fn(async () => ({ id: "job-1" }));
     const plate = { id: "ctrl-plate", projectId: "project_1", type: "image", displayName: "Plate", status: {} };
     await render(baseContext({ createImageJob, imageModels: [FULL_CONTROL], assets: [plate] }));
+    await expandControlPanel();
     await click(controlTabByLabel("Canny"));
     // Open the control-image picker and double-click the asset to confirm it.
     await click(
@@ -1540,6 +1547,7 @@ describe("ImageStudio strict-control panel (epic 8236, sc-8245)", () => {
     const createImageJob = vi.fn(async () => ({ id: "job-1" }));
     const plate = { id: "ctrl-plate", projectId: "project_1", type: "image", displayName: "Plate", status: {} };
     await render(baseContext({ createImageJob, imageModels: [FULL_CONTROL], assets: [plate] }));
+    await expandControlPanel();
     await click(controlTabByLabel("Depth"));
     await click(
       [...document.body.querySelectorAll(".asset-picker-head button")].find((b) => b.textContent === "Select image"),

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2513,6 +2513,26 @@ label {
 }
 
 .control-panel-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+}
+
+.control-panel-caret {
+  font-size: 11px;
+  line-height: 18px;
+  color: var(--text-muted);
+  flex: 0 0 auto;
+}
+
+.control-panel-headings {
   display: grid;
   gap: 2px;
 }


### PR DESCRIPTION
## What

Makes the **Structure control** section in **Image Studio → Text to Image** a collapsible disclosure that is **collapsed by default**.

## Why

The strict-control panel (pose / canny / depth, epic 8236) renders in full for every strict-control-capable backbone — Flux being the one that prompted this. It's a large, optional section (mode tabs + the full pose-library grid + control-scale slider) that pushed the rest of the generation form down for everyone, even those not using structure control. Collapsing it by default keeps the form compact; the user expands it only when they want to lock output structure to a reference.

This is self-contained in `ControlPanel` — no parent (`ImageStudio`) changes needed — so every backbone that surfaces the panel gets the same collapsed-by-default behavior, not just Flux.

## Changes

- **`ControlPanel.jsx`** — the header is now a `<button>` toggling a `useState(false)` (collapsed by default), with a ▸/▾ caret and `aria-expanded`. The mode tabs, pose/upload section, and control-scale slider only mount when expanded.
- **`styles.css`** — restyled `.control-panel-head` as an inline clickable row with the caret; headings moved into a `.control-panel-headings` wrapper.
- **`ControlPanel.test.jsx`** — added a collapsed-by-default / expand / re-collapse test; updated the content-inspecting tests to expand the panel first.

## Verification

- `vitest` — 10/10 pass; `eslint` — clean.
- Verified live in the running dev app (real component + CSS): collapsed by default shows only the compact header (▸); clicking expands to the 3 tabs + pose grid + slider (▾); clicking again re-collapses.

## Notes for reviewer

- Purely presentational/UX; no request-wiring or backend changes. The parent still owns all state; the panel remains controlled.
- Small standalone fix — not currently tracked under a Shortcut story. Happy to file one under epic 8236 if you'd like it tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)