### PR TITLE
feat(image-editor): AI Edit LoRA support (sc-10254)

### DIFF
--- a/apps/web/src/imageJobs.js
+++ b/apps/web/src/imageJobs.js
@@ -35,6 +35,7 @@ export function buildEditJobBody({
   width,
   height,
   fitMode = "crop",
+  loras = null,
 }) {
   const body = {
     projectId: project.id,
@@ -54,6 +55,9 @@ export function buildEditJobBody({
     count: 1,
     advanced: {},
   };
+  // Style/subject LoRAs (sc-10254): serialized top-level, same shape + resolver the
+  // generation path uses (serializeLora → worker resolve_adapters). Omitted when empty.
+  if (loras && loras.length) body.loras = loras;
   // Inpaint mask (sc-2436): only sent for inpaint-capable models with a painted
   // region; the worker confines the edit to it. Omitted entirely otherwise.
   if (maskAssetId) body.maskAssetId = maskAssetId;

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -8,6 +8,8 @@ import { DEFAULT_MAC_CAPABILITIES, macFeatureBlock } from "../macGating.js";
 import { assetUrl, assetCanRenderAsImage } from "../components/assetMedia.jsx";
 import { DatasetAddDialog } from "../components/DatasetAddDialog.jsx";
 import { FitModeControl, effectiveFitMode } from "../components/FitModeControl.jsx";
+import { useLoraSelection } from "../components/LoraPickerField.jsx";
+import { MAX_JOB_LORAS_TOTAL } from "../presetUtils.js";
 import {
   BLEND_MODES,
   activeLayerOf,
@@ -607,6 +609,9 @@ export function ImageEditor() {
     editorLaunch = null,
     clearEditorLaunch,
     macCapabilities = DEFAULT_MAC_CAPABILITIES,
+    // Project LoRA catalog (sc-10254): fed to the AI Edit LoRA picker, gated to the
+    // edit model's compatible families.
+    loras = [],
     // Global theme (sc-10244): the redesign top-bar ☾/☀ toggle drives the app-wide
     // data-theme, not a screen-local override — consistent with the rest of the app.
     theme = "light",
@@ -747,6 +752,10 @@ export function ImageEditor() {
   // The chosen edit model + whether it accepts an inpaint mask (gates the mask tool).
   const selectedEditModel = editModels.find((model) => model.id === editModel) ?? null;
   const canMask = modelIsInpaintCapable(selectedEditModel);
+  // Style/subject LoRAs for the AI Edit tool (sc-10254). Same family-gated selection +
+  // serialization the studios use (useLoraSelection → serializeLora), threaded top-level
+  // into buildEditJobBody; the worker's edit streams apply them via resolve_adapters.
+  const editLoraSelection = useLoraSelection(loras, selectedEditModel);
   // Whether the edit model conditions on extra reference images (FLUX.2 multi-reference edit, sc-6107):
   // the manifest tags it `ui.multiReference`. Gates the reference picker; off-models hide it entirely.
   const multiRefCapable = Boolean(selectedEditModel?.ui?.multiReference);
@@ -2030,6 +2039,7 @@ export function ImageEditor() {
           width: outWidth,
           height: outHeight,
           fitMode,
+          loras: editLoraSelection.serializedLoras,
         }),
     });
   }
@@ -2659,6 +2669,63 @@ export function ImageEditor() {
     }
   };
 
+  const renderLoraSection = () => {
+    const { compatibleLoras, selectedLoraIds, toggleLora, weightFor, setWeight } = editLoraSelection;
+    const nextLora = compatibleLoras.find((lora) => !selectedLoraIds.includes(lora.id));
+    const addDisabled = !nextLora || selectedLoraIds.length >= MAX_JOB_LORAS_TOTAL;
+    return (
+      <div className="ie-section">
+        <div className="ie-sec-title">
+          LoRAs
+          <button
+            className="ie-btn sm ghost"
+            disabled={addDisabled}
+            onClick={() => nextLora && toggleLora(nextLora)}
+            style={{ height: "24px" }}
+            type="button"
+          >
+            + Add
+          </button>
+        </div>
+        {selectedLoraIds.length ? (
+          selectedLoraIds
+            .map((id) => compatibleLoras.find((lora) => lora.id === id))
+            .filter(Boolean)
+            .map((lora) => (
+              <div className="ie-lora" key={lora.id}>
+                <div className="ie-lora-top">
+                  <span className="ie-lora-name">{lora.name ?? lora.id}</span>
+                  <button className="ie-btn icon sm ghost" onClick={() => toggleLora(lora)} title="Remove" type="button">
+                    ✕
+                  </button>
+                </div>
+                <div className="ie-field">
+                  <div className="ie-field-top">
+                    <span className="ie-field-label" style={{ fontSize: "11.5px", color: "var(--ie-muted)" }}>
+                      Weight
+                    </span>
+                    <span className="ie-field-val">{weightFor(lora).toFixed(2)}</span>
+                  </div>
+                  <input
+                    aria-label={`${lora.name ?? lora.id} weight`}
+                    className="ie-range"
+                    max={2}
+                    min={0}
+                    onChange={(event) => setWeight(lora.id, Number(event.target.value))}
+                    step={0.05}
+                    type="range"
+                    value={weightFor(lora)}
+                  />
+                </div>
+              </div>
+            ))
+        ) : (
+          <p className="ie-note">No LoRAs applied. Add a style or subject LoRA to steer the edit.</p>
+        )}
+      </div>
+    );
+  };
+
   const renderEditPanel = () => {
     if (editModels.length === 0) {
       return (
@@ -2690,6 +2757,8 @@ export function ImageEditor() {
             />
           </div>
         </div>
+
+        {editLoraSelection.compatibleLoras.length ? renderLoraSection() : null}
 
         <div className="ie-section">
           <div className="ie-sec-title">Output</div>

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -1009,6 +1009,26 @@ describe("AI prompt edit", () => {
       buildEditJobBody({ ...base, referenceAssetIds: ["work_scratch", "ref_a"] }).referenceAssetIds,
     ).toEqual(["work_scratch", "ref_a"]);
   });
+
+  it("includes loras only when a non-empty list is supplied (sc-10254)", () => {
+    const base = {
+      project: { id: "p", name: "P" },
+      requestedGpu: "auto",
+      sourceAssetId: "a",
+      model: "flux2_dev",
+      prompt: "x",
+      width: 10,
+      height: 10,
+    };
+    // Omitted entirely by default and for an empty list (worker sees no loras key).
+    expect("loras" in buildEditJobBody(base)).toBe(false);
+    expect("loras" in buildEditJobBody({ ...base, loras: [] })).toBe(false);
+    // Passed through top-level (sibling of advanced), verbatim, when present.
+    const loras = [{ id: "l1", name: "Film Grain", weight: 0.8 }];
+    const body = buildEditJobBody({ ...base, loras });
+    expect(body.loras).toEqual(loras);
+    expect(body.advanced).toEqual({});
+  });
 });
 
 describe("reference conditioning (sc-6107)", () => {


### PR DESCRIPTION
## Summary

Adds the design-handoff **LoRAs** section to the AI Edit inspector (epic [10243](https://app.shortcut.com/trefry/epic/10243), story [sc-10254](https://app.shortcut.com/trefry/story/10254)) — a family-gated picker (**+ Add** / remove) with a per-LoRA weight slider, rendered as `.ie-lora` cards.

Reuses the existing studio contract end-to-end — nothing new invented:
- `useLoraSelection` (family gate via `loraMatchesModel`, `MAX_JOB_LORAS_TOTAL` cap) → `serializeLora` → a **top-level `loras`** array on the edit job body (sibling of `advanced`), the exact shape the generation path sends.
- The section hides entirely when the edit model has no compatible LoRAs (no clutter); `buildEditJobBody` omits `loras` unless non-empty.

## Platform coverage
- **macOS / MLX — fully functional, no worker change.** The DTO (`dto.rs` `loras`), API route (`generation.rs`), request struct (`image_request.rs`), and every MLX edit stream (sdxl / qwen / flux2 / base via `resolve_adapters`) already forward + apply top-level `loras` for `edit_image` jobs.
- **candle / Windows-CUDA — not yet.** The candle edit streams don't apply user LoRAs; tracked as the worker parity twin **[sc-10271](https://app.shortcut.com/trefry/story/10271)** (needs CUDA runtime verification — Windows-agent lane, like the epic 10043 candle twins / flux2 sc-10222).

## Verification
- eslint + `vite build` clean; full web suite **1313/1313** (added a `buildEditJobBody` loras test — omitted when empty, top-level & verbatim when present).
- Browser-checked the LoRAs section with a mock catalog: add, weight slider (0.80 default), remove — all render + wire per design.

## Files
- `apps/web/src/imageJobs.js` — `buildEditJobBody` accepts + forwards top-level `loras`.
- `apps/web/src/screens/ImageEditor.jsx` — LoRA picker section in AI Edit (reuses `useLoraSelection`), threaded into `runEdit`.
- `apps/web/src/screens/ImageEditor.test.jsx` — loras job-body test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)