### PR TITLE
fix(image-editor): snap AI-edit output dims to a multiple of 16 (sc-10219)

### DIFF
--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -231,13 +231,26 @@ export function editOutputAspectRatio(key) {
   return EDIT_OUTPUT_ASPECTS.find((aspect) => aspect.key === key)?.ratio ?? null;
 }
 
+// Snap an edit-output pixel dimension to a multiple of 16 (min 16). Every image engine
+// requires dims divisible by 16 (VAE ×8 · patch ×2 — e.g. mlx-gen z-image's SIZE_MULTIPLE
+// guard); an imported/cropped source at arbitrary dims (e.g. 832×1165) would otherwise be
+// forwarded verbatim and hard-fail at generation. Mirrors snapCanvasDim's rounding, without
+// its blank-canvas [256, 2048] clamp — an edit must not force-grow a small source to 256.
+function alignEditDim(px) {
+  return Math.max(16, Math.round(px / 16) * 16);
+}
+
 // Output W×H for an editor edit given the target aspect + fit mode, keeping the working
 // image at native scale (never upscales). "match"/unknown aspect → working size. crop =
 // largest target-aspect rect INSIDE the image (trim the overflow); pad/outpaint =
-// smallest target-aspect canvas CONTAINING the image (extend → border to fill). Pure.
+// smallest target-aspect canvas CONTAINING the image (extend → border to fill). Result dims
+// are always snapped to a multiple of 16 so the engine's size guard accepts them; the worker
+// crop/pad-fits the source to these dims (never stretches). Pure.
 export function editOutputDims(workingW, workingH, aspectKey, fitMode) {
   const ratio = editOutputAspectRatio(aspectKey);
-  if (!ratio || !workingW || !workingH) return { width: workingW, height: workingH };
+  if (!ratio || !workingW || !workingH) {
+    return { width: alignEditDim(workingW), height: alignEditDim(workingH) };
+  }
   const imageRatio = workingW / workingH;
   let width;
   let height;
@@ -260,7 +273,7 @@ export function editOutputDims(workingW, workingH, aspectKey, fitMode) {
       height = Math.round(workingW / ratio);
     }
   }
-  return { width: Math.max(1, width), height: Math.max(1, height) };
+  return { width: alignEditDim(width), height: alignEditDim(height) };
 }
 
 // Whether a model accepts an inpaint mask — the manifest tags it `image_inpaint`

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -941,18 +941,22 @@ describe("AI prompt edit", () => {
   });
 
   it("computes output dims for the canvas-extend control (match / extend / crop)", () => {
-    // Match canvas → working size unchanged, fit mode irrelevant.
+    // Match canvas → working size unchanged (already 16-aligned), fit mode irrelevant.
     expect(editOutputDims(1024, 1024, "match", "outpaint")).toEqual({ width: 1024, height: 1024 });
     // 16:9 outpaint on a square → extend width, keep height at native (add side border).
-    expect(editOutputDims(1024, 1024, "16:9", "outpaint")).toEqual({ width: 1820, height: 1024 });
+    // 1820 (1024·16/9) is snapped up to the nearest multiple of 16 → 1824.
+    expect(editOutputDims(1024, 1024, "16:9", "outpaint")).toEqual({ width: 1824, height: 1024 });
     // 16:9 pad behaves the same geometry as outpaint (extend, then bars vs generate).
-    expect(editOutputDims(1024, 1024, "16:9", "pad")).toEqual({ width: 1820, height: 1024 });
-    // 16:9 crop on a square → shrink to the aspect inside the image (trim height).
+    expect(editOutputDims(1024, 1024, "16:9", "pad")).toEqual({ width: 1824, height: 1024 });
+    // 16:9 crop on a square → shrink to the aspect inside the image (trim height); 576 = 36·16.
     expect(editOutputDims(1024, 1024, "16:9", "crop")).toEqual({ width: 1024, height: 576 });
     // Portrait target on a square extends height.
-    expect(editOutputDims(1024, 1024, "9:16", "outpaint")).toEqual({ width: 1024, height: 1820 });
-    // Unknown aspect / zero dims fall back to the working size.
-    expect(editOutputDims(800, 600, "bogus", "pad")).toEqual({ width: 800, height: 600 });
+    expect(editOutputDims(1024, 1024, "9:16", "outpaint")).toEqual({ width: 1024, height: 1824 });
+    // Unknown aspect / zero dims fall back to the working size — snapped to a multiple of 16
+    // (600 → 608), so the engine's size guard accepts an arbitrary imported/cropped source.
+    expect(editOutputDims(800, 600, "bogus", "pad")).toEqual({ width: 800, height: 608 });
+    // A cropped source at arbitrary dims (the z-image failure: 832×1165) snaps to 832×1168.
+    expect(editOutputDims(832, 1165, "match", "crop")).toEqual({ width: 832, height: 1168 });
     expect(editOutputAspectRatio("1:1")).toBe(1);
     expect(editOutputAspectRatio("match")).toBeNull();
   });


### PR DESCRIPTION
## What

The Image Editor's AI-edit path forwarded the working image's **raw** pixel dimensions to the worker, which passes them straight through to the engine. The z-image engine hard-rejects dims not divisible by 16 (`SIZE_MULTIPLE`), so editing a cropped/imported source at arbitrary dims failed with:

```
generation failed: z_image_turbo: 832x1165 must be a multiple of 16 (VAE 8 × patch 2)
```

## Why

`editOutputDims` (`apps/web/src/screens/ImageEditor.jsx`) is the single source of truth for AI-edit output size but never aligned its result. This wasn't crop-specific — **any** off-grid source (a cropped region *or* a plain 1000×1000 import) tripped the guard. The blank-canvas / txt2img paths already snap to 16 via `snapCanvasDim`; the edit path was the lone gap. The existing unit tests even asserted invalid outputs (e.g. `{1820, 1024}`, where 1820 = 113.75×16).

## Fix

- Add `alignEditDim` — snap to the nearest multiple of 16 (min 16). Mirrors `snapCanvasDim`'s rounding, without its blank-canvas 256–2048 clamp (an edit must not force-grow a small source to 256).
- Apply it to every return path of `editOutputDims`. `832×1165 → 832×1168`; the worker crop/pad-fits the source to these dims (never stretches), so the visible result changes by ≤15px.
- Update the stale unit assertions (which encoded invalid dims) and add explicit cases for the reported 832×1165 crop and a non-aligned source.

## Reviewer notes

- 16 is the universal image-model alignment (z-image and sd3 both use 16); svd is video-only.
- **Not changed:** the worker still trusts client dims rather than defensively aligning them, so the raw API can still trip the same engine guard. Belt-and-suspenders worker-side normalization would be a separate change if wanted (noted on sc-10219).

## Validation

- 1310/1310 web tests pass (`npm test` in `apps/web`).
- eslint clean on both changed files.

Closes sc-10219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)