### PR TITLE
MCP v1 follow-up hardening: cancel propagation, host-derived URLs, configurable waits, resilience (epic 10231)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5874,6 +5874,7 @@ version = "0.2.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
+ "http",
  "percent-encoding",
  "reqwest 0.12.28",
  "rmcp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5874,6 +5874,7 @@ version = "0.2.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
+ "percent-encoding",
  "reqwest 0.12.28",
  "rmcp",
  "serde",

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -851,10 +851,18 @@ pub(crate) fn create_app_with_state(
     // apply unchanged. Its tools call back into this API over plain HTTP
     // (`settings.mcp_api_url`, i.e. `SCENEWORKS_API_URL` or our own loopback
     // port) carrying the access token, so there is no second engine/DB path.
-    let mcp_service = sceneworks_mcp::streamable_http_service(sceneworks_mcp::ApiClientConfig {
-        base_url: state.settings.mcp_api_url.clone(),
-        access_token: Some(state.settings.access_token.clone()),
-    });
+    // Blocking-job wait policy comes from Settings (sc-10277: SCENEWORKS_MCP_JOB_*
+    // env knobs), clamped to the invariants the poll loop needs.
+    let mcp_service = sceneworks_mcp::streamable_http_service_with(
+        sceneworks_mcp::ApiClientConfig {
+            base_url: state.settings.mcp_api_url.clone(),
+            access_token: Some(state.settings.access_token.clone()),
+        },
+        sceneworks_mcp::JobWaitConfig::clamped(
+            state.settings.mcp_job_poll_interval,
+            state.settings.mcp_job_timeout,
+        ),
+    );
 
     let router = Router::new()
         .nest_service("/mcp", mcp_service)

--- a/apps/rust-api/src/server.rs
+++ b/apps/rust-api/src/server.rs
@@ -110,9 +110,10 @@ impl Settings {
             .ok()
             .and_then(|value| value.parse().ok())
             .unwrap_or(8000);
+        let host = env_string("SCENEWORKS_API_HOST", DEFAULT_API_HOST);
         Self {
             app_version: env_string("SCENEWORKS_APP_VERSION", "0.2.0"),
-            host: env_string("SCENEWORKS_API_HOST", DEFAULT_API_HOST),
+            host: host.clone(),
             port,
             data_dir,
             config_dir: env_path_or("SCENEWORKS_CONFIG_DIR", &defaults.config_dir),
@@ -149,15 +150,45 @@ impl Settings {
             trust_loopback: std::env::var("SCENEWORKS_TRUST_LOOPBACK")
                 .map(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "True"))
                 .unwrap_or(false),
-            // Loopback (not `host`, which may be 0.0.0.0) — the MCP self-calls
-            // originate on this machine by definition.
-            mcp_api_url: env_string("SCENEWORKS_API_URL", &format!("http://127.0.0.1:{port}")),
+            // The MCP self-calls originate on this machine; derive a base URL that
+            // resolves to an interface this API actually binds (sc-10260).
+            // `SCENEWORKS_API_URL` still overrides for reverse-proxy/container setups.
+            mcp_api_url: env_string("SCENEWORKS_API_URL", &default_mcp_api_url(&host, port)),
         }
     }
 
     pub fn projects_dir(&self) -> PathBuf {
         self.data_dir.join("projects")
     }
+}
+
+/// The self-call base URL the embedded MCP client uses when `SCENEWORKS_API_URL`
+/// is unset (sc-10260). The MCP tools call back into THIS process's `/api/v1/*`,
+/// so the URL must resolve to an interface this API is actually listening on:
+///   - a wildcard bind (`0.0.0.0`/`::`) or an explicit loopback host → dial
+///     loopback (`127.0.0.1`), which a wildcard socket also accepts;
+///   - a specific interface IP (e.g. `192.168.4.97`) → dial THAT host, because a
+///     socket bound only to it never accepts a `127.0.0.1` connection (the old
+///     hardcoded loopback default failed every catalog tool call in that setup).
+fn default_mcp_api_url(host: &str, port: u16) -> String {
+    let host = host.trim();
+    let is_wildcard_or_loopback = host.is_empty()
+        || host == "0.0.0.0"
+        || host == "::"
+        || host == "[::]"
+        || host == "127.0.0.1"
+        || host == "::1"
+        || host == "[::1]"
+        || host.eq_ignore_ascii_case("localhost");
+    let dial_host = if is_wildcard_or_loopback {
+        "127.0.0.1".to_owned()
+    } else if host.contains(':') && !host.starts_with('[') {
+        // Bare IPv6 literal (e.g. `fe80::1`) needs bracketing in a URL authority.
+        format!("[{host}]")
+    } else {
+        host.to_owned()
+    };
+    format!("http://{dial_host}:{port}")
 }
 
 #[derive(Clone)]
@@ -334,4 +365,58 @@ pub async fn run_worker() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod server_tests {
+    use super::default_mcp_api_url;
+
+    #[test]
+    fn default_mcp_api_url_dials_loopback_for_wildcard_and_loopback_hosts() {
+        for host in [
+            "0.0.0.0",
+            "::",
+            "[::]",
+            "127.0.0.1",
+            "::1",
+            "[::1]",
+            "localhost",
+            "LocalHost",
+            "",
+        ] {
+            assert_eq!(
+                default_mcp_api_url(host, 8000),
+                "http://127.0.0.1:8000",
+                "host {host:?} should self-dial loopback"
+            );
+        }
+    }
+
+    #[test]
+    fn default_mcp_api_url_dials_a_specific_interface_ip() {
+        // A socket bound only to this IP never accepts a 127.0.0.1 connection, so
+        // the self-call must target the bound interface (sc-10260).
+        assert_eq!(
+            default_mcp_api_url("192.168.4.97", 8000),
+            "http://192.168.4.97:8000"
+        );
+        assert_eq!(
+            default_mcp_api_url("  10.0.0.5  ", 9001),
+            "http://10.0.0.5:9001",
+            "surrounding whitespace is trimmed"
+        );
+    }
+
+    #[test]
+    fn default_mcp_api_url_brackets_a_bare_ipv6_literal() {
+        assert_eq!(
+            default_mcp_api_url("fe80::1", 8000),
+            "http://[fe80::1]:8000"
+        );
+        // An already-bracketed literal is left as-is.
+        assert_eq!(
+            default_mcp_api_url("[fe80::1]", 8000),
+            "http://[fe80::1]:8000"
+        );
+    }
 }

--- a/apps/rust-api/src/server.rs
+++ b/apps/rust-api/src/server.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use parking_lot::Mutex;
 use tokio::sync::Mutex as AsyncMutex;
@@ -95,6 +96,18 @@ pub struct Settings {
     /// sends `access_token` as `X-SceneWorks-Token`, so the self-calls pass the
     /// access-control gate whether or not loopback trust is enabled.
     pub mcp_api_url: String,
+    /// Epic 10231 (sc-10277) — poll cadence for the MCP blocking job tools
+    /// (`generate_image`): how often they re-poll `GET /api/v1/jobs/:id` while
+    /// waiting for a terminal status. Read from `SCENEWORKS_MCP_JOB_POLL_INTERVAL`
+    /// (whole seconds); defaults to the `JobWaitConfig` default. Clamped non-zero
+    /// at the mount point.
+    pub mcp_job_poll_interval: Duration,
+    /// Epic 10231 (sc-10277) — overall deadline for the MCP blocking job tools:
+    /// after this long without a terminal status the tool returns a clear timeout
+    /// error (the job itself is NOT canceled). Read from
+    /// `SCENEWORKS_MCP_JOB_TIMEOUT` (whole seconds); defaults to the
+    /// `JobWaitConfig` default (30 min). Clamped to ≥ the poll interval.
+    pub mcp_job_timeout: Duration,
 }
 
 impl Settings {
@@ -154,6 +167,17 @@ impl Settings {
             // resolves to an interface this API actually binds (sc-10260).
             // `SCENEWORKS_API_URL` still overrides for reverse-proxy/container setups.
             mcp_api_url: env_string("SCENEWORKS_API_URL", &default_mcp_api_url(&host, port)),
+            // MCP blocking-job wait knobs (sc-10277); whole seconds, default from
+            // JobWaitConfig. Invariants are enforced by JobWaitConfig::clamped at
+            // the mount point, so an out-of-range value here can't misbehave.
+            mcp_job_poll_interval: env_secs(
+                "SCENEWORKS_MCP_JOB_POLL_INTERVAL",
+                sceneworks_mcp::JobWaitConfig::default().poll_interval,
+            ),
+            mcp_job_timeout: env_secs(
+                "SCENEWORKS_MCP_JOB_TIMEOUT",
+                sceneworks_mcp::JobWaitConfig::default().timeout,
+            ),
         }
     }
 
@@ -189,6 +213,16 @@ fn default_mcp_api_url(host: &str, port: u16) -> String {
         host.to_owned()
     };
     format!("http://{dial_host}:{port}")
+}
+
+/// Parse a whole-seconds env var into a [`Duration`], keeping `default` when the
+/// variable is unset or not a non-negative integer (sc-10277).
+fn env_secs(name: &str, default: Duration) -> Duration {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(default)
 }
 
 #[derive(Clone)]
@@ -369,7 +403,29 @@ pub async fn run_worker() -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(test)]
 mod server_tests {
-    use super::default_mcp_api_url;
+    use super::{default_mcp_api_url, env_secs};
+    use std::time::Duration;
+
+    #[test]
+    fn env_secs_parses_whole_seconds_and_falls_back() {
+        // A unique name so this never collides with a real SCENEWORKS_* var.
+        let name = "SCENEWORKS_TEST_ENV_SECS_SC10277";
+        let default = Duration::from_secs(1800);
+
+        std::env::remove_var(name);
+        assert_eq!(env_secs(name, default), default, "unset → default");
+
+        std::env::set_var(name, "42");
+        assert_eq!(env_secs(name, default), Duration::from_secs(42));
+
+        std::env::set_var(name, "  7  ");
+        assert_eq!(env_secs(name, default), Duration::from_secs(7), "trimmed");
+
+        std::env::set_var(name, "notanumber");
+        assert_eq!(env_secs(name, default), default, "unparseable → default");
+
+        std::env::remove_var(name);
+    }
 
     #[test]
     fn default_mcp_api_url_dials_loopback_for_wildcard_and_loopback_hosts() {

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -289,6 +289,8 @@ fn test_settings(temp_dir: &tempfile::TempDir) -> Settings {
         // Placeholder for oneshot tests (the MCP self-client never dials it);
         // the live-listener MCP tests overwrite it with the bound address.
         mcp_api_url: "http://127.0.0.1:0".to_owned(),
+        mcp_job_poll_interval: sceneworks_mcp::JobWaitConfig::default().poll_interval,
+        mcp_job_timeout: sceneworks_mcp::JobWaitConfig::default().timeout,
     }
 }
 

--- a/crates/sceneworks-mcp/Cargo.toml
+++ b/crates/sceneworks-mcp/Cargo.toml
@@ -17,6 +17,11 @@ publish = false
 # Inline tool results: generated images come back as base64 `ImageContent` blocks
 # (sc-10234), so MCP clients can render them without another fetch.
 base64 = "0.22"
+# Read the incoming MCP request's Host header (via the `http::request::Parts` the
+# rmcp streamable-HTTP transport injects into the request extensions) so
+# get_job_result's ticket URLs point at the host the client actually used (sc-10290).
+# Pinned to rmcp's `http` major so the injected `Parts` type unifies.
+http = "1"
 # Per-segment percent-encoding of project-relative media paths before they are
 # spliced into `/files/*relative_path` URLs (sc-10279 defensive hardening).
 percent-encoding = "2.3"

--- a/crates/sceneworks-mcp/Cargo.toml
+++ b/crates/sceneworks-mcp/Cargo.toml
@@ -17,6 +17,9 @@ publish = false
 # Inline tool results: generated images come back as base64 `ImageContent` blocks
 # (sc-10234), so MCP clients can render them without another fetch.
 base64 = "0.22"
+# Per-segment percent-encoding of project-relative media paths before they are
+# spliced into `/files/*relative_path` URLs (sc-10279 defensive hardening).
+percent-encoding = "2.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 # Pinned exact (sc-10233): the official MCP Rust SDK moves fast and its
 # streamable-HTTP server surface (StreamableHttpService / tool_router macros) has

--- a/crates/sceneworks-mcp/src/api_client.rs
+++ b/crates/sceneworks-mcp/src/api_client.rs
@@ -11,10 +11,29 @@ use serde_json::Value;
 /// `SCENEWORKS_API_URL` (the same variable the Rust worker uses) and the token is
 /// the API's own `SCENEWORKS_ACCESS_TOKEN` — sent as `X-SceneWorks-Token`, the
 /// header `access_control` accepts.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ApiClientConfig {
     pub base_url: String,
     pub access_token: Option<String>,
+}
+
+// Manual `Debug` that never prints the token (sc-10260): the config is a plausible
+// argument to a future `tracing::debug!(?config)`, and this type is the one place
+// the secret is held in the clear (the crate-internal `ApiClient` deliberately does
+// not derive `Debug`). Presence — not value — is all a log needs.
+impl std::fmt::Debug for ApiClientConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiClientConfig")
+            .field("base_url", &self.base_url)
+            .field(
+                "access_token",
+                match &self.access_token {
+                    Some(_) => &"Some(<redacted>)",
+                    None => &"None",
+                },
+            )
+            .finish()
+    }
 }
 
 #[derive(Clone)]
@@ -144,5 +163,32 @@ impl ApiClient {
             return Err(ApiClientError::Api { status, detail });
         }
         Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_config_redacts_the_access_token() {
+        let config = ApiClientConfig {
+            base_url: "http://127.0.0.1:8000".to_owned(),
+            access_token: Some("super-secret-token".to_owned()),
+        };
+        let rendered = format!("{config:?}");
+        assert!(
+            !rendered.contains("super-secret-token"),
+            "Debug must never print the token: {rendered}"
+        );
+        assert!(rendered.contains("<redacted>"), "{rendered}");
+        assert!(rendered.contains("http://127.0.0.1:8000"), "{rendered}");
+
+        // Auth-off configs are distinguishable without leaking anything.
+        let no_token = ApiClientConfig {
+            base_url: "http://127.0.0.1:8000".to_owned(),
+            access_token: None,
+        };
+        assert!(format!("{no_token:?}").contains("None"));
     }
 }

--- a/crates/sceneworks-mcp/src/server.rs
+++ b/crates/sceneworks-mcp/src/server.rs
@@ -31,11 +31,11 @@ use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use rmcp::{
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
     model::{
-        CallToolResult, ContentBlock, Meta, ProgressNotificationParam, ProgressToken, Resource,
+        CallToolResult, ContentBlock, ProgressNotificationParam, ProgressToken, Resource,
         ServerCapabilities, ServerInfo,
     },
     schemars,
-    service::RoleServer,
+    service::{RequestContext, RoleServer},
     tool, tool_handler, tool_router, ErrorData, Peer, ServerHandler,
 };
 use serde_json::{json, Map, Value};
@@ -296,8 +296,7 @@ impl SceneWorksMcp {
     async fn generate_image(
         &self,
         Parameters(args): Parameters<GenerateImageArgs>,
-        meta: Meta,
-        peer: Peer<RoleServer>,
+        ctx: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let body =
             image_job_body(&args).map_err(|message| ErrorData::invalid_params(message, None))?;
@@ -316,13 +315,33 @@ impl SceneWorksMcp {
 
         // Progress notifications ride the client-supplied progressToken; without
         // one we just poll silently (the spec forbids inventing a token).
-        let progress_token = meta.get_progress_token();
-        let mut reporter = ProgressReporter::new(peer, progress_token);
+        let progress_token = ctx.meta.get_progress_token();
+        let mut reporter = ProgressReporter::new(ctx.peer.clone(), progress_token);
         reporter.report(&submitted).await;
 
         let started = tokio::time::Instant::now();
         let job = loop {
-            tokio::time::sleep(self.job_wait.poll_interval).await;
+            // Cooperative cancellation (sc-10276): rmcp cancels `ctx.ct` when the
+            // client sends `notifications/cancelled` (it does NOT abort the tool
+            // future, so a drop-guard would never fire). Catch it at the top of the
+            // wait and ask the job to stop, freeing the worker/GPU instead of
+            // letting a canceled render run to completion.
+            tokio::select! {
+                biased;
+                () = ctx.ct.cancelled() => {
+                    // Best-effort: the job may already be terminal, in which case the
+                    // cancel route is a harmless no-op.
+                    let _ = self
+                        .api
+                        .post_json(&format!("/api/v1/jobs/{job_id}/cancel"), &json!({}))
+                        .await;
+                    return tool_error(format!(
+                        "Image job {job_id} was canceled: the client canceled the \
+                         request, so the job was asked to stop."
+                    ));
+                }
+                () = tokio::time::sleep(self.job_wait.poll_interval) => {}
+            }
             let job = self
                 .api
                 .get_json(&format!("/api/v1/jobs/{job_id}"), &[])

--- a/crates/sceneworks-mcp/src/server.rs
+++ b/crates/sceneworks-mcp/src/server.rs
@@ -31,8 +31,8 @@ use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use rmcp::{
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
     model::{
-        CallToolResult, ContentBlock, ProgressNotificationParam, ProgressToken, Resource,
-        ServerCapabilities, ServerInfo,
+        CallToolResult, ContentBlock, Extensions, ProgressNotificationParam, ProgressToken,
+        Resource, ServerCapabilities, ServerInfo,
     },
     schemars,
     service::{RequestContext, RoleServer},
@@ -524,6 +524,7 @@ impl SceneWorksMcp {
     async fn get_job_result(
         &self,
         Parameters(args): Parameters<JobIdArgs>,
+        extensions: Extensions,
     ) -> Result<CallToolResult, ErrorData> {
         let job_id = valid_job_id(&args.job_id)
             .map_err(|message| ErrorData::invalid_params(message, None))?;
@@ -611,6 +612,20 @@ impl SceneWorksMcp {
         };
         let expires_in_seconds = ticket_response.get("expiresInSeconds").cloned();
 
+        // Absolute URL base for the ticket links (sc-10290). `/mcp` and `/api/v1`
+        // are the SAME axum app, so the host the client used to reach `/mcp` is
+        // exactly the host that serves the media — derive it from the incoming
+        // request so the URL is reachable by THIS client regardless of how
+        // `SCENEWORKS_API_URL` is configured (e.g. a loopback-default desktop
+        // answering a LAN client). Falls back to the configured API base when the
+        // request parts / Host aren't available. The Host is only reflected back to
+        // the caller that supplied it (never stored / shown to other users), and
+        // `/mcp` is already gated by access_control, so reflecting it is safe.
+        let link_base = extensions
+            .get::<http::request::Parts>()
+            .and_then(|parts| request_base_url(&parts.headers, &parts.uri))
+            .unwrap_or_else(|| self.api.base_url().to_owned());
+
         let mut blocks = Vec::with_capacity(assets.len() + 1);
         let mut summary_assets = Vec::with_capacity(assets.len());
         for (asset, media_path) in assets {
@@ -618,7 +633,7 @@ impl SceneWorksMcp {
                 "/api/v1/projects/{project_id}/files/{}?ticket={ticket}",
                 encode_media_path(&media_path)
             );
-            let url = format!("{}{relative_url}", self.api.base_url());
+            let url = format!("{link_base}{relative_url}");
             let mime_type = media_mime_type(
                 &media_path,
                 asset.pointer("/file/mimeType").and_then(Value::as_str),
@@ -654,11 +669,11 @@ impl SceneWorksMcp {
             "ticketExpiresInSeconds": expires_in_seconds,
             "note": format!(
                 "Each url embeds a short-lived media ticket — download promptly \
-                 (call get_job_result again for fresh links). The urls use the \
-                 SceneWorks API base \"{}\"; if that host is not reachable from \
-                 your machine, apply relativeUrl to the base you use to reach \
-                 this MCP server (everything before /mcp).",
-                self.api.base_url()
+                 (call get_job_result again for fresh links). The urls use the base \
+                 \"{link_base}\" (derived from the host you used to reach this MCP \
+                 server, so they should be directly fetchable); if that base is not \
+                 reachable, apply relativeUrl to the base you use to reach /mcp \
+                 (everything before /mcp)."
             ),
         }))?);
         Ok(CallToolResult::success(blocks))
@@ -1009,6 +1024,43 @@ pub(crate) fn media_mime_type(path: &str, sidecar_mime: Option<&str>) -> Option<
         _ => return None,
     };
     Some(mime.to_owned())
+}
+
+/// The absolute base (`scheme://authority`) a returned ticket URL should use so
+/// the CALLING client can fetch it (sc-10290): prefer what the client actually
+/// used to reach `/mcp` — `X-Forwarded-Host` then `Host` for the authority (with
+/// the request-target authority as a last resort), and `X-Forwarded-Proto` then
+/// the request scheme (default `http`) for the scheme. Returns `None` when no
+/// authority is available, so the caller falls back to the configured API base.
+pub(crate) fn request_base_url(headers: &http::HeaderMap, uri: &http::Uri) -> Option<String> {
+    let raw_authority = header_str(headers, "x-forwarded-host")
+        .or_else(|| header_str(headers, "host"))
+        .or_else(|| uri.authority().map(http::uri::Authority::as_str))?;
+    let authority = first_csv(raw_authority);
+    if authority.is_empty() {
+        return None;
+    }
+    let scheme = header_str(headers, "x-forwarded-proto")
+        .or_else(|| uri.scheme_str())
+        .map(first_csv)
+        .filter(|scheme| !scheme.is_empty())
+        .unwrap_or("http");
+    Some(format!("{scheme}://{authority}"))
+}
+
+/// A request header as a trimmed, non-empty `&str` (ASCII values only).
+fn header_str<'a>(headers: &'a http::HeaderMap, name: &str) -> Option<&'a str> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+/// The first entry of a possibly comma-separated forwarded header, trimmed — a
+/// proxy chain sets e.g. `X-Forwarded-Host: client-host, inner-host`.
+fn first_csv(value: &str) -> &str {
+    value.split(',').next().unwrap_or(value).trim()
 }
 
 /// Keep an asset for the inline result: image-typed (or untyped legacy) records.
@@ -1698,6 +1750,34 @@ mod tests {
         assert!(valid_job_id("../secrets").is_err());
         assert!(valid_job_id("job_1?x=1").is_err());
         assert!(valid_job_id("job 1").is_err());
+    }
+
+    #[test]
+    fn request_base_url_prefers_forwarded_then_host_then_none() {
+        use http::{HeaderMap, HeaderValue, Uri};
+        let uri: Uri = "/mcp".parse().unwrap();
+
+        // A plain Host header → http scheme by default.
+        let mut headers = HeaderMap::new();
+        headers.insert("host", HeaderValue::from_static("192.168.4.97:8000"));
+        assert_eq!(
+            request_base_url(&headers, &uri).as_deref(),
+            Some("http://192.168.4.97:8000")
+        );
+
+        // Reverse-proxy headers win, and only the first CSV entry is used.
+        headers.insert(
+            "x-forwarded-host",
+            HeaderValue::from_static("studio.example.com, inner:8000"),
+        );
+        headers.insert("x-forwarded-proto", HeaderValue::from_static("https"));
+        assert_eq!(
+            request_base_url(&headers, &uri).as_deref(),
+            Some("https://studio.example.com")
+        );
+
+        // No authority anywhere → None so the caller keeps the configured base.
+        assert_eq!(request_base_url(&HeaderMap::new(), &uri), None);
     }
 
     #[test]

--- a/crates/sceneworks-mcp/src/server.rs
+++ b/crates/sceneworks-mcp/src/server.rs
@@ -42,6 +42,12 @@ use serde_json::{json, Map, Value};
 
 use crate::api_client::{ApiClient, ApiClientError};
 
+/// How many consecutive `GET /api/v1/jobs/:id` failures the blocking poll loop
+/// tolerates before giving up (sc-10279). A single network blip / brief API
+/// restart must not throw away a possibly-20-minute render that is still running
+/// server-side; only a sustained failure streak surfaces as an error.
+const MAX_CONSECUTIVE_POLL_ERRORS: u32 = 5;
+
 /// How the blocking job tools (generate_image) wait for a terminal JobSnapshot:
 /// poll `GET /api/v1/jobs/:id` every `poll_interval` until terminal, and give up
 /// with a clear tool error after `timeout` so a stuck job can never hang the MCP
@@ -320,6 +326,7 @@ impl SceneWorksMcp {
         reporter.report(&submitted).await;
 
         let started = tokio::time::Instant::now();
+        let mut consecutive_poll_errors: u32 = 0;
         let job = loop {
             // Cooperative cancellation (sc-10276): rmcp cancels `ctx.ct` when the
             // client sends `notifications/cancelled` (it does NOT abort the tool
@@ -342,11 +349,33 @@ impl SceneWorksMcp {
                 }
                 () = tokio::time::sleep(self.job_wait.poll_interval) => {}
             }
-            let job = self
+            // Tolerate transient poll failures (sc-10279): the render keeps running
+            // server-side, so a single blip must not abort the whole tool call.
+            let job = match self
                 .api
                 .get_json(&format!("/api/v1/jobs/{job_id}"), &[])
                 .await
-                .map_err(api_error)?;
+            {
+                Ok(job) => {
+                    consecutive_poll_errors = 0;
+                    job
+                }
+                Err(error) => {
+                    consecutive_poll_errors += 1;
+                    if consecutive_poll_errors >= MAX_CONSECUTIVE_POLL_ERRORS {
+                        return Err(api_error(error));
+                    }
+                    if started.elapsed() >= self.job_wait.timeout {
+                        return tool_error(format!(
+                            "Image job {job_id} status polling kept failing (last error: \
+                             {error}) and the {}s deadline elapsed. The job may still be \
+                             running; it was not canceled.",
+                            self.job_wait.timeout.as_secs()
+                        ));
+                    }
+                    continue;
+                }
+            };
             reporter.report(&job).await;
             let status = job.get("status").and_then(Value::as_str).unwrap_or("");
             match status {
@@ -408,7 +437,10 @@ impl SceneWorksMcp {
             };
             let (bytes, header_mime) = self
                 .api
-                .get_bytes(&format!("/api/v1/projects/{project_id}/files/{media_path}"))
+                .get_bytes(&format!(
+                    "/api/v1/projects/{project_id}/files/{}",
+                    encode_media_path(&media_path)
+                ))
                 .await
                 .map_err(api_error)?;
             let mime_type = image_mime_type(
@@ -582,8 +614,10 @@ impl SceneWorksMcp {
         let mut blocks = Vec::with_capacity(assets.len() + 1);
         let mut summary_assets = Vec::with_capacity(assets.len());
         for (asset, media_path) in assets {
-            let relative_url =
-                format!("/api/v1/projects/{project_id}/files/{media_path}?ticket={ticket}");
+            let relative_url = format!(
+                "/api/v1/projects/{project_id}/files/{}?ticket={ticket}",
+                encode_media_path(&media_path)
+            );
             let url = format!("{}{relative_url}", self.api.base_url());
             let mime_type = media_mime_type(
                 &media_path,
@@ -983,6 +1017,31 @@ fn is_image_asset(asset: &Value) -> bool {
         Some(media_type) => media_type == "image",
         None => true,
     }
+}
+
+/// Percent-encode each segment of a project-relative media path for splicing into
+/// a `/files/*relative_path` URL, preserving the `/` separators (sc-10279).
+/// Generated media paths are slug-safe today, so this is byte-identical for them;
+/// it defends a future path segment containing a space, `%`, `#`, or `?` from
+/// silently mis-resolving. The set is the URL path percent-encode set plus `%`
+/// itself (the input is a raw filesystem path, not an already-escaped URL).
+pub(crate) fn encode_media_path(path: &str) -> String {
+    use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+    const SEGMENT: &AsciiSet = &CONTROLS
+        .add(b' ')
+        .add(b'"')
+        .add(b'#')
+        .add(b'%')
+        .add(b'<')
+        .add(b'>')
+        .add(b'?')
+        .add(b'`')
+        .add(b'{')
+        .add(b'}');
+    path.split('/')
+        .map(|segment| utf8_percent_encode(segment, SEGMENT).to_string())
+        .collect::<Vec<_>>()
+        .join("/")
 }
 
 /// The project-relative media path of a result asset, normalized for the
@@ -1639,6 +1698,22 @@ mod tests {
         assert!(valid_job_id("../secrets").is_err());
         assert!(valid_job_id("job_1?x=1").is_err());
         assert!(valid_job_id("job 1").is_err());
+    }
+
+    #[test]
+    fn encode_media_path_encodes_unsafe_segments_but_keeps_separators() {
+        // The common case: slug-safe generated paths are byte-identical.
+        assert_eq!(
+            encode_media_path("assets/images/g1/img_0001.png"),
+            "assets/images/g1/img_0001.png"
+        );
+        // Separators survive; space/#/% inside a segment are encoded.
+        assert_eq!(
+            encode_media_path("assets/my folder/a#b%c.png"),
+            "assets/my%20folder/a%23b%25c.png"
+        );
+        // A '?' in a segment can't be mistaken for the query string.
+        assert_eq!(encode_media_path("a/b?c.png"), "a/b%3Fc.png");
     }
 
     #[test]

--- a/crates/sceneworks-mcp/src/server.rs
+++ b/crates/sceneworks-mcp/src/server.rs
@@ -63,6 +63,25 @@ impl Default for JobWaitConfig {
     }
 }
 
+impl JobWaitConfig {
+    /// Build a config from deployment-supplied values (sc-10277), enforcing the
+    /// invariants the poll loop relies on: a zero/absent poll interval would spin
+    /// the CPU (or, as a `sleep(0)`, hammer the API), and a timeout below the
+    /// interval would fire before the first poll. A zero interval falls back to
+    /// the default cadence; the timeout is raised to at least one interval.
+    pub fn clamped(poll_interval: Duration, timeout: Duration) -> Self {
+        let poll_interval = if poll_interval.is_zero() {
+            Self::default().poll_interval
+        } else {
+            poll_interval
+        };
+        Self {
+            poll_interval,
+            timeout: timeout.max(poll_interval),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct SceneWorksMcp {
     api: ApiClient,
@@ -1619,6 +1638,24 @@ mod tests {
         );
         // Unknown extension + no sidecar → omit rather than guess.
         assert_eq!(media_mime_type("clips/c.bin", Some("")), None);
+    }
+
+    #[test]
+    fn job_wait_config_clamped_enforces_invariants() {
+        // Normal values pass through untouched.
+        let c = JobWaitConfig::clamped(Duration::from_secs(2), Duration::from_secs(600));
+        assert_eq!(c.poll_interval, Duration::from_secs(2));
+        assert_eq!(c.timeout, Duration::from_secs(600));
+
+        // A zero interval falls back to the default cadence (never sleep(0)).
+        let c = JobWaitConfig::clamped(Duration::ZERO, Duration::from_secs(600));
+        assert_eq!(c.poll_interval, JobWaitConfig::default().poll_interval);
+        assert_eq!(c.timeout, Duration::from_secs(600));
+
+        // A timeout below the interval is raised so the loop polls at least once.
+        let c = JobWaitConfig::clamped(Duration::from_secs(10), Duration::from_secs(3));
+        assert_eq!(c.poll_interval, Duration::from_secs(10));
+        assert_eq!(c.timeout, Duration::from_secs(10));
     }
 
     #[test]

--- a/crates/sceneworks-mcp/tests/generate_image_tool.rs
+++ b/crates/sceneworks-mcp/tests/generate_image_tool.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 use axum::extract::{Path, State};
 use axum::http::{header, HeaderMap, StatusCode};
+use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
@@ -495,6 +496,116 @@ async fn client_cancellation_propagates_to_the_job_cancel_route() {
     .await;
 
     let _ = harness.client.cancel().await;
+}
+
+#[tokio::test]
+async fn transient_poll_failures_are_tolerated_until_the_job_completes() {
+    // The first two `GET /jobs/:id` polls fail (500) — a transient blip — before
+    // the job reports completed. The tool must ride through, not abort the render
+    // (sc-10279).
+    #[derive(Clone)]
+    struct FlakyState {
+        polls: Arc<Mutex<usize>>,
+    }
+    let state = FlakyState {
+        polls: Arc::new(Mutex::new(0)),
+    };
+    let polls = state.polls.clone();
+    let router = Router::new()
+        .route(
+            "/api/v1/image/jobs",
+            post(|| async {
+                (
+                    StatusCode::CREATED,
+                    Json(json!({
+                        "id": "job-1", "status": "queued", "projectId": "p1",
+                        "progress": 0.0, "stage": "queued"
+                    })),
+                )
+            }),
+        )
+        .route(
+            "/api/v1/jobs/:job_id",
+            get(
+                |State(state): State<FlakyState>, Path(_job_id): Path<String>| async move {
+                    let n = {
+                        let mut polls = state.polls.lock().unwrap();
+                        let n = *polls;
+                        *polls += 1;
+                        n
+                    };
+                    if n < 2 {
+                        // Two consecutive transient failures (< the tolerance).
+                        return (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            Json(json!({ "detail": "temporary glitch" })),
+                        )
+                            .into_response();
+                    }
+                    Json(json!({
+                        "id": "job-1", "status": "completed", "projectId": "p1",
+                        "progress": 1.0, "stage": "completed",
+                        "result": { "assets": [image_asset("asset_1", PNG_PATH, "image/png")] }
+                    }))
+                    .into_response()
+                },
+            ),
+        )
+        .route(
+            "/api/v1/projects/:project_id/files/*relative_path",
+            get(
+                |Path((_project_id, relative_path)): Path<(String, String)>| async move {
+                    if relative_path == PNG_PATH {
+                        let mut headers = HeaderMap::new();
+                        headers.insert(header::CONTENT_TYPE, "image/png".parse().unwrap());
+                        (headers, PNG_BYTES.to_vec()).into_response()
+                    } else {
+                        StatusCode::NOT_FOUND.into_response()
+                    }
+                },
+            ),
+        )
+        .with_state(state);
+    let api_base = spawn(router).await;
+    let mcp_service = sceneworks_mcp::streamable_http_service_with(
+        ApiClientConfig {
+            base_url: api_base,
+            access_token: None,
+        },
+        JobWaitConfig {
+            poll_interval: Duration::from_millis(10),
+            timeout: Duration::from_secs(10),
+        },
+    );
+    let mcp_base = spawn(Router::new().nest_service("/mcp", mcp_service)).await;
+    let transport = StreamableHttpClientTransport::from_config(
+        StreamableHttpClientTransportConfig::with_uri(format!("{mcp_base}/mcp")),
+    );
+    let client = RecordingClient::default()
+        .serve(transport)
+        .await
+        .expect("MCP client initializes");
+
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("generate_image").with_arguments(generate_args(json!({}))),
+        )
+        .await
+        .expect("generate_image succeeds despite the transient poll failures");
+    assert_ne!(result.is_error, Some(true), "unexpected error: {result:?}");
+    let images: Vec<_> = result
+        .content
+        .iter()
+        .filter_map(|block| block.as_image())
+        .collect();
+    assert_eq!(images.len(), 1, "the render survived the blips: {result:?}");
+    // It really did fail twice and recover, not skip the failures.
+    assert!(
+        *polls.lock().unwrap() >= 3,
+        "expected 2 failed polls + a successful one"
+    );
+
+    let _ = client.cancel().await;
 }
 
 #[tokio::test]

--- a/crates/sceneworks-mcp/tests/generate_image_tool.rs
+++ b/crates/sceneworks-mcp/tests/generate_image_tool.rs
@@ -16,10 +16,10 @@ use axum::{Json, Router};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use rmcp::handler::client::ClientHandler;
 use rmcp::model::{
-    CallToolRequestParams, ClientInfo, Meta, NumberOrString, ProgressNotificationParam,
-    ProgressToken,
+    CallToolRequestParams, ClientInfo, ClientRequest, Meta, NumberOrString,
+    ProgressNotificationParam, ProgressToken, Request,
 };
-use rmcp::service::{NotificationContext, RoleClient};
+use rmcp::service::{NotificationContext, PeerRequestOptions, RoleClient};
 use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
 use rmcp::transport::StreamableHttpClientTransport;
 use rmcp::ServiceExt;
@@ -39,6 +39,8 @@ struct StubState {
     submitted: Arc<Mutex<Vec<Value>>>,
     polls: Arc<Mutex<usize>>,
     snapshots: Arc<Vec<Value>>,
+    /// Job ids the tool asked to cancel via `POST /jobs/:id/cancel` (sc-10276).
+    cancels: Arc<Mutex<Vec<String>>>,
 }
 
 fn snapshot(status: &str, progress: f64, stage: &str, extra: Value) -> Value {
@@ -101,6 +103,15 @@ fn stub_api_router(state: StubState) -> Router {
             ),
         )
         .route(
+            "/api/v1/jobs/:job_id/cancel",
+            post(
+                |State(state): State<StubState>, Path(job_id): Path<String>| async move {
+                    state.cancels.lock().unwrap().push(job_id);
+                    Json(json!({ "status": "canceled" }))
+                },
+            ),
+        )
+        .route(
             "/api/v1/projects/:project_id/files/*relative_path",
             get(
                 |Path((_project_id, relative_path)): Path<(String, String)>| async move {
@@ -156,6 +167,7 @@ struct Harness {
     submitted: Arc<Mutex<Vec<Value>>>,
     polls: Arc<Mutex<usize>>,
     progress: Arc<Mutex<Vec<ProgressNotificationParam>>>,
+    cancels: Arc<Mutex<Vec<String>>>,
 }
 
 /// Stub API + mounted MCP service (fast 10ms polls) + connected recording client.
@@ -164,9 +176,11 @@ async fn harness(snapshots: Vec<Value>) -> Harness {
         submitted: Arc::new(Mutex::new(Vec::new())),
         polls: Arc::new(Mutex::new(0)),
         snapshots: Arc::new(snapshots),
+        cancels: Arc::new(Mutex::new(Vec::new())),
     };
     let submitted = state.submitted.clone();
     let polls = state.polls.clone();
+    let cancels = state.cancels.clone();
     let api_base = spawn(stub_api_router(state)).await;
     let mcp_service = sceneworks_mcp::streamable_http_service_with(
         ApiClientConfig {
@@ -194,6 +208,7 @@ async fn harness(snapshots: Vec<Value>) -> Harness {
         submitted,
         polls,
         progress,
+        cancels,
     }
 }
 
@@ -223,6 +238,18 @@ fn error_text(result: &rmcp::model::CallToolResult) -> String {
         .map(|text| text.text.clone())
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+/// Poll `condition` until it holds, failing (never hanging) if it never does.
+async fn wait_until(mut condition: impl FnMut() -> bool) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while !condition() {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "condition was not met within 5s"
+        );
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
 }
 
 #[tokio::test]
@@ -421,6 +448,56 @@ async fn canceled_job_surfaces_clearly_not_as_a_hang() {
 }
 
 #[tokio::test]
+async fn client_cancellation_propagates_to_the_job_cancel_route() {
+    // The script never leaves "running", so the job would run forever on its own;
+    // the ONLY way the tool returns is the client canceling the in-flight request
+    // (sc-10276). That cancellation must reach POST /api/v1/jobs/:id/cancel.
+    let harness = harness(vec![snapshot("running", 0.4, "generating", json!({}))]).await;
+
+    let handle = harness
+        .client
+        .send_cancellable_request(
+            ClientRequest::CallToolRequest(Request::new(
+                CallToolRequestParams::new("generate_image")
+                    .with_arguments(generate_args(json!({}))),
+            )),
+            PeerRequestOptions::no_options(),
+        )
+        .await
+        .expect("cancellable generate_image request is sent");
+
+    // Let the tool get past submit and into its poll loop, so the cancellation
+    // lands mid-wait (the case the story is about), not before the job exists.
+    wait_until(|| {
+        !harness.submitted.lock().unwrap().is_empty() && *harness.polls.lock().unwrap() >= 1
+    })
+    .await;
+    assert!(
+        harness.cancels.lock().unwrap().is_empty(),
+        "no cancel before the client asks for one"
+    );
+
+    // Client cancels the in-flight request (MCP notifications/cancelled).
+    handle
+        .cancel(Some("user canceled".to_owned()))
+        .await
+        .expect("cancel notification is sent");
+
+    // The tool forwards it to the job cancel route, freeing the worker/GPU.
+    wait_until(|| {
+        harness
+            .cancels
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|id| id == "job-1")
+    })
+    .await;
+
+    let _ = harness.client.cancel().await;
+}
+
+#[tokio::test]
 async fn stuck_job_times_out_with_a_clear_error_instead_of_hanging() {
     // The script never leaves `running`; the (test-shortened) overall deadline
     // must turn that into a clear tool error, not an endless poll.
@@ -428,7 +505,9 @@ async fn stuck_job_times_out_with_a_clear_error_instead_of_hanging() {
         submitted: Arc::new(Mutex::new(Vec::new())),
         polls: Arc::new(Mutex::new(0)),
         snapshots: Arc::new(vec![snapshot("running", 0.5, "generating", json!({}))]),
+        cancels: Arc::new(Mutex::new(Vec::new())),
     };
+    let cancels = state.cancels.clone();
     let api_base = spawn(stub_api_router(state)).await;
     let mcp_service = sceneworks_mcp::streamable_http_service_with(
         ApiClientConfig {
@@ -464,6 +543,11 @@ async fn stuck_job_times_out_with_a_clear_error_instead_of_hanging() {
     assert!(
         text.contains("did not reach a terminal state"),
         "timeout must be explicit: {text}"
+    );
+    // A timeout is NOT a cancellation — the job is left running (sc-10276).
+    assert!(
+        cancels.lock().unwrap().is_empty(),
+        "the timeout path must not cancel the job"
     );
 
     let _ = client.cancel().await;

--- a/crates/sceneworks-mcp/tests/video_job_tools.rs
+++ b/crates/sceneworks-mcp/tests/video_job_tools.rs
@@ -137,7 +137,11 @@ struct Harness {
     client: rmcp::service::RunningService<rmcp::service::RoleClient, TestClient>,
     submitted: Arc<Mutex<Vec<Value>>>,
     tickets_minted: Arc<Mutex<usize>>,
-    api_base: String,
+    /// The base the client uses to reach `/mcp`. get_job_result derives the
+    /// ticket URL host from the incoming request (sc-10290), so in this split
+    /// harness (stub API on a different port than the mounted /mcp) the returned
+    /// url is based on THIS, not the stub API base.
+    mcp_base: String,
 }
 
 /// Stub API + mounted MCP service + connected client.
@@ -153,7 +157,7 @@ async fn harness(snapshots: Vec<Value>) -> Harness {
     let api_base = spawn(stub_api_router(state)).await;
     let mcp_service = sceneworks_mcp::streamable_http_service_with(
         ApiClientConfig {
-            base_url: api_base.clone(),
+            base_url: api_base,
             access_token: None,
         },
         JobWaitConfig {
@@ -173,7 +177,7 @@ async fn harness(snapshots: Vec<Value>) -> Harness {
         client,
         submitted,
         tickets_minted,
-        api_base,
+        mcp_base,
     }
 }
 
@@ -386,10 +390,13 @@ async fn get_job_result_returns_ticketed_video_link_without_inline_bytes() {
     assert_ne!(result.is_error, Some(true), "unexpected error: {result:?}");
 
     // A resource link (never inline bytes) whose URL is the absolute ticketed
-    // media URL — fetchable from another machine that can reach the API.
+    // media URL. The host is derived from the incoming MCP request (sc-10290), so
+    // it is the base the client used to reach /mcp — in production /mcp and
+    // /api/v1 are the same app, but this split test harness proves the derivation
+    // by using `mcp_base` (a different port than the stub `api_base`).
     let expected_url = format!(
         "{}/api/v1/projects/p1/files/{VIDEO_PATH}?ticket={TICKET}",
-        harness.api_base
+        harness.mcp_base
     );
     let links: Vec<_> = result
         .content

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -57,6 +57,8 @@ All knobs are on the API process (`Settings::from_env` in
 | `SCENEWORKS_API_URL` | `http://127.0.0.1:<port>` | Base URL the MCP server uses to call back into its own API **and the base of the absolute ticketed URLs `get_job_result` returns**. LAN deployments must set this to the LAN-reachable base — see below. |
 | `SCENEWORKS_TRUST_LOOPBACK` | off | `1`/`true` = requests from `127.0.0.1`/`::1` bypass the token. The desktop sets it; never set it behind a reverse proxy or on a shared multi-user machine. |
 | `SCENEWORKS_ALLOW_OPEN_BIND` | off | `1`/`true`/`yes` = allow a non-loopback bind with **no** token (the API refuses to start otherwise). Only for fully trusted networks. |
+| `SCENEWORKS_MCP_JOB_POLL_INTERVAL` | `1` | Seconds between status polls for the blocking `generate_image` tool. A zero value falls back to the default. |
+| `SCENEWORKS_MCP_JOB_TIMEOUT` | `1800` | Seconds the blocking `generate_image` tool waits for a job before returning a timeout error (the job itself keeps running / is not canceled). Clamped to ≥ the poll interval. |
 
 ### `SCENEWORKS_API_URL` on the LAN — read this
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -54,34 +54,33 @@ All knobs are on the API process (`Settings::from_env` in
 | `SCENEWORKS_API_HOST` | `127.0.0.1` | Bind address. Loopback by default — set `0.0.0.0` to serve the LAN. |
 | `SCENEWORKS_API_PORT` | `8000` | Bind port (Docker Compose publishes `8010` by default). |
 | `SCENEWORKS_ACCESS_TOKEN` | *(empty)* | The access token. Empty = auth off (loopback-only use). Required in practice for any non-loopback bind (see the open-bind guard). |
-| `SCENEWORKS_API_URL` | `http://127.0.0.1:<port>` | Base URL the MCP server uses to call back into its own API **and the base of the absolute ticketed URLs `get_job_result` returns**. LAN deployments must set this to the LAN-reachable base — see below. |
+| `SCENEWORKS_API_URL` | derived from bind host/port | Base URL the MCP server uses to call back into its own API, and the **fallback** base for `get_job_result`'s ticket URLs (which now default to the incoming request's `Host` — see below). Defaults to the bound interface (`sc-10260`); override for reverse-proxy/container setups. |
 | `SCENEWORKS_TRUST_LOOPBACK` | off | `1`/`true` = requests from `127.0.0.1`/`::1` bypass the token. The desktop sets it; never set it behind a reverse proxy or on a shared multi-user machine. |
 | `SCENEWORKS_ALLOW_OPEN_BIND` | off | `1`/`true`/`yes` = allow a non-loopback bind with **no** token (the API refuses to start otherwise). Only for fully trusted networks. |
 | `SCENEWORKS_MCP_JOB_POLL_INTERVAL` | `1` | Seconds between status polls for the blocking `generate_image` tool. A zero value falls back to the default. |
 | `SCENEWORKS_MCP_JOB_TIMEOUT` | `1800` | Seconds the blocking `generate_image` tool waits for a job before returning a timeout error (the job itself keeps running / is not canceled). Clamped to ≥ the poll interval. |
 
-### `SCENEWORKS_API_URL` on the LAN — read this
+### `SCENEWORKS_API_URL` on the LAN
 
-Two things derive from `SCENEWORKS_API_URL` (`Settings.mcp_api_url`):
-
-1. the MCP tools' outbound self-calls into `/api/v1/*`, and
-2. the **absolute URLs** in `get_job_result`'s download links.
-
-It defaults to `http://127.0.0.1:<port>`, which is correct for self-calls but
-useless to a remote client: without an override, `get_job_result` hands a LAN
-caller `http://127.0.0.1:8000/...` links that only resolve on the server
-itself. **When serving the LAN, set `SCENEWORKS_API_URL` to the base your
-clients can reach**, e.g.:
+`SCENEWORKS_API_URL` (`Settings.mcp_api_url`) is the base for the MCP tools'
+outbound self-calls into `/api/v1/*`. When unset it is derived from the bind
+host/port: a wildcard/loopback bind self-dials `127.0.0.1`, and a specific
+interface bind (e.g. `SCENEWORKS_API_HOST=192.168.4.97`) self-dials that
+interface (sc-10260). Override it only for reverse-proxy / container setups
+where the process cannot reach its own `/api/v1` at the bound address:
 
 ```text
 SCENEWORKS_API_URL=http://192.168.4.97:8000
 ```
 
-Each result asset also carries a `relativeUrl`, and the result's `note` says to
-re-base it onto whatever base you use to reach the MCP server (everything
-before `/mcp`) — so a mis-set base is recoverable client-side, just annoying.
-Deriving ticket URLs from the request's `Host` header instead is filed as
-sc-10290.
+**Ticket download URLs** (`get_job_result`) no longer depend on this variable:
+because `/mcp` and `/api/v1` are the same app, the absolute URL host is derived
+per-request from the `Host` (or `X-Forwarded-Host`/`-Proto`) the client used to
+reach `/mcp`, so it is reachable by that client regardless of `SCENEWORKS_API_URL`
+(sc-10290). `SCENEWORKS_API_URL` (or the loopback default) is only the fallback
+when the request carries no usable Host. Each asset also carries a `relativeUrl`,
+and the result `note` says to re-base it onto whatever host reaches `/mcp`, so an
+edge case is still recoverable client-side.
 
 ## Security posture for LAN exposure
 
@@ -289,18 +288,18 @@ Expected failure modes: no/wrong token → `401` with
    links). If the absolute URL host is not reachable from your machine, apply
    `relativeUrl` to the base you use to reach the MCP server.
 
-## Known limitations (filed follow-ups)
+## Known limitations
 
-- Absolute ticket URLs come from `SCENEWORKS_API_URL`, not the request's Host
-  header (sc-10290) — set the variable correctly on LAN deployments.
-- Cancelling the MCP call does not cancel the underlying SceneWorks job
-  (sc-10276): a cancelled `generate_image` keeps rendering server-side.
-- The blocking-wait poll interval/deadline are not operator-configurable yet
-  (sc-10277).
-- With `SCENEWORKS_API_HOST` set to a specific non-loopback interface IP and
-  no `SCENEWORKS_API_URL`, the MCP self-calls still default to loopback, which
-  works only when the listener also answers on loopback (sc-10260) — set
-  `SCENEWORKS_API_URL` explicitly in that configuration.
+- End-to-end validation from a physically separate second machine on the LAN
+  (true NIC-to-NIC + Windows Defender Firewall traversal) is still outstanding
+  (sc-10301); the validation record below was run against the host's own LAN IP,
+  which exercises the auth/throttle/ticket paths but not separate-hardware
+  reachability.
+
+Earlier follow-ups filed during epic execution are now resolved: ticket URLs
+derive from the request Host (sc-10290), MCP-call cancellation propagates to the
+job (sc-10276), the blocking-wait poll interval/deadline are operator-configurable
+(sc-10277), and the self-call base auto-derives from the bound interface (sc-10260).
 
 ## Validation record
 


### PR DESCRIPTION
Closes the five implementable v1 follow-up stories filed during epic [10231](https://app.shortcut.com/trefry/epic/10231) execution. One PR for the whole hardening phase, one commit per story. (Deferred-v2 stories sc-10237/38/39 are intentionally out of scope; sc-10301 needs a physical second LAN machine and cannot be automated.)

## Stories

- **[sc-10260](https://app.shortcut.com/trefry/story/10260)** (chore) — `ApiClientConfig` no longer derives `Debug`; a manual impl prints `access_token` as `Some(<redacted>)`/`None` so a future `tracing::debug!(?config)` can't leak the token. The `mcp_api_url` self-call default now dials the **bound interface** (not hardcoded loopback) when `SCENEWORKS_API_HOST` is a specific IP, so catalog tools stop failing in that setup.
- **[sc-10276](https://app.shortcut.com/trefry/story/10276)** (feature) — `generate_image` propagates MCP client cancellation to `POST /api/v1/jobs/:id/cancel`, freeing the GPU instead of letting a canceled render finish. rmcp 2.1.0 does **not** abort the tool future on cancel (it cancels `ctx.ct`), so this is cooperative — a drop-guard would never fire. Timeout deliberately does *not* cancel.
- **[sc-10277](https://app.shortcut.com/trefry/story/10277)** (chore) — `SCENEWORKS_MCP_JOB_POLL_INTERVAL` / `SCENEWORKS_MCP_JOB_TIMEOUT` env knobs, clamped (non-zero interval, timeout ≥ interval), threaded through the `/mcp` mount. Tool-agnostic so future blocking tools inherit them.
- **[sc-10279](https://app.shortcut.com/trefry/story/10279)** (chore) — the poll loop tolerates up to 5 consecutive transient `GET /jobs/:id` failures before erroring (a blip no longer discards a 20-min render); media paths are percent-encoded per segment before splicing into `/files/*` URLs.
- **[sc-10290](https://app.shortcut.com/trefry/story/10290)** (feature) — `get_job_result` derives the ticket-URL host from the incoming MCP request (`X-Forwarded-Host`/`Host` + `-Proto`) instead of the configured API base, so links are reachable by the calling client regardless of `SCENEWORKS_API_URL`. Falls back to the configured base when no Host is present.

## Tests
All new behavior is covered by tests driving a **real rmcp streamable-HTTP client** against a stub `/api/v1`:
- cancellation propagation (cancel mid-wait → asserts the job-cancel route was hit; timeout asserts it was *not*),
- transient-failure tolerance (two 500s then completes → render survives),
- host-derived ticket URL (split harness proves the URL uses the `/mcp` base, not the stub API base),
- plus unit tests for token redaction, `default_mcp_api_url` host classes, `env_secs`, `JobWaitConfig::clamped`, `encode_media_path`, and `request_base_url`.

`docs/mcp-server.md` updated (new env knobs, ticket-URL host behavior, resolved follow-ups).

Verified locally: `cargo fmt --all --check`, `cargo clippy -p sceneworks-mcp -p sceneworks-rust-api --all-targets -D warnings`, full `sceneworks-mcp` suite + all 211 `sceneworks-rust-api` lib tests green.

## Not in scope
- **sc-10301** — physical second-machine LAN E2E validation (needs separate hardware + Windows Firewall traversal; cannot be automated from the host box). Left in To Do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)