### PR TITLE
polish(model-manager): Import LoRA form — match select height + default to Upload (sc-10328 follow-up)

### DIFF
--- a/apps/web/src/App.models.test.jsx
+++ b/apps/web/src/App.models.test.jsx
@@ -243,6 +243,7 @@ describe("SceneWorks app shell", () => {
     await settle();
     await selectModelTab("LoRAs");
     const panel = loraPanel(container);
+    await act(async () => buttonInside(panel, "URL").click());
     await changeField(field(panel, "Source URL"), "https://example.com/loras/detail.safetensors");
     await act(async () => {
       buttonInside(panel, "Queue Import").click();
@@ -648,6 +649,7 @@ describe("SceneWorks app shell", () => {
 
     await selectModelTab("LoRAs");
     const panel = loraPanel(container);
+    await act(async () => buttonInside(panel, "URL").click());
     await changeField(field(panel, "Source URL"), "https://example.com/loras/detail.safetensors");
     await changeField(field(panel, "Name"), "Detail LoRA");
     await act(async () => {
@@ -689,6 +691,7 @@ describe("SceneWorks app shell", () => {
     expect(familyFilter(container).value).toBe("all");
     await changeField(familyFilter(container), "qwen-image");
     const panel = loraPanel(container);
+    await act(async () => buttonInside(panel, "URL").click());
     await changeField(field(panel, "Source URL"), "https://example.com/loras/detail.safetensors");
     await act(async () => {
       buttonInside(panel, "Queue Import").click();
@@ -919,6 +922,7 @@ describe("SceneWorks app shell", () => {
 
     await selectModelTab("LoRAs");
     const panel = () => loraPanel(container);
+    await act(async () => buttonInside(panel(), "URL").click());
     await changeField(field(panel(), "Source URL"), "https://example.com/loras/one.safetensors");
     await changeField(field(panel(), "Name"), "First Detail");
     await act(async () => {
@@ -1085,6 +1089,7 @@ describe("SceneWorks app shell", () => {
 
     await selectModelTab("LoRAs");
     const panel = loraPanel(container);
+    await act(async () => buttonInside(panel, "URL").click());
     await changeField(field(panel, "Source URL"), "file:///tmp/detail.safetensors");
     await act(async () => {
       buttonInside(panel, "Queue Import").click();

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -525,7 +525,9 @@ export function ModelManagerScreen() {
   const [importingLora, setImportingLora] = useState(false);
   const [importMessage, setImportMessage] = useState({ tone: "neutral", text: "" });
   const [importForm, setImportForm] = useState({
-    mode: "url",
+    // Default to file upload: most LoRAs are a file the user already downloaded
+    // (e.g. from civit.ai); the URL tab remains one click away.
+    mode: "file",
     sourceUrl: "",
     file: null,
     secondaryFile: null,

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -389,6 +389,14 @@ describe("ModelManagerScreen Wan A14B MoE LoRA import (sc-1991)", () => {
     await change(familySelect, "wan-video");
   }
 
+  it("defaults the LoRA import to Upload mode", async () => {
+    await render();
+    // Most LoRAs are a file the user already downloaded (e.g. from civit.ai), so the
+    // form opens on Upload: the file input is shown and Source URL is not.
+    expect(labelStartingWith("LoRA File")).toBeTruthy();
+    expect(labelStartingWith("Source URL")).toBeUndefined();
+  });
+
   it("reveals the base-model selector only after the wan-video family is chosen", async () => {
     await render();
     expect(labelStartingWith("Base model")).toBeUndefined();
@@ -417,6 +425,9 @@ describe("ModelManagerScreen Wan A14B MoE LoRA import (sc-1991)", () => {
     await render();
     await selectWanVideoFamily();
     await change(labelStartingWith("Base model").querySelector("select"), "wan_2_2_t2v_14b");
+    await act(async () => {
+      [...loraForm().querySelectorAll("button")].find((button) => button.textContent === "URL").click();
+    });
     await change(labelStartingWith("Source URL").querySelector("input"), "https://example.com/wan-moe.safetensors");
     const form = container.querySelector('form[aria-label="Import LoRA"]');
     await act(async () => {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5092,6 +5092,19 @@ details[open] > summary.lora-scope-group-heading::before,
   align-items: end;
 }
 
+/* A native <select> renders shorter than a text input even with matching padding.
+   Strip the native chrome (so it honors the shared 9px 12px padding + line-height)
+   and add a chevron, so the Scope/Family selects match the URL/Name input height. */
+.models-import-grid select {
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2.5'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 30px;
+  cursor: pointer;
+}
+
 /* Full-width trigger-keyword + notes fields below the import grid (epic 10328). */
 .lora-import-metadata {
   display: grid;


### PR DESCRIPTION
## Summary
Two small polish tweaks to the Import LoRA form (epic sc-10328), from user feedback.

### 1. Match Scope/Family select height to the text inputs
A native `<select>` sizes to its own intrinsic height and ignored the input's padding + line-height, so the **Scope**/**Family** selects looked stubby next to **Source URL**/**Name**. Give `.models-import-grid select` `appearance: none` (so it honors the shared box model) + a chevron — the app's existing `.ie-select` pattern. Verified in-browser: select height == input height (41px == 41px).

### 2. Default the import to Upload (not URL)
Most LoRAs are a file the user already downloaded (e.g. from civit.ai), so the form now opens on **Upload**; the URL tab is one click away. Updated the URL-import tests to select the URL tab explicitly (no longer the default) and added a test asserting the Upload default.

## Testing
- Full web vitest: **1336 pass**.
- `npm run build` clean.
- CSS-only + a JSX default + test updates; no Rust touched (no parity impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)