### PR TITLE
fix(loras): update contract snapshot for always-emitted triggerWords (sc-10328 follow-up)

### DIFF
--- a/tests/fixtures/rust_api_contract_snapshots/snapshots.json
+++ b/tests/fixtures/rust_api_contract_snapshots/snapshots.json
@@ -2004,13 +2004,15 @@
           "provider": "huggingface",
           "repo": "owner/style-lora"
         },
+        "triggerWords": [],
         "updatedAt": "<timestamp>"
       },
       "manifestPath": "<runtime-root>/config/manifests/user.loras.jsonc",
       "name": "Imported LoRA",
       "repo": "owner/style-lora",
       "scope": "global",
-      "targetDir": "<runtime-root>/data/loras/imported_lora"
+      "targetDir": "<runtime-root>/data/loras/imported_lora",
+      "triggerWords": []
     },
     "progress": 0.0,
     "projectId": null,


### PR DESCRIPTION
## Summary
Follow-up to #1287. That PR added the trigger-keyword/notes feature but was merged one second after the `parity` check reported failure, so **main's parity lane is currently red**.

The LoRA import job now always emits `triggerWords: []` (on both the job payload and the `manifestEntry`), but the contract-snapshot golden wasn't updated in the merged commit (the fix was in an amended commit that never landed on the PR before merge). This adds the two `triggerWords` fields to the golden.

## Testing
- `python -m pytest -q -m parity --strict-markers` → **12 passed** (main is currently 1 failed / 11 passed).

Restores green CI on main. sc-10328 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)