### PR TITLE
fix(web): split img2img into its own 'Image reference' prompt tool (sc-10195)

### DIFF
--- a/apps/web/src/components/ReferenceCaptionPicker.jsx
+++ b/apps/web/src/components/ReferenceCaptionPicker.jsx
@@ -47,17 +47,6 @@ export default function ReferenceCaptionPicker({
   onOpenModels,
   onOpenQueue,
   onCancelJob,
-  // img2img double-duty (epic 8588 slice A, sc-8593): when the selected model supports img2img,
-  // the SAME picked reference can drive generation (reference-guided / latent-init) via a strength
-  // slider — in addition to (or instead of) the describe → prompt flow above. All additive + default
-  // off, so the Ideogram-JSON + all-t2i describe consumers are byte-unaffected. `onReferenceAssetChange`
-  // lifts the picked asset id so the parent can send it as `referenceAssetId`. `showImg2imgStrength`
-  // also un-gates the picker without the vision captioner (img2img needs no captioner).
-  onReferenceAssetChange,
-  showImg2imgStrength = false,
-  img2imgStrength = 0.5,
-  onImg2imgStrengthChange,
-  img2imgStrengthConfig,
   // Multi-image "mood board" (epic 8588, sc-8595): when true, an additional multi-select gallery lets the
   // user add MORE reference images beyond the primary. `onCaption` is then called with the FULL array of
   // ids ([primary, ...extras]) and the worker synthesizes ONE prompt/caption from the shared aesthetic. A
@@ -72,11 +61,10 @@ export default function ReferenceCaptionPicker({
   const [error, setError] = useState("");
 
   // The extra mood-board picks, minus the primary (it is already the first image) and capped. This is
-  // what actually augments the describe call; `referenceAssetId` stays the primary / img2img seed.
+  // what actually augments the describe call; `referenceAssetId` stays the primary reference.
   const moodBoardExtras = moodBoardIds
     .filter((id) => id && id !== referenceAssetId)
     .slice(0, Math.max(0, moodBoardMax - 1));
-  const moodBoardActive = showMoodBoard && moodBoardExtras.length > 0;
 
   // Feed the uploaded image's natural dimensions to the sc-8109 auto-preset seam.
   function reportReferenceDimensions(asset) {
@@ -95,7 +83,6 @@ export default function ReferenceCaptionPicker({
   function handleReferenceChange(assetId) {
     setReferenceAssetId(assetId);
     setError("");
-    onReferenceAssetChange?.(assetId);
   }
 
   // Run the auto-preset from an effect on the SELECTED id rather than the picker's onChange: a freshly
@@ -117,7 +104,7 @@ export default function ReferenceCaptionPicker({
     try {
       // A mood board sends the FULL ordered list ([primary, ...extras]); a lone reference keeps the
       // scalar id so consumers that never opted into `showMoodBoard` see the unchanged string contract.
-      const arg = moodBoardActive
+      const arg = moodBoardExtras.length > 0
         ? [referenceAssetId, ...moodBoardExtras]
         : referenceAssetId;
       const result = await onCaption(arg);
@@ -136,7 +123,7 @@ export default function ReferenceCaptionPicker({
   return (
     <div className="structured-reference">
       <ModelAvailabilityGate
-        ready={visionCaptionReady || showImg2imgStrength}
+        ready={visionCaptionReady}
         title={gateTitle}
         description={gateDescription}
         offers={visionCaptionOffers}
@@ -175,8 +162,9 @@ export default function ReferenceCaptionPicker({
             values={moodBoardExtras}
           />
         ) : null}
-        {/* Describe → prompt (epic 8203): only when the vision captioner is present. An img2img-only
-            model (no captioner) still gets the picker + strength slider below via `showImg2imgStrength`. */}
+        {/* Describe → prompt (epic 8203): the vision captioner turns the picked reference (or the whole
+            mood board) into prompt text. img2img reference-guidance is a SEPARATE prompt-tool tile now
+            (sc-10195), so this component is purely describe + mood board. */}
         {visionCaptionReady ? (
           <button
             type="button"
@@ -186,24 +174,6 @@ export default function ReferenceCaptionPicker({
           >
             {busy ? busyLabel : buttonLabel}
           </button>
-        ) : null}
-        {/* img2img strength (epic 8588 slice A, sc-8593): the SAME picked reference guides generation
-            (reference-guided / latent-init) at this strength. Shown for img2img-capable models once a
-            SINGLE reference is chosen — hidden when a mood board is active, since img2img seeds from one
-            image, not a blend. */}
-        {showImg2imgStrength && referenceAssetId && !moodBoardActive ? (
-          <label className="reference-strength img2img-strength">
-            {img2imgStrengthConfig?.label ?? "Reference strength"}
-            <input
-              max={img2imgStrengthConfig?.max ?? 1}
-              min={img2imgStrengthConfig?.min ?? 0}
-              onChange={(event) => onImg2imgStrengthChange?.(Number(event.target.value))}
-              step={img2imgStrengthConfig?.step ?? 0.05}
-              type="range"
-              value={img2imgStrength}
-            />
-            <span>{Number(img2imgStrength).toFixed(2)}</span>
-          </label>
         ) : null}
         {error ? (
           <p className="structured-error" role="alert">

--- a/apps/web/src/components/ReferenceCaptionPicker.test.jsx
+++ b/apps/web/src/components/ReferenceCaptionPicker.test.jsx
@@ -170,18 +170,17 @@ describe("ReferenceCaptionPicker", () => {
     expect(onCaption).toHaveBeenCalledWith("ref-1");
   });
 
-  it("hides the img2img strength slider once a mood board is active", async () => {
+  it("never renders an img2img strength slider — that lives in a separate tile now (sc-10195)", async () => {
+    // The picker is describe + mood board only; img2img reference-guidance moved to its own prompt-tool
+    // tile, so this component no longer carries the strength slider regardless of props.
     await mount({
       onCaption: vi.fn(async () => "x"),
       showMoodBoard: true,
-      showImg2imgStrength: true,
       referenceAssets: [refAsset, refAsset2],
     });
     await selectReference();
-    // A single reference is a valid img2img seed → the strength slider shows.
-    expect(document.body.querySelector(".img2img-strength")).toBeTruthy();
+    expect(document.body.querySelector(".img2img-strength")).toBeFalsy();
     await addMoodBoardExtra();
-    // A blend has no single seed → the slider is hidden.
     expect(document.body.querySelector(".img2img-strength")).toBeFalsy();
   });
 

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AssetPickerField, ImageEditSourcePickerField } from "../components/AssetPicker.jsx";
 import { AssetCard } from "../components/assetPanels.jsx";
-import { AssetMedia } from "../components/assetMedia.jsx";
+import { AssetMedia, assetUrl } from "../components/assetMedia.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { PromptGuideModal } from "../components/PromptGuideModal.jsx";
@@ -1005,6 +1005,24 @@ export function ImageStudio() {
     },
     [resolutionOptions],
   );
+  // Auto-preset the Aspect from the picked img2img reference (sc-10195): matching the reference's
+  // aspect keeps the latent-init composition valid (a 4:5 reference rendered at 16:9 comes out
+  // wrong-shaped). Mirrors the describe picker's probe (sc-8109/8220) — keyed on the id AND the asset
+  // list so a freshly imported reference re-runs once it resolves. User Aspect override still wins.
+  useEffect(() => {
+    if (!img2imgReferenceAssetId) return;
+    const asset = editImageAssets.find((item) => item.id === img2imgReferenceAssetId);
+    const src = asset && assetUrl(asset);
+    if (!src || typeof Image === "undefined") return;
+    const probe = new Image();
+    probe.onload = () => {
+      if (probe.naturalWidth && probe.naturalHeight) {
+        onReferenceImageLoaded(probe.naturalWidth, probe.naturalHeight);
+      }
+    };
+    probe.src = src;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [img2imgReferenceAssetId, editImageAssets]);
   // Sampler / scheduler menus declared by the model, gated to the ACTIVE backend
   // (epic 7114 P5): `macGatingActive` is the worker `mlx_required` master switch, so
   // it picks the manifest's `mlx.limits` override on Mac/MLX and the `candle.limits`
@@ -2119,24 +2137,26 @@ export function ImageStudio() {
             </div>
           )}
 
-          {/* Prompt tools (UI-refinement 1b): one framed strip of two equally-weighted toggle
-              tiles that replace the disjointed ReferenceCaptionPicker card + lone Refine link.
-              Tile A wraps the reference-image → plain-text describe flow (epic 8203, sc-8208):
-              gated to text-to-image and hidden unless the macOS-first captioner is platform-
-              eligible (ready, or an install offer exists — both false off-Mac). C1: captioning-
-              only, never sent to generation. Tile B wraps RefinePromptControl (sc-2041). Only
-              one panel opens at a time; both are free-text only (structured models excluded). */}
+          {/* Prompt tools (UI-refinement 1b; restructured sc-10195): a framed strip of up to THREE
+              distinct tiles, one panel open at a time (all free-text only — structured models excluded).
+              1) "Image reference" — img2img reference-guided generation (a picked image + strength slider
+                 VISUALLY guides the render). Shown only for img2img-capable models (`supportsImg2img`).
+              2) "Prompt from image" — the reference→text describe flow + mood board (epic 8203/8595): the
+                 vision captioner writes prompt TEXT (captioning-only, never sent to generation). Gated on
+                 the macOS-first captioner being platform-eligible.
+              3) "Refine my prompt" — RefinePromptControl (sc-2041).
+              img2img and describe used to share ONE overloaded tile (sc-8593); splitting them makes the
+              "guide the render vs. write a prompt" choice explicit (Michael, on-device). */}
           {structuredPromptModel ? null : (() => {
             const describeAvailable =
               mode === "text_to_image" &&
               typeof imageDescribe === "function" &&
               (visionCaptionReady || visionCaptionOffers.length > 0);
-            // The "Start from an image" tile serves BOTH the describe→prompt flow AND img2img
-            // reference-guided generation (sc-8593). img2img needs no vision captioner, so it can open
-            // the panel on its own — the picked reference then rides generation via the strength slider.
+            // img2img reference-guidance is its own tile now — a picked image + strength that SEED the
+            // render (latent-init). Needs no vision captioner; shown whenever the model advertises img2img.
             const img2imgAvailable = supportsImg2img && mode === "text_to_image";
-            const referenceToolAvailable = describeAvailable || img2imgAvailable;
-            const describeActive = referenceToolAvailable && promptTool === "describe";
+            const imageRefActive = img2imgAvailable && promptTool === "imageReference";
+            const describeActive = describeAvailable && promptTool === "describe";
             const refineActive = promptTool === "refine";
             return (
               <div className="prompt-tools">
@@ -2145,7 +2165,20 @@ export function ImageStudio() {
                   <span className="hairline" />
                 </div>
                 <div className="prompt-tools-tiles">
-                  {referenceToolAvailable ? (
+                  {img2imgAvailable ? (
+                    <button
+                      type="button"
+                      className={imageRefActive ? "prompt-tool active" : "prompt-tool"}
+                      aria-pressed={imageRefActive}
+                      onClick={() => togglePromptTool("imageReference")}
+                    >
+                      <span className="prompt-tool-title">
+                        <Icon.Image size={15} /> Image reference
+                      </span>
+                      <span className="prompt-tool-desc">Guide the render with an image (image-to-image)</span>
+                    </button>
+                  ) : null}
+                  {describeAvailable ? (
                     <button
                       type="button"
                       className={describeActive ? "prompt-tool active" : "prompt-tool"}
@@ -2153,13 +2186,9 @@ export function ImageStudio() {
                       onClick={() => togglePromptTool("describe")}
                     >
                       <span className="prompt-tool-title">
-                        <Icon.Image size={15} /> Start from an image
+                        <Icon.Image size={15} /> Prompt from image
                       </span>
-                      <span className="prompt-tool-desc">
-                        {img2imgAvailable
-                          ? "Describe it into a prompt, or guide the render with it"
-                          : "Caption a reference into an editable prompt"}
-                      </span>
+                      <span className="prompt-tool-desc">Caption a reference (or mood board) into an editable prompt</span>
                     </button>
                   ) : null}
                   <button
@@ -2174,26 +2203,53 @@ export function ImageStudio() {
                     <span className="prompt-tool-desc">Rewrite what you typed for clarity &amp; detail</span>
                   </button>
                 </div>
+                {imageRefActive ? (
+                  <div className="prompt-tool-panel">
+                    <div className="structured-reference">
+                      <p className="structured-hint">
+                        Pick an image to guide the render (image-to-image). A higher reference strength
+                        stays closer to it; lower lets the prompt take over.
+                      </p>
+                      <ImageEditSourcePickerField
+                        assets={editImageAssets}
+                        buttonLabel="Select reference image"
+                        changeLabel="Change reference"
+                        characters={characters}
+                        emptyLabel="No reference image selected"
+                        importAsset={importAsset}
+                        label="Reference image"
+                        onChange={setImg2imgReferenceAssetId}
+                        projectId={activeProject?.id}
+                        value={img2imgReferenceAssetId}
+                      />
+                      {img2imgReferenceAssetId ? (
+                        <label className="reference-strength img2img-strength">
+                          {img2imgStrengthConfig?.label ?? "Reference strength"}
+                          <input
+                            max={img2imgStrengthConfig?.max ?? 1}
+                            min={img2imgStrengthConfig?.min ?? 0}
+                            onChange={(event) => setImg2imgStrength(Number(event.target.value))}
+                            step={img2imgStrengthConfig?.step ?? 0.05}
+                            type="range"
+                            value={img2imgStrength}
+                          />
+                          <span>{Number(img2imgStrength).toFixed(2)}</span>
+                        </label>
+                      ) : null}
+                    </div>
+                  </div>
+                ) : null}
                 {describeActive ? (
                   <div className="prompt-tool-panel">
                     <ReferenceCaptionPicker
                       onCaption={onImageDescribe}
                       onApply={(text) => setPromptFromUser(text)}
                       onReferenceImageLoaded={onReferenceImageLoaded}
-                      onReferenceAssetChange={setImg2imgReferenceAssetId}
-                      showImg2imgStrength={img2imgAvailable}
-                      img2imgStrength={img2imgStrength}
-                      onImg2imgStrengthChange={setImg2imgStrength}
-                      img2imgStrengthConfig={img2imgStrengthConfig}
                       referenceAssets={editImageAssets}
                       referenceCharacters={characters}
                       importAsset={importAsset}
                       projectId={activeProject?.id ?? ""}
-                      hint={
-                        img2imgAvailable
-                          ? "Describe it into a prompt, or set a reference strength below to guide the render."
-                          : "The image is only used to write the prompt — it isn’t sent to generation."
-                      }
+                      hint="The image is only used to write the prompt — it isn’t sent to generation."
                       buttonLabel="✨ Describe image"
                       busyLabel="Describing…"
                       showMoodBoard={visionCaptionReady}

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -1427,7 +1427,7 @@ describe("ImageStudio PiD decoder toggle (sc-7851)", () => {
   });
 });
 
-describe("ImageStudio img2img reference tile (epic 8588 slice A, sc-8593)", () => {
+describe("ImageStudio Image-reference (img2img) tile (epic 8588, sc-8593/sc-10195)", () => {
   let container;
   let root;
 
@@ -1456,19 +1456,23 @@ describe("ImageStudio img2img reference tile (epic 8588 slice A, sc-8593)", () =
   // Krea-like img2img model: a `ui.img2img` toggle, plain text-to-image capability, no vision
   // captioner in context (baseContext leaves `imageDescribe` undefined → describe flow unavailable).
   const KREA_IMG2IMG = { ...Z_IMAGE, id: "krea_2_turbo", name: "Krea 2 Turbo", ui: { img2img: true } };
-  const startFromImageTile = () =>
-    [...document.body.querySelectorAll("button")].find((b) =>
-      b.textContent.includes("Start from an image"),
-    );
+  const tileByText = (text) =>
+    [...document.body.querySelectorAll("button")].find((b) => b.textContent.includes(text));
 
-  it("hides the 'Start from an image' tile for a plain t2i model with no captioner", async () => {
+  it("hides the 'Image reference' tile for a plain t2i model without ui.img2img", async () => {
+    // sc-10195: img2img is its own tile, gated purely on `ui.img2img`. A plain model with no captioner
+    // shows neither the img2img nor the describe tile.
     await render(baseContext({ imageModels: [Z_IMAGE], models: [Z_IMAGE] }));
-    expect(startFromImageTile()).toBeFalsy();
+    expect(tileByText("Image reference")).toBeFalsy();
+    expect(tileByText("Prompt from image")).toBeFalsy();
   });
 
-  it("shows the tile for a ui.img2img model even without the vision captioner (sc-8593)", async () => {
+  it("shows the 'Image reference' tile for a ui.img2img model even without the vision captioner", async () => {
+    // img2img needs no captioner — the tile appears on the flag alone, decoupled from describe (sc-10195).
     await render(baseContext({ imageModels: [KREA_IMG2IMG], models: [KREA_IMG2IMG] }));
-    expect(startFromImageTile()).toBeTruthy();
+    expect(tileByText("Image reference")).toBeTruthy();
+    // The describe tile stays hidden without a captioner, proving the two are independent now.
+    expect(tileByText("Prompt from image")).toBeFalsy();
   });
 });
 


### PR DESCRIPTION
## Why
On-device testing (Michael, Krea 2 Turbo) surfaced two real problems with the A3/B1 "Start from an image" tile:
- The img2img strength **slider was undiscoverable**, and once you added a **mood-board image it vanished entirely** — B1 gated it on `!moodBoardActive`, so building a mood board silently removed the img2img control.
- There was **no explicit "guide the render (img2img) vs. write a prompt (describe)" choice** — one tile did both implicitly. And "mood board" (which actually produces prompt *text*) read as visual conditioning.

## What
Split the Prompt-tools strip into **three distinct tiles**:

| Tile | Does | Shown when |
|---|---|---|
| **Image reference** (new) | img2img — a single picked image + an **always-visible strength slider** that visually seeds the render; auto-presets Aspect from the reference | model has `ui.img2img` (no captioner needed) |
| **Prompt from image** | describe + mood board → prompt **text** (never sent to generation) | vision captioner eligible |
| **Refine my prompt** | unchanged | always (non-structured) |

`ReferenceCaptionPicker` is now **describe + mood-board only**: removed the A3 img2img double-duty props (`showImg2imgStrength` / `img2imgStrength` / `onImg2imgStrengthChange` / `img2imgStrengthConfig` / `onReferenceAssetChange`), the strength slider, and the `moodBoardActive` gate. `StructuredPromptBuilder` (Ideogram JSON) never used those props → unaffected. Generation payload is unchanged (strength still sent when a `ui.img2img` model has an img2img reference picked).

## Tests
New Image-reference tile visibility (shows on a `ui.img2img` model without a captioner; hidden otherwise; independent of the describe tile); `ReferenceCaptionPicker` no longer renders a slider under any props. **Full web suite green (1309).**

## Note on the "no slider at all" report
Verified the code + the on-disk seeded manifest (`~/Library/Application Support/SceneWorks/config/manifests/builtin.models.jsonc`) both correctly carry `krea_2_turbo → ui.img2img: true`, so `supportsImg2img` should be true. The disabled state in the screenshot points to a **stale in-session model list / process predating the manifest refresh** — a full app restart should surface it (and then this new "Image reference" tile appears). Separately flagged: the API seeds builtin manifests `IfMissing`, so a dev/API config seeded before a new `ui.*` flag never refreshes — worth revisiting (desktop already `Overwrite`s each launch, so production is fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)