### PR TITLE
feat(web): show app version at bottom of left sidebar

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -72,6 +72,10 @@ const ImageEditor = React.lazy(() =>
   import("./screens/ImageEditor.jsx").then((module) => ({ default: module.ImageEditor })),
 );
 
+// Product version, injected at build time from package.json (see vite.config.js).
+// Empty in unconfigured contexts (e.g. some test paths); the footer is hidden then.
+const APP_VERSION = import.meta.env.VITE_APP_VERSION ?? "";
+
 const navSections = [
   {
     label: "Workspace",
@@ -2147,6 +2151,13 @@ export function App() {
           </div>
         ))}
 
+        {APP_VERSION ? (
+          <div className="sidebar-footer">
+            <span className="app-version" title={`SceneWorks ${APP_VERSION}`}>
+              v{APP_VERSION}
+            </span>
+          </div>
+        ) : null}
       </aside>
 
       <section className="workspace">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -344,6 +344,20 @@ button:focus-visible {
   gap: 4px;
 }
 
+/* Pinned to the bottom of the flex-column sidebar (margin-top: auto). Shows the
+   product version injected at build time (see App.jsx / vite.config.js). */
+.sidebar-footer {
+  margin-top: auto;
+  padding: 6px 10px 2px;
+  border-top: 1px solid var(--border);
+}
+
+.app-version {
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  color: var(--text-faint);
+}
+
 .sidebar-section-title {
   font-size: 10.5px;
   font-weight: 700;

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -1,8 +1,18 @@
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import { defineConfig, searchForWorkspaceRoot } from "vite";
 
 import themeInitPlugin from "./vite-plugin-theme-init.js";
+
+// Expose the product version (kept in lockstep across the repo's package.json /
+// tauri.conf.json by scripts/sync-version.mjs) to the frontend as a build-time
+// constant. Reading package.json here works in both the desktop shell and the
+// remote-LAN browser (epic 4484), where window.__TAURI__ / getVersion() is
+// unavailable — see the sidebar footer in App.jsx.
+const pkg = JSON.parse(
+  readFileSync(fileURLToPath(new URL("./package.json", import.meta.url)), "utf8"),
+);
 
 // The About → Licenses screen (sc-3778) imports the bundled-license corpus
 // directly from apps/desktop/licenses/ (single source of truth, no second copy).
@@ -15,6 +25,11 @@ export default defineConfig({
   // Generate the pre-paint /theme-init.js from src/accents.js at dev/build time
   // (single source of truth for the accent-id list). See vite-plugin-theme-init.js.
   plugins: [themeInitPlugin()],
+  // Matches the existing import.meta.env.VITE_* convention (see api.js). Defining
+  // the specific key keeps it lint-safe (no bare global) under no-undef.
+  define: {
+    "import.meta.env.VITE_APP_VERSION": JSON.stringify(pkg.version),
+  },
   // react-konva pulls its own react-reconciler; without deduping, Vite's dep
   // optimizer can hand it a second React copy, tripping "Invalid hook call /
   // cannot read useRef of null" when the canvas <Stage> mounts. Force a single


### PR DESCRIPTION
## What

Displays the current software version at the bottom of the left sidebar. `v0.7.1` renders pinned to the bottom, in the same muted style as the other secondary sidebar text, with a subtle top-border separator.

## How

- **`vite.config.js`** — reads the version from `apps/web/package.json` at build time and injects it as `import.meta.env.VITE_APP_VERSION` via Vite's `define`. This matches the existing `import.meta.env.VITE_*` convention (see `api.js`) and stays lint-safe under `no-undef`.
- **`App.jsx`** — a module-level `APP_VERSION` constant plus a `.sidebar-footer` element rendered before `</aside>` (hidden when the version is empty, e.g. some test paths).
- **`styles.css`** — `.sidebar-footer` uses `margin-top: auto` to pin to the bottom of the flex-column sidebar; `.app-version` uses the theme-aware `--text-faint` token.

## Why a build-time constant, not Tauri `getVersion()`

The frontend also runs as a plain remote-LAN browser (epic 4484) where `window.__TAURI__` is `undefined`. A build-time constant sourced from `package.json` (kept in lockstep across the repo by `scripts/sync-version.mjs`) works in **both** desktop and browser modes.

## Verification

- Previewed in-browser: renders `v0.7.1`, correct in light and dark mode, no console errors.
- `eslint src/App.jsx` → 0 errors.
- `npm run build` → succeeds; `0.7.1` baked into the app bundle.
- `npm run test` (web) → 99 files / 1335 tests pass.

No Rust, API contract, or payload-shape changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)