### PR TITLE
fix(worker): apply user LoRAs on candle Qwen-Image-Edit (sc-10271)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
@@ -310,7 +310,7 @@ async fn generate_candle_qwen_edit_stream(
     let repo = qwen_edit_candle_repo(request);
     // The lightx2v distill LoRA, lazily fetched into the HF cache — `QwenEdit` folds it into the MMDiT at
     // load (sc-6220). Empty for the production (multi-step true-CFG) variants.
-    let adapters: Vec<AdapterSpec> = if lightning {
+    let mut adapters: Vec<AdapterSpec> = if lightning {
         let lora = ensure_qwen_lightning_lora_cached(
             api,
             settings,
@@ -323,6 +323,11 @@ async fn generate_candle_qwen_edit_stream(
     } else {
         Vec::new()
     };
+    // User style/subject LoRAs (sc-10271): folded in alongside any built-in distill LoRA,
+    // mirroring the MLX twin (qwen.rs) — `QwenEdit` applies the whole adapter list at load.
+    // This closes the candle edit-LoRA gap for the Qwen-Image-Edit family; the SDXL / FLUX.2 /
+    // Z-Image candle edit engines still need an `adapters` field in candle-gen (tracked).
+    adapters.extend(resolve_adapters(request, settings)?);
     let mut raw_settings = qwen_edit_candle_raw_settings(request, &repo, steps, guidance);
     // Record the Lightning recipe for telemetry / A-B parity (matches the MLX `distillLora` key format).
     if lightning {


### PR DESCRIPTION
## Summary

Closes the candle (Windows/CUDA) edit-LoRA gap for the **Qwen-Image-Edit** family (epic [10243](https://app.shortcut.com/trefry/epic/10243), story [sc-10271](https://app.shortcut.com/trefry/story/10271)) — the parity twin of the merged AI Edit LoRA feature (sc-10254).

The candle edit streams didn't apply the AI Edit LoRA picker's `loras` (the API accepted them, but they were silently ignored at generation). For Qwen this is **worker-only**: `QwenEditPaths` already carries an `adapters` list (it folds the built-in Lightning distill LoRA at load), so I extend that vec with `resolve_adapters(request, settings)` — exactly mirroring the MLX twin (`qwen.rs:682`). `QwenEdit` applies the whole adapter list.

## Scope / follow-up
The other three candle edit engines can't apply user LoRAs yet — their candle-gen load structs have **no `adapters` field**:
- `SdxlEditPaths` (`candle_gen_sdxl::SdxlEdit`)
- `Flux2EditPaths` (`candle_gen_flux2::Flux2Edit`)
- `ZImageEditPaths` (`candle_gen_z_image::ZImageEdit`)

Adding LoRAs there needs an `adapters` field + fold-in logic **in the external candle-gen crate** plus the cross-repo pin-bump — filed as **[sc-10281](https://app.shortcut.com/trefry/story/10281)** (Windows-agent lane, CUDA runtime verification).

## Verification
- Compiles clean on the candle backend: `cargo check -p sceneworks-worker --no-default-features -F backend-candle --all-targets` → Finished, no warnings. `cargo fmt --check` clean.
- Runtime CUDA verification is out of reach on the macOS dev box — Windows-agent lane. The `parity` CI lane compile-checks candle/Linux.

## Files
- `crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs` — extend the adapter list with `resolve_adapters`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)