### PR TITLE
fix(worker): route krea_2_raw through the Krea tier-subdir resolver (epic 9992)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -464,10 +464,16 @@ pub(crate) fn resolve_weights_dir(
     ) {
         return Ok(snapshot.map(|root| boogu_model_subdir(&root, request)));
     }
-    // Krea 2 Turbo (epic 7565) ships a turnkey with packed `q8/` (default) + `q4/` self-contained subdirs;
-    // point the engine at the chosen quant's subdir rather than the repo root. The packed weights
-    // auto-detect their quant on load, so the resolved `spec.quantize` is a no-op on them.
-    if request.model == "krea_2_turbo" {
+    // Krea 2 Turbo (epic 7565) + Krea 2 Raw (epic 9992) ship a turnkey with self-contained quant subdirs
+    // (Turbo: packed `q8/` default + `q4/`; Raw: packed `q8/` default + `q4/` + dense `bf16/`); point the
+    // engine at the chosen quant's subdir rather than the repo root. The packed weights auto-detect their
+    // quant on load, so the resolved `spec.quantize` is a no-op on them. `krea_model_subdir` also falls
+    // back to any downloaded tier when the preferred one is absent — so Raw generates off the `bf16/`
+    // training-base tier when only that is present, instead of failing at the repo root (no `tokenizer/`
+    // there). Without this branch Raw fell through to `Ok(snapshot)` (the repo root) and load errored
+    // with "tokenizer: No such file or directory" (epic 9992 P5/P6 wiring gap — the `krea_2_raw` engine
+    // row already documents this resolver, but the branch was never added).
+    if request.model == "krea_2_turbo" || request.model == "krea_2_raw" {
         return Ok(snapshot.map(|root| krea_model_subdir(&root, request)));
     }
     // Catalog-wide quant-matrix models (sc-8513, epic 8506) ship as SceneWorks pre-quantized
@@ -3408,7 +3414,7 @@ fn candle_adapter_label(model: &str) -> &'static str {
         | "sensenova_u1_8b_infographic_v2_fast" => "candle_sensenova",
         "ideogram_4" | "ideogram_4_turbo" => "candle_ideogram",
         "boogu_image" | "boogu_image_turbo" | "boogu_image_edit" => "candle_boogu",
-        "krea_2_turbo" => "candle_krea",
+        "krea_2_turbo" | "krea_2_raw" => "candle_krea",
         // Stable Diffusion 3.5 (sc-7880): Large / Large Turbo / Medium share the candle SD3.5 engine.
         "sd3_5_large" | "sd3_5_large_turbo" | "sd3_5_medium" => "candle_sd3",
         // sdxl / realvisxl share the candle "sdxl" engine.
@@ -4540,6 +4546,52 @@ mod standard_tier_tests {
     /// MLX lane). This proves the shared tier resolver picks the requested q4/q8/bf16 subdir of a Lens
     /// turnkey snapshot off-Mac — the candle-lane sibling of the SD3.5 `standard_tier_subdir` tests
     /// above — so the retired resolver is fully replaced by the standard machinery.
+    #[test]
+    fn krea_model_subdir_selects_tier_and_falls_back_to_downloaded() {
+        let krea_request = |bits: serde_json::Value| {
+            ImageRequest::from_payload(
+                json!({ "model": "krea_2_raw", "advanced": { "mlxQuantize": bits } })
+                    .as_object()
+                    .unwrap(),
+            )
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // Krea turnkey: packed q4/q8 single-file transformer + dense sharded bf16 (index.json only).
+        seed_tier(root, "q4", "diffusion_pytorch_model.safetensors");
+        seed_tier(root, "q8", "diffusion_pytorch_model.safetensors");
+        seed_tier(root, "bf16", "diffusion_pytorch_model.safetensors.index.json");
+
+        // q8-default (no selection) / q4 (bits<=4) / bf16 (bits<=0) each resolve to their tier subdir.
+        assert_eq!(
+            krea_model_subdir(root, &krea_request(json!(null))),
+            root.join("q8")
+        );
+        assert_eq!(
+            krea_model_subdir(root, &krea_request(json!(4))),
+            root.join("q4")
+        );
+        assert_eq!(
+            krea_model_subdir(root, &krea_request(json!(0))),
+            root.join("bf16")
+        );
+
+        // Regression guard (epic 9992): with ONLY the `bf16/` training-base tier downloaded (the Path-1
+        // unify scenario), a q8-default generation must fall back to the present bf16 tier — NOT the repo
+        // root (which has no `tokenizer/`, the reported "tokenizer: No such file or directory" load error).
+        let bf16_only = tempfile::tempdir().unwrap();
+        seed_tier(
+            bf16_only.path(),
+            "bf16",
+            "diffusion_pytorch_model.safetensors.index.json",
+        );
+        assert_eq!(
+            krea_model_subdir(bf16_only.path(), &krea_request(json!(null))),
+            bf16_only.path().join("bf16"),
+            "q8-default must fall back to the only downloaded tier (bf16), not the repo root"
+        );
+    }
+
     #[test]
     fn candle_lens_resolves_packed_turnkey_tier_subdir() {
         let lens_request = |bits: serde_json::Value| {


### PR DESCRIPTION
## Symptom (user-reported)
Generating with **Krea 2 Raw** fails at load: `krea_2_raw load failed: tokenizer: No such file or directory (os error 2)`.

## Root cause
The worker's tier-subdir resolver `resolve_weights_dir` ([base.rs](crates/sceneworks-worker/src/image_jobs/base.rs)) had a branch for `krea_2_turbo` but **not** `krea_2_raw`. Raw fell through to `Ok(snapshot)` — the **repo root** — instead of a tier subdir. The repo root has no `tokenizer/`; it lives inside the `q8/`/`bf16/` tier subdirs → load error.

The `krea_2_raw` engine row in `engines.rs` *already documents* that it loads via `krea_model_subdir` ("the same resolver as Turbo") — the resolver branch was just never added when Raw generation shipped (epic 9992 P5/P6). It was **unreachable** until `krea_2_raw` gained its `text_to_image` capability ([sc-10229](https://app.shortcut.com/trefry/story/10229) / #1262), which made it selectable in Image Studio.

## Fix
1. **`resolve_weights_dir`** — route `krea_2_raw` through `krea_model_subdir` (shared by the MLX + candle lanes, `cfg(any(macos, backend-candle))`). That resolver already does q8-default tier selection **and** falls back `q8 → q4 → bf16` to any downloaded tier — so a user who only has the **bf16 training-base tier** (the Path-1 unify scenario) now generates off bf16 instead of erroring.
2. **`candle_adapter_label`** — add `krea_2_raw → "candle_krea"`. Raw is `candle_routed` (catalog.rs), but the map only had Turbo, so the Windows/Linux gen lane would mislabel Raw to the default adapter. (Parallel gap; unverified on this Mac — no CUDA — but it's the obvious sibling wiring.)
3. **test** — `krea_model_subdir` tier selection + the exact regression scenario (only `bf16/` present → q8-default falls back to `bf16/`, not the repo root).

Already-correct spots confirmed: PiD backbone (`pid.rs`) and the engine registry (`engines.rs`) both handle `krea_2_raw`; `wants_krea_convrot` is correctly Turbo-only.

## Verification
`cargo test -p sceneworks-worker --lib krea_model_subdir_selects_tier_and_falls_back_to_downloaded` → passes; `cargo fmt --check` clean. On-device: with only the bf16 tier cached, Raw now resolves to `bf16/` and loads (eyeball to follow).

Relates to epic 9992 (Krea 2 Raw generation surface). A tracking bug story will be linked once the Shortcut MCP is reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)