### PR TITLE
feat(video-studio): single-column layout matching Image Studio

### DIFF
--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -3,7 +3,7 @@ import { pickClosestResolution } from "../resolutionMatch.js";
 import { AssetPickerField } from "../components/AssetPicker.jsx";
 import { FitModeControl, effectiveFitMode } from "../components/FitModeControl.jsx";
 import { AssetCard } from "../components/assetPanels.jsx";
-import { AssetMedia, assetCanRenderAsVideo } from "../components/assetMedia.jsx";
+import { AssetMedia } from "../components/assetMedia.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { PromptGuideModal } from "../components/PromptGuideModal.jsx";
@@ -21,27 +21,6 @@ const MOTIONS = [
   "tilt down",
   "handheld",
 ];
-
-function formatGpuLabel(requestedGpu) {
-  if (!requestedGpu || requestedGpu === "auto") {
-    return "auto GPU";
-  }
-  return `GPU ${requestedGpu}`;
-}
-
-function estimateRenderSeconds(durationSeconds, quality) {
-  // Rough heuristic: every clip second ~3s on Balanced, ±50% for Draft/Final.
-  const base = Math.max(1, Number(durationSeconds) || 6) * 3;
-  if (quality === "fast") return Math.round(base * 0.5);
-  if (quality === "best") return Math.round(base * 1.5);
-  return Math.round(base);
-}
-
-function formatPlaybackTime(seconds) {
-  const safeSeconds = Math.max(0, Math.round(Number(seconds) || 0));
-  const minutes = Math.floor(safeSeconds / 60);
-  return `${minutes}:${String(safeSeconds % 60).padStart(2, "0")}`;
-}
 
 // Resolve a video job's result assets against the live catalog so the
 // WorkerProgressCard video-player variant can play the finished clip (sc-2089).
@@ -120,7 +99,6 @@ export function VideoStudio() {
     jobAction,
     rememberLocalGenerationJob,
     setActiveView,
-    setSelectedAssetId,
     setPreviewAsset,
     personTracks = [],
     personReadiness = {},
@@ -152,12 +130,6 @@ export function VideoStudio() {
   const onOpenPresets = () => setActiveView("Presets");
   const onOpenQueue = () => setActiveView("Queue");
   const onPreview = setPreviewAsset;
-  const onSendToEditor = (asset) => {
-    if (asset?.id) {
-      setSelectedAssetId(asset.id);
-    }
-    setActiveView("Editor");
-  };
   // Last-used settings for this workspace, restored on mount. The component is keyed
   // by workspace in App.jsx, so this reads the right snapshot per workspace.
   const saved = useMemo(() => loadStudioSettings("video", activeProject?.id ?? null), [activeProject?.id]);
@@ -281,10 +253,6 @@ export function VideoStudio() {
   const [comparisonMode, setComparisonMode] = useState("side_by_side");
   const [abSide, setAbSide] = useState("replacement");
   const [submitting, setSubmitting] = useState(false);
-  const previewVideoRef = useRef(null);
-  const [previewPlaying, setPreviewPlaying] = useState(false);
-  const [previewTime, setPreviewTime] = useState(0);
-  const [previewDuration, setPreviewDuration] = useState(0);
   const capabilities = selectedModel?.capabilities ?? [];
   const supportsMode = capabilities.includes(mode);
   // GGUF quantization variants the torch adapter can load (sc-1982). Declared in
@@ -837,30 +805,6 @@ export function VideoStudio() {
 
   const generateDisabled = submitting || !canSubmit;
   const renderLabel = mode === "replace_person" ? "Replace person" : "Render clip";
-  const previewAsset = latestAssets[0] ?? null;
-  const estimateSeconds = estimateRenderSeconds(duration, quality);
-  const gpuLabel = formatGpuLabel(requestedGpu);
-  const previewCanPlay = assetCanRenderAsVideo(previewAsset);
-  const previewTotalSeconds = previewDuration || Number(previewAsset?.file?.duration) || Number(duration) || 0;
-  const previewProgress = previewTotalSeconds ? `${Math.min(100, (previewTime / previewTotalSeconds) * 100)}%` : "0%";
-
-  useEffect(() => {
-    setPreviewPlaying(false);
-    setPreviewTime(0);
-    setPreviewDuration(0);
-  }, [previewAsset?.id]);
-
-  function togglePreviewPlayback() {
-    const video = previewVideoRef.current;
-    if (!video || !previewCanPlay) {
-      return;
-    }
-    if (video.paused) {
-      video.play().catch(() => setPreviewPlaying(false));
-      return;
-    }
-    video.pause();
-  }
 
   return (
     <ModelAvailabilityGate
@@ -876,7 +820,7 @@ export function VideoStudio() {
     >
     <section className="main-surface video-studio">
       <form className="studio-shell" onSubmit={submit}>
-        <div className="surface-header hero studio-prompt-hero video-prompt-hero">
+        <div className="surface-header hero studio-prompt-hero">
           <div className="prompt-hero-top">
             <div className="mode-tabs mode-control" role="tablist" aria-label="Video mode">
               {modeOptions.map(([value, label]) => {
@@ -958,9 +902,8 @@ export function VideoStudio() {
               </button>
             ))}
           </div>
-        </div>
 
-        {mode !== "text_to_video" ? (
+          {mode !== "text_to_video" ? (
           <div className="studio-source-band">
             {mode === "image_to_video" || mode === "first_last_frame" ? (
               <AssetPickerField
@@ -1125,8 +1068,413 @@ export function VideoStudio() {
           </div>
         ) : null}
 
-        <div className="video-results">
-          <div className="video-main-stack">
+          <div className="settings-bar">
+            <div className="settings-bar-row">
+              <label className="settings-field settings-field-model">
+                Model
+                <select onChange={(event) => setModel(event.target.value)} value={model}>
+                  {/* Models gated on the selected tab (sc-5716): show only models that serve the
+                      active mode, falling back to the full available list if none do (a reduced
+                      catalog) so the picker is never empty. */}
+                  {(modelsForMode(mode).length ? modelsForMode(mode) : baseVideoModels).map((item) => (
+                    <option key={item.id} value={item.id}>
+                      {item.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="settings-field settings-field-aspect">
+                Resolution
+                <select onChange={(event) => setResolution(event.target.value)} value={resolution}>
+                  {resolutionOptions.map((value) => (
+                    <option key={value} value={value}>
+                      {value.replace("x", " × ")}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="settings-field settings-field-count">
+                Duration
+                <select onChange={(event) => setDuration(Number(event.target.value))} value={duration}>
+                  {durationOptions.map((value) => (
+                    <option key={value} value={value}>
+                      {value}s
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="settings-field">
+                Quality
+                <div className="quality-segment" role="radiogroup" aria-label="Quality">
+                  {qualityChoices.map(([value, label]) => (
+                    <button
+                      aria-checked={quality === value}
+                      className={quality === value ? "active" : ""}
+                      key={value}
+                      onClick={() => setQuality(value)}
+                      role="radio"
+                      type="button"
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+              </label>
+            </div>
+            <div className="settings-bar-styles">
+              <span className="settings-bar-label">Style preset</span>
+              <div className="preset-chips">
+                <button
+                  className={!selectedPreset ? "preset-chip active" : "preset-chip"}
+                  onClick={() => setSelectedPresetId(noPresetId)}
+                  type="button"
+                >
+                  None
+                </button>
+                {availablePresets.map((preset) => (
+                  <button
+                    className={selectedPreset?.id === preset.id ? "preset-chip active" : "preset-chip"}
+                    key={preset.id}
+                    onClick={() => setSelectedPresetId(preset.id)}
+                    type="button"
+                  >
+                    {preset.name ?? preset.id}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <PresetGuidanceStrip
+            selectedPreset={selectedPreset}
+            presetPromptParts={presetPromptParts}
+            presetLoraDetails={presetLoraDetails}
+          />
+
+          {durationHint ? <p className="helper-copy">{durationHint}</p> : null}
+
+          <button className="advanced-toggle" onClick={() => setAdvancedOpen((value) => !value)} type="button">
+            <Icon.ChevDown className={advancedOpen ? "chev-rotate open" : "chev-rotate"} size={14} />
+            {advancedOpen ? "Hide advanced" : "Advanced"}
+          </button>
+
+          {advancedOpen ? (
+            <div className="advanced-panel">
+              <label>
+                Frames
+                <select onChange={(event) => setFps(Number(event.target.value))} value={fps}>
+                  {fpsOptions.map((value) => (
+                    <option key={value} value={value}>
+                      {value} fps
+                    </option>
+                  ))}
+                </select>
+              </label>
+              {showLightning ? (
+                <div className="lightning-toggle">
+                  <label className="checkline">
+                    <input
+                      checked={lightning}
+                      onChange={(event) => setLightning(event.target.checked)}
+                      type="checkbox"
+                    />
+                    Lightning (fast 4-step)
+                  </label>
+                  <p className="helper-copy">
+                    {lightning
+                      ? "On: ~10× faster, 4 steps, CFG off, small quality trade-off. Steps and guidance are governed by the recipe."
+                      : "Off: full multi-step quality with CFG (slower). Use the Steps and Guidance controls below."}
+                  </p>
+                </div>
+              ) : null}
+              {model === ltxVideoModelId ? (
+                <>
+                  <label>
+                    LTX pipeline
+                    <select onChange={(event) => setLtxPipeline(event.target.value)} value={ltxPipeline}>
+                      <option value="auto">Auto (follow quality)</option>
+                      <option value="distilled">Distilled (single-stage)</option>
+                      <option value="two_stage">Two-stage (dev + upscaler)</option>
+                    </select>
+                  </label>
+                  <label>
+                    Distilled variant
+                    <select onChange={(event) => setDistilledVariant(event.target.value)} value={distilledVariant}>
+                      <option value="1.1">1.1 (newer aesthetic + audio)</option>
+                      <option value="1.0">1.0 (original)</option>
+                    </select>
+                  </label>
+                  <label>
+                    Precision
+                    <select onChange={(event) => setPrecision(event.target.value)} value={precision}>
+                      <option value="fp8">FP8 (lower VRAM)</option>
+                      <option value="bf16">BF16 (higher quality, CPU offload)</option>
+                    </select>
+                  </label>
+                </>
+              ) : null}
+              {selectedModel?.adapter === "ltx_video" ? (
+                <>
+                  <label>
+                    Video CFG
+                    <input
+                      min="0"
+                      max="30"
+                      onChange={(event) => setLtxVideoCfg(event.target.value)}
+                      placeholder="4.0"
+                      step="0.1"
+                      type="number"
+                      value={ltxVideoCfg}
+                    />
+                  </label>
+                  <label>
+                    Video STG
+                    <input
+                      min="0"
+                      max="10"
+                      onChange={(event) => setLtxVideoStg(event.target.value)}
+                      placeholder="0.0"
+                      step="0.1"
+                      type="number"
+                      value={ltxVideoStg}
+                    />
+                  </label>
+                  <label>
+                    Video rescale
+                    <input
+                      min="0"
+                      max="2"
+                      onChange={(event) => setLtxVideoRescale(event.target.value)}
+                      placeholder="0.7"
+                      step="0.05"
+                      type="number"
+                      value={ltxVideoRescale}
+                    />
+                  </label>
+                </>
+              ) : null}
+              {["extend_clip", "video_bridge"].includes(mode) ? (
+                <>
+                  <label>
+                    {mode === "video_bridge" ? "Left clip strength" : "Clip strength"}
+                    <input
+                      min="0"
+                      max="1"
+                      onChange={(event) => setVideoConditioningStrength(event.target.value)}
+                      placeholder="1.0"
+                      step="0.05"
+                      type="number"
+                      value={videoConditioningStrength}
+                    />
+                  </label>
+                  {mode === "video_bridge" ? (
+                    <label>
+                      Right clip strength
+                      <input
+                        min="0"
+                        max="1"
+                        onChange={(event) => setBridgeRightVideoConditioningStrength(event.target.value)}
+                        placeholder="1.0"
+                        step="0.05"
+                        type="number"
+                        value={bridgeRightVideoConditioningStrength}
+                      />
+                    </label>
+                  ) : null}
+                </>
+              ) : null}
+              {supportsQuantization ? (
+                <label>
+                  Quantization
+                  <select onChange={(event) => setQuantization(event.target.value)} value={quantization}>
+                    <option value="auto">Auto (per-platform default)</option>
+                    {quantVariants.map(([id, variant]) => (
+                      <option key={id} value={id}>
+                        {variant?.label ?? id}
+                      </option>
+                    ))}
+                    <option value="none">Full precision (unquantized)</option>
+                  </select>
+                </label>
+              ) : null}
+              <label>
+                GPU
+                <select onChange={(event) => setRequestedGpu(event.target.value)} value={requestedGpu}>
+                  {gpuOptions.map((gpu) => (
+                    <option key={gpu} value={gpu}>
+                      {gpu === "auto" ? "Auto" : gpu}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Seed
+                <input onChange={(event) => setSeed(event.target.value)} placeholder="Random" type="number" value={seed} />
+              </label>
+              {showSamplerPicker ? (
+                <label>
+                  Sampler
+                  <select onChange={(event) => setSampler(event.target.value)} value={sampler}>
+                    {samplerOptions.map((key) => (
+                      <option key={key} value={key}>
+                        {SAMPLER_LABELS[key] ?? key}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              ) : null}
+              {showSchedulerPicker ? (
+                <label>
+                  Scheduler
+                  <select onChange={(event) => setScheduler(event.target.value)} value={scheduler}>
+                    {schedulerOptions.map((key) => (
+                      <option key={key} value={key}>
+                        {SCHEDULER_LABELS[key] ?? key}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              ) : null}
+              {showSchedulerPicker && scheduler !== "default" ? (
+                <label>
+                  Schedule shift
+                  <input
+                    max="10"
+                    min="0.1"
+                    onChange={(event) => setSchedulerShift(Number(event.target.value))}
+                    step="0.1"
+                    type="number"
+                    value={schedulerShift}
+                  />
+                </label>
+              ) : null}
+              <label>
+                Steps
+                <input
+                  min="1"
+                  max="80"
+                  disabled={lightningActive}
+                  onChange={(event) => setStepsOverride(event.target.value)}
+                  placeholder={lightningActive ? "4 (Lightning)" : String(stepsDefaultFromModel(selectedModel) ?? "")}
+                  title={lightningActive ? "Governed by Lightning (fast 4-step). Turn Lightning off to set steps." : undefined}
+                  type="number"
+                  value={lightningActive ? "" : stepsOverride}
+                />
+              </label>
+              <label>
+                Guidance
+                <input
+                  min="0"
+                  max="30"
+                  disabled={lightningActive}
+                  onChange={(event) => setGuidanceOverride(event.target.value)}
+                  placeholder={lightningActive ? "off (Lightning)" : (() => {
+                    const value = guidanceDefaultFromModel(selectedModel);
+                    return value == null ? "" : String(value);
+                  })()}
+                  step="0.1"
+                  title={lightningActive ? "Governed by Lightning (fast 4-step). Turn Lightning off to set guidance." : undefined}
+                  type="number"
+                  value={lightningActive ? "" : guidanceOverride}
+                />
+              </label>
+              <label>
+                Character
+                <select onChange={(event) => setCharacterId(event.target.value)} value={characterId}>
+                  <option value="">No character</option>
+                  {characters.map((character) => (
+                    <option key={character.id} value={character.id}>
+                      {character.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Look
+                <select onChange={(event) => setCharacterLookId(event.target.value)} value={characterLookId}>
+                  <option value="">Default look</option>
+                  {(characters.find((character) => character.id === characterId)?.looks ?? []).map((look) => (
+                    <option key={look.id} value={look.id}>
+                      {look.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="prompt-field">
+                Negative prompt
+                <textarea onChange={(event) => setNegativePrompt(event.target.value)} value={negativePrompt} />
+              </label>
+              <LoraPickerSection
+                selectedModel={selectedModel}
+                selectedLoras={selectedLoras}
+                selectedLoraIds={selectedLoraIds}
+                compatibleLoras={compatibleLoras}
+                userSelectedLoraCount={userSelectedLoraCount}
+                showIncompatibleLoras={showIncompatibleLoras}
+                setShowIncompatibleLoras={setShowIncompatibleLoras}
+                toggleLora={toggleLora}
+                effectiveLoraWeight={effectiveLoraWeight}
+                setLoraWeight={setLoraWeight}
+                loraEmptyMessage={loraEmptyMessage}
+              />
+              {characterId ? (
+                <div className="guidance-strip">
+                  <strong>Character reference</strong>
+                  <span>
+                    Character and look are saved with the recipe; LTX image conditioning uses IC-LoRA when the selected preset includes one.
+                  </span>
+                </div>
+              ) : null}
+              {/* Save-as-preset folds into Advanced with the rest of the power-user
+                  knobs, matching Image Studio. Gated to the presetable video modes. */}
+              <SavePresetPanel
+                presetName={presetName}
+                setPresetName={setPresetName}
+                savingPreset={savingPreset}
+                presetSaveMessage={presetSaveMessage}
+                setPresetSaveMessage={setPresetSaveMessage}
+                onSave={handleSaveAsPreset}
+                presetScope={presetScope}
+                setPresetScope={setPresetScope}
+                activeProject={activeProject}
+                saveDisabled={!VIDEO_PRESET_MODES.includes(mode)}
+                saveTitle={VIDEO_PRESET_MODES.includes(mode) ? undefined : "Presets are available in Image→Video, Text→Video, or First/Last mode."}
+              />
+              {/* Video upscale (super-resolve an existing clip) folds into Advanced — it
+                  previously lived in the render rail this layout removes. It operates on a
+                  selected existing asset, independent of the current generation payload. */}
+              <VideoUpscalePanel
+                createVideoUpscaleJob={createVideoUpscaleJob}
+                macCapabilities={macCapabilities}
+                onSubmitted={(job) => {
+                  onLocalJobCreated(job);
+                  onOpenQueue();
+                }}
+                selectedAsset={selectedAsset}
+                videoAssets={videoAssets}
+              />
+            </div>
+          ) : null}
+
+          <PresetValidationWarnings presetValidationResult={presetValidationResult} selectedModel={selectedModel} />
+          {blockedMessage ? <p className="inline-warning">{blockedMessage}</p> : null}
+          {selectedLoraValidationResult.incompatible.length ? (
+            <p className="inline-warning">
+              Generate is blocked because these selected LoRAs are incompatible with {selectedModel?.name ?? "the selected model"}: {selectedLoraValidationResult.incompatible.join(", ")}.
+            </p>
+          ) : null}
+        </div>
+
+        <div className="studio-results">
+          <section className="review-panel">
+            <div className="review-panel-head">
+              <h2>Latest batch</h2>
+              <span className="kbd-hint">
+                <kbd>⌘</kbd>
+                <kbd>↵</kbd>
+                to render
+              </span>
+            </div>
             {localJobs.length ? (
               <div className="worker-progress-card-stack local-job-stack">
                 {localJobs.map((job) => {
@@ -1145,553 +1493,70 @@ export function VideoStudio() {
                 })}
               </div>
             ) : null}
-
-            <div className="video-preview-card">
-              <div className="video-preview-stage">
-                {previewAsset ? (
-                  <AssetMedia
-                    asset={previewAsset}
-                    controls={false}
-                    onEnded={() => setPreviewPlaying(false)}
-                    onLoadedMetadata={(event) => setPreviewDuration(event.currentTarget.duration || 0)}
-                    onPause={() => setPreviewPlaying(false)}
-                    onPlay={() => setPreviewPlaying(true)}
-                    onTimeUpdate={(event) => setPreviewTime(event.currentTarget.currentTime || 0)}
-                    ref={previewVideoRef}
-                  />
-                ) : (
-                  <span className="video-preview-empty">No clip rendered yet — set up the prompt above and hit Render</span>
-                )}
-              </div>
-
-              <div className="video-playback-bar">
-                <button
-                  aria-label={previewPlaying ? "Pause preview" : "Play preview"}
-                  className="play-btn"
-                  disabled={!previewCanPlay}
-                  onClick={togglePreviewPlayback}
-                  type="button"
-                >
-                  {previewPlaying ? <Icon.Pause size={14} /> : <Icon.Play size={14} />}
-                </button>
-                <div aria-hidden="true" className="video-playback-scrub">
-                  <span className="video-playback-scrub-fill" style={{ width: previewProgress }} />
-                </div>
-                <span className="video-playback-time">
-                  {formatPlaybackTime(previewTime)} / {formatPlaybackTime(previewTotalSeconds)}
-                </span>
-                <span className="video-playback-estimate">~{estimateSeconds}s on {gpuLabel}</span>
-                <button
-                  className="send-editor-btn"
-                  disabled={!previewAsset || !onSendToEditor}
-                  onClick={() => previewAsset && onSendToEditor?.(previewAsset)}
-                  type="button"
-                >
-                  <Icon.Editor size={14} /> Send to editor
-                </button>
-              </div>
-            </div>
-
-            {videoAssets.length ? (
-              <div className="recent-clips-card">
-                <div className="recent-clips-head">
-                  <h3>Recent clips</h3>
-                  <span className="meta">{localJobs.length || latestAssets.length} this session</span>
-                </div>
-                <div className="recent-clips-strip">
-                  {videoAssets.slice(0, 4).map((asset) => (
-                    <button className="tray-item" key={asset.id} onClick={() => onPreview(asset, videoAssets.slice(0, 4))} type="button">
-                      <AssetMedia asset={asset} />
-                      <span>{asset.displayName}</span>
-                    </button>
+            {latestAssets.length ? (
+              <div className="recent-assets">
+                {localJobs.length ? <h3 className="recent-assets__title">Recent Assets</h3> : null}
+                <div className="review-grid">
+                  {latestAssets.map((asset) => (
+                    <AssetCard
+                      asset={asset}
+                      deleteAsset={deleteAsset}
+                      key={asset.id}
+                      onPreview={(previewed) => onPreview(previewed, latestAssets)}
+                      purgeAsset={purgeAsset}
+                      updateAssetStatus={updateAssetStatus}
+                    />
                   ))}
                 </div>
               </div>
-            ) : null}
+            ) : localJobs.length ? null : (
+              <div className="empty-panel">No fresh clip batch</div>
+            )}
+          </section>
 
-            {comparisonAsset?.recipe?.mode === "replace_person" && comparisonSource ? (
-              <div className="comparison-panel">
-                <div className="comparison-toolbar">
-                  <div className="segmented-control compact-segment" aria-label="Comparison mode">
-                    <button className={comparisonMode === "side_by_side" ? "active" : ""} onClick={() => setComparisonMode("side_by_side")} type="button">
-                      Side by Side
-                    </button>
-                    <button className={comparisonMode === "ab" ? "active" : ""} onClick={() => setComparisonMode("ab")} type="button">
-                      A/B
-                    </button>
-                  </div>
-                  {comparisonMode === "ab" ? (
-                    <div className="segmented-control compact-segment" aria-label="A/B source">
-                      <button className={abSide === "original" ? "active" : ""} onClick={() => setAbSide("original")} type="button">
-                        A
-                      </button>
-                      <button className={abSide === "replacement" ? "active" : ""} onClick={() => setAbSide("replacement")} type="button">
-                        B
-                      </button>
-                    </div>
-                  ) : null}
-                </div>
-                {comparisonMode === "side_by_side" ? (
-                  <div className="comparison-grid">
-                    <div>
-                      <p className="eyebrow">Original</p>
-                      <AssetMedia asset={comparisonSource} />
-                    </div>
-                    <div>
-                      <p className="eyebrow">Replacement</p>
-                      <AssetMedia asset={comparisonAsset} />
-                    </div>
-                  </div>
-                ) : (
-                  <div className="comparison-single">
-                    <p className="eyebrow">{abSide === "original" ? "A Original" : "B Replacement"}</p>
-                    <AssetMedia asset={abSide === "original" ? comparisonSource : comparisonAsset} />
-                  </div>
-                )}
-              </div>
-            ) : null}
-
-            {latestAssets.length > 1 ? (
-              <div className="review-grid video-review-grid">
-                {latestAssets.slice(1).map((asset) => (
-                  <AssetCard
-                    asset={asset}
-                    deleteAsset={deleteAsset}
-                    key={asset.id}
-                    onPreview={(previewed) => onPreview(previewed, latestAssets.slice(1))}
-                    purgeAsset={purgeAsset}
-                    updateAssetStatus={updateAssetStatus}
-                  />
-                ))}
-              </div>
-            ) : null}
-
-            {blockedMessage ? <p className="inline-warning">{blockedMessage}</p> : null}
-            <PresetValidationWarnings presetValidationResult={presetValidationResult} selectedModel={selectedModel} />
-            {selectedLoraValidationResult.incompatible.length ? (
-              <p className="inline-warning">
-                Generate is blocked because these selected LoRAs are incompatible with {selectedModel?.name ?? "the selected model"}: {selectedLoraValidationResult.incompatible.join(", ")}.
-              </p>
-            ) : null}
-          </div>
-
-          <div className="video-rail">
-            <aside className="render-rail">
-              <div className="preset-rail-head">
-                <h3>Render settings</h3>
-                <span className="preset-rail-model-tag">{selectedModel?.name ?? "—"}</span>
-              </div>
-
-              <label>
-                Model
-                <select onChange={(event) => setModel(event.target.value)} value={model}>
-                  {/* Models gated on the selected tab (sc-5716): show only models that serve the
-                      active mode, falling back to the full available list if none do (a reduced
-                      catalog) so the picker is never empty. */}
-                  {(modelsForMode(mode).length ? modelsForMode(mode) : baseVideoModels).map((item) => (
-                    <option key={item.id} value={item.id}>
-                      {item.name}
-                    </option>
-                  ))}
-                </select>
-              </label>
-
-              <div className="style-preset-strip">
-                <span className="style-preset-label">Style preset</span>
-                <div className="preset-chips">
-                  <button
-                    className={!selectedPreset ? "preset-chip active" : "preset-chip"}
-                    onClick={() => setSelectedPresetId(noPresetId)}
-                    type="button"
-                  >
-                    None
+          {/* Replace-person A/B / side-by-side review (video-specific, no Image Studio
+              equivalent) — surfaces the latest replacement clip against its source. */}
+          {comparisonAsset?.recipe?.mode === "replace_person" && comparisonSource ? (
+            <div className="comparison-panel">
+              <div className="comparison-toolbar">
+                <div className="segmented-control compact-segment" aria-label="Comparison mode">
+                  <button className={comparisonMode === "side_by_side" ? "active" : ""} onClick={() => setComparisonMode("side_by_side")} type="button">
+                    Side by Side
                   </button>
-                  {availablePresets.map((preset) => (
-                    <button
-                      className={selectedPreset?.id === preset.id ? "preset-chip active" : "preset-chip"}
-                      key={preset.id}
-                      onClick={() => setSelectedPresetId(preset.id)}
-                      type="button"
-                    >
-                      {preset.name ?? preset.id}
+                  <button className={comparisonMode === "ab" ? "active" : ""} onClick={() => setComparisonMode("ab")} type="button">
+                    A/B
+                  </button>
+                </div>
+                {comparisonMode === "ab" ? (
+                  <div className="segmented-control compact-segment" aria-label="A/B source">
+                    <button className={abSide === "original" ? "active" : ""} onClick={() => setAbSide("original")} type="button">
+                      A
                     </button>
-                  ))}
-                </div>
-              </div>
-
-              <SavePresetPanel
-                presetName={presetName}
-                setPresetName={setPresetName}
-                savingPreset={savingPreset}
-                presetSaveMessage={presetSaveMessage}
-                setPresetSaveMessage={setPresetSaveMessage}
-                onSave={handleSaveAsPreset}
-                presetScope={presetScope}
-                setPresetScope={setPresetScope}
-                activeProject={activeProject}
-                saveDisabled={!VIDEO_PRESET_MODES.includes(mode)}
-                saveTitle={VIDEO_PRESET_MODES.includes(mode) ? undefined : "Presets are available in Image→Video, Text→Video, or First/Last mode."}
-              />
-
-              <label>
-                Quality
-                <div className="quality-segment" role="radiogroup" aria-label="Quality">
-                  {qualityChoices.map(([value, label]) => (
-                    <button
-                      aria-checked={quality === value}
-                      className={quality === value ? "active" : ""}
-                      key={value}
-                      onClick={() => setQuality(value)}
-                      role="radio"
-                      type="button"
-                    >
-                      {label}
+                    <button className={abSide === "replacement" ? "active" : ""} onClick={() => setAbSide("replacement")} type="button">
+                      B
                     </button>
-                  ))}
-                </div>
-              </label>
-
-              <div className="control-grid preset-rail-row">
-                <label>
-                  Duration
-                  <select onChange={(event) => setDuration(Number(event.target.value))} value={duration}>
-                    {durationOptions.map((value) => (
-                      <option key={value} value={value}>
-                        {value}s
-                      </option>
-                    ))}
-                  </select>
-                </label>
-                <label>
-                  Frames
-                  <select onChange={(event) => setFps(Number(event.target.value))} value={fps}>
-                    {fpsOptions.map((value) => (
-                      <option key={value} value={value}>
-                        {value} fps
-                      </option>
-                    ))}
-                  </select>
-                </label>
+                  </div>
+                ) : null}
               </div>
-
-              <label>
-                Resolution
-                <select onChange={(event) => setResolution(event.target.value)} value={resolution}>
-                  {resolutionOptions.map((value) => (
-                    <option key={value} value={value}>
-                      {value.replace("x", " × ")}
-                    </option>
-                  ))}
-                </select>
-              </label>
-
-              <PresetGuidanceStrip
-                selectedPreset={selectedPreset}
-                presetPromptParts={presetPromptParts}
-                presetLoraDetails={presetLoraDetails}
-              />
-
-              {durationHint ? <p className="helper-copy">{durationHint}</p> : null}
-
-              <button className="advanced-toggle" onClick={() => setAdvancedOpen((value) => !value)} type="button">
-                <Icon.ChevDown className={advancedOpen ? "chev-rotate open" : "chev-rotate"} size={14} />
-                {advancedOpen ? "Hide advanced" : "Advanced"}
-              </button>
-
-              {advancedOpen ? (
-                <div className="advanced-panel">
-                  {showLightning ? (
-                    <div className="lightning-toggle">
-                      <label className="checkline">
-                        <input
-                          checked={lightning}
-                          onChange={(event) => setLightning(event.target.checked)}
-                          type="checkbox"
-                        />
-                        Lightning (fast 4-step)
-                      </label>
-                      <p className="helper-copy">
-                        {lightning
-                          ? "On: ~10× faster, 4 steps, CFG off, small quality trade-off. Steps and guidance are governed by the recipe."
-                          : "Off: full multi-step quality with CFG (slower). Use the Steps and Guidance controls below."}
-                      </p>
-                    </div>
-                  ) : null}
-                  {model === ltxVideoModelId ? (
-                    <>
-                      <label>
-                        LTX pipeline
-                        <select onChange={(event) => setLtxPipeline(event.target.value)} value={ltxPipeline}>
-                          <option value="auto">Auto (follow quality)</option>
-                          <option value="distilled">Distilled (single-stage)</option>
-                          <option value="two_stage">Two-stage (dev + upscaler)</option>
-                        </select>
-                      </label>
-                      <label>
-                        Distilled variant
-                        <select onChange={(event) => setDistilledVariant(event.target.value)} value={distilledVariant}>
-                          <option value="1.1">1.1 (newer aesthetic + audio)</option>
-                          <option value="1.0">1.0 (original)</option>
-                        </select>
-                      </label>
-                      <label>
-                        Precision
-                        <select onChange={(event) => setPrecision(event.target.value)} value={precision}>
-                          <option value="fp8">FP8 (lower VRAM)</option>
-                          <option value="bf16">BF16 (higher quality, CPU offload)</option>
-                        </select>
-                      </label>
-                    </>
-                  ) : null}
-                  {selectedModel?.adapter === "ltx_video" ? (
-                    <>
-                      <label>
-                        Video CFG
-                        <input
-                          min="0"
-                          max="30"
-                          onChange={(event) => setLtxVideoCfg(event.target.value)}
-                          placeholder="4.0"
-                          step="0.1"
-                          type="number"
-                          value={ltxVideoCfg}
-                        />
-                      </label>
-                      <label>
-                        Video STG
-                        <input
-                          min="0"
-                          max="10"
-                          onChange={(event) => setLtxVideoStg(event.target.value)}
-                          placeholder="0.0"
-                          step="0.1"
-                          type="number"
-                          value={ltxVideoStg}
-                        />
-                      </label>
-                      <label>
-                        Video rescale
-                        <input
-                          min="0"
-                          max="2"
-                          onChange={(event) => setLtxVideoRescale(event.target.value)}
-                          placeholder="0.7"
-                          step="0.05"
-                          type="number"
-                          value={ltxVideoRescale}
-                        />
-                      </label>
-                    </>
-                  ) : null}
-                  {["extend_clip", "video_bridge"].includes(mode) ? (
-                    <>
-                      <label>
-                        {mode === "video_bridge" ? "Left clip strength" : "Clip strength"}
-                        <input
-                          min="0"
-                          max="1"
-                          onChange={(event) => setVideoConditioningStrength(event.target.value)}
-                          placeholder="1.0"
-                          step="0.05"
-                          type="number"
-                          value={videoConditioningStrength}
-                        />
-                      </label>
-                      {mode === "video_bridge" ? (
-                        <label>
-                          Right clip strength
-                          <input
-                            min="0"
-                            max="1"
-                            onChange={(event) => setBridgeRightVideoConditioningStrength(event.target.value)}
-                            placeholder="1.0"
-                            step="0.05"
-                            type="number"
-                            value={bridgeRightVideoConditioningStrength}
-                          />
-                        </label>
-                      ) : null}
-                    </>
-                  ) : null}
-                  {supportsQuantization ? (
-                    <label>
-                      Quantization
-                      <select onChange={(event) => setQuantization(event.target.value)} value={quantization}>
-                        <option value="auto">Auto (per-platform default)</option>
-                        {quantVariants.map(([id, variant]) => (
-                          <option key={id} value={id}>
-                            {variant?.label ?? id}
-                          </option>
-                        ))}
-                        <option value="none">Full precision (unquantized)</option>
-                      </select>
-                    </label>
-                  ) : null}
-                  <label>
-                    GPU
-                    <select onChange={(event) => setRequestedGpu(event.target.value)} value={requestedGpu}>
-                      {gpuOptions.map((gpu) => (
-                        <option key={gpu} value={gpu}>
-                          {gpu === "auto" ? "Auto" : gpu}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                  <label>
-                    Seed
-                    <input onChange={(event) => setSeed(event.target.value)} placeholder="Random" type="number" value={seed} />
-                  </label>
-                  {showSamplerPicker ? (
-                    <label>
-                      Sampler
-                      <select onChange={(event) => setSampler(event.target.value)} value={sampler}>
-                        {samplerOptions.map((key) => (
-                          <option key={key} value={key}>
-                            {SAMPLER_LABELS[key] ?? key}
-                          </option>
-                        ))}
-                      </select>
-                    </label>
-                  ) : null}
-                  {showSchedulerPicker ? (
-                    <label>
-                      Scheduler
-                      <select onChange={(event) => setScheduler(event.target.value)} value={scheduler}>
-                        {schedulerOptions.map((key) => (
-                          <option key={key} value={key}>
-                            {SCHEDULER_LABELS[key] ?? key}
-                          </option>
-                        ))}
-                      </select>
-                    </label>
-                  ) : null}
-                  {showSchedulerPicker && scheduler !== "default" ? (
-                    <label>
-                      Schedule shift
-                      <input
-                        max="10"
-                        min="0.1"
-                        onChange={(event) => setSchedulerShift(Number(event.target.value))}
-                        step="0.1"
-                        type="number"
-                        value={schedulerShift}
-                      />
-                    </label>
-                  ) : null}
-                  <label>
-                    Steps
-                    <input
-                      min="1"
-                      max="80"
-                      disabled={lightningActive}
-                      onChange={(event) => setStepsOverride(event.target.value)}
-                      placeholder={lightningActive ? "4 (Lightning)" : String(stepsDefaultFromModel(selectedModel) ?? "")}
-                      title={lightningActive ? "Governed by Lightning (fast 4-step). Turn Lightning off to set steps." : undefined}
-                      type="number"
-                      value={lightningActive ? "" : stepsOverride}
-                    />
-                  </label>
-                  <label>
-                    Guidance
-                    <input
-                      min="0"
-                      max="30"
-                      disabled={lightningActive}
-                      onChange={(event) => setGuidanceOverride(event.target.value)}
-                      placeholder={lightningActive ? "off (Lightning)" : (() => {
-                        const value = guidanceDefaultFromModel(selectedModel);
-                        return value == null ? "" : String(value);
-                      })()}
-                      step="0.1"
-                      title={lightningActive ? "Governed by Lightning (fast 4-step). Turn Lightning off to set guidance." : undefined}
-                      type="number"
-                      value={lightningActive ? "" : guidanceOverride}
-                    />
-                  </label>
-                  <label>
-                    Character
-                    <select onChange={(event) => setCharacterId(event.target.value)} value={characterId}>
-                      <option value="">No character</option>
-                      {characters.map((character) => (
-                        <option key={character.id} value={character.id}>
-                          {character.name}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                  <label>
-                    Look
-                    <select onChange={(event) => setCharacterLookId(event.target.value)} value={characterLookId}>
-                      <option value="">Default look</option>
-                      {(characters.find((character) => character.id === characterId)?.looks ?? []).map((look) => (
-                        <option key={look.id} value={look.id}>
-                          {look.name}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                  <label className="prompt-field">
-                    Negative prompt
-                    <textarea onChange={(event) => setNegativePrompt(event.target.value)} value={negativePrompt} />
-                  </label>
-                  <LoraPickerSection
-                    selectedModel={selectedModel}
-                    selectedLoras={selectedLoras}
-                    selectedLoraIds={selectedLoraIds}
-                    compatibleLoras={compatibleLoras}
-                    userSelectedLoraCount={userSelectedLoraCount}
-                    showIncompatibleLoras={showIncompatibleLoras}
-                    setShowIncompatibleLoras={setShowIncompatibleLoras}
-                    toggleLora={toggleLora}
-                    effectiveLoraWeight={effectiveLoraWeight}
-                    setLoraWeight={setLoraWeight}
-                    loraEmptyMessage={loraEmptyMessage}
-                  />
-                  {characterId ? (
-                    <div className="guidance-strip">
-                      <strong>Character reference</strong>
-                      <span>
-                        Character and look are saved with the recipe; LTX image conditioning uses IC-LoRA when the selected preset includes one.
-                      </span>
-                    </div>
-                  ) : null}
+              {comparisonMode === "side_by_side" ? (
+                <div className="comparison-grid">
+                  <div>
+                    <p className="eyebrow">Original</p>
+                    <AssetMedia asset={comparisonSource} />
+                  </div>
+                  <div>
+                    <p className="eyebrow">Replacement</p>
+                    <AssetMedia asset={comparisonAsset} />
+                  </div>
                 </div>
-              ) : null}
-            </aside>
-
-            <VideoUpscalePanel
-              createVideoUpscaleJob={createVideoUpscaleJob}
-              macCapabilities={macCapabilities}
-              onSubmitted={(job) => {
-                onLocalJobCreated(job);
-                onOpenQueue();
-              }}
-              selectedAsset={selectedAsset}
-              videoAssets={videoAssets}
-            />
-
-            <aside className="tips-card">
-              <h3>Tips</h3>
-              <ul>
-                <li>Short clips (4–6s) compose better in the editor.</li>
-                <li>Describe the motion, not just the scene.</li>
-                <li>Pick a motion chip above to guide the camera.</li>
-              </ul>
-            </aside>
-
-            <aside className="keyboard-card">
-              <h3>Keyboard</h3>
-              <dl>
-                <div className="kbd-row">
-                  <span>Render</span>
-                  <span className="kbd-keys">
-                    <kbd>⌘</kbd>
-                    <kbd>↵</kbd>
-                  </span>
+              ) : (
+                <div className="comparison-single">
+                  <p className="eyebrow">{abSide === "original" ? "A Original" : "B Replacement"}</p>
+                  <AssetMedia asset={abSide === "original" ? comparisonSource : comparisonAsset} />
                 </div>
-              </dl>
-            </aside>
-          </div>
+              )}
+            </div>
+          ) : null}
         </div>
       </form>
       {guideOpen ? (

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -76,6 +76,16 @@ const buttonWithText = (root, text) =>
 const saveButton = (container) =>
   [...container.querySelectorAll("button")].find((b) => b.textContent.includes("Save as Preset"));
 const nameInput = (container) => container.querySelector('input[aria-label="Preset name"]');
+// Save-as-Preset folds into the Advanced panel (collapsed by default), matching Image
+// Studio's single-column layout — open it before touching the preset controls.
+const openAdvanced = async (container) => {
+  const toggle = [...container.querySelectorAll("button.advanced-toggle")].find((b) =>
+    b.textContent.includes("Advanced"),
+  );
+  if (toggle) {
+    await click(toggle);
+  }
+};
 
 describe("VideoStudio Save as Preset", () => {
   let container;
@@ -106,6 +116,7 @@ describe("VideoStudio Save as Preset", () => {
   it("snapshots the video config into a text_to_video preset without the seed", async () => {
     const context = baseContext();
     await render(context);
+    await openAdvanced(container);
 
     const input = nameInput(container);
     expect(input).toBeTruthy();
@@ -141,6 +152,7 @@ describe("VideoStudio Save as Preset", () => {
       ],
     });
     await render(context);
+    await openAdvanced(container);
 
     await act(async () => setInput(nameInput(container), "Push In"));
     await click(saveButton(container));
@@ -765,10 +777,7 @@ describe("VideoStudio Mac mode gating (sc-5716)", () => {
   }
 
   const modeButton = (label) => buttonWithText(container.querySelector(".mode-control"), label);
-  const modelSelect = () =>
-    [...container.querySelectorAll(".render-rail label")]
-      .find((el) => el.textContent.trim().startsWith("Model"))
-      ?.querySelector("select");
+  const modelSelect = () => container.querySelector(".settings-field-model select");
 
   it("does not trap the user after switching to a model-specific mode", async () => {
     const context = baseContext({

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3725,6 +3725,12 @@ label {
   transform: rotate(180deg);
 }
 
+/* The video upscale sub-panel folds into Advanced; span the full 2-column grid so its
+   own fields aren't squeezed into a single cell. */
+.advanced-panel .upscale-card {
+  grid-column: 1 / -1;
+}
+
 /* ---------- Video Studio hero variants ---------- */
 /* Hero contains: mode tabs row, prompt + render CTA row, motion chips row. */
 .prompt-source-thumb {


### PR DESCRIPTION
## Summary
Restructures the **Video Studio** from the two-column render-rail layout to the single-column generation flow used by Image Studio, per the design handoff *"Video Studio layout update"*. Everything above the results now lives in one `studio-prompt-hero` container; the results reclaim the full width below it.

**New hero order:** mode tabs → prompt + Render CTA → Refine → motion chips → source band → **settings bar** (Model / Resolution / Duration / Quality + Style-preset chips) → full-width **Advanced** button → Advanced panel. Results become a single-column `studio-results` review panel ("Latest batch").

## Changes
- **Fold into Advanced:** Frames (fps) + all power-user knobs (LTX pipeline/variant/precision, LTX CFG/STG/rescale, clip strengths, quantization, GPU, seed, sampler/scheduler, steps, guidance, Lightning, character/look, negative prompt, LoRA picker, Save-preset, and the VideoUpscale panel).
- **Removed:** inline preview player + playback bar, recent-clips strip, Tips/Keyboard side cards, and the two-column `video-results`/`video-rail`/`render-rail` scaffolding — plus the now-dead preview-player state/helpers.
- **Preserved:** the replace-person A/B comparison panel (video-specific, no Image Studio equivalent) inside the single-column results.
- **Advanced button:** rendered full-width + centered via the existing `.advanced-toggle` rule by virtue of being a direct hero-grid child — identical to Image Studio, no new modifier. Only added a full-width CSS rule for the folded `.upscale-card` in the 2-column Advanced grid.
- **Tests:** model-select helper now targets `.settings-field-model`; Save-as-Preset tests open Advanced first (the panel moved there).

## Notes / follow-ups
- `VideoUpscalePanel` (a *post-process* on an existing clip) is folded into the generation Advanced panel as an **interim**. True parity with Image Studio's inline upscale is generation-time (in-render) upscaling, filed as **sc-10294** (epic 4811).
- No backend/contract changes — web-only. `VideoUpscalePanel`, `createVideoJob` payload, and all state/effects are unchanged; this is a render-tree reorganization.

## Verification
- All **1313** web tests pass (`vitest`); **0** ESLint errors.
- Browser-verified the real component via a temporary mock-context harness: confirmed exact hero child order, settings bar, full-width Advanced button, folded controls, source band inside the hero, and the single-column review panel — none of the old classes present. Matches the design reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)