### PR TITLE
fix(contracts): regenerate lora-import snapshot for triggerWords (sc-10328)

### DIFF
--- a/tests/fixtures/rust_api_contract_snapshots/snapshots.json
+++ b/tests/fixtures/rust_api_contract_snapshots/snapshots.json
@@ -2004,13 +2004,15 @@
           "provider": "huggingface",
           "repo": "owner/style-lora"
         },
+        "triggerWords": [],
         "updatedAt": "<timestamp>"
       },
       "manifestPath": "<runtime-root>/config/manifests/user.loras.jsonc",
       "name": "Imported LoRA",
       "repo": "owner/style-lora",
       "scope": "global",
-      "targetDir": "<runtime-root>/data/loras/imported_lora"
+      "targetDir": "<runtime-root>/data/loras/imported_lora",
+      "triggerWords": []
     },
     "progress": 0.0,
     "projectId": null,


### PR DESCRIPTION
## Problem
[#1287](https://github.com/SceneWorks/SceneWorks/pull/1287) (sc-10328) added `triggerWords` to the `lora_import` job payload and its `manifestEntry` in the Rust API, but the contract snapshot was not regenerated. `tests/fixtures/rust_api_contract_snapshots/snapshots.json` was left stale, so the **"lora import job response"** contract reports:

```
$.payload.triggerWords: only in candidate
$.payload.manifestEntry.triggerWords: only in candidate
```

This turned the **`parity`** lane red on `main` (tip `eae370f5`) and on every branch merged with it (e.g. #1091, #1092). `main` is not branch-protected, so #1287 merged before the lane finished.

## Fix
Regenerate the "lora import job response" snapshot via `UPDATE_SNAPSHOTS=1 pytest -m parity` — adds `"triggerWords": []` to the payload and its `manifestEntry` to match the emitted contract. No production code change.

## Verification
- Targeted regen produced a minimal diff (+`triggerWords` in two places, nothing else).
- Full `pytest -q -m parity` → **12 passed** locally against a freshly built `sceneworks-rust-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)