### PR TITLE
feat(image-editor): AI Edit Guidance field (sc-10275)

### DIFF
--- a/apps/web/src/imageJobs.js
+++ b/apps/web/src/imageJobs.js
@@ -36,7 +36,16 @@ export function buildEditJobBody({
   height,
   fitMode = "crop",
   loras = null,
+  guidanceScale = null,
 }) {
+  // Guidance override (sc-10275): only sent when the user set a finite value —
+  // otherwise omitted so the worker's per-family model default stands. The worker
+  // maps `advanced.guidanceScale` to `guidance` or, for true-CFG edit families
+  // (qwen/sdxl/flux2), `true_cfg` (base.rs resolve_guidance/resolve_true_cfg).
+  const advanced = {};
+  if (Number.isFinite(Number(guidanceScale)) && guidanceScale !== "" && guidanceScale != null) {
+    advanced.guidanceScale = Number(guidanceScale);
+  }
   const body = {
     projectId: project.id,
     projectName: project.name ?? null,
@@ -53,7 +62,7 @@ export function buildEditJobBody({
     fitMode,
     seed: seed == null || seed === "" ? null : Number(seed),
     count: 1,
-    advanced: {},
+    advanced,
   };
   // Style/subject LoRAs (sc-10254): serialized top-level, same shape + resolver the
   // generation path uses (serializeLora → worker resolve_adapters). Omitted when empty.

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -10,6 +10,7 @@ import { DatasetAddDialog } from "../components/DatasetAddDialog.jsx";
 import { FitModeControl, effectiveFitMode } from "../components/FitModeControl.jsx";
 import { useLoraSelection } from "../components/LoraPickerField.jsx";
 import { MAX_JOB_LORAS_TOTAL } from "../presetUtils.js";
+import { guidanceDefaultFromModel } from "../samplerOptions.js";
 import {
   BLEND_MODES,
   activeLayerOf,
@@ -713,6 +714,9 @@ export function ImageEditor() {
   const [editModel, setEditModel] = useState("");
   const [editPrompt, setEditPrompt] = useState("");
   const [editSeed, setEditSeed] = useState("");
+  // Guidance override (sc-10275): "" = use the edit model's default (shown as the
+  // input placeholder); a finite value rides advanced.guidanceScale.
+  const [editGuidance, setEditGuidance] = useState("");
   // Canvas-extend / outpaint (sc-2556): target output aspect (default "match" = the
   // working size) and how to fill it (crop trims, pad bars, outpaint generates).
   const [editAspect, setEditAspect] = useState("match");
@@ -2092,6 +2096,7 @@ export function ImageEditor() {
           height: outHeight,
           fitMode,
           loras: editLoraSelection.serializedLoras,
+          guidanceScale: editGuidance,
         }),
     });
   }
@@ -3100,19 +3105,36 @@ export function ImageEditor() {
         ) : null}
 
         <div className="ie-section">
-          <div className="ie-field">
-            <span className="ie-field-label" style={{ marginBottom: "2px" }}>
-              Seed
-            </span>
-            <input
-              className="ie-input"
-              min={0}
-              onChange={(event) => setEditSeed(event.target.value)}
-              placeholder="Random"
-              style={{ fontFamily: "var(--ie-mono)" }}
-              type="number"
-              value={editSeed}
-            />
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "10px" }}>
+            <div className="ie-field">
+              <span className="ie-field-label" style={{ marginBottom: "2px" }}>
+                Seed
+              </span>
+              <input
+                className="ie-input"
+                min={0}
+                onChange={(event) => setEditSeed(event.target.value)}
+                placeholder="Random"
+                style={{ fontFamily: "var(--ie-mono)" }}
+                type="number"
+                value={editSeed}
+              />
+            </div>
+            <div className="ie-field">
+              <span className="ie-field-label" style={{ marginBottom: "2px" }}>
+                Guidance
+              </span>
+              <input
+                className="ie-input"
+                min={0}
+                onChange={(event) => setEditGuidance(event.target.value)}
+                placeholder={guidanceDefaultFromModel(selectedEditModel)?.toString() ?? "Default"}
+                step={0.1}
+                style={{ fontFamily: "var(--ie-mono)" }}
+                type="number"
+                value={editGuidance}
+              />
+            </div>
           </div>
           <button className="ie-btn block primary" disabled={!editPrompt.trim() || !!aiOp} onClick={runEdit} type="button">
             {maskActive ? "Inpaint region" : "Generate edit"}

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -1029,6 +1029,25 @@ describe("AI prompt edit", () => {
     expect(body.loras).toEqual(loras);
     expect(body.advanced).toEqual({});
   });
+
+  it("sends advanced.guidanceScale only for a finite override (sc-10275)", () => {
+    const base = {
+      project: { id: "p", name: "P" },
+      requestedGpu: "auto",
+      sourceAssetId: "a",
+      model: "flux2_dev",
+      prompt: "x",
+      width: 10,
+      height: 10,
+    };
+    // Empty / null / non-numeric → omitted, so the model's per-family default stands.
+    expect(buildEditJobBody(base).advanced).toEqual({});
+    expect(buildEditJobBody({ ...base, guidanceScale: "" }).advanced).toEqual({});
+    expect(buildEditJobBody({ ...base, guidanceScale: null }).advanced).toEqual({});
+    // A finite value (number or numeric string) rides advanced.guidanceScale.
+    expect(buildEditJobBody({ ...base, guidanceScale: 3.5 }).advanced).toEqual({ guidanceScale: 3.5 });
+    expect(buildEditJobBody({ ...base, guidanceScale: "4" }).advanced).toEqual({ guidanceScale: 4 });
+  });
 });
 
 describe("reference conditioning (sc-6107)", () => {


### PR DESCRIPTION
## Summary

Wires the last mockup control in the redesigned AI Edit panel — a **Guidance** input beside Seed (2-col footer). Epic [10243](https://app.shortcut.com/trefry/epic/10243), story [sc-10275](https://app.shortcut.com/trefry/story/10275).

- **Empty = use the edit model's default** (shown as the input placeholder via `guidanceDefaultFromModel`); a finite value rides `advanced.guidanceScale`.
- **Verified real, not a dead control:** the worker already honors `advanced.guidanceScale` for `edit_image` — `base.rs` `resolve_guidance` / `resolve_true_cfg` map it to `guidance` or, for true-CFG families (qwen/sdxl/flux2), `true_cfg`. `advanced` is passed through for edits. Same knob the Image Studio guidance override uses.
- `buildEditJobBody` omits `advanced.guidanceScale` unless the override is finite, so the tuned model default stands by default.

## Verification
- eslint + `vite build` clean; full web suite **1314/1314** (added a `buildEditJobBody` guidance test — omitted when empty/null/non-numeric, set for a finite number or numeric string).
- Browser-checked the Seed + Guidance footer with a mock edit model (placeholder = model default 3.5).

## Files
- `apps/web/src/imageJobs.js` — `buildEditJobBody` accepts `guidanceScale`, sets `advanced.guidanceScale` when finite.
- `apps/web/src/screens/ImageEditor.jsx` — `editGuidance` state; Seed + Guidance 2-col footer; threaded into `runEdit`.
- `apps/web/src/screens/ImageEditor.test.jsx` — guidance job-body test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)