### PR TITLE
feat(ideogram): img2img reference-guided t2i via ui.img2img flag (sc-10192)

### DIFF
--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -3859,9 +3859,10 @@ async fn real_builtin_catalog_exposes_krea_img2img_ui_flag() {
         Value::Bool(true),
         "krea_2_turbo must expose ui.img2img in the /models response (the img2img tile's gate)"
     );
-    // And SD3.5 (A4.1) + Z-Image (A4.5, sc-10193) + Boogu (A4.3, sc-10191) — the img2img flags added
-    // since — must be exposed the same way (a duplicate-`ui`-key drop would silently strip the flag
-    // while still parsing, sc-10198).
+    // And SD3.5 (A4.1) + Z-Image (A4.5, sc-10193) + Boogu (A4.3, sc-10191) + Ideogram (A4.4, sc-10192) —
+    // the img2img flags added since — must be exposed the same way (a duplicate-`ui`-key drop would
+    // silently strip the flag while still parsing, sc-10198). Ideogram is a `structuredPrompt` model, so
+    // its flag additionally drives the img2img tile INSIDE the JSON-caption builder surface.
     for id in [
         "sd3_5_large",
         "sd3_5_large_turbo",
@@ -3870,6 +3871,8 @@ async fn real_builtin_catalog_exposes_krea_img2img_ui_flag() {
         "z_image_turbo",
         "boogu_image",
         "boogu_image_turbo",
+        "ideogram_4",
+        "ideogram_4_turbo",
     ] {
         let m = models
             .as_array()

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -2147,15 +2147,85 @@ export function ImageStudio() {
               3) "Refine my prompt" — RefinePromptControl (sc-2041).
               img2img and describe used to share ONE overloaded tile (sc-8593); splitting them makes the
               "guide the render vs. write a prompt" choice explicit (Michael, on-device). */}
-          {structuredPromptModel ? null : (() => {
+          {(() => {
+            // img2img "Image reference" tile — a picked image + strength that SEED the render
+            // (latent-init). Available for every `ui.img2img` model in text-to-image mode, INCLUDING
+            // structured-prompt models (Ideogram, epic 8588 A4.4 sc-10192): the caption builder replaces
+            // the free-text prompt tools, but reference-guided generation is orthogonal to how the prompt
+            // is authored, so the tile coexists with the JSON-caption builder. Needs no vision captioner.
+            const img2imgAvailable = supportsImg2img && mode === "text_to_image";
+            const imageRefActive = img2imgAvailable && promptTool === "imageReference";
+            const img2imgTile = img2imgAvailable ? (
+              <button
+                type="button"
+                className={imageRefActive ? "prompt-tool active" : "prompt-tool"}
+                aria-pressed={imageRefActive}
+                onClick={() => togglePromptTool("imageReference")}
+              >
+                <span className="prompt-tool-title">
+                  <Icon.Image size={15} /> Image reference
+                </span>
+                <span className="prompt-tool-desc">Guide the render with an image (image-to-image)</span>
+              </button>
+            ) : null;
+            const img2imgPanel = imageRefActive ? (
+              <div className="prompt-tool-panel">
+                <div className="structured-reference">
+                  <p className="structured-hint">
+                    Pick an image to guide the render (image-to-image). A higher reference strength
+                    stays closer to it; lower lets the prompt take over.
+                  </p>
+                  <ImageEditSourcePickerField
+                    assets={editImageAssets}
+                    buttonLabel="Select reference image"
+                    changeLabel="Change reference"
+                    characters={characters}
+                    emptyLabel="No reference image selected"
+                    importAsset={importAsset}
+                    label="Reference image"
+                    onChange={setImg2imgReferenceAssetId}
+                    projectId={activeProject?.id}
+                    value={img2imgReferenceAssetId}
+                  />
+                  {img2imgReferenceAssetId ? (
+                    <label className="reference-strength img2img-strength">
+                      {img2imgStrengthConfig?.label ?? "Reference strength"}
+                      <input
+                        max={img2imgStrengthConfig?.max ?? 1}
+                        min={img2imgStrengthConfig?.min ?? 0}
+                        onChange={(event) => setImg2imgStrength(Number(event.target.value))}
+                        step={img2imgStrengthConfig?.step ?? 0.05}
+                        type="range"
+                        value={img2imgStrength}
+                      />
+                      <span>{Number(img2imgStrength).toFixed(2)}</span>
+                    </label>
+                  ) : null}
+                </div>
+              </div>
+            ) : null;
+
+            // Structured-prompt models (Ideogram) get ONLY the img2img tile in this strip: "Prompt from
+            // image" is served by the caption builder's own image→caption picker (epic 8102) and "Refine
+            // my prompt" by its magic-expand, so rendering them here would duplicate those. Nothing to
+            // show when the model doesn't advertise img2img.
+            if (structuredPromptModel) {
+              return img2imgAvailable ? (
+                <div className="prompt-tools">
+                  <div className="prompt-tools-head">
+                    <span className="prompt-tools-title">Prompt tools</span>
+                    <span className="hairline" />
+                  </div>
+                  <div className="prompt-tools-tiles">{img2imgTile}</div>
+                  {img2imgPanel}
+                </div>
+              ) : null;
+            }
+
             const describeAvailable =
               mode === "text_to_image" &&
               typeof imageDescribe === "function" &&
               (visionCaptionReady || visionCaptionOffers.length > 0);
-            // img2img reference-guidance is its own tile now — a picked image + strength that SEED the
-            // render (latent-init). Needs no vision captioner; shown whenever the model advertises img2img.
-            const img2imgAvailable = supportsImg2img && mode === "text_to_image";
-            const imageRefActive = img2imgAvailable && promptTool === "imageReference";
             const describeActive = describeAvailable && promptTool === "describe";
             const refineActive = promptTool === "refine";
             return (
@@ -2165,19 +2235,7 @@ export function ImageStudio() {
                   <span className="hairline" />
                 </div>
                 <div className="prompt-tools-tiles">
-                  {img2imgAvailable ? (
-                    <button
-                      type="button"
-                      className={imageRefActive ? "prompt-tool active" : "prompt-tool"}
-                      aria-pressed={imageRefActive}
-                      onClick={() => togglePromptTool("imageReference")}
-                    >
-                      <span className="prompt-tool-title">
-                        <Icon.Image size={15} /> Image reference
-                      </span>
-                      <span className="prompt-tool-desc">Guide the render with an image (image-to-image)</span>
-                    </button>
-                  ) : null}
+                  {img2imgTile}
                   {describeAvailable ? (
                     <button
                       type="button"
@@ -2203,42 +2261,7 @@ export function ImageStudio() {
                     <span className="prompt-tool-desc">Rewrite what you typed for clarity &amp; detail</span>
                   </button>
                 </div>
-                {imageRefActive ? (
-                  <div className="prompt-tool-panel">
-                    <div className="structured-reference">
-                      <p className="structured-hint">
-                        Pick an image to guide the render (image-to-image). A higher reference strength
-                        stays closer to it; lower lets the prompt take over.
-                      </p>
-                      <ImageEditSourcePickerField
-                        assets={editImageAssets}
-                        buttonLabel="Select reference image"
-                        changeLabel="Change reference"
-                        characters={characters}
-                        emptyLabel="No reference image selected"
-                        importAsset={importAsset}
-                        label="Reference image"
-                        onChange={setImg2imgReferenceAssetId}
-                        projectId={activeProject?.id}
-                        value={img2imgReferenceAssetId}
-                      />
-                      {img2imgReferenceAssetId ? (
-                        <label className="reference-strength img2img-strength">
-                          {img2imgStrengthConfig?.label ?? "Reference strength"}
-                          <input
-                            max={img2imgStrengthConfig?.max ?? 1}
-                            min={img2imgStrengthConfig?.min ?? 0}
-                            onChange={(event) => setImg2imgStrength(Number(event.target.value))}
-                            step={img2imgStrengthConfig?.step ?? 0.05}
-                            type="range"
-                            value={img2imgStrength}
-                          />
-                          <span>{Number(img2imgStrength).toFixed(2)}</span>
-                        </label>
-                      ) : null}
-                    </div>
-                  </div>
-                ) : null}
+                {img2imgPanel}
                 {describeActive ? (
                   <div className="prompt-tool-panel">
                     <ReferenceCaptionPicker

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -1474,6 +1474,39 @@ describe("ImageStudio Image-reference (img2img) tile (epic 8588, sc-8593/sc-1019
     // The describe tile stays hidden without a captioner, proving the two are independent now.
     expect(tileByText("Prompt from image")).toBeFalsy();
   });
+
+  // Ideogram-like structured-prompt img2img model (epic 8588 A4.4, sc-10192): the free-text prompt-tools
+  // strip is replaced by the JSON-caption builder, but the img2img "Image reference" tile must still
+  // surface — reference-guided latent-init is orthogonal to how the prompt is authored.
+  const IDEOGRAM_IMG2IMG = {
+    ...Z_IMAGE,
+    id: "ideogram_4",
+    name: "Ideogram 4",
+    family: "ideogram",
+    structuredPrompt: true,
+    ui: { img2img: true },
+  };
+
+  it("shows the 'Image reference' tile for a structured-prompt img2img model (Ideogram)", async () => {
+    await render(baseContext({ imageModels: [IDEOGRAM_IMG2IMG], models: [IDEOGRAM_IMG2IMG] }));
+    // The tile coexists with the structured caption builder…
+    expect(tileByText("Image reference")).toBeTruthy();
+    expect(document.body.querySelector(".structured-prompt-builder, .prompt-input-row.structured")).toBeTruthy();
+    // …but the free-text-only tiles ("Prompt from image" / "Refine my prompt") stay out of the strip —
+    // the caption builder owns image→caption + magic-expand, so this is the slim img2img-only strip.
+    expect(tileByText("Refine my prompt")).toBeFalsy();
+  });
+
+  it("activating the structured img2img tile reveals the reference-guidance panel", async () => {
+    await render(baseContext({ imageModels: [IDEOGRAM_IMG2IMG], models: [IDEOGRAM_IMG2IMG] }));
+    await click(tileByText("Image reference"));
+    // The img2img panel's hint distinguishes it from the caption builder's own reference→caption picker.
+    expect(
+      [...document.body.querySelectorAll(".prompt-tool-panel .structured-hint")].some((p) =>
+        p.textContent.includes("guide the render (image-to-image)"),
+      ),
+    ).toBe(true);
+  });
 });
 
 describe("ImageStudio strict-control panel (epic 8236, sc-8245)", () => {

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1796,6 +1796,16 @@
       // license and access are intentionally two different pages for this model. Leave as upstream.
       "licenseUrl": "https://huggingface.co/ideogram-ai/ideogram-4-fp8",
       "ui": {
+        // img2img reference-guided t2i (epic 8588 A4.4, sc-10192): the `ui.img2img` flag drives the
+        // Image Studio "Image reference" tile + strength slider (referenceAssetId + advanced.strength).
+        // No engine change was needed — a `Conditioning::Reference` with NO `Mask` already IS a plain
+        // img2img denoise (start step from strength, tail of schedule) in the native edit path (sc-6303);
+        // this just exposes it as a plain-t2i surface. Distinct from the Remix/inpaint `edit_image`
+        // surface (which adds a `Mask`); the worker routes the two by mode (edit_image →
+        // resolve_ideogram_edit, text_to_image → the generic img2img arm). Ideogram is a
+        // `structuredPrompt` model, so the tile renders alongside the JSON-caption builder.
+        "img2img": true,
+        "img2imgStrength": { "label": "Reference strength", "default": 0.5, "min": 0.0, "max": 1.0, "step": 0.05 },
         "label": "Ideogram 4",
         "description": "Ideogram 4 — 9.3B flow-matching text-to-image with structured JSON-caption prompting (bounding-box layout + color palettes). Runs on Apple Silicon (MLX) and Windows/Linux (candle/CUDA). Pre-quantized Q4 (~15 GB, default) + Q8 (~29 GB) tiers. Distributed under the Ideogram Non-Commercial Model Agreement (gated): accept the license at huggingface.co/ideogram-ai/ideogram-4-fp8, then use Request access on the model page and add a Hugging Face token under Settings → Service credentials before downloading. Trained on JSON captions — SceneWorks builds the caption from your prompt.",
         "recommendedFor": ["text_to_image"],
@@ -1935,6 +1945,11 @@
       // access" button (`gatedRepoUrl` → SceneWorks/ideogram-4-mlx, sc-5999). Leave as upstream.
       "licenseUrl": "https://huggingface.co/ideogram-ai/ideogram-4-fp8",
       "ui": {
+        // img2img reference-guided t2i (epic 8588 A4.4, sc-10192): same plain-t2i "Image reference"
+        // surface as the base `ideogram_4` (a `Conditioning::Reference` with no `Mask` = plain img2img in
+        // the CFG-free turbo denoise; only the initial latent + start step differ). See `ideogram_4` ui.
+        "img2img": true,
+        "img2imgStrength": { "label": "Reference strength", "default": 0.5, "min": 0.0, "max": 1.0, "step": 0.05 },
         "label": "Ideogram 4 Turbo",
         "description": "Ideogram 4 Turbo — the few-step (~8) fast variant of Ideogram 4: same 9.3B flow-matching model and structured JSON-caption prompting, distilled to a CFG-free single-DiT path (the ostris TurboTime LoRA) for ~2x faster renders. Runs on Apple Silicon (MLX) and Windows/Linux (candle/CUDA). Shares the gated Ideogram 4 turnkey (Q4 default + Q8 selectable) — accept the license at huggingface.co/ideogram-ai/ideogram-4-fp8, then use Request access on the model page and add a Hugging Face token under Settings → Service credentials before downloading.",
         "recommendedFor": ["text_to_image"],

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -4263,6 +4263,48 @@ mod standard_tier_tests {
         assert!(!zimage_uses_generic_img2img(&no_flag, true));
     }
 
+    /// A4.4 (sc-10192): Ideogram opts into the generic `ui.img2img` surface (the Image Studio "Image
+    /// reference" tile, `text_to_image` mode) while ALSO owning the bespoke Remix/inpaint edit arm
+    /// (`edit_image` mode, [`resolve_ideogram_edit`], sc-6303). The two arms in
+    /// [`resolve_generic_lane_conditioning`] are mutually exclusive by mode — the edit arm is checked
+    /// first and gates on `mode == "edit_image"`, the generic img2img arm on `mode != "edit_image"` — so a
+    /// plain-t2i reference routes to the generic init (a single `Conditioning::Reference`, no mask, which
+    /// the native engine's edit path denoises as plain img2img) while an Edit-tab job keeps the
+    /// mask-capable path. No engine change was needed: mlx-gen `resolve_edit` already treats a Reference
+    /// with no Mask as img2img. This tripwire locks the flag + mode-split; the disk-backed resolve
+    /// (asset decode) is validated on-device.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn ideogram_img2img_routes_by_mode() {
+        let req = |model: &str, mode: &str| {
+            ImageRequest::from_payload(
+                json!({
+                    "model": model,
+                    "mode": mode,
+                    "modelManifestEntry": { "ui": { "img2img": true } },
+                    "referenceAssetId": "asset-1",
+                })
+                .as_object()
+                .unwrap(),
+            )
+        };
+        for model in ["ideogram_4", "ideogram_4_turbo"] {
+            let is_ideogram_edit = |r: &ImageRequest| {
+                matches!(r.model.as_str(), "ideogram_4" | "ideogram_4_turbo")
+                    && r.mode == "edit_image"
+            };
+            // Plain t2i + reference: the generic img2img arm's gate holds (flag on, non-edit mode) and the
+            // earlier Ideogram edit arm does not — so the reference takes the generic img2img init.
+            let t2i = req(model, "text_to_image");
+            assert!(model_supports_img2img(&t2i) && t2i.mode != "edit_image");
+            assert!(!is_ideogram_edit(&t2i));
+            // Edit tab: the Ideogram edit arm claims it first and the generic arm yields (edit mode).
+            let edit = req(model, "edit_image");
+            assert!(is_ideogram_edit(&edit));
+            assert!(!(model_supports_img2img(&edit) && edit.mode != "edit_image"));
+        }
+    }
+
     /// Write a minimal present `<tier>/transformer/<file>` so [`standard_tier_subdir`]'s
     /// filename-agnostic probe sees the tier as downloaded.
     fn seed_tier(root: &Path, tier: &str, file: &str) {


### PR DESCRIPTION
Epic 8588 slice **A4.4** — Ideogram 4 + Turbo join the catalog-wide plain-t2i img2img rollout (the "Image reference" surface: a picked image + strength that seed the denoise from the VAE-encoded reference).

## Key finding: no engine or worker-routing code change needed

The story scoped this as "moderate: wire a plain-t2i img2img denoise reusing `encode_init_latents` + `init_time_step` + `add_noise_by_interpolation`." Tracing the code showed the pieces were **already fully connected** by the sc-6303 edit port:

- **mlx-gen** — Ideogram's native edit path treats a `Conditioning::Reference` with **no `Mask`** as exactly a plain img2img denoise (start step from strength, tail of schedule). `run_denoise`'s mask-blend is conditional on a mask being present; `resolve_edit` defaults a lone reference to `DEFAULT_IMG2IMG_STRENGTH`. Locked by the existing `resolve_edit_defaults_and_pairing` test. **Zero engine change → no mlx-gen PR, no lockstep repin.**
- **worker** — `resolve_generic_lane_conditioning`'s generic img2img arm (`model_supports_img2img && has_reference && mode != "edit_image"`) already catches any `ui.img2img` model and feeds it a single `Conditioning::Reference`. It sits *after* Ideogram's bespoke `edit_image` (Remix/inpaint) arm, so the two are mutually exclusive by mode. **Zero worker routing change.**

So this reduces to a **catalog flag flip + one web fix**, exactly the epic's "a new text-only model joins by flipping `ui.img2img`" design.

## Changes
- **catalog** (`builtin.models.jsonc`): `ui.img2img` + `img2imgStrength` on `ideogram_4` + `ideogram_4_turbo`.
- **web** (`ImageStudio.jsx`): the "Image reference" tile was suppressed for `structuredPrompt` models (Ideogram) along with the whole free-text prompt-tools strip. Surface a **slim img2img-only strip** for structured models so the tile coexists with the JSON-caption builder — "Prompt from image" and "Refine my prompt" stay owned by the builder (its image→caption picker + magic-expand). Submit + `advanced.strength` payload were already model-agnostic. The tile/panel JSX is extracted once and shared between the structured and free-text branches (non-structured render is unchanged).

## Tests
- rust-api `real_builtin_catalog_exposes_krea_img2img_ui_flag`: extended to assert both Ideogram ids expose `ui.img2img` through the real `/api/v1/models` path.
- worker `ideogram_img2img_routes_by_mode`: mode-split tripwire (t2i → generic arm, edit_image → Ideogram edit arm).
- web: structured img2img tile appears (+ coexists with the builder; free-text tiles stay out) and the panel reveals on click.

Green locally: web vitest (ImageStudio 52, imageJobAdvanced 20), worker + rust-api tests, `cargo fmt --check` + clippy clean.

## Deferred / pending
- Candle worker-lane parity (deferred, mirrors z-image sc-10209 / boogu sc-10240 — will file if not already tracked).
- On-device render validation (Metal + gated Ideogram weights) — story stays In Progress until eyeballed, per the "drive a real run" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)