### PR TITLE
chore: repoint dead microsoft/Lens* references to live SceneWorks rehosts (sc-8965)

### DIFF
--- a/apps/web/public/prompt-guides/lens-turbo.md
+++ b/apps/web/public/prompt-guides/lens-turbo.md
@@ -66,5 +66,5 @@ Use concise negatives: `blurred lettering, extra objects, low contrast, warped l
 
 ## Sources
 
-- [Microsoft Lens-Turbo model card](https://huggingface.co/microsoft/Lens-Turbo)
-- [Microsoft Lens model card](https://huggingface.co/microsoft/Lens)
+- [Lens-Turbo — SceneWorks MLX rehost](https://huggingface.co/SceneWorks/lens-turbo-mlx)
+- [Lens — SceneWorks MLX rehost](https://huggingface.co/SceneWorks/lens-mlx)

--- a/apps/web/public/prompt-guides/lens.md
+++ b/apps/web/public/prompt-guides/lens.md
@@ -75,5 +75,5 @@ Use short negatives for unwanted artifacts: `blurry text, malformed hands, disto
 
 ## Sources
 
-- [Microsoft Lens model card](https://huggingface.co/microsoft/Lens)
-- [Microsoft Lens-Turbo model card](https://huggingface.co/microsoft/Lens-Turbo)
+- [Lens — SceneWorks MLX rehost](https://huggingface.co/SceneWorks/lens-mlx)
+- [Lens-Turbo — SceneWorks MLX rehost](https://huggingface.co/SceneWorks/lens-turbo-mlx)

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -865,8 +865,8 @@
           "title": "Lens Prompt Guide",
           "path": "/prompt-guides/lens.md",
           "sources": [
-            { "label": "Microsoft Lens model card", "url": "https://huggingface.co/microsoft/Lens" },
-            { "label": "Microsoft Lens-Turbo model card", "url": "https://huggingface.co/microsoft/Lens-Turbo" }
+            { "label": "Lens — SceneWorks MLX rehost", "url": "https://huggingface.co/SceneWorks/lens-mlx" },
+            { "label": "Lens-Turbo — SceneWorks MLX rehost", "url": "https://huggingface.co/SceneWorks/lens-turbo-mlx" }
           ]
         }
       }
@@ -992,8 +992,8 @@
           "title": "Lens-Turbo Prompt Guide",
           "path": "/prompt-guides/lens-turbo.md",
           "sources": [
-            { "label": "Microsoft Lens-Turbo model card", "url": "https://huggingface.co/microsoft/Lens-Turbo" },
-            { "label": "Microsoft Lens model card", "url": "https://huggingface.co/microsoft/Lens" }
+            { "label": "Lens-Turbo — SceneWorks MLX rehost", "url": "https://huggingface.co/SceneWorks/lens-turbo-mlx" },
+            { "label": "Lens — SceneWorks MLX rehost", "url": "https://huggingface.co/SceneWorks/lens-mlx" }
           ]
         }
       }

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -1481,16 +1481,17 @@ fn lens_real_weights_generates_one_image() {
 }
 
 /// Real-weights smoke: Lens-Turbo (the distilled 4-step / guidance 1.0 variant, ≈ no CFG) — same
-/// architecture/weights tree as base Lens, different defaults. Loads the `microsoft/Lens-Turbo`
-/// snapshot at the Q8 default. Needs the HF cache + a Metal device; run on demand:
+/// architecture/weights tree as base Lens, different defaults. Loads the `SceneWorks/lens-turbo-mlx`
+/// `bf16/` tier subdir (mirrors the base `lens` smoke; the dead flat `microsoft/Lens-Turbo` repo was
+/// retired, sc-8797/sc-8965). Needs the HF cache + a Metal device; run on demand:
 /// `cargo test -p sceneworks-worker --lib -- --ignored lens_turbo_real_weights`.
 #[cfg(target_os = "macos")]
 #[test]
-#[ignore = "needs real microsoft/Lens-Turbo weights + Metal device"]
+#[ignore = "needs real SceneWorks/lens-turbo-mlx weights + Metal device"]
 fn lens_turbo_real_weights_generates_one_image() {
     smoke_generate_one(
         "lens_turbo",
-        hf_snapshot("models--microsoft--Lens-Turbo"),
+        hf_snapshot("models--SceneWorks--lens-turbo-mlx").join("bf16"),
         Some(1.0),
         None,
     );
@@ -1503,12 +1504,12 @@ fn lens_turbo_real_weights_generates_one_image() {
 /// `cargo test -p sceneworks-worker --lib -- --ignored lens_turbo_real_weights_bucket`.
 #[cfg(target_os = "macos")]
 #[test]
-#[ignore = "needs real microsoft/Lens-Turbo weights + Metal device"]
+#[ignore = "needs real SceneWorks/lens-turbo-mlx weights + Metal device"]
 fn lens_turbo_real_weights_bucket_resolution() {
     let model = mlx_model("lens_turbo").unwrap();
     let generator = load_engine(
         model.engine_id(),
-        hf_snapshot("models--microsoft--Lens-Turbo"),
+        hf_snapshot("models--SceneWorks--lens-turbo-mlx").join("bf16"),
         Some(gen_core::Quant::Q8),
         Vec::new(),
         None,

--- a/scripts/smoke-lens.ps1
+++ b/scripts/smoke-lens.ps1
@@ -17,7 +17,7 @@
   - Build the binaries (VS2022 v143 BuildTools / CUDA 12.9; sm_120 native PTX shown):
       cmd /c 'call "<vcvars64.bat>" && set CUDA_COMPUTE_CAP=120 && cargo build --release ^
         -p sceneworks-rust-api -p sceneworks-rust-worker --features sceneworks-worker/backend-candle'
-  - microsoft/Lens + microsoft/Lens-Turbo snapshots in the HF cache (~/.cache/huggingface/hub).
+  - SceneWorks/lens-mlx + SceneWorks/lens-turbo-mlx snapshots in the HF cache (~/.cache/huggingface/hub).
 
 .EXAMPLE
   pwsh scripts/smoke-lens.ps1


### PR DESCRIPTION
## What

`microsoft/Lens` and `microsoft/Lens-Turbo` were pulled from Hugging Face (sc-8797). This clears the remaining stale references to them.

## Re-scope note

Half of this story's original bullets are now **obsolete**: the Python torch lens lane (`apps/worker/scene_worker/image_adapters.py`) and its test (`tests/test_worker_image_adapters.py`) are **deleted** with `apps/worker/` (epic 8283, Python eradication). And **no live code path** ever fetched the dead repo — the MLX lane loads `SceneWorks/lens-mlx` tiers, candle loads `SceneWorks/Lens`. So this is stale **test globs + doc links**, not a runtime 404.

## Changes

- **`crates/sceneworks-worker/src/image_jobs/tests.rs`** — the two `#[ignore]`d macOS `lens_turbo` real-weights smokes still globbed `models--microsoft--Lens-Turbo`. Repointed to `hf_snapshot("models--SceneWorks--lens-turbo-mlx").join("bf16")` — a straight mirror of the already-repointed base-`lens` smoke (tests.rs:1477). Comments + `#[ignore]` messages updated.
- **`apps/web/public/prompt-guides/lens.md`, `lens-turbo.md`, `config/manifests/builtin.models.jsonc`** (promptGuide.sources) — dead `huggingface.co/microsoft/Lens{,-Turbo}` links → the live SceneWorks MLX rehost cards (`SceneWorks/lens-mlx`, `SceneWorks/lens-turbo-mlx`).
- **`scripts/smoke-lens.ps1`** — requirement note repointed to the SceneWorks snapshots.

Remaining `microsoft/Lens` mentions (in `training.rs` / `engines.rs` / `training_jobs.rs` / manifest comments) are accurate **historical provenance** ("the original microsoft/Lens is dead, sc-8797") and left as-is.

## Verification
- `npm run check` (scaffold/manifest): pass.
- `cargo fmt -p sceneworks-worker --check`: clean.
- `cargo check -p sceneworks-worker --all-targets`: green (the repointed smokes compile).

Closes sc-8965.

🤖 Generated with [Claude Code](https://claude.com/claude-code)