### PR TITLE
feat(model-manager): tabbed interface — Image/Video/Utility/LoRAs + search (sc-10309)

### DIFF
--- a/apps/web/src/App.models.test.jsx
+++ b/apps/web/src/App.models.test.jsx
@@ -3,7 +3,7 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App, eventUrl } from "./main.jsx";
 import { liveElapsedSeconds } from "./formatting.js";
-import { withModelManagerContext, FakeEventSource, response, settle, field, loraPanel, modelImportPanel, buttonInside, changeField, changeFile } from "./main.testSupport.jsx";
+import { withModelManagerContext, FakeEventSource, response, settle, field, loraPanel, modelImportPanel, buttonInside, changeField, changeFile, selectModelTab, familyFilter } from "./main.testSupport.jsx";
 
 describe("SceneWorks app shell", () => {
   let container;
@@ -241,6 +241,7 @@ describe("SceneWorks app shell", () => {
       [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Models").click();
     });
     await settle();
+    await selectModelTab("LoRAs");
     const panel = loraPanel(container);
     await changeField(field(panel, "Source URL"), "https://example.com/loras/detail.safetensors");
     await act(async () => {
@@ -375,7 +376,8 @@ describe("SceneWorks app shell", () => {
       [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Models").click();
     });
     await settle();
-    await changeField(field(container, "LoRA family"), "z-image");
+    await selectModelTab("LoRAs");
+    await changeField(familyFilter(container), "z-image");
     await act(async () => {
       FakeEventSource.instances[0].listeners["job.updated"]({
         data: JSON.stringify({
@@ -554,6 +556,7 @@ describe("SceneWorks app shell", () => {
       [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Models").click();
     });
     await settle();
+    await selectModelTab("LoRAs");
     await act(async () => {
       buttonInside(loraPanel(container), "Upload").click();
     });
@@ -619,6 +622,7 @@ describe("SceneWorks app shell", () => {
       [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Open Models").click();
     });
     await settle();
+    await selectModelTab("LoRAs");
 
     expect(container.textContent).toContain("Models");
     expect(container.textContent).toContain("Import LoRA");
@@ -642,6 +646,7 @@ describe("SceneWorks app shell", () => {
       );
     });
 
+    await selectModelTab("LoRAs");
     const panel = loraPanel(container);
     await changeField(field(panel, "Source URL"), "https://example.com/loras/detail.safetensors");
     await changeField(field(panel, "Name"), "Detail LoRA");
@@ -680,8 +685,9 @@ describe("SceneWorks app shell", () => {
       );
     });
 
-    expect(field(container, "LoRA family").value).toBe("all");
-    await changeField(field(container, "LoRA family"), "qwen-image");
+    await selectModelTab("LoRAs");
+    expect(familyFilter(container).value).toBe("all");
+    await changeField(familyFilter(container), "qwen-image");
     const panel = loraPanel(container);
     await changeField(field(panel, "Source URL"), "https://example.com/loras/detail.safetensors");
     await act(async () => {
@@ -726,6 +732,7 @@ describe("SceneWorks app shell", () => {
       ]);
     });
 
+    await selectModelTab("LoRAs");
     const panel = loraPanel(container);
     await changeField(field(panel, "Family"), "qwen-image");
     expect(field(panel, "Family").value).toBe("qwen-image");
@@ -785,7 +792,7 @@ describe("SceneWorks app shell", () => {
       );
     });
 
-    expect(container.textContent).toContain("Download size");
+    // The card footer surfaces each model's download size (the old repo/size <dl> is gone).
     expect(container.textContent).toContain("~30.6 GB");
     expect(container.textContent).toContain("8.0 GB");
     expect(container.textContent).toContain("Unavailable");
@@ -813,15 +820,17 @@ describe("SceneWorks app shell", () => {
       );
     });
 
+    await selectModelTab("LoRAs");
     const rows = [...document.body.querySelectorAll(".lora-row")];
     expect(rows).toHaveLength(2);
     expect(rows[0].textContent).toContain("Ready Style");
     expect(rows[0].textContent).toContain("installed");
-    expect(rows[0].classList.contains("warning")).toBe(false);
+    expect(rows[0].classList.contains("unavailable")).toBe(false);
     expect(rows[1].textContent).toContain("Broken Style");
+    // A registered user LoRA with no local files reads "unavailable" and carries the
+    // danger-tinted row treatment.
     expect(rows[1].textContent).toContain("unavailable");
-    expect(rows[1].classList.contains("warning")).toBe(true);
-    expect(container.textContent).toContain("1 installed · 1 unavailable");
+    expect(rows[1].classList.contains("unavailable")).toBe(true);
   });
 
   it("confirms and deletes models and LoRAs from the Models page", async () => {
@@ -847,7 +856,7 @@ describe("SceneWorks app shell", () => {
     });
 
     await act(async () => {
-      document.body.querySelector(".model-row .danger-action").click();
+      document.body.querySelector(".model-card .danger-action").click();
     });
 
     expect(confirm).toHaveBeenCalledWith(expect.stringContaining('Delete model "Z-Image Turbo"?'));
@@ -855,6 +864,7 @@ describe("SceneWorks app shell", () => {
     expect(onDeleteModel).toHaveBeenCalledWith(expect.objectContaining({ id: "z_image_turbo" }));
     expect(container.textContent).toContain("Removed the registry entry for Z-Image Turbo.");
 
+    await selectModelTab("LoRAs");
     await act(async () => {
       document.body.querySelector(".lora-row .danger-action").click();
     });
@@ -907,6 +917,7 @@ describe("SceneWorks app shell", () => {
       root.render(<Harness />);
     });
 
+    await selectModelTab("LoRAs");
     const panel = () => loraPanel(container);
     await changeField(field(panel(), "Source URL"), "https://example.com/loras/one.safetensors");
     await changeField(field(panel(), "Name"), "First Detail");
@@ -956,6 +967,7 @@ describe("SceneWorks app shell", () => {
       );
     });
 
+    await selectModelTab("LoRAs");
     await act(async () => {
       buttonInside(loraPanel(container), "Upload").click();
     });
@@ -1003,6 +1015,7 @@ describe("SceneWorks app shell", () => {
       );
     });
 
+    await selectModelTab("LoRAs");
     expect(container.textContent).toContain("LoRA imports");
     expect(container.textContent).toContain("broken_detail");
     expect(container.textContent).toContain("Adapter crashed");
@@ -1045,6 +1058,7 @@ describe("SceneWorks app shell", () => {
       );
     });
 
+    await selectModelTab("LoRAs");
     expect(container.textContent).not.toContain("LoRA manifestPath must target");
     expect(container.textContent).not.toContain("LoRA imports");
     expect(container.textContent).toContain("No user LoRAs yet");
@@ -1069,6 +1083,7 @@ describe("SceneWorks app shell", () => {
       );
     });
 
+    await selectModelTab("LoRAs");
     const panel = loraPanel(container);
     await changeField(field(panel, "Source URL"), "file:///tmp/detail.safetensors");
     await act(async () => {
@@ -1101,9 +1116,11 @@ describe("SceneWorks app shell", () => {
 
     expect(modelImportPanel(container)).toBeNull();
     expect(container.textContent).not.toContain("Import model");
-    // LoRA import is unaffected, and the rest of the Models page still renders.
-    expect(loraPanel(container)).not.toBeNull();
+    // The image model's card is on the default (Image) tab.
     expect(container.textContent).toContain("Z-Image Turbo");
+    // LoRA import is unaffected — its form is on the LoRAs tab.
+    await selectModelTab("LoRAs");
+    expect(loraPanel(container)).not.toBeNull();
   });
 
   it("renders unassociated models with a needs-family badge", async () => {
@@ -1153,6 +1170,7 @@ describe("SceneWorks app shell", () => {
       );
     });
 
+    await selectModelTab("LoRAs");
     expect(container.textContent).toContain("Model imports in progress");
     expect(container.textContent).toContain("Model Import");
     expect(container.textContent).toContain("Downloading");

--- a/apps/web/src/main.testSupport.jsx
+++ b/apps/web/src/main.testSupport.jsx
@@ -212,6 +212,23 @@ export function loraPanel(container) {
   return container.querySelector("form[aria-label='Import LoRA']");
 }
 
+// The Model Manager is a tabbed interface (epic 10309): Image / Video / Utility / LoRAs.
+// A model card or the LoRA import form is only mounted while its tab is active, so tests
+// switch tabs after opening the Models page. The tab button text carries a trailing count
+// badge, so match by substring.
+export async function selectModelTab(label) {
+  await act(async () => {
+    [...document.body.querySelectorAll('[role="tab"]')].find((tab) => tab.textContent.includes(label))?.click();
+  });
+  await settle();
+}
+
+// The family filter moved onto the tab bar (aria-label "Filter by family"), no longer a
+// labelled control, so `field(container, "LoRA family")` no longer resolves it.
+export function familyFilter(container) {
+  return container.querySelector(".models-family-select");
+}
+
 export function modelImportPanel(container) {
   return container.querySelector("form[aria-label='Import model']");
 }

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -121,14 +121,6 @@ const MODEL_TYPE_OPTIONS = [
 // restoration point is preserved. Removing it would discard tracked, in-progress roadmap work.
 const MODEL_IMPORT_ENABLED = false;
 
-// Models render in type-grouped sections. Order is fixed; any model whose `type`
-// isn't listed here falls into a trailing "Other" group so nothing is hidden.
-const MODEL_TYPE_GROUPS = [
-  { type: "image", label: "Image Models" },
-  { type: "video", label: "Video Models" },
-  { type: "utility", label: "Utility Models" },
-];
-
 // Capability descriptors shown as chips on each model card. With models now grouped
 // by `type`, the chips are what tell the user what a card actually does (plain
 // text-to-image vs editing vs character reference, etc.). Unknown keys fall back to
@@ -551,21 +543,26 @@ export function ModelManagerScreen() {
   const [modelFileInputKey, setModelFileInputKey] = useState(0);
   const [deletingItem, setDeletingItem] = useState("");
   const [deleteMessage, setDeleteMessage] = useState({ tone: "neutral", text: "" });
-  // Expandable model rows (UI-refinement 1c): each model is a collapsed row (name · family ·
-  // status · size) that expands to reveal capabilities, description, repo/MLX and actions —
-  // the same rhythm as the LoRA rows. Rows needing attention (an active download/convert, an
-  // incomplete cache) auto-expand.
-  const [expandedModels, setExpandedModels] = useState(() => new Set());
-  const toggleModel = (id) =>
-    setExpandedModels((current) => {
-      const next = new Set(current);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
-      return next;
-    });
+  // Tabbed interface (epic 10309): the active tab, the tab to restore when a search
+  // clears, and the persistent search query. Every model now renders as an always-open
+  // card, so the old per-row expand state is gone. Tabs: image | video | utility | lora,
+  // plus a transient "search" tab that only exists while `search` is non-empty.
+  const [activeTab, setActiveTab] = useState("image");
+  const [prevTab, setPrevTab] = useState("image");
+  const [search, setSearch] = useState("");
+  // Typing into search auto-switches to the transient Search Results tab (remembering the
+  // tab we came from); clearing it restores that tab. Clicking a tab just sets it.
+  const handleSearchChange = (event) => {
+    const value = event.target.value;
+    const hasValue = value.trim() !== "";
+    setSearch(value);
+    if (hasValue && activeTab !== "search") {
+      setPrevTab(activeTab);
+      setActiveTab("search");
+    } else if (!hasValue && activeTab === "search") {
+      setActiveTab(prevTab || "image");
+    }
+  };
   // Read the host's memory so MLX models can be gated against their memory tier.
   // Desktop reads it from the Tauri GPU probe; a remote LAN browser reads the
   // auth-protected REST signal (epic 4484 story 9). `isDesktop`/`tauriInvoke` come
@@ -906,29 +903,12 @@ export function ModelManagerScreen() {
     (isModelFileImport ? !modelImportForm.file : !modelImportForm.sourceUrl.trim());
   const hiddenImportCount =
     familyFilter === "all" ? 0 : pendingLoraImportJobs.filter((job) => job.status !== "completed" && !matchesFamily(job, familyFilter)).length;
-  const visibleLoraCount = visibleLoras.length + localLoraImportJobs.length;
-  const installedLoraCount = visibleLoras.filter((lora) => lora.installState === "installed").length;
-  const unavailableLoraCount = visibleLoras.filter((lora) => lora.installState === "missing").length;
-  const pendingLoraCount = visibleLoraCount - installedLoraCount - unavailableLoraCount;
-  const loraCountText = [
-    installedLoraCount ? `${installedLoraCount} installed` : null,
-    unavailableLoraCount ? `${unavailableLoraCount} unavailable` : null,
-    pendingLoraCount ? `${pendingLoraCount} pending` : null,
-  ].filter(Boolean).join(" · ") || "0 visible";
   const isFileImport = importForm.mode === "file";
   const importDisabled =
     importingLora ||
     !onImportLora ||
     (importForm.scope === "project" && !activeProject) ||
     (isFileImport ? !importForm.file : !importForm.sourceUrl.trim());
-
-  // Models grouped by type for the sectioned layout. Known types keep their fixed
-  // order; anything else lands in a trailing "Other" group. Empty groups drop out.
-  const knownModelTypes = new Set(MODEL_TYPE_GROUPS.map((group) => group.type));
-  const modelGroups = [
-    ...MODEL_TYPE_GROUPS.map((group) => ({ ...group, items: models.filter((model) => model.type === group.type) })),
-    { type: "other", label: "Other Models", items: models.filter((model) => !knownModelTypes.has(model.type)) },
-  ].filter((group) => group.items.length > 0);
 
   // LoRAs split into Built-In (catalog `scope: "builtin"`) and User (global/project)
   // containers. Built-in entries are a flat list with a Download affordance; user
@@ -982,37 +962,36 @@ export function ModelManagerScreen() {
     // Quant-matrix models (sc-8509): render the per-tier download panel with a RAM-based suggestion
     // + multi-select instead of the single Download button. Single-variant models are unchanged.
     const hasTierMatrix = model.hasVariantMatrix === true && orderedMatrixVariants(model).length > 0;
-    const autoOpen =
-      Boolean(localDownloadJob) || incomplete || Boolean(convertJob) || Boolean(failedConvert) || Boolean(failedDownload);
-    const open = expandedModels.has(model.id) || autoOpen;
     const firstCapability = capabilities.length ? capabilityLabel(capabilities[0]) : null;
     const familyMeta = [model.family ?? "unassociated", firstCapability].filter(Boolean).join(" · ");
+    const macBlock = macModelBlock(model, macCapabilities);
+    // Header install-status badge: warn tones for an incomplete cache, accent for installed,
+    // neutral for missing.
+    const statusClass = incomplete ? "status-badge warning" : installed ? "status-badge installed" : "status-badge";
+    const statusText = incomplete ? "incomplete" : installed ? "installed" : "missing";
     return (
-      <div className="model-row" key={model.id}>
-        <button className="model-row-summary" type="button" aria-expanded={open} onClick={() => toggleModel(model.id)}>
-          <span className={open ? "model-row-caret open" : "model-row-caret"} aria-hidden="true">
-            ▶
-          </span>
-          <span className="model-row-heading">
+      <article className={model.recommended ? "model-card recommended" : "model-card"} key={model.id}>
+        <div className="model-card-head">
+          <span className="model-card-title">
             <strong>{model.name}</strong>
             <small>{familyMeta}</small>
           </span>
-          <span className={incomplete ? "status-badge warning" : installed ? "status-badge installed" : "status-badge"}>
-            {incomplete ? "incomplete" : installed ? "installed" : "missing"}
+          <span className="model-card-status">
+            <span className={statusClass}>{statusText}</span>
+            {unassociated ? (
+              <span className="status-badge warning" title="Set this model's family in user.models.jsonc before using it for generation.">
+                needs family
+              </span>
+            ) : null}
+            {macBlock ? (
+              <span className="status-badge warning" title={macBlock.text}>
+                not on Mac
+              </span>
+            ) : null}
           </span>
-          {unassociated ? (
-            <span className="status-badge warning" title="Set this model's family in user.models.jsonc before using it for generation.">
-              needs family
-            </span>
-          ) : null}
-          {macModelBlock(model, macCapabilities) ? (
-            <span className="status-badge warning" title={macModelBlock(model, macCapabilities).text}>
-              not on Mac
-            </span>
-          ) : null}
-          <span className="model-row-size">{downloadSize}</span>
-        </button>
-        <div className="model-row-body" hidden={!open}>
+        </div>
+        {isRecommendedModel(model) ? <span className="model-card-rec-chip">★ Recommended</span> : null}
+        <p className="model-card-description">{model.ui?.description ?? model.family ?? model.id}</p>
         {capabilities.length ? (
           <ul className="model-capabilities">
             {capabilities.map((capability) => (
@@ -1022,7 +1001,6 @@ export function ModelManagerScreen() {
             ))}
           </ul>
         ) : null}
-        <p>{model.ui?.description ?? model.family ?? model.id}</p>
         {gated && !installed ? (
           <GatedModelNotice
             host={model.credentialHost}
@@ -1040,16 +1018,6 @@ export function ModelManagerScreen() {
             {missingRequiredFiles.length ? `: ${missingRequiredFiles.slice(0, 3).join(", ")}${missingRequiredFiles.length > 3 ? "..." : ""}` : ""}.
           </p>
         ) : null}
-        <dl>
-          <div>
-            <dt>Repo</dt>
-            <dd>{model.downloads?.[0]?.repo ?? "none"}</dd>
-          </div>
-          <div>
-            <dt>Download size</dt>
-            <dd>{downloadSize}</dd>
-          </div>
-        </dl>
         {localDownloadJob ? (
           <WorkerProgressCard
             job={localDownloadJob}
@@ -1129,13 +1097,31 @@ export function ModelManagerScreen() {
             onDownloadVariant={onDownloadVariant}
           />
         ) : null}
-        <div className="model-card-actions">
-          {hasTierMatrix ? (
-            // A quant-matrix model installs its tiers from the panel above. Keep only a Fix
-            // affordance here for an incomplete cache; otherwise there's no single-tier button.
-            incomplete ? (
+        <div className="model-card-footer">
+          <span className="model-card-size">{downloadSize}</span>
+          <div className="model-card-footer-actions">
+            {hasTierMatrix ? (
+              // A quant-matrix model installs its tiers from the panel above. Keep only a Fix
+              // affordance here for an incomplete cache; otherwise there's no single-tier button.
+              incomplete ? (
+                <button
+                  className="model-card-primary"
+                  disabled={!model.downloadable || Boolean(downloadJob) || licenseAckRequired}
+                  title={licenseAckRequired ? "Accept the license above before downloading." : undefined}
+                  onClick={() =>
+                    failedDownload
+                      ? onResumeDownloadJob(localDownloadJob, { payloadChanges: { downloadAction: "resume" } })
+                      : onDownloadModel(model)
+                  }
+                  type="button"
+                >
+                  {downloadJob ? downloadJob.status : failedDownload ? "Resume Download" : "Fix"}
+                </button>
+              ) : null
+            ) : (
               <button
-                disabled={!model.downloadable || Boolean(downloadJob) || licenseAckRequired}
+                className="model-card-primary"
+                disabled={(installed && !incomplete) || !model.downloadable || Boolean(downloadJob) || licenseAckRequired}
                 title={licenseAckRequired ? "Accept the license above before downloading." : undefined}
                 onClick={() =>
                   failedDownload
@@ -1144,46 +1130,38 @@ export function ModelManagerScreen() {
                 }
                 type="button"
               >
-                {downloadJob ? downloadJob.status : failedDownload ? "Resume Download" : "Fix"}
+                {downloadJob
+                  ? downloadJob.status
+                  : failedDownload
+                      ? "Resume Download"
+                      : incomplete
+                        ? "Fix"
+                        : installed
+                          ? "Ready"
+                          : model.downloadSizeLabel
+                            ? `Download ${downloadSize}`
+                            : "Download"}
               </button>
-            ) : null
-          ) : (
-            <button
-              disabled={(installed && !incomplete) || !model.downloadable || Boolean(downloadJob) || licenseAckRequired}
-              title={licenseAckRequired ? "Accept the license above before downloading." : undefined}
-              onClick={() =>
-                failedDownload
-                  ? onResumeDownloadJob(localDownloadJob, { payloadChanges: { downloadAction: "resume" } })
-                  : onDownloadModel(model)
-              }
-              type="button"
-            >
-              {downloadJob
-                ? downloadJob.status
-                : failedDownload
-                    ? "Resume Download"
-                    : incomplete
-                      ? "Fix"
-                      : installed
-                        ? "Ready"
-                        : model.downloadSizeLabel
-                          ? `Download ${downloadSize}`
-                          : "Download"}
+            )}
+            <button className="danger-action" disabled={!canDelete || deletingItem === deleteKey} onClick={() => deleteModel(model)} type="button">
+              {model.removable === false ? "Protected" : deletingItem === deleteKey ? "Deleting" : "Delete"}
             </button>
-          )}
-          <button className="danger-action" disabled={!canDelete || deletingItem === deleteKey} onClick={() => deleteModel(model)} type="button">
-            {model.removable === false ? "Protected" : deletingItem === deleteKey ? "Deleting" : "Delete"}
-          </button>
+          </div>
         </div>
-        </div>
-      </div>
+      </article>
     );
   }
 
   function renderLoraRow(lora) {
     const installed = lora.installState === "installed";
     const missing = lora.installState === "missing";
-    const statusText = missing ? "unavailable" : installed ? "installed" : "pending";
+    const isBuiltin = lora.scope === "builtin";
+    // A built-in that isn't downloaded reads "not installed" (neutral) — it can be fetched.
+    // A user LoRA with no local files reads "unavailable" (danger) — it's registered but broken.
+    const userUnavailable = missing && !isBuiltin;
+    const statusText = installed ? "installed" : missing ? (isBuiltin ? "not installed" : "unavailable") : "pending";
+    const statusClass = installed ? "status-badge installed" : userUnavailable ? "status-badge danger" : "status-badge";
+    const rowClass = userUnavailable ? "lora-row unavailable" : "lora-row";
     const deleteKey = `lora:${lora.scope ?? "global"}:${lora.id}`;
     // Built-in LoRAs with a Hugging Face source can be fetched on demand (sc-5944) —
     // user LoRAs are installed via the import form, so they get no Download affordance.
@@ -1191,12 +1169,12 @@ export function ModelManagerScreen() {
     const canDownload = Boolean(onDownloadLora) && lora.scope === "builtin" && !installed && hfSource;
     const downloadJob = loraDownloadJobsFor(lora).find((job) => !terminalStatuses.has(job.status));
     return (
-      <article className={missing ? "lora-row warning" : "lora-row"} key={lora.id ?? lora.name}>
+      <article className={rowClass} key={lora.id ?? lora.name}>
         <span>
           <strong>{lora.name ?? lora.id}</strong>
           <small>{[lora.scope, lora.family ?? "compatible"].filter(Boolean).join(" | ")}</small>
         </span>
-        <span className={installed ? "status-badge installed" : "status-badge"}>{statusText}</span>
+        <span className={statusClass}>{statusText}</span>
         <span className="lora-row-actions">
           {canDownload ? (
             <button disabled={Boolean(downloadJob)} onClick={() => onDownloadLora(lora)} type="button">
@@ -1221,16 +1199,174 @@ export function ModelManagerScreen() {
     );
   }
 
+  // --- Tabbed interface derivation (epic 10309) ---
+  const query = search.trim().toLowerCase();
+  const hasSearch = query !== "";
+  // When search is cleared but the transient Search tab is still nominally active, fall back
+  // to the tab we came from (handleSearchChange normally does this; this guards other paths).
+  const effectiveTab = activeTab === "search" && !hasSearch ? prevTab || "image" : activeTab;
+
+  // Family filter applies to models via their LoRA-compatibility families (the same union the
+  // dropdown is built from) and to LoRAs via matchesFamily — so a selected token never hides
+  // everything. Search is case-insensitive over name/family/capability labels (models) and
+  // name/family (LoRAs).
+  const modelMatchesFamily = (model) => familyFilter === "all" || modelLoraFamilies(model).includes(familyFilter);
+  const modelCapabilityLabels = (model) =>
+    (Array.isArray(model.capabilities) ? model.capabilities : []).map(capabilityLabel);
+  const modelMatchesQuery = (model) =>
+    !hasSearch ||
+    (model.name ?? model.id ?? "").toLowerCase().includes(query) ||
+    (model.family ?? "").toLowerCase().includes(query) ||
+    modelCapabilityLabels(model).some((label) => label.toLowerCase().includes(query));
+  const loraMatchesQuery = (lora) =>
+    !hasSearch ||
+    (lora.name ?? lora.id ?? "").toLowerCase().includes(query) ||
+    (lora.family ?? "").toLowerCase().includes(query);
+
+  // Cross-type search matches feed the transient Search Results tab + its badge count. LoRAs are
+  // taken from the already family-filtered `visibleLoras`.
+  const searchModelMatches = models.filter(modelMatchesQuery).filter(modelMatchesFamily);
+  const searchLoraMatches = visibleLoras.filter(loraMatchesQuery);
+  const searchTotalCount = searchModelMatches.length + searchLoraMatches.length;
+
+  // Tab definitions — counts are TOTALS per type (not the filtered view). The transient Search
+  // Results tab is appended only while a search is active; its badge is the live match count.
+  const tabDefs = [
+    ["image", "Image Models", models.filter((model) => model.type === "image").length],
+    ["video", "Video Models", models.filter((model) => model.type === "video").length],
+    ["utility", "Utility Models", models.filter((model) => model.type === "utility").length],
+    ["lora", "LoRAs", loras.length],
+  ];
+  if (hasSearch) {
+    tabDefs.push(["search", "⌕ Search Results", searchTotalCount]);
+  }
+
+  const isSearchTab = effectiveTab === "search";
+  const isLoraTab = effectiveTab === "lora";
+  const isModelTab = !isSearchTab && !isLoraTab;
+
+  // A model type panel: an accent Recommended band (when any recommended match) over an
+  // "All {type} models" grid of the rest. Both filtered by the active search + family.
+  function renderModelTabPanel(type) {
+    const activeModels = models
+      .filter((model) => model.type === type)
+      .filter(modelMatchesQuery)
+      .filter(modelMatchesFamily);
+    const recommended = activeModels.filter(isRecommendedModel);
+    const others = activeModels.filter((model) => !isRecommendedModel(model));
+    const typeLabel = { image: "image", video: "video", utility: "utility" }[type] ?? type;
+    const othersHeading =
+      recommended.length > 0 ? `All ${typeLabel} models` : `${typeLabel.charAt(0).toUpperCase()}${typeLabel.slice(1)} models`;
+    return (
+      <div className="models-tab-panel">
+        {recommended.length ? (
+          <div className="models-accent-band">
+            <div className="models-accent-band-head">
+              <span className="models-accent-dot" aria-hidden="true" />
+              <p className="eyebrow">Recommended</p>
+              <span className="models-accent-band-count">{recommended.length}</span>
+              <span className="models-accent-band-caption">Curated getting-started picks</span>
+            </div>
+            <div className="models-card-grid">{recommended.map((model) => renderModelCard(model))}</div>
+          </div>
+        ) : null}
+        {others.length ? (
+          <div className="models-section">
+            <div className="models-section-heading">
+              <h3>{othersHeading}</h3>
+              <span>{others.length}</span>
+            </div>
+            <div className="models-card-grid">{others.map((model) => renderModelCard(model))}</div>
+          </div>
+        ) : null}
+        {recommended.length === 0 && others.length === 0 ? (
+          <div className="models-empty">No models match your search.</div>
+        ) : null}
+      </div>
+    );
+  }
+
+  // The transient Search Results tab: cross-type model matches grouped by type, then a LoRA
+  // section using the shared row. Only non-empty groups render.
+  function renderSearchTabPanel() {
+    const groups = [
+      ["image", "Image Models"],
+      ["video", "Video Models"],
+      ["utility", "Utility Models"],
+    ]
+      .map(([type, label]) => ({ label, items: searchModelMatches.filter((model) => model.type === type) }))
+      .filter((group) => group.items.length > 0);
+    const isEmpty = groups.length === 0 && searchLoraMatches.length === 0;
+    return (
+      <div className="models-tab-panel">
+        {groups.map((group) => (
+          <div className="models-section" key={group.label}>
+            <div className="models-section-heading">
+              <h3>{group.label}</h3>
+              <span>{group.items.length}</span>
+            </div>
+            <div className="models-card-grid">{group.items.map((model) => renderModelCard(model))}</div>
+          </div>
+        ))}
+        {searchLoraMatches.length ? (
+          <div className="models-section">
+            <div className="models-section-heading">
+              <h3>LoRAs</h3>
+              <span>{searchLoraMatches.length}</span>
+            </div>
+            <div className="lora-list">{searchLoraMatches.map((lora) => renderLoraRow(lora))}</div>
+          </div>
+        ) : null}
+        {isEmpty ? <div className="models-empty">No models or LoRAs match &ldquo;{search}&rdquo;.</div> : null}
+      </div>
+    );
+  }
+
   return (
     <section className="main-surface models-surface">
-      <div className="surface-header">
-        <div className="section-heading">
-          <p className="eyebrow">Runtime assets</p>
-          <h2>Models</h2>
+      <div className="section-heading">
+        <p className="eyebrow">Runtime assets</p>
+        <h2>Models</h2>
+      </div>
+
+      <div className="models-tabbar">
+        <div className="mode-tabs" role="tablist" aria-label="Model type">
+          {tabDefs.map(([key, label, count]) => {
+            const active = effectiveTab === key;
+            return (
+              <button
+                key={key}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                className={active ? "mode-tab active" : "mode-tab"}
+                onClick={() => setActiveTab(key)}
+              >
+                {label}
+                <span className="models-tab-count">{count}</span>
+              </button>
+            );
+          })}
         </div>
-        <label>
-          LoRA family
-          <select onChange={(event) => setFamilyFilter(event.target.value)} value={familyFilter}>
+        <div className="models-tabbar-controls">
+          <div className="models-search">
+            <span className="models-search-glyph" aria-hidden="true">
+              ⌕
+            </span>
+            <input
+              type="search"
+              value={search}
+              onChange={handleSearchChange}
+              placeholder="Search models"
+              aria-label="Search models"
+            />
+          </div>
+          <select
+            className="models-family-select"
+            value={familyFilter}
+            onChange={(event) => setFamilyFilter(event.target.value)}
+            aria-label="Filter by family"
+          >
             <option value="all">All families</option>
             {families.map((family) => (
               <option key={family} value={family}>
@@ -1238,368 +1374,337 @@ export function ModelManagerScreen() {
               </option>
             ))}
           </select>
-        </label>
+        </div>
       </div>
 
-      {modelGroups.map((group) => {
-        const recommended = group.items.filter(isRecommendedModel);
-        const additional = group.items.filter((model) => !isRecommendedModel(model));
-        // Only split into Recommended / Additional Supported when both buckets exist;
-        // otherwise show a single grid so we never render an empty or redundant header.
-        const split = recommended.length > 0 && additional.length > 0;
-        return (
-          <details className="model-type-group" key={group.type} open>
-            <summary className="model-type-group-heading">
-              <h3>{group.label}</h3>
-              <span>{group.items.length}</span>
-            </summary>
-            {split ? (
-              <>
-                <div className="model-subgroup">
-                  <div className="model-subgroup-heading">
-                    <h4>Recommended Models</h4>
-                    <span>{recommended.length}</span>
-                  </div>
-                  <div className="model-grid">{recommended.map((model) => renderModelCard(model))}</div>
-                </div>
-                <details className="model-subgroup model-subgroup-additional">
-                  <summary className="model-subgroup-heading">
-                    <h4>Additional Supported Models</h4>
-                    <span>{additional.length}</span>
-                  </summary>
-                  <div className="model-grid">{additional.map((model) => renderModelCard(model))}</div>
-                </details>
-              </>
-            ) : (
-              <div className="model-grid">{group.items.map((model) => renderModelCard(model))}</div>
-            )}
-          </details>
-        );
-      })}
       {deleteMessage.text ? <p className={deleteMessage.tone === "success" ? "inline-success" : "inline-warning"}>{deleteMessage.text}</p> : null}
 
-      <section className="model-import-panel-section">
-        {MODEL_IMPORT_ENABLED && (
-        <form className="lora-import-panel models-import-panel" aria-label="Import model" onSubmit={importModel}>
-          <div>
-            <strong>Import model</strong>
-            <span>{modelImportForm.family || "auto-detect family"}</span>
-          </div>
-          <div className="segmented-control compact-segment" aria-label="Model import source">
-            <button
-              className={modelImportForm.mode === "url" ? "active" : ""}
-              disabled={importingModel}
-              onClick={() => setModelImportForm((current) => ({ ...current, mode: "url" }))}
-              type="button"
-            >
-              URL
-            </button>
-            <button
-              className={modelImportForm.mode === "file" ? "active" : ""}
-              disabled={importingModel}
-              onClick={() => setModelImportForm((current) => ({ ...current, mode: "file" }))}
-              type="button"
-            >
-              Upload
-            </button>
-          </div>
-          <div className="models-import-grid">
-            <label>
-              Type
-              <select
-                disabled={importingModel}
-                onChange={(event) => setModelImportForm((current) => ({ ...current, type: event.target.value }))}
-                value={modelImportForm.type}
-              >
-                {MODEL_TYPE_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label>
-              Family
-              <select
-                disabled={importingModel || !families.length}
-                onChange={(event) => setModelImportForm((current) => ({ ...current, family: event.target.value }))}
-                value={modelImportForm.family}
-              >
-                {families.length ? (
-                  <>
-                    <option value="">Auto-detect</option>
-                    {families.map((family) => (
-                      <option key={family} value={family}>
-                        {family}
-                      </option>
-                    ))}
-                  </>
-                ) : (
-                  <option value="">No known families</option>
-                )}
-              </select>
-            </label>
-            {isModelFileImport ? (
-              <label>
-                Model File
-                <span className="file-picker-row">
-                  <span className="file-upload-button">
-                    Choose
-                    <input
-                      accept=".safetensors,.ckpt,.pt,.bin"
-                      disabled={importingModel}
-                      key={modelFileInputKey}
-                      onChange={(event) => setModelImportForm((current) => ({ ...current, file: event.target.files?.[0] ?? null }))}
-                      type="file"
-                    />
-                  </span>
-                  <span className="selected-file-name">{modelImportForm.file?.name ?? "No file selected"}</span>
-                </span>
-              </label>
-            ) : (
-              <label>
-                Source URL
-                <input
-                  disabled={importingModel}
-                  onChange={(event) => setModelImportForm((current) => ({ ...current, sourceUrl: event.target.value }))}
-                  placeholder="https://..."
-                  value={modelImportForm.sourceUrl}
-                />
-              </label>
-            )}
-            <label>
-              Name
-              <input
-                disabled={importingModel}
-                onChange={(event) => setModelImportForm((current) => ({ ...current, name: event.target.value }))}
-                placeholder="Optional"
-                value={modelImportForm.name}
-              />
-            </label>
-            <button disabled={modelImportDisabled} type="submit">
-              {importingModel ? (isModelFileImport ? "Uploading" : "Queueing...") : "Queue Import"}
-            </button>
-          </div>
-          {modelImportMessage.text ? <p className={modelImportMessage.tone === "success" ? "inline-success" : "inline-warning"}>{modelImportMessage.text}</p> : null}
-        </form>
-        )}
-        {pendingModelImportJobs.length ? (
-          <div className="lora-import-progress">
-            <strong>Model imports in progress</strong>
-            <div className="local-job-stack">
-              {pendingModelImportJobs.map((job) => (
-                <WorkerProgressCard job={job} key={job.id} onCancel={onCancelJob} onOpenQueue={onOpenQueue} />
-              ))}
+      {isModelTab ? renderModelTabPanel(effectiveTab) : null}
+      {isSearchTab ? renderSearchTabPanel() : null}
+
+      {isLoraTab ? (
+        <div className="models-tab-panel">
+          {/* Import LoRA — same accent-band treatment as the Recommended band. */}
+          <form className="models-accent-band models-import-panel" aria-label="Import LoRA" onSubmit={importLora}>
+            <div className="models-accent-band-head">
+              <span className="models-accent-dot" aria-hidden="true" />
+              <p className="eyebrow">Import LoRA</p>
+              <span className="models-accent-band-caption">Add a LoRA from a URL or file — auto-detects family</span>
             </div>
-          </div>
-        ) : null}
-      </section>
-
-      <section className="lora-panel">
-        <div className="lora-panel-header">
-          <div className="section-heading">
-            <p className="eyebrow">LoRAs</p>
-            <h2>{familyFilter === "all" ? "All compatible" : familyFilter}</h2>
-          </div>
-          <span>{loraCountText}</span>
-        </div>
-
-        {builtinLoras.length ? (
-          <details className="lora-scope-group" open>
-            <summary className="lora-scope-group-heading">
-              <h3>Built-In LoRAs</h3>
-              <span>{builtinLoras.length}</span>
-            </summary>
-            <div className="lora-list">{builtinLoras.map((lora) => renderLoraRow(lora))}</div>
-          </details>
-        ) : null}
-
-        <details className="lora-scope-group" open>
-        <summary className="lora-scope-group-heading">
-          <h3>User LoRAs</h3>
-          <span>{userLoras.length}</span>
-        </summary>
-        <form className="lora-import-panel models-import-panel" aria-label="Import LoRA" onSubmit={importLora}>
-          <div>
-            <strong>Import LoRA</strong>
-            <span>{importForm.family || "auto-detect"}</span>
-          </div>
-          <div className="segmented-control compact-segment" aria-label="LoRA import source">
-            <button
-              className={importForm.mode === "url" ? "active" : ""}
-              disabled={importingLora}
-              onClick={() => setImportForm((current) => ({ ...current, mode: "url" }))}
-              type="button"
-            >
-              URL
-            </button>
-            <button
-              className={importForm.mode === "file" ? "active" : ""}
-              disabled={importingLora}
-              onClick={() => setImportForm((current) => ({ ...current, mode: "file" }))}
-              type="button"
-            >
-              Upload
-            </button>
-          </div>
-          <div className="models-import-grid">
-            <label>
-              Scope
-              <select
+            <div className="segmented-control compact-segment" aria-label="LoRA import source">
+              <button
+                className={importForm.mode === "url" ? "active" : ""}
                 disabled={importingLora}
-                onChange={(event) => setImportForm((current) => ({ ...current, scope: event.target.value }))}
-                value={importForm.scope}
+                onClick={() => setImportForm((current) => ({ ...current, mode: "url" }))}
+                type="button"
               >
-                <option value="global">Global</option>
-                <option disabled={!activeProject} value="project">
-                  Project
-                </option>
-              </select>
-            </label>
-            <label>
-              Family
-              <select
-                disabled={importingLora || !families.length}
-                onChange={(event) => setImportForm((current) => ({ ...current, family: event.target.value }))}
-                value={importForm.family}
+                URL
+              </button>
+              <button
+                className={importForm.mode === "file" ? "active" : ""}
+                disabled={importingLora}
+                onClick={() => setImportForm((current) => ({ ...current, mode: "file" }))}
+                type="button"
               >
-                {families.length ? (
-                  <>
-                    <option value="">Auto-detect</option>
-                    {families.map((family) => (
-                      <option key={family} value={family}>
-                        {family}
-                      </option>
-                    ))}
-                  </>
-                ) : (
-                  <option value="">No model families</option>
-                )}
-              </select>
-            </label>
-            {showBaseModelSelect ? (
+                Upload
+              </button>
+            </div>
+            <div className="models-import-grid">
               <label>
-                Base model
+                Scope
                 <select
                   disabled={importingLora}
-                  onChange={(event) => setImportForm((current) => ({ ...current, baseModel: event.target.value }))}
-                  value={importForm.baseModel}
+                  onChange={(event) => setImportForm((current) => ({ ...current, scope: event.target.value }))}
+                  value={importForm.scope}
                 >
-                  <option value="">Auto / unspecified</option>
-                  {wanBaseModelOptions.map((model) => (
-                    <option key={model.id} value={model.id}>
-                      {model.name ?? model.id}
-                    </option>
-                  ))}
+                  <option value="global">Global</option>
+                  <option disabled={!activeProject} value="project">
+                    Project
+                  </option>
                 </select>
               </label>
-            ) : null}
-            {isFileImport ? (
-              <>
+              <label>
+                Family
+                <select
+                  disabled={importingLora || !families.length}
+                  onChange={(event) => setImportForm((current) => ({ ...current, family: event.target.value }))}
+                  value={importForm.family}
+                >
+                  {families.length ? (
+                    <>
+                      <option value="">Auto-detect</option>
+                      {families.map((family) => (
+                        <option key={family} value={family}>
+                          {family}
+                        </option>
+                      ))}
+                    </>
+                  ) : (
+                    <option value="">No model families</option>
+                  )}
+                </select>
+              </label>
+              {showBaseModelSelect ? (
                 <label>
-                  LoRA File
-                  <span className="file-picker-row">
-                    <span className="file-upload-button">
-                      Choose
-                      <input
-                        accept=".safetensors,.ckpt,.pt,.bin"
-                        disabled={importingLora}
-                        key={fileInputKey}
-                        onChange={(event) => setImportForm((current) => ({ ...current, file: event.target.files?.[0] ?? null }))}
-                        type="file"
-                      />
-                    </span>
-                    <span className="selected-file-name">{importForm.file?.name ?? "No file selected"}</span>
-                  </span>
+                  Base model
+                  <select
+                    disabled={importingLora}
+                    onChange={(event) => setImportForm((current) => ({ ...current, baseModel: event.target.value }))}
+                    value={importForm.baseModel}
+                  >
+                    <option value="">Auto / unspecified</option>
+                    {wanBaseModelOptions.map((model) => (
+                      <option key={model.id} value={model.id}>
+                        {model.name ?? model.id}
+                      </option>
+                    ))}
+                  </select>
                 </label>
-                {showSecondaryFileSlot ? (
+              ) : null}
+              {isFileImport ? (
+                <>
                   <label>
-                    Low-noise expert (Wan A14B MoE)
+                    LoRA File
                     <span className="file-picker-row">
                       <span className="file-upload-button">
                         Choose
                         <input
                           accept=".safetensors,.ckpt,.pt,.bin"
                           disabled={importingLora}
-                          key={`secondary-${fileInputKey}`}
-                          onChange={(event) => setImportForm((current) => ({ ...current, secondaryFile: event.target.files?.[0] ?? null }))}
+                          key={fileInputKey}
+                          onChange={(event) => setImportForm((current) => ({ ...current, file: event.target.files?.[0] ?? null }))}
                           type="file"
                         />
                       </span>
-                      <span className="selected-file-name">{importForm.secondaryFile?.name ?? "No file selected"}</span>
+                      <span className="selected-file-name">{importForm.file?.name ?? "No file selected"}</span>
                     </span>
                   </label>
-                ) : null}
-              </>
-            ) : (
+                  {showSecondaryFileSlot ? (
+                    <label>
+                      Low-noise expert (Wan A14B MoE)
+                      <span className="file-picker-row">
+                        <span className="file-upload-button">
+                          Choose
+                          <input
+                            accept=".safetensors,.ckpt,.pt,.bin"
+                            disabled={importingLora}
+                            key={`secondary-${fileInputKey}`}
+                            onChange={(event) => setImportForm((current) => ({ ...current, secondaryFile: event.target.files?.[0] ?? null }))}
+                            type="file"
+                          />
+                        </span>
+                        <span className="selected-file-name">{importForm.secondaryFile?.name ?? "No file selected"}</span>
+                      </span>
+                    </label>
+                  ) : null}
+                </>
+              ) : (
+                <label>
+                  Source URL
+                  <input
+                    disabled={importingLora}
+                    onChange={(event) => setImportForm((current) => ({ ...current, sourceUrl: event.target.value }))}
+                    placeholder="https://..."
+                    value={importForm.sourceUrl}
+                  />
+                </label>
+              )}
               <label>
-                Source URL
+                Name
                 <input
                   disabled={importingLora}
-                  onChange={(event) => setImportForm((current) => ({ ...current, sourceUrl: event.target.value }))}
-                  placeholder="https://..."
-                  value={importForm.sourceUrl}
+                  onChange={(event) => setImportForm((current) => ({ ...current, name: event.target.value }))}
+                  placeholder="Optional"
+                  value={importForm.name}
                 />
               </label>
-            )}
-            <label>
-              Name
-              <input
-                disabled={importingLora}
-                onChange={(event) => setImportForm((current) => ({ ...current, name: event.target.value }))}
-                placeholder="Optional"
-                value={importForm.name}
-              />
-            </label>
-            <button disabled={importDisabled} type="submit">
-              {importingLora ? (isFileImport ? "Uploading" : "Queueing...") : "Queue Import"}
-            </button>
-          </div>
-          {showSecondaryFileSlot ? (
-            <p className="helper-copy">
-              Wan A14B is a two-expert model. Upload both the high-noise file and the low-noise expert so each expert
-              gets its own weights.
-            </p>
-          ) : null}
-          {moeMissingSecondary ? (
-            <p className="inline-warning">
-              No low-noise expert selected — this LoRA will load into the high-noise expert only, leaving the
-              low-noise expert un-adapted.
-            </p>
-          ) : null}
-          {importForm.scope === "project" && !activeProject ? <p className="helper-copy">Open a project before importing a project LoRA.</p> : null}
-          {importMessage.text ? <p className={importMessage.tone === "success" ? "inline-success" : "inline-warning"}>{importMessage.text}</p> : null}
-        </form>
-        {localLoraImportJobs.length ? (
-          <div className="lora-import-progress">
-            <strong>LoRA imports in progress</strong>
-            <div className="local-job-stack">
-              {localLoraImportJobs.map((job) => (
-                <WorkerProgressCard job={job} key={job.id} onCancel={onCancelJob} onOpenQueue={onOpenQueue} />
-              ))}
+              <button disabled={importDisabled} type="submit">
+                {importingLora ? (isFileImport ? "Uploading" : "Queueing...") : "Queue Import"}
+              </button>
             </div>
-          </div>
-        ) : null}
-        {hiddenImportCount ? <p className="helper-copy">{hiddenImportCount} LoRA import{hiddenImportCount === 1 ? " is" : "s are"} hidden by this family filter.</p> : null}
-        {userLoras.length ? (
-          <div className="lora-family-groups">
-            {loraGroups.map((group) => (
-              <div className="lora-family-group" key={group.family}>
-                <div className="lora-family-group-heading">
-                  <h3>{group.family === "compatible" ? "Other / compatible" : group.family}</h3>
-                  <span>{group.items.length}</span>
-                </div>
-                <div className="lora-list">{group.items.map((lora) => renderLoraRow(lora))}</div>
+            {showSecondaryFileSlot ? (
+              <p className="helper-copy">
+                Wan A14B is a two-expert model. Upload both the high-noise file and the low-noise expert so each expert
+                gets its own weights.
+              </p>
+            ) : null}
+            {moeMissingSecondary ? (
+              <p className="inline-warning">
+                No low-noise expert selected — this LoRA will load into the high-noise expert only, leaving the
+                low-noise expert un-adapted.
+              </p>
+            ) : null}
+            {importForm.scope === "project" && !activeProject ? <p className="helper-copy">Open a project before importing a project LoRA.</p> : null}
+            {importMessage.text ? <p className={importMessage.tone === "success" ? "inline-success" : "inline-warning"}>{importMessage.text}</p> : null}
+          </form>
+          {localLoraImportJobs.length ? (
+            <div className="lora-import-progress">
+              <strong>LoRA imports in progress</strong>
+              <div className="local-job-stack">
+                {localLoraImportJobs.map((job) => (
+                  <WorkerProgressCard job={job} key={job.id} onCancel={onCancelJob} onOpenQueue={onOpenQueue} />
+                ))}
               </div>
-            ))}
+            </div>
+          ) : null}
+          {hiddenImportCount ? <p className="helper-copy">{hiddenImportCount} LoRA import{hiddenImportCount === 1 ? " is" : "s are"} hidden by this family filter.</p> : null}
+
+          {builtinLoras.length ? (
+            <div className="models-section">
+              <div className="models-section-heading">
+                <h3>Built-In LoRAs</h3>
+                <span>{builtinLoras.length}</span>
+              </div>
+              <div className="lora-list">{builtinLoras.map((lora) => renderLoraRow(lora))}</div>
+            </div>
+          ) : null}
+
+          <div className="models-section">
+            <div className="models-section-heading">
+              <h3>User LoRAs</h3>
+              <span>{userLoras.length}</span>
+            </div>
+            {userLoras.length ? (
+              <div className="models-subgroups">
+                {loraGroups.map((group) => (
+                  <div className="models-subsection" key={group.family}>
+                    <div className="models-section-heading">
+                      <h4>{group.family === "compatible" ? "Other / compatible" : group.family}</h4>
+                      <span>{group.items.length}</span>
+                    </div>
+                    <div className="lora-list">{group.items.map((lora) => renderLoraRow(lora))}</div>
+                  </div>
+                ))}
+              </div>
+            ) : localLoraImportJobs.length ? null : loras.length && familyFilter !== "all" ? (
+              <div className="models-empty">No user LoRAs match {familyFilter}.</div>
+            ) : (
+              <div className="models-empty">No user LoRAs yet — import one above.</div>
+            )}
           </div>
-        ) : localLoraImportJobs.length ? null : loras.length && familyFilter !== "all" ? (
-          <div className="empty-panel compact-panel">No user LoRAs match {familyFilter}</div>
-        ) : (
-          <div className="empty-panel compact-panel">No user LoRAs yet — import one above.</div>
-        )}
-        </details>
-      </section>
+
+          {/* Model import stays compile-gated (epic 7080 / sc-8941 F-139) and renders nothing while
+              disabled; the section only appears to surface any in-flight model-import progress. */}
+          {MODEL_IMPORT_ENABLED || pendingModelImportJobs.length > 0 ? (
+            <section className="model-import-panel-section">
+              {MODEL_IMPORT_ENABLED && (
+                <form className="lora-import-panel models-import-panel" aria-label="Import model" onSubmit={importModel}>
+                  <div>
+                    <strong>Import model</strong>
+                    <span>{modelImportForm.family || "auto-detect family"}</span>
+                  </div>
+                  <div className="segmented-control compact-segment" aria-label="Model import source">
+                    <button
+                      className={modelImportForm.mode === "url" ? "active" : ""}
+                      disabled={importingModel}
+                      onClick={() => setModelImportForm((current) => ({ ...current, mode: "url" }))}
+                      type="button"
+                    >
+                      URL
+                    </button>
+                    <button
+                      className={modelImportForm.mode === "file" ? "active" : ""}
+                      disabled={importingModel}
+                      onClick={() => setModelImportForm((current) => ({ ...current, mode: "file" }))}
+                      type="button"
+                    >
+                      Upload
+                    </button>
+                  </div>
+                  <div className="models-import-grid">
+                    <label>
+                      Type
+                      <select
+                        disabled={importingModel}
+                        onChange={(event) => setModelImportForm((current) => ({ ...current, type: event.target.value }))}
+                        value={modelImportForm.type}
+                      >
+                        {MODEL_TYPE_OPTIONS.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <label>
+                      Family
+                      <select
+                        disabled={importingModel || !families.length}
+                        onChange={(event) => setModelImportForm((current) => ({ ...current, family: event.target.value }))}
+                        value={modelImportForm.family}
+                      >
+                        {families.length ? (
+                          <>
+                            <option value="">Auto-detect</option>
+                            {families.map((family) => (
+                              <option key={family} value={family}>
+                                {family}
+                              </option>
+                            ))}
+                          </>
+                        ) : (
+                          <option value="">No known families</option>
+                        )}
+                      </select>
+                    </label>
+                    {isModelFileImport ? (
+                      <label>
+                        Model File
+                        <span className="file-picker-row">
+                          <span className="file-upload-button">
+                            Choose
+                            <input
+                              accept=".safetensors,.ckpt,.pt,.bin"
+                              disabled={importingModel}
+                              key={modelFileInputKey}
+                              onChange={(event) => setModelImportForm((current) => ({ ...current, file: event.target.files?.[0] ?? null }))}
+                              type="file"
+                            />
+                          </span>
+                          <span className="selected-file-name">{modelImportForm.file?.name ?? "No file selected"}</span>
+                        </span>
+                      </label>
+                    ) : (
+                      <label>
+                        Source URL
+                        <input
+                          disabled={importingModel}
+                          onChange={(event) => setModelImportForm((current) => ({ ...current, sourceUrl: event.target.value }))}
+                          placeholder="https://..."
+                          value={modelImportForm.sourceUrl}
+                        />
+                      </label>
+                    )}
+                    <label>
+                      Name
+                      <input
+                        disabled={importingModel}
+                        onChange={(event) => setModelImportForm((current) => ({ ...current, name: event.target.value }))}
+                        placeholder="Optional"
+                        value={modelImportForm.name}
+                      />
+                    </label>
+                    <button disabled={modelImportDisabled} type="submit">
+                      {importingModel ? (isModelFileImport ? "Uploading" : "Queueing...") : "Queue Import"}
+                    </button>
+                  </div>
+                  {modelImportMessage.text ? <p className={modelImportMessage.tone === "success" ? "inline-success" : "inline-warning"}>{modelImportMessage.text}</p> : null}
+                </form>
+              )}
+              {pendingModelImportJobs.length ? (
+                <div className="lora-import-progress">
+                  <strong>Model imports in progress</strong>
+                  <div className="local-job-stack">
+                    {pendingModelImportJobs.map((job) => (
+                      <WorkerProgressCard job={job} key={job.id} onCancel={onCancelJob} onOpenQueue={onOpenQueue} />
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </section>
+          ) : null}
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -3,6 +3,16 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { click } from "../testUtils/dom.js";
 
+// The screen is a tabbed interface (epic 10309): Image / Video / Utility / LoRAs tabs,
+// each showing only its own models, plus a transient Search Results tab. A model card
+// or the LoRA import form is only in the DOM while its tab is active, so tests select
+// the relevant tab first. The tab button's text also carries a trailing count badge, so
+// match by substring.
+async function selectTab(container, label) {
+  const tab = [...container.querySelectorAll('[role="tab"]')].find((button) => button.textContent.includes(label));
+  await click(tab);
+}
+
 // ModelManagerScreen reads `window.__TAURI__` at module load (via ../credentials.js)
 // to pick the keychain transport, so we set the Tauri bridge and re-import the
 // module fresh in each test. Credentials are served by the mocked `list_credentials`
@@ -208,7 +218,7 @@ describe("ModelManagerScreen gated-model notice", () => {
   // SD3.5). The download button is disabled until then.
   it("blocks the gated download until the license is acknowledged (sc-7872)", async () => {
     await render([SD3_5_MODEL]);
-    const downloadButton = [...container.querySelectorAll(".model-card-actions button")].find(
+    const downloadButton = [...container.querySelectorAll(".model-card-footer-actions button")].find(
       (button) => button.textContent.startsWith("Download"),
     );
     expect(downloadButton).toBeTruthy();
@@ -244,7 +254,7 @@ describe("ModelManagerScreen gated-model notice", () => {
     await render([SD3_5_MODEL]);
     const ackCheckbox = container.querySelector(".model-license-ack input");
     expect(ackCheckbox.checked).toBe(true);
-    const downloadButton = [...container.querySelectorAll(".model-card-actions button")].find(
+    const downloadButton = [...container.querySelectorAll(".model-card-footer-actions button")].find(
       (button) => button.textContent.startsWith("Download"),
     );
     expect(downloadButton.disabled).toBe(false);
@@ -264,7 +274,7 @@ describe("ModelManagerScreen gated-model notice", () => {
     const ackCheckbox = container.querySelector(".model-license-ack input");
     expect(ackCheckbox).toBeTruthy();
     expect(ackCheckbox.checked).toBe(true);
-    const downloadButton = [...container.querySelectorAll(".model-card-actions button")].find(
+    const downloadButton = [...container.querySelectorAll(".model-card-footer-actions button")].find(
       (button) => button.textContent.startsWith("Download"),
     );
     expect(downloadButton.disabled).toBe(false);
@@ -274,7 +284,7 @@ describe("ModelManagerScreen gated-model notice", () => {
   it("does not gate a non-gated model's download on any acknowledgment (sc-7872)", async () => {
     await render([PLAIN_MODEL]);
     expect(container.querySelector(".model-license-ack")).toBeNull();
-    const downloadButton = [...container.querySelectorAll(".model-card-actions button")].find(
+    const downloadButton = [...container.querySelectorAll(".model-card-footer-actions button")].find(
       (button) => button.textContent.startsWith("Download"),
     );
     expect(downloadButton.disabled).toBe(false);
@@ -347,6 +357,8 @@ describe("ModelManagerScreen Wan A14B MoE LoRA import (sc-1991)", () => {
       );
     });
     await act(async () => {});
+    // The Import LoRA form lives on the LoRAs tab.
+    await selectTab(container, "LoRAs");
   }
 
   // Both the model and LoRA import forms share the .lora-import-panel class, so
@@ -455,6 +467,7 @@ describe("ModelManagerScreen Wan A14B MoE LoRA import (sc-1991)", () => {
       );
     });
     await act(async () => {});
+    await selectTab(container, "LoRAs");
     const familyOptions = [...labelStartingWith("Family").querySelectorAll("option")].map((option) => option.value);
     expect(familyOptions).toContain("flux2");
     expect(familyOptions).not.toContain("flux2-klein");
@@ -528,53 +541,63 @@ describe("ModelManagerScreen type-grouped layout", () => {
     { id: "real_esrgan", name: "Real-ESRGAN", type: "utility", family: "real-esrgan", capabilities: [], installState: "missing" },
   ];
 
-  function groupHeadings() {
-    return [...container.querySelectorAll(".model-type-group-heading h3")].map((h) => h.textContent);
+  function tabLabels() {
+    return [...container.querySelectorAll('[role="tab"]')].map((tab) => tab.textContent);
   }
 
-  it("renders one section per populated model type, in fixed order", async () => {
+  it("renders a tab per model type in fixed order, each scoped to its own type", async () => {
     await render({ models: MODELS });
-    expect(groupHeadings()).toEqual(["Image Models", "Video Models", "Utility Models"]);
-    // Each group holds exactly its own type's card.
-    const groups = container.querySelectorAll(".model-type-group");
-    expect(groups.length).toBe(3);
-    expect(groups[0].querySelectorAll(".model-row").length).toBe(1);
-    expect(groups[0].textContent).toContain("Z-Image-Turbo");
-    expect(groups[1].textContent).toContain("Wan T2V");
-    expect(groups[2].textContent).toContain("Real-ESRGAN");
+    // Four fixed tabs; the model tabs carry a total-count badge (LoRAs has 0 here).
+    expect(tabLabels()).toEqual(["Image Models1", "Video Models1", "Utility Models1", "LoRAs0"]);
+    // The default (Image) tab shows only its own type's card.
+    expect(container.querySelectorAll(".model-card").length).toBe(1);
+    expect(container.textContent).toContain("Z-Image-Turbo");
+    expect(container.textContent).not.toContain("Wan T2V");
+    // Switching tabs scopes the cards to that type.
+    await selectTab(container, "Video Models");
+    expect(container.textContent).toContain("Wan T2V");
+    expect(container.textContent).not.toContain("Z-Image-Turbo");
+    await selectTab(container, "Utility Models");
+    expect(container.textContent).toContain("Real-ESRGAN");
   });
 
-  it("omits a type section when no model has that type", async () => {
+  it("always shows all four tabs, with a zero count and empty state for an unpopulated type", async () => {
     await render({ models: [MODELS[0]] });
-    expect(groupHeadings()).toEqual(["Image Models"]);
+    expect(tabLabels()).toEqual(["Image Models1", "Video Models0", "Utility Models0", "LoRAs0"]);
+    await selectTab(container, "Video Models");
+    expect(container.querySelector(".models-empty")).toBeTruthy();
+    expect(container.textContent).toContain("No models match your search.");
   });
 
-  it("splits a type into Recommended and a collapsed Additional Supported when both exist", async () => {
+  it("shows a Recommended band over an 'All {type} models' section when a recommended model exists", async () => {
     await render({
       models: [
         { id: "z_image_turbo", name: "Z-Image-Turbo", type: "image", family: "z-image", capabilities: ["text_to_image"], installState: "missing", recommended: true },
         { id: "flux_dev", name: "FLUX.1 [dev]", type: "image", family: "flux", capabilities: ["text_to_image"], installState: "missing" },
       ],
     });
-    const imageGroup = container.querySelector(".model-type-group");
-    const recommendedGrid = imageGroup.querySelector(".model-subgroup .model-grid");
-    expect(imageGroup.textContent).toContain("Recommended Models");
-    expect(recommendedGrid.querySelectorAll(".model-row").length).toBe(1);
-    expect(recommendedGrid.textContent).toContain("Z-Image-Turbo");
-    const additional = imageGroup.querySelector(".model-subgroup-additional");
-    expect(additional.tagName).toBe("DETAILS");
-    expect(additional.open).toBe(false); // collapsed by default to cut clutter
-    expect(additional.textContent).toContain("Additional Supported Models");
-    expect(additional.querySelectorAll(".model-row").length).toBe(1);
-    expect(additional.textContent).toContain("FLUX.1 [dev]");
+    const band = container.querySelector(".models-accent-band");
+    expect(band).toBeTruthy();
+    expect(band.textContent).toContain("Recommended");
+    expect(band.querySelectorAll(".model-card").length).toBe(1);
+    expect(band.textContent).toContain("Z-Image-Turbo");
+    // The recommended card carries the ★ chip.
+    expect(band.querySelector(".model-card-rec-chip")).toBeTruthy();
+    // The non-recommended model sits under an "All image models" section.
+    const section = [...container.querySelectorAll(".models-section")].find((s) => s.textContent.includes("All image models"));
+    expect(section).toBeTruthy();
+    expect(section.querySelectorAll(".model-card").length).toBe(1);
+    expect(section.textContent).toContain("FLUX.1 [dev]");
+    // No collapsible <details> — every model is an always-open card.
+    expect(container.querySelector("details")).toBeNull();
   });
 
-  it("shows a single grid (no Recommended/Additional split) when a type has no recommended model", async () => {
+  it("shows a single '{Type} models' section (no Recommended band) when nothing is recommended", async () => {
     await render({ models: [MODELS[0]] }); // fixture has no recommended flag
-    const imageGroup = container.querySelector(".model-type-group");
-    expect(imageGroup.textContent).not.toContain("Recommended Models");
-    expect(imageGroup.querySelector(".model-subgroup-additional")).toBeNull();
-    expect(imageGroup.querySelectorAll(".model-row").length).toBe(1);
+    expect(container.querySelector(".models-accent-band")).toBeNull();
+    const section = container.querySelector(".models-section");
+    expect(section.textContent).toContain("Image models");
+    expect(section.querySelectorAll(".model-card").length).toBe(1);
   });
 
   it("describes each model's capabilities as chips on the card", async () => {
@@ -599,7 +622,7 @@ describe("ModelManagerScreen type-grouped layout", () => {
     });
     expect(container.textContent).toContain("incomplete");
     expect(container.textContent).toContain("vae/config.json");
-    const fixButton = [...container.querySelectorAll(".model-card-actions button")].find(
+    const fixButton = [...container.querySelectorAll(".model-card-footer-actions button")].find(
       (button) => button.textContent === "Fix",
     );
     expect(fixButton).toBeTruthy();
@@ -624,7 +647,7 @@ describe("ModelManagerScreen type-grouped layout", () => {
         },
       ],
     });
-    const fixButton = [...container.querySelectorAll(".model-card-actions button")].find(
+    const fixButton = [...container.querySelectorAll(".model-card-footer-actions button")].find(
       (button) => button.textContent === "Fix",
     );
     expect(fixButton).toBeTruthy();
@@ -635,7 +658,21 @@ describe("ModelManagerScreen type-grouped layout", () => {
     );
   });
 
-  it("groups LoRAs by family with a heading per family", async () => {
+  // On the LoRAs tab, User LoRAs are grouped by family into `.models-subsection`s
+  // (h4 heading); the Built-In / User scope sections are `.models-section`s (h3).
+  function userFamilyHeadings() {
+    return [...container.querySelectorAll(".models-subsection .models-section-heading h4")].map((h) => h.textContent);
+  }
+  function scopeHeadings() {
+    return [...container.querySelectorAll(".models-section > .models-section-heading h3")].map((h) => h.textContent);
+  }
+  function builtinSection() {
+    return [...container.querySelectorAll(".models-section")].find(
+      (group) => group.querySelector("h3")?.textContent === "Built-In LoRAs",
+    );
+  }
+
+  it("groups user LoRAs by family with a heading per family", async () => {
     await render({
       models: MODELS,
       loras: [
@@ -644,14 +681,14 @@ describe("ModelManagerScreen type-grouped layout", () => {
         { id: "c", name: "Wan C", family: "wan-video", installState: "installed" },
       ],
     });
-    const families = [...container.querySelectorAll(".lora-family-group-heading h3")].map((h) => h.textContent);
-    expect(families).toEqual(["flux", "wan-video"]);
-    const groups = container.querySelectorAll(".lora-family-group");
+    await selectTab(container, "LoRAs");
+    expect(userFamilyHeadings()).toEqual(["flux", "wan-video"]);
+    const groups = container.querySelectorAll(".models-subsection");
     expect(groups[0].querySelectorAll(".lora-row").length).toBe(2);
     expect(groups[1].querySelectorAll(".lora-row").length).toBe(1);
   });
 
-  it("buckets family-less LoRAs under a trailing 'Other / compatible' group", async () => {
+  it("buckets family-less user LoRAs under a trailing 'Other / compatible' group", async () => {
     await render({
       models: MODELS,
       loras: [
@@ -659,8 +696,8 @@ describe("ModelManagerScreen type-grouped layout", () => {
         { id: "x", name: "Loose", scope: "global", installState: "installed" },
       ],
     });
-    const families = [...container.querySelectorAll(".lora-family-group-heading h3")].map((h) => h.textContent);
-    expect(families).toEqual(["flux", "Other / compatible"]);
+    await selectTab(container, "LoRAs");
+    expect(userFamilyHeadings()).toEqual(["flux", "Other / compatible"]);
   });
 
   it("separates built-in LoRAs from user LoRAs into their own sections", async () => {
@@ -671,24 +708,15 @@ describe("ModelManagerScreen type-grouped layout", () => {
         { id: "u1", name: "My LoRA", family: "flux", scope: "global", installState: "installed" },
       ],
     });
-    const scopeHeadings = [...container.querySelectorAll(".lora-scope-group-heading h3")].map((h) => h.textContent);
-    expect(scopeHeadings).toEqual(["Built-In LoRAs", "User LoRAs"]);
-    const builtin = [...container.querySelectorAll(".lora-scope-group")].find((group) =>
-      group.querySelector("h3")?.textContent === "Built-In LoRAs",
-    );
+    await selectTab(container, "LoRAs");
+    expect(scopeHeadings()).toEqual(["Built-In LoRAs", "User LoRAs"]);
+    const builtin = builtinSection();
     expect(builtin.querySelectorAll(".lora-row").length).toBe(1);
     expect(builtin.textContent).toContain("LTX IC");
     expect(builtin.textContent).not.toContain("My LoRA");
     // The user LoRA is family-grouped inside the User section only.
-    const families = [...container.querySelectorAll(".lora-family-group-heading h3")].map((h) => h.textContent);
-    expect(families).toEqual(["flux"]);
+    expect(userFamilyHeadings()).toEqual(["flux"]);
   });
-
-  function builtinSection() {
-    return [...container.querySelectorAll(".lora-scope-group")].find(
-      (group) => group.querySelector("h3")?.textContent === "Built-In LoRAs",
-    );
-  }
 
   it("offers a Download button on a built-in HF LoRA and queues a download", async () => {
     const createLoraDownloadJob = vi.fn();
@@ -706,6 +734,7 @@ describe("ModelManagerScreen type-grouped layout", () => {
         },
       ],
     });
+    await selectTab(container, "LoRAs");
     const downloadButton = [...builtinSection().querySelectorAll(".lora-row-actions button")].find(
       (button) => button.textContent === "Download",
     );
@@ -729,6 +758,7 @@ describe("ModelManagerScreen type-grouped layout", () => {
       ],
       jobs: [{ id: "j1", type: "lora_download", status: "downloading", progress: 0.4, payload: { loraId: "ltx_ic" } }],
     });
+    await selectTab(container, "LoRAs");
     const actionButton = builtinSection().querySelector(".lora-row-actions button");
     expect(actionButton.disabled).toBe(true);
     expect(actionButton.textContent).toBe("downloading");
@@ -750,6 +780,7 @@ describe("ModelManagerScreen type-grouped layout", () => {
         },
       ],
     });
+    await selectTab(container, "LoRAs");
     const downloadButton = [...builtinSection().querySelectorAll(".lora-row-actions button")].find(
       (button) => button.textContent === "Download",
     );
@@ -1057,8 +1088,9 @@ describe("ModelManagerScreen quant-tier download panel (sc-8509)", () => {
 
   it("leaves a single-variant model's download UX unchanged (no tier panel)", async () => {
     await render([SINGLE_MODEL]);
+    await selectTab(container, "Utility Models"); // SINGLE_MODEL is a utility model
     expect(container.querySelector(".model-tier-panel")).toBeNull();
-    const downloadButton = [...container.querySelectorAll(".model-card-actions button")].find((button) =>
+    const downloadButton = [...container.querySelectorAll(".model-card-footer-actions button")].find((button) =>
       button.textContent.startsWith("Download"),
     );
     expect(downloadButton).toBeTruthy();
@@ -1147,6 +1179,7 @@ describe("ModelManagerScreen convert-at-install Update button", () => {
 
   it("shows an Update button when updateAvailable, and clicking it re-downloads the source", async () => {
     await render([convertModel({ updateAvailable: true })]);
+    await selectTab(container, "Video Models"); // convertModel is a video model
     const updateButton = mlxButtons().find((button) => button.textContent === "Update");
     expect(updateButton).toBeTruthy();
     // The stale converted state does NOT also render the disabled "MLX ready" button.
@@ -1157,6 +1190,7 @@ describe("ModelManagerScreen convert-at-install Update button", () => {
 
   it("shows the normal MLX-ready state (no Update button) when up to date", async () => {
     await render([convertModel({ updateAvailable: false })]);
+    await selectTab(container, "Video Models"); // convertModel is a video model
     expect(mlxButtons().some((button) => button.textContent === "Update")).toBe(false);
     expect(mlxButtons().some((button) => button.textContent === "MLX ready")).toBe(true);
     expect(createModelDownloadJob).not.toHaveBeenCalled();

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5191,6 +5191,368 @@ details[open] > summary.lora-scope-group-heading::before,
   background: var(--warm-soft);
 }
 
+/* User LoRA that's registered but has no local files (installState "missing"): a
+   danger-tinted border marks it as broken/unavailable, distinct from a built-in that
+   is simply "not installed" (neutral). Design: LoraRow handoff (epic 10309). */
+.lora-row.unavailable {
+  border-color: color-mix(in oklch, var(--danger) 30%, var(--border));
+}
+
+/* ============================================================================
+   Model Manager — tabbed interface (epic 10309)
+   Replaces the single scrolling page of collapsible <details> groups + collapsed
+   model rows with four flat-underline tabs (Image / Video / Utility / LoRAs), a
+   persistent search + family filter on the tab bar, a transient Search Results
+   tab, a Recommended band per tab, and always-open model cards. Reuses .mode-tabs
+   / .mode-tab, .status-badge, .chip / .model-capabilities, .model-tier-panel,
+   .model-gated-notice, .lora-row, .segmented-control, .models-import-grid,
+   .danger-action — this block adds only the genuinely new primitives.
+   ============================================================================ */
+
+/* Tab-bar row: the .mode-tabs tablist on the left, search + family on the right,
+   sharing one baseline. The row owns the 1px underline; the nested .mode-tabs
+   drops its own border so the two don't double up. */
+.models-tabbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 16px;
+  flex-wrap: wrap;
+  border-bottom: 1px solid var(--border);
+}
+
+.models-tabbar .mode-tabs {
+  border-bottom: 0;
+}
+
+/* Count badge trailing each tab label. Active tab = accent pill; inactive = muted. */
+.models-tab-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  padding: 1px 7px;
+  border-radius: var(--r-pill);
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  background: var(--surface-2);
+  color: var(--text-faint);
+}
+
+.mode-tab.active .models-tab-count {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+[data-theme="dark"] .mode-tab.active .models-tab-count {
+  color: var(--accent);
+}
+
+/* Search + family controls, nudged up so they sit above the shared baseline. */
+.models-tabbar-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 9px;
+  flex-wrap: wrap;
+}
+
+.models-search {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.models-search-glyph {
+  position: absolute;
+  left: 11px;
+  font-size: 14px;
+  color: var(--text-faint);
+  pointer-events: none;
+}
+
+/* Explicit width: the global `input { width: 100% }` reset would otherwise blow the
+   search box out to fill the flex row. */
+.models-search input {
+  width: 220px;
+  max-width: 100%;
+  height: 34px;
+  padding: 0 12px 0 31px;
+  border-radius: var(--r-sm);
+  font-size: 13px;
+}
+
+.models-family-select {
+  width: auto;
+  height: 34px;
+  padding: 0 10px;
+  border-radius: var(--r-sm);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+/* One tab's panel: a vertical stack of bands/sections. */
+.models-tab-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+/* Card grid shared by every model section (recommended band, all-models, search groups). */
+.models-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(302px, 1fr));
+  gap: 14px;
+}
+
+/* Accent band: the Recommended header container + the Import-LoRA form banner. */
+.models-accent-band {
+  display: flex;
+  flex-direction: column;
+  gap: 13px;
+  padding: 16px;
+  border-radius: 14px;
+  background: color-mix(in oklch, var(--accent) 5%, var(--surface));
+  border: 1px solid color-mix(in oklch, var(--accent) 22%, var(--border));
+}
+
+.models-accent-band-head {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.models-accent-band-head .eyebrow {
+  color: var(--accent-strong);
+}
+
+/* Accent dot with a soft ring, marking a band header. */
+.models-accent-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 22%, transparent);
+  flex: 0 0 auto;
+}
+
+.models-accent-band-count {
+  font-size: 12px;
+  color: var(--text-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+.models-accent-band-caption {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-left: auto;
+}
+
+/* The Import-LoRA form adopts .models-accent-band (flex column); keep its URL/Upload
+   segmented control compact rather than stretched to the band width. */
+.models-accent-band > .segmented-control {
+  align-self: flex-start;
+}
+
+/* Plain section (All {type} models, Built-In LoRAs, a User family group, a Search group). */
+.models-section {
+  display: flex;
+  flex-direction: column;
+  gap: 13px;
+}
+
+.models-subgroups {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.models-subsection {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.models-section-heading {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.models-section-heading h3,
+.models-section-heading h4 {
+  margin: 0;
+  color: var(--text);
+}
+
+.models-section-heading h3 {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.models-section-heading h4 {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.models-section-heading > span {
+  font-size: 12px;
+  color: var(--text-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Always-open model card (replaces the collapsed .model-row summary/body). */
+.model-card {
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+  min-width: 0;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+}
+
+.model-card.recommended {
+  border-color: color-mix(in oklch, var(--accent) 45%, var(--border));
+}
+
+.model-card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+/* Header right column: the install-status badge plus any attention badges
+   (needs family / not on Mac), wrapping right-aligned. */
+.model-card-status {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 6px;
+}
+
+.model-card-title {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.model-card-title strong {
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.model-card-title small {
+  font-size: 11.5px;
+  color: var(--text-muted);
+}
+
+/* ★ Recommended chip. */
+.model-card-rec-chip {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 9px;
+  border-radius: var(--r-pill);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--accent-strong);
+  background: var(--accent-soft);
+}
+
+[data-theme="dark"] .model-card-rec-chip {
+  color: var(--accent);
+}
+
+.model-card-description {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+/* Footer: download size (mono) left, primary + delete right. */
+.model-card-footer {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding-top: 4px;
+}
+
+.model-card-size {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-faint);
+  white-space: nowrap;
+}
+
+.model-card-footer-actions {
+  display: flex;
+  gap: 8px;
+}
+
+/* Card primary action: accent-filled when actionable, muted when disabled. Uses
+   --accent-fg for the label so it reads on the (light-in-dark-mode) accent fill. */
+.model-card-primary {
+  min-height: 34px;
+  padding: 0 15px;
+  border-radius: var(--r-sm);
+  font-size: 13px;
+  font-weight: 600;
+  background: var(--accent-strong);
+  color: var(--accent-fg);
+  border: 1px solid var(--accent-strong);
+}
+
+.model-card-primary:hover:not(:disabled) {
+  filter: brightness(1.05);
+}
+
+.model-card-primary:disabled {
+  background: var(--surface-2);
+  color: var(--text-faint);
+  border-color: var(--border);
+}
+
+/* Empty-state dashed box shared by the model + search panels. */
+.models-empty {
+  padding: 44px;
+  text-align: center;
+  color: var(--text-muted);
+  border: 1px dashed var(--border);
+  border-radius: var(--r-md);
+  font-size: 14px;
+}
+
+/* Incomplete / attention status badge — warn tones. No such rule existed before;
+   the design's incomplete state and the pre-existing `needs family` / `not on Mac`
+   badges (which used `status-badge warning` with no matching rule) both adopt it. */
+.status-badge.warning {
+  border-color: color-mix(in oklch, var(--warn) 45%, transparent);
+  background: var(--warn-soft);
+  color: color-mix(in oklch, var(--warn) 80%, var(--text));
+}
+
+/* Danger status badge — an unavailable (broken) user LoRA. */
+.status-badge.danger {
+  border-color: color-mix(in oklch, var(--danger) 45%, transparent);
+  background: var(--danger-soft);
+  color: color-mix(in oklch, var(--danger) 85%, var(--text));
+}
+
 /* ---------- Characters / presets ---------- */
 .character-layout {
   display: grid;


### PR DESCRIPTION
## What

Recreates the "Model Manager — Tabbed Redesign" design handoff inside the existing React app. Replaces the single long-scrolling page of collapsible `<details>` groups + collapsed model rows with a **four-tab interface** modeled on the Image Studio mode tabs:

- **Tabs:** Image Models · Video Models · Utility Models · LoRAs, each with a total-count badge. Every model of a type is shown (no more collapsed "Additional Supported").
- **Recommended band:** an accent-tinted section floats the curated `recommended` picks to the top of each model tab.
- **Persistent search + family filter** on the tab bar; typing spawns a transient **⌕ Search Results** tab (cross-type matches grouped by category), and clearing it restores the previous tab.
- **Always-open model cards** (no click-to-expand) with header/status/★-chip/description/capability-chips/footer — keeping the existing `GatedModelNotice`, `ModelTierDownloadPanel` (quant tiers), and the MLX/convert/update + incomplete-cache + `WorkerProgressCard` blocks unchanged.
- **LoRAs tab:** the Import LoRA form re-skinned into the accent band (URL/Upload + Scope/Family/Source/Name, Wan A14B MoE base-model + low-noise slot preserved), then Built-In and family-grouped User sections using the shared `.lora-row`.

## Why

Implements epic [sc-10309](https://app.shortcut.com/trefry/epic/10309) (successor to the shipped Models UX overhaul, epic 5941). The old grouped/collapsed layout buried models behind expand clicks and split each type across Recommended / Additional-Supported disclosures; the tabbed layout surfaces everything per type and makes cross-type search a first-class affordance.

## Scope of change

- `apps/web/src/screens/ModelManagerScreen.jsx` — the refactor (tab/search state, tab bar, model/search/LoRA panels, always-open card). Removed `expandedModels` and the type-grouped `<details>`/`MODEL_TYPE_GROUPS`/`modelGroups` machinery.
- `apps/web/src/styles.css` — new token-driven primitives (`.models-tabbar`, `.models-tab-count`, `.models-search`, `.models-accent-band`, `.models-section`, `.model-card` + footer/primary, `.models-empty`). Reuses `status-badge`, `chip`, `model-tier-panel`, `model-gated-notice`, `lora-row`, `segmented-control`, `models-import-grid`, `danger-action`. Adds a **new `.status-badge.warning`** rule (warn tones) — none existed before, so this also fixes the pre-existing `needs family` / `not on Mac` badges that rendered neutral.
- `apps/web/src/screens/ModelManagerScreen.test.jsx`, `apps/web/src/App.models.test.jsx`, `apps/web/src/main.testSupport.jsx` — rewrote structural assertions for the tab model; added `selectModelTab` / `familyFilter` helpers.

## Reviewer notes / deliberate decisions

- **Family filter semantics:** narrows models via `modelLoraFamilies(model).includes(filter)` (the same union the dropdown is built from), not the `model.family` identity — so a selected token never hides everything (e.g. FLUX.2 [klein] identity `flux2-klein` vs LoRA family `flux2`).
- **Dropped from the old card:** the repo/"Download size" `<dl>` and the "N installed · N unavailable" LoRA aggregate line — neither is in the design; per-row status badges + the footer size carry that information.
- **Card keeps more than the mock:** the prototype card omitted the MLX/convert/update blocks (sample data); the real card retains them per the handoff.
- **Fixed 4-tab set hides nothing:** the builtin catalog only has `image`/`video`/`utility` model types, so no "Other" fallback is needed.
- **Model import** stays compile-gated (`MODEL_IMPORT_ENABLED`, epic 7080 / sc-8941 scaffold) and now only renders when there is in-flight model-import progress.

## Verification

- `npm --prefix apps/web run test` → **1316/1316 pass** (incl. the rewritten `ModelManagerScreen.test.jsx` 36 + `App.models.test.jsx` 26).
- `npm --prefix apps/web run lint` → 0 errors (pre-existing warnings only); production `build` clean.
- Live-verified against the real catalog (rust-api + Vite) in **light and dark**: tab counts (Image 40 / Video 9 / Utility 10 / LoRAs 6), Recommended band (7 ★ picks), search → Search Results auto-switch + restore, LoRAs import band + rows. Dark-mode Download button uses `--accent-fg` (dark text on the light accent) exactly as the handoff calls out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
