### PR TITLE
feat(worker): Z-Image t2i img2img via ui.img2img (reconcile with identity ref) (sc-10193)

### DIFF
--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -3839,8 +3839,15 @@ async fn real_builtin_catalog_exposes_krea_img2img_ui_flag() {
         Value::Bool(true),
         "krea_2_turbo must expose ui.img2img in the /models response (the img2img tile's gate)"
     );
-    // And SD3.5 (A4.1) — the flag just added — must be exposed the same way.
-    for id in ["sd3_5_large", "sd3_5_large_turbo", "sd3_5_medium"] {
+    // And SD3.5 (A4.1) + Z-Image (A4.5, sc-10193) — the img2img flags added since — must be exposed the
+    // same way (a duplicate-`ui`-key drop would silently strip the flag while still parsing, sc-10198).
+    for id in [
+        "sd3_5_large",
+        "sd3_5_large_turbo",
+        "sd3_5_medium",
+        "z_image",
+        "z_image_turbo",
+    ] {
         let m = models
             .as_array()
             .unwrap()

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -122,6 +122,14 @@
         "measured": true
       },
       "ui": {
+        // img2img reference-guided t2i (epic 8588 A4.5, sc-10193): the `ui.img2img` flag drives the
+        // Image Studio "Image reference" tile + strength slider (referenceAssetId + advanced.strength).
+        // Distinct from the Character Studio `referenceStrength` identity-init (sc-3619) below, which
+        // keeps precedence on the worker (resolve_identity_init first, then this generic img2img). Both
+        // feed the same z-image img2img entrypoint (Conditioning::Reference); only the strength keying
+        // differs. Full 0–1 slider (default 0.5), unclamped — usable band is model-specific.
+        "img2img": true,
+        "img2imgStrength": { "label": "Reference strength", "default": 0.5, "min": 0.0, "max": 1.0, "step": 0.05 },
         "label": "Z-Image-Turbo",
         "description": "Fast first image target for local text-to-image generation.",
         "recommendedFor": ["text_to_image", "style_variations"],
@@ -245,6 +253,12 @@
         }
       },
       "ui": {
+        // img2img reference-guided t2i (epic 8588 A4.5, sc-10193): base Z-Image is NOT in the worker's
+        // z_image_turbo|z_image_edit reference arm, so this `ui.img2img` flag routes it straight through
+        // the generic img2img latent-init (resolve_img2img_init_generic → the shared Conditioning::Reference
+        // → z-image base engine's encode_init_latents). Full 0–1 slider (default 0.5), unclamped.
+        "img2img": true,
+        "img2imgStrength": { "label": "Reference strength", "default": 0.5, "min": 0.0, "max": 1.0, "step": 0.05 },
         "label": "Z-Image",
         "description": "Undistilled base Z-Image text-to-image (real CFG, ~50 steps); higher quality than Turbo at a higher compute cost.",
         "recommendedFor": ["text_to_image", "style_variations"],

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -2318,6 +2318,23 @@ fn model_supports_img2img(request: &ImageRequest) -> bool {
         .unwrap_or(false)
 }
 
+/// Whether a Z-Image t2i request should take the generic `ui.img2img` reference-guided latent-init
+/// rather than the Character Studio identity-init (sc-3619). Z-Image already owns a bespoke reference
+/// arm in [`resolve_generic_lane_conditioning`] (keyed on `referenceStrength`), so it never reaches the
+/// generic img2img arm below — this predicate re-introduces the generic path INSIDE that arm.
+///
+/// Identity-init keeps precedence (it also drives face-likeness scoring), so the generic img2img fires
+/// ONLY when identity-init doesn't engage (no `referenceStrength`) yet the model opts into `ui.img2img`
+/// and a reference is present — i.e. the Image Studio "Image reference" tile (`referenceAssetId` +
+/// `advanced.strength`). The two surfaces are mutually exclusive by mode (character_image vs
+/// text_to_image); encoding the precedence purely keeps it unit-testable without image I/O (epic 8588
+/// A4.5, sc-10193). Base `z_image` is NOT in the z-image arm, so it reaches the generic arm directly and
+/// never consults this predicate.
+#[cfg(target_os = "macos")]
+fn zimage_uses_generic_img2img(request: &ImageRequest, has_reference: bool) -> bool {
+    identity_strength(request).is_none() && has_reference && model_supports_img2img(request)
+}
+
 /// The source identity reference (decoded image + its asset id) a strict-control pose set scores its
 /// finished poses against (epic 4406, sc-4410), or `None` when the job carries no identity reference.
 ///
@@ -2828,8 +2845,17 @@ fn resolve_generic_lane_conditioning(
         // otherwise the identity-init reference (referenceAssetId + referenceStrength, sc-3619).
         // Both feed the engine's single `Reference` conditioning; only the source + strength
         // keying differs. The strict-pose ControlNet tier diverts earlier (zimage_control_available).
+        // Character Studio identity-init (referenceStrength, sc-3619) is the primary reference surface
+        // and keeps precedence — it also drives face-likeness scoring. When it doesn't engage (the Image
+        // Studio "Image reference" tile sends referenceAssetId + advanced.strength with NO
+        // referenceStrength), the generic `ui.img2img` reference-guided latent-init (epic 8588 A4.5,
+        // sc-10193) takes over so the slider actually reaches the engine. The two surfaces are mutually
+        // exclusive by mode (character_image vs text_to_image), so this never double-drives; both produce
+        // the same single `Conditioning::Reference`.
         let init = if request.mode == "edit_image" {
             resolve_zimage_edit_init(request, settings, project_path)?
+        } else if zimage_uses_generic_img2img(request, has_reference) {
+            resolve_img2img_init_generic(request, settings, project_path)?
         } else {
             resolve_identity_init(request, settings, project_path)?
         };
@@ -4189,6 +4215,52 @@ mod standard_tier_tests {
         )));
         assert!(!model_supports_img2img(&entry(json!({ "family": "sd3" }))));
         assert!(!model_supports_img2img(&entry(json!({ "ui": {} }))));
+    }
+
+    /// A4.5 (sc-10193): on Z-Image t2i the Character Studio identity-init (`referenceStrength`, sc-3619)
+    /// keeps precedence; the generic `ui.img2img` reference-guided init (Image Studio "Image reference"
+    /// tile: `advanced.strength`, no `referenceStrength`) fires only when identity-init doesn't engage,
+    /// the model opts into `ui.img2img`, AND a reference is present. Otherwise plain txt2img.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn zimage_generic_img2img_yields_to_identity_reference() {
+        let req = |advanced: serde_json::Value| {
+            ImageRequest::from_payload(
+                json!({
+                    "model": "z_image_turbo",
+                    "modelManifestEntry": { "ui": { "img2img": true } },
+                    // Both surfaces carry a reference asset; `identity_strength` reads it too.
+                    "referenceAssetId": "asset-1",
+                    "advanced": advanced,
+                })
+                .as_object()
+                .unwrap(),
+            )
+        };
+        // Image Studio "Image reference": strength only, no referenceStrength, a reference present →
+        // generic img2img takes over.
+        assert!(zimage_uses_generic_img2img(
+            &req(json!({ "strength": 0.6 })),
+            true
+        ));
+        // Character Studio identity: referenceStrength set → identity-init keeps precedence, generic
+        // img2img yields (even though ui.img2img is on and a reference is present).
+        assert!(!zimage_uses_generic_img2img(
+            &req(json!({ "referenceStrength": 0.7 })),
+            true
+        ));
+        // No reference asset present → neither surface engages (plain txt2img).
+        assert!(!zimage_uses_generic_img2img(
+            &req(json!({ "strength": 0.6 })),
+            false
+        ));
+        // Model without the ui.img2img flag → never the generic path.
+        let no_flag = ImageRequest::from_payload(
+            json!({ "model": "z_image_turbo", "modelManifestEntry": { "ui": {} }, "advanced": {} })
+                .as_object()
+                .unwrap(),
+        );
+        assert!(!zimage_uses_generic_img2img(&no_flag, true));
     }
 
     /// Write a minimal present `<tier>/transformer/<file>` so [`standard_tier_subdir`]'s


### PR DESCRIPTION
## What

Rolls the epic-8588 A4 img2img **"Image reference"** tile out to **Z-Image t2i** (`z_image` + `z_image_turbo`) — the next A4 catalog slice after Krea (A) and SD3.5 (A4.1).

mlx-gen z-image is **already img2img-ready** (it's the reference implementation the other A4 models copy: advertises `ConditioningKind::Reference`, `generate_impl` routes, `encode_init_latents` exists). So this is **worker + catalog only — no mlx-gen change, no repin.**

## The reconciliation (why this is its own slice)

`z_image_turbo` already sits in a bespoke z-image reference arm that calls `resolve_identity_init` — the Character Studio "With Character" surface (sc-3619), keyed on `advanced.referenceStrength` and driving face-likeness scoring. The A4 img2img tile is a *different* surface: `ui.img2img` → `referenceAssetId` + `advanced.strength`. Left alone, the img2img tile's slider (no `referenceStrength`) made `resolve_identity_init` return `None` → the reference was silently dropped and z-image rendered plain t2i.

**Decision: COEXIST, identity-first.** A new `zimage_uses_generic_img2img()` precedence predicate:
- Character Studio identity-init keeps precedence (still drives likeness scoring).
- The generic `ui.img2img` reference-guided latent-init fires only when identity-init doesn't engage.
- The two surfaces are mutually exclusive by mode (`character_image` vs `text_to_image`) → no double-drive.
- Base `z_image` isn't in the z-image arm, so the flag routes it straight through the generic A4.1 arm — no worker change for it.

## Changes

- **Catalog** (`builtin.models.jsonc`): `ui.img2img` + `img2imgStrength` on `z_image` and `z_image_turbo` — folded into the single existing `ui` block per entry (no duplicate-key drop, cf. sc-10198).
- **Worker** (`image_jobs/base.rs`): `zimage_uses_generic_img2img()` predicate + fall-through in the z-image arm.
- **Tests**: pure precedence unit test (identity ref wins; no ref / no flag → neither surface); extended the real-manifest catalog test to assert both z-image entries expose `ui.img2img` through `/api/v1/models`.

## Verification

- `cargo test -p sceneworks-worker --lib img2img` — green (precedence + flag tests).
- `cargo test -p sceneworks-rust-api real_builtin_catalog_exposes_krea_img2img_ui_flag` — green (real manifest → catalog exposes z-image `ui.img2img`).
- `cargo fmt --check` clean; candle-lane `cargo check -p sceneworks-worker --no-default-features -F backend-candle --all-targets` clean.
- On-device end-to-end render pending (Michael).

## Follow-up

- **sc-10209** — candle (Windows/CUDA) worker-lane parity for the generic z-image img2img tile (engine already supports it; macOS/MLX ships first per the whole A-slice pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)