### PR TITLE
feat(mcp): generate_image blocking tool with progress + inline image results (sc-10234)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5873,6 +5873,7 @@ name = "sceneworks-mcp"
 version = "0.2.0"
 dependencies = [
  "axum",
+ "base64 0.22.1",
  "reqwest 0.12.28",
  "rmcp",
  "serde",

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -12571,7 +12571,12 @@ async fn mcp_client_round_trips_catalog_tools_via_loopback_trust() {
     // Tool discovery.
     let tools = client.list_tools(None).await.expect("tools/list succeeds");
     let names: Vec<&str> = tools.tools.iter().map(|tool| tool.name.as_ref()).collect();
-    for expected in ["list_projects", "list_models", "list_loras"] {
+    for expected in [
+        "list_projects",
+        "list_models",
+        "list_loras",
+        "generate_image",
+    ] {
         assert!(
             names.contains(&expected),
             "missing tool {expected}: {names:?}"

--- a/crates/sceneworks-mcp/Cargo.toml
+++ b/crates/sceneworks-mcp/Cargo.toml
@@ -14,6 +14,9 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
+# Inline tool results: generated images come back as base64 `ImageContent` blocks
+# (sc-10234), so MCP clients can render them without another fetch.
+base64 = "0.22"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 # Pinned exact (sc-10233): the official MCP Rust SDK moves fast and its
 # streamable-HTTP server surface (StreamableHttpService / tool_router macros) has
@@ -23,6 +26,9 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 rmcp = { version = "=2.1.0", features = ["transport-streamable-http-server"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+# `time` for the blocking generate_image submit→poll wait (sc-10234); the async
+# runtime itself is the API app's (this crate is a library mounted into it).
+tokio = { version = "1.40", features = ["time"] }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/sceneworks-mcp/src/api_client.rs
+++ b/crates/sceneworks-mcp/src/api_client.rs
@@ -89,6 +89,42 @@ impl ApiClient {
                 request = request.query(&[(*key, value)]);
             }
         }
+        let response = self.send_checked(request).await?;
+        Ok(response.json::<Value>().await?)
+    }
+
+    /// POST a JSON `body` to `path` and decode the JSON response. Used by the
+    /// job-submitting tools (`POST /api/v1/image/jobs` → `JobSnapshot`).
+    pub async fn post_json(&self, path: &str, body: &Value) -> Result<Value, ApiClientError> {
+        let request = self
+            .client
+            .post(format!("{}{}", self.base_url, path))
+            .json(body);
+        let response = self.send_checked(request).await?;
+        Ok(response.json::<Value>().await?)
+    }
+
+    /// GET raw bytes from `path` (project media via
+    /// `GET /api/v1/projects/:id/files/*rel`). Returns the body plus the
+    /// response `Content-Type` (parameters stripped) when the server sent one.
+    pub async fn get_bytes(&self, path: &str) -> Result<(Vec<u8>, Option<String>), ApiClientError> {
+        let request = self.client.get(format!("{}{}", self.base_url, path));
+        let response = self.send_checked(request).await?;
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(|value| value.split(';').next().unwrap_or("").trim().to_owned())
+            .filter(|value| !value.is_empty());
+        Ok((response.bytes().await?.to_vec(), content_type))
+    }
+
+    /// Attach the auth header, send, and turn any non-2xx into
+    /// [`ApiClientError::Api`] carrying the body text (never the token).
+    async fn send_checked(
+        &self,
+        mut request: reqwest::RequestBuilder,
+    ) -> Result<reqwest::Response, ApiClientError> {
         if let Some(token) = &self.access_token {
             request = request.header("X-SceneWorks-Token", token);
         }
@@ -101,6 +137,6 @@ impl ApiClient {
                 .unwrap_or_else(|_| "request failed".to_owned());
             return Err(ApiClientError::Api { status, detail });
         }
-        Ok(response.json::<Value>().await?)
+        Ok(response)
     }
 }

--- a/crates/sceneworks-mcp/src/lib.rs
+++ b/crates/sceneworks-mcp/src/lib.rs
@@ -22,7 +22,7 @@ use rmcp::transport::streamable_http_server::{
 };
 
 pub use api_client::{ApiClient, ApiClientConfig};
-pub use server::SceneWorksMcp;
+pub use server::{JobWaitConfig, SceneWorksMcp};
 
 /// The concrete tower service type the API mounts at `/mcp`.
 pub type McpHttpService = StreamableHttpService<SceneWorksMcp, LocalSessionManager>;
@@ -37,9 +37,19 @@ pub type McpHttpService = StreamableHttpService<SceneWorksMcp, LocalSessionManag
 /// for `/mcp` is the surrounding `access_control` middleware — identical to
 /// every `/api/v1` route (sc-10233 acceptance).
 pub fn streamable_http_service(config: ApiClientConfig) -> McpHttpService {
+    streamable_http_service_with(config, JobWaitConfig::default())
+}
+
+/// [`streamable_http_service`] with an explicit blocking-job wait policy
+/// (generate_image's poll interval + overall deadline). Tests shrink both so
+/// submit→poll round trips run in milliseconds.
+pub fn streamable_http_service_with(
+    config: ApiClientConfig,
+    job_wait: JobWaitConfig,
+) -> McpHttpService {
     let api = ApiClient::new(config);
     StreamableHttpService::new(
-        move || Ok(SceneWorksMcp::new(api.clone())),
+        move || Ok(SceneWorksMcp::new(api.clone()).with_job_wait(job_wait.clone())),
         Arc::new(LocalSessionManager::default()),
         StreamableHttpServerConfig::default().disable_allowed_hosts(),
     )

--- a/crates/sceneworks-mcp/src/server.rs
+++ b/crates/sceneworks-mcp/src/server.rs
@@ -1,29 +1,66 @@
-//! The SceneWorks MCP tool surface (epic 10231, sc-10233).
+//! The SceneWorks MCP tool surface (epic 10231, sc-10233 catalog + sc-10234
+//! generate_image).
 //!
 //! `SceneWorksMcp` is the rmcp server/service struct: a `#[tool_router]` impl
 //! holds one method per MCP tool, and `#[tool_handler]` wires that router into
 //! the `ServerHandler` the streamable-HTTP transport serves. Every tool is a
 //! thin wrapper over an existing `/api/v1/*` route via [`ApiClient`] — later
-//! stories (generate_image, video tools) add methods to the `#[tool_router]`
-//! block, nothing else.
+//! stories (video tools …) add methods to the `#[tool_router]` block, nothing
+//! else.
 //!
 //! The catalog endpoints return large manifest-derived objects (multi-KB per
 //! model: downloads, footprints, platform notes …). Tools re-shape them into
 //! compact JSON an LLM can actually use — ids/names plus the values a job
 //! request needs — via the pure `compact_*` mappers below (unit-tested).
+//!
+//! `generate_image` (sc-10234) is the first BLOCKING job tool: it submits a
+//! real `POST /api/v1/image/jobs`, polls `GET /api/v1/jobs/:id` to a terminal
+//! status (relaying JobSnapshot progress as MCP progress notifications), then
+//! fetches the produced media through the project files route and returns it
+//! inline as base64 image content.
 
+use std::time::Duration;
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use rmcp::{
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
-    model::{CallToolResult, ContentBlock, ServerCapabilities, ServerInfo},
-    schemars, tool, tool_handler, tool_router, ErrorData, ServerHandler,
+    model::{
+        CallToolResult, ContentBlock, Meta, ProgressNotificationParam, ProgressToken,
+        ServerCapabilities, ServerInfo,
+    },
+    schemars,
+    service::RoleServer,
+    tool, tool_handler, tool_router, ErrorData, Peer, ServerHandler,
 };
-use serde_json::{Map, Value};
+use serde_json::{json, Map, Value};
 
 use crate::api_client::{ApiClient, ApiClientError};
+
+/// How the blocking job tools (generate_image) wait for a terminal JobSnapshot:
+/// poll `GET /api/v1/jobs/:id` every `poll_interval` until terminal, and give up
+/// with a clear tool error after `timeout` so a stuck job can never hang the MCP
+/// call forever. Tests shrink both; production uses the defaults.
+#[derive(Debug, Clone)]
+pub struct JobWaitConfig {
+    pub poll_interval: Duration,
+    pub timeout: Duration,
+}
+
+impl Default for JobWaitConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: Duration::from_secs(1),
+            // Generous: a cold first run legitimately spends minutes in
+            // `downloading`/`loading_model` before it ever renders.
+            timeout: Duration::from_secs(30 * 60),
+        }
+    }
+}
 
 #[derive(Clone)]
 pub struct SceneWorksMcp {
     api: ApiClient,
+    job_wait: JobWaitConfig,
     tool_router: ToolRouter<Self>,
 }
 
@@ -31,8 +68,15 @@ impl SceneWorksMcp {
     pub fn new(api: ApiClient) -> Self {
         Self {
             api,
+            job_wait: JobWaitConfig::default(),
             tool_router: Self::tool_router(),
         }
+    }
+
+    /// Override the blocking-job polling cadence/deadline (tests).
+    pub fn with_job_wait(mut self, job_wait: JobWaitConfig) -> Self {
+        self.job_wait = job_wait;
+        self
     }
 }
 
@@ -49,6 +93,58 @@ pub struct ListLorasArgs {
         description = "Also include LoRAs trained/imported in this project (by project id)."
     )]
     pub project_id: Option<String>,
+}
+
+/// Arguments for `generate_image`, mapped 1:1 onto the API's `ImageJobRequest`
+/// (`apps/rust-api/src/dto.rs`). Only the provided fields are sent, so the API's
+/// serde defaults stay authoritative — except `count`, which defaults to 1 here
+/// (the API's default of 4 is a web-UI batch size; 4 inline base64 images is a
+/// lot of tokens to return unasked).
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct GenerateImageArgs {
+    #[schemars(description = "Project to generate into (from list_projects).")]
+    pub project_id: String,
+    #[schemars(description = "The image prompt (1-4000 characters).")]
+    pub prompt: String,
+    #[schemars(
+        description = "\"generate\" (default, text-to-image) or \"edit_image\" (image-to-image; needs sourceAssetId or referenceAssetIds)."
+    )]
+    pub mode: Option<String>,
+    #[schemars(description = "Things to avoid in the image.")]
+    pub negative_prompt: Option<String>,
+    #[schemars(description = "Model id from list_models. Omit for the server default.")]
+    pub model: Option<String>,
+    #[schemars(description = "How many images to generate (1-8, default 1).")]
+    pub count: Option<u32>,
+    #[schemars(description = "Seed for reproducible output. Omit for random per-image seeds.")]
+    pub seed: Option<i64>,
+    #[schemars(description = "Output width in pixels (default 1024).")]
+    pub width: Option<u32>,
+    #[schemars(description = "Output height in pixels (default 1024).")]
+    pub height: Option<u32>,
+    #[schemars(description = "Style preset name (default \"cinematic\").")]
+    pub style_preset: Option<String>,
+    #[schemars(
+        description = "LoRA adapters to apply: [{\"id\": <from list_loras>, \"weight\": 0.0-2.0}]."
+    )]
+    pub loras: Option<Vec<Value>>,
+    #[schemars(description = "Character to condition on (character id).")]
+    pub character_id: Option<String>,
+    #[schemars(description = "Edit base image asset id (edit_image mode).")]
+    pub source_asset_id: Option<String>,
+    #[schemars(
+        description = "Reference image asset id for IP-Adapter style/identity conditioning."
+    )]
+    pub reference_asset_id: Option<String>,
+    #[schemars(
+        description = "Multi-image reference set for a multi-reference edit (each id jointly conditions the edit)."
+    )]
+    pub reference_asset_ids: Option<Vec<String>>,
+    #[schemars(
+        description = "Inpaint mask asset id (white = edit region; inpaint-capable models only)."
+    )]
+    pub mask_asset_id: Option<String>,
 }
 
 #[tool_router]
@@ -97,6 +193,177 @@ impl SceneWorksMcp {
             .map_err(api_error)?;
         json_result(compact_loras(&loras))
     }
+
+    #[tool(
+        description = "Generate images (or edit an existing image) and return them inline. Submits an image job, waits for it to finish (emitting progress notifications while it runs), and returns each generated image as base64 image content plus a JSON summary with the asset ids. Long-running: seconds to minutes depending on the model."
+    )]
+    async fn generate_image(
+        &self,
+        Parameters(args): Parameters<GenerateImageArgs>,
+        meta: Meta,
+        peer: Peer<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let body =
+            image_job_body(&args).map_err(|message| ErrorData::invalid_params(message, None))?;
+        let submitted = self
+            .api
+            .post_json("/api/v1/image/jobs", &body)
+            .await
+            .map_err(api_error)?;
+        let job_id = submitted
+            .get("id")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                ErrorData::internal_error("image job submission returned no job id", None)
+            })?
+            .to_owned();
+
+        // Progress notifications ride the client-supplied progressToken; without
+        // one we just poll silently (the spec forbids inventing a token).
+        let progress_token = meta.get_progress_token();
+        let mut reporter = ProgressReporter::new(peer, progress_token);
+        reporter.report(&submitted).await;
+
+        let started = tokio::time::Instant::now();
+        let job = loop {
+            tokio::time::sleep(self.job_wait.poll_interval).await;
+            let job = self
+                .api
+                .get_json(&format!("/api/v1/jobs/{job_id}"), &[])
+                .await
+                .map_err(api_error)?;
+            reporter.report(&job).await;
+            let status = job.get("status").and_then(Value::as_str).unwrap_or("");
+            match status {
+                "completed" => break job,
+                "failed" => {
+                    let detail = job
+                        .get("error")
+                        .and_then(Value::as_str)
+                        .filter(|error| !error.is_empty())
+                        .unwrap_or("the worker reported no error detail");
+                    return tool_error(format!("Image job {job_id} failed: {detail}"));
+                }
+                "canceled" => {
+                    return tool_error(format!(
+                        "Image job {job_id} was canceled before it finished."
+                    ));
+                }
+                "interrupted" => {
+                    return tool_error(format!(
+                        "Image job {job_id} was interrupted (worker restarted mid-run); \
+                         call generate_image again to retry."
+                    ));
+                }
+                _ => {}
+            }
+            if started.elapsed() >= self.job_wait.timeout {
+                return tool_error(format!(
+                    "Image job {job_id} did not reach a terminal state within {}s \
+                     (last status: {status}). The job may still be running; it was \
+                     not canceled.",
+                    self.job_wait.timeout.as_secs()
+                ));
+            }
+        };
+
+        // The job row is authoritative for the project id (mirrors the API).
+        let project_id = job
+            .get("projectId")
+            .and_then(Value::as_str)
+            .unwrap_or(&args.project_id)
+            .to_owned();
+        let assets: Vec<&Value> = job
+            .pointer("/result/assets")
+            .and_then(Value::as_array)
+            .map(|assets| {
+                assets
+                    .iter()
+                    .filter(|asset| is_image_asset(asset))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if assets.is_empty() {
+            return tool_error(format!(
+                "Image job {job_id} completed but reported no image assets."
+            ));
+        }
+
+        let mut blocks = Vec::with_capacity(assets.len() + 1);
+        let mut summary_assets = Vec::with_capacity(assets.len());
+        for asset in assets {
+            let Some(media_path) = asset_media_path(asset) else {
+                continue;
+            };
+            let (bytes, header_mime) = self
+                .api
+                .get_bytes(&format!("/api/v1/projects/{project_id}/files/{media_path}"))
+                .await
+                .map_err(api_error)?;
+            let mime_type = image_mime_type(
+                &media_path,
+                asset.pointer("/file/mimeType").and_then(Value::as_str),
+                header_mime.as_deref(),
+            );
+            summary_assets.push(json!({
+                "id": asset.get("id").cloned().unwrap_or(Value::Null),
+                "path": &media_path,
+                "mimeType": &mime_type,
+            }));
+            blocks.push(ContentBlock::image(BASE64.encode(&bytes), mime_type));
+        }
+        if blocks.is_empty() {
+            return tool_error(format!(
+                "Image job {job_id} completed but its assets carried no media paths."
+            ));
+        }
+        blocks.push(ContentBlock::json(json!({
+            "jobId": job_id,
+            "projectId": project_id,
+            "assets": summary_assets,
+        }))?);
+        Ok(CallToolResult::success(blocks))
+    }
+}
+
+/// Sends MCP progress notifications for JobSnapshot polls, deduplicated on
+/// (percent, stage) so a queued job doesn't spam identical updates. A `None`
+/// token (client sent no progressToken) makes every call a no-op. Notification
+/// failures are ignored — progress is advisory, never worth failing the job for.
+struct ProgressReporter {
+    peer: Peer<RoleServer>,
+    token: Option<ProgressToken>,
+    last: Option<(u32, String)>,
+}
+
+impl ProgressReporter {
+    fn new(peer: Peer<RoleServer>, token: Option<ProgressToken>) -> Self {
+        Self {
+            peer,
+            token,
+            last: None,
+        }
+    }
+
+    async fn report(&mut self, job: &Value) {
+        let Some(token) = &self.token else {
+            return;
+        };
+        let (percent, message) = job_progress(job);
+        let key = (percent, message.clone());
+        if self.last.as_ref() == Some(&key) {
+            return;
+        }
+        self.last = Some(key);
+        let _ = self
+            .peer
+            .notify_progress(
+                ProgressNotificationParam::new(token.clone(), f64::from(percent))
+                    .with_total(100.0)
+                    .with_message(message),
+            )
+            .await;
+    }
 }
 
 #[tool_handler(router = self.tool_router)]
@@ -120,6 +387,161 @@ fn json_result(value: Value) -> Result<CallToolResult, ErrorData> {
 /// includes the upstream status + detail, and never the token.
 fn api_error(error: ApiClientError) -> ErrorData {
     ErrorData::internal_error(error.to_string(), None)
+}
+
+/// A domain failure (failed/canceled job, timeout) as a tool-level error result
+/// — `isError: true` with a plain-text explanation — so the calling LLM sees a
+/// message it can react to, rather than a raw JSON-RPC protocol error.
+fn tool_error(message: String) -> Result<CallToolResult, ErrorData> {
+    Ok(CallToolResult::error(vec![ContentBlock::text(message)]))
+}
+
+/// Map `generate_image` args onto the `ImageJobRequest` wire shape (camelCase).
+/// Only provided fields are emitted so the API's serde defaults apply; `count`
+/// deliberately defaults to 1 (see [`GenerateImageArgs`]). The tool-facing
+/// `"generate"` mode maps to the API's `"text_to_image"`.
+pub(crate) fn image_job_body(args: &GenerateImageArgs) -> Result<Value, String> {
+    let mode = match args.mode.as_deref().map(str::trim).unwrap_or("generate") {
+        "" | "generate" | "text_to_image" => "text_to_image",
+        "edit_image" => "edit_image",
+        other => {
+            return Err(format!(
+                "unsupported mode \"{other}\": use \"generate\" or \"edit_image\""
+            ))
+        }
+    };
+    if mode == "edit_image"
+        && args.source_asset_id.is_none()
+        && args
+            .reference_asset_ids
+            .as_deref()
+            .map_or(true, |ids| ids.is_empty())
+    {
+        return Err(
+            "edit_image mode requires a sourceAssetId (or referenceAssetIds for a \
+             multi-reference edit)"
+                .to_owned(),
+        );
+    }
+    let mut body = Map::new();
+    body.insert("projectId".to_owned(), json!(args.project_id));
+    body.insert("mode".to_owned(), json!(mode));
+    body.insert("prompt".to_owned(), json!(args.prompt));
+    body.insert("count".to_owned(), json!(args.count.unwrap_or(1)));
+    let optional = [
+        (
+            "negativePrompt",
+            args.negative_prompt.as_ref().map(|v| json!(v)),
+        ),
+        ("model", args.model.as_ref().map(|v| json!(v))),
+        ("seed", args.seed.map(|v| json!(v))),
+        ("width", args.width.map(|v| json!(v))),
+        ("height", args.height.map(|v| json!(v))),
+        ("stylePreset", args.style_preset.as_ref().map(|v| json!(v))),
+        ("loras", args.loras.as_ref().map(|v| json!(v))),
+        ("characterId", args.character_id.as_ref().map(|v| json!(v))),
+        (
+            "sourceAssetId",
+            args.source_asset_id.as_ref().map(|v| json!(v)),
+        ),
+        (
+            "referenceAssetId",
+            args.reference_asset_id.as_ref().map(|v| json!(v)),
+        ),
+        (
+            "referenceAssetIds",
+            args.reference_asset_ids.as_ref().map(|v| json!(v)),
+        ),
+        ("maskAssetId", args.mask_asset_id.as_ref().map(|v| json!(v))),
+    ];
+    for (key, value) in optional {
+        if let Some(value) = value {
+            body.insert(key.to_owned(), value);
+        }
+    }
+    Ok(Value::Object(body))
+}
+
+/// Keep an asset for the inline result: image-typed (or untyped legacy) records.
+fn is_image_asset(asset: &Value) -> bool {
+    match asset.get("type").and_then(Value::as_str) {
+        Some(media_type) => media_type == "image",
+        None => true,
+    }
+}
+
+/// The project-relative media path of a result asset, normalized for the
+/// `/files/*relative_path` route: prefers the sidecar's `file.path`, falls back
+/// to a top-level `path`, converts backslashes and strips any leading slash.
+pub(crate) fn asset_media_path(asset: &Value) -> Option<String> {
+    let path = asset
+        .pointer("/file/path")
+        .and_then(Value::as_str)
+        .or_else(|| asset.get("path").and_then(Value::as_str))?;
+    let normalized = path.replace('\\', "/");
+    let trimmed = normalized.trim_start_matches('/');
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_owned())
+    }
+}
+
+/// The mime type for an inline image block: the asset sidecar's recorded
+/// `file.mimeType` wins, then the file extension, then the file route's
+/// `Content-Type` header; `image/png` as the final fallback (the worker's own
+/// default). Non-image values are skipped — an ImageContent block must be
+/// renderable.
+pub(crate) fn image_mime_type(
+    path: &str,
+    sidecar_mime: Option<&str>,
+    header_mime: Option<&str>,
+) -> String {
+    if let Some(mime) = sidecar_mime.filter(|mime| mime.starts_with("image/")) {
+        return mime.to_owned();
+    }
+    let extension = path.rsplit('.').next().unwrap_or("").to_ascii_lowercase();
+    let from_extension = match extension.as_str() {
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "webp" => Some("image/webp"),
+        "gif" => Some("image/gif"),
+        "bmp" => Some("image/bmp"),
+        _ => None,
+    };
+    if let Some(mime) = from_extension {
+        return mime.to_owned();
+    }
+    if let Some(mime) = header_mime.filter(|mime| mime.starts_with("image/")) {
+        return mime.to_owned();
+    }
+    "image/png".to_owned()
+}
+
+/// (percent 0..=100, human message) for a JobSnapshot poll. `progress` is the
+/// contract's 0..1 fraction; the message is "stage" or "stage: message".
+pub(crate) fn job_progress(job: &Value) -> (u32, String) {
+    let fraction = job
+        .get("progress")
+        .and_then(Value::as_f64)
+        .unwrap_or(0.0)
+        .clamp(0.0, 1.0);
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let percent = (fraction * 100.0).round() as u32;
+    let stage = job
+        .get("stage")
+        .and_then(Value::as_str)
+        .filter(|stage| !stage.is_empty())
+        .unwrap_or("queued");
+    let message = job
+        .get("message")
+        .and_then(Value::as_str)
+        .filter(|message| !message.is_empty());
+    let message = match message {
+        Some(detail) => format!("{stage}: {detail}"),
+        None => stage.to_owned(),
+    };
+    (percent, message)
 }
 
 /// Map an API array response item-by-item; anything non-array (defensive — the
@@ -299,5 +721,162 @@ mod tests {
         assert_eq!(compact_projects(&detail), detail);
         assert_eq!(compact_models(&detail), detail);
         assert_eq!(compact_loras(&detail), detail);
+    }
+
+    // -----------------------------------------------------------------------
+    // generate_image (sc-10234): args → ImageJobRequest mapping.
+    // -----------------------------------------------------------------------
+
+    fn args_from(value: Value) -> GenerateImageArgs {
+        serde_json::from_value(value).expect("args deserialize")
+    }
+
+    #[test]
+    fn image_job_body_maps_every_optional_field() {
+        let args = args_from(json!({
+            "projectId": "p1",
+            "prompt": "a city at night",
+            "mode": "edit_image",
+            "negativePrompt": "blurry",
+            "model": "z_image_turbo",
+            "count": 3,
+            "seed": 42,
+            "width": 1280,
+            "height": 768,
+            "stylePreset": "photoreal",
+            "loras": [{ "id": "lora1", "weight": 0.8 }],
+            "characterId": "char1",
+            "sourceAssetId": "asset_src",
+            "referenceAssetId": "asset_ref",
+            "referenceAssetIds": ["asset_r1", "asset_r2"],
+            "maskAssetId": "asset_mask"
+        }));
+        assert_eq!(
+            image_job_body(&args).expect("body builds"),
+            json!({
+                "projectId": "p1",
+                "mode": "edit_image",
+                "prompt": "a city at night",
+                "count": 3,
+                "negativePrompt": "blurry",
+                "model": "z_image_turbo",
+                "seed": 42,
+                "width": 1280,
+                "height": 768,
+                "stylePreset": "photoreal",
+                "loras": [{ "id": "lora1", "weight": 0.8 }],
+                "characterId": "char1",
+                "sourceAssetId": "asset_src",
+                "referenceAssetId": "asset_ref",
+                "referenceAssetIds": ["asset_r1", "asset_r2"],
+                "maskAssetId": "asset_mask"
+            })
+        );
+    }
+
+    #[test]
+    fn image_job_body_minimal_defaults_to_text_to_image_count_1() {
+        // Absent optionals must be OMITTED (the API's serde defaults are
+        // authoritative), except count where the MCP default is 1.
+        let args = args_from(json!({ "projectId": "p1", "prompt": "hi" }));
+        assert_eq!(
+            image_job_body(&args).expect("body builds"),
+            json!({
+                "projectId": "p1",
+                "mode": "text_to_image",
+                "prompt": "hi",
+                "count": 1
+            })
+        );
+    }
+
+    #[test]
+    fn image_job_body_maps_generate_mode_to_text_to_image() {
+        let args = args_from(json!({ "projectId": "p1", "prompt": "hi", "mode": "generate" }));
+        let body = image_job_body(&args).expect("body builds");
+        assert_eq!(body["mode"], "text_to_image");
+    }
+
+    #[test]
+    fn image_job_body_rejects_unknown_mode() {
+        let args =
+            args_from(json!({ "projectId": "p1", "prompt": "hi", "mode": "style_variations" }));
+        let error = image_job_body(&args).expect_err("unknown mode rejected");
+        assert!(error.contains("style_variations"), "{error}");
+    }
+
+    #[test]
+    fn image_job_body_rejects_edit_without_a_source() {
+        let args = args_from(json!({ "projectId": "p1", "prompt": "hi", "mode": "edit_image" }));
+        let error = image_job_body(&args).expect_err("sourceless edit rejected");
+        assert!(error.contains("sourceAssetId"), "{error}");
+
+        // ... but a multi-reference edit (no sourceAssetId) is valid.
+        let args = args_from(json!({
+            "projectId": "p1",
+            "prompt": "hi",
+            "mode": "edit_image",
+            "referenceAssetIds": ["asset_r1"]
+        }));
+        assert!(image_job_body(&args).is_ok());
+    }
+
+    // -----------------------------------------------------------------------
+    // generate_image (sc-10234): result asset → file fetch mapping.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn asset_media_path_prefers_file_path_and_normalizes() {
+        // The persisted sidecar shape: the path lives at file.path.
+        let sidecar = json!({ "id": "a1", "file": { "path": "assets/images/g1/img_0001.png" } });
+        assert_eq!(
+            asset_media_path(&sidecar).as_deref(),
+            Some("assets/images/g1/img_0001.png")
+        );
+        // Fallback to a top-level path; backslashes and a leading slash normalize.
+        let flat = json!({ "path": "\\assets\\images\\g1\\img_0001.png" });
+        assert_eq!(
+            asset_media_path(&flat).as_deref(),
+            Some("assets/images/g1/img_0001.png")
+        );
+        assert_eq!(asset_media_path(&json!({ "id": "a1" })), None);
+        assert_eq!(asset_media_path(&json!({ "path": "/" })), None);
+    }
+
+    #[test]
+    fn image_mime_type_prefers_sidecar_then_extension_then_header() {
+        // Sidecar mimeType wins.
+        assert_eq!(
+            image_mime_type("assets/x.png", Some("image/webp"), Some("image/gif")),
+            "image/webp"
+        );
+        // A non-image sidecar value is ignored; extension decides.
+        assert_eq!(
+            image_mime_type("assets/x.jpg", Some("application/json"), None),
+            "image/jpeg"
+        );
+        assert_eq!(image_mime_type("assets/x.PNG", None, None), "image/png");
+        // No sidecar/extension signal → the response header.
+        assert_eq!(
+            image_mime_type("assets/x.bin", None, Some("image/webp")),
+            "image/webp"
+        );
+        // Nothing usable → the worker's png default.
+        assert_eq!(
+            image_mime_type("assets/x.bin", None, Some("text/html")),
+            "image/png"
+        );
+    }
+
+    #[test]
+    fn job_progress_scales_the_contract_fraction_to_percent() {
+        let job = json!({ "progress": 0.375, "stage": "generating", "message": "step 3/8" });
+        assert_eq!(job_progress(&job), (38, "generating: step 3/8".to_owned()));
+        // Missing fields degrade to a queued zero, and out-of-range clamps.
+        assert_eq!(job_progress(&json!({})), (0, "queued".to_owned()));
+        assert_eq!(
+            job_progress(&json!({ "progress": 7.5, "stage": "saving" })),
+            (100, "saving".to_owned())
+        );
     }
 }

--- a/crates/sceneworks-mcp/tests/generate_image_tool.rs
+++ b/crates/sceneworks-mcp/tests/generate_image_tool.rs
@@ -1,0 +1,528 @@
+//! generate_image round-trip tests (sc-10234): a REAL rmcp streamable-HTTP
+//! client calls the blocking tool against a stub `/api/v1` job pipeline —
+//! submit (`POST /image/jobs`) → scripted `GET /jobs/:id` polls → media bytes
+//! from `GET /projects/:id/files/*`. Covers the acceptance criteria end to end:
+//! inline base64 image results (all of them for `count > 1`), mid-call progress
+//! notifications on a client-supplied progressToken, and clear errors (never a
+//! hang) for failed / canceled / stuck jobs.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use axum::extract::{Path, State};
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use rmcp::handler::client::ClientHandler;
+use rmcp::model::{
+    CallToolRequestParams, ClientInfo, Meta, NumberOrString, ProgressNotificationParam,
+    ProgressToken,
+};
+use rmcp::service::{NotificationContext, RoleClient};
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::ServiceExt;
+use sceneworks_mcp::{ApiClientConfig, JobWaitConfig};
+use serde_json::{json, Value};
+
+const PNG_BYTES: &[u8] = b"fake-png-payload-0001";
+const JPG_BYTES: &[u8] = b"fake-jpeg-payload-0002";
+const PNG_PATH: &str = "assets/images/genset_1/img_0001.png";
+const JPG_PATH: &str = "assets/images/genset_1/img_0002.jpg";
+
+/// Scripted `/api/v1` job pipeline: the submit returns a queued JobSnapshot,
+/// then each `GET /jobs/:id` poll steps through `snapshots` (the last repeats,
+/// so a "stuck" script of `[running]` polls forever).
+#[derive(Clone)]
+struct StubState {
+    submitted: Arc<Mutex<Vec<Value>>>,
+    polls: Arc<Mutex<usize>>,
+    snapshots: Arc<Vec<Value>>,
+}
+
+fn snapshot(status: &str, progress: f64, stage: &str, extra: Value) -> Value {
+    let mut job = json!({
+        "id": "job-1",
+        "type": "image_generate",
+        "status": status,
+        "projectId": "p1",
+        "progress": progress,
+        "stage": stage,
+        "message": "",
+        "error": null,
+        "result": {}
+    });
+    if let (Some(job_obj), Some(extra_obj)) = (job.as_object_mut(), extra.as_object()) {
+        for (key, value) in extra_obj {
+            job_obj.insert(key.clone(), value.clone());
+        }
+    }
+    job
+}
+
+fn image_asset(id: &str, path: &str, mime: &str) -> Value {
+    // The persisted sidecar shape `persist_reported_assets` embeds in
+    // `result.assets` — media path + mime live under `file`.
+    json!({
+        "id": id,
+        "type": "image",
+        "file": { "path": path, "mimeType": mime }
+    })
+}
+
+fn stub_api_router(state: StubState) -> Router {
+    Router::new()
+        .route(
+            "/api/v1/image/jobs",
+            post(
+                |State(state): State<StubState>, Json(body): Json<Value>| async move {
+                    state.submitted.lock().unwrap().push(body);
+                    (
+                        StatusCode::CREATED,
+                        Json(snapshot("queued", 0.0, "queued", json!({}))),
+                    )
+                },
+            ),
+        )
+        .route(
+            "/api/v1/jobs/:job_id",
+            get(
+                |State(state): State<StubState>, Path(_job_id): Path<String>| async move {
+                    let index = {
+                        let mut polls = state.polls.lock().unwrap();
+                        let index = *polls;
+                        *polls += 1;
+                        index
+                    };
+                    let clamped = index.min(state.snapshots.len() - 1);
+                    Json(state.snapshots[clamped].clone())
+                },
+            ),
+        )
+        .route(
+            "/api/v1/projects/:project_id/files/*relative_path",
+            get(
+                |Path((_project_id, relative_path)): Path<(String, String)>| async move {
+                    let (bytes, mime) = match relative_path.as_str() {
+                        PNG_PATH => (PNG_BYTES, "image/png"),
+                        JPG_PATH => (JPG_BYTES, "image/jpeg"),
+                        _ => return Err(StatusCode::NOT_FOUND),
+                    };
+                    let mut headers = HeaderMap::new();
+                    headers.insert(header::CONTENT_TYPE, mime.parse().unwrap());
+                    Ok((headers, bytes.to_vec()))
+                },
+            ),
+        )
+        .with_state(state)
+}
+
+async fn spawn(router: Router) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind stub listener");
+    let addr = listener.local_addr().expect("stub addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+    format!("http://{addr}")
+}
+
+/// A minimal MCP client handler that records every progress notification the
+/// server pushes mid-call.
+#[derive(Clone, Default)]
+struct RecordingClient {
+    progress: Arc<Mutex<Vec<ProgressNotificationParam>>>,
+}
+
+impl ClientHandler for RecordingClient {
+    fn get_info(&self) -> ClientInfo {
+        ClientInfo::default()
+    }
+
+    fn on_progress(
+        &self,
+        params: ProgressNotificationParam,
+        _context: NotificationContext<RoleClient>,
+    ) -> impl std::future::Future<Output = ()> + Send + '_ {
+        self.progress.lock().unwrap().push(params);
+        std::future::ready(())
+    }
+}
+
+struct Harness {
+    client: rmcp::service::RunningService<RoleClient, RecordingClient>,
+    submitted: Arc<Mutex<Vec<Value>>>,
+    polls: Arc<Mutex<usize>>,
+    progress: Arc<Mutex<Vec<ProgressNotificationParam>>>,
+}
+
+/// Stub API + mounted MCP service (fast 10ms polls) + connected recording client.
+async fn harness(snapshots: Vec<Value>) -> Harness {
+    let state = StubState {
+        submitted: Arc::new(Mutex::new(Vec::new())),
+        polls: Arc::new(Mutex::new(0)),
+        snapshots: Arc::new(snapshots),
+    };
+    let submitted = state.submitted.clone();
+    let polls = state.polls.clone();
+    let api_base = spawn(stub_api_router(state)).await;
+    let mcp_service = sceneworks_mcp::streamable_http_service_with(
+        ApiClientConfig {
+            base_url: api_base,
+            access_token: None,
+        },
+        JobWaitConfig {
+            poll_interval: Duration::from_millis(10),
+            timeout: Duration::from_secs(10),
+        },
+    );
+    let mcp_base = spawn(Router::new().nest_service("/mcp", mcp_service)).await;
+
+    let handler = RecordingClient::default();
+    let progress = handler.progress.clone();
+    let transport = StreamableHttpClientTransport::from_config(
+        StreamableHttpClientTransportConfig::with_uri(format!("{mcp_base}/mcp")),
+    );
+    let client = handler
+        .serve(transport)
+        .await
+        .expect("MCP client initializes against the mounted /mcp service");
+    Harness {
+        client,
+        submitted,
+        polls,
+        progress,
+    }
+}
+
+fn generate_args(extra: Value) -> serde_json::Map<String, Value> {
+    let mut args = json!({ "projectId": "p1", "prompt": "a city at night" });
+    if let (Some(args_obj), Some(extra_obj)) = (args.as_object_mut(), extra.as_object()) {
+        for (key, value) in extra_obj {
+            args_obj.insert(key.clone(), value.clone());
+        }
+    }
+    args.as_object().expect("args are an object").clone()
+}
+
+fn call_with_progress_token(args: serde_json::Map<String, Value>) -> CallToolRequestParams {
+    let mut params = CallToolRequestParams::new("generate_image").with_arguments(args);
+    params.meta = Some(Meta::with_progress_token(ProgressToken(
+        NumberOrString::String("progress-tok-1".into()),
+    )));
+    params
+}
+
+fn error_text(result: &rmcp::model::CallToolResult) -> String {
+    result
+        .content
+        .iter()
+        .filter_map(|block| block.as_text())
+        .map(|text| text.text.clone())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[tokio::test]
+async fn happy_path_returns_inline_image_with_progress_notifications() {
+    let harness = harness(vec![
+        snapshot("queued", 0.0, "queued", json!({})),
+        snapshot(
+            "running",
+            0.5,
+            "generating",
+            json!({ "message": "step 4/8" }),
+        ),
+        snapshot(
+            "completed",
+            1.0,
+            "completed",
+            json!({ "result": { "assets": [image_asset("asset_1", PNG_PATH, "image/png")],
+                                "assetIds": ["asset_1"] } }),
+        ),
+    ])
+    .await;
+
+    let result = harness
+        .client
+        .call_tool(call_with_progress_token(generate_args(json!({
+            "negativePrompt": "blurry",
+            "model": "z_image_turbo",
+            "seed": 7,
+            "width": 1280,
+            "height": 768
+        }))))
+        .await
+        .expect("generate_image succeeds");
+    assert_ne!(result.is_error, Some(true), "unexpected error: {result:?}");
+
+    // Exactly one inline image + the trailing JSON summary block.
+    let images: Vec<_> = result
+        .content
+        .iter()
+        .filter_map(|block| block.as_image())
+        .collect();
+    assert_eq!(images.len(), 1, "one generated image: {result:?}");
+    assert_eq!(images[0].data, BASE64.encode(PNG_BYTES));
+    assert_eq!(images[0].mime_type, "image/png");
+    let summary: Value = serde_json::from_str(
+        &result
+            .content
+            .iter()
+            .rev()
+            .find_map(|block| block.as_text())
+            .expect("summary text block")
+            .text,
+    )
+    .expect("summary is JSON");
+    assert_eq!(summary["jobId"], "job-1");
+    assert_eq!(summary["assets"][0]["id"], "asset_1");
+    assert_eq!(summary["assets"][0]["path"], PNG_PATH);
+
+    // The submit body carried the mapped ImageJobRequest fields. (Clone out of
+    // the lock: guards must not be held across the cancel().await below.)
+    let submitted = harness.submitted.lock().unwrap().clone();
+    assert_eq!(submitted.len(), 1);
+    assert_eq!(submitted[0]["mode"], "text_to_image");
+    assert_eq!(submitted[0]["prompt"], "a city at night");
+    assert_eq!(submitted[0]["negativePrompt"], "blurry");
+    assert_eq!(submitted[0]["model"], "z_image_turbo");
+    assert_eq!(submitted[0]["seed"], 7);
+    assert_eq!(submitted[0]["width"], 1280);
+    assert_eq!(submitted[0]["height"], 768);
+    assert_eq!(submitted[0]["count"], 1);
+
+    // The tool actually polled to terminal (queued → running → completed).
+    assert!(*harness.polls.lock().unwrap() >= 3, "polled to terminal");
+
+    // Progress was observable mid-call on the supplied token, ending at 100%.
+    let progress = harness.progress.lock().unwrap().clone();
+    assert!(
+        progress.len() >= 2,
+        "expected mid-call progress notifications: {progress:?}"
+    );
+    // NOTE: rmcp's client layer (send_request_with_option) overwrites any
+    // caller-set progressToken with its own generated one, so we assert the
+    // notifications all ride ONE request token rather than a literal value.
+    let token = &progress[0].progress_token;
+    assert!(progress
+        .iter()
+        .all(|notification| notification.progress_token == *token));
+    assert!(progress
+        .iter()
+        .any(|notification| notification.message.as_deref() == Some("generating: step 4/8")));
+    assert_eq!(progress.last().unwrap().progress, 100.0);
+    assert_eq!(progress.last().unwrap().total, Some(100.0));
+
+    let _ = harness.client.cancel().await;
+}
+
+#[tokio::test]
+async fn count_greater_than_one_returns_every_image() {
+    let harness = harness(vec![
+        snapshot("running", 0.5, "generating", json!({})),
+        snapshot(
+            "completed",
+            1.0,
+            "completed",
+            json!({ "result": { "assets": [
+                image_asset("asset_1", PNG_PATH, "image/png"),
+                image_asset("asset_2", JPG_PATH, "image/jpeg"),
+            ] } }),
+        ),
+    ])
+    .await;
+
+    let result = harness
+        .client
+        .call_tool(
+            CallToolRequestParams::new("generate_image")
+                .with_arguments(generate_args(json!({ "count": 2 }))),
+        )
+        .await
+        .expect("generate_image succeeds");
+    assert_ne!(result.is_error, Some(true), "unexpected error: {result:?}");
+
+    let images: Vec<_> = result
+        .content
+        .iter()
+        .filter_map(|block| block.as_image())
+        .collect();
+    assert_eq!(images.len(), 2, "count=2 returns both images: {result:?}");
+    assert_eq!(images[0].data, BASE64.encode(PNG_BYTES));
+    assert_eq!(images[0].mime_type, "image/png");
+    assert_eq!(images[1].data, BASE64.encode(JPG_BYTES));
+    assert_eq!(images[1].mime_type, "image/jpeg");
+
+    assert_eq!(harness.submitted.lock().unwrap()[0]["count"], 2);
+
+    let _ = harness.client.cancel().await;
+}
+
+#[tokio::test]
+async fn failed_job_surfaces_the_worker_error_message() {
+    let harness = harness(vec![
+        snapshot("running", 0.2, "loading_model", json!({})),
+        snapshot(
+            "failed",
+            0.2,
+            "failed",
+            json!({ "error": "CUDA out of memory on gpu0" }),
+        ),
+    ])
+    .await;
+
+    let result = harness
+        .client
+        .call_tool(
+            CallToolRequestParams::new("generate_image").with_arguments(generate_args(json!({}))),
+        )
+        .await
+        .expect("tool call transports (the failure is a tool-level error)");
+    assert_eq!(
+        result.is_error,
+        Some(true),
+        "failed job must error: {result:?}"
+    );
+    let text = error_text(&result);
+    assert!(
+        text.contains("CUDA out of memory on gpu0"),
+        "error must carry the job's error message: {text}"
+    );
+    assert!(text.contains("job-1"), "error names the job: {text}");
+
+    let _ = harness.client.cancel().await;
+}
+
+#[tokio::test]
+async fn canceled_job_surfaces_clearly_not_as_a_hang() {
+    let harness = harness(vec![snapshot("canceled", 0.0, "canceled", json!({}))]).await;
+
+    let result = harness
+        .client
+        .call_tool(
+            CallToolRequestParams::new("generate_image").with_arguments(generate_args(json!({}))),
+        )
+        .await
+        .expect("tool call transports");
+    assert_eq!(
+        result.is_error,
+        Some(true),
+        "canceled job must error: {result:?}"
+    );
+    assert!(
+        error_text(&result).contains("canceled"),
+        "error must say the job was canceled: {result:?}"
+    );
+
+    let _ = harness.client.cancel().await;
+}
+
+#[tokio::test]
+async fn stuck_job_times_out_with_a_clear_error_instead_of_hanging() {
+    // The script never leaves `running`; the (test-shortened) overall deadline
+    // must turn that into a clear tool error, not an endless poll.
+    let state = StubState {
+        submitted: Arc::new(Mutex::new(Vec::new())),
+        polls: Arc::new(Mutex::new(0)),
+        snapshots: Arc::new(vec![snapshot("running", 0.5, "generating", json!({}))]),
+    };
+    let api_base = spawn(stub_api_router(state)).await;
+    let mcp_service = sceneworks_mcp::streamable_http_service_with(
+        ApiClientConfig {
+            base_url: api_base,
+            access_token: None,
+        },
+        JobWaitConfig {
+            poll_interval: Duration::from_millis(10),
+            timeout: Duration::from_millis(100),
+        },
+    );
+    let mcp_base = spawn(Router::new().nest_service("/mcp", mcp_service)).await;
+    let transport = StreamableHttpClientTransport::from_config(
+        StreamableHttpClientTransportConfig::with_uri(format!("{mcp_base}/mcp")),
+    );
+    let client = RecordingClient::default()
+        .serve(transport)
+        .await
+        .expect("MCP client initializes");
+
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("generate_image").with_arguments(generate_args(json!({}))),
+        )
+        .await
+        .expect("tool call transports");
+    assert_eq!(
+        result.is_error,
+        Some(true),
+        "stuck job must time out: {result:?}"
+    );
+    let text = error_text(&result);
+    assert!(
+        text.contains("did not reach a terminal state"),
+        "timeout must be explicit: {text}"
+    );
+
+    let _ = client.cancel().await;
+}
+
+#[tokio::test]
+async fn edit_image_mode_maps_and_threads_the_source_asset() {
+    let harness = harness(vec![snapshot(
+        "completed",
+        1.0,
+        "completed",
+        json!({ "result": { "assets": [image_asset("asset_1", PNG_PATH, "image/png")] } }),
+    )])
+    .await;
+
+    let result = harness
+        .client
+        .call_tool(
+            CallToolRequestParams::new("generate_image").with_arguments(generate_args(json!({
+                "mode": "edit_image",
+                "sourceAssetId": "asset_src",
+                "maskAssetId": "asset_mask"
+            }))),
+        )
+        .await
+        .expect("generate_image succeeds");
+    assert_ne!(result.is_error, Some(true), "unexpected error: {result:?}");
+
+    let submitted = harness.submitted.lock().unwrap().clone();
+    assert_eq!(submitted[0]["mode"], "edit_image");
+    assert_eq!(submitted[0]["sourceAssetId"], "asset_src");
+    assert_eq!(submitted[0]["maskAssetId"], "asset_mask");
+
+    let _ = harness.client.cancel().await;
+}
+
+#[tokio::test]
+async fn invalid_mode_is_rejected_before_submitting_a_job() {
+    let harness = harness(vec![snapshot("queued", 0.0, "queued", json!({}))]).await;
+
+    let outcome = harness
+        .client
+        .call_tool(
+            CallToolRequestParams::new("generate_image")
+                .with_arguments(generate_args(json!({ "mode": "style_variations" }))),
+        )
+        .await;
+    match outcome {
+        Err(_) => {}
+        Ok(result) => assert_eq!(
+            result.is_error,
+            Some(true),
+            "an unsupported mode must not look like success: {result:?}"
+        ),
+    }
+    assert!(
+        harness.submitted.lock().unwrap().is_empty(),
+        "no job may be submitted for an invalid mode"
+    );
+
+    let _ = harness.client.cancel().await;
+}


### PR DESCRIPTION
Story: https://app.shortcut.com/trefry/story/10234 (epic 10231 — SceneWorks MCP Server)

## What / why

Adds `generate_image`, the first blocking job tool on the MCP server scaffolded in #1265 (sc-10233): an MCP client can ask for an image and get it back **inline in the same tool call**, with progress observable while it renders.

- **Submit**: wraps `POST /api/v1/image/jobs` for both modes — tool-facing `"generate"` (mapped to the API's `text_to_image`) and `"edit_image"` — carrying the full `ImageJobRequest` optional surface (`apps/rust-api/src/dto.rs`): `negativePrompt`, `model`, `count`, `seed`, `width`/`height`, `stylePreset`, `loras`, `characterId`, `sourceAssetId`, `referenceAssetId`, `referenceAssetIds`, `maskAssetId`. Absent args are omitted from the wire body so the API's serde defaults stay authoritative; `count` deliberately defaults to **1** on the MCP side (the API's 4 is a web-UI batch size — 4 inline base64 images is a lot of tokens to return unasked). `edit_image` without a source (`sourceAssetId` or `referenceAssetIds`) is rejected up front as invalid params, before any job is created.
- **Wait**: polls `GET /api/v1/jobs/:id` to a terminal `JobStatus`, relaying each snapshot's `progress`/`stage`/`message` as MCP progress notifications on the request's client-supplied `progressToken` (`0..100`, deduplicated on percent+stage; skipped gracefully when no token is present — the spec forbids inventing one).
- **Return**: on `completed`, fetches every result asset's media (`result.assets[].file.path`) via `GET /api/v1/projects/:id/files/*rel` and returns **all** of them as base64 `ImageContent` blocks (mime: sidecar `file.mimeType` → file extension → response `Content-Type` → `image/png`), plus a trailing JSON summary block (`jobId`, asset ids/paths) so the model can reference the assets in follow-up calls (e.g. an edit).
- **Fail loudly, never hang**: `failed` surfaces the job's `error` message, `canceled`/`interrupted` say so explicitly — all as tool-level errors (`isError: true`) the LLM can react to. A configurable overall deadline (`JobWaitConfig`, default 1 s polls / 30 min timeout — cold runs legitimately spend minutes downloading/loading) turns a stuck job into a clear timeout error that names the job id and notes the job was not canceled.
- `ApiClient` grows `post_json` + `get_bytes` (auth/status handling factored into a shared `send_checked`); `streamable_http_service_with(config, JobWaitConfig)` lets tests shrink the polling to milliseconds while `streamable_http_service` keeps the production defaults (no rust-api call-site changes).

## Scope vs acceptance criteria

- ✅ `generate_image` from an MCP client returns a viewable image inline; progress is observable mid-call (integration-tested with a real rmcp streamable-HTTP client).
- ✅ Multi-image `count>1` returns all images (one `ImageContent` per asset, batch order preserved).
- ✅ Failed/canceled jobs return a clear error, not a hang (plus `interrupted` and an overall timeout).
- ✅ Both `generate` and `edit_image` modes; all listed optional inputs mapped to `ImageJobRequest`.

## Tests

- **Unit (8 new, `crates/sceneworks-mcp/src/server.rs`)**: args→`ImageJobRequest` mapping with every optional field (loras/character/source/reference(s)/mask), minimal-args defaults (`text_to_image`, count 1, absent fields omitted), `generate`→`text_to_image` alias, unknown-mode + sourceless-edit rejection, asset-path extraction/normalization (`file.path` vs `path`, backslashes, leading slash), mime precedence, JobSnapshot progress→percent mapping.
- **Integration (7 new, `crates/sceneworks-mcp/tests/generate_image_tool.rs`)**: real rmcp client against the mounted service with a scripted stub `/api/v1` job pipeline (10 ms polls): happy path (submit→queued→running→completed→base64 bytes verified, submit body verified, ≥3 polls, mid-call progress notifications ending at 100/100), `count=2` returns both images with correct mimes, failed job carries the worker error text, canceled job is explicit, stuck job times out with a clear error, `edit_image` threads source/mask, invalid mode rejected before any submit. NOTE: rmcp's client layer always injects its own generated `progressToken` per request, so the progress test asserts one consistent token rather than a caller-chosen literal.
- **rust-api**: tools/list round-trip assertion now includes `generate_image`.

## Verification

- `cargo fmt -p sceneworks-mcp -p sceneworks-rust-api -- --check` clean.
- `cargo clippy -p sceneworks-mcp -p sceneworks-rust-api --all-targets -- -D warnings` clean.
- `cargo test -p sceneworks-mcp`: 22/22 pass (13 unit + 7 generate_image integration + 2 scaffold round-trip).
- `cargo test -p sceneworks-rust-api --lib`: 189 passed; the 15 failures are the known pre-existing catalog install-state set (populated HF cache, sc-10259) — all 5 MCP tests pass, nothing new broken.
- Not exercised against a live worker/GPU in this PR (the API contract is fully stubbed); live end-to-end from a real MCP client is the natural epic-level validation once the tool ships.

## Follow-ups

- Cancel-propagation: if the MCP client cancels the request mid-wait, the tool's future is dropped but the server-side image job keeps running; forwarding a cancellation to `POST /api/v1/jobs/:id/cancel` would free the GPU sooner.
- `JobWaitConfig` is code-level only; env/Settings knobs (e.g. `SCENEWORKS_MCP_JOB_TIMEOUT`) could be exposed if real deployments need different deadlines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)