### PR TITLE
feat(mood-board): multi-image reference → one synthesized prompt (sc-8595)

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -35,6 +35,12 @@ pub(crate) struct PromptRefineRequest {
     /// Reference image for the vision tasks (`image_caption` / `image_describe`): a project
     /// asset id resolved to a confined on-disk path before the job is enqueued (epic 8102/8203).
     pub(crate) source_asset_id: Option<String>,
+    /// Multiple reference images for a "mood board" synthesis (epic 8588, sc-8595): the vision task
+    /// examines them together and emits ONE prompt/caption capturing the aesthetic they share. When
+    /// non-empty this takes precedence over `source_asset_id`; each id is resolved to a confined path
+    /// and forwarded as the worker's `imagePaths` array. Empty/absent → the single-image path above.
+    #[serde(default)]
+    pub(crate) source_asset_ids: Vec<String>,
     /// Project owning `source_asset_id` (required for the vision tasks so the
     /// asset's relative `file.path` can be resolved to an absolute path).
     pub(crate) project_id: Option<String>,

--- a/apps/rust-api/src/prompts.rs
+++ b/apps/rust-api/src/prompts.rs
@@ -1,5 +1,11 @@
 use super::*;
 
+/// Maximum reference images in one "mood board" describe/caption request (epic 8588, sc-8595). Each
+/// reference is downscaled to ~1 MP before the dense Qwen-VL ViT, so the cost scales with N; this bounds
+/// the vision attention + context a single request can demand. The Image Studio picker enforces the same
+/// ceiling client-side — this is the authoritative server-side guard.
+pub(crate) const MAX_MOOD_BOARD_IMAGES: usize = 6;
+
 /// Enqueue a `prompt_refine` job: a lightweight, non-GPU job that asks an
 /// OpenAI-compatible LLM to rewrite the user's prompt to follow the selected
 /// model's prompt guide. The job runs in the Python worker (which reuses the
@@ -31,14 +37,42 @@ pub(crate) async fn create_prompt_refine_job(
     }
 
     if is_vision_task {
-        let asset_id = payload
-            .source_asset_id
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .ok_or_else(|| {
-                ApiError::bad_request("sourceAssetId is required for a reference-image task")
-            })?;
+        // A "mood board" (epic 8588, sc-8595) sends several references in `sourceAssetIds`; the worker
+        // synthesizes ONE prompt/caption from the aesthetic they share. When that plural list is non-empty
+        // it takes precedence over the single `sourceAssetId`; otherwise the single id is the sole
+        // reference (the unchanged single-image path). Every id is resolved to a confined on-disk path.
+        let asset_ids: Vec<&str> = {
+            let plural: Vec<&str> = payload
+                .source_asset_ids
+                .iter()
+                .map(|value| value.trim())
+                .filter(|value| !value.is_empty())
+                .collect();
+            if plural.is_empty() {
+                payload
+                    .source_asset_id
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .into_iter()
+                    .collect()
+            } else {
+                plural
+            }
+        };
+        if asset_ids.is_empty() {
+            return Err(ApiError::bad_request(
+                "sourceAssetId (or sourceAssetIds) is required for a reference-image task",
+            ));
+        }
+        // Bound the board: each reference is downscaled to ~1 MP before the dense Qwen-VL ViT, so N
+        // references cost ~N MP of vision attention + context. Cap it so a runaway list cannot exhaust
+        // memory. The UI enforces the same ceiling; this is the server-side guard.
+        if asset_ids.len() > MAX_MOOD_BOARD_IMAGES {
+            return Err(ApiError::bad_request(format!(
+                "A mood board accepts at most {MAX_MOOD_BOARD_IMAGES} reference images"
+            )));
+        }
         let project_id = payload
             .project_id
             .as_deref()
@@ -47,8 +81,24 @@ pub(crate) async fn create_prompt_refine_job(
             .ok_or_else(|| {
                 ApiError::bad_request("projectId is required for a reference-image task")
             })?;
-        let image_path = resolve_image_caption_path(state.clone(), project_id, asset_id).await?;
-        job_payload.insert("imagePath".to_owned(), Value::String(image_path));
+        let mut image_paths = Vec::with_capacity(asset_ids.len());
+        for asset_id in &asset_ids {
+            image_paths
+                .push(resolve_image_caption_path(state.clone(), project_id, asset_id).await?);
+        }
+        // A single reference keeps the scalar `imagePath` (byte-identical to the pre-mood-board path);
+        // multiple references ride the `imagePaths` array the worker prefers.
+        if image_paths.len() == 1 {
+            job_payload.insert(
+                "imagePath".to_owned(),
+                Value::String(image_paths.into_iter().next().unwrap()),
+            );
+        } else {
+            job_payload.insert(
+                "imagePaths".to_owned(),
+                Value::Array(image_paths.into_iter().map(Value::String).collect()),
+            );
+        }
         // The vision model is named by its HF repo string; the worker resolves it by repo (like the
         // refiner), so it must be carried verbatim rather than as a catalog id.
         if let Some(model) = payload

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -4740,6 +4740,96 @@ async fn image_describe_refine_job_requires_source_asset_and_project() {
 }
 
 #[tokio::test]
+async fn mood_board_refine_job_resolves_multiple_assets_to_image_paths() {
+    // epic 8588 / sc-8595: a "mood board" describe POSTs `sourceAssetIds` (plural). The handler resolves
+    // EACH id to a confined on-disk path, in order, and forwards them as the worker's `imagePaths` array
+    // (no scalar `imagePath`), so the vision model synthesizes ONE prompt from the shared aesthetic.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Mood Board Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id").to_owned();
+    let project_path = std::path::PathBuf::from(project["path"].as_str().unwrap());
+
+    let mut asset_ids = Vec::new();
+    let mut rel_paths = Vec::new();
+    for name in ["First.png", "Second.png"] {
+        let (status, asset) = request_multipart_upload(
+            app.clone(),
+            &format!("/api/v1/projects/{project_id}/assets"),
+            name,
+            "image/png",
+            b"png-bytes",
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED);
+        asset_ids.push(asset["id"].as_str().expect("asset id").to_owned());
+        rel_paths.push(
+            asset["file"]["path"]
+                .as_str()
+                .expect("file path")
+                .to_owned(),
+        );
+    }
+
+    let (status, job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/prompts/refine",
+        json!({
+            "task": "image_describe",
+            "sourceAssetIds": asset_ids,
+            "projectId": project_id,
+            "model": "huihui-ai/Huihui-Qwen3-VL-8B-Instruct-abliterated"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(job["payload"]["task"], "image_describe");
+    // The plural array is emitted; the scalar single-image key is NOT.
+    assert!(job["payload"].get("imagePath").is_none());
+    let paths = job["payload"]["imagePaths"]
+        .as_array()
+        .expect("imagePaths array");
+    assert_eq!(paths.len(), 2, "both references resolved");
+    for (path, rel) in paths.iter().zip(rel_paths.iter()) {
+        // Path (not string) comparison: separator-agnostic on Windows (sc-8967).
+        let expected = project_path.join(rel);
+        assert_eq!(std::path::Path::new(path.as_str().unwrap()), expected);
+    }
+}
+
+#[tokio::test]
+async fn mood_board_refine_job_rejects_more_than_the_cap() {
+    // sc-8595: the server-side ceiling (MAX_MOOD_BOARD_IMAGES) is authoritative — a board over the cap is
+    // rejected with 400 before any asset resolution, so a runaway list cannot exhaust the vision runtime.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    let too_many: Vec<String> = (0..(crate::prompts::MAX_MOOD_BOARD_IMAGES + 1))
+        .map(|i| format!("asset-{i}"))
+        .collect();
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/prompts/refine",
+        json!({
+            "task": "image_describe",
+            "sourceAssetIds": too_many,
+            "projectId": "project-1"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn image_and_video_job_routes_normalize_payloads() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let app = create_app(test_settings(&temp_dir)).expect("app creates");

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1377,10 +1377,12 @@ export function App() {
   // the returned JSON with `parseVisionCaption` (aspect_ratio stripped, bboxes KEPT). C1: the image is
   // consumed only to produce the caption — it is NEVER passed to generation as img2img conditioning.
   const imageCaption = useCallback(
-    ({ sourceAssetId, projectId, model, signal }) =>
+    ({ sourceAssetId, sourceAssetIds, projectId, model, signal }) =>
       pollJobToCompletion({
         createPath: "/api/v1/prompts/refine",
-        body: { task: "image_caption", sourceAssetId, projectId, model },
+        // A mood board (epic 8588, sc-8595) sends `sourceAssetIds` (plural); the API synthesizes ONE
+        // caption from the shared aesthetic. A single reference keeps the scalar `sourceAssetId`.
+        body: { task: "image_caption", sourceAssetId, sourceAssetIds, projectId, model },
         deadlineMs: 180000,
         resolveResult: (job) => {
           const caption = job.result?.refinedPrompt;
@@ -1405,10 +1407,12 @@ export function App() {
   // text the caller drops into the prompt box. C1: the image is consumed only to produce the prompt — it
   // is NEVER passed to generation as img2img conditioning.
   const imageDescribe = useCallback(
-    ({ sourceAssetId, projectId, model, captionStyle, signal }) =>
+    ({ sourceAssetId, sourceAssetIds, projectId, model, captionStyle, signal }) =>
       pollJobToCompletion({
         createPath: "/api/v1/prompts/refine",
-        body: { task: "image_describe", sourceAssetId, projectId, model, captionStyle },
+        // A mood board (epic 8588, sc-8595) sends `sourceAssetIds` (plural); the API synthesizes ONE
+        // prompt from the aesthetic they share. A single reference keeps the scalar `sourceAssetId`.
+        body: { task: "image_describe", sourceAssetId, sourceAssetIds, projectId, model, captionStyle },
         deadlineMs: 180000,
         resolveResult: (job) => {
           const description = job.result?.refinedPrompt;

--- a/apps/web/src/components/ReferenceCaptionPicker.jsx
+++ b/apps/web/src/components/ReferenceCaptionPicker.jsx
@@ -13,7 +13,7 @@
 // the result to its own state). C1: the image is captioning-only — never sent to generation.
 
 import React, { useEffect, useState } from "react";
-import { ImageEditSourcePickerField } from "./AssetPicker.jsx";
+import { AssetPickerField, ImageEditSourcePickerField } from "./AssetPicker.jsx";
 import { assetUrl } from "./assetMedia.jsx";
 import { ModelAvailabilityGate } from "./ModelAvailabilityGate.jsx";
 
@@ -58,10 +58,25 @@ export default function ReferenceCaptionPicker({
   img2imgStrength = 0.5,
   onImg2imgStrengthChange,
   img2imgStrengthConfig,
+  // Multi-image "mood board" (epic 8588, sc-8595): when true, an additional multi-select gallery lets the
+  // user add MORE reference images beyond the primary. `onCaption` is then called with the FULL array of
+  // ids ([primary, ...extras]) and the worker synthesizes ONE prompt/caption from the shared aesthetic. A
+  // single reference (no extras) still calls `onCaption` with the plain id string — so describe/Ideogram
+  // consumers that don't opt in are byte-unaffected. `moodBoardMax` bounds the board (server also caps).
+  showMoodBoard = false,
+  moodBoardMax = 6,
 }) {
   const [referenceAssetId, setReferenceAssetId] = useState("");
+  const [moodBoardIds, setMoodBoardIds] = useState([]);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
+
+  // The extra mood-board picks, minus the primary (it is already the first image) and capped. This is
+  // what actually augments the describe call; `referenceAssetId` stays the primary / img2img seed.
+  const moodBoardExtras = moodBoardIds
+    .filter((id) => id && id !== referenceAssetId)
+    .slice(0, Math.max(0, moodBoardMax - 1));
+  const moodBoardActive = showMoodBoard && moodBoardExtras.length > 0;
 
   // Feed the uploaded image's natural dimensions to the sc-8109 auto-preset seam.
   function reportReferenceDimensions(asset) {
@@ -100,7 +115,12 @@ export default function ReferenceCaptionPicker({
     setBusy(true);
     setError("");
     try {
-      const result = await onCaption(referenceAssetId);
+      // A mood board sends the FULL ordered list ([primary, ...extras]); a lone reference keeps the
+      // scalar id so consumers that never opted into `showMoodBoard` see the unchanged string contract.
+      const arg = moodBoardActive
+        ? [referenceAssetId, ...moodBoardExtras]
+        : referenceAssetId;
+      const result = await onCaption(arg);
       if (result) {
         onApply(result);
       } else {
@@ -139,6 +159,22 @@ export default function ReferenceCaptionPicker({
           projectId={projectId}
           value={referenceAssetId}
         />
+        {/* Mood board (epic 8588, sc-8595): add MORE reference images beyond the primary; the model
+            synthesizes ONE prompt/caption from the aesthetic they share. Only once a primary is chosen
+            (it is the first image). The extras come from the project library (the primary picker keeps
+            import/characters). Capped at moodBoardMax − 1 extras; the server enforces the same ceiling. */}
+        {showMoodBoard && referenceAssetId ? (
+          <AssetPickerField
+            assets={referenceAssets.filter((asset) => asset.id !== referenceAssetId)}
+            buttonLabel="Add mood-board images"
+            changeLabel="Edit mood board"
+            emptyLabel="Add more images to blend their style (optional)"
+            label="Mood board (optional)"
+            multiple
+            onChange={setMoodBoardIds}
+            values={moodBoardExtras}
+          />
+        ) : null}
         {/* Describe → prompt (epic 8203): only when the vision captioner is present. An img2img-only
             model (no captioner) still gets the picker + strength slider below via `showImg2imgStrength`. */}
         {visionCaptionReady ? (
@@ -152,9 +188,10 @@ export default function ReferenceCaptionPicker({
           </button>
         ) : null}
         {/* img2img strength (epic 8588 slice A, sc-8593): the SAME picked reference guides generation
-            (reference-guided / latent-init) at this strength. Shown only for img2img-capable models
-            once a reference is chosen. */}
-        {showImg2imgStrength && referenceAssetId ? (
+            (reference-guided / latent-init) at this strength. Shown for img2img-capable models once a
+            SINGLE reference is chosen — hidden when a mood board is active, since img2img seeds from one
+            image, not a blend. */}
+        {showImg2imgStrength && referenceAssetId && !moodBoardActive ? (
           <label className="reference-strength img2img-strength">
             {img2imgStrengthConfig?.label ?? "Reference strength"}
             <input

--- a/apps/web/src/components/ReferenceCaptionPicker.test.jsx
+++ b/apps/web/src/components/ReferenceCaptionPicker.test.jsx
@@ -45,8 +45,24 @@ describe("ReferenceCaptionPicker", () => {
     file: { path: "uploads/ref.png", mimeType: "image/png" },
   };
 
+  const refAsset2 = {
+    id: "ref-2",
+    type: "image",
+    projectId: "proj-1",
+    file: { path: "uploads/ref2.png", mimeType: "image/png" },
+  };
+
   async function selectReference() {
     await clickAndSettle(buttonByText("Select reference image"));
+    const card = document.body.querySelector(".asset-picker-card");
+    await clickAndSettle(card);
+    await clickAndSettle(buttonByText("Use Selection"));
+  }
+
+  // Add one extra image to the mood board (the extras picker excludes the primary, so ref-2 is the only
+  // card shown). Multi-select mode: click the card to toggle it, then confirm.
+  async function addMoodBoardExtra() {
+    await clickAndSettle(buttonByText("Add mood-board images"));
     const card = document.body.querySelector(".asset-picker-card");
     await clickAndSettle(card);
     await clickAndSettle(buttonByText("Use Selection"));
@@ -112,6 +128,61 @@ describe("ReferenceCaptionPicker", () => {
     await clickAndSettle(buttonByText("✨ Describe image"));
 
     expect(document.body.querySelector(".structured-error")?.textContent).toContain("describe blew up");
+  });
+
+  // ── epic 8588 / sc-8595: multi-image "mood board" ──
+
+  it("does not render the mood-board picker unless showMoodBoard is set", async () => {
+    await mount({ onCaption: vi.fn(async () => "x"), referenceAssets: [refAsset, refAsset2] });
+    await selectReference();
+    // Additive: the default consumers (describe/Ideogram that don't opt in) never see the gallery.
+    expect(buttonByText("Add mood-board images")).toBeFalsy();
+  });
+
+  it("sends the full ordered array to onCaption when a mood board is assembled", async () => {
+    const onCaption = vi.fn(async () => "a shared cinematic mood");
+    const onApply = vi.fn();
+    await mount({
+      onCaption,
+      onApply,
+      showMoodBoard: true,
+      referenceAssets: [refAsset, refAsset2],
+    });
+    await selectReference(); // primary → ref-1
+    await addMoodBoardExtra(); // extra → ref-2
+    await clickAndSettle(buttonByText("✨ Describe image"));
+
+    expect(onCaption).toHaveBeenCalledWith(["ref-1", "ref-2"]);
+    expect(onApply).toHaveBeenCalledWith("a shared cinematic mood");
+  });
+
+  it("still sends a plain id string when showMoodBoard is on but no extras are added", async () => {
+    const onCaption = vi.fn(async () => "x");
+    await mount({
+      onCaption,
+      showMoodBoard: true,
+      referenceAssets: [refAsset, refAsset2],
+    });
+    await selectReference();
+    await clickAndSettle(buttonByText("✨ Describe image"));
+
+    // A lone reference collapses to the scalar string — the unchanged single-image contract.
+    expect(onCaption).toHaveBeenCalledWith("ref-1");
+  });
+
+  it("hides the img2img strength slider once a mood board is active", async () => {
+    await mount({
+      onCaption: vi.fn(async () => "x"),
+      showMoodBoard: true,
+      showImg2imgStrength: true,
+      referenceAssets: [refAsset, refAsset2],
+    });
+    await selectReference();
+    // A single reference is a valid img2img seed → the strength slider shows.
+    expect(document.body.querySelector(".img2img-strength")).toBeTruthy();
+    await addMoodBoardExtra();
+    // A blend has no single seed → the slider is hidden.
+    expect(document.body.querySelector(".img2img-strength")).toBeFalsy();
   });
 
   it("gates behind the download offer (no picker/button) when the captioner is missing", async () => {

--- a/apps/web/src/components/StructuredPromptBuilder.jsx
+++ b/apps/web/src/components/StructuredPromptBuilder.jsx
@@ -406,6 +406,7 @@ export default function StructuredPromptBuilder({
               hint="Or start from a reference image — the captioner reads it into a grounded JSON caption you can edit. The image is only used to write the caption; it isn’t sent to generation."
               buttonLabel="✨ Generate JSON from image"
               busyLabel="Captioning…"
+              showMoodBoard={visionCaptionReady}
               emptyMessage="The image did not produce a usable caption. Try another reference."
               errorFallback="Could not caption the image."
               gateDescription="Download the vision captioner to turn a reference image into an editable JSON caption. It runs locally on the native worker; the image is only used to write the caption."

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -1299,15 +1299,20 @@ export function ImageStudio() {
   // surfaces the error and lets the user retry, mirroring the magic-prompt error UX. C1: the image is
   // captioning-only — it is consumed here to produce JSON and never passed to generation.
   const onImageCaption = useCallback(
-    async (sourceAssetId) => {
+    // Single id (string) for one reference, or an ARRAY of ids for a mood board (sc-8595): >1 synthesizes
+    // ONE Ideogram JSON caption from the shared style, exactly one keeps the scalar single-image path.
+    async (source) => {
       if (typeof imageCaption !== "function") {
         throw new Error("Image captioning is unavailable.");
       }
       if (!activeProject?.id) {
         throw new Error("Open a project first.");
       }
+      const ids = Array.isArray(source) ? source.filter(Boolean) : [source].filter(Boolean);
+      const multi = ids.length > 1;
       const raw = await imageCaption({
-        sourceAssetId,
+        sourceAssetId: multi ? undefined : ids[0],
+        sourceAssetIds: multi ? ids : undefined,
         projectId: activeProject.id,
         model: VISION_CAPTION_MODEL_REPO,
       });
@@ -1329,15 +1334,21 @@ export function ImageStudio() {
   // never passed to generation.
   const describeCaptionStyle = selectedModel?.captionStyle;
   const onImageDescribe = useCallback(
-    async (sourceAssetId) => {
+    // The shared picker passes a single asset id (string) for one reference, or an ARRAY of ids for a
+    // mood board (sc-8595). Normalize: >1 rides `sourceAssetIds` (worker synthesizes one prompt from the
+    // shared style), exactly one collapses to the scalar `sourceAssetId` (the unchanged single path).
+    async (source) => {
       if (typeof imageDescribe !== "function") {
         throw new Error("Image description is unavailable.");
       }
       if (!activeProject?.id) {
         throw new Error("Open a project first.");
       }
+      const ids = Array.isArray(source) ? source.filter(Boolean) : [source].filter(Boolean);
+      const multi = ids.length > 1;
       const text = await imageDescribe({
-        sourceAssetId,
+        sourceAssetId: multi ? undefined : ids[0],
+        sourceAssetIds: multi ? ids : undefined,
         projectId: activeProject.id,
         model: VISION_CAPTION_MODEL_REPO,
         captionStyle: describeCaptionStyle,
@@ -2185,6 +2196,7 @@ export function ImageStudio() {
                       }
                       buttonLabel="✨ Describe image"
                       busyLabel="Describing…"
+                      showMoodBoard={visionCaptionReady}
                       emptyMessage="The image did not produce a usable description. Try another reference."
                       errorFallback="Could not describe the image."
                       gateDescription="Download the vision captioner to turn a reference image into a prompt. It runs locally on the native worker; the image is only used to write the prompt."

--- a/crates/sceneworks-worker/src/ideogram_image_caption_moodboard_v1.txt
+++ b/crates/sceneworks-worker/src/ideogram_image_caption_moodboard_v1.txt
@@ -1,0 +1,122 @@
+[META]
+frozen: false
+description: Multi-image "mood board" Ideogram JSON synthesis (epic 8588, sc-8595) — examine SEVERAL reference images and emit ONE schema-valid Ideogram caption for a NEW image that shares their style/mood/composition. style_description is grounded in the SHARED look across the board; the composition is synthesized (like magic_prompt from a text idea). Vision system prompt for the core_llm TextLlm path; output in a json code fence. Thinking off. The N>1 sibling of ideogram_image_caption_v1.
+thinking_mode: disabled
+
+[SYSTEM]
+You are a mood-board captioner. You are given SEVERAL reference images (a mood board). You EXAMINE all of them together and emit a single structured JSON caption for a NEW image that shares their common visual language, in the format an image renderer consumes. You SYNTHESIZE across the images: the STYLE fields are grounded in the aesthetic the images share, and the composition is a coherent NEW scene rendered in that shared style — not a copy of any one image.
+
+## OUTPUT CONTRACT — emit ONE JSON object, in a fenced code block
+
+Wrap the object in a ```json … ``` fence so the markdown survives transport. Emit exactly these top-level keys, in this order (every key required):
+
+```json
+{"high_level_description":"...","style_description":{...},"compositional_deconstruction":{"background":"...","elements":[ ... ]}}
+```
+
+- Emit valid JSON — the only content is the single object inside the fence. No commentary, no extra prose, no other top-level keys.
+- Do NOT emit an `aspect_ratio` key.
+- Do NOT reference the images as separate pictures ("the first image", "image 2"). Emit ONE unified caption for a single new image.
+- Preserve non-ASCII characters as-is (CJK, Cyrillic, Devanagari, Arabic, accented Latin). Never escape with `\uNNNN`, transliterate, or replace `café` with `cafe`.
+- Use SINGLE quotes for embedded text references in prose fields (`'Joe's Diner'`, not `\"Joe's Diner\"`). The `text` field of text elements is the exception — that field holds verbatim characters.
+
+## SYNTHESIZE ACROSS THE BOARD
+
+- `style_description` is GROUNDED: capture the medium, lighting, aesthetic, and palette the images genuinely SHARE. Weigh recurring traits heavily; a trait in only one image is incidental unless it is clearly the board's point. When the board conflicts on a trait, prefer the majority or the most distinctive shared quality — never average conflicting looks into an incoherent blend.
+- The composition (`background` + `elements`) is a coherent NEW scene you compose to sit naturally in that shared style. If the board is unified around one recurring subject, feature it; if subjects vary but the STYLE is shared, compose a representative subject in that style.
+- Do not fabricate a style the images do not show. The STYLE is observed; the SCENE is synthesized to fit it.
+
+## `high_level_description` — synthesized summary (50-word hard cap)
+
+- ONE long sentence preferred, never more than two.
+- Reads like a short natural-language prompt, not an analysis. Starts immediately with the subject — no "this image shows", "depicts", "a mood board of".
+- Identifies subject(s), medium, and overall composition of the new scene.
+- `various`, `multiple`, general categories ARE appropriate here. The specificity rule (below) applies to element descs and `background`, NOT this field.
+
+## `style_description` — the SHARED look (grounded in the board)
+
+A JSON object capturing the visual style the images share. ALWAYS include `aesthetics`, `lighting`, `medium`, `color_palette`, AND exactly one discriminator key (`photo` or `art_style` — see the hard rule below):
+- `aesthetics`: the overall visual character the board converges on (e.g. `cinematic`, `flat vector illustration`, `gritty documentary`, `soft pastel`).
+- `lighting`: the recurring light across the board (direction, hardness, color temperature, time-of-day cues) — `hard side light, warm golden-hour tone`.
+- `medium`: the shared production medium — `photograph`, `3D render`, `oil painting`, `watercolor`, `digital illustration`, `pencil sketch`.
+- `color_palette`: the whole-board dominant colors actually present, as a list of UPPERCASE `#RRGGBB` hex codes — up to 16, ordered most→least prominent. Use hex codes, NOT color names: write `#F5F5DC`, never `beige` (e.g. `["#1A2B3C", "#F5F5DC", "#8B5A2B"]`).
+
+### REQUIRED discriminator — emit EXACTLY ONE of `photo` or `art_style` (never both, never neither)
+
+`style_description` MUST contain exactly ONE of these two keys. Emitting BOTH is invalid; omitting BOTH is invalid.
+- If the board is real PHOTOGRAPHY (camera capture — film grain, lens character, photographic depth of field), emit `photo` and DO NOT emit `art_style`. `photo` = the photographic character (`35mm`, `shallow depth of field`, `wide angle`). Place it right after `medium`.
+- Otherwise — for ANYTHING that is not real photography (illustration, 3D/CGI render, painting, sketch, vector art, anime, photoreal render) — emit `art_style` and DO NOT emit `photo`. `art_style` = the named look (`art nouveau`, `cel-shaded anime`, `low-poly`, `impressionist`, `photorealistic 3D render`). Place it right after `medium`.
+- When unsure, decide from `medium`: a `photograph` medium → `photo`; any other medium → `art_style`. Never leave both out. If no specific value comes to mind, still emit the key with a concrete generic value (`photo`: `standard lens`; `art_style`: `realistic digital illustration`).
+
+Observe the medium from the pixels — film grain and lens character mean photograph; visible brushstrokes mean a painting; clean flat fills and outlines mean vector illustration. Do not assume.
+
+## ELEMENTS — the synthesized scene
+
+Each subject in the new scene is one element:
+```
+{"type":"obj","bbox":[y1,x1,y2,x2],"desc":"...","color_palette":["#RRGGBB", ...]}
+{"type":"text","bbox":[y1,x1,y2,x2],"text":"LINE ONE","desc":"...","color_palette":["#RRGGBB", ...]}
+```
+
+### SINGLE SUBJECT = SINGLE ELEMENT
+
+A coherent subject — one animal, person, vehicle, building, plant, instrument, machine — is exactly ONE `obj` element. Anatomical and structural parts are descriptive attributes inside that element's `desc`, NOT separate elements. When MULTIPLE distinct subjects appear in the composed scene, use MULTIPLE elements — one per subject.
+
+**Test:** part-of-one-thing → goes in that thing's desc. Separate thing → its own element.
+
+### Element `color_palette` — OPTIONAL, per subject
+
+Each element MAY carry its own `color_palette` as the LAST key. Include it ONLY when the subject has a clear, distinct palette worth recording — omit it otherwise.
+- Same format as the style palette: UPPERCASE `#RRGGBB` hex codes, NOT color names. 2–4 colors typical, **MAXIMUM 5**.
+
+### Element desc — what to write (30–60 words, 60-word HARD CAP)
+
+Identity first, then the major attributes, then one distinguishing detail. Each desc is a standalone catalog entry — open with the subject's identity, not "the X".
+- People: skin tone, hair (color + style), each garment with color, expression/gaze, pose, one distinguishing feature.
+- Objects: shape, material, color, distinctive parts.
+- Scenes/structures: type, primary material, color, distinctive structural elements.
+
+**Skip:** surface-finish micro-prose, per-limb pose mechanics, per-element camera/lighting detail (belongs in `background` or `style_description`), fabric weave.
+
+### Element desc — what NOT to include
+
+**No shadows.** Cast/drop/ground shadows — describe in `background` only when scene-wide, otherwise omit.
+**No camera or render language inside an obj desc** — that belongs in `style_description`. EXCEPTION: viewpoint/angle (`from a low-angle perspective`) when the scene clearly has it.
+**No impressions instead of physical reality.** Avoid `luminous`, `radiant`, `vibrant`, `stunning`. Use observable properties.
+**No scene-context repetition per-element.** Scene-wide lighting/ambient → describe ONCE in `background`.
+
+## BACKGROUND — the scene shell only (CRITICAL)
+
+`background` describes the scene SHELL: walls and finishes, floor/ground and surface state, ceiling and architectural fixtures, windows as architecture, atmospheric context (sky, clouds, fog), scene-wide ambient lighting, distant out-of-focus context — all in the shared style.
+
+### No double-counting
+
+Anything in `background` CANNOT also be an obj element. Each component lives in EXACTLY ONE field.
+
+### ALWAYS-BACKGROUND — these live in `background` only, never as obj elements:
+- sky, clouds, atmospheric color; horizon; distant mountains/hills/tree lines; atmospheric weather (fog, haze, mist, smoke); distant cityscape architecture; distant blurred crowds; the floor / ground / turf / paving surface; ambient walls or studio backdrop behind focal subjects.
+
+The surface the scene sits on (floor, ground, turf, asphalt, water, snow, tile) lives in `background` only, including its visible state. Discrete objects ON the floor remain obj elements.
+
+### For a transparent / cut-out image
+
+If the shared style is subjects on a plain cut-out background, set `background` to the literal phrase (`on a transparent background`) and emit the subject(s) as elements.
+
+## BBOX STRATEGY
+
+The scene is synthesized, so place each subject where it reads naturally in the frame. INCLUDE bboxes on individually-placeable subjects (a portrait subject, a product, a sign). OMIT bboxes only on dense/hard-to-enumerate visuals (crowds, fields, scattered particles).
+
+### Coordinate system
+
+Coordinates are normalized to the image: `x` runs left→right along full width (0 = left edge, 1000 = right), `y` runs top→bottom along full height (0 = top, 1000 = bottom). Top-left origin. Format `[y1, x1, y2, x2]` with `y1 < y2`, `x1 < x2`. Do not default to a full-image `[0, 0, 1000, 1000]` box unless the subject genuinely fills the frame.
+
+## SPECIFICITY — commit to one value
+
+This JSON feeds a diffusion model. Compose the scene with one concrete value per property.
+
+**Banned hedge phrasings** (in elements and background): `things like`, `such as`, `e.g.`, `for example`, `or similar`, `various`, `could include`, `might be`, `some kind of`. Replace with the concrete noun/color/material.
+**Banned alternative listings for one property:** `oak or walnut`, `cream or ivory`. Pick ONE.
+**Banned "implied/suggested" hedges:** `implied, suggested, hinted, possibly, perhaps, reads as`.
+
+[USER]
+Examine the reference images attached to this message as a single mood board and emit ONE JSON caption object as specified, wrapped in a ```json … ``` fence. Ground the style_description in the look the images SHARE, and compose a coherent new scene in that shared style.

--- a/crates/sceneworks-worker/src/image_describe_moodboard_tags_v1.txt
+++ b/crates/sceneworks-worker/src/image_describe_moodboard_tags_v1.txt
@@ -1,0 +1,35 @@
+[META]
+frozen: false
+description: Multi-image "mood board" TAG-STYLE synthesis (epic 8588, sc-8595) — examine SEVERAL reference images and emit ONE comma-separated booru/danbooru-style tag list capturing the SHARED style/mood across them, usable directly as a prompt for an anime/booru SDXL checkpoint. Vision system prompt for the core_llm TextLlm path; NO JSON, NO prose sentences. Thinking off. The N>1 sibling of image_describe_tags_v1.
+thinking_mode: disabled
+
+[SYSTEM]
+You are a mood-board tagger. You are given SEVERAL reference images (a mood board). You EXAMINE all of them together and emit a single comma-separated list of booru/danbooru-style tags that captures the visual language they have in COMMON, in the form an anime/illustration SDXL checkpoint consumes as a prompt. You SYNTHESIZE across the images — you distill the recurring, shared traits, and you never add tags for an aesthetic that none of them show.
+
+## OUTPUT CONTRACT — emit ONE comma-separated tag list
+
+- Output ONLY the tag list: lowercase tags separated by ", " (comma-space), on a single line. No JSON, no code fences, no sentences, no headings, no numbering, no commentary, no preamble. Just the tags.
+- Do NOT tag the images one by one and do NOT emit per-image sections. Emit ONE unified tag list describing a new image in the shared style.
+- Tags use underscores for multi-word concepts in the danbooru convention (depth_of_field, looking_at_viewer, cinematic_lighting), and spaces only where that is the conventional tag.
+- Order from most to least salient, roughly: medium/style, then the shared subject or a representative subject, then shared attributes/clothing, then pose/mood, then setting, then composition/framing, then lighting/color, then a few aesthetic/quality tags.
+- Aim for roughly 15–35 tags. Specific over generic; do not pad with redundant or speculative tags.
+
+## WHAT TO TAG — the shared thread, grounded in the pixels
+
+Identify what the images have in COMMON and tag that. Weigh recurring traits heavily; treat a trait present in only one image as incidental unless it is clearly the board's point.
+- Medium / style: the shared rendered look the board converges on (anime_coloring, realistic, watercolor_(medium), 3d, sketch, flat_color, cel_shading, monochrome).
+- Subject: the recurring subject if the board is unified around one (1girl, 1boy, no_humans, scenery), otherwise a representative subject rendered in the shared style.
+- Shared attributes / clothing: recurring hair, wardrobe, or design motifs common across the images.
+- Pose / mood / action: the emotional register and recurring poses.
+- Setting / background: locations and props the board favors (indoors, forest, cityscape, simple_background).
+- Composition / framing: shared shot types and crops (full_body, upper_body, portrait, from_above, wide_shot).
+- Lighting / color: the recurring lighting and palette cues (backlighting, rim_light, sunlight, pastel_colors, muted_color, high_contrast).
+- A few aesthetic/quality tags that match the shared look (highres, detailed, masterpiece) — only if warranted, never as filler.
+
+Rules:
+- Tag the shared style, colors, and composition you actually SEE across the images — not what is plausible or typical for the genre.
+- When the images conflict on a trait, prefer the majority or the most distinctive shared quality; do not tag conflicting traits at once.
+- This is a faithful synthesis of the mood board's shared visual language, written so a renderer can produce a NEW image in that shared style.
+
+[USER]
+Examine the reference images attached to this message as a single mood board and emit ONE comma-separated booru-style tag list as specified, capturing the style, mood, palette, and composition they share. Emit only the unified tag list.

--- a/crates/sceneworks-worker/src/image_describe_moodboard_v1.txt
+++ b/crates/sceneworks-worker/src/image_describe_moodboard_v1.txt
@@ -1,0 +1,31 @@
+[META]
+frozen: false
+description: Multi-image "mood board" PROSE synthesis (epic 8588, sc-8595) — examine SEVERAL reference images and emit ONE detailed natural-language prompt that captures the SHARED mood/style/composition across them, usable directly as a text-to-image prompt for a non-structured model. Vision system prompt for the core_llm TextLlm path; NO JSON, NO bboxes. Thinking off. The N>1 sibling of image_describe_v1.
+thinking_mode: disabled
+
+[SYSTEM]
+You are a mood-board synthesizer. You are given SEVERAL reference images (a mood board). You EXAMINE all of them together and write a single detailed, natural-language prompt for a NEW image that shares their COMMON aesthetic, in the form a text-to-image model consumes. You SYNTHESIZE across the images — you distill the recurring visual language they have in common, and you never invent an aesthetic that none of them show.
+
+## OUTPUT CONTRACT — emit ONE plain-text prompt
+
+- Output ONLY the prompt itself: flowing natural-language prose. No JSON, no code fences, no bullet lists, no headings, no bbox coordinates, no key/value fields, no commentary, no preamble ("These images show…", "The mood board is…", "Image 1…"). Start immediately with the subject or scene.
+- Do NOT describe the images one by one, and do NOT reference them as separate pictures ("the first image", "the second"). Emit ONE unified prompt as if it described a single new image in the shared style.
+- One coherent paragraph (occasionally two for a rich mood). Aim for roughly 60–120 words — long enough to be specific, short enough to read as a prompt.
+- Preserve non-ASCII characters as-is (CJK, Cyrillic, Devanagari, Arabic, accented Latin). Never transliterate or escape.
+
+## WHAT TO SYNTHESIZE — the shared thread, grounded in the pixels
+
+Identify what the images have in COMMON and express it as one prompt. Weigh recurring traits heavily; treat a trait that appears in only one image as incidental unless it is clearly the point of the board.
+- Medium & style: the shared rendered look — photograph vs illustration vs 3D render vs painting vs sketch; the named aesthetic they converge on (e.g. moody analog film, flat vector, painterly fantasy, clean product photography). For a photographic board, the shared lens/depth-of-field character.
+- Color & palette: the dominant colors and overall mood the board shares (warm amber and deep teal, muted desaturated pastels, high-contrast neon). Name them plainly.
+- Lighting: the recurring lighting character — direction, hardness, color temperature, time-of-day feel.
+- Composition & framing: the framing tendencies the board favors (tight close-ups, wide negative-space, centered symmetry, low angles).
+- Subject & mood: the kind of subject matter and the emotional register the board evokes. If the board is unified around ONE recurring subject, feature it; if the subjects vary but the STYLE is shared, describe a representative subject rendered in that shared style.
+
+Rules:
+- Ground the shared style in what you actually SEE across the images — not what is plausible or typical for the genre.
+- When the images conflict on a trait, prefer the majority or the most distinctive shared quality; do not average conflicting traits into an incoherent blend.
+- This is a synthesis written so a renderer can produce a NEW image in the mood board's shared style and spirit — not an analysis of the individual pictures.
+
+[USER]
+Examine the reference images attached to this message as a single mood board and write ONE detailed plain-text prompt as specified, capturing the mood, style, palette, lighting, and composition they share. Emit only the unified prompt.

--- a/crates/sceneworks-worker/src/prompt_refine_jobs.rs
+++ b/crates/sceneworks-worker/src/prompt_refine_jobs.rs
@@ -438,6 +438,41 @@ const IMAGE_DESCRIBE_V1: &str = include_str!("image_describe_v1.txt");
 ))]
 const IMAGE_DESCRIBE_TAGS_V1: &str = include_str!("image_describe_tags_v1.txt");
 
+/// Multi-image "mood board" PROSE synthesis system prompt (epic 8588, sc-8595) — the N>1 sibling of
+/// [`IMAGE_DESCRIBE_V1`]. When a describe job carries MORE THAN ONE reference image, the model examines
+/// them together and synthesizes ONE prose prompt capturing the mood/style/composition they SHARE
+/// (rather than describing a single picture). Same `core_llm` vision path, same unconstrained-prose
+/// cleanup; only the instruction differs. Selected by [`build_image_describe_messages`] when `multi`.
+#[cfg(any(
+    test,
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+const IMAGE_DESCRIBE_MOODBOARD_V1: &str = include_str!("image_describe_moodboard_v1.txt");
+
+/// Multi-image "mood board" TAG-STYLE synthesis system prompt (epic 8588, sc-8595) — the N>1, booru
+/// sibling of [`IMAGE_DESCRIBE_TAGS_V1`]. Synthesizes the SHARED style across several references into
+/// one comma-separated tag list for an anime/booru SDXL checkpoint. Selected by
+/// [`build_image_describe_messages`] when `multi` and the style is [`DescribeStyle::Tags`].
+#[cfg(any(
+    test,
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+const IMAGE_DESCRIBE_MOODBOARD_TAGS_V1: &str = include_str!("image_describe_moodboard_tags_v1.txt");
+
+/// Multi-image "mood board" Ideogram JSON synthesis system prompt (epic 8588, sc-8595) — the N>1
+/// sibling of [`IMAGE_CAPTION_V1`]. Grounds `style_description` in the look several references SHARE and
+/// composes a coherent NEW scene in that style (the composition is synthesized, like `magic_prompt` from
+/// a text idea — so the caption stays schema-valid without per-image grounded bboxes). Same JSON
+/// constraint + `is_caption` validation. Selected by [`build_image_caption_messages`] when `multi`.
+#[cfg(any(
+    test,
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+const IMAGE_CAPTION_MOODBOARD_V1: &str = include_str!("ideogram_image_caption_moodboard_v1.txt");
+
 /// Body of a `[NAME]` section in the magic-prompt file (port of the reference `_load_sections`):
 /// section markers are a bracketed single word alone on a line. Returns the trimmed body, or empty.
 #[cfg(any(
@@ -528,13 +563,26 @@ pub(crate) fn build_magic_prompt_messages(prompt: &str, aspect_ratio: &str) -> (
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
-pub(crate) fn build_image_caption_messages() -> (String, String) {
-    let system = magic_section_from(IMAGE_CAPTION_V1, "SYSTEM");
-    let mut user = magic_section_from(IMAGE_CAPTION_V1, "USER");
+pub(crate) fn build_image_caption_messages(multi: bool) -> (String, String) {
+    // With more than one reference image the model synthesizes ONE caption for a new image in the
+    // aesthetic the board SHARES (mood board, sc-8595); the single-image asset is unchanged for N==1.
+    let asset = if multi {
+        IMAGE_CAPTION_MOODBOARD_V1
+    } else {
+        IMAGE_CAPTION_V1
+    };
+    let system = magic_section_from(asset, "SYSTEM");
+    let mut user = magic_section_from(asset, "USER");
     if user.is_empty() {
-        user = "Examine the reference image attached to this message and emit the single JSON \
-                caption object as specified. Describe only what is visible in the image."
-            .to_owned();
+        user = if multi {
+            "Examine the reference images attached to this message as a single mood board and emit \
+             the single JSON caption object as specified, grounding the style in the look they share \
+             and composing a coherent new scene in that style."
+        } else {
+            "Examine the reference image attached to this message and emit the single JSON \
+             caption object as specified. Describe only what is visible in the image."
+        }
+        .to_owned();
     }
     (system, user)
 }
@@ -579,23 +627,38 @@ impl DescribeStyle {
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
-pub(crate) fn build_image_describe_messages(style: DescribeStyle) -> (String, String) {
-    let asset = match style {
-        DescribeStyle::Prose => IMAGE_DESCRIBE_V1,
-        DescribeStyle::Tags => IMAGE_DESCRIBE_TAGS_V1,
+pub(crate) fn build_image_describe_messages(style: DescribeStyle, multi: bool) -> (String, String) {
+    // With more than one reference image the model synthesizes ONE prompt from the mood/style the board
+    // SHARES (mood board, sc-8595) instead of describing a single picture; N==1 keeps the sc-8204/8205
+    // single-image assets byte-for-byte.
+    let asset = match (style, multi) {
+        (DescribeStyle::Prose, false) => IMAGE_DESCRIBE_V1,
+        (DescribeStyle::Prose, true) => IMAGE_DESCRIBE_MOODBOARD_V1,
+        (DescribeStyle::Tags, false) => IMAGE_DESCRIBE_TAGS_V1,
+        (DescribeStyle::Tags, true) => IMAGE_DESCRIBE_MOODBOARD_TAGS_V1,
     };
     let system = magic_section_from(asset, "SYSTEM");
     let mut user = magic_section_from(asset, "USER");
     if user.is_empty() {
-        user = match style {
-            DescribeStyle::Prose => {
+        user = match (style, multi) {
+            (DescribeStyle::Prose, false) => {
                 "Examine the reference image attached to this message and write the single detailed \
                  plain-text description as specified. Describe only what is visible in the image."
             }
-            DescribeStyle::Tags => {
+            (DescribeStyle::Prose, true) => {
+                "Examine the reference images attached to this message as a single mood board and \
+                 write ONE detailed plain-text prompt as specified, capturing the mood, style, \
+                 palette, lighting, and composition they share."
+            }
+            (DescribeStyle::Tags, false) => {
                 "Examine the reference image attached to this message and emit the single \
                  comma-separated booru-style tag list as specified. Tag only what is visible in the \
                  image."
+            }
+            (DescribeStyle::Tags, true) => {
+                "Examine the reference images attached to this message as a single mood board and \
+                 emit ONE comma-separated booru-style tag list as specified, capturing the style, \
+                 mood, palette, and composition they share."
             }
         }
         .to_owned();
@@ -737,24 +800,51 @@ pub(crate) async fn run_prompt_refine_job(
     // InstantID/captioner reference reads, the LoRA load path) — confine it to an app-managed root via
     // `normalize_app_managed_model_path` BEFORE opening it. That rejects `..` traversal and any absolute
     // path outside the app data dir / HF hub cache, closing the arbitrary-file-read gap.
-    let image_ref = if task.is_vision() {
-        let image_path = payload
-            .get("imagePath")
-            .or_else(|| payload.get("referencePath"))
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .ok_or_else(|| {
-                WorkerError::InvalidPayload(
-                    "This task requires a non-empty `imagePath` reference image.".to_owned(),
-                )
-            })?;
-        let safe_path =
-            normalize_app_managed_model_path(settings, image_path, "Vision reference image")?;
-        Some(load_caption_image_ref(&safe_path)?)
+    // A vision task carries one OR MORE reference images. The plural `imagePaths` array (a mood board,
+    // sc-8595) takes precedence; otherwise the single `imagePath`/`referencePath` (unchanged single-image
+    // path). Every path is UNTRUSTED (it arrives on the job payload over the LAN-remote API boundary,
+    // epic 4484), so each is confined to an app-managed root via `normalize_app_managed_model_path`
+    // BEFORE opening it — rejecting `..` traversal and any absolute path outside the app data dir / HF
+    // hub cache. The order of `imagePaths` is preserved so the model reads the board in the order the
+    // user assembled it. N is bounded API-side (`MAX_MOOD_BOARD_IMAGES`).
+    let image_refs: Vec<gen_core::core_llm::ImageRef> = if task.is_vision() {
+        let paths: Vec<String> = match payload.get("imagePaths").and_then(Value::as_array) {
+            Some(items) => items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+                .collect(),
+            None => payload
+                .get("imagePath")
+                .or_else(|| payload.get("referencePath"))
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+                .into_iter()
+                .collect(),
+        };
+        if paths.is_empty() {
+            return Err(WorkerError::InvalidPayload(
+                "This task requires at least one non-empty `imagePath`/`imagePaths` reference image."
+                    .to_owned(),
+            ));
+        }
+        let mut refs = Vec::with_capacity(paths.len());
+        for path in &paths {
+            let safe_path =
+                normalize_app_managed_model_path(settings, path, "Vision reference image")?;
+            refs.push(load_caption_image_ref(&safe_path)?);
+        }
+        refs
     } else {
-        None
+        Vec::new()
     };
+    // More than one reference image switches the vision instruction to mood-board SYNTHESIS (one prompt
+    // capturing the shared aesthetic) rather than describing a single picture.
+    let multi_reference = image_refs.len() > 1;
     let model = payload
         .get("model")
         .and_then(Value::as_str)
@@ -775,13 +865,13 @@ pub(crate) async fn run_prompt_refine_job(
     // prompt in for the rewrite rules, describe supplies the prose/tags describe asset, and the default
     // rewrite assembles its guide/workflow system prompt with the user's prompt as the turn.
     let (system, user_message) = match task {
-        RefineTask::ImageCaption => build_image_caption_messages(),
+        RefineTask::ImageCaption => build_image_caption_messages(multi_reference),
         RefineTask::ImageDescribe => {
             // sc-8205: the describe style (prose vs booru tags) is selected per-model by the
             // `captionStyle` payload field the web forwards from the catalog; absent/unknown → prose.
             let style =
                 DescribeStyle::from_payload(payload.get("captionStyle").and_then(Value::as_str));
-            build_image_describe_messages(style)
+            build_image_describe_messages(style, multi_reference)
         }
         RefineTask::MagicPrompt => {
             let aspect_ratio = payload
@@ -901,18 +991,25 @@ pub(crate) async fn run_prompt_refine_job(
                 if !system.trim().is_empty() {
                     messages.push(Message::system(system));
                 }
-                // A vision task (image_caption / image_describe) user turn carries the reference image (a
-                // `Content::Image` block) alongside the instruction text, so the loaded provider examines the
-                // picture at generate time. Every other task is a plain text user turn.
-                let carries_image = image_ref.is_some();
-                match image_ref {
-                    Some(image) => messages.push(Message {
+                // A vision task (image_caption / image_describe) user turn carries the reference image(s)
+                // as `Content::Image` block(s) BEFORE the instruction text, so the loaded provider examines
+                // the picture(s) at generate time. The provider collects every `Content::Image` in the turn
+                // and expands per-image vision tokens (mlx-llama + candle-llama both loop over all images),
+                // so a mood board of N references (sc-8595) rides one generate call. Every other task is a
+                // plain text user turn.
+                let carries_image = !image_refs.is_empty();
+                if carries_image {
+                    let mut content: Vec<Content> =
+                        image_refs.into_iter().map(Content::Image).collect();
+                    content.push(Content::text(prompt));
+                    messages.push(Message {
                         role: Role::User,
-                        content: vec![Content::Image(image), Content::text(prompt)],
+                        content,
                         thinking: None,
                         tool_calls: Vec::new(),
-                    }),
-                    None => messages.push(Message::user(prompt)),
+                    });
+                } else {
+                    messages.push(Message::user(prompt));
                 }
                 let request = TextLlmRequest {
                     messages,
@@ -1609,7 +1706,7 @@ mod tests {
 
     #[test]
     fn build_image_caption_messages_returns_system_and_user() {
-        let (system, user) = build_image_caption_messages();
+        let (system, user) = build_image_caption_messages(false);
         assert!(!system.trim().is_empty(), "system block is non-empty");
         assert!(system.contains("compositional_deconstruction"));
         assert!(!user.trim().is_empty(), "user block is non-empty");
@@ -1655,7 +1752,7 @@ mod tests {
 
     #[test]
     fn build_image_describe_messages_returns_prose_system_and_user() {
-        let (system, user) = build_image_describe_messages(DescribeStyle::Prose);
+        let (system, user) = build_image_describe_messages(DescribeStyle::Prose, false);
         assert!(!system.trim().is_empty(), "system block is non-empty");
         assert!(
             !system.contains("compositional_deconstruction"),
@@ -1719,8 +1816,8 @@ mod tests {
 
     #[test]
     fn build_image_describe_messages_selects_the_style_asset() {
-        let (prose_sys, _) = build_image_describe_messages(DescribeStyle::Prose);
-        let (tags_sys, tags_user) = build_image_describe_messages(DescribeStyle::Tags);
+        let (prose_sys, _) = build_image_describe_messages(DescribeStyle::Prose, false);
+        let (tags_sys, tags_user) = build_image_describe_messages(DescribeStyle::Tags, false);
         assert_ne!(
             prose_sys, tags_sys,
             "prose and tags select DIFFERENT system prompts"
@@ -1733,6 +1830,75 @@ mod tests {
             tags_user.to_lowercase().contains("tag"),
             "tags user turn instructs tagging"
         );
+    }
+
+    // ── sc-8595 (epic 8588): multi-image "mood board" synthesis variants ──
+
+    #[test]
+    fn build_image_describe_messages_multi_selects_the_mood_board_asset() {
+        // N>1 swaps in the mood-board synthesis asset for BOTH styles; N==1 keeps the single-image asset.
+        let (prose_single, _) = build_image_describe_messages(DescribeStyle::Prose, false);
+        let (prose_multi, prose_multi_user) =
+            build_image_describe_messages(DescribeStyle::Prose, true);
+        assert_ne!(
+            prose_single, prose_multi,
+            "a mood board selects a DIFFERENT prose system prompt than single-image describe"
+        );
+        assert!(
+            prose_multi.to_lowercase().contains("mood board")
+                || prose_multi.to_lowercase().contains("mood-board"),
+            "the multi-image prose system prompt frames the task as a mood board"
+        );
+        assert!(
+            prose_multi.to_lowercase().contains("share")
+                || prose_multi.to_lowercase().contains("shared"),
+            "the mood-board prose prompt instructs synthesizing the SHARED aesthetic"
+        );
+        // Still prose — never the JSON caption schema.
+        assert!(!prose_multi.contains("compositional_deconstruction"));
+        assert!(prose_multi_user.to_lowercase().contains("mood board"));
+
+        let (tags_single, _) = build_image_describe_messages(DescribeStyle::Tags, false);
+        let (tags_multi, _) = build_image_describe_messages(DescribeStyle::Tags, true);
+        assert_ne!(
+            tags_single, tags_multi,
+            "a mood board selects a DIFFERENT tags system prompt than single-image tagging"
+        );
+        assert!(
+            tags_multi.contains("comma-separated"),
+            "the multi-image tags prompt still pins a comma-separated tag list"
+        );
+        assert!(
+            tags_multi.to_lowercase().contains("mood board")
+                || tags_multi.to_lowercase().contains("mood-board"),
+            "the multi-image tags system prompt frames the task as a mood board"
+        );
+    }
+
+    #[test]
+    fn build_image_caption_messages_multi_selects_the_mood_board_json_asset() {
+        // N>1 swaps in the mood-board JSON asset; it STILL carries the Ideogram caption schema so the
+        // reply validates as a caption, but grounds the style in the shared look + synthesizes the scene.
+        let (single_sys, _) = build_image_caption_messages(false);
+        let (multi_sys, multi_user) = build_image_caption_messages(true);
+        assert_ne!(
+            single_sys, multi_sys,
+            "a mood board selects a DIFFERENT caption system prompt than single-image caption"
+        );
+        assert!(
+            multi_sys.contains("compositional_deconstruction"),
+            "the mood-board caption prompt still emits the Ideogram JSON schema"
+        );
+        assert!(
+            multi_sys.contains("style_description"),
+            "the mood-board caption prompt still requires style_description"
+        );
+        assert!(
+            multi_sys.to_lowercase().contains("mood board")
+                || multi_sys.to_lowercase().contains("mood-board"),
+            "the mood-board caption prompt frames the task as a mood board"
+        );
+        assert!(!multi_user.contains("{{"), "no template placeholders");
     }
 
     #[test]
@@ -1877,7 +2043,7 @@ mod tests {
             TextLlmRequest,
         };
 
-        let (system, user) = build_image_caption_messages();
+        let (system, user) = build_image_caption_messages(false);
         let image = ImageRef::new(2, 2, vec![0u8; 12]).expect("image ref");
         let request = TextLlmRequest {
             messages: vec![
@@ -2261,7 +2427,7 @@ mod tests {
 
         let image =
             load_caption_image_ref(std::path::Path::new(&ref_path)).expect("decode ref image");
-        let (system, user) = build_image_caption_messages();
+        let (system, user) = build_image_caption_messages(false);
         let request = TextLlmRequest {
             messages: vec![
                 Message::system(system),
@@ -2337,7 +2503,7 @@ mod tests {
 
         let image =
             load_caption_image_ref(std::path::Path::new(&ref_path)).expect("decode ref image");
-        let (system, user) = build_image_caption_messages();
+        let (system, user) = build_image_caption_messages(false);
         let request = TextLlmRequest {
             messages: vec![
                 Message::system(system),
@@ -2411,7 +2577,7 @@ mod tests {
 
         let image =
             load_caption_image_ref(std::path::Path::new(&ref_path)).expect("decode ref image");
-        let (system, user) = build_image_describe_messages(DescribeStyle::Prose);
+        let (system, user) = build_image_describe_messages(DescribeStyle::Prose, false);
         let request = TextLlmRequest {
             messages: vec![
                 Message::system(system),


### PR DESCRIPTION
## What & why

The **"mood board"** half of reference-guided generation (epic 8588, **sc-8595**), done purely at the **prompt layer** — model-agnostic, works for **every text-to-image model**. Extends epic 8203's single-image reference→prompt to **N images synthesized into ONE prompt/caption** capturing the aesthetic they share. Pairs with slice A (img2img): mood-board sets the *prompt*, img2img sets the *visual init*.

## Key finding — no engine change needed

The Qwen-VL captioner **already handles multiple images in one generate call**. Both vision ports (`mlx-llama` and `candle-llama`) collect every `Content::Image`, expand per-image vision tokens, concatenate features, and interleave M-RoPE positions — MLX even has an explicit 2-image test. So this is a **pure worker + API + web change**: no `mlx-gen`/`candle-gen` change, no cross-repo pin, no platform gating.

## Changes

**Worker** (`prompt_refine_jobs.rs`): read the plural `imagePaths` array (falling back to the single `imagePath`), decode into a `Vec<ImageRef>`, push one `Content::Image` per reference before the instruction. For **N>1** the instruction switches to a mood-board **synthesis** asset — new prose / tags / Ideogram-JSON variants that distill the *shared* style; **N==1 keeps the single-image assets byte-for-byte**. The JSON mood-board grounds `style_description` in the shared look and *synthesizes* the composition (like `magic_prompt` from a text idea), so it stays schema-valid without per-image grounded bboxes.

**API** (`dto.rs` / `prompts.rs`): additive `sourceAssetIds: Vec<String>` (`#[serde(default)]`); the handler resolves each id to a confined on-disk path and emits `imagePaths` (scalar `imagePath` preserved for the single case). Bounded by `MAX_MOOD_BOARD_IMAGES` (6) server-side.

**Web**: `imageDescribe`/`imageCaption` clients accept `sourceAssetIds`; `ReferenceCaptionPicker` gains an additive `showMoodBoard` multi-select gallery (reusing `AssetPickerField`) whose describe/caption call passes the full ordered id array — **a lone reference still calls with the plain string**, so opt-out consumers (Ideogram JSON / all-t2i describe) are byte-unaffected. Wired into the Image Studio describe tile **and** the Ideogram `StructuredPromptBuilder`. The img2img strength slider hides once a board is active (img2img seeds from one image, not a blend).

## Tests & checks
- Worker asset-selection unit tests (prose/tags/JSON mood-board vs single-image).
- API handler tests (multi-image → `imagePaths`, cap enforced, single unchanged).
- Picker vitest (array contract, single-string fallback, strength-slider gating, additive gating).
- `cargo fmt --check` + `clippy -D warnings` clean; **macOS + candle-parity** checks green; worker **668** + API **193** + full web **1301** tests green.

## Follow-ups (not blocking)
- candle has the multi-image code path but no dedicated multi-image *test* (MLX does) — a candle engine test would be nice-to-have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)