### PR TITLE
fix(lora): detect Ideogram-4 LoRA family so imports scope correctly (sc-10297)

### DIFF
--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -504,6 +504,7 @@ pub fn detect_lora_family(header: &Value) -> Option<String> {
         Bucket::Flux2 => Some("flux2".to_owned()),
         Bucket::LtxVideo => Some("ltx-video".to_owned()),
         Bucket::Sd3 => Some("sd3".to_owned()),
+        Bucket::Ideogram => Some("ideogram".to_owned()),
         Bucket::Sdxl => Some("sdxl".to_owned()),
         Bucket::Sd15 => Some("sd1.5".to_owned()),
         Bucket::MmDit => disambiguate_mm_dit(&keys),
@@ -564,6 +565,12 @@ enum Bucket {
     /// so SD3.5 community LoRAs are positively recognized rather than falling
     /// into the Qwen/Z-Image block-count disambiguation (sc-7874).
     Sd3,
+    /// Ideogram 4 (epic 4725): a single-stream 34-layer flow-matching DiT with a
+    /// unique `diffusion_model.layers.<n>.` block prefix and fused `attention.qkv`,
+    /// `adaln_modulation`, and `feed_forward.w{1,2,3}` modules — shared with no other
+    /// family we detect. Metadata (`ss_base_model_version: ideogram4`) is the primary
+    /// signal; this bucket catches metadata-less ComfyUI-style exports.
+    Ideogram,
     MmDit,
     Sdxl,
     Sd15,
@@ -738,6 +745,37 @@ const SIGNATURES: &[BucketSignature] = &[
             "diffusion_model.transformer_blocks.",
             ".attn1.",
             ".attn2.",
+        ],
+    },
+    BucketSignature {
+        bucket: Bucket::Ideogram,
+        // Ideogram 4 (epic 4725) native / ComfyUI export. Its single-stream 34-layer
+        // DiT prefixes every block key with `diffusion_model.layers.<n>.` — a segment
+        // no other detected family uses (`blocks`, `transformer_blocks`, `double_blocks`,
+        // `single_blocks` are all block-word forms; the CLIP text encoder uses
+        // `text_model.encoder.layers.`, a different prefix). Its modules are the fused
+        // `attention.qkv` / `attention.o`, `feed_forward.w{1,2,3}`, and `adaln_modulation`
+        // (full-word `attention`, not the `attn`/`self_attn`/`attn1` every other family
+        // uses). Requiring the prefix AND one Ideogram-specific module marker keeps this
+        // from firing on anything else; the block-word disqualifiers are belt-and-braces.
+        require_all_of: &[
+            &["diffusion_model.layers."],
+            &[".attention.qkv", ".adaln_modulation", ".feed_forward.w"],
+        ],
+        disqualifiers: &[
+            "transformer_blocks.",
+            "double_blocks.",
+            "single_blocks",
+            "diffusion_model.blocks.",
+        ],
+        markers: &[
+            "diffusion_model.layers.",
+            ".attention.qkv",
+            ".attention.o.",
+            ".feed_forward.w1",
+            ".feed_forward.w2",
+            ".feed_forward.w3",
+            ".adaln_modulation",
         ],
     },
     BucketSignature {
@@ -1104,6 +1142,14 @@ fn metadata_value_to_family(value: &str) -> Option<String> {
     // The label is `krea_2` (underscore) to match the catalog/trainer convention.
     if normalized.contains("krea") {
         return Some("krea_2".to_owned());
+    }
+    // Ideogram 4 (epic 4725): its own MMDiT (`diffusion_model.layers.<n>.attention.qkv`
+    // + `adaln_modulation`), a distinct family from every SD/Flux/Qwen architecture. The
+    // ai-toolkit trainer stamps `ss_base_model_version: "ideogram4"`; no other family's
+    // architecture string contains "ideogram", so match it here. The label is `ideogram`
+    // to match the `ideogram_4` catalog `family` / `loraCompatibility.families`.
+    if normalized.contains("ideogram") {
+        return Some("ideogram".to_owned());
     }
     // Check flux2 before flux: FLUX.2 architecture strings ("flux2", "flux-2",
     // "flux.2", "flux_2") all contain the "flux" substring, so the generic flux
@@ -1569,6 +1615,50 @@ mod tests {
         });
 
         assert_eq!(detect_lora_family(&header).as_deref(), Some("chroma"));
+    }
+
+    #[test]
+    fn ideogram_metadata_detects_ideogram_family() {
+        // An Ideogram 4 LoKr (ai-toolkit) stamps `ss_base_model_version: "ideogram4"`.
+        // Its MMDiT keys (`diffusion_model.layers.<n>.attention.qkv`) match no bucket
+        // signature, so without the metadata branch it detects as `None` — the failure
+        // that let an Ideogram LoRA import into a krea_2 folder. Metadata is read first
+        // and yields the canonical `ideogram` family token.
+        let mut header = header_from_keys(&[
+            "diffusion_model.layers.0.attention.qkv.lokr_w1",
+            "diffusion_model.layers.0.attention.qkv.lokr_w2",
+            "diffusion_model.layers.0.adaln_modulation.lokr_w2",
+        ]);
+        header["__metadata__"] = json!({
+            "ss_base_model_version": "ideogram4"
+        });
+
+        assert_eq!(detect_lora_family(&header).as_deref(), Some("ideogram"));
+    }
+
+    #[test]
+    fn ideogram_keys_detect_without_metadata() {
+        // A metadata-less Ideogram export (no `ss_base_model_version`) must still
+        // detect from its `diffusion_model.layers.<n>.` MMDiT keys via the bucket
+        // scorer, not fall through to None.
+        let mut keys = Vec::new();
+        for layer in 0..6 {
+            keys.push(format!(
+                "diffusion_model.layers.{layer}.attention.qkv.lokr_w2"
+            ));
+            keys.push(format!(
+                "diffusion_model.layers.{layer}.attention.o.lokr_w2"
+            ));
+            keys.push(format!(
+                "diffusion_model.layers.{layer}.feed_forward.w1.lokr_w2"
+            ));
+            keys.push(format!(
+                "diffusion_model.layers.{layer}.adaln_modulation.lokr_w2"
+            ));
+        }
+        let header = header_from_keys(&keys.iter().map(String::as_str).collect::<Vec<_>>());
+
+        assert_eq!(detect_lora_family(&header).as_deref(), Some("ideogram"));
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds Ideogram-4 to the LoRA architecture-family detector in `sceneworks_core::lora_family`, via two paths:

1. **Metadata** — `metadata_value_to_family` now maps `ss_base_model_version: ideogram4` (ai-toolkit's stamp; unique `ideogram` substring) → the canonical `ideogram` family token.
2. **Tensor keys** — new `Bucket::Ideogram` + `BucketSignature` keyed on the Ideogram-unique `diffusion_model.layers.<n>.` block prefix plus an Ideogram module marker (`attention.qkv` / `adaln_modulation` / `feed_forward.w{1,2,3}`), with block-word disqualifiers. This catches metadata-less ComfyUI-style exports.

## Why

An Ideogram-4 LoRA had **no** signature at all in the detector, so `detect_lora_family` returned `None`. With no detected family, the LoRA import couldn't scope the adapter — an Ideogram LoKr ended up in the `krea_2` LoRA folder and the manifest's declared file was repointed to it. A later `krea_2_raw` generation then resolved that file and failed deep in the engine:

```
krea_2_raw load failed: krea_2 adapters: no target modules matched across 1 adapter file(s)
```

That error was correct — the Ideogram namespace (`diffusion_model.layers.N.attention.qkv`) is architecturally disjoint from the Krea DiT (`transformer_blocks.N.attn.to_q/k/v`). The real defect was upstream: the file should never have been scoped to `krea_2`. Restoring auto-detection fixes the import-scoping at the source.

`ideogram_4`/`ideogram_4_turbo` already advertise `supports_lora`/`supports_lokr` and declare `family: ideogram` with `loraCompatibility.families: [ideogram]`, so detection was the only missing piece.

## Tests

- `lora_family::tests::ideogram_metadata_detects_ideogram_family` (metadata path, from the real file's keys+metadata)
- `lora_family::tests::ideogram_keys_detect_without_metadata` (key-based bucket path, no metadata)
- Full `lora_family` module green (75/75); `cargo fmt --check` + `cargo clippy -p sceneworks-core --lib` clean.

## Reviewer notes

- Scope is intentionally just detection (one file, +90 lines). The related **import/validation hardening** — `validate_lora_compatibility` trusts the *declared* manifest family rather than the resolved file's architecture, and the import lets a wrong-arch file pile into an existing family folder + repoint `files[]` — is **not** in this PR. It's the same class as sc-10214 and is captured as a follow-up on sc-10297.
- Branch merged with latest `main`.

Story: sc-10297 (epic 4725, relates to sc-10214)

🤖 Generated with [Claude Code](https://claude.com/claude-code)