### PR TITLE
fix(assets): "Move" to a character is a true move, not a link (sc-10200)

### DIFF
--- a/apps/rust-api/src/assets.rs
+++ b/apps/rust-api/src/assets.rs
@@ -246,6 +246,25 @@ pub(crate) async fn move_asset_to_library(
     ))
 }
 
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AssetMoveToCharacterBody {
+    character_id: String,
+}
+
+pub(crate) async fn move_asset_to_character(
+    State(state): State<AppState>,
+    Path((project_id, asset_id)): Path<(String, String)>,
+    Json(body): Json<AssetMoveToCharacterBody>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    Ok(Json(
+        project_call(state, move |store| {
+            store.move_asset_to_character(&project_id, &asset_id, &body.character_id)
+        })
+        .await?,
+    ))
+}
+
 pub(crate) async fn delete_asset(
     State(state): State<AppState>,
     Path((project_id, asset_id)): Path<(String, String)>,

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -89,9 +89,9 @@ mod projects;
 use projects::{create_project, get_project, list_projects, reindex_project_endpoint};
 mod assets;
 use assets::{
-    delete_asset, get_asset, import_asset, list_assets, move_asset_to_library, purge_asset,
-    sweep_stale_asset_uploads, update_asset_status, update_asset_tags, write_upload_field_to_dir,
-    write_upload_field_to_temp_file,
+    delete_asset, get_asset, import_asset, list_assets, move_asset_to_character,
+    move_asset_to_library, purge_asset, sweep_stale_asset_uploads, update_asset_status,
+    update_asset_tags, write_upload_field_to_dir, write_upload_field_to_temp_file,
 };
 // Test-only crate-root imports: the `tests` module reaches these helpers via
 // `super::` (either `use super::{...}` or a fully-qualified `super::fn(...)` call).
@@ -854,6 +854,10 @@ pub(crate) fn create_app_with_state(
         .route(
             "/api/v1/projects/:project_id/assets/:asset_id/move-to-library",
             post(move_asset_to_library),
+        )
+        .route(
+            "/api/v1/projects/:project_id/assets/:asset_id/move-to-character",
+            post(move_asset_to_character),
         )
         .route(
             "/api/v1/projects/:project_id/assets/:asset_id/status",

--- a/apps/web/src/App.character.test.jsx
+++ b/apps/web/src/App.character.test.jsx
@@ -1441,6 +1441,74 @@ describe("SceneWorks app shell", () => {
     expect(document.body.querySelector(".batch-selection-bar")).toBeNull();
   });
 
+  it("bulk-moves selected character media into another character as a true move (sc-10200)", async () => {
+    const moveAssetToCharacter = vi.fn(async (asset) => ({ ...asset, origin: "character_studio" }));
+    const selectedCharacter = { id: "char-1", name: "Mira" };
+    const otherCharacter = { id: "char-2", name: "Dax" };
+    const assets = [
+      {
+        id: "ca-1",
+        type: "image",
+        projectId: "project-1",
+        displayName: "Shot A",
+        recipe: { normalizedSettings: { characterId: "char-1" } },
+        status: { trashed: false },
+      },
+    ];
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            assets,
+            characters: [selectedCharacter, otherCharacter],
+            deleteAsset: () => {},
+            moveAssetToCharacter,
+            moveAssetToLibrary: vi.fn(),
+            purgeAsset: () => {},
+            updateAssetStatus: () => {},
+            importAsset: () => {},
+            setPreviewAsset: () => {},
+            jobs: [],
+            imageModels: [],
+          },
+          <CharacterAssets
+            assets={assets}
+            deleteAsset={() => {}}
+            onPreview={vi.fn()}
+            projectId="project-1"
+            purgeAsset={() => {}}
+            selectedCharacter={selectedCharacter}
+            updateAssetStatus={() => {}}
+          />,
+        ),
+      );
+    });
+    await settle();
+
+    await act(async () => {
+      document.body.querySelector('input[aria-label="Select Shot A"]').click();
+    });
+    await settle();
+
+    await act(async () => {
+      [...document.body.querySelectorAll(".batch-selection-bar button")].find((button) => button.textContent === "Move").click();
+    });
+    await settle();
+    await changeField(document.body.querySelector('select[aria-label="Move target"]'), "char-2");
+    await act(async () => {
+      [...document.body.querySelectorAll("button")].find((button) => button.textContent?.startsWith("Move 1 to assets")).click();
+    });
+    await settle();
+
+    // The move endpoint is hit per asset; no character reference (Approved-set
+    // entry) is created for the target.
+    expect(moveAssetToCharacter).toHaveBeenCalledTimes(1);
+    expect(moveAssetToCharacter).toHaveBeenCalledWith(assets[0], "char-2");
+    expect(document.body.querySelector(".batch-selection-bar")).toBeNull();
+  });
+
   it("lists a character's associated datasets and opens one (sc-2022)", async () => {
     const onOpenDataset = vi.fn();
     const onCreateDataset = vi.fn();

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1714,6 +1714,30 @@ export function App() {
     [token],
   );
 
+  // Move an asset into a character's assets (sc-10200): the true-move twin of
+  // moveAssetToLibrary, NOT a link — the backend flips origin to character_studio
+  // (so the asset leaves the Library) and re-anchors the character association
+  // without touching the curated references[] ("Approved set"). Refresh characters
+  // so any curated reference the move detached drops out of their panels too.
+  const moveAssetToCharacter = useCallback(
+    async (asset, characterId) => {
+      try {
+        const updated = await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}/move-to-character`, token, {
+          method: "POST",
+          body: JSON.stringify({ characterId }),
+        });
+        setAssets((items) => items.map((item) => (item.id === updated.id ? updated : item)));
+        refreshCharactersRef.current?.(asset.projectId);
+        setError("");
+        return updated;
+      } catch (err) {
+        setError(err.message);
+        throw err;
+      }
+    },
+    [token],
+  );
+
   const deleteAsset = useCallback(
     async (asset) => {
       try {
@@ -1896,6 +1920,7 @@ export function App() {
     deleteAsset,
     purgeAsset,
     moveAssetToLibrary,
+    moveAssetToCharacter,
     importAsset,
     updateAssetStatus,
     updateAssetTags,
@@ -2026,7 +2051,7 @@ export function App() {
     activeProject, mediaAssets, openPreview, sendAssetToImage, sendAssetToVideo,
     activeTimeline, timelines, selectedTimelineId, setSelectedTimelineId, setActiveTimeline,
     createTimeline, saveTimeline, exportTimeline, extractTimelineFrame, queueTimelineVideoJob,
-    assets, selectedAsset, setSelectedAssetId, deleteAsset, purgeAsset, moveAssetToLibrary, importAsset,
+    assets, selectedAsset, setSelectedAssetId, deleteAsset, purgeAsset, moveAssetToLibrary, moveAssetToCharacter, importAsset,
     updateAssetStatus, updateAssetTags, latestImageAssets,
     jobAction, createVqaJob, createInterleaveJob, createPlaceholderJob,
     jobPrompt, setJobPrompt, projectFilter, setProjectFilter, projects,

--- a/apps/web/src/App.library.test.jsx
+++ b/apps/web/src/App.library.test.jsx
@@ -270,7 +270,9 @@ describe("SceneWorks app shell", () => {
   });
 
   it("moves a Library asset into a selected character's assets", async () => {
-    const addCharacterReference = vi.fn(async () => ({ id: "char-2", references: [] }));
+    // sc-10200: a TRUE move — the context action hits the move-to-character
+    // endpoint; no character reference (Approved set entry) is created.
+    const moveAssetToCharacter = vi.fn(async (asset) => ({ ...asset, origin: "character_studio" }));
     const asset = {
       id: "asset-portrait",
       projectId: "project-1",
@@ -290,7 +292,7 @@ describe("SceneWorks app shell", () => {
               { id: "char-1", name: "Mira", type: "person", references: [], approvedReferences: [], looks: [], loras: [] },
               { id: "char-2", name: "Dax", type: "person", references: [], approvedReferences: [], looks: [], loras: [] },
             ],
-            addCharacterReference,
+            moveAssetToCharacter,
             jobs: [],
             imageModels: [],
             createVqaJob: vi.fn(),
@@ -318,13 +320,8 @@ describe("SceneWorks app shell", () => {
     });
     await settle();
 
-    expect(addCharacterReference).toHaveBeenCalledWith("char-2", {
-      assetId: "asset-portrait",
-      approved: false,
-      role: "asset",
-      notes: "Added from Asset Library.",
-    });
-    expect(container.textContent).toContain("Added to Dax's assets.");
+    expect(moveAssetToCharacter).toHaveBeenCalledWith(asset, "char-2");
+    expect(container.textContent).toContain("Moved to Dax's assets.");
   });
 
   it("bulk-discards every selected Library asset to the Trash", async () => {
@@ -394,7 +391,8 @@ describe("SceneWorks app shell", () => {
   });
 
   it("bulk-moves selected Library assets into a chosen character's assets", async () => {
-    const addCharacterReference = vi.fn(async () => ({ id: "char-2", references: [] }));
+    // sc-10200: the batch Move is a TRUE move per asset — no Approved-set links.
+    const moveAssetToCharacter = vi.fn(async (asset) => ({ ...asset, origin: "character_studio" }));
     const assetA = {
       id: "asset-a",
       projectId: "project-1",
@@ -420,7 +418,7 @@ describe("SceneWorks app shell", () => {
               { id: "char-1", name: "Mira", type: "person", references: [], approvedReferences: [], looks: [], loras: [] },
               { id: "char-2", name: "Dax", type: "person", references: [], approvedReferences: [], looks: [], loras: [] },
             ],
-            addCharacterReference,
+            moveAssetToCharacter,
             jobs: [],
             imageModels: [],
             createVqaJob: vi.fn(),
@@ -461,24 +459,14 @@ describe("SceneWorks app shell", () => {
     });
     await settle();
 
-    expect(addCharacterReference).toHaveBeenCalledTimes(2);
-    expect(addCharacterReference).toHaveBeenCalledWith("char-2", {
-      assetId: "asset-a",
-      approved: false,
-      role: "asset",
-      notes: "Added from Asset Library.",
-    });
-    expect(addCharacterReference).toHaveBeenCalledWith("char-2", {
-      assetId: "asset-b",
-      approved: false,
-      role: "asset",
-      notes: "Added from Asset Library.",
-    });
+    expect(moveAssetToCharacter).toHaveBeenCalledTimes(2);
+    expect(moveAssetToCharacter).toHaveBeenCalledWith(assetA, "char-2");
+    expect(moveAssetToCharacter).toHaveBeenCalledWith(assetB, "char-2");
     expect(document.body.querySelector(".batch-selection-bar")).toBeNull();
   });
 
   it("disables the Library move action for a character that already owns the asset", async () => {
-    const addCharacterReference = vi.fn();
+    const moveAssetToCharacter = vi.fn();
     const asset = {
       id: "asset-portrait",
       projectId: "project-1",
@@ -505,7 +493,7 @@ describe("SceneWorks app shell", () => {
                 loras: [],
               },
             ],
-            addCharacterReference,
+            moveAssetToCharacter,
             jobs: [],
             imageModels: [],
             createVqaJob: vi.fn(),
@@ -533,7 +521,7 @@ describe("SceneWorks app shell", () => {
     await act(async () => {
       button.click();
     });
-    expect(addCharacterReference).not.toHaveBeenCalled();
+    expect(moveAssetToCharacter).not.toHaveBeenCalled();
   });
 
   it("excludes Character Studio outputs from the Asset Library (sc-2024)", async () => {

--- a/apps/web/src/assetBatch.jsx
+++ b/apps/web/src/assetBatch.jsx
@@ -32,7 +32,7 @@ export function useAssetBatch() {
     imageModels = [],
     characters = [],
     deleteAsset,
-    addCharacterReference,
+    moveAssetToCharacter,
     moveAssetToLibrary,
     token = "",
     requestedGpu = "auto",
@@ -56,8 +56,8 @@ export function useAssetBatch() {
   const availableUpscaleEngines = UPSCALE_ENGINES.filter((engine) => !macUpscaleEngineBlocked(macCapabilities, engine.key));
   const editModels = editCapableModels(imageModels);
   const detailModels = detailCapableModels(imageModels);
-  // Move targets the same "Character Assets" link the per-asset panel uses (role "asset",
-  // unapproved) — NOT the character's reference images — so only link-capable media counts.
+  // Move targets a character's assets (true move, sc-10200) — NOT the character's
+  // curated reference set — so only move-capable media counts.
   const availableCharacters = characters.filter((character) => !character?.archived);
   const movableSelected = selectedAssetList.filter(assetSupportsCharacterLink);
 
@@ -140,13 +140,14 @@ export function useAssetBatch() {
     }
   }
 
-  // Fan out the move across every movable selection. The target is either the Main Asset
-  // Library (a true move — sc-8341) or a character (the per-asset link AssetDetail uses:
-  // role "asset", unapproved, library-member note).
+  // Fan out the move across every movable selection. Both targets are TRUE moves:
+  // the Main Asset Library (sc-8341) or a character's assets (sc-10200 — the asset
+  // leaves the Library and every other character; it is NOT added to the target's
+  // curated "Approved set").
   async function moveSelectedToCharacter() {
     if (!moveCharacterId || !movableSelected.length || bulkAction) return;
     const toLibrary = moveCharacterId === LIBRARY_MOVE_TARGET;
-    if (toLibrary ? !moveAssetToLibrary : !addCharacterReference) return;
+    if (toLibrary ? !moveAssetToLibrary : !moveAssetToCharacter) return;
     setBulkAction("move");
     try {
       for (const asset of movableSelected) {
@@ -154,15 +155,10 @@ export function useAssetBatch() {
           if (toLibrary) {
             await moveAssetToLibrary(asset);
           } else {
-            await addCharacterReference(moveCharacterId, {
-              assetId: asset.id,
-              approved: false,
-              role: "asset",
-              notes: "Added from Asset Library.",
-            });
+            await moveAssetToCharacter(asset, moveCharacterId);
           }
         } catch {
-          // One asset failing (e.g. already linked) shouldn't abort the rest.
+          // One asset failing (e.g. already moved) shouldn't abort the rest.
         }
       }
       clearSelection();

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -254,9 +254,9 @@ function CharacterAssetLinker({ asset, characters = [], onMoveToCharacter }) {
     setMessage("");
     try {
       await onMoveToCharacter(asset, selectedCharacter.id);
-      setMessage(`Added to ${selectedCharacter.name}'s assets.`);
+      setMessage(`Moved to ${selectedCharacter.name}'s assets.`);
     } catch (err) {
-      setMessage(err?.message ?? "Could not add this asset to the character.");
+      setMessage(err?.message ?? "Could not move this asset to the character.");
     } finally {
       setMoving(false);
     }

--- a/apps/web/src/screens/LibraryScreen.jsx
+++ b/apps/web/src/screens/LibraryScreen.jsx
@@ -15,7 +15,7 @@ export function LibraryScreen() {
     deleteAsset,
     purgeAsset,
     characters = [],
-    addCharacterReference,
+    moveAssetToCharacter,
     importAsset,
     setPreviewAsset,
     sendAssetToImage,
@@ -109,19 +109,6 @@ export function LibraryScreen() {
     await importAsset(file);
     setIsImporting(false);
     event.target.value = "";
-  }
-
-  async function moveAssetToCharacter(asset, characterId) {
-    const updated = await addCharacterReference?.(characterId, {
-      assetId: asset.id,
-      approved: false,
-      role: "asset",
-      notes: "Added from Asset Library.",
-    });
-    if (!updated) {
-      throw new Error("Could not add this asset to the character.");
-    }
-    return updated;
   }
 
   const imageCount = libraryAssets.filter((asset) => asset.type === "image").length;
@@ -222,7 +209,7 @@ export function LibraryScreen() {
           onSendVideo={onSendVideo}
           onSendEditor={onSendEditor}
           characters={characters}
-          onMoveToCharacter={addCharacterReference ? moveAssetToCharacter : null}
+          onMoveToCharacter={moveAssetToCharacter ?? null}
           updateAssetStatus={updateAssetStatus}
           updateAssetTags={updateAssetTags}
           availableTags={availableTags}

--- a/crates/sceneworks-core/src/character_store.rs
+++ b/crates/sceneworks-core/src/character_store.rs
@@ -1256,7 +1256,20 @@ fn update_asset_character_link(
         .and_then(|value| value.as_array().cloned())
         .unwrap_or_default()
         .into_iter()
-        .filter(|item| item.get("characterId").and_then(Value::as_str) != Some(character_id))
+        .filter(|item| {
+            if item.get("characterId").and_then(Value::as_str) != Some(character_id) {
+                return true;
+            }
+            // Only rebuild this function's own mirror entries. A "library-move"
+            // anchor (move_asset_to_character, sc-10200) must survive curated
+            // reference add/remove cycles — dropping it would orphan the moved
+            // asset (origin `character_studio`, no character association left).
+            // Entries without a `source` predate the distinction and were all
+            // written here, so they count as sidecar-managed.
+            item.get("source")
+                .and_then(Value::as_str)
+                .is_some_and(|source| source != "character-sidecar")
+        })
         .collect::<Vec<_>>();
     if !remove {
         links.push(json!({

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -2192,6 +2192,77 @@ impl ProjectStore {
         normalize_asset(project_id, &project_path, &sidecar_path)
     }
 
+    /// Move a library asset into a character's assets (sc-10200): the true-move
+    /// twin of [`Self::move_asset_to_library`]. A character-sidecar `references[]`
+    /// entry is NOT the right vehicle for a move — it leaves the asset in the Main
+    /// Asset Library (its `origin` stays library-visible) and surfaces it in the
+    /// curated "Approved set" panel (which renders every `references[]` entry). So
+    /// a move must: flip `origin` to `character_studio` (the Library's allow-list
+    /// then excludes it), anchor the target association in
+    /// `metadata.characterReferences` only (the Character assets grid and the
+    /// `?character=` scope both match on it), and detach the asset from everything
+    /// else — the recipe's `characterId` and every character's curated
+    /// `references[]` — without adding a curated reference to the target.
+    pub fn move_asset_to_character(
+        &self,
+        project_id: &str,
+        asset_id: &str,
+        character_id: &str,
+    ) -> ProjectStoreResult<Value> {
+        let (project_path, _project_guard) = self.lock_project(project_id)?;
+        let character_store = CharacterStore::new(&self.data_dir, project_path.clone());
+        // Reject an unknown/deleted target before mutating anything.
+        character_store.get_character(project_id, character_id)?;
+        let sidecar_path = self.find_asset_sidecar(&project_path, asset_id)?;
+        let mut asset = read_json(&sidecar_path)?;
+        {
+            let object = asset.as_object_mut().ok_or_else(|| {
+                ProjectStoreError::BadRequest("Asset sidecar must be an object".to_owned())
+            })?;
+            object.insert(
+                "origin".to_owned(),
+                Value::String("character_studio".to_owned()),
+            );
+            // The recipe's characterId is a competing association vector (it would
+            // keep the asset in the previous character's grid), so clear it and let
+            // the metadata anchor own the membership.
+            if let Some(settings) = object
+                .get_mut("recipe")
+                .and_then(Value::as_object_mut)
+                .and_then(|recipe| recipe.get_mut("normalizedSettings"))
+                .and_then(Value::as_object_mut)
+            {
+                settings.remove("characterId");
+            }
+            let metadata = object
+                .entry("metadata".to_owned())
+                .or_insert_with(|| json!({}));
+            let metadata = metadata.as_object_mut().ok_or_else(|| {
+                ProjectStoreError::BadRequest("Asset metadata must be an object".to_owned())
+            })?;
+            // `source` distinguishes this move anchor from the "character-sidecar"
+            // mirror entries `update_asset_character_link` manages — that rebuild
+            // must not drop the anchor when a curated reference is added/removed.
+            metadata.insert(
+                "characterReferences".to_owned(),
+                json!([{
+                    "characterId": character_id,
+                    "source": "library-move",
+                    "approved": false,
+                    "role": "asset",
+                    "linkedAt": utc_now(),
+                }]),
+            );
+        }
+        write_json(&sidecar_path, &asset)?;
+        index_asset(&project_path, &asset, Some(&sidecar_path))?;
+        // Leave no curated membership behind: the move detaches the asset from every
+        // character's references[] (including the target's — the Approved set is
+        // hand-curated and a bulk move must not populate it).
+        character_store.remove_asset_references(asset_id)?;
+        normalize_asset(project_id, &project_path, &sidecar_path)
+    }
+
     pub fn get_asset(&self, project_id: &str, asset_id: &str) -> ProjectStoreResult<Value> {
         let project_path = self.find_project_path(project_id)?;
         let sidecar_path = self.find_asset_sidecar(&project_path, asset_id)?;
@@ -4086,8 +4157,9 @@ mod tests {
         connect_project_db, find_timeline_file, guess_mime_from_filename, index_timeline,
         is_safe_relative_path, is_safe_upload_extension, normalize_asset_tags, read_json,
         sniff_image_format, upload_extension, AssetScope, CharacterCreateInput, CharacterLookInput,
-        ProjectStore, ProjectStoreError, UploadAsset, GLOBAL_KEYPOINTS_PROJECT_ID,
-        GLOBAL_POSES_PROJECT_ID, PROJECT_FOLDERS, PROJECT_SCHEMA_VERSION, SAFE_UPLOAD_EXTENSIONS,
+        CharacterReferenceInput, ProjectStore, ProjectStoreError, UploadAsset,
+        GLOBAL_KEYPOINTS_PROJECT_ID, GLOBAL_POSES_PROJECT_ID, PROJECT_FOLDERS,
+        PROJECT_SCHEMA_VERSION, SAFE_UPLOAD_EXTENSIONS,
     };
     use rusqlite::Connection;
     use serde_json::{json, Value};
@@ -4812,6 +4884,134 @@ mod tests {
             .get_asset(&project.id, "char_shot")
             .expect("get after");
         assert_eq!(after["origin"], json!("image_studio"));
+    }
+
+    /// sc-10200: the true-move twin of `move_asset_to_library`. A Library asset
+    /// moved into a character must leave the Library (origin flip), anchor on the
+    /// target via `metadata.characterReferences` ONLY (no curated `references[]`
+    /// entry — the "Approved set" is hand-curated), detach from every other
+    /// character, and survive a curated reference add/remove cycle on the target.
+    #[test]
+    fn move_asset_to_character_flips_origin_and_anchors_without_curated_reference() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Gallery").expect("project creates");
+
+        // A plain Image Studio output: origin image_studio, library-visible.
+        let fact = json!({
+            "assetId": "lib_shot",
+            "mediaPath": "assets/images/genset_lib/lib_shot.png",
+            "mimeType": "image/png",
+            "displayName": "Plate #1",
+            "createdAt": "2026-05-25T00:00:00Z",
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "adapter": "z_image_diffusers",
+            "prompt": "plate",
+        });
+        store
+            .persist_generated_asset(&project.id, "job-1", "genset_lib", &fact)
+            .expect("asset persists");
+
+        let mira = store
+            .create_character(
+                &project.id,
+                CharacterCreateInput {
+                    name: "Mira".to_owned(),
+                    character_type: "person".to_owned(),
+                    description: String::new(),
+                },
+            )
+            .expect("Mira creates");
+        let dax = store
+            .create_character(
+                &project.id,
+                CharacterCreateInput {
+                    name: "Dax".to_owned(),
+                    character_type: "person".to_owned(),
+                    description: String::new(),
+                },
+            )
+            .expect("Dax creates");
+        let mira_id = mira["id"].as_str().expect("Mira id").to_owned();
+        let dax_id = dax["id"].as_str().expect("Dax id").to_owned();
+
+        // Pre-existing curated link on Mira (the legacy "Move" behavior): the move
+        // must clean this up rather than leave a dual membership behind.
+        store
+            .add_character_reference(
+                &project.id,
+                &mira_id,
+                CharacterReferenceInput {
+                    asset_id: "lib_shot".to_owned(),
+                    approved: false,
+                    role: "asset".to_owned(),
+                    notes: String::new(),
+                },
+            )
+            .expect("Mira link");
+
+        // An unknown target must reject before mutating anything.
+        assert!(store
+            .move_asset_to_character(&project.id, "lib_shot", "char_missing")
+            .is_err());
+
+        let moved = store
+            .move_asset_to_character(&project.id, "lib_shot", &dax_id)
+            .expect("move to Dax");
+
+        // Origin flipped, so the Library allow-list now excludes the asset.
+        assert_eq!(moved["origin"], json!("character_studio"));
+        // Anchored on Dax via metadata only, tagged as a move (not a sidecar mirror).
+        let links = moved["metadata"]["characterReferences"]
+            .as_array()
+            .expect("anchor links");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0]["characterId"], json!(dax_id));
+        assert_eq!(links[0]["source"], json!("library-move"));
+        // Neither character carries a curated references[] entry: Mira's stale link
+        // is gone and Dax's Approved set stays hand-curated.
+        let mira_after = store
+            .get_character(&project.id, &mira_id)
+            .expect("Mira after");
+        assert_eq!(mira_after["references"].as_array().map(Vec::len), Some(0));
+        let dax_after = store
+            .get_character(&project.id, &dax_id)
+            .expect("Dax after");
+        assert_eq!(dax_after["references"].as_array().map(Vec::len), Some(0));
+
+        // A curated reference add/remove cycle on the target must not orphan the
+        // asset: the sidecar mirror rebuild only manages its own entries.
+        store
+            .add_character_reference(
+                &project.id,
+                &dax_id,
+                CharacterReferenceInput {
+                    asset_id: "lib_shot".to_owned(),
+                    approved: true,
+                    role: "reference".to_owned(),
+                    notes: String::new(),
+                },
+            )
+            .expect("Dax curated link");
+        store
+            .remove_character_reference(&project.id, &dax_id, "lib_shot")
+            .expect("Dax curated unlink");
+        let cycled = store
+            .get_asset(&project.id, "lib_shot")
+            .expect("get cycled");
+        let cycled_links = cycled["metadata"]["characterReferences"]
+            .as_array()
+            .expect("anchor survives");
+        assert_eq!(cycled_links.len(), 1);
+        assert_eq!(cycled_links[0]["source"], json!("library-move"));
+
+        // Reversible: move-to-library restores a library origin and drops the anchor.
+        let back = store
+            .move_asset_to_library(&project.id, "lib_shot")
+            .expect("move back");
+        assert_eq!(back["origin"], json!("image_studio"));
+        assert!(back["metadata"]["characterReferences"].is_null());
     }
 
     /// V-4: a pre-migration project surfaces an EMPTY `assets` table even though


### PR DESCRIPTION
## Problem

Batch **Move** in the Asset Library (and the per-asset "Move to Character" panel) *linked* assets to the character via `addCharacterReference` instead of moving them:

- The images **stayed visible in the Asset Library** — their `origin` never changed, and Library visibility is decided solely by the `isLibraryAsset` origin allow-list.
- Every moved image **landed in the character's "Approved set"** — that panel renders every `references[]` entry, and the link wrote one per asset. The Approved set is supposed to be hand-curated.

Meanwhile the opposite direction (Character → "Assets Library", sc-8341) was already a true move, so the two directions were asymmetric while both said "Move". Michael's call: **move only, no link semantics**.

## Fix

`ProjectStore::move_asset_to_character` — the true-move twin of `move_asset_to_library`:

- flips `origin` → `character_studio`, so the Library origin filter excludes the asset;
- anchors the target association in `metadata.characterReferences` **only** (`source: "library-move"`) — the Character assets grid and the `?character=` API scope both match on it, and the curated `references[]` is never touched;
- clears the recipe's `characterId` and detaches the asset from every character's curated `references[]` (no dual membership after character→character moves);
- rejects an unknown target character before mutating anything; exposed as `POST /api/v1/projects/:project_id/assets/:asset_id/move-to-character`.

`update_asset_character_link`'s mirror rebuild now only manages its own `character-sidecar` entries, so a later curated-reference add/remove cycle can't drop the move anchor and orphan the asset.

Web: new `moveAssetToCharacter` context action (refreshes characters after the move); the shared batch hook and the Library detail panel call it instead of `addCharacterReference`. The Character Assets page **Import** dialog intentionally keeps link semantics (it exists to make media selectable in the reference picker).

## Validation

- New core test `move_asset_to_character_flips_origin_and_anchors_without_curated_reference`: origin flip, metadata-only anchor, stale-link cleanup on the old character, no curated entry on the target, anchor survives a curated add/remove cycle, reversible via move-to-library.
- New/updated web tests: single + bulk move from the Library, character→character bulk move, already-owned gating.
- `cargo test -p sceneworks-core` (380 lib + integration suites) and `-p sceneworks-rust-api` (192) green; clippy `-D warnings` clean; web vitest 1310/1310, build + lint green.

Shortcut: [sc-10200](https://app.shortcut.com/trefry/story/10200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)