### PR TITLE
fix(catalog): Krea 2 Raw missing text_to_image capability (sc-10229)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2455,6 +2455,12 @@
       "family": "krea_2",
       "type": "image",
       "adapter": "mlx_krea",
+      // Text-to-image GENERATION model (mirrors Krea 2 Turbo). This top-level `capabilities` array is what
+      // the web layer keys on: ImageStudio/`imageModelServesMode` gates the model into the picker on
+      // `capabilities.includes("text_to_image")`, and the Model Manager renders the "Text to Image" chip
+      // from it. `ui.recommendedFor` is a separate recommendation hint and does NOT confer the capability —
+      // without this line Raw is invisible in Image Studio and untagged in the Model Manager (epic 9992).
+      "capabilities": ["text_to_image"],
       // Routing (not this flag) drives availability: `krea_2_raw` is BOTH mlx- and candle-routed
       // (sc-9994). All-platform downloads serve generation on all three platforms + the candle trainer.
       "macOnly": false,


### PR DESCRIPTION
## Symptom (user-reported)
Krea 2 Raw was added as a text-to-image generation model (epic 9992) but doesn't appear in the Image Studio model list and has no **"Text to Image"** tag in the Model Manager.

## Root cause
The `krea_2_raw` entry in [config/manifests/builtin.models.jsonc](config/manifests/builtin.models.jsonc) had **no top-level `capabilities` array**. Both surfaces key off it:
- **Image Studio** — `imageModelServesMode` (`apps/web/src/modelEligibility.js`) gates a model into the text-to-image tab on `capabilities.includes("text_to_image")`; a missing array falls to `?? []` → not usable → hidden.
- **Model Manager** — the capability chips (`.model-capabilities .chip`) render straight from `capabilities`; no array → no chip.

`ui.recommendedFor: ["text_to_image"]` was present, but that's a recommendation hint, **not** a capability. The sibling `krea_2_turbo` has `"capabilities": ["text_to_image"]`; Raw was just missing the equivalent.

## Fix
Add `"capabilities": ["text_to_image"]` to `krea_2_raw` (matches Turbo). No `edit_image` — Raw's img2img (reference latent-init) is a separate `ui.img2img` surface, not a capability (that engine work is epic 8588: [mlx-gen#670](https://github.com/SceneWorks/mlx-gen/pull/670) / sc-10224, plus sc-10225/sc-10226).

## Verification
JSONC parses; `krea_2_raw.capabilities = ["text_to_image"]`, `type: image`. No rust contract or web snapshot test asserts Raw's capabilities (they use synthetic fixtures), so nothing else needed touching. Takes effect on the next rust-api rebuild/launch (app-owned builtin catalog refresh, sc-10212).

🤖 Generated with [Claude Code](https://claude.com/claude-code)