### PR TITLE
feat(web): Krea 2 Turbo reference-guided generation UI / img2img (sc-8593)

### DIFF
--- a/apps/web/src/components/ReferenceCaptionPicker.jsx
+++ b/apps/web/src/components/ReferenceCaptionPicker.jsx
@@ -47,6 +47,17 @@ export default function ReferenceCaptionPicker({
   onOpenModels,
   onOpenQueue,
   onCancelJob,
+  // img2img double-duty (epic 8588 slice A, sc-8593): when the selected model supports img2img,
+  // the SAME picked reference can drive generation (reference-guided / latent-init) via a strength
+  // slider — in addition to (or instead of) the describe → prompt flow above. All additive + default
+  // off, so the Ideogram-JSON + all-t2i describe consumers are byte-unaffected. `onReferenceAssetChange`
+  // lifts the picked asset id so the parent can send it as `referenceAssetId`. `showImg2imgStrength`
+  // also un-gates the picker without the vision captioner (img2img needs no captioner).
+  onReferenceAssetChange,
+  showImg2imgStrength = false,
+  img2imgStrength = 0.5,
+  onImg2imgStrengthChange,
+  img2imgStrengthConfig,
 }) {
   const [referenceAssetId, setReferenceAssetId] = useState("");
   const [busy, setBusy] = useState(false);
@@ -69,6 +80,7 @@ export default function ReferenceCaptionPicker({
   function handleReferenceChange(assetId) {
     setReferenceAssetId(assetId);
     setError("");
+    onReferenceAssetChange?.(assetId);
   }
 
   // Run the auto-preset from an effect on the SELECTED id rather than the picker's onChange: a freshly
@@ -104,7 +116,7 @@ export default function ReferenceCaptionPicker({
   return (
     <div className="structured-reference">
       <ModelAvailabilityGate
-        ready={visionCaptionReady}
+        ready={visionCaptionReady || showImg2imgStrength}
         title={gateTitle}
         description={gateDescription}
         offers={visionCaptionOffers}
@@ -127,14 +139,35 @@ export default function ReferenceCaptionPicker({
           projectId={projectId}
           value={referenceAssetId}
         />
-        <button
-          type="button"
-          className="secondary-action"
-          disabled={!referenceAssetId || busy}
-          onClick={handleCaption}
-        >
-          {busy ? busyLabel : buttonLabel}
-        </button>
+        {/* Describe → prompt (epic 8203): only when the vision captioner is present. An img2img-only
+            model (no captioner) still gets the picker + strength slider below via `showImg2imgStrength`. */}
+        {visionCaptionReady ? (
+          <button
+            type="button"
+            className="secondary-action"
+            disabled={!referenceAssetId || busy}
+            onClick={handleCaption}
+          >
+            {busy ? busyLabel : buttonLabel}
+          </button>
+        ) : null}
+        {/* img2img strength (epic 8588 slice A, sc-8593): the SAME picked reference guides generation
+            (reference-guided / latent-init) at this strength. Shown only for img2img-capable models
+            once a reference is chosen. */}
+        {showImg2imgStrength && referenceAssetId ? (
+          <label className="reference-strength img2img-strength">
+            {img2imgStrengthConfig?.label ?? "Reference strength"}
+            <input
+              max={img2imgStrengthConfig?.max ?? 1}
+              min={img2imgStrengthConfig?.min ?? 0}
+              onChange={(event) => onImg2imgStrengthChange?.(Number(event.target.value))}
+              step={img2imgStrengthConfig?.step ?? 0.05}
+              type="range"
+              value={img2imgStrength}
+            />
+            <span>{Number(img2imgStrength).toFixed(2)}</span>
+          </label>
+        ) : null}
         {error ? (
           <p className="structured-error" role="alert">
             {error}

--- a/apps/web/src/imageJobAdvanced.js
+++ b/apps/web/src/imageJobAdvanced.js
@@ -52,6 +52,10 @@ export function buildImageJobAdvanced(state) {
     controlnetScale,
     variationStrength,
     trueCfgScale,
+    // img2img reference-guided generation (epic 8588 slice A, sc-8593).
+    supportsImg2img,
+    img2imgReferenceAssetId,
+    img2imgStrength,
     viewAngles,
     viewAngle,
     // Pose library.
@@ -167,6 +171,14 @@ export function buildImageJobAdvanced(state) {
     // declares a variationStrength slider AND a reference is attached.
     ...(mode === "character_image" && referenceAssetId && variationStrength
       ? { trueCfgScale }
+      : {}),
+    // img2img reference-guided generation (epic 8588 slice A, sc-8593): emit advanced.strength when an
+    // img2img-capable model (Krea 2 Turbo) has a reference picked in the shared "Start from an image"
+    // panel. The worker's krea arm routes referenceAssetId + this strength to generate_turbo_img2img.
+    // Full 0.0–1.0 (default 0.5, the slider midpoint); always sent when a reference is attached so the
+    // worker owns the band semantics (the usable window is model-specific — A0/sc-8589).
+    ...(supportsImg2img && img2imgReferenceAssetId
+      ? { strength: img2imgStrength }
       : {}),
     // View angle (InstantID) — only when a specific angle is chosen and no pose is
     // selected (a library pose drives the whole body, superseding the head angle).

--- a/apps/web/src/imageJobAdvanced.test.js
+++ b/apps/web/src/imageJobAdvanced.test.js
@@ -47,6 +47,9 @@ function offState(overrides = {}) {
     activeControlMode: null,
     controlPassthroughId: null,
     effectiveControlScale: 0.7,
+    supportsImg2img: false,
+    img2imgReferenceAssetId: null,
+    img2imgStrength: 0.5,
     ...overrides,
   };
 }
@@ -68,6 +71,23 @@ describe("buildImageJobAdvanced", () => {
     const custom = buildImageJobAdvanced(offState({ sampler: "euler", scheduler: "karras" }));
     expect(custom.sampler).toBe("euler");
     expect(custom.scheduler).toBe("karras");
+  });
+
+  it("emits advanced.strength only for an img2img model with a reference (sc-8593)", () => {
+    // No img2img support → omitted even with a reference asset present.
+    expect(
+      buildImageJobAdvanced(offState({ img2imgReferenceAssetId: "ref-1", img2imgStrength: 0.4 })),
+    ).not.toHaveProperty("strength");
+    // img2img model but no reference picked → omitted.
+    expect(
+      buildImageJobAdvanced(offState({ supportsImg2img: true, img2imgReferenceAssetId: null })),
+    ).not.toHaveProperty("strength");
+    // img2img model + a picked reference → the full-range strength rides advanced.
+    expect(
+      buildImageJobAdvanced(
+        offState({ supportsImg2img: true, img2imgReferenceAssetId: "ref-1", img2imgStrength: 0.4 }),
+      ).strength,
+    ).toBe(0.4);
   });
 
   it("omits guidanceMethod for the engine no-op 'cfg' and rides a non-default method", () => {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -498,6 +498,13 @@ export function ImageStudio() {
   // InstantID, `controlnetScale` (IdentityNet landmark lock) rides there too.
   const [referenceAssetId, setReferenceAssetId] = useState("");
   const [ipAdapterScale, setIpAdapterScale] = useState(saved.ipAdapterScale ?? 0.6);
+  // img2img reference-guided generation (epic 8588 slice A, sc-8593): the reference picked in the
+  // "Start from an image" panel (lifted from ReferenceCaptionPicker) drives generation at this
+  // strength on an img2img-capable model (Krea 2 Turbo). Distinct from the character `referenceAssetId`
+  // above — same picker, different purpose. Default 0.5 (the full-range slider midpoint; the usable
+  // band is model-specific, so no clamp beyond the slider's 0–1).
+  const [img2imgReferenceAssetId, setImg2imgReferenceAssetId] = useState("");
+  const [img2imgStrength, setImg2imgStrength] = useState(saved.img2imgStrength ?? 0.5);
   const [controlnetScale, setControlnetScale] = useState(saved.controlnetScale ?? 0.8);
   // Variation knob for backbones whose CFG is decoupled from IP-Adapter:
   // FLUX (true_cfg_scale alongside ipAdapterScale) and Qwen-Image-Edit (true_cfg_scale
@@ -771,6 +778,14 @@ export function ImageStudio() {
   // Optional label/range override for the primary reference-strength slider (sc-8278: klein maps it
   // to image-guidance over 1.0–2.5). Absent ⇒ the legacy "Reference strength" 0–1 slider.
   const referenceStrengthCfg = selectedModel?.ui?.referenceStrength;
+  // img2img / reference-guided generation (epic 8588 slice A, sc-8593): a `ui.img2img` flag (Krea 2
+  // Turbo) — a UI toggle like poseLibrary/multiReference, NOT a `capabilities` value (z-image already
+  // uses "image_to_image" for its distinct edit-mode img2img, so a capability gate would collide).
+  // Turns the shared "Start from an image" picker double-duty: the same reference can be described into
+  // a prompt AND/OR guide the render via a strength slider, without needing the vision captioner.
+  // `ui.img2imgStrength` optionally overrides the slider label/range.
+  const supportsImg2img = Boolean(selectedModel?.ui?.img2img);
+  const img2imgStrengthConfig = selectedModel?.ui?.img2imgStrength ?? null;
   // Whether the edit model can outpaint (generate the padded border) — only models that
   // accept an inpaint mask (image_inpaint, SDXL family). Gates the Outpaint fit option.
   const editInpaintCapable = (selectedModel?.capabilities ?? []).includes("image_inpaint");
@@ -1377,6 +1392,7 @@ export function ImageStudio() {
       ["schedulerShift", setSchedulerShift],
       ["guidanceMethod", setGuidanceMethod],
       ["ipAdapterScale", setIpAdapterScale],
+      ["img2imgStrength", setImg2imgStrength],
       ["controlnetScale", setControlnetScale],
       ["trueCfgScale", setTrueCfgScale],
       ["viewAngle", setViewAngle],
@@ -1580,7 +1596,15 @@ export function ImageStudio() {
         // Fit mode applies to edits only; coerced so a stale "outpaint" never reaches a
         // non-inpaint model (epic 2551). Omitted for non-edit modes (worker default crop).
         fitMode: mode === "edit_image" ? effectiveFitMode(fitMode, editInpaintCapable) : undefined,
-        referenceAssetId: mode === "character_image" ? referenceAssetId || null : null,
+        // character_image: the IP-Adapter identity reference. Otherwise, on an img2img-capable model
+        // (Krea 2 Turbo, sc-8593), the reference picked in the "Start from an image" panel — sent so the
+        // worker's krea arm routes it to img2img latent-init (advanced.strength below).
+        referenceAssetId:
+          mode === "character_image"
+            ? referenceAssetId || null
+            : supportsImg2img
+              ? img2imgReferenceAssetId || null
+              : null,
         loras: selectedLoras.map((lora) => serializeLora(lora, { weight: effectiveLoraWeight(lora) })),
         ...(upscaleEnabled
           ? {
@@ -1623,6 +1647,10 @@ export function ImageStudio() {
           referenceAssetId,
           hideReferenceStrength,
           ipAdapterScale,
+          // img2img (sc-8593): emit advanced.strength when an img2img-capable model has a reference.
+          supportsImg2img,
+          img2imgReferenceAssetId,
+          img2imgStrength,
           identityStructure,
           controlnetScale,
           variationStrength,
@@ -2092,7 +2120,12 @@ export function ImageStudio() {
               mode === "text_to_image" &&
               typeof imageDescribe === "function" &&
               (visionCaptionReady || visionCaptionOffers.length > 0);
-            const describeActive = describeAvailable && promptTool === "describe";
+            // The "Start from an image" tile serves BOTH the describe→prompt flow AND img2img
+            // reference-guided generation (sc-8593). img2img needs no vision captioner, so it can open
+            // the panel on its own — the picked reference then rides generation via the strength slider.
+            const img2imgAvailable = supportsImg2img && mode === "text_to_image";
+            const referenceToolAvailable = describeAvailable || img2imgAvailable;
+            const describeActive = referenceToolAvailable && promptTool === "describe";
             const refineActive = promptTool === "refine";
             return (
               <div className="prompt-tools">
@@ -2101,7 +2134,7 @@ export function ImageStudio() {
                   <span className="hairline" />
                 </div>
                 <div className="prompt-tools-tiles">
-                  {describeAvailable ? (
+                  {referenceToolAvailable ? (
                     <button
                       type="button"
                       className={describeActive ? "prompt-tool active" : "prompt-tool"}
@@ -2111,7 +2144,11 @@ export function ImageStudio() {
                       <span className="prompt-tool-title">
                         <Icon.Image size={15} /> Start from an image
                       </span>
-                      <span className="prompt-tool-desc">Caption a reference into an editable prompt</span>
+                      <span className="prompt-tool-desc">
+                        {img2imgAvailable
+                          ? "Describe it into a prompt, or guide the render with it"
+                          : "Caption a reference into an editable prompt"}
+                      </span>
                     </button>
                   ) : null}
                   <button
@@ -2132,11 +2169,20 @@ export function ImageStudio() {
                       onCaption={onImageDescribe}
                       onApply={(text) => setPromptFromUser(text)}
                       onReferenceImageLoaded={onReferenceImageLoaded}
+                      onReferenceAssetChange={setImg2imgReferenceAssetId}
+                      showImg2imgStrength={img2imgAvailable}
+                      img2imgStrength={img2imgStrength}
+                      onImg2imgStrengthChange={setImg2imgStrength}
+                      img2imgStrengthConfig={img2imgStrengthConfig}
                       referenceAssets={editImageAssets}
                       referenceCharacters={characters}
                       importAsset={importAsset}
                       projectId={activeProject?.id ?? ""}
-                      hint="The image is only used to write the prompt — it isn’t sent to generation."
+                      hint={
+                        img2imgAvailable
+                          ? "Describe it into a prompt, or set a reference strength below to guide the render."
+                          : "The image is only used to write the prompt — it isn’t sent to generation."
+                      }
                       buttonLabel="✨ Describe image"
                       busyLabel="Describing…"
                       emptyMessage="The image did not produce a usable description. Try another reference."

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -1427,6 +1427,51 @@ describe("ImageStudio PiD decoder toggle (sc-7851)", () => {
   });
 });
 
+describe("ImageStudio img2img reference tile (epic 8588 slice A, sc-8593)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <ImageStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  // Krea-like img2img model: a `ui.img2img` toggle, plain text-to-image capability, no vision
+  // captioner in context (baseContext leaves `imageDescribe` undefined → describe flow unavailable).
+  const KREA_IMG2IMG = { ...Z_IMAGE, id: "krea_2_turbo", name: "Krea 2 Turbo", ui: { img2img: true } };
+  const startFromImageTile = () =>
+    [...document.body.querySelectorAll("button")].find((b) =>
+      b.textContent.includes("Start from an image"),
+    );
+
+  it("hides the 'Start from an image' tile for a plain t2i model with no captioner", async () => {
+    await render(baseContext({ imageModels: [Z_IMAGE], models: [Z_IMAGE] }));
+    expect(startFromImageTile()).toBeFalsy();
+  });
+
+  it("shows the tile for a ui.img2img model even without the vision captioner (sc-8593)", async () => {
+    await render(baseContext({ imageModels: [KREA_IMG2IMG], models: [KREA_IMG2IMG] }));
+    expect(startFromImageTile()).toBeTruthy();
+  });
+});
+
 describe("ImageStudio strict-control panel (epic 8236, sc-8245)", () => {
   let container;
   let root;

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2238,6 +2238,16 @@
       "type": "image",
       "adapter": "mlx_krea",
       "capabilities": ["text_to_image"],
+      // img2img reference-guided generation (epic 8588 slice A, sc-8593): the shared "Start from an
+      // image" picker doubles as a reference-guided init on Krea — the picked image + `img2imgStrength`
+      // seed the CFG-free Turbo denoise (worker resolve_krea_img2img_init → generate_turbo_img2img).
+      // A `ui.img2img` toggle (not a capabilities value — z-image already owns "image_to_image" for its
+      // distinct edit-mode img2img). Full 0–1 slider (default 0.5); NOT clamped — the usable band is
+      // model-specific (A0/sc-8589 ~0.35–0.65) and the worker owns the semantics.
+      "ui": {
+        "img2img": true,
+        "img2imgStrength": { "label": "Reference strength", "default": 0.5, "min": 0.0, "max": 1.0, "step": 0.05 }
+      },
       // macOnly is now a no-op label (mirroring klein/flux2_dev): candle availability is driven by the
       // routing tables (`CANDLE_ROUTED_MODELS` / `is_candle_engine`), not this flag. sc-9092: the candle
       // (Windows/Linux) lane now packed-loads the SAME `SceneWorks/krea-2-turbo-mlx` q4/q8/bf16 turnkey


### PR DESCRIPTION
## What
The user-facing UI for **Krea 2 Turbo reference-guided generation** (epic 8588 slice A, A3). Per Michael's design, the shared **"Start from an image"** picker is now double-duty: the same reference image can be **described into a prompt** (existing epic-8203 flow) AND/OR **used to guide the render** via a strength slider on an img2img-capable model.

## How (all additive — existing consumers untouched)
- **`ReferenceCaptionPicker`** (shared with Ideogram-JSON + all-t2i describe): new default-off props — `onReferenceAssetChange` lifts the picked asset to the parent; `showImg2imgStrength` un-gates the picker without the vision captioner AND renders the strength slider. The "Describe" button stays gated on the captioner. Absent props → byte-identical to today.
- **`ImageStudio`**: reads a **`ui.img2img`** toggle (a UI flag like `poseLibrary`/`multiReference`, **not** a `capabilities` value — z-image already owns `"image_to_image"` for its distinct edit-mode img2img, so a capability gate would collide). Adds img2img-strength state + persistence; the "Start from an image" tile now shows for img2img models **even without the captioner**; the payload sends top-level `referenceAssetId` + `advanced.strength`.
- **`imageJobAdvanced`**: emits `advanced.strength` when an img2img model has a picked reference (worker A2/sc-8591 routes it to `generate_turbo_img2img`).
- **manifest**: `krea_2_turbo` gets `ui.img2img: true` + `ui.img2imgStrength` (0–1, default 0.5, **no clamp** — the usable band is model-specific per A0/sc-8589).

## Tests / verification
- **payload**: `advanced.strength` rides only for an img2img model with a picked reference (`imageJobAdvanced.test.js`).
- **UI gating**: the "Start from an image" tile appears for a `ui.img2img` model even with no vision captioner, and stays hidden for a plain t2i model (`ImageStudio.test.jsx`).
- Full web vitest suite **green (1293 tests)**; eslint **0 errors**. Verified through the integration tests that render the real component tree — a backend-less browser preview can't populate `krea_2_turbo` to exercise the control.

Epic **8588**. Completes the slice-A user path: A1 (#664) → routing (#666) → repin (#1239) → worker A2 (#1240) → **this UI**. Candle parity is sc-10134; mood-board is B1 (sc-8595).

🤖 Generated with [Claude Code](https://claude.com/claude-code)