### PR TITLE
fix(web): Training Studio gate tracks the lens training-base variant, not the default tier (sc-8966)

### DIFF
--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -13,6 +13,7 @@ import {
   joyCaptionModel,
 } from "../training/joyCaptionPrompts.js";
 import { asText, boundedNumber, integerFromDraft } from "../training/drafts.js";
+import { trainingBaseState, trainingBaseTier } from "../trainingBase.js";
 import {
   captionDraftsFromDataset,
   datasetHealth,
@@ -507,19 +508,10 @@ export function TrainingStudio({ mode = "training" } = {}) {
   // install reads the true state). Only gated when targets exist but every trainable base is
   // missing — a target-registry error keeps its own "registry unavailable" message.
   const usableTrainingTargets = trainingTargets.filter((target) => !macTargetBlocked(target));
-  // A training base that is a quant-matrix re-host (epic 9992 Krea 2 Raw) is trained on its DENSE `bf16`
-  // tier — generation may have installed only the q8 default, but LoRA training needs the full-precision
-  // weights. Readiness + the install offer therefore track the `bf16` variant when present; a non-matrix
-  // base (z-image / sdxl / lens) has no such variant and uses its default tier.
-  const trainingBaseTier = (base) =>
-    base?.variants?.some((variant) => variant.variant === "bf16") ? "bf16" : undefined;
-  const trainingBaseState = (base) => {
-    const tier = trainingBaseTier(base);
-    if (tier) {
-      return base.variants.find((variant) => variant.variant === tier)?.installState ?? "missing";
-    }
-    return base.installState;
-  };
+  // Readiness + the install offer track the tier LoRA training actually needs — a dedicated `training`
+  // variant (lens, sc-8797) or else the DENSE `bf16` tier (Krea 2 Raw quant-matrix re-host, epic 9992) —
+  // not the default (q4) inference tier a user may have installed for generation. Resolution lives in the
+  // pure, unit-tested `trainingBase.js` (sc-8966). A non-matrix base (z-image / sdxl) uses its default tier.
   const trainingBaseMissing = (target) => {
     const base = models.find((item) => item.id === target?.baseModel);
     return Boolean(base) && trainingBaseState(base) === "missing";

--- a/apps/web/src/trainingBase.js
+++ b/apps/web/src/trainingBase.js
@@ -1,0 +1,43 @@
+// Resolve which tier of a model's catalog entry is its LoRA-TRAINING base (sc-8966). Pure +
+// unit-testable, deliberately separate from TrainingStudio.jsx (mirrors tierSuggestion.js /
+// quantTier.js) so the readiness gate + install offer share one source of truth.
+//
+// A quant-matrix base can ship MLX *inference* tiers (q4/q8/bf16) AND, independently, a base used for
+// LoRA training. The training base is NOT always the same artifact a user installed for generation:
+//   1. A dedicated flat-diffusers `training` variant (lens, sc-8797 — SceneWorks/Lens) — the LoRA
+//      trainer loads THIS, not the packed MLX inference tiers. It tracks its own per-variant install
+//      state (sc-8508), so a user can have lens q4 installed for gen while the training base is absent.
+//   2. Otherwise the DENSE `bf16` tier (Krea 2 Raw quant-matrix re-host, epic 9992): generation may
+//      have installed only the q8 default, but training needs full-precision weights.
+//   3. Otherwise undefined — a non-matrix base (z-image / sdxl) trains on its single default tier.
+export function trainingBaseTier(base) {
+  const variants = base?.variants;
+  if (!Array.isArray(variants)) {
+    return undefined;
+  }
+  // `training` wins over `bf16`: a base with both (lens) trains on the flat-diffusers training base,
+  // never the bf16 inference tier.
+  if (variants.some((variant) => variant?.variant === "training")) {
+    return "training";
+  }
+  if (variants.some((variant) => variant?.variant === "bf16")) {
+    return "bf16";
+  }
+  return undefined;
+}
+
+// The install state of the tier LoRA training actually needs. For a matrix base whose training tier is
+// a `training`/`bf16` variant, this is that tier's OWN per-variant `installState` (sc-8508) — so lens
+// with q4 installed but the training base missing correctly reads "missing" rather than the top-level
+// default-tier state (the sc-8966 bug: the Training Studio said "ready", then the submit failed
+// server-side because `SceneWorks/Lens` wasn't cached). A non-matrix base falls back to the model-level
+// `installState`.
+export function trainingBaseState(base) {
+  const tier = trainingBaseTier(base);
+  if (tier) {
+    return (
+      base?.variants?.find((variant) => variant?.variant === tier)?.installState ?? "missing"
+    );
+  }
+  return base?.installState;
+}

--- a/apps/web/src/trainingBase.test.js
+++ b/apps/web/src/trainingBase.test.js
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { trainingBaseState, trainingBaseTier } from "./trainingBase.js";
+
+// A /models-shaped base with per-variant install states (sc-8508). `installState` is the string the
+// catalog emits per tier ("installed" / "missing").
+function base(variants, installState = "installed") {
+  return { installState, variants };
+}
+const v = (variant, installState) => ({ variant, installState });
+
+describe("trainingBaseTier", () => {
+  it("prefers a dedicated `training` variant (lens, sc-8797) over the bf16 inference tier", () => {
+    // Lens ships q4/q8/bf16 MLX inference tiers AND a separate flat-diffusers training base.
+    const lens = base([v("q4", "installed"), v("q8", "missing"), v("bf16", "missing"), v("training", "missing")]);
+    expect(trainingBaseTier(lens)).toBe("training");
+  });
+
+  it("falls back to the dense bf16 tier when there is no training variant (Krea 2 Raw, epic 9992)", () => {
+    const krea = base([v("q4", "installed"), v("q8", "installed"), v("bf16", "missing")]);
+    expect(trainingBaseTier(krea)).toBe("bf16");
+  });
+
+  it("returns undefined for a non-matrix base (z-image / sdxl — trains on its default tier)", () => {
+    expect(trainingBaseTier(base(undefined))).toBe(undefined);
+    expect(trainingBaseTier(base([]))).toBe(undefined);
+    expect(trainingBaseTier(base([v("q4", "installed"), v("q8", "missing")]))).toBe(undefined);
+    expect(trainingBaseTier(undefined)).toBe(undefined);
+  });
+});
+
+describe("trainingBaseState", () => {
+  it("reports the TRAINING variant's own state — lens q4-installed but training-missing reads missing (the sc-8966 bug)", () => {
+    const lens = base(
+      [v("q4", "installed"), v("q8", "missing"), v("bf16", "missing"), v("training", "missing")],
+      // Top-level installState is "installed" (reflects the default q4 tier) — the OLD gate read this and
+      // wrongly said "ready". The fix reads the training variant instead.
+      "installed",
+    );
+    expect(trainingBaseState(lens)).toBe("missing");
+  });
+
+  it("reports installed once the training base itself is present", () => {
+    const lens = base([v("q4", "installed"), v("training", "installed")], "installed");
+    expect(trainingBaseState(lens)).toBe("installed");
+  });
+
+  it("reports the bf16 tier's state for a training-variant-less matrix base (Krea)", () => {
+    expect(trainingBaseState(base([v("q4", "installed"), v("bf16", "missing")]))).toBe("missing");
+    expect(trainingBaseState(base([v("q4", "installed"), v("bf16", "installed")]))).toBe("installed");
+  });
+
+  it("falls back to the top-level installState for a non-matrix base", () => {
+    expect(trainingBaseState(base([v("q4", "installed")], "installed"))).toBe("installed");
+    expect(trainingBaseState(base(undefined, "missing"))).toBe("missing");
+  });
+
+  it("treats a training tier declared but absent from variants as missing (never a false ready)", () => {
+    // Defensive: trainingBaseTier says "training" but no matching entry carries a state.
+    const weird = { installState: "installed", variants: [{ variant: "training" }] };
+    expect(trainingBaseState(weird)).toBe("missing");
+  });
+});


### PR DESCRIPTION
## What

On macOS, the Training Studio readiness gate said **ready** for a lens LoRA-training target when only the lens **q4** inference tier was installed — then the submit failed server-side: *"Base model 'lens' is not installed. Install it from the model catalog."* A confusing round-trip.

## Root cause

sc-8797 made the lens LoRA-training base a separate **`variant: "training"`** download (the `SceneWorks/Lens` flat-diffusers rehost — the MLX q4/q8/bf16 inference tiers don't include it). But the readiness gate's `trainingBaseTier` only recognized the **`bf16`** tier (added for Krea 2 Raw, epic 9992):

```js
const trainingBaseTier = (base) =>
  base?.variants?.some((v) => v.variant === "bf16") ? "bf16" : undefined;
```

For lens that returns `undefined`, so `trainingBaseState` fell back to the model's **top-level** `installState` (the default q4 tier). q4 installed → gate reads "ready", but the training base (`SceneWorks/Lens`) is absent → server rejects.

## Fix

- Extracted the training-base resolution to a pure, unit-tested **`apps/web/src/trainingBase.js`** (mirrors `tierSuggestion.js` / `quantTier.js`).
- `trainingBaseTier` now resolves **`training` → `bf16` → undefined**: a dedicated flat-diffusers training base (lens) wins over the bf16 inference tier; a matrix base with only bf16 (Krea) uses bf16; a non-matrix base (z-image/sdxl) uses its default tier.
- `trainingBaseState` reads that tier's **own per-variant `installState`** (sc-8508). The catalog already emits the `training` entry in `variants[]` with an independent install state (`model_variant_states`, serialized `"installState": "installed"|"missing"` at models.rs:1243), probed against `SceneWorks/Lens` — so lens-q4-installed-but-training-missing now correctly reads "missing" and the gate offers the training-base install.
- `TrainingStudio.jsx` imports the helpers; `trainingBaseMissing` / `trainingReady` / `installTrainingBase` are unchanged in behavior (they already derived from these).

## Verification

- New `trainingBase.test.js`: 7 cases (lens training-missing → missing; installed once present; Krea bf16; non-matrix top-level fallback; `training` > `bf16` precedence; defensive absent-tier → never a false ready).
- Full `apps/web` vitest: **1300/1300**. eslint 0 errors. Prod build clean.

Windows/Linux unaffected (the off-Mac lens install is the whole `SceneWorks/Lens` repo; a non-matrix base still uses its default install state).

Closes sc-8966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)