### PR TITLE
fix(desktop): bundle mlx.metallib so packaged Macs can load MLX; release 0.7.2 (sc-10349)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,6 +222,8 @@ apps/desktop/python-src/
 apps/desktop/onnxruntime/
 # static ffmpeg staged by build-sidecar.mjs for the Rust worker (sc-3767)
 apps/desktop/ffmpeg/
+# MLX Metal shader library staged by build-sidecar.mjs for the in-process MLX worker (sc-10349)
+apps/desktop/mlx/
 # CUDA runtime redist DLLs staged by build-sidecar.mjs for the candle worker (sc-5560)
 apps/desktop/cuda/
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -2,7 +2,7 @@
 
 SceneWorks Desktop packages the full SceneWorks AI image and video studio as a
 single native application — no Docker, no terminal, no Python to install. It is a
-[Tauri](https://tauri.app) shell (`net.trefry.sceneworks`, v0.7.1) that bundles
+[Tauri](https://tauri.app) shell (`net.trefry.sceneworks`, v0.7.2) that bundles
 the SceneWorks API and runs generation on a native, platform-specific engine:
 
 - **macOS** runs on Apple's **MLX** engine (Apple Silicon only).

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/desktop",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/desktop",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/desktop",
   "private": true,
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "SceneWorks desktop shell (Tauri).",
   "scripts": {
     "dev": "tauri dev",

--- a/apps/desktop/scripts/build-sidecar.mjs
+++ b/apps/desktop/scripts/build-sidecar.mjs
@@ -9,6 +9,9 @@ import {
   chmodSync,
   writeFileSync,
   readFileSync,
+  existsSync,
+  readdirSync,
+  statSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -43,6 +46,30 @@ function run(cmd, args, extraEnv = {}) {
     return;
   }
   execFileSync(cmd, args, opts);
+}
+
+// Locate the mlx.metallib produced by the api build's pmetal-mlx-sys compile
+// (sc-10349). Prefer the build tree — the exact, freshly-built artifact matching
+// the api binary we just staged. There can be several pmetal-mlx-sys-<hash> build
+// dirs (feature/profile variants), so pick the newest that actually holds the file.
+// Fall back to ~/.cache/pmetal/lib/mlx.metallib, which mlx-sys build.rs refreshes
+// (newest-wins) after every build. Returns null if neither exists (caller errors).
+function findBuiltMetallib() {
+  const buildRoot = join(repoRoot, "target", "release", "build");
+  const candidates = [];
+  if (existsSync(buildRoot)) {
+    for (const entry of readdirSync(buildRoot)) {
+      if (!entry.startsWith("pmetal-mlx-sys-")) continue;
+      const lib = join(buildRoot, entry, "out", "build", "lib", "mlx.metallib");
+      if (existsSync(lib)) candidates.push([lib, statSync(lib).mtimeMs]);
+    }
+  }
+  if (candidates.length) {
+    candidates.sort((a, b) => b[1] - a[1]);
+    return candidates[0][0];
+  }
+  const cached = join(os.homedir(), ".cache", "pmetal", "lib", "mlx.metallib");
+  return existsSync(cached) ? cached : null;
 }
 
 // Host target triple, e.g. aarch64-apple-darwin or x86_64-pc-windows-msvc.
@@ -244,6 +271,45 @@ if (triple.includes("apple-darwin")) {
     "Static ffmpeg is bundled on macOS only (sc-3767); Windows/Linux use PATH ffmpeg.\n",
   );
   console.log(`build-sidecar: ${ffmpegDir} placeholder (non-macOS, PATH ffmpeg)`);
+}
+
+// The in-process MLX worker (macOS) loads MLX's compiled Metal shader library
+// (mlx.metallib, ~158 MB) at runtime — it is NOT embedded in the api binary. The
+// pmetal-mlx-rs fork's resolver (sc-7898) looks for it via PMETAL_METALLIB_PATH,
+// then a path into the *build machine's* target dir baked into the binary, then
+// ~/.cache/pmetal — NONE of which exist on a clean end-user Mac (the cache is only
+// populated as a side effect of a local `cargo build`). A packaged app that doesn't
+// ship the file therefore fails on first MLX use with "Failed to load the default
+// metallib. library not found" (sc-10349). Bundle it as a Tauri resource; setup.rs
+// points the worker at it via PMETAL_METALLIB_PATH (mirrors the ffmpeg/onnxruntime
+// staging above). A .metallib is NOT a Mach-O — it's sealed by the .app signature
+// as a plain resource, so unlike the ffmpeg/onnxruntime binaries it needs no
+// separate codesign. macOS-only; other platforms use candle and ship no metallib
+// (placeholder so the `mlx/**/*` resource glob still matches — Tauri errors on an
+// empty glob).
+const mlxDir = join(desktopDir, "mlx");
+mkdirSync(mlxDir, { recursive: true });
+if (triple.includes("apple-darwin")) {
+  const metallibSrc = findBuiltMetallib();
+  if (!metallibSrc) {
+    console.error(
+      "build-sidecar: could not locate mlx.metallib under " +
+        `${join(repoRoot, "target", "release", "build")}/pmetal-mlx-sys-*/out/build/lib/ ` +
+        "or ~/.cache/pmetal/lib/ — a macOS build without it ships an app that fails on " +
+        "first MLX use (sc-10349). The api build above compiles pmetal-mlx-sys, which " +
+        "produces it, so this usually means that build did not run or was redirected.",
+    );
+    process.exit(1);
+  }
+  const metallibDest = join(mlxDir, "mlx.metallib");
+  copyFileSync(metallibSrc, metallibDest);
+  console.log(`build-sidecar: staged ${metallibDest} (from ${metallibSrc})`);
+} else {
+  writeFileSync(
+    join(mlxDir, "README.txt"),
+    "mlx.metallib is bundled on macOS only (the in-process MLX worker). Windows/Linux use the candle backend and ship no MLX shader library (sc-10349).\n",
+  );
+  console.log(`build-sidecar: ${mlxDir} placeholder (non-macOS, no MLX metallib)`);
 }
 
 // The candle (Windows/CUDA) worker links cudarc with dynamic-linking, which

--- a/apps/desktop/scripts/stage-test-sidecars.mjs
+++ b/apps/desktop/scripts/stage-test-sidecars.mjs
@@ -37,8 +37,11 @@ for (const name of ["sceneworks-api"]) {
 // Only the bundled resource dirs (tauri.conf.json `bundle.resources`) need a
 // placeholder for the build-script resource validation. The CUDA/onnxruntime GPU
 // runtime is no longer bundled — it's downloaded on first run (cuda_provision.rs) —
-// so there's no `cuda` resource glob to satisfy.
-for (const dir of ["onnxruntime", "ffmpeg"]) {
+// so there's no `cuda` resource glob to satisfy. `mlx` holds the MLX metallib on
+// macOS (a placeholder elsewhere, sc-10349) but is a declared resource glob on
+// every platform, so it needs a placeholder here too or Tauri's build.rs panics
+// ("glob pattern mlx/**/* … didn't match any files") during the desktop tests/lints.
+for (const dir of ["onnxruntime", "ffmpeg", "mlx"]) {
   const path = join(desktopDir, dir);
   mkdirSync(path, { recursive: true });
   writeFileSync(

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -375,6 +375,29 @@ fn resolve_bundled_onnxruntime(app: &AppHandle) -> Option<String> {
     None
 }
 
+/// Resolve MLX's compiled Metal shader library (`mlx.metallib`), which the
+/// in-process MLX worker loads at runtime. It is NOT embedded in the binary: the
+/// pmetal-mlx-rs fork's resolver (sc-7898) searches `PMETAL_METALLIB_PATH`, then a
+/// path into the *build machine's* target dir baked into the binary, then
+/// `~/.cache/pmetal` — none of which exist on a clean end-user Mac (the cache is
+/// only populated as a side effect of a local `cargo build`), so a packaged app must
+/// ship the file and point the worker at it or MLX fails on first use with "Failed
+/// to load the default metallib. library not found" (sc-10349). Prefers the copy
+/// bundled next to the app (staged by build-sidecar.mjs into the `mlx` resource
+/// dir); returns None in dev/pre-bundle, where the fork's own build-tree / cache
+/// resolution applies (caller then leaves `PMETAL_METALLIB_PATH` unset). macOS-only —
+/// MLX is the macOS inference backend.
+#[cfg(target_os = "macos")]
+fn resolve_bundled_metallib(app: &AppHandle) -> Option<String> {
+    if let Ok(resources) = app.path().resource_dir() {
+        let bundled = resources.join("mlx").join("mlx.metallib");
+        if bundled.exists() {
+            return Some(bundled.to_string_lossy().to_string());
+        }
+    }
+    None
+}
+
 /// Resolve the CUDA-enabled onnxruntime DLL the candle worker's `ort` paths (DWPose
 /// pose_detect sc-5496, + YOLO/Real-ESRGAN, epic 5482) dlopen at runtime via
 /// `ORT_DYLIB_PATH` (the `load-dynamic` feature). The Windows/CUDA analogue of the
@@ -571,6 +594,16 @@ fn spawn_api(app: &AppHandle) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     if let Some(ort_dylib) = resolve_bundled_onnxruntime(app) {
         command = command.env("ORT_DYLIB_PATH", ort_dylib);
+    }
+    // MLX loads its Metal shader library (mlx.metallib) at runtime; point the pmetal
+    // resolver at the bundled copy so a packaged Mac (no build tree, no
+    // ~/.cache/pmetal) finds it instead of failing "Failed to load the default
+    // metallib" (sc-10349). The API sidecar's in-process utility worker touches MLX
+    // too (e.g. the native YOLO11 person detector), so it needs this — not just the
+    // separately-spawned MLX GPU worker below.
+    #[cfg(target_os = "macos")]
+    if let Some(metallib) = resolve_bundled_metallib(app) {
+        command = command.env("PMETAL_METALLIB_PATH", metallib);
     }
     // The candle (Windows/CUDA) worker's cudarc dynamic-linking `LoadLibrary`s the
     // CUDA runtime DLLs by name; prepend the bundled redist dir to the sidecar's
@@ -926,6 +959,13 @@ fn supervise_mlx_worker(app: AppHandle, api_port: u16) {
             // point `ort` at the bundled CoreML onnxruntime dylib it dlopens.
             if let Some(ort_dylib) = resolve_bundled_onnxruntime(&app) {
                 command = command.env("ORT_DYLIB_PATH", ort_dylib);
+            }
+            // This is the process that runs MLX generation; point the pmetal resolver
+            // at the bundled Metal shader library so a packaged Mac (no build tree, no
+            // ~/.cache/pmetal) finds it instead of failing "Failed to load the default
+            // metallib" on first MLX use (sc-10349, as spawn_api does).
+            if let Some(metallib) = resolve_bundled_metallib(&app) {
+                command = command.env("PMETAL_METALLIB_PATH", metallib);
             }
             // Lazy credentials (sc-5891): instead of reading the keychain here and
             // injecting HF_TOKEN/SCENEWORKS_CREDENTIALS (which prompted at launch),

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SceneWorks",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "identifier": "net.trefry.sceneworks",
   "build": {
     "frontendDist": "ui",
@@ -31,7 +31,8 @@
     "externalBin": ["binaries/sceneworks-api"],
     "resources": [
       "onnxruntime/**/*",
-      "ffmpeg/**/*"
+      "ffmpeg/**/*",
+      "mlx/**/*"
     ],
     "icon": [
       "icons/32x32.png",

--- a/apps/desktop/tauri.macos.conf.json
+++ b/apps/desktop/tauri.macos.conf.json
@@ -5,6 +5,6 @@
   },
   "bundle": {
     "externalBin": ["binaries/sceneworks-api"],
-    "resources": ["onnxruntime/**/*", "ffmpeg/**/*"]
+    "resources": ["onnxruntime/**/*", "ffmpeg/**/*", "mlx/**/*"]
   }
 }

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/web",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/web",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "dependencies": {
         "konva": "^9.3.22",
         "react": "18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/web",
   "private": true,
-  "version": "0.7.1",
+  "version": "0.7.2",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sceneworks",
   "private": true,
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Local AI image and video generation studio runtime skeleton.",
   "license": "SEE LICENSE IN LICENSE",
   "scripts": {


### PR DESCRIPTION
Fixes **[sc-10349](https://app.shortcut.com/trefry/story/10349)**. Cuts release **0.7.2**.

## Problem
Non-developer users installing the packaged/notarized macOS `.app` crash on first MLX use with:

```
MLX error: Failed to load the default metallib. library not found library not found library not found library not found library not found at .../pmetal-mlx-sys-.../mlx/c/array.cpp:232
```

MLX's compiled Metal shader library (`mlx.metallib`, ~158 MB, a **separate file — not embedded** in the binary) was never shipped inside the `.app`. The `pmetal-mlx-rs` resolver (sc-7898) searches `PMETAL_METALLIB_PATH` → a build-machine path baked into the binary → `~/.cache/pmetal` → colocated — and **none** of those exist on a clean Mac. The 5× `library not found` is exactly the five file-path candidates missing.

**Why now / not a regression:** every machine that ran the app until now (dev Macs, the `nax` release runner) had `~/.cache/pmetal/lib/mlx.metallib` populated as a side effect of a local `cargo build`, so that fallback silently rescued every internal install. The first genuinely clean Mac misses all of them. `git log -S metallib` confirms bundling never existed.

## Fix — mirror the ffmpeg (sc-3767) / onnxruntime (sc-3487) native-dep bundling
- **`build-sidecar.mjs`** — stage `mlx.metallib` into `apps/desktop/mlx/` on macOS (from the release build tree, fallback `~/.cache/pmetal`); hard-errors if missing; placeholder on other platforms.
- **`tauri.conf.json`** — add `mlx/**/*` to `bundle.resources`.
- **`setup.rs`** — `resolve_bundled_metallib()` + set `PMETAL_METALLIB_PATH` on **both** MLX-linked spawn sites (`spawn_api` + `supervise_mlx_worker`).
- **`.gitignore`** — ignore the staged `apps/desktop/mlx/`.

Env-var (not colocation) because Tauri stages resources in `Contents/Resources/` while the fork's colocated resolver only checks the sidecar's own dir — same mechanism already used for `ORT_DYLIB_PATH` / `SCENEWORKS_FFMPEG`. A `.metallib` is not Mach-O → sealed by the `.app` signature, no separate codesign.

Also bumps the app version `0.7.1 → 0.7.2`.

## Verification
- `cargo check -p sceneworks-desktop` ✅ (compiles `setup.rs` + proves Tauri's `build.rs` accepts the new `mlx/**/*` glob) · `clippy -D warnings` ✅ · `cargo fmt --check` ✅
- `node --check` build-sidecar.mjs ✅ · tauri.conf.json valid JSON ✅
- `findBuiltMetallib()` resolves a real 158 MB metallib (build-tree preferred, `~/.cache/pmetal` fallback)

## Residual
Full packaged-build E2E on a *clean* Mac is the nax-runner + signing release lane, not runnable in-worktree. A local signed `tauri build` + cache-aside launch is being run to confirm before tag. +158 MB to the DMG (unavoidable). Notarization expected unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)