### PR TITLE
fix(lora): load the declared adapter, not a step checkpoint, for trained LoRAs (sc-10221)

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1785,6 +1785,10 @@ fn serialize_job_lora(lora: &Value, selected_lora: &Value, lora_id: &str) -> Val
         "conditioningRole": preferred_lora_value(selected_lora, lora, "conditioningRole"),
         "installedPath": preferred_lora_value(selected_lora, lora, "installedPath"),
         "sourcePath": preferred_lora_value(selected_lora, lora, "sourcePath"),
+        // Declared adapter filename(s): lets the worker load the record's final adapter
+        // from its folder instead of an arbitrary sibling — e.g. a trained LoRA's final
+        // `<stem>.safetensors` over a `<stem>-stepNNN` checkpoint (sc-10221).
+        "files": preferred_lora_value(selected_lora, lora, "files"),
         "source": preferred_lora_value(selected_lora, lora, "source"),
         "presetManaged": selected_lora.get("presetManaged").and_then(Value::as_bool).unwrap_or(false)
     })

--- a/apps/rust-api/src/recipe_presets.rs
+++ b/apps/rust-api/src/recipe_presets.rs
@@ -987,6 +987,10 @@ pub(crate) fn serialize_preset_lora(lora: &Value, preset_lora: &Value, lora_id: 
         "icLora": lora.get("icLora").cloned().unwrap_or(Value::Bool(false)),
         "conditioningRole": lora.get("conditioningRole").cloned().unwrap_or(Value::Null),
         "installedPath": lora.get("installedPath").cloned().unwrap_or(Value::Null),
+        // Carry the declared adapter filename(s) so the worker loads the record's final
+        // adapter from its folder rather than an arbitrary sibling — e.g. a trained
+        // LoRA's `<stem>.safetensors` over a `<stem>-stepNNN` checkpoint (sc-10221).
+        "files": lora.get("files").cloned().unwrap_or(Value::Null),
         "source": lora.get("source").cloned().unwrap_or(Value::Null),
         "presetManaged": true
     })

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -146,6 +146,37 @@ fn has_safetensors_extension(path: &Path) -> bool {
         .is_some_and(|extension| extension.eq_ignore_ascii_case("safetensors"))
 }
 
+/// Resolves the adapter file to load from a LoRA record `dir`, preferring `declared`
+/// (the plain filename the record's manifest `files` list names) when it exists,
+/// otherwise falling back to [`first_safetensors_path`] (sc-10221).
+///
+/// A trainer leaves periodic step checkpoints (`<stem>-stepNNN.safetensors`, `save_every`
+/// default 250) in the same folder as the final `<stem>.safetensors`; a bare directory
+/// scan (`first_safetensors_path`, unordered `read_dir`) can therefore load an
+/// under-trained checkpoint — and since `-stepNNN` sorts before `.safetensors`, a
+/// checkpoint is even the likely pick. Honoring the declared final name loads the
+/// intended adapter deterministically.
+///
+/// `declared` is treated as untrusted (it rides the job payload): only a plain in-`dir`
+/// filename — no path separators, not `.`/`..` — is accepted, so a crafted `files` value
+/// cannot redirect the load outside `dir`. Anything else falls through to the scan.
+pub fn resolve_adapter_in_dir(dir: &Path, declared: Option<&str>) -> Option<PathBuf> {
+    if let Some(name) = declared.map(str::trim).filter(|name| !name.is_empty()) {
+        let is_plain = name != "."
+            && name != ".."
+            && !name.contains('/')
+            && !name.contains('\\')
+            && Path::new(name).file_name().and_then(|value| value.to_str()) == Some(name);
+        if is_plain {
+            let candidate = dir.join(name);
+            if candidate.is_file() && has_safetensors_extension(&candidate) {
+                return Some(candidate);
+            }
+        }
+    }
+    first_safetensors_path(dir)
+}
+
 /// Returns the detected family for a base model directory or file.
 ///
 /// Detection strategy, in priority order:
@@ -2705,5 +2736,66 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.contains("sdxllora"), "got: {err}");
+    }
+
+    // sc-10221: resolve_adapter_in_dir prefers the manifest-declared adapter over an
+    // arbitrary directory scan, so a trained LoRA loads its final adapter rather than a
+    // step checkpoint sharing the folder.
+    fn touch(path: &Path) {
+        std::fs::File::create(path).expect("create fixture file");
+    }
+
+    #[test]
+    fn resolve_adapter_in_dir_prefers_declared_over_checkpoint() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // A trainer folder: the final adapter plus a step checkpoint that sorts BEFORE it
+        // (`-` 0x2D < `.` 0x2E), so an ordered scan would grab the checkpoint.
+        let final_adapter = dir.path().join("my_style.safetensors");
+        touch(&dir.path().join("my_style-step250.safetensors"));
+        touch(&final_adapter);
+        assert_eq!(
+            resolve_adapter_in_dir(dir.path(), Some("my_style.safetensors")),
+            Some(final_adapter)
+        );
+    }
+
+    #[test]
+    fn resolve_adapter_in_dir_falls_back_when_no_or_missing_declared() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let only = dir.path().join("adapter.safetensors");
+        touch(&only);
+        // No declared name → first_safetensors_path fallback.
+        assert_eq!(resolve_adapter_in_dir(dir.path(), None), Some(only.clone()));
+        // Declared name that doesn't exist on disk → fallback (not an error).
+        assert_eq!(
+            resolve_adapter_in_dir(dir.path(), Some("does_not_exist.safetensors")),
+            Some(only)
+        );
+    }
+
+    #[test]
+    fn resolve_adapter_in_dir_rejects_traversal_and_non_safetensors() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let final_adapter = dir.path().join("final.safetensors");
+        touch(&final_adapter);
+        // Outside the dir: a real sibling the crafted name tries to reach via `..`.
+        let outside = dir.path().parent().unwrap().join("evil.safetensors");
+        touch(&outside);
+        // Path-separated / traversing declared names are ignored (fall back to the scan),
+        // so a crafted `files` value can't redirect the load outside the record dir.
+        for crafted in ["../evil.safetensors", "sub/final.safetensors", "..", "."] {
+            assert_eq!(
+                resolve_adapter_in_dir(dir.path(), Some(crafted)),
+                Some(final_adapter.clone()),
+                "crafted name {crafted:?} must not escape the dir"
+            );
+        }
+        // A declared non-.safetensors file is not accepted; fall back to the scan.
+        touch(&dir.path().join("notes.txt"));
+        assert_eq!(
+            resolve_adapter_in_dir(dir.path(), Some("notes.txt")),
+            Some(final_adapter)
+        );
+        let _ = std::fs::remove_file(&outside);
     }
 }

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1517,6 +1517,24 @@ pub(crate) fn lora_path(lora: &Value) -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
+/// The adapter filename a LoRA record's manifest `files` list declares (its first
+/// entry), if any (sc-10221). When `lora_path` resolves to a record *directory*, this
+/// is the specific adapter to load — e.g. a trained LoRA's final `<stem>.safetensors`
+/// rather than a `<stem>-stepNNN` checkpoint sharing the folder. Untrusted (rides the
+/// job payload); `resolve_adapter_in_dir` re-validates it as a plain in-dir filename.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+pub(crate) fn declared_adapter_file(lora: &Value) -> Option<&str> {
+    lora.get("files")
+        .and_then(Value::as_array)
+        .and_then(|files| files.first())
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
 /// Classify a LoRA file into the mlx-gen adapter `kind`. SceneWorks peft-LoKr (stamped
 /// `networkType: lokr`) → `Lokr` (the engine's metadata-gated `apply_lokr` peft path). Everything
 /// else → `Lora`, INCLUDING third-party LyCORIS (LoHa / kohya non-peft LoKr): since epic 3641
@@ -1568,7 +1586,9 @@ fn resolve_adapters(request: &ImageRequest, settings: &Settings) -> WorkerResult
         // root before any on-disk use (sc-5723 / WKA-002).
         let path = crate::normalize_app_managed_lora_path(settings, &raw)?;
         let file = if path.is_dir() {
-            first_safetensors_path(&path).ok_or_else(|| {
+            // Prefer the manifest-declared adapter over an arbitrary directory scan so a
+            // trained LoRA loads its final adapter, not a step checkpoint (sc-10221).
+            crate::resolve_adapter_in_dir(&path, declared_adapter_file(lora)).ok_or_else(|| {
                 WorkerError::InvalidPayload(format!(
                     "LoRA has no .safetensors under {}",
                     path.display()

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -16,7 +16,8 @@ use sceneworks_core::hf_home::{huggingface_hub_cache_dir, huggingface_repo_cache
 use sceneworks_core::jsonc::strip_jsonc_comments;
 use sceneworks_core::lora_family::{
     apply_model_manifest_defaults, detect_lora_family, detect_model_family, first_safetensors_path,
-    read_safetensors_header, reconcile_detected_family, FamilyMismatch, SafetensorsHeaderError,
+    read_safetensors_header, reconcile_detected_family, resolve_adapter_in_dir, FamilyMismatch,
+    SafetensorsHeaderError,
 };
 use sceneworks_core::lora_url::{
     lora_source_url_file_name, lora_source_url_file_stem, parse_lora_source_url_with_private,

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -16,9 +16,16 @@ use sceneworks_core::hf_home::{huggingface_hub_cache_dir, huggingface_repo_cache
 use sceneworks_core::jsonc::strip_jsonc_comments;
 use sceneworks_core::lora_family::{
     apply_model_manifest_defaults, detect_lora_family, detect_model_family, first_safetensors_path,
-    read_safetensors_header, reconcile_detected_family, resolve_adapter_in_dir, FamilyMismatch,
-    SafetensorsHeaderError,
+    read_safetensors_header, reconcile_detected_family, FamilyMismatch, SafetensorsHeaderError,
 };
+// Only the cfg-gated adapter resolvers (image `resolve_adapters`, video
+// `resolve_lora_file`) use this, so gate the import identically or the parity
+// build (no `backend-candle`) trips `-D unused-imports` (sc-10221).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+use sceneworks_core::lora_family::resolve_adapter_in_dir;
 use sceneworks_core::lora_url::{
     lora_source_url_file_name, lora_source_url_file_stem, parse_lora_source_url_with_private,
     validate_public_ip,

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -2442,10 +2442,16 @@ fn lora_scale(lora: &Value) -> f32 {
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
-fn resolve_lora_file(settings: &Settings, path: PathBuf) -> WorkerResult<PathBuf> {
+fn resolve_lora_file(
+    settings: &Settings,
+    path: PathBuf,
+    declared: Option<&str>,
+) -> WorkerResult<PathBuf> {
     let path = crate::normalize_app_managed_lora_path(settings, &path)?;
     let file = if path.is_dir() {
-        first_safetensors_path(&path).ok_or_else(|| {
+        // Prefer the manifest-declared adapter over an arbitrary directory scan so a
+        // trained LoRA loads its final adapter, not a step checkpoint (sc-10221).
+        crate::resolve_adapter_in_dir(&path, declared).ok_or_else(|| {
             WorkerError::InvalidPayload(format!(
                 "LoRA has no .safetensors under {}",
                 path.display()
@@ -2488,7 +2494,11 @@ fn resolve_dense_adapters(
         let path = crate::image_jobs::lora_path(lora).ok_or_else(|| {
             WorkerError::InvalidPayload("LoRA is missing a usable path.".to_owned())
         })?;
-        let file = resolve_lora_file(settings, path)?;
+        let file = resolve_lora_file(
+            settings,
+            path,
+            crate::image_jobs::declared_adapter_file(lora),
+        )?;
         let kind = crate::image_jobs::classify_adapter(&file)?;
         specs.push(AdapterSpec {
             path: file,
@@ -3143,7 +3153,11 @@ fn resolve_wan_adapters(
         let path = lora_path(lora).ok_or_else(|| {
             WorkerError::InvalidPayload("LoRA is missing a usable path.".to_owned())
         })?;
-        let file = resolve_lora_file(settings, path)?;
+        let file = resolve_lora_file(
+            settings,
+            path,
+            crate::image_jobs::declared_adapter_file(lora),
+        )?;
         let kind = classify_adapter(&file)?;
         let scale = lora_scale(lora);
         match (is_moe, wan_moe_low_noise_sibling(&file)) {
@@ -4672,7 +4686,11 @@ fn candle_resolve_wan_adapters(
         let path = crate::image_jobs::lora_path(lora).ok_or_else(|| {
             WorkerError::InvalidPayload("LoRA is missing a usable path.".to_owned())
         })?;
-        let file = resolve_lora_file(settings, path)?;
+        let file = resolve_lora_file(
+            settings,
+            path,
+            crate::image_jobs::declared_adapter_file(lora),
+        )?;
         let kind = crate::image_jobs::classify_adapter(&file)?;
         let scale = lora_scale(lora);
         match (is_moe, candle_wan_moe_low_noise_sibling(&file)) {
@@ -6881,7 +6899,11 @@ fn resolve_ltx_adapters(
         let path = lora_path(lora).ok_or_else(|| {
             WorkerError::InvalidPayload("LoRA is missing a usable path.".to_owned())
         })?;
-        let file = resolve_lora_file(settings, path)?;
+        let file = resolve_lora_file(
+            settings,
+            path,
+            crate::image_jobs::declared_adapter_file(lora),
+        )?;
         let kind = classify_adapter(&file)?;
         specs.push(AdapterSpec::new(file, lora_scale(lora), kind));
     }
@@ -10928,9 +10950,32 @@ mod tests {
             ..Settings::from_env()
         };
         // Point the resolver at the LoRA dir (not the file); it must recurse into `adapter/`.
-        let resolved =
-            resolve_lora_file(&settings, dir.clone()).expect("nested .safetensors must resolve");
+        // No declared file → falls back to the recursive scan.
+        let resolved = resolve_lora_file(&settings, dir.clone(), None)
+            .expect("nested .safetensors must resolve");
         assert_eq!(resolved, weight.canonicalize().unwrap());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// sc-10221: a trained LoRA's folder holds step checkpoints alongside the final
+    /// adapter; the video resolver must load the manifest-declared final file, not an
+    /// arbitrary sibling the directory scan might pick.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn resolve_lora_file_prefers_declared_over_checkpoint() {
+        let dir = std::env::temp_dir().join(format!("sw_lora_ckpt_{}", Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let final_adapter = dir.join("my_style.safetensors");
+        write_lora_fixture(&dir.join("my_style-step250.safetensors"), None);
+        write_lora_fixture(&final_adapter, None);
+
+        let settings = Settings {
+            data_dir: dir.clone(),
+            ..Settings::from_env()
+        };
+        let resolved = resolve_lora_file(&settings, dir.clone(), Some("my_style.safetensors"))
+            .expect("declared adapter must resolve");
+        assert_eq!(resolved, final_adapter.canonicalize().unwrap());
         let _ = std::fs::remove_dir_all(&dir);
     }
 


### PR DESCRIPTION
## Problem

A trained LoRA can generate with a **mid-training step checkpoint** instead of its final adapter — non-deterministically.

**Chain (code-verified):**
1. The trainer keeps periodic checkpoints (`<stem>-stepNNN.safetensors`, `save_every` **default 250**) in the same folder as the final `<stem>.safetensors` ([training.rs:1651-1654](apps/rust-api/src/training.rs)).
2. Registration records the final adapter in the manifest `files` list — but that only protects the catalog.
3. The catalog sets `installedPath` to the record **directory** ([loras.rs `normalize_lora_entry`](apps/rust-api/src/loras.rs)).
4. The outgoing LoRA spec **dropped `files`** ([serialize_preset_lora](apps/rust-api/src/recipe_presets.rs) / [serialize_job_lora](apps/rust-api/src/lib.rs)).
5. Both worker resolvers scanned the dir with `first_safetensors_path` (unordered `read_dir`) and never consulted `files` ([image_jobs/base.rs](crates/sceneworks-worker/src/image_jobs/base.rs), [video_jobs.rs](crates/sceneworks-worker/src/video_jobs.rs)).

Net: generation re-scans the folder, bypassing the `files` guard. Since `-stepNNN` (`-`, 0x2D) sorts before `.safetensors` (`.`, 0x2E), a checkpoint is even the *likely* pick.

Found while closing sc-10214 (which family-scopes import folders — imports are unaffected: single file + isolated).

## Fix — honor the declared file; keep `installedPath` as the dir

- **Core** `resolve_adapter_in_dir(dir, declared)`: prefer the manifest-declared filename when it exists in the dir, else fall back to `first_safetensors_path`. `declared` is re-validated as a plain in-dir filename (no separators, no `.`/`..`) so a crafted `files` value can't redirect the load outside the record folder.
- **Worker**: image `resolve_adapters` and video `resolve_lora_file` (all 4 callers) pass the spec's declared filename (`declared_adapter_file`) into the resolver.
- **Server**: thread the manifest `files` list into the outgoing LoRA spec in both builders (`serialize_preset_lora`, `serialize_job_lora`); `normalize_inline_job_lora` already preserves it.

`installedPath` stays the **directory**, so deletion (`lora_artifact_paths`) still removes the whole folder incl. checkpoints. Records with no `files` (legacy / single-file imports) resolve via `first_safetensors_path` exactly as before.

## Scope

- Covers both image and video user-LoRA adapter loading. The other `first_safetensors_path` callers are import-time detection and single-file ControlNet-model resolution — not this hazard.
- No `installedPath` semantics change; no migration.

## Tests

- Core: `resolve_adapter_in_dir` — declared-preferred over a `-step250` sibling, no-`files`/missing-`files` fallback, and traversal + non-`.safetensors` rejection.
- Worker: `resolve_lora_file_prefers_declared_over_checkpoint`.
- Full core (392) / rust-api (200) / worker (672) lib suites green; `cargo fmt --check` + `clippy` clean; candle-backend worker build clean.

Note: I could not drive a live training run (>250 steps then generate) here; the fix is proven by the unit tests exercising the resolver against a real temp dir containing a checkpoint + final adapter.

Story: sc-10221 (epic 1084 — Model & LoRA Manifests). Follow-on to sc-10214 (#1259).

🤖 Generated with [Claude Code](https://claude.com/claude-code)