### PR TITLE
feat(mcp): video submit/poll tools + ticketed result links (sc-10235)

### DIFF
--- a/crates/sceneworks-mcp/src/api_client.rs
+++ b/crates/sceneworks-mcp/src/api_client.rs
@@ -75,6 +75,12 @@ impl ApiClient {
         }
     }
 
+    /// The normalized (no trailing slash) API base URL. `get_job_result` uses it
+    /// to hand back absolute ticketed media URLs a remote client can fetch.
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
     /// GET `path` (an absolute `/api/v1/...` path) with optional query pairs and
     /// decode the JSON body. Empty query values are skipped so optional tool
     /// arguments don't turn into `?modelFamily=` noise.

--- a/crates/sceneworks-mcp/src/server.rs
+++ b/crates/sceneworks-mcp/src/server.rs
@@ -1,12 +1,11 @@
 //! The SceneWorks MCP tool surface (epic 10231, sc-10233 catalog + sc-10234
-//! generate_image).
+//! generate_image + sc-10235 video submit/poll).
 //!
 //! `SceneWorksMcp` is the rmcp server/service struct: a `#[tool_router]` impl
 //! holds one method per MCP tool, and `#[tool_handler]` wires that router into
 //! the `ServerHandler` the streamable-HTTP transport serves. Every tool is a
 //! thin wrapper over an existing `/api/v1/*` route via [`ApiClient`] — later
-//! stories (video tools …) add methods to the `#[tool_router]` block, nothing
-//! else.
+//! stories add methods to the `#[tool_router]` block, nothing else.
 //!
 //! The catalog endpoints return large manifest-derived objects (multi-KB per
 //! model: downloads, footprints, platform notes …). Tools re-shape them into
@@ -18,6 +17,13 @@
 //! status (relaying JobSnapshot progress as MCP progress notifications), then
 //! fetches the produced media through the project files route and returns it
 //! inline as base64 image content.
+//!
+//! Video generation runs minutes and outlives a single blocking call, so
+//! sc-10235 adds a NON-blocking submit/poll trio instead: `submit_video_job`
+//! (`POST /api/v1/video/jobs` → job id + initial snapshot), `get_job_status`
+//! (a generic `GET /api/v1/jobs/:id` view usable for image jobs too), and
+//! `get_job_result` (ticketed download links via `POST /api/v1/files/ticket`
+//! — media bytes are never inlined for these).
 
 use std::time::Duration;
 
@@ -25,7 +31,7 @@ use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use rmcp::{
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
     model::{
-        CallToolResult, ContentBlock, Meta, ProgressNotificationParam, ProgressToken,
+        CallToolResult, ContentBlock, Meta, ProgressNotificationParam, ProgressToken, Resource,
         ServerCapabilities, ServerInfo,
     },
     schemars,
@@ -147,6 +153,77 @@ pub struct GenerateImageArgs {
     pub mask_asset_id: Option<String>,
 }
 
+/// Arguments for `submit_video_job`, mapped onto the API's `VideoJobRequest`
+/// (`apps/rust-api/src/dto.rs`). The tool exposes four task-level modes and maps
+/// them to the API's wire modes in [`video_job_body`]; only provided fields are
+/// sent so the API's serde defaults (duration 6s, 25fps, 768x512, ltx_2_3 …)
+/// stay authoritative.
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmitVideoJobArgs {
+    #[schemars(description = "Project to generate into (from list_projects).")]
+    pub project_id: String,
+    #[schemars(description = "The video prompt (1-4000 characters).")]
+    pub prompt: String,
+    #[schemars(
+        description = "\"generate\" (default: text-to-video, or image-to-video when sourceAssetId is set, or first/last-frame when lastFrameAssetId is also set), \"extend\" (continue a clip; needs sourceClipAssetId), \"bridge\" (fill between two clips; needs sourceClipAssetId + bridgeRightClipAssetId), or \"person_replace\" (swap a tracked person; needs sourceClipAssetId + personTrackId + characterId)."
+    )]
+    pub mode: Option<String>,
+    #[schemars(description = "Things to avoid in the video.")]
+    pub negative_prompt: Option<String>,
+    #[schemars(
+        description = "Video model id from list_models (type \"video\"). Omit for the server default."
+    )]
+    pub model: Option<String>,
+    #[schemars(description = "Clip length in seconds (1-30, default 6).")]
+    pub duration: Option<f64>,
+    #[schemars(description = "Frames per second (1-60, default 25).")]
+    pub fps: Option<u32>,
+    #[schemars(description = "Output width in pixels (256-1920, default 768).")]
+    pub width: Option<u32>,
+    #[schemars(description = "Output height in pixels (256-1920, default 512).")]
+    pub height: Option<u32>,
+    #[schemars(description = "Quality preset (\"draft\", \"balanced\" (default) or \"high\").")]
+    pub quality: Option<String>,
+    #[schemars(description = "Seed for reproducible output. Omit for a random seed.")]
+    pub seed: Option<i64>,
+    #[schemars(
+        description = "LoRA adapters to apply: [{\"id\": <from list_loras>, \"weight\": 0.0-2.0}]."
+    )]
+    pub loras: Option<Vec<Value>>,
+    #[schemars(
+        description = "Character to condition on (character id; required for person_replace)."
+    )]
+    pub character_id: Option<String>,
+    #[schemars(description = "Starting image asset id (generate mode: makes it image-to-video).")]
+    pub source_asset_id: Option<String>,
+    #[schemars(
+        description = "Ending image asset id (generate mode: with sourceAssetId, makes it a first/last-frame generation)."
+    )]
+    pub last_frame_asset_id: Option<String>,
+    #[schemars(
+        description = "Source video clip asset id (extend: the clip to continue; bridge: the LEFT clip; person_replace: the clip to edit)."
+    )]
+    pub source_clip_asset_id: Option<String>,
+    #[schemars(description = "RIGHT video clip asset id for bridge mode.")]
+    pub bridge_right_clip_asset_id: Option<String>,
+    #[schemars(description = "Person track id to replace (person_replace mode).")]
+    pub person_track_id: Option<String>,
+    #[schemars(description = "person_replace scope: \"face_only\" (default) or \"full_body\".")]
+    pub replacement_mode: Option<String>,
+}
+
+/// Arguments for the generic job-polling tools (`get_job_status` /
+/// `get_job_result`) — they work for any job type (video AND image).
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct JobIdArgs {
+    #[schemars(
+        description = "The job id returned by submit_video_job (or any other job-submitting call)."
+    )]
+    pub job_id: String,
+}
+
 #[tool_router]
 impl SceneWorksMcp {
     #[tool(
@@ -237,11 +314,7 @@ impl SceneWorksMcp {
             match status {
                 "completed" => break job,
                 "failed" => {
-                    let detail = job
-                        .get("error")
-                        .and_then(Value::as_str)
-                        .filter(|error| !error.is_empty())
-                        .unwrap_or("the worker reported no error detail");
+                    let detail = job_error_detail(&job);
                     return tool_error(format!("Image job {job_id} failed: {detail}"));
                 }
                 "canceled" => {
@@ -324,6 +397,200 @@ impl SceneWorksMcp {
         }))?);
         Ok(CallToolResult::success(blocks))
     }
+
+    #[tool(
+        description = "Submit a video generation job WITHOUT waiting for it (video renders for minutes). Modes: \"generate\" (text-to-video; add sourceAssetId for image-to-video, plus lastFrameAssetId for first/last-frame), \"extend\" (continue a clip), \"bridge\" (fill between two clips), \"person_replace\" (swap a tracked person for a Character). Returns the job id + initial snapshot; poll get_job_status, then fetch links with get_job_result once completed."
+    )]
+    async fn submit_video_job(
+        &self,
+        Parameters(args): Parameters<SubmitVideoJobArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let body =
+            video_job_body(&args).map_err(|message| ErrorData::invalid_params(message, None))?;
+        let job = self
+            .api
+            .post_json("/api/v1/video/jobs", &body)
+            .await
+            .map_err(api_error)?;
+        if job.get("id").and_then(Value::as_str).is_none() {
+            return Err(ErrorData::internal_error(
+                "video job submission returned no job id",
+                None,
+            ));
+        }
+        let mut snapshot = compact_job_status(&job);
+        if let Some(out) = snapshot.as_object_mut() {
+            out.insert(
+                "next".to_owned(),
+                json!(
+                    "Video jobs run for minutes. Poll get_job_status with this jobId; \
+                     once status is \"completed\", call get_job_result for download links."
+                ),
+            );
+        }
+        json_result(snapshot)
+    }
+
+    #[tool(
+        description = "Get the current status of a submitted job (works for video AND image jobs): status (queued/running/completed/failed/canceled/interrupted), stage, progressPercent, etaSeconds, and the error message when the job failed."
+    )]
+    async fn get_job_status(
+        &self,
+        Parameters(args): Parameters<JobIdArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let job_id = valid_job_id(&args.job_id)
+            .map_err(|message| ErrorData::invalid_params(message, None))?;
+        let job = self
+            .api
+            .get_json(&format!("/api/v1/jobs/{job_id}"), &[])
+            .await
+            .map_err(api_error)?;
+        json_result(compact_job_status(&job))
+    }
+
+    #[tool(
+        description = "Fetch the result of a COMPLETED job (video or image) as downloadable links. Mints a short-lived media ticket and returns one resource link per result asset — the URL works from any machine that can reach the SceneWorks API (no auth header needed while the ticket is valid). Video/image bytes are never inlined by this tool. If the job is still running it reports ready=false; if it failed, the job error."
+    )]
+    async fn get_job_result(
+        &self,
+        Parameters(args): Parameters<JobIdArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let job_id = valid_job_id(&args.job_id)
+            .map_err(|message| ErrorData::invalid_params(message, None))?;
+        let job = self
+            .api
+            .get_json(&format!("/api/v1/jobs/{job_id}"), &[])
+            .await
+            .map_err(api_error)?;
+        match job.get("status").and_then(Value::as_str).unwrap_or("") {
+            "completed" => {}
+            "failed" => {
+                let detail = job_error_detail(&job);
+                return tool_error(format!("Job {job_id} failed: {detail}"));
+            }
+            "canceled" => {
+                return tool_error(format!("Job {job_id} was canceled before it finished."));
+            }
+            "interrupted" => {
+                return tool_error(format!(
+                    "Job {job_id} was interrupted (worker restarted mid-run); resubmit it."
+                ));
+            }
+            // Not terminal yet: a clear ready=false answer, NOT an error — the
+            // caller simply keeps polling get_job_status.
+            _ => {
+                let mut snapshot = compact_job_status(&job);
+                if let Some(out) = snapshot.as_object_mut() {
+                    out.insert("ready".to_owned(), json!(false));
+                    out.insert(
+                        "note".to_owned(),
+                        json!(
+                            "The job has not completed yet — keep polling get_job_status \
+                             and call get_job_result again once status is \"completed\"."
+                        ),
+                    );
+                }
+                return json_result(snapshot);
+            }
+        }
+
+        let Some(project_id) = job
+            .get("projectId")
+            .and_then(Value::as_str)
+            .filter(|id| !id.is_empty())
+        else {
+            return tool_error(format!(
+                "Job {job_id} completed but carries no project id, so its files \
+                 cannot be located."
+            ));
+        };
+        let assets: Vec<(&Value, String)> = job
+            .pointer("/result/assets")
+            .and_then(Value::as_array)
+            .map(|assets| {
+                assets
+                    .iter()
+                    .filter_map(|asset| asset_media_path(asset).map(|path| (asset, path)))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if assets.is_empty() {
+            return tool_error(format!(
+                "Job {job_id} completed but reported no downloadable result assets."
+            ));
+        }
+
+        // One sliding multi-use media ticket covers every link (sc-8810 flavor):
+        // it authorizes GET /api/v1/projects/:id/files/* via `?ticket=` with no
+        // auth header, so the URL is fetchable from any machine that can reach
+        // the API — exactly what a remote MCP client needs.
+        let ticket_response = self
+            .api
+            .post_json("/api/v1/files/ticket", &json!({}))
+            .await
+            .map_err(api_error)?;
+        let Some(ticket) = ticket_response
+            .get("ticket")
+            .and_then(Value::as_str)
+            .filter(|ticket| !ticket.is_empty())
+        else {
+            return Err(ErrorData::internal_error(
+                "the media ticket endpoint returned no ticket",
+                None,
+            ));
+        };
+        let expires_in_seconds = ticket_response.get("expiresInSeconds").cloned();
+
+        let mut blocks = Vec::with_capacity(assets.len() + 1);
+        let mut summary_assets = Vec::with_capacity(assets.len());
+        for (asset, media_path) in assets {
+            let relative_url =
+                format!("/api/v1/projects/{project_id}/files/{media_path}?ticket={ticket}");
+            let url = format!("{}{relative_url}", self.api.base_url());
+            let mime_type = media_mime_type(
+                &media_path,
+                asset.pointer("/file/mimeType").and_then(Value::as_str),
+            );
+            let name = media_path
+                .rsplit('/')
+                .next()
+                .filter(|name| !name.is_empty())
+                .unwrap_or(&media_path)
+                .to_owned();
+            let mut link = Resource::new(&url, name).with_description(format!(
+                "SceneWorks {} asset {} from job {job_id}",
+                asset.get("type").and_then(Value::as_str).unwrap_or("media"),
+                asset.get("id").and_then(Value::as_str).unwrap_or("?"),
+            ));
+            if let Some(mime) = &mime_type {
+                link = link.with_mime_type(mime);
+            }
+            blocks.push(ContentBlock::resource_link(link));
+            summary_assets.push(json!({
+                "id": asset.get("id").cloned().unwrap_or(Value::Null),
+                "type": asset.get("type").cloned().unwrap_or(Value::Null),
+                "mimeType": mime_type,
+                "url": url,
+                "relativeUrl": relative_url,
+            }));
+        }
+        blocks.push(ContentBlock::json(json!({
+            "jobId": job_id,
+            "projectId": project_id,
+            "status": "completed",
+            "assets": summary_assets,
+            "ticketExpiresInSeconds": expires_in_seconds,
+            "note": format!(
+                "Each url embeds a short-lived media ticket — download promptly \
+                 (call get_job_result again for fresh links). The urls use the \
+                 SceneWorks API base \"{}\"; if that host is not reachable from \
+                 your machine, apply relativeUrl to the base you use to reach \
+                 this MCP server (everything before /mcp).",
+                self.api.base_url()
+            ),
+        }))?);
+        Ok(CallToolResult::success(blocks))
+    }
 }
 
 /// Sends MCP progress notifications for JobSnapshot polls, deduplicated on
@@ -372,7 +639,10 @@ impl ServerHandler for SceneWorksMcp {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build()).with_instructions(
             "SceneWorks local generation studio. Use list_projects for project ids, \
              list_models for the generation model catalog (model ids + job defaults), and \
-             list_loras for LoRA adapters compatible with a model family.",
+             list_loras for LoRA adapters compatible with a model family. generate_image \
+             blocks until the images are ready; video runs minutes, so use \
+             submit_video_job, poll get_job_status, then get_job_result for ticketed \
+             download links (get_job_status/get_job_result work for image jobs too).",
         )
     }
 }
@@ -460,6 +730,213 @@ pub(crate) fn image_job_body(args: &GenerateImageArgs) -> Result<Value, String> 
         }
     }
     Ok(Value::Object(body))
+}
+
+/// Map `submit_video_job` args onto the `VideoJobRequest` wire shape
+/// (camelCase). The tool's four task-level modes map to the API's wire modes —
+/// `generate` picks `text_to_video` / `image_to_video` / `first_last_frame`
+/// from the provided image assets — and the mode-specific required assets are
+/// checked here so a bad call fails fast with a precise message instead of a
+/// submitted-then-rejected job. Only provided optional fields are emitted so
+/// the API's serde defaults stay authoritative.
+pub(crate) fn video_job_body(args: &SubmitVideoJobArgs) -> Result<Value, String> {
+    let mode = match args.mode.as_deref().map(str::trim).unwrap_or("generate") {
+        "" | "generate" => {
+            if args.last_frame_asset_id.is_some() {
+                if args.source_asset_id.is_none() {
+                    return Err(
+                        "generate mode with a lastFrameAssetId also needs a sourceAssetId \
+                         (the first frame)"
+                            .to_owned(),
+                    );
+                }
+                "first_last_frame"
+            } else if args.source_asset_id.is_some() {
+                "image_to_video"
+            } else {
+                "text_to_video"
+            }
+        }
+        "extend" => {
+            if args.source_clip_asset_id.is_none() {
+                return Err(
+                    "extend mode requires a sourceClipAssetId (the clip to continue)".to_owned(),
+                );
+            }
+            "extend_clip"
+        }
+        "bridge" => {
+            if args.source_clip_asset_id.is_none() || args.bridge_right_clip_asset_id.is_none() {
+                return Err(
+                    "bridge mode requires a sourceClipAssetId (left clip) and a \
+                     bridgeRightClipAssetId (right clip)"
+                        .to_owned(),
+                );
+            }
+            "video_bridge"
+        }
+        "person_replace" => {
+            if args.source_clip_asset_id.is_none() {
+                return Err(
+                    "person_replace mode requires a sourceClipAssetId (the clip to edit)"
+                        .to_owned(),
+                );
+            }
+            if args.person_track_id.is_none() {
+                return Err(
+                    "person_replace mode requires a personTrackId (the person to replace)"
+                        .to_owned(),
+                );
+            }
+            if args.character_id.is_none() {
+                return Err(
+                    "person_replace mode requires a characterId (the replacement Character)"
+                        .to_owned(),
+                );
+            }
+            "replace_person"
+        }
+        other => {
+            return Err(format!(
+                "unsupported mode \"{other}\": use \"generate\", \"extend\", \"bridge\" or \
+                 \"person_replace\""
+            ))
+        }
+    };
+    let mut body = Map::new();
+    body.insert("projectId".to_owned(), json!(args.project_id));
+    body.insert("mode".to_owned(), json!(mode));
+    body.insert("prompt".to_owned(), json!(args.prompt));
+    let optional = [
+        (
+            "negativePrompt",
+            args.negative_prompt.as_ref().map(|v| json!(v)),
+        ),
+        ("model", args.model.as_ref().map(|v| json!(v))),
+        ("duration", args.duration.map(|v| json!(v))),
+        ("fps", args.fps.map(|v| json!(v))),
+        ("width", args.width.map(|v| json!(v))),
+        ("height", args.height.map(|v| json!(v))),
+        ("quality", args.quality.as_ref().map(|v| json!(v))),
+        ("seed", args.seed.map(|v| json!(v))),
+        ("loras", args.loras.as_ref().map(|v| json!(v))),
+        ("characterId", args.character_id.as_ref().map(|v| json!(v))),
+        (
+            "sourceAssetId",
+            args.source_asset_id.as_ref().map(|v| json!(v)),
+        ),
+        (
+            "lastFrameAssetId",
+            args.last_frame_asset_id.as_ref().map(|v| json!(v)),
+        ),
+        (
+            "sourceClipAssetId",
+            args.source_clip_asset_id.as_ref().map(|v| json!(v)),
+        ),
+        (
+            "bridgeRightClipAssetId",
+            args.bridge_right_clip_asset_id.as_ref().map(|v| json!(v)),
+        ),
+        (
+            "personTrackId",
+            args.person_track_id.as_ref().map(|v| json!(v)),
+        ),
+        (
+            "replacementMode",
+            args.replacement_mode.as_ref().map(|v| json!(v)),
+        ),
+    ];
+    for (key, value) in optional {
+        if let Some(value) = value {
+            body.insert(key.to_owned(), value);
+        }
+    }
+    Ok(Value::Object(body))
+}
+
+/// The compact, job-type-agnostic status view of a JobSnapshot the polling
+/// tools return: identity + status/stage/progress/eta plus the error when the
+/// job failed. Works identically for video and image jobs.
+pub(crate) fn compact_job_status(job: &Value) -> Value {
+    let mut out = Map::new();
+    if let Some(id) = job.get("id").filter(|id| !id.is_null()) {
+        out.insert("jobId".to_owned(), id.clone());
+    }
+    copy_keys(
+        job,
+        &[
+            "type",
+            "status",
+            "projectId",
+            "stage",
+            "message",
+            "etaSeconds",
+            "elapsedSeconds",
+            "error",
+            "createdAt",
+            "completedAt",
+        ],
+        &mut out,
+    );
+    // Drop empty message/stage strings — they carry no information for an LLM.
+    for key in ["message", "stage"] {
+        if out.get(key).and_then(Value::as_str) == Some("") {
+            out.remove(key);
+        }
+    }
+    let (percent, _) = job_progress(job);
+    out.insert("progressPercent".to_owned(), json!(percent));
+    Value::Object(out)
+}
+
+/// A job's failure detail for error surfaces (failed status), with a stable
+/// fallback when the worker recorded nothing.
+pub(crate) fn job_error_detail(job: &Value) -> &str {
+    job.get("error")
+        .and_then(Value::as_str)
+        .filter(|error| !error.is_empty())
+        .unwrap_or("the worker reported no error detail")
+}
+
+/// Validate a caller-supplied job id before splicing it into a `/api/v1/jobs/…`
+/// path: SceneWorks ids are `job_<hex uuid>`-shaped, so anything outside
+/// `[A-Za-z0-9_-]` (path separators, query metacharacters …) is rejected.
+pub(crate) fn valid_job_id(job_id: &str) -> Result<&str, String> {
+    let job_id = job_id.trim();
+    if job_id.is_empty()
+        || !job_id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_'))
+    {
+        return Err(format!(
+            "\"{job_id}\" is not a valid job id (expected letters, digits, '-' or '_')"
+        ));
+    }
+    Ok(job_id)
+}
+
+/// Best-effort mime type for a result download link: the asset sidecar's
+/// recorded `file.mimeType` wins, then the file extension; `None` (omit the
+/// field) when neither identifies the media — a link stays useful without one.
+pub(crate) fn media_mime_type(path: &str, sidecar_mime: Option<&str>) -> Option<String> {
+    if let Some(mime) = sidecar_mime.map(str::trim).filter(|mime| !mime.is_empty()) {
+        return Some(mime.to_owned());
+    }
+    let extension = path.rsplit('.').next().unwrap_or("").to_ascii_lowercase();
+    let mime = match extension.as_str() {
+        "mp4" | "m4v" => "video/mp4",
+        "webm" => "video/webm",
+        "mov" => "video/quicktime",
+        "mkv" => "video/x-matroska",
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "webp" => "image/webp",
+        "gif" => "image/gif",
+        "wav" => "audio/wav",
+        "mp3" => "audio/mpeg",
+        _ => return None,
+    };
+    Some(mime.to_owned())
 }
 
 /// Keep an asset for the inline result: image-typed (or untyped legacy) records.
@@ -866,6 +1343,282 @@ mod tests {
             image_mime_type("assets/x.bin", None, Some("text/html")),
             "image/png"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // submit_video_job (sc-10235): args → VideoJobRequest mapping, all four
+    // tool modes + their mode-specific required fields.
+    // -----------------------------------------------------------------------
+
+    fn video_args_from(value: Value) -> SubmitVideoJobArgs {
+        serde_json::from_value(value).expect("video args deserialize")
+    }
+
+    #[test]
+    fn video_job_body_minimal_generate_is_text_to_video() {
+        // Absent optionals must be OMITTED — the API's serde defaults
+        // (duration 6, fps 25, 768x512, ltx_2_3 …) are authoritative.
+        let args = video_args_from(json!({ "projectId": "p1", "prompt": "a storm" }));
+        assert_eq!(
+            video_job_body(&args).expect("body builds"),
+            json!({ "projectId": "p1", "mode": "text_to_video", "prompt": "a storm" })
+        );
+    }
+
+    #[test]
+    fn video_job_body_generate_with_source_image_is_image_to_video() {
+        let args = video_args_from(json!({
+            "projectId": "p1",
+            "prompt": "a storm",
+            "mode": "generate",
+            "sourceAssetId": "img_1"
+        }));
+        let body = video_job_body(&args).expect("body builds");
+        assert_eq!(body["mode"], "image_to_video");
+        assert_eq!(body["sourceAssetId"], "img_1");
+    }
+
+    #[test]
+    fn video_job_body_generate_with_both_frames_is_first_last_frame() {
+        let args = video_args_from(json!({
+            "projectId": "p1",
+            "prompt": "a storm",
+            "sourceAssetId": "img_first",
+            "lastFrameAssetId": "img_last"
+        }));
+        let body = video_job_body(&args).expect("body builds");
+        assert_eq!(body["mode"], "first_last_frame");
+        assert_eq!(body["sourceAssetId"], "img_first");
+        assert_eq!(body["lastFrameAssetId"], "img_last");
+
+        // A last frame without a first frame is ambiguous → rejected.
+        let args = video_args_from(json!({
+            "projectId": "p1",
+            "prompt": "a storm",
+            "lastFrameAssetId": "img_last"
+        }));
+        let error = video_job_body(&args).expect_err("last frame alone rejected");
+        assert!(error.contains("sourceAssetId"), "{error}");
+    }
+
+    #[test]
+    fn video_job_body_extend_requires_and_threads_the_source_clip() {
+        let args =
+            video_args_from(json!({ "projectId": "p1", "prompt": "keep going", "mode": "extend" }));
+        let error = video_job_body(&args).expect_err("clipless extend rejected");
+        assert!(error.contains("sourceClipAssetId"), "{error}");
+
+        let args = video_args_from(json!({
+            "projectId": "p1",
+            "prompt": "keep going",
+            "mode": "extend",
+            "sourceClipAssetId": "clip_1"
+        }));
+        let body = video_job_body(&args).expect("body builds");
+        assert_eq!(body["mode"], "extend_clip");
+        assert_eq!(body["sourceClipAssetId"], "clip_1");
+    }
+
+    #[test]
+    fn video_job_body_bridge_requires_both_clips() {
+        let args = video_args_from(json!({
+            "projectId": "p1",
+            "prompt": "bridge",
+            "mode": "bridge",
+            "sourceClipAssetId": "clip_left"
+        }));
+        let error = video_job_body(&args).expect_err("one-sided bridge rejected");
+        assert!(error.contains("bridgeRightClipAssetId"), "{error}");
+
+        let args = video_args_from(json!({
+            "projectId": "p1",
+            "prompt": "bridge",
+            "mode": "bridge",
+            "sourceClipAssetId": "clip_left",
+            "bridgeRightClipAssetId": "clip_right"
+        }));
+        let body = video_job_body(&args).expect("body builds");
+        assert_eq!(body["mode"], "video_bridge");
+        assert_eq!(body["sourceClipAssetId"], "clip_left");
+        assert_eq!(body["bridgeRightClipAssetId"], "clip_right");
+    }
+
+    #[test]
+    fn video_job_body_person_replace_requires_clip_track_and_character() {
+        let base = json!({ "projectId": "p1", "prompt": "swap", "mode": "person_replace" });
+
+        let error = video_job_body(&video_args_from(base.clone()))
+            .expect_err("clipless person_replace rejected");
+        assert!(error.contains("sourceClipAssetId"), "{error}");
+
+        let mut with_clip = base.clone();
+        with_clip["sourceClipAssetId"] = json!("clip_1");
+        let error = video_job_body(&video_args_from(with_clip.clone()))
+            .expect_err("trackless person_replace rejected");
+        assert!(error.contains("personTrackId"), "{error}");
+
+        with_clip["personTrackId"] = json!("track_1");
+        let error = video_job_body(&video_args_from(with_clip.clone()))
+            .expect_err("characterless person_replace rejected");
+        assert!(error.contains("characterId"), "{error}");
+
+        with_clip["characterId"] = json!("char_1");
+        with_clip["replacementMode"] = json!("full_body");
+        let body = video_job_body(&video_args_from(with_clip)).expect("body builds");
+        assert_eq!(body["mode"], "replace_person");
+        assert_eq!(body["sourceClipAssetId"], "clip_1");
+        assert_eq!(body["personTrackId"], "track_1");
+        assert_eq!(body["characterId"], "char_1");
+        assert_eq!(body["replacementMode"], "full_body");
+    }
+
+    #[test]
+    fn video_job_body_rejects_unknown_mode() {
+        let args =
+            video_args_from(json!({ "projectId": "p1", "prompt": "x", "mode": "style_remix" }));
+        let error = video_job_body(&args).expect_err("unknown mode rejected");
+        assert!(error.contains("style_remix"), "{error}");
+        assert!(error.contains("person_replace"), "{error}");
+    }
+
+    #[test]
+    fn video_job_body_maps_every_optional_field() {
+        let args = video_args_from(json!({
+            "projectId": "p1",
+            "prompt": "a storm",
+            "negativePrompt": "static",
+            "model": "ltx_2_3",
+            "duration": 8.5,
+            "fps": 24,
+            "width": 1280,
+            "height": 720,
+            "quality": "high",
+            "seed": 42,
+            "loras": [{ "id": "lora1", "weight": 0.8 }],
+            "characterId": "char_1"
+        }));
+        assert_eq!(
+            video_job_body(&args).expect("body builds"),
+            json!({
+                "projectId": "p1",
+                "mode": "text_to_video",
+                "prompt": "a storm",
+                "negativePrompt": "static",
+                "model": "ltx_2_3",
+                "duration": 8.5,
+                "fps": 24,
+                "width": 1280,
+                "height": 720,
+                "quality": "high",
+                "seed": 42,
+                "loras": [{ "id": "lora1", "weight": 0.8 }],
+                "characterId": "char_1"
+            })
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // get_job_status / get_job_result (sc-10235): snapshot + result mapping.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn compact_job_status_keeps_the_generic_polling_fields() {
+        let job = json!({
+            "id": "job_abc",
+            "type": "video_generate",
+            "status": "running",
+            "projectId": "p1",
+            "stage": "generating",
+            "message": "step 12/40",
+            "progress": 0.3,
+            "etaSeconds": 95,
+            "elapsedSeconds": 41,
+            "error": null,
+            "createdAt": "2026-07-07T00:00:00Z",
+            "completedAt": null,
+            // Verbose snapshot fields that must be dropped:
+            "payload": { "prompt": "x" },
+            "result": {},
+            "workerId": "w1",
+            "attempts": 1
+        });
+        assert_eq!(
+            compact_job_status(&job),
+            json!({
+                "jobId": "job_abc",
+                "type": "video_generate",
+                "status": "running",
+                "projectId": "p1",
+                "stage": "generating",
+                "message": "step 12/40",
+                "etaSeconds": 95,
+                "elapsedSeconds": 41,
+                "createdAt": "2026-07-07T00:00:00Z",
+                "progressPercent": 30
+            })
+        );
+    }
+
+    #[test]
+    fn compact_job_status_surfaces_the_failure_error_and_drops_empty_strings() {
+        let job = json!({
+            "id": "job_abc",
+            "status": "failed",
+            "stage": "",
+            "message": "",
+            "progress": 0.2,
+            "error": "CUDA out of memory on gpu0"
+        });
+        assert_eq!(
+            compact_job_status(&job),
+            json!({
+                "jobId": "job_abc",
+                "status": "failed",
+                "error": "CUDA out of memory on gpu0",
+                "progressPercent": 20
+            })
+        );
+    }
+
+    #[test]
+    fn job_error_detail_falls_back_when_the_worker_recorded_nothing() {
+        assert_eq!(job_error_detail(&json!({ "error": "boom" })), "boom");
+        assert_eq!(
+            job_error_detail(&json!({ "error": "" })),
+            "the worker reported no error detail"
+        );
+        assert_eq!(
+            job_error_detail(&json!({})),
+            "the worker reported no error detail"
+        );
+    }
+
+    #[test]
+    fn valid_job_id_rejects_path_and_query_metacharacters() {
+        assert_eq!(valid_job_id("job_ab12cd34"), Ok("job_ab12cd34"));
+        assert_eq!(valid_job_id("  job-1  "), Ok("job-1"));
+        assert!(valid_job_id("").is_err());
+        assert!(valid_job_id("../secrets").is_err());
+        assert!(valid_job_id("job_1?x=1").is_err());
+        assert!(valid_job_id("job 1").is_err());
+    }
+
+    #[test]
+    fn media_mime_type_prefers_sidecar_then_extension() {
+        assert_eq!(
+            media_mime_type("clips/c.mp4", Some("video/webm")).as_deref(),
+            Some("video/webm")
+        );
+        assert_eq!(
+            media_mime_type("clips/c.MP4", None).as_deref(),
+            Some("video/mp4")
+        );
+        assert_eq!(
+            media_mime_type("images/i.png", None).as_deref(),
+            Some("image/png")
+        );
+        // Unknown extension + no sidecar → omit rather than guess.
+        assert_eq!(media_mime_type("clips/c.bin", Some("")), None);
     }
 
     #[test]

--- a/crates/sceneworks-mcp/tests/video_job_tools.rs
+++ b/crates/sceneworks-mcp/tests/video_job_tools.rs
@@ -1,0 +1,540 @@
+//! Video job tool round-trip tests (sc-10235): a REAL rmcp streamable-HTTP
+//! client drives the non-blocking submit/poll trio against a stub `/api/v1`
+//! pipeline — `submit_video_job` (`POST /video/jobs`), `get_job_status`
+//! (scripted `GET /jobs/:id`), and `get_job_result` (ticket minting via
+//! `POST /files/ticket` → ticketed resource links, never inline bytes).
+//! Covers the acceptance criteria: submit returns the job id + initial
+//! snapshot, status polls report progress/stage/eta, terminal failure surfaces
+//! the job error, a completed job hands back a ticketed URL another machine
+//! can fetch, and the tools stay generic across image jobs.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use rmcp::handler::client::ClientHandler;
+use rmcp::model::{CallToolRequestParams, ClientInfo};
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::ServiceExt;
+use sceneworks_mcp::{ApiClientConfig, JobWaitConfig};
+use serde_json::{json, Value};
+
+const TICKET: &str = "tkt0123456789abcdef";
+const VIDEO_PATH: &str = "assets/videos/genset_1/clip_0001.mp4";
+const IMAGE_PATH: &str = "assets/images/genset_1/img_0001.png";
+
+/// Scripted `/api/v1` job pipeline for the non-blocking tools: the submit
+/// records its body and returns a queued snapshot; each `GET /jobs/:id` steps
+/// through `snapshots` (the last repeats); `POST /files/ticket` counts mints.
+#[derive(Clone)]
+struct StubState {
+    submitted: Arc<Mutex<Vec<Value>>>,
+    polls: Arc<Mutex<usize>>,
+    snapshots: Arc<Vec<Value>>,
+    tickets_minted: Arc<Mutex<usize>>,
+}
+
+fn snapshot(job_type: &str, status: &str, progress: f64, stage: &str, extra: Value) -> Value {
+    let mut job = json!({
+        "id": "job_v1",
+        "type": job_type,
+        "status": status,
+        "projectId": "p1",
+        "progress": progress,
+        "stage": stage,
+        "message": "",
+        "error": null,
+        "result": {}
+    });
+    if let (Some(job_obj), Some(extra_obj)) = (job.as_object_mut(), extra.as_object()) {
+        for (key, value) in extra_obj {
+            job_obj.insert(key.clone(), value.clone());
+        }
+    }
+    job
+}
+
+fn media_asset(id: &str, media_type: &str, path: &str, mime: &str) -> Value {
+    // The persisted sidecar shape `persist_reported_assets` embeds in
+    // `result.assets` — media path + mime live under `file`.
+    json!({
+        "id": id,
+        "type": media_type,
+        "file": { "path": path, "mimeType": mime }
+    })
+}
+
+fn stub_api_router(state: StubState) -> Router {
+    Router::new()
+        .route(
+            "/api/v1/video/jobs",
+            post(
+                |State(state): State<StubState>, Json(body): Json<Value>| async move {
+                    state.submitted.lock().unwrap().push(body);
+                    (
+                        StatusCode::CREATED,
+                        Json(snapshot(
+                            "video_generate",
+                            "queued",
+                            0.0,
+                            "queued",
+                            json!({ "etaSeconds": 300 }),
+                        )),
+                    )
+                },
+            ),
+        )
+        .route(
+            "/api/v1/jobs/:job_id",
+            get(
+                |State(state): State<StubState>, Path(_job_id): Path<String>| async move {
+                    let index = {
+                        let mut polls = state.polls.lock().unwrap();
+                        let index = *polls;
+                        *polls += 1;
+                        index
+                    };
+                    let clamped = index.min(state.snapshots.len() - 1);
+                    Json(state.snapshots[clamped].clone())
+                },
+            ),
+        )
+        .route(
+            "/api/v1/files/ticket",
+            post(|State(state): State<StubState>| async move {
+                *state.tickets_minted.lock().unwrap() += 1;
+                Json(json!({ "ticket": TICKET, "expiresInSeconds": 600 }))
+            }),
+        )
+        .with_state(state)
+}
+
+async fn spawn(router: Router) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind stub listener");
+    let addr = listener.local_addr().expect("stub addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+    format!("http://{addr}")
+}
+
+#[derive(Clone, Default)]
+struct TestClient;
+
+impl ClientHandler for TestClient {
+    fn get_info(&self) -> ClientInfo {
+        ClientInfo::default()
+    }
+}
+
+struct Harness {
+    client: rmcp::service::RunningService<rmcp::service::RoleClient, TestClient>,
+    submitted: Arc<Mutex<Vec<Value>>>,
+    tickets_minted: Arc<Mutex<usize>>,
+    api_base: String,
+}
+
+/// Stub API + mounted MCP service + connected client.
+async fn harness(snapshots: Vec<Value>) -> Harness {
+    let state = StubState {
+        submitted: Arc::new(Mutex::new(Vec::new())),
+        polls: Arc::new(Mutex::new(0)),
+        snapshots: Arc::new(snapshots),
+        tickets_minted: Arc::new(Mutex::new(0)),
+    };
+    let submitted = state.submitted.clone();
+    let tickets_minted = state.tickets_minted.clone();
+    let api_base = spawn(stub_api_router(state)).await;
+    let mcp_service = sceneworks_mcp::streamable_http_service_with(
+        ApiClientConfig {
+            base_url: api_base.clone(),
+            access_token: None,
+        },
+        JobWaitConfig {
+            poll_interval: Duration::from_millis(10),
+            timeout: Duration::from_secs(10),
+        },
+    );
+    let mcp_base = spawn(Router::new().nest_service("/mcp", mcp_service)).await;
+    let transport = StreamableHttpClientTransport::from_config(
+        StreamableHttpClientTransportConfig::with_uri(format!("{mcp_base}/mcp")),
+    );
+    let client = TestClient
+        .serve(transport)
+        .await
+        .expect("MCP client initializes against the mounted /mcp service");
+    Harness {
+        client,
+        submitted,
+        tickets_minted,
+        api_base,
+    }
+}
+
+/// The JSON payload of a tool result (its text content blocks parsed as JSON;
+/// the last one wins — get_job_result appends the summary block last).
+fn result_json(result: &rmcp::model::CallToolResult) -> Value {
+    result
+        .content
+        .iter()
+        .rev()
+        .find_map(|block| block.as_text())
+        .map(|text| serde_json::from_str(&text.text).expect("tool result text is JSON"))
+        .expect("tool result carries a text block")
+}
+
+fn error_text(result: &rmcp::model::CallToolResult) -> String {
+    result
+        .content
+        .iter()
+        .filter_map(|block| block.as_text())
+        .map(|text| text.text.clone())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[tokio::test]
+async fn submit_video_job_returns_job_id_and_initial_snapshot() {
+    let harness = harness(vec![]).await;
+
+    let result = harness
+        .client
+        .call_tool(
+            CallToolRequestParams::new("submit_video_job").with_arguments(
+                json!({
+                    "projectId": "p1",
+                    "prompt": "a lighthouse in a storm",
+                    "sourceAssetId": "img_1",
+                    "negativePrompt": "static",
+                    "model": "ltx_2_3",
+                    "duration": 8,
+                    "fps": 24,
+                    "width": 1280,
+                    "height": 720,
+                    "seed": 7
+                })
+                .as_object()
+                .unwrap()
+                .clone(),
+            ),
+        )
+        .await
+        .expect("submit_video_job succeeds");
+    assert_ne!(result.is_error, Some(true), "unexpected error: {result:?}");
+
+    // The tool returned the job id + initial snapshot and how to continue.
+    let payload = result_json(&result);
+    assert_eq!(payload["jobId"], "job_v1");
+    assert_eq!(payload["status"], "queued");
+    assert_eq!(payload["type"], "video_generate");
+    assert_eq!(payload["etaSeconds"], 300);
+    assert_eq!(payload["progressPercent"], 0);
+    assert!(
+        payload["next"]
+            .as_str()
+            .is_some_and(|next| next.contains("get_job_status")),
+        "submit points at the polling tool: {payload}"
+    );
+
+    // The submit body carried the mapped VideoJobRequest fields — a start
+    // image makes "generate" an image_to_video job.
+    let submitted = harness.submitted.lock().unwrap().clone();
+    assert_eq!(submitted.len(), 1);
+    assert_eq!(submitted[0]["mode"], "image_to_video");
+    assert_eq!(submitted[0]["prompt"], "a lighthouse in a storm");
+    assert_eq!(submitted[0]["sourceAssetId"], "img_1");
+    assert_eq!(submitted[0]["negativePrompt"], "static");
+    assert_eq!(submitted[0]["model"], "ltx_2_3");
+    assert_eq!(submitted[0]["duration"], 8.0);
+    assert_eq!(submitted[0]["fps"], 24);
+    assert_eq!(submitted[0]["width"], 1280);
+    assert_eq!(submitted[0]["height"], 720);
+    assert_eq!(submitted[0]["seed"], 7);
+
+    let _ = harness.client.cancel().await;
+}
+
+#[tokio::test]
+async fn submit_video_job_rejects_incomplete_mode_inputs_before_submitting() {
+    let harness = harness(vec![]).await;
+
+    // bridge without its right clip must fail fast, client-side.
+    let outcome = harness
+        .client
+        .call_tool(
+            CallToolRequestParams::new("submit_video_job").with_arguments(
+                json!({
+                    "projectId": "p1",
+                    "prompt": "bridge these",
+                    "mode": "bridge",
+                    "sourceClipAssetId": "clip_left"
+                })
+                .as_object()
+                .unwrap()
+                .clone(),
+            ),
+        )
+        .await;
+    match outcome {
+        Err(_) => {}
+        Ok(result) => assert_eq!(
+            result.is_error,
+            Some(true),
+            "an incomplete bridge call must not look like success: {result:?}"
+        ),
+    }
+    assert!(
+        harness.submitted.lock().unwrap().is_empty(),
+        "no job may be submitted for invalid mode inputs"
+    );
+
+    let _ = harness.client.cancel().await;
+}
+
+#[tokio::test]
+async fn get_job_status_reports_progress_stage_and_eta() {
+    let harness = harness(vec![snapshot(
+        "video_generate",
+        "running",
+        0.4,
+        "generating",
+        json!({ "message": "step 16/40", "etaSeconds": 95, "elapsedSeconds": 63 }),
+    )])
+    .await;
+
+    let result = harness
+        .client
+        .call_tool(
+            CallToolRequestParams::new("get_job_status")
+                .with_arguments(json!({ "jobId": "job_v1" }).as_object().unwrap().clone()),
+        )
+        .await
+        .expect("get_job_status succeeds");
+    assert_ne!(result.is_error, Some(true), "unexpected error: {result:?}");
+
+    let payload = result_json(&result);
+    assert_eq!(payload["jobId"], "job_v1");
+    assert_eq!(payload["status"], "running");
+    assert_eq!(payload["stage"], "generating");
+    assert_eq!(payload["message"], "step 16/40");
+    assert_eq!(payload["progressPercent"], 40);
+    assert_eq!(payload["etaSeconds"], 95);
+    assert_eq!(payload["elapsedSeconds"], 63);
+
+    let _ = harness.client.cancel().await;
+}
+
+#[tokio::test]
+async fn get_job_status_surfaces_the_failed_job_error() {
+    let harness = harness(vec![snapshot(
+        "video_generate",
+        "failed",
+        0.4,
+        "failed",
+        json!({ "error": "CUDA out of memory on gpu0" }),
+    )])
+    .await;
+
+    let result = harness
+        .client
+        .call_tool(
+            CallToolRequestParams::new("get_job_status")
+                .with_arguments(json!({ "jobId": "job_v1" }).as_object().unwrap().clone()),
+        )
+        .await
+        .expect("get_job_status succeeds");
+    assert_ne!(
+        result.is_error,
+        Some(true),
+        "status is a report: {result:?}"
+    );
+
+    let payload = result_json(&result);
+    assert_eq!(payload["status"], "failed");
+    assert_eq!(payload["error"], "CUDA out of memory on gpu0");
+
+    let _ = harness.client.cancel().await;
+}
+
+#[tokio::test]
+async fn get_job_result_returns_ticketed_video_link_without_inline_bytes() {
+    let harness = harness(vec![snapshot(
+        "video_generate",
+        "completed",
+        1.0,
+        "completed",
+        json!({ "result": { "assets": [
+            media_asset("vid_1", "video", VIDEO_PATH, "video/mp4"),
+        ] } }),
+    )])
+    .await;
+
+    let result = harness
+        .client
+        .call_tool(
+            CallToolRequestParams::new("get_job_result")
+                .with_arguments(json!({ "jobId": "job_v1" }).as_object().unwrap().clone()),
+        )
+        .await
+        .expect("get_job_result succeeds");
+    assert_ne!(result.is_error, Some(true), "unexpected error: {result:?}");
+
+    // A resource link (never inline bytes) whose URL is the absolute ticketed
+    // media URL — fetchable from another machine that can reach the API.
+    let expected_url = format!(
+        "{}/api/v1/projects/p1/files/{VIDEO_PATH}?ticket={TICKET}",
+        harness.api_base
+    );
+    let links: Vec<_> = result
+        .content
+        .iter()
+        .filter_map(|block| block.as_resource_link())
+        .collect();
+    assert_eq!(links.len(), 1, "one video link: {result:?}");
+    assert_eq!(links[0].uri, expected_url);
+    assert_eq!(links[0].mime_type.as_deref(), Some("video/mp4"));
+    assert!(
+        !result
+            .content
+            .iter()
+            .any(|block| block.as_image().is_some()),
+        "get_job_result must never inline media bytes: {result:?}"
+    );
+
+    let payload = result_json(&result);
+    assert_eq!(payload["jobId"], "job_v1");
+    assert_eq!(payload["projectId"], "p1");
+    assert_eq!(payload["assets"][0]["id"], "vid_1");
+    assert_eq!(payload["assets"][0]["type"], "video");
+    assert_eq!(payload["assets"][0]["url"], Value::String(expected_url));
+    assert_eq!(
+        payload["assets"][0]["relativeUrl"],
+        format!("/api/v1/projects/p1/files/{VIDEO_PATH}?ticket={TICKET}")
+    );
+    assert_eq!(payload["ticketExpiresInSeconds"], 600);
+
+    // Exactly one ticket mint covered the link set.
+    assert_eq!(*harness.tickets_minted.lock().unwrap(), 1);
+
+    let _ = harness.client.cancel().await;
+}
+
+#[tokio::test]
+async fn get_job_result_is_generic_over_image_jobs() {
+    let harness = harness(vec![snapshot(
+        "image_generate",
+        "completed",
+        1.0,
+        "completed",
+        json!({ "result": { "assets": [
+            media_asset("asset_1", "image", IMAGE_PATH, "image/png"),
+        ] } }),
+    )])
+    .await;
+
+    let result = harness
+        .client
+        .call_tool(
+            CallToolRequestParams::new("get_job_result")
+                .with_arguments(json!({ "jobId": "job_v1" }).as_object().unwrap().clone()),
+        )
+        .await
+        .expect("get_job_result succeeds");
+    assert_ne!(result.is_error, Some(true), "unexpected error: {result:?}");
+
+    let links: Vec<_> = result
+        .content
+        .iter()
+        .filter_map(|block| block.as_resource_link())
+        .collect();
+    assert_eq!(links.len(), 1, "one image link: {result:?}");
+    assert!(links[0].uri.contains(IMAGE_PATH), "{}", links[0].uri);
+    assert!(links[0].uri.contains(TICKET), "{}", links[0].uri);
+    assert_eq!(links[0].mime_type.as_deref(), Some("image/png"));
+
+    let _ = harness.client.cancel().await;
+}
+
+#[tokio::test]
+async fn get_job_result_on_a_running_job_reports_not_ready_without_error() {
+    let harness = harness(vec![snapshot(
+        "video_generate",
+        "running",
+        0.6,
+        "generating",
+        json!({ "etaSeconds": 40 }),
+    )])
+    .await;
+
+    let result = harness
+        .client
+        .call_tool(
+            CallToolRequestParams::new("get_job_result")
+                .with_arguments(json!({ "jobId": "job_v1" }).as_object().unwrap().clone()),
+        )
+        .await
+        .expect("get_job_result succeeds");
+    assert_ne!(
+        result.is_error,
+        Some(true),
+        "a not-ready job is a report, not an error: {result:?}"
+    );
+
+    let payload = result_json(&result);
+    assert_eq!(payload["ready"], false);
+    assert_eq!(payload["status"], "running");
+    assert_eq!(payload["progressPercent"], 60);
+    assert!(
+        payload["note"]
+            .as_str()
+            .is_some_and(|note| note.contains("get_job_status")),
+        "not-ready points back at polling: {payload}"
+    );
+    assert_eq!(
+        *harness.tickets_minted.lock().unwrap(),
+        0,
+        "no ticket may be minted for an unfinished job"
+    );
+
+    let _ = harness.client.cancel().await;
+}
+
+#[tokio::test]
+async fn get_job_result_on_a_failed_job_surfaces_the_error() {
+    let harness = harness(vec![snapshot(
+        "video_generate",
+        "failed",
+        0.2,
+        "failed",
+        json!({ "error": "model weights missing: ltx_2_3" }),
+    )])
+    .await;
+
+    let result = harness
+        .client
+        .call_tool(
+            CallToolRequestParams::new("get_job_result")
+                .with_arguments(json!({ "jobId": "job_v1" }).as_object().unwrap().clone()),
+        )
+        .await
+        .expect("tool call transports (the failure is a tool-level error)");
+    assert_eq!(
+        result.is_error,
+        Some(true),
+        "failed job must error: {result:?}"
+    );
+    let text = error_text(&result);
+    assert!(
+        text.contains("model weights missing: ltx_2_3"),
+        "error must carry the job's error message: {text}"
+    );
+    assert!(text.contains("job_v1"), "error names the job: {text}");
+
+    let _ = harness.client.cancel().await;
+}


### PR DESCRIPTION
Shortcut story: https://app.shortcut.com/trefry/story/10235 (epic 10231 SceneWorks MCP Server)

Video generation runs minutes and outlives a single blocking MCP call, so this adds a non-blocking submit/poll tool trio to `crates/sceneworks-mcp` (building on the sc-10233 scaffold #1265 and sc-10234 generate_image #1275):

## Tools

- **`submit_video_job`** — wraps `POST /api/v1/video/jobs`. Exposes four task-level modes and maps them onto `VideoJobRequest` wire modes:
  - `generate` → `text_to_video`, or `image_to_video` when `sourceAssetId` is set, or `first_last_frame` when `lastFrameAssetId` is also set
  - `extend` → `extend_clip` (requires `sourceClipAssetId`)
  - `bridge` → `video_bridge` (requires `sourceClipAssetId` + `bridgeRightClipAssetId`)
  - `person_replace` → `replace_person` (requires `sourceClipAssetId` + `personTrackId` + `characterId`)

  Mode-specific required assets are validated client-side with precise messages (mirroring `validate_video_job`) so a bad call fails fast instead of submitting a doomed job. Only provided optional fields are sent, keeping the API serde defaults (duration 6s, 25fps, 768x512, ltx_2_3, quality balanced) authoritative. Returns the job id + initial compact snapshot with a "poll get_job_status" pointer.

- **`get_job_status`** — generic `GET /api/v1/jobs/:id` view usable for video AND image jobs: `status` / `stage` / `progressPercent` / `message` / `etaSeconds` / `elapsedSeconds`, plus `error` for a failed job. Caller-supplied job ids are validated (`[A-Za-z0-9_-]`) before being spliced into the path.

- **`get_job_result`** — for a completed job (any type), mints ONE short-lived multi-use media ticket via `POST /api/v1/files/ticket` (the sc-8810 sliding ticket, honored by `GET /api/v1/projects/:id/files/*?ticket=`) and returns one MCP resource-link block per result asset. Media bytes are **never** inlined. Each link's URL is the absolute ticketed URL built from the MCP self-client's API base (`SCENEWORKS_API_URL`), so with a LAN-configured base the URL is fetchable from another LAN machine with no auth header; the JSON summary also carries `relativeUrl` + a note explaining to re-base against the MCP endpoint's host when the configured base (e.g. loopback desktop default) isn't reachable remotely. Non-terminal jobs get a clear `ready: false` report (not an error); failed/canceled/interrupted jobs surface the job error as a tool-level error.

Also refactors `generate_image`'s failed-branch error extraction into a shared `job_error_detail` helper and adds `ApiClient::base_url()`.

## Acceptance criteria

- ✅ A video can be submitted, polled to completion, and fetched via the ticketed URL from another LAN machine (absolute ticketed URL + relative fallback; integration-tested end to end against a stub `/api/v1` with a real rmcp client)
- ✅ Terminal failure surfaces the job error (both in `get_job_status`'s `error` field and as a `get_job_result` tool error)
- ✅ `get_job_status` / `get_job_result` are generic over image jobs (integration-tested with an `image_generate` job)
- ✅ All four modes covered incl. mode-specific required-field validation

## Tests

- 16 new unit tests: `video_job_body` mapping across all four modes + required-field rejections + full optional-field mapping; `compact_job_status` (progress/eta/error, empty-string dropping); `job_error_detail`; `valid_job_id` (path/query metacharacter rejection); `media_mime_type`
- 8 new integration tests (`tests/video_job_tools.rs`, real rmcp streamable-HTTP client against the mounted service + scripted stub upstream): submit returns job id + snapshot and threads the mapped body; invalid bridge inputs rejected before any submit; status reports progress/stage/eta; status surfaces failed error; completed video job returns ticketed resource link (exactly one ticket minted, no inline bytes); image job works generically; running job returns ready=false without minting a ticket; failed job is a tool error carrying the worker message
- `cargo test -p sceneworks-mcp`: 26 unit + 17 integration, all green; `cargo fmt` + `clippy --all-targets -D warnings` clean; `cargo check -p sceneworks-rust-api` green (no API-side changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)