### PR TITLE
fix(flux2): point default_repo at SceneWorks re-host turnkeys (klein/kv/dev)

### DIFF
--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -187,20 +187,29 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     // are the separate `*_edit`/`*_kv_edit` engine models, story sc-3029); the variants
     // differ only in their weights. Distilled klein runs guidance 1.0 (CFG-free) with no
     // negative prompt; the engine accepts guidance but rejects a negative prompt.
+    // `default_repo` is the SceneWorks pre-quantized q4/q8/bf16 turnkey re-host (sc-8711,
+    // epic 8506) — the model is registered in `STANDARD_TIER_MODELS`, so both the MLX and the
+    // candle txt2img lanes resolve the packed subdir through the shared `resolve_weights_dir`
+    // → `standard_tier_subdir` (base.rs). It must match the manifest `downloads[].repo`; the
+    // stale gated `black-forest-labs/FLUX.2-klein-9B` default made `model_repo` probe the wrong
+    // HF-cache dir and fail with "MLX weights not found or incomplete".
     ModelRow {
         sceneworks_id: "flux2_klein_9b",
         engine_id: "flux2_klein_9b",
-        default_repo: "black-forest-labs/FLUX.2-klein-9B",
+        default_repo: "SceneWorks/flux2-klein-9b-mlx",
         default_steps: 4,
         default_guidance: 1.0,
         adapter_label: "mlx_flux2",
     },
     ModelRow {
-        // Separately-distilled checkpoint, same architecture — its snapshot carries the
-        // full diffusers tree, so txt2img loads through the base `flux2_klein_9b` loader.
+        // Separately-distilled checkpoint, same architecture — txt2img loads through the base
+        // `flux2_klein_9b` loader. `default_repo` is the SceneWorks q4/q8/bf16 turnkey re-host
+        // (sc-8711); like the base 9B it is a `STANDARD_TIER_MODELS` member resolved via
+        // `standard_tier_subdir`, so it must match the manifest `downloads[].repo` rather than
+        // the pre-rehost gated `black-forest-labs/FLUX.2-klein-9b-kv`.
         sceneworks_id: "flux2_klein_9b_kv",
         engine_id: "flux2_klein_9b",
-        default_repo: "black-forest-labs/FLUX.2-klein-9b-kv",
+        default_repo: "SceneWorks/flux2-klein-9b-kv-mlx",
         default_steps: 4,
         default_guidance: 1.0,
         adapter_label: "mlx_flux2",
@@ -222,17 +231,21 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     // model `flux2_dev` (Mistral3 TE + 48/48/15360 DiT), NOT a klein weight variant, so it
     // maps to its own engine id. Embedded distilled guidance (FLUX.1-dev pattern, NOT
     // true-CFG): the descriptor advertises `supports_guidance` but not negative prompt, so
-    // the engine takes the guidance scalar (default 4.0) over ~28 steps. On MLX it loads
-    // from a pre-quantized Q4 dir assembled by the install-time `flux2_dev_quant` convert
-    // job (sc-5917 / sc-5921). On the **candle** off-Mac lane (sc-7458) there is no packed
-    // convert: it loads the dense `black-forest-labs/FLUX.2-dev` diffusers snapshot and
-    // Q4-quantizes it at load — the 32B dense never lands on the GPU (CPU-staged in system
-    // RAM, then `quantize_onto` the GPU; candle-gen-flux2 sc-7457). `resolve_quant` reads
-    // the manifest `mlx.quantize: 4` so the candle descriptor's Q4 support drives it.
+    // the engine takes the guidance scalar (default 4.0) over ~28 steps. `default_repo` is the
+    // SceneWorks pre-quantized q4/q8/bf16 turnkey re-host (sc-8513, epic 8506) — a
+    // `STANDARD_TIER_MODELS` member, so both the MLX and the candle txt2img lanes packed-load
+    // the chosen tier's subdir via the shared `resolve_weights_dir` → `standard_tier_subdir`
+    // (sc-9092 retired the old candle dense-BFL load for the generic lane). It must match the
+    // manifest `downloads[].repo`; the pre-rehost gated `black-forest-labs/FLUX.2-dev` default
+    // made `model_repo` probe the wrong HF-cache dir. NOTE: the bespoke off-Mac candle *edit*
+    // lane in `flux2_edit_candle.rs` still keys its own dense-BFL default for both flux2 klein
+    // and dev, which no longer matches the re-hosted packed turnkey the catalog downloads — a
+    // separate off-Mac gap that needs candle-hardware verification, tracked as sc-10222 (epic
+    // 9083 gap #3), not touched here.
     ModelRow {
         sceneworks_id: "flux2_dev",
         engine_id: "flux2_dev",
-        default_repo: "black-forest-labs/FLUX.2-dev",
+        default_repo: "SceneWorks/flux2-dev-mlx",
         default_steps: 28,
         default_guidance: 4.0,
         adapter_label: "mlx_flux2",

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -529,13 +529,25 @@ fn mlx_model_table_maps_known_families() {
         mlx_model("flux2_klein_9b_true_v2").unwrap().default_steps(),
         24
     );
+    // The two distilled turnkeys resolve their weights from the SceneWorks q4/q8/bf16 re-host
+    // (sc-8711) — `default_repo` MUST match the manifest `downloads[].repo`, else `model_repo`
+    // probes a stale gated BFL cache dir and the MLX/candle load fails "weights not found".
+    // true_v2 is the convert-at-install variant and legitimately keeps its `wikeeyang` source.
+    assert_eq!(
+        mlx_model("flux2_klein_9b").unwrap().default_repo(),
+        "SceneWorks/flux2-klein-9b-mlx"
+    );
+    assert_eq!(
+        mlx_model("flux2_klein_9b_kv").unwrap().default_repo(),
+        "SceneWorks/flux2-klein-9b-kv-mlx"
+    );
     // FLUX.2-dev (epic 5914): its OWN engine model (not a klein weight variant), embedded
     // distilled guidance (guidance scalar, no negative prompt — like klein but ~28 steps /
     // guidance 4.0). Shares the `mlx_flux2` adapter.
     let dev = mlx_model("flux2_dev").unwrap();
     assert_eq!(dev.engine_id(), "flux2_dev");
     assert_eq!(dev.adapter_label(), "mlx_flux2");
-    assert_eq!(dev.default_repo(), "black-forest-labs/FLUX.2-dev");
+    assert_eq!(dev.default_repo(), "SceneWorks/flux2-dev-mlx");
     assert_eq!(dev.default_steps(), 28);
     assert_eq!(dev.default_guidance(), 4.0);
     assert!(dev.supports_guidance() && !dev.supports_negative_prompt());


### PR DESCRIPTION
## Problem

The Image Editor failed to load **FLUX.2 [klein] 9B** with:

> `flux2_klein_9b: MLX weights not found or incomplete (Hugging Face repo black-forest-labs/FLUX.2-klein-9B). Re-download the model in Model Manager, then retry.`

…even though the weights were installed. The message was both the *cause* and *misleading* — nothing needed re-downloading; the worker was probing the wrong HF-cache directory, and telling the user to re-fetch a gated repo the model isn't even hosted at anymore.

## Root cause

The worker resolves a model's repo via `model_repo()` = top-level manifest `repo` **else** the hardcoded `default_repo` in the engines `MODEL_TABLE`. The builtin manifest keeps `repo` only *nested inside* `downloads[]` (there is no top-level `repo`, and turnkeys get no injected `modelPath`), so for every `STANDARD_TIER_MODELS` turnkey the worker **always** falls back to `engines.rs` `default_repo`. That constant — not the manifest `downloads[].repo` — is the real source of truth the loader probes, for both the macOS MLX lane and the candle txt2img lane (both packed-load the same SceneWorks turnkey via `standard_tier_subdir`, sc-9092).

The sc-8711 / sc-8513 SceneWorks re-host sweep updated `default_repo` for z-image, flux1, qwen, lens, and sd3.5 — but **missed the entire FLUX.2 family**, leaving them pointed at the pre-rehost gated `black-forest-labs/*` repos. So `resolve_weights_dir` looked under `models--black-forest-labs--FLUX.2-klein-9B`, found nothing → `Ok(None)` → `mlx_weights_gap` threw, echoing that stale repo id back.

## Fix

Update the three stale `default_repo` values to match the manifest `downloads[].repo`:

| model | before | after |
|---|---|---|
| `flux2_klein_9b` | `black-forest-labs/FLUX.2-klein-9B` | `SceneWorks/flux2-klein-9b-mlx` |
| `flux2_klein_9b_kv` | `black-forest-labs/FLUX.2-klein-9b-kv` | `SceneWorks/flux2-klein-9b-kv-mlx` |
| `flux2_dev` | `black-forest-labs/FLUX.2-dev` | `SceneWorks/flux2-dev-mlx` |

- `flux2_dev` had the **identical latent bug** — fixed in the same pass. It rarely surfaces because it needs a 128 GB Mac.
- `flux2_klein_9b_true_v2` is **unchanged**: it is convert-at-install and correctly keeps its `wikeeyang/...` source repo (it gets a `modelPath` injected instead of using `default_repo`).
- Added `default_repo` regression assertions (klein/kv/dev) to `mlx_model_table_maps_known_families` so this can't silently drift back.

## Reviewer notes

- Verified correct for **both** lanes: `base.rs` documents that candle now packed-loads the same SceneWorks turnkey via the shared resolver (sc-9092), and all three ids are already in `STANDARD_TIER_MODELS`.
- **Out of scope / separate off-Mac gap (not touched here):** the bespoke candle *edit* lane in `flux2_edit_candle.rs` still keys its own dense-`black-forest-labs` defaults (`FLUX2_EDIT_CANDLE_DEFAULT_REPO` / `_DEV_REPO`), which no longer match the packed turnkey the catalog downloads. That needs Windows/CUDA candle-hardware verification and should be a follow-up story.

## Verification

- `cargo test -p sceneworks-worker mlx_model_table_maps_known_families` ✅ passes
- worker crate compiles ✅
- `cargo fmt -p sceneworks-worker -- --check` ✅ clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)