### PR TITLE
chore(mcp): scaffold sceneworks-mcp crate + /mcp streamable-http route + catalog tools (sc-10233)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,6 +1049,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1196,6 +1207,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1993,12 +2013,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -2053,6 +2089,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2446,6 +2483,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -4647,7 +4685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4726,6 +4764,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pathdiff"
@@ -5158,6 +5202,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5194,6 +5249,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -5469,6 +5530,51 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pastey",
+ "pin-project-lite",
+ "rand 0.10.2",
+ "reqwest 0.13.3",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee70afb7956da9f30d5348a2539b5eb90d9038f834463657ab717076ac3b1ad"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5763,6 +5869,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sceneworks-mcp"
+version = "0.2.0"
+dependencies = [
+ "axum",
+ "reqwest 0.12.28",
+ "rmcp",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "sceneworks-rust-api"
 version = "0.2.0"
 dependencies = [
@@ -5775,9 +5894,11 @@ dependencies = [
  "nix",
  "parking_lot",
  "reqwest 0.12.28",
+ "rmcp",
  "rust-embed",
  "sceneworks-core",
  "sceneworks-image-quality",
+ "sceneworks-mcp",
  "sceneworks-worker",
  "serde",
  "serde_json",
@@ -5903,7 +6024,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -5928,8 +6049,10 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -5939,6 +6062,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6221,7 +6356,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -6420,6 +6555,19 @@ dependencies = [
  "nom",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f24a9b78c40b90817bbcd1821c74ddfd74916aadd29403d001532a9195532d"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "apps/rust-worker",
     "crates/sceneworks-core",
     "crates/sceneworks-image-quality",
+    "crates/sceneworks-mcp",
     "crates/sceneworks-worker",
 ]
 # apps/desktop (Tauri) needs platform GUI libs (WebKit/GTK on Linux) and is built
@@ -17,6 +18,7 @@ default-members = [
     "apps/rust-worker",
     "crates/sceneworks-core",
     "crates/sceneworks-image-quality",
+    "crates/sceneworks-mcp",
     "crates/sceneworks-worker",
 ]
 

--- a/apps/rust-api/Cargo.toml
+++ b/apps/rust-api/Cargo.toml
@@ -18,6 +18,10 @@ sceneworks-core = { path = "../../crates/sceneworks-core" }
 # Tier-0 dataset-quality pixel extraction for the readiness endpoint (sc-6533). GPU-free
 # (image/imageproc/image_hasher), so it does not add to the worker/MLX build surface.
 sceneworks-image-quality = { path = "../../crates/sceneworks-image-quality" }
+# MCP server (epic 10231, sc-10233): the streamable-HTTP tower service nested at
+# `/mcp` inside create_app_with_state, behind the same access_control middleware
+# as the /api/v1 routes.
+sceneworks-mcp = { path = "../../crates/sceneworks-mcp" }
 sceneworks-worker = { path = "../../crates/sceneworks-worker" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -52,6 +56,9 @@ embed-web = ["dep:rust-embed", "dep:mime_guess"]
 backend-candle = ["sceneworks-worker/backend-candle"]
 
 [dev-dependencies]
+# Real MCP streamable-HTTP client for the /mcp round-trip test (sc-10233); same
+# pinned version as crates/sceneworks-mcp — client features are additive.
+rmcp = { version = "=2.1.0", features = ["client", "transport-streamable-http-client-reqwest"] }
 tempfile = "3.13"
 tower = { version = "0.5", features = ["util"] }
 # Encode real test images for the synchronous image-fix round-trips (sc-6539).

--- a/apps/rust-api/src/auth.rs
+++ b/apps/rust-api/src/auth.rs
@@ -219,6 +219,13 @@ pub(crate) fn cors_layer(settings: &Settings) -> CorsLayer {
 /// authenticated). All other `PUBLIC_PATHS` entries expose a single route method,
 /// so a path-only exemption for them is already method-correct.
 pub(crate) fn requires_token(method: &Method, path: &str) -> bool {
+    // The MCP mount (sc-10233) is gated for every method, exactly like a gated
+    // `/api/v1` route: an unauthenticated LAN caller must not reach the MCP
+    // session layer at all. Loopback trust and the token header both work the
+    // same as for the API routes (this predicate only decides "gated or not").
+    if path == "/mcp" || path.starts_with("/mcp/") {
+        return true;
+    }
     if !path.starts_with("/api/") {
         return false;
     }

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -844,7 +844,20 @@ pub(crate) fn create_app_with_state(
     let cors = cors_layer(&state.settings);
     let returned_state = state.clone();
 
+    // MCP server (epic 10231, sc-10233): the rmcp streamable-HTTP service is
+    // nested at `/mcp` INSIDE this router, so the `access_control` layer below
+    // gates it exactly like every `/api/v1` route (`requires_token` includes
+    // `/mcp`) — token header, loopback trust, and the brute-force throttle all
+    // apply unchanged. Its tools call back into this API over plain HTTP
+    // (`settings.mcp_api_url`, i.e. `SCENEWORKS_API_URL` or our own loopback
+    // port) carrying the access token, so there is no second engine/DB path.
+    let mcp_service = sceneworks_mcp::streamable_http_service(sceneworks_mcp::ApiClientConfig {
+        base_url: state.settings.mcp_api_url.clone(),
+        access_token: Some(state.settings.access_token.clone()),
+    });
+
     let router = Router::new()
+        .nest_service("/mcp", mcp_service)
         .route("/api/v1/health", get(health))
         .route("/api/v1/access", get(access))
         .route("/api/v1/auth/verify", post(verify_access))

--- a/apps/rust-api/src/server.rs
+++ b/apps/rust-api/src/server.rs
@@ -87,6 +87,14 @@ pub struct Settings {
     /// (other source IPs) stay gated. The desktop sets `SCENEWORKS_TRUST_LOOPBACK`;
     /// Docker/server never does, so a reverse-proxied deployment stays fail-closed.
     pub trust_loopback: bool,
+    /// Epic 10231 (sc-10233) — base URL the embedded MCP server's thin API client
+    /// uses to call back into this API's `/api/v1/*` routes (the MCP tools are a
+    /// thin HTTP client over the existing surface, mirroring the Rust worker — no
+    /// direct engine/DB path). Read from `SCENEWORKS_API_URL` (the same variable
+    /// the worker uses); defaults to loopback on this API's own port. The client
+    /// sends `access_token` as `X-SceneWorks-Token`, so the self-calls pass the
+    /// access-control gate whether or not loopback trust is enabled.
+    pub mcp_api_url: String,
 }
 
 impl Settings {
@@ -98,13 +106,14 @@ impl Settings {
             .filter(|value| !value.trim().is_empty())
             .map(PathBuf::from)
             .unwrap_or_else(|| data_dir.join("cache").join("jobs.db"));
+        let port: u16 = std::env::var("SCENEWORKS_API_PORT")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(8000);
         Self {
             app_version: env_string("SCENEWORKS_APP_VERSION", "0.2.0"),
             host: env_string("SCENEWORKS_API_HOST", DEFAULT_API_HOST),
-            port: std::env::var("SCENEWORKS_API_PORT")
-                .ok()
-                .and_then(|value| value.parse().ok())
-                .unwrap_or(8000),
+            port,
             data_dir,
             config_dir: env_path_or("SCENEWORKS_CONFIG_DIR", &defaults.config_dir),
             access_token: std::env::var("SCENEWORKS_ACCESS_TOKEN")
@@ -140,6 +149,9 @@ impl Settings {
             trust_loopback: std::env::var("SCENEWORKS_TRUST_LOOPBACK")
                 .map(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "True"))
                 .unwrap_or(false),
+            // Loopback (not `host`, which may be 0.0.0.0) — the MCP self-calls
+            // originate on this machine by definition.
+            mcp_api_url: env_string("SCENEWORKS_API_URL", &format!("http://127.0.0.1:{port}")),
         }
     }
 

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -286,6 +286,9 @@ fn test_settings(temp_dir: &tempfile::TempDir) -> Settings {
         candle_required: false,
         candle_enforce_unsupported: false,
         trust_loopback: false,
+        // Placeholder for oneshot tests (the MCP self-client never dials it);
+        // the live-listener MCP tests overwrite it with the bound address.
+        mcp_api_url: "http://127.0.0.1:0".to_owned(),
     }
 }
 
@@ -12403,4 +12406,262 @@ async fn upload_route_accepts_body_larger_than_json_cap() {
         StatusCode::CREATED,
         "large upload should be staged successfully (got {status}: {upload})"
     );
+}
+
+// ---------------------------------------------------------------------------
+// MCP mount (epic 10231, sc-10233): /mcp rides the same access_control gate as
+// /api/v1, and a real MCP streamable-HTTP client can round-trip the catalog
+// tools against the live app.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn requires_token_gates_the_mcp_mount_for_every_method() {
+    use axum::http::Method;
+    // The MCP mount is token-gated exactly like a gated /api/v1 route — for every
+    // method the transport uses (POST messages, GET SSE stream, DELETE session).
+    for method in [Method::GET, Method::POST, Method::DELETE] {
+        assert!(
+            requires_token(&method, "/mcp"),
+            "{method} /mcp must be gated"
+        );
+        assert!(
+            requires_token(&method, "/mcp/anything"),
+            "{method} /mcp/* must be gated"
+        );
+    }
+    // No prefix bleed: an unrelated path starting with "mcp" is still SPA fallback.
+    assert!(!requires_token(&Method::GET, "/mcpx"));
+}
+
+#[tokio::test]
+async fn mcp_rejects_unauthenticated_lan_request_exactly_like_api_v1() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let mut settings = test_settings(&temp_dir);
+    settings.access_token = "secret-token".to_owned();
+    let app = create_app(settings).expect("app creates");
+
+    // Same peer, no token: /mcp and a gated /api/v1 route must answer identically.
+    let (mcp_status, mcp_body) =
+        request_with_peer(app.clone(), "POST", "/mcp", json!({}), "192.168.1.9:50000").await;
+    let (api_status, api_body) =
+        request_with_peer(app, "GET", "/api/v1/jobs", Value::Null, "192.168.1.9:50001").await;
+    assert_eq!(mcp_status, StatusCode::UNAUTHORIZED);
+    assert_eq!(api_status, StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        mcp_body, api_body,
+        "rejection body must match the /api/v1 shape"
+    );
+    assert_eq!(mcp_body["authRequired"], true);
+}
+
+/// Status-only variant of `request_with_peer_headers`: rmcp's non-auth error
+/// bodies (e.g. the 406 below) are plain text, so the JSON-parsing helpers
+/// don't apply.
+async fn mcp_status_with_peer(
+    app: axum::Router,
+    peer: &str,
+    headers: &[(&str, &str)],
+) -> StatusCode {
+    use axum::extract::ConnectInfo;
+    use std::net::SocketAddr;
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri("/mcp")
+        .header("content-type", "application/json")
+        // Real HTTP/1.1 clients always send Host; the raw oneshot path doesn't,
+        // and rmcp 400s a host-less request before the Accept check.
+        .header("host", "127.0.0.1");
+    for (name, value) in headers {
+        builder = builder.header(*name, *value);
+    }
+    let mut request = builder
+        .body(Body::from(json!({}).to_string()))
+        .expect("request builds");
+    let addr: SocketAddr = peer.parse().expect("peer addr parses");
+    request.extensions_mut().insert(ConnectInfo(addr));
+    let response = app.oneshot(request).await.expect("response returns");
+    response.status()
+}
+
+#[tokio::test]
+async fn mcp_passes_auth_with_valid_token_or_loopback_trust() {
+    // A request that clears auth reaches the rmcp transport, which answers 406
+    // ("must accept application/json and text/event-stream") for a bare POST —
+    // distinct from the middleware's 401, so it proves the gate opened.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+
+    // Valid header token from a LAN peer.
+    let mut settings = test_settings(&temp_dir);
+    settings.access_token = "secret-token".to_owned();
+    let app = create_app(settings).expect("app creates");
+    let status = mcp_status_with_peer(
+        app.clone(),
+        "192.168.1.9:50000",
+        &[("x-sceneworks-token", "secret-token")],
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_ACCEPTABLE);
+
+    // Loopback-trusted peer with no token (desktop mode, SCENEWORKS_TRUST_LOOPBACK).
+    let mut settings = test_settings(&temp_dir);
+    settings.access_token = "secret-token".to_owned();
+    settings.trust_loopback = true;
+    let app = create_app(settings).expect("app creates");
+    let status = mcp_status_with_peer(app.clone(), "127.0.0.1:50000", &[]).await;
+    assert_eq!(status, StatusCode::NOT_ACCEPTABLE);
+    // ... but loopback trust must not leak to a LAN peer.
+    let status = mcp_status_with_peer(app, "192.168.1.9:50000", &[]).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+fn mcp_tool_content_json(result: &rmcp::model::CallToolResult) -> Value {
+    let text = result
+        .content
+        .first()
+        .and_then(|block| block.as_text())
+        .map(|text| text.text.as_str())
+        .expect("tool result has one text content block");
+    serde_json::from_str(text).expect("tool content is JSON")
+}
+
+#[tokio::test]
+async fn mcp_client_round_trips_catalog_tools_via_loopback_trust() {
+    use rmcp::model::CallToolRequestParams;
+    use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+    use rmcp::transport::StreamableHttpClientTransport;
+    use rmcp::ServiceExt;
+
+    // Desktop-style deployment: loopback trusted, no token. The MCP self-client
+    // (settings.mcp_api_url) points back at this same live listener.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral listener");
+    let addr = listener.local_addr().expect("listener addr");
+    let mut settings = test_settings(&temp_dir);
+    settings.trust_loopback = true;
+    settings.mcp_api_url = format!("http://{addr}");
+    let (app, state) = create_app_with_state(settings).expect("app creates");
+    state
+        .project_store
+        .create_project("MCP Round Trip")
+        .expect("project creates");
+    tokio::spawn(async move {
+        let _ = axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await;
+    });
+
+    let transport = StreamableHttpClientTransport::from_config(
+        StreamableHttpClientTransportConfig::with_uri(format!("http://{addr}/mcp")),
+    );
+    let client = rmcp::model::ClientInfo::default()
+        .serve(transport)
+        .await
+        .expect("MCP client initializes against /mcp");
+
+    // Tool discovery.
+    let tools = client.list_tools(None).await.expect("tools/list succeeds");
+    let names: Vec<&str> = tools.tools.iter().map(|tool| tool.name.as_ref()).collect();
+    for expected in ["list_projects", "list_models", "list_loras"] {
+        assert!(
+            names.contains(&expected),
+            "missing tool {expected}: {names:?}"
+        );
+    }
+
+    // list_projects round-trips through the real /api/v1/projects route.
+    let result = client
+        .call_tool(CallToolRequestParams::new("list_projects"))
+        .await
+        .expect("list_projects succeeds");
+    assert_ne!(result.is_error, Some(true));
+    let projects = mcp_tool_content_json(&result);
+    let project_names: Vec<&str> = projects
+        .as_array()
+        .expect("projects array")
+        .iter()
+        .filter_map(|project| project["name"].as_str())
+        .collect();
+    assert!(
+        project_names.contains(&"MCP Round Trip"),
+        "created project must be listed: {project_names:?}"
+    );
+
+    // list_models round-trips through the real /api/v1/models route (empty temp
+    // config dir → an array; the round trip is what's under test).
+    let result = client
+        .call_tool(CallToolRequestParams::new("list_models"))
+        .await
+        .expect("list_models succeeds");
+    assert_ne!(result.is_error, Some(true));
+    assert!(mcp_tool_content_json(&result).is_array());
+
+    let _ = client.cancel().await;
+}
+
+#[tokio::test]
+async fn mcp_client_round_trips_with_access_token_and_no_loopback_trust() {
+    use rmcp::model::CallToolRequestParams;
+    use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+    use rmcp::transport::StreamableHttpClientTransport;
+    use rmcp::ServiceExt;
+    use std::collections::HashMap;
+
+    // LAN-style deployment: token required, loopback NOT trusted. The MCP client
+    // must present the token on /mcp, and the MCP self-client must present it on
+    // its /api/v1 calls (it gets settings.access_token) — both gates are real here.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral listener");
+    let addr = listener.local_addr().expect("listener addr");
+    let mut settings = test_settings(&temp_dir);
+    settings.access_token = "round-trip-token".to_owned();
+    settings.mcp_api_url = format!("http://{addr}");
+    let (app, state) = create_app_with_state(settings).expect("app creates");
+    state
+        .project_store
+        .create_project("Tokened Round Trip")
+        .expect("project creates");
+    tokio::spawn(async move {
+        let _ = axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await;
+    });
+
+    let mut headers = HashMap::new();
+    headers.insert(
+        axum::http::HeaderName::from_static("x-sceneworks-token"),
+        axum::http::HeaderValue::from_static("round-trip-token"),
+    );
+    let transport = StreamableHttpClientTransport::from_config(
+        StreamableHttpClientTransportConfig::with_uri(format!("http://{addr}/mcp"))
+            .custom_headers(headers),
+    );
+    let client = rmcp::model::ClientInfo::default()
+        .serve(transport)
+        .await
+        .expect("tokened MCP client initializes against /mcp");
+
+    let result = client
+        .call_tool(CallToolRequestParams::new("list_projects"))
+        .await
+        .expect("list_projects succeeds");
+    assert_ne!(result.is_error, Some(true));
+    let projects = mcp_tool_content_json(&result);
+    assert!(
+        projects
+            .as_array()
+            .expect("projects array")
+            .iter()
+            .any(|project| project["name"] == "Tokened Round Trip"),
+        "created project must be listed: {projects}"
+    );
+
+    let _ = client.cancel().await;
 }

--- a/crates/sceneworks-mcp/Cargo.toml
+++ b/crates/sceneworks-mcp/Cargo.toml
@@ -1,0 +1,39 @@
+# SceneWorks MCP server (epic 10231, sc-10233). A Model Context Protocol server
+# built on the official `rmcp` SDK, exposed over the Streamable-HTTP transport and
+# mounted INTO the existing API's axum router at `/mcp` (apps/rust-api), so it sits
+# behind the same `access_control` middleware as every `/api/v1` route. The tool
+# handlers are a THIN CLIENT over the existing `/api/v1/*` HTTP surface (mirroring
+# crates/sceneworks-worker/src/api_client.rs) — no new direct path into the
+# engine/DB. Base URL comes from `SCENEWORKS_API_URL`; auth rides the
+# `X-SceneWorks-Token` header.
+[package]
+name = "sceneworks-mcp"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+# Pinned exact (sc-10233): the official MCP Rust SDK moves fast and its
+# streamable-HTTP server surface (StreamableHttpService / tool_router macros) has
+# broken across minor bumps before — bump deliberately, with the round-trip tests.
+# `transport-streamable-http-server` adds the tower service the API mounts at
+# `/mcp`; default features keep `server` + `macros` (tool router derive).
+rmcp = { version = "=2.1.0", features = ["transport-streamable-http-server"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tracing = { workspace = true }
+
+[dev-dependencies]
+# Minimal stub `/api/v1` server on an ephemeral port for the client round-trip
+# tests; matches the axum the API app itself uses.
+axum = "0.7"
+# The round-trip test drives the mounted service through a REAL MCP client
+# (initialize → tools/list → tools/call over streamable HTTP), not hand-rolled
+# JSON-RPC — client features are additive on the same pinned version.
+rmcp = { version = "=2.1.0", features = ["client", "transport-streamable-http-client-reqwest"] }
+tokio = { version = "1.40", features = ["macros", "net", "rt-multi-thread"] }
+
+[lints]
+workspace = true

--- a/crates/sceneworks-mcp/src/api_client.rs
+++ b/crates/sceneworks-mcp/src/api_client.rs
@@ -1,0 +1,106 @@
+//! Thin HTTP client over the existing `/api/v1/*` surface (epic 10231).
+//!
+//! Modeled on `crates/sceneworks-worker/src/api_client.rs`: every MCP tool call
+//! becomes a plain authenticated HTTP request against the SceneWorks API — there
+//! is deliberately NO direct path into the engine/DB from the MCP server, so the
+//! tools inherit exactly the behavior (and fixes) of the routes the web UI uses.
+
+use serde_json::Value;
+
+/// How the MCP tools reach the SceneWorks API. `base_url` normally comes from
+/// `SCENEWORKS_API_URL` (the same variable the Rust worker uses) and the token is
+/// the API's own `SCENEWORKS_ACCESS_TOKEN` — sent as `X-SceneWorks-Token`, the
+/// header `access_control` accepts.
+#[derive(Debug, Clone)]
+pub struct ApiClientConfig {
+    pub base_url: String,
+    pub access_token: Option<String>,
+}
+
+#[derive(Clone)]
+pub struct ApiClient {
+    client: reqwest::Client,
+    base_url: String,
+    access_token: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum ApiClientError {
+    /// Transport-level failure (connection refused, timeout, invalid body …).
+    Http(reqwest::Error),
+    /// The API answered with a non-2xx status; `detail` carries its body text.
+    Api {
+        status: reqwest::StatusCode,
+        detail: String,
+    },
+}
+
+impl std::fmt::Display for ApiClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Http(error) => write!(f, "SceneWorks API request failed: {error}"),
+            Self::Api { status, detail } => {
+                write!(f, "SceneWorks API returned {status}: {detail}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ApiClientError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Http(error) => Some(error),
+            Self::Api { .. } => None,
+        }
+    }
+}
+
+impl From<reqwest::Error> for ApiClientError {
+    fn from(error: reqwest::Error) -> Self {
+        Self::Http(error)
+    }
+}
+
+impl ApiClient {
+    pub fn new(config: ApiClientConfig) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            base_url: config.base_url.trim_end_matches('/').to_owned(),
+            // An empty/whitespace token means auth is off — send no header, exactly
+            // like the worker's `Settings::from_env` filter.
+            access_token: config
+                .access_token
+                .map(|token| token.trim().to_owned())
+                .filter(|token| !token.is_empty()),
+        }
+    }
+
+    /// GET `path` (an absolute `/api/v1/...` path) with optional query pairs and
+    /// decode the JSON body. Empty query values are skipped so optional tool
+    /// arguments don't turn into `?modelFamily=` noise.
+    pub async fn get_json(
+        &self,
+        path: &str,
+        query: &[(&str, Option<&str>)],
+    ) -> Result<Value, ApiClientError> {
+        let mut request = self.client.get(format!("{}{}", self.base_url, path));
+        for (key, value) in query {
+            if let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) {
+                request = request.query(&[(*key, value)]);
+            }
+        }
+        if let Some(token) = &self.access_token {
+            request = request.header("X-SceneWorks-Token", token);
+        }
+        let response = request.send().await?;
+        let status = response.status();
+        if !status.is_success() {
+            let detail = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "request failed".to_owned());
+            return Err(ApiClientError::Api { status, detail });
+        }
+        Ok(response.json::<Value>().await?)
+    }
+}

--- a/crates/sceneworks-mcp/src/lib.rs
+++ b/crates/sceneworks-mcp/src/lib.rs
@@ -1,0 +1,46 @@
+//! SceneWorks MCP server (epic 10231, sc-10233).
+//!
+//! A Model Context Protocol server over the official `rmcp` SDK's
+//! streamable-HTTP transport. [`streamable_http_service`] returns a tower
+//! service the API app nests at `/mcp` inside its existing axum router
+//! (`apps/rust-api/src/lib.rs`, `create_app_with_state`), so every MCP request
+//! rides the existing `access_control` middleware (X-SceneWorks-Token / Bearer,
+//! `SCENEWORKS_TRUST_LOOPBACK`, brute-force throttle) — the MCP layer adds NO
+//! auth of its own.
+//!
+//! The tools themselves are a thin client over `/api/v1/*` (see
+//! [`api_client`]): the MCP process calls back into the API over HTTP exactly
+//! like the Rust worker does, so there is one behavior surface to maintain.
+
+pub mod api_client;
+pub mod server;
+
+use std::sync::Arc;
+
+use rmcp::transport::streamable_http_server::{
+    session::local::LocalSessionManager, StreamableHttpServerConfig, StreamableHttpService,
+};
+
+pub use api_client::{ApiClient, ApiClientConfig};
+pub use server::SceneWorksMcp;
+
+/// The concrete tower service type the API mounts at `/mcp`.
+pub type McpHttpService = StreamableHttpService<SceneWorksMcp, LocalSessionManager>;
+
+/// Build the streamable-HTTP MCP service. One service instance per app; rmcp
+/// spins up a fresh [`SceneWorksMcp`] (sharing the one [`ApiClient`]) per MCP
+/// session.
+///
+/// rmcp's own `allowed_hosts` (DNS-rebinding) check is disabled deliberately:
+/// its loopback-only default would 403 the supported LAN deployment
+/// (`SCENEWORKS_API_HOST=0.0.0.0` + access token), and the real access control
+/// for `/mcp` is the surrounding `access_control` middleware — identical to
+/// every `/api/v1` route (sc-10233 acceptance).
+pub fn streamable_http_service(config: ApiClientConfig) -> McpHttpService {
+    let api = ApiClient::new(config);
+    StreamableHttpService::new(
+        move || Ok(SceneWorksMcp::new(api.clone())),
+        Arc::new(LocalSessionManager::default()),
+        StreamableHttpServerConfig::default().disable_allowed_hosts(),
+    )
+}

--- a/crates/sceneworks-mcp/src/server.rs
+++ b/crates/sceneworks-mcp/src/server.rs
@@ -1,0 +1,303 @@
+//! The SceneWorks MCP tool surface (epic 10231, sc-10233).
+//!
+//! `SceneWorksMcp` is the rmcp server/service struct: a `#[tool_router]` impl
+//! holds one method per MCP tool, and `#[tool_handler]` wires that router into
+//! the `ServerHandler` the streamable-HTTP transport serves. Every tool is a
+//! thin wrapper over an existing `/api/v1/*` route via [`ApiClient`] — later
+//! stories (generate_image, video tools) add methods to the `#[tool_router]`
+//! block, nothing else.
+//!
+//! The catalog endpoints return large manifest-derived objects (multi-KB per
+//! model: downloads, footprints, platform notes …). Tools re-shape them into
+//! compact JSON an LLM can actually use — ids/names plus the values a job
+//! request needs — via the pure `compact_*` mappers below (unit-tested).
+
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{CallToolResult, ContentBlock, ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router, ErrorData, ServerHandler,
+};
+use serde_json::{Map, Value};
+
+use crate::api_client::{ApiClient, ApiClientError};
+
+#[derive(Clone)]
+pub struct SceneWorksMcp {
+    api: ApiClient,
+    tool_router: ToolRouter<Self>,
+}
+
+impl SceneWorksMcp {
+    pub fn new(api: ApiClient) -> Self {
+        Self {
+            api,
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+/// Optional filters for `list_loras`, forwarded verbatim to the
+/// `GET /api/v1/loras` query params (`LorasQuery` in the API is camelCase).
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ListLorasArgs {
+    #[schemars(
+        description = "Only return LoRAs compatible with this model family (e.g. \"sdxl\", \"z-image\", \"flux\")."
+    )]
+    pub model_family: Option<String>,
+    #[schemars(
+        description = "Also include LoRAs trained/imported in this project (by project id)."
+    )]
+    pub project_id: Option<String>,
+}
+
+#[tool_router]
+impl SceneWorksMcp {
+    #[tool(
+        description = "List SceneWorks projects. Returns [{id, name, createdAt}]; use the id as projectId in other calls."
+    )]
+    async fn list_projects(&self) -> Result<CallToolResult, ErrorData> {
+        let projects = self
+            .api
+            .get_json("/api/v1/projects", &[])
+            .await
+            .map_err(api_error)?;
+        json_result(compact_projects(&projects))
+    }
+
+    #[tool(
+        description = "List the generation model catalog. Returns compact entries: id (use as the model for a job), name, family, type (image/video), capabilities, installState, defaults (resolution/steps/guidanceScale/count) and supported resolutions."
+    )]
+    async fn list_models(&self) -> Result<CallToolResult, ErrorData> {
+        let models = self
+            .api
+            .get_json("/api/v1/models", &[])
+            .await
+            .map_err(api_error)?;
+        json_result(compact_models(&models))
+    }
+
+    #[tool(
+        description = "List the LoRA adapter catalog (built-in, imported and trained). Returns compact entries: id, name, family, compatibleFamilies, triggerWords, defaultWeight, installState. Optionally filter by model family and/or project."
+    )]
+    async fn list_loras(
+        &self,
+        Parameters(args): Parameters<ListLorasArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let loras = self
+            .api
+            .get_json(
+                "/api/v1/loras",
+                &[
+                    ("modelFamily", args.model_family.as_deref()),
+                    ("projectId", args.project_id.as_deref()),
+                ],
+            )
+            .await
+            .map_err(api_error)?;
+        json_result(compact_loras(&loras))
+    }
+}
+
+#[tool_handler(router = self.tool_router)]
+impl ServerHandler for SceneWorksMcp {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build()).with_instructions(
+            "SceneWorks local generation studio. Use list_projects for project ids, \
+             list_models for the generation model catalog (model ids + job defaults), and \
+             list_loras for LoRA adapters compatible with a model family.",
+        )
+    }
+}
+
+/// A tool result whose single content block is the compact JSON payload. Plain
+/// text-JSON (not `structured_content`) for the widest MCP-client compatibility.
+fn json_result(value: Value) -> Result<CallToolResult, ErrorData> {
+    Ok(CallToolResult::success(vec![ContentBlock::json(&value)?]))
+}
+
+/// Surface an API failure as a JSON-RPC internal error; the Display impl already
+/// includes the upstream status + detail, and never the token.
+fn api_error(error: ApiClientError) -> ErrorData {
+    ErrorData::internal_error(error.to_string(), None)
+}
+
+/// Map an API array response item-by-item; anything non-array (defensive — the
+/// routes today always return arrays) passes through unchanged so a future shape
+/// change degrades to "verbose" rather than "wrong".
+fn compact_array(value: &Value, compact_one: impl Fn(&Value) -> Value) -> Value {
+    match value.as_array() {
+        Some(items) => Value::Array(items.iter().map(compact_one).collect()),
+        None => value.clone(),
+    }
+}
+
+/// Copy the given top-level keys, skipping absent/null ones.
+fn copy_keys(item: &Value, keys: &[&str], out: &mut Map<String, Value>) {
+    for key in keys {
+        if let Some(value) = item.get(*key).filter(|value| !value.is_null()) {
+            out.insert((*key).to_owned(), value.clone());
+        }
+    }
+}
+
+pub(crate) fn compact_projects(projects: &Value) -> Value {
+    compact_array(projects, |project| {
+        let mut out = Map::new();
+        copy_keys(project, &["id", "name", "createdAt"], &mut out);
+        Value::Object(out)
+    })
+}
+
+pub(crate) fn compact_models(models: &Value) -> Value {
+    compact_array(models, |model| {
+        let mut out = Map::new();
+        copy_keys(
+            model,
+            &[
+                "id",
+                "name",
+                "family",
+                "type",
+                "capabilities",
+                "installState",
+                "gated",
+                "defaults",
+            ],
+            &mut out,
+        );
+        // The resolution menu is the one `limits` field a job request needs; the
+        // rest (sampler/scheduler menus, counts) stays on the full API response.
+        if let Some(resolutions) = model.pointer("/limits/resolutions") {
+            out.insert("resolutions".to_owned(), resolutions.clone());
+        }
+        // Which LoRA families this model accepts — pairs with list_loras.
+        if let Some(families) = model.pointer("/loraCompatibility/families") {
+            out.insert("loraFamilies".to_owned(), families.clone());
+        }
+        Value::Object(out)
+    })
+}
+
+pub(crate) fn compact_loras(loras: &Value) -> Value {
+    compact_array(loras, |lora| {
+        let mut out = Map::new();
+        copy_keys(
+            lora,
+            &[
+                "id",
+                "name",
+                "family",
+                "triggerWords",
+                "defaultWeight",
+                "installState",
+            ],
+            &mut out,
+        );
+        if let Some(families) = lora.pointer("/compatibility/families") {
+            out.insert("compatibleFamilies".to_owned(), families.clone());
+        }
+        Value::Object(out)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn compact_projects_keeps_only_id_name_created_at() {
+        let full = json!([{
+            "id": "p1",
+            "name": "My Film",
+            "path": "/data/projects/p1",
+            "createdAt": "2026-07-07T00:00:00Z"
+        }]);
+        assert_eq!(
+            compact_projects(&full),
+            json!([{ "id": "p1", "name": "My Film", "createdAt": "2026-07-07T00:00:00Z" }])
+        );
+    }
+
+    #[test]
+    fn compact_models_keeps_job_request_fields_and_flattens_menus() {
+        let full = json!([{
+            "id": "z_image_turbo",
+            "name": "Z-Image-Turbo",
+            "family": "z-image",
+            "type": "image",
+            "capabilities": ["text_to_image"],
+            "installState": "installed",
+            "gated": false,
+            "defaults": { "resolution": "1024x1024", "steps": 8, "guidanceScale": 0, "count": 4 },
+            "limits": {
+                "resolutions": ["768x768", "1024x1024"],
+                "samplers": ["default", "euler"]
+            },
+            "loraCompatibility": { "families": ["z-image"], "types": ["style"] },
+            // Verbose catalog fields that must be dropped:
+            "downloads": [{ "repo": "SceneWorks/z-image-turbo-mlx", "files": ["q4/*"] }],
+            "mlx": { "minMemoryGb": 40 },
+            "candle": { "minMemoryGb": 40 }
+        }]);
+        assert_eq!(
+            compact_models(&full),
+            json!([{
+                "id": "z_image_turbo",
+                "name": "Z-Image-Turbo",
+                "family": "z-image",
+                "type": "image",
+                "capabilities": ["text_to_image"],
+                "installState": "installed",
+                "gated": false,
+                "defaults": { "resolution": "1024x1024", "steps": 8, "guidanceScale": 0, "count": 4 },
+                "resolutions": ["768x768", "1024x1024"],
+                "loraFamilies": ["z-image"]
+            }])
+        );
+    }
+
+    #[test]
+    fn compact_loras_keeps_trigger_and_compatibility_fields() {
+        let full = json!([{
+            "id": "ltx_2_3_ic_hdr",
+            "name": "LTX-2.3 IC-LoRA HDR",
+            "family": "ltx-video",
+            "triggerWords": [],
+            "compatibility": { "families": ["ltx-video"] },
+            "icLora": true,
+            "defaultWeight": 0.8,
+            "installState": "missing",
+            "source": { "provider": "huggingface", "repo": "Lightricks/x", "file": "y.safetensors" }
+        }]);
+        assert_eq!(
+            compact_loras(&full),
+            json!([{
+                "id": "ltx_2_3_ic_hdr",
+                "name": "LTX-2.3 IC-LoRA HDR",
+                "family": "ltx-video",
+                "triggerWords": [],
+                "defaultWeight": 0.8,
+                "installState": "missing",
+                "compatibleFamilies": ["ltx-video"]
+            }])
+        );
+    }
+
+    #[test]
+    fn compact_mappers_skip_absent_and_null_fields() {
+        let sparse = json!([{ "id": "m1", "name": null }]);
+        assert_eq!(compact_models(&sparse), json!([{ "id": "m1" }]));
+        assert_eq!(compact_loras(&sparse), json!([{ "id": "m1" }]));
+    }
+
+    #[test]
+    fn compact_mappers_pass_non_arrays_through() {
+        // Defensive: an unexpected shape must degrade to verbose, not panic/lie.
+        let detail = json!({ "detail": "unexpected" });
+        assert_eq!(compact_projects(&detail), detail);
+        assert_eq!(compact_models(&detail), detail);
+        assert_eq!(compact_loras(&detail), detail);
+    }
+}

--- a/crates/sceneworks-mcp/tests/mcp_roundtrip.rs
+++ b/crates/sceneworks-mcp/tests/mcp_roundtrip.rs
@@ -1,0 +1,212 @@
+//! MCP round-trip tests (sc-10233): a REAL rmcp streamable-HTTP client speaks to
+//! the mounted `/mcp` service (initialize → tools/list → tools/call), with the
+//! tool handlers' [`ApiClient`] pointed at a stub `/api/v1` axum server on an
+//! ephemeral port. Proves the whole chain the acceptance criteria describe —
+//! session handshake, tool discovery, catalog calls, the `X-SceneWorks-Token`
+//! header on the upstream API call, and error surfacing on an upstream 401.
+
+use axum::extract::Query;
+use axum::http::{HeaderMap, StatusCode};
+use axum::routing::get;
+use axum::{Json, Router};
+use rmcp::model::{CallToolRequestParams, ClientInfo};
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::ServiceExt;
+use serde_json::{json, Value};
+
+const STUB_TOKEN: &str = "test-secret-token";
+
+/// Stub of the three `/api/v1` catalog routes. Requires `X-SceneWorks-Token:
+/// test-secret-token` exactly like the real `access_control` gate, and echoes the
+/// `list_loras` query filters into the fixture so the test can assert they were
+/// forwarded.
+fn stub_api_router() -> Router {
+    fn authorized(headers: &HeaderMap) -> bool {
+        headers
+            .get("x-sceneworks-token")
+            .and_then(|value| value.to_str().ok())
+            == Some(STUB_TOKEN)
+    }
+
+    Router::new()
+        .route(
+            "/api/v1/projects",
+            get(|headers: HeaderMap| async move {
+                if !authorized(&headers) {
+                    return Err(StatusCode::UNAUTHORIZED);
+                }
+                Ok(Json(json!([{
+                    "id": "p1",
+                    "name": "My Film",
+                    "path": "/data/projects/p1",
+                    "createdAt": "2026-07-07T00:00:00Z"
+                }])))
+            }),
+        )
+        .route(
+            "/api/v1/models",
+            get(|headers: HeaderMap| async move {
+                if !authorized(&headers) {
+                    return Err(StatusCode::UNAUTHORIZED);
+                }
+                Ok(Json(json!([{
+                    "id": "z_image_turbo",
+                    "name": "Z-Image-Turbo",
+                    "family": "z-image",
+                    "type": "image",
+                    "installState": "installed",
+                    "defaults": { "resolution": "1024x1024", "steps": 8 },
+                    "limits": { "resolutions": ["1024x1024"], "samplers": ["default"] },
+                    "downloads": [{ "repo": "SceneWorks/z-image-turbo-mlx" }]
+                }])))
+            }),
+        )
+        .route(
+            "/api/v1/loras",
+            get(
+                |headers: HeaderMap, Query(query): Query<Value>| async move {
+                    if !authorized(&headers) {
+                        return Err(StatusCode::UNAUTHORIZED);
+                    }
+                    let family = query
+                        .get("modelFamily")
+                        .and_then(Value::as_str)
+                        .unwrap_or("none")
+                        .to_owned();
+                    Ok(Json(json!([{
+                        "id": format!("lora-for-{family}"),
+                        "name": "Fixture LoRA",
+                        "family": family,
+                        "compatibility": { "families": [family] },
+                        "source": { "provider": "huggingface", "repo": "x/y" }
+                    }])))
+                },
+            ),
+        )
+}
+
+async fn spawn(router: Router) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind stub listener");
+    let addr = listener.local_addr().expect("stub addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+    format!("http://{addr}")
+}
+
+/// Spin up stub API + mounted MCP service, return a connected MCP client.
+async fn connect_client(
+    access_token: Option<String>,
+) -> rmcp::service::RunningService<rmcp::RoleClient, ClientInfo> {
+    let api_base = spawn(stub_api_router()).await;
+    let mcp_service = sceneworks_mcp::streamable_http_service(sceneworks_mcp::ApiClientConfig {
+        base_url: api_base,
+        access_token,
+    });
+    let mcp_base = spawn(Router::new().nest_service("/mcp", mcp_service)).await;
+
+    let transport = StreamableHttpClientTransport::from_config(
+        StreamableHttpClientTransportConfig::with_uri(format!("{mcp_base}/mcp")),
+    );
+    ClientInfo::default()
+        .serve(transport)
+        .await
+        .expect("MCP client initializes against the mounted /mcp service")
+}
+
+fn content_json(result: &rmcp::model::CallToolResult) -> Value {
+    let text = result
+        .content
+        .first()
+        .and_then(|block| block.as_text())
+        .map(|text| text.text.as_str())
+        .expect("tool result has one text content block");
+    serde_json::from_str(text).expect("tool content is JSON")
+}
+
+fn call_args(value: Value) -> serde_json::Map<String, Value> {
+    value.as_object().expect("args are an object").clone()
+}
+
+#[tokio::test]
+async fn mcp_client_lists_tools_and_calls_catalog_tools() {
+    let client = connect_client(Some(STUB_TOKEN.to_owned())).await;
+
+    // Tool discovery: the three catalog tools are advertised.
+    let tools = client
+        .list_tools(Default::default())
+        .await
+        .expect("tools/list succeeds");
+    let names: Vec<&str> = tools.tools.iter().map(|tool| tool.name.as_ref()).collect();
+    for expected in ["list_projects", "list_models", "list_loras"] {
+        assert!(
+            names.contains(&expected),
+            "missing tool {expected}: {names:?}"
+        );
+    }
+
+    // list_projects → compact rows (id/name/createdAt only — no path).
+    let result = client
+        .call_tool(CallToolRequestParams::new("list_projects"))
+        .await
+        .expect("list_projects succeeds");
+    assert_ne!(result.is_error, Some(true));
+    assert_eq!(
+        content_json(&result),
+        json!([{ "id": "p1", "name": "My Film", "createdAt": "2026-07-07T00:00:00Z" }])
+    );
+
+    // list_models → compact rows with the job-request fields, verbose keys dropped.
+    let result = client
+        .call_tool(CallToolRequestParams::new("list_models"))
+        .await
+        .expect("list_models succeeds");
+    assert_ne!(result.is_error, Some(true));
+    let models = content_json(&result);
+    assert_eq!(models[0]["id"], "z_image_turbo");
+    assert_eq!(models[0]["defaults"]["steps"], 8);
+    assert_eq!(models[0]["resolutions"], json!(["1024x1024"]));
+    assert!(
+        models[0].get("downloads").is_none(),
+        "verbose keys must be dropped"
+    );
+
+    // list_loras forwards the modelFamily filter to the API's query string.
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("list_loras")
+                .with_arguments(call_args(json!({ "modelFamily": "sdxl" }))),
+        )
+        .await
+        .expect("list_loras succeeds");
+    assert_ne!(result.is_error, Some(true));
+    let loras = content_json(&result);
+    assert_eq!(loras[0]["id"], "lora-for-sdxl");
+    assert_eq!(loras[0]["compatibleFamilies"], json!(["sdxl"]));
+
+    let _ = client.cancel().await;
+}
+
+#[tokio::test]
+async fn upstream_api_rejection_surfaces_as_tool_error_not_success() {
+    // No token configured on the MCP side → the stub API 401s → the tool call must
+    // fail loudly (JSON-RPC error), never return an empty-but-"successful" list.
+    let client = connect_client(None).await;
+
+    let outcome = client
+        .call_tool(CallToolRequestParams::new("list_projects"))
+        .await;
+    match outcome {
+        Err(_) => {}
+        Ok(result) => assert_eq!(
+            result.is_error,
+            Some(true),
+            "a 401 from the API must not look like success: {result:?}"
+        ),
+    }
+
+    let _ = client.cancel().await;
+}

--- a/docker/rust.Dockerfile
+++ b/docker/rust.Dockerfile
@@ -18,6 +18,7 @@ COPY Cargo.toml Cargo.lock rust-toolchain.toml rustfmt.toml ./
 COPY crates/sceneworks-core/Cargo.toml ./crates/sceneworks-core/Cargo.toml
 COPY crates/sceneworks-worker/Cargo.toml ./crates/sceneworks-worker/Cargo.toml
 COPY crates/sceneworks-image-quality/Cargo.toml ./crates/sceneworks-image-quality/Cargo.toml
+COPY crates/sceneworks-mcp/Cargo.toml ./crates/sceneworks-mcp/Cargo.toml
 COPY apps/rust-api/Cargo.toml ./apps/rust-api/Cargo.toml
 COPY apps/rust-worker/Cargo.toml ./apps/rust-worker/Cargo.toml
 COPY apps/desktop/Cargo.toml ./apps/desktop/Cargo.toml
@@ -29,10 +30,11 @@ RUN mkdir -p \
       crates/sceneworks-core/src \
       crates/sceneworks-worker/src \
       crates/sceneworks-image-quality/src \
+      crates/sceneworks-mcp/src \
     && printf 'fn main() {}\n' > apps/desktop/src/main.rs \
     && printf 'fn main() {}\n' > apps/rust-api/src/main.rs \
     && printf 'fn main() {}\n' > apps/rust-worker/src/main.rs \
-    && touch crates/sceneworks-core/src/lib.rs crates/sceneworks-worker/src/lib.rs crates/sceneworks-image-quality/src/lib.rs
+    && touch crates/sceneworks-core/src/lib.rs crates/sceneworks-worker/src/lib.rs crates/sceneworks-image-quality/src/lib.rs crates/sceneworks-mcp/src/lib.rs
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
@@ -119,16 +121,18 @@ COPY Cargo.toml Cargo.lock rust-toolchain.toml rustfmt.toml ./
 COPY crates/sceneworks-core/Cargo.toml ./crates/sceneworks-core/Cargo.toml
 COPY crates/sceneworks-worker/Cargo.toml ./crates/sceneworks-worker/Cargo.toml
 COPY crates/sceneworks-image-quality/Cargo.toml ./crates/sceneworks-image-quality/Cargo.toml
+COPY crates/sceneworks-mcp/Cargo.toml ./crates/sceneworks-mcp/Cargo.toml
 COPY apps/rust-api/Cargo.toml ./apps/rust-api/Cargo.toml
 COPY apps/rust-worker/Cargo.toml ./apps/rust-worker/Cargo.toml
 COPY apps/desktop/Cargo.toml ./apps/desktop/Cargo.toml
 RUN mkdir -p \
       apps/desktop/src apps/rust-api/src apps/rust-worker/src \
       crates/sceneworks-core/src crates/sceneworks-worker/src crates/sceneworks-image-quality/src \
+      crates/sceneworks-mcp/src \
     && printf 'fn main() {}\n' > apps/desktop/src/main.rs \
     && printf 'fn main() {}\n' > apps/rust-api/src/main.rs \
     && printf 'fn main() {}\n' > apps/rust-worker/src/main.rs \
-    && touch crates/sceneworks-core/src/lib.rs crates/sceneworks-worker/src/lib.rs crates/sceneworks-image-quality/src/lib.rs
+    && touch crates/sceneworks-core/src/lib.rs crates/sceneworks-worker/src/lib.rs crates/sceneworks-image-quality/src/lib.rs crates/sceneworks-mcp/src/lib.rs
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     cargo fetch --locked


### PR DESCRIPTION
Story: https://app.shortcut.com/trefry/story/10233 (epic 10231 — SceneWorks MCP Server)

## What & why

Stands up the MCP server foundation so MCP clients (Claude Code CLI, Cursor, …) can talk to SceneWorks at `http://<host>:<port>/mcp`, behind the exact same access control as the `/api/v1` surface.

- **New workspace crate `crates/sceneworks-mcp`** built on the official `rmcp` SDK (**pinned `=2.1.0`**, `transport-streamable-http-server`). Structured for the follow-up tools (generate_image, video): a `SceneWorksMcp` service struct with a `#[tool_router]` impl (add a method = add a tool), plus an `api_client` module.
- **Thin API client over `/api/v1/*`** (`crates/sceneworks-mcp/src/api_client.rs`, modeled on `crates/sceneworks-worker/src/api_client.rs`): base URL from `SCENEWORKS_API_URL` (default: this API's own loopback port), token sent as `X-SceneWorks-Token`. The MCP tools call back into the API over HTTP — **no new direct path into the engine/DB**.
- **`/mcp` mounted INTO the existing axum app** (`create_app_with_state()` in `apps/rust-api/src/lib.rs` via `nest_service`), so it sits behind the existing `access_control` middleware unchanged (token/Bearer, `SCENEWORKS_TRUST_LOOPBACK`, brute-force throttle, open-bind guard). `requires_token` in `apps/rust-api/src/auth.rs` now gates `/mcp` (every method) exactly like a gated `/api/v1` route — no new auth code.
- **First tools proving the round-trip:** `list_projects`, `list_models`, and `list_loras` (cheap — wraps the existing `GET /api/v1/loras`, with optional `modelFamily`/`projectId` filters). Each returns compact JSON the LLM can use: ids/names plus the values a job request needs (model `defaults`, `resolutions`, `loraFamilies`, LoRA `triggerWords`/`defaultWeight`/`compatibleFamilies`, `installState`).
- rmcp's own loopback-only `Host` allow-list (DNS-rebinding guard) is deliberately disabled: it would 403 the supported LAN deployment (`0.0.0.0` bind + access token), and the real gate for `/mcp` is `access_control` — identical to `/api/v1`.

## Scope vs acceptance criteria

- ✅ MCP client can connect to `/mcp` and call `list_projects`/`list_models` (proven by real-rmcp-client round-trip tests against the live app; `list_loras` included).
- ✅ Unauthenticated LAN request rejected exactly like `/api/v1` (test asserts identical 401 status + body); loopback-trusted request works with `SCENEWORKS_TRUST_LOOPBACK` (live-listener test).
- ✅ `rust:check` constituents clean: `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo build`.

## Tests added

- `crates/sceneworks-mcp` (7): unit tests for the compact `compact_projects`/`compact_models`/`compact_loras` mappers (drop verbose manifest keys, skip null/absent, non-array pass-through); `tests/mcp_roundtrip.rs` — a real rmcp streamable-HTTP client against the mounted service with the ApiClient pointed at a stub `/api/v1` axum server (tool discovery, compact payloads, `modelFamily` filter forwarding, `X-SceneWorks-Token` on upstream calls, upstream 401 surfacing as a tool error not an empty success).
- `apps/rust-api` (5): `requires_token` gates `/mcp` for GET/POST/DELETE; LAN request without token → 401 with byte-identical body to `/api/v1`; valid token or loopback trust passes the gate (and loopback trust does NOT leak to LAN peers); two live-listener round-trips with a real MCP client — desktop-style (loopback trust, no token) and LAN-style (token on `/mcp` + token on the MCP self-calls, `trust_loopback=false`).

## How verified

- `cargo fmt --all -- --check` ✅, `cargo clippy --all-targets -- -D warnings` ✅, `cargo build` ✅.
- `cargo test -p sceneworks-mcp` ✅ (7/7), `cargo test -p sceneworks-rust-api --lib mcp` ✅ (5/5), full `cargo test` green except 15 **pre-existing environment-dependent** catalog install-state failures on this dev box (populated local HF cache): reproduced identically on `main` with no changes, and they pass with a clean `HF_HOME`/`HF_HUB_CACHE`. Not touched here; parity CI is the gate.

## Follow-ups

- Later epic-10231 stories: `generate_image` + video tools on this scaffold.
- Desktop/docs: document `/mcp` + client config once the tool surface grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)