### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/desktop",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/desktop",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/desktop",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/desktop",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/desktop",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "SceneWorks desktop shell (Tauri).",
   "scripts": {
     "dev": "tauri dev",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/desktop",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "SceneWorks desktop shell (Tauri).",
   "scripts": {
     "dev": "tauri dev",

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SceneWorks",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "identifier": "net.trefry.sceneworks",
   "build": {
     "frontendDist": "ui",

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SceneWorks",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "identifier": "net.trefry.sceneworks",
   "build": {
     "frontendDist": "ui",

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/web",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/web",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "dependencies": {
         "konva": "^9.3.22",
         "react": "18.3.1",

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/web",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/web",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "konva": "^9.3.22",
         "react": "18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/web",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/web",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sceneworks",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Local AI image and video generation studio runtime skeleton.",
   "license": "SEE LICENSE IN LICENSE",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sceneworks",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Local AI image and video generation studio runtime skeleton.",
   "license": "SEE LICENSE IN LICENSE",
   "scripts": {


### PR DESCRIPTION
Version bump to `0.7.0` (root + tauri.conf.json + apps/desktop + apps/web via sync-version.mjs).

After this merges, cut the release:
```
git switch main && git pull
npm run release -- tag
```
The tag push triggers `.github/workflows/release.yml`, which drafts the GitHub Release.