### PR TITLE
fix(api): refresh app-owned builtin catalog on launch (stale seed) (sc-10212)

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -367,6 +367,28 @@ fn open_bind_override_enabled(value: &str) -> bool {
     matches!(value.trim(), "1" | "true" | "TRUE" | "yes" | "YES")
 }
 
+/// Choose the builtin-manifest seed mode from the raw `SCENEWORKS_CONFIG_DIR` value (sc-10212).
+///
+/// An explicit, non-empty override marks an operator-owned config dir — a repo checkout or a Compose
+/// bind mount — which must stay authoritative, so seed `IfMissing` (fill gaps, never clobber an edited
+/// copy or dirty a checked-out `config/`). Unset or blank means `config_dir` fell back to the
+/// platform-default app-owned dir (the same one the desktop seeds `Overwrite`), so `Overwrite` there
+/// refreshes the builtin catalog on launch instead of serving a stale seed after an upgrade — the
+/// sc-10193 img2img flag was invisible on a directly-launched API because the months-old seed was
+/// never rewritten. Pure so the choice is unit-tested without touching process env or the filesystem.
+///
+/// The trim/non-empty rule mirrors [`env_path_or`] exactly, so the seed mode and the resolved
+/// `config_dir` always agree on whether the override was actually applied.
+fn seed_mode_for_config_dir(
+    config_dir_env: Option<&str>,
+) -> sceneworks_core::builtin_manifests::SeedMode {
+    use sceneworks_core::builtin_manifests::SeedMode;
+    match config_dir_env.map(str::trim) {
+        Some(value) if !value.is_empty() => SeedMode::IfMissing,
+        _ => SeedMode::Overwrite,
+    }
+}
+
 fn json_rejection_response(rejection: JsonRejection) -> Response {
     // sc-8812 (F-010): a body over the route's `DefaultBodyLimit` surfaces here as a
     // `BytesRejection` whose own status is 413. Preserve the rejection's status code

--- a/apps/rust-api/src/server.rs
+++ b/apps/rust-api/src/server.rs
@@ -32,8 +32,8 @@ use crate::models::ModelSizeCache;
 use crate::tickets::TicketStore;
 use crate::{
     create_app, env_path_or, env_string, open_bind_override_enabled, parent_death,
-    parent_pid_to_watch, should_warn_open_bind, shutdown_signal, spawn_inprocess_utility_worker,
-    DEFAULT_API_HOST, DEFAULT_CORS_ORIGINS,
+    parent_pid_to_watch, seed_mode_for_config_dir, should_warn_open_bind, shutdown_signal,
+    spawn_inprocess_utility_worker, DEFAULT_API_HOST, DEFAULT_CORS_ORIGINS,
 };
 
 #[derive(Debug, Clone)]
@@ -185,12 +185,21 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // it. The desktop wrapper and the Compose bind mount normally provide it; seed
     // any missing manifests here so launching the API binary directly works too,
     // and fail loudly rather than serving an empty catalog if seeding can't finish.
-    // Seed-if-missing (not overwrite) keeps an explicit config dir — a repo
-    // checkout or a Compose bind mount — authoritative; see `builtin_manifests`.
-    if let Err(error) = sceneworks_core::builtin_manifests::seed_builtin_manifests(
-        &settings.config_dir,
-        sceneworks_core::builtin_manifests::SeedMode::IfMissing,
-    ) {
+    //
+    // Seed mode by config-dir origin (sc-10212): an EXPLICIT `SCENEWORKS_CONFIG_DIR`
+    // marks an operator-owned dir — a repo checkout or a Compose bind mount — that must
+    // stay authoritative, so keep `IfMissing` there (fill gaps, never clobber an edited
+    // copy or dirty a checked-out `config/`). When unset, `config_dir` is the platform
+    // default app-owned dir (the same one the desktop seeds `Overwrite`), so refresh it
+    // on launch — otherwise a directly-launched API binary keeps serving a STALE seeded
+    // catalog after an upgrade (the sc-10193 img2img flag stayed invisible because the
+    // months-old seed was never rewritten). Builtin manifests are app-managed; operator
+    // customizations live in the separate `user.*.jsonc` files, which seeding never touches.
+    let seed_mode =
+        seed_mode_for_config_dir(std::env::var("SCENEWORKS_CONFIG_DIR").ok().as_deref());
+    if let Err(error) =
+        sceneworks_core::builtin_manifests::seed_builtin_manifests(&settings.config_dir, seed_mode)
+    {
         return Err(format!(
             "failed to seed builtin manifests into {}: {error}",
             settings.config_dir.join("manifests").display()

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -7,11 +7,11 @@ use super::workers::person_readiness_from_workers;
 use super::{
     create_app, create_app_with_state, huggingface_repo_cache_path, inject_converted_model_path,
     inprocess_worker_gpu_id, lora_artifact_paths, merge_model_manifest_entry, mlx_catalog_status,
-    open_bind_override_enabled, safe_download_dir, serialize_job_lora, should_warn_open_bind,
-    strip_jsonc_comments, sweep_stale_asset_uploads_before, sweep_stale_lora_uploads_before,
-    sweep_stale_uploads, Settings, WorkerCapability, WorkerSnapshot, WorkerStatus,
-    API_MANAGED_MANIFEST_HEADER, DEFAULT_API_HOST, EVENT_BUFFER_SIZE, HEARTBEAT_SSE_DATA,
-    HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
+    open_bind_override_enabled, safe_download_dir, seed_mode_for_config_dir, serialize_job_lora,
+    should_warn_open_bind, strip_jsonc_comments, sweep_stale_asset_uploads_before,
+    sweep_stale_lora_uploads_before, sweep_stale_uploads, Settings, WorkerCapability,
+    WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER, DEFAULT_API_HOST, EVENT_BUFFER_SIZE,
+    HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
 };
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
@@ -74,6 +74,26 @@ fn open_bind_override_only_for_explicit_optin() {
             "{value:?} must not opt in"
         );
     }
+}
+
+#[test]
+fn seed_mode_refreshes_the_app_owned_default_but_not_an_explicit_config_dir() {
+    use sceneworks_core::builtin_manifests::SeedMode;
+    // sc-10212: an explicit, non-empty SCENEWORKS_CONFIG_DIR marks an operator-owned dir (repo
+    // checkout / Compose bind mount) → stay authoritative (IfMissing), never dirty a checkout.
+    assert_eq!(
+        seed_mode_for_config_dir(Some("/srv/sceneworks/config")),
+        SeedMode::IfMissing
+    );
+    assert_eq!(
+        seed_mode_for_config_dir(Some("./config")),
+        SeedMode::IfMissing
+    );
+    // Unset, or blank/whitespace (env_path_or treats those as unset) → the platform-default
+    // app-owned dir → Overwrite so a directly-launched API refreshes its builtin catalog on launch.
+    assert_eq!(seed_mode_for_config_dir(None), SeedMode::Overwrite);
+    assert_eq!(seed_mode_for_config_dir(Some("")), SeedMode::Overwrite);
+    assert_eq!(seed_mode_for_config_dir(Some("   ")), SeedMode::Overwrite);
 }
 
 #[test]

--- a/crates/sceneworks-core/src/builtin_manifests.rs
+++ b/crates/sceneworks-core/src/builtin_manifests.rs
@@ -41,10 +41,13 @@ pub enum SeedMode {
     /// so the builtin catalog tracks the app version; user customizations live in
     /// the separate `user.*.jsonc` files, which seeding never touches.
     Overwrite,
-    /// Only write a manifest that is missing. The API seeds this way so an
-    /// explicit config dir — a repo checkout or a Compose bind mount — stays
-    /// authoritative: it fills gaps but never clobbers a copy the operator is
-    /// editing (and never dirties a checked-out `config/`).
+    /// Only write a manifest that is missing. The API seeds this way when its config
+    /// dir is EXPLICIT (`SCENEWORKS_CONFIG_DIR` set — a repo checkout or a Compose bind
+    /// mount) so that dir stays authoritative: it fills gaps but never clobbers a copy
+    /// the operator is editing (and never dirties a checked-out `config/`). When the API
+    /// falls back to the platform-default app-owned dir it seeds `Overwrite` instead, so a
+    /// directly-launched binary refreshes its builtin catalog on launch rather than serving
+    /// a stale seed after an upgrade (sc-10212; see `seed_mode_for_config_dir` in rust-api).
     IfMissing,
 }
 


### PR DESCRIPTION
## The bug (found on-device)

After merging [#1253](https://github.com/SceneWorks/SceneWorks/pull/1253) (Z-Image `ui.img2img`), pulling, and rebuilding, the **"Image reference" tile never appeared for Z-Image** — while Krea's tile (an older flag) did. The code was correct: the merged manifest and the real-manifest catalog test both pass. The stale artifact was the **seeded copy on disk**.

`apps/rust-api/src/server.rs` seeded builtin manifests with `SeedMode::IfMissing` **unconditionally**. Once `config_dir/manifests/builtin.models.jsonc` exists, `IfMissing` never rewrites it — so a directly-launched API binary keeps the OLD seeded manifest across builds. The on-disk copy still had Krea's flag (seeded when #1249 landed) but not Z-Image's newer one — which is why Krea's tile showed and masked the problem. The packaged **desktop seeds `Overwrite` every launch**, so end users were unaffected; this only bit the dev/standalone-API workflow.

## The fix

`IfMissing` is deliberate — it keeps an **explicit** config dir authoritative (a repo checkout or a Compose bind mount the operator owns: fill gaps, never clobber an edited copy or dirty a checked-out `config/`). That signal is exactly `SCENEWORKS_CONFIG_DIR` being set. So choose the seed mode by config-dir origin:

- **`SCENEWORKS_CONFIG_DIR` set** (explicit, operator-owned) → `IfMissing` (unchanged; checkout/bind-mount protected).
- **unset** → the platform-default app-owned dir (the same one the desktop seeds) → `Overwrite`, refreshing the builtin catalog on launch.

Pure `seed_mode_for_config_dir(Option<&str>)` helper (mirrors `env_path_or`'s trim/non-empty rule, so the seed mode and the resolved `config_dir` always agree on whether the override applied) + unit test. **No sidecar/bootstrap gap — fixes every existing install on next launch.** Builtin manifests are app-managed; operator customizations live in `user.*.jsonc`, which seeding never touches, so `Overwrite` on the app-owned dir matches desktop semantics.

## Changes

- `apps/rust-api/src/lib.rs`: `seed_mode_for_config_dir` pure helper.
- `apps/rust-api/src/server.rs`: pick the mode from `SCENEWORKS_CONFIG_DIR` at the seed call.
- `apps/rust-api/src/tests.rs`: unit test (explicit → IfMissing; unset/blank/whitespace → Overwrite).
- `crates/sceneworks-core/src/builtin_manifests.rs`: doc update on `SeedMode::IfMissing`.

## Verification

- `cargo test -p sceneworks-rust-api -- seed_mode warns_only_on_open_bind real_builtin_catalog` — 3 green.
- `cargo fmt --check` clean; `cargo check -p sceneworks-rust-api -p sceneworks-core --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)