### PR TITLE
docs: add contribution guidelines, code of conduct, and security policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: Bug report
+description: Report something that isn't working the way it should
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! Please search
+        [existing issues](https://github.com/SceneWorks/SceneWorks/issues) first
+        to avoid duplicates.
+
+        **Do not report security vulnerabilities here** — see
+        [SECURITY.md](https://github.com/SceneWorks/SceneWorks/blob/main/SECURITY.md).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, and what you expected instead.
+      placeholder: When I click Generate in Image Studio, the app…
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: How can we make it happen?
+      placeholder: |
+        1. Open '…'
+        2. Click '…'
+        3. See error
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      description: Where did this happen?
+      options:
+        - macOS (Apple Silicon / MLX)
+        - Windows (NVIDIA / candle)
+        - Docker server (candle / CPU)
+        - Other / not sure
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: SceneWorks version
+      description: Shown at the bottom of the left sidebar in the app, or your commit SHA if building from source.
+      placeholder: "0.7.1"
+    validations:
+      required: true
+  - type: input
+    id: model
+    attributes:
+      label: Model / LoRA involved (if any)
+      description: If the bug is generation-related, which model or LoRA were you using?
+      placeholder: e.g. FLUX.1 [dev], Wan 2.2 TI2V-5B
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: |
+        Paste relevant output from the Logs view or console, and attach
+        screenshots if helpful. This will be automatically formatted as code.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/SceneWorks/SceneWorks/security/policy
+    about: Please report security issues privately — do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: Feature request
+description: Suggest an idea or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! Please search
+        [existing issues](https://github.com/SceneWorks/SceneWorks/issues) first
+        in case it's already been suggested.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What are you trying to do that's hard or impossible today?
+      placeholder: I'm always frustrated when…
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to see happen?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of SceneWorks does this relate to?
+      options:
+        - Image Studio
+        - Video Studio
+        - Character Studio
+        - Document Studio
+        - Training Studio
+        - Image / Video Editor
+        - Model Manager / models
+        - Assets / Data Sets / libraries
+        - Server / Docker / API
+        - MCP server
+        - Other / not sure
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds you're using today, or other approaches you thought about.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+<!--
+Thanks for contributing to SceneWorks! Please fill this out so reviewers have
+the context they need. See CONTRIBUTING.md for the full process.
+-->
+
+## What does this PR do?
+
+<!-- A clear description of the change and why it's needed. -->
+
+## Related issue
+
+<!-- e.g. "Closes #123". For anything non-trivial, please open an issue first. -->
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behavior)
+- [ ] Documentation only
+- [ ] Refactor / chore (no user-facing behavior change)
+
+## How was this tested?
+
+<!-- Describe how you verified the change. Which platform(s) did you test on? -->
+
+- [ ] macOS (Apple Silicon / MLX)
+- [ ] Windows (NVIDIA / candle)
+- [ ] Docker server (candle / CPU)
+- [ ] Not platform-specific (web UI, docs, shared crate)
+
+## Checklist
+
+- [ ] I ran `npm run rust:check` (if I touched Rust) and it passed
+- [ ] I ran `npm --prefix apps/web run lint && npm --prefix apps/web run test && npm --prefix apps/web run build` (if I touched the web app)
+- [ ] I ran `npm run check` (scaffold checks)
+- [ ] I updated documentation where relevant
+- [ ] All my commits are signed off (`git commit -s` — see the DCO section in CONTRIBUTING.md)
+- [ ] My PR is focused on a single logical change

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**michael@trefry.net**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,184 @@
+# Contributing to SceneWorks
+
+First off — thank you. SceneWorks is free, open-source software
+([`AGPL-3.0-or-later`](LICENSE)), and it gets better because people like you
+take the time to file a bug, improve the docs, or send a patch.
+
+This guide covers how to propose changes. It's written to be friendly to
+first-time contributors, so if anything here is unclear, that's a bug in this
+document — please open an issue.
+
+## Table of contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Ways to contribute](#ways-to-contribute)
+- [Before you start on something big](#before-you-start-on-something-big)
+- [Development setup](#development-setup)
+- [Running the checks locally](#running-the-checks-locally)
+- [Opening a pull request](#opening-a-pull-request)
+- [Commit messages](#commit-messages)
+- [Sign your work (DCO)](#sign-your-work-dco)
+- [How your contribution is licensed](#how-your-contribution-is-licensed)
+- [Reporting security issues](#reporting-security-issues)
+
+## Code of Conduct
+
+This project is governed by our [Code of Conduct](CODE_OF_CONDUCT.md). By
+participating, you're expected to uphold it. Please report unacceptable behavior
+to **michael@trefry.net**.
+
+## Ways to contribute
+
+You don't have to write code to help:
+
+- **Report a bug** — open a [bug report](https://github.com/SceneWorks/SceneWorks/issues/new?template=bug_report.yml).
+- **Request a feature** — open a [feature request](https://github.com/SceneWorks/SceneWorks/issues/new?template=feature_request.yml).
+- **Improve the docs** — READMEs, `docs/`, and the per-crate `ARCHITECTURE.md`
+  files are all fair game.
+- **Send a fix or feature** — see the flow below.
+
+> **Note on planning:** the maintainers track internal work in a private tracker
+> using `sc-####` identifiers you'll see in commit messages. You don't need
+> access to that — **GitHub Issues and Pull Requests are the front door for all
+> outside contributions.** Reference GitHub issue numbers (e.g. `#123`), not
+> `sc-####`, in your PRs.
+
+## Before you start on something big
+
+- **Small, obvious fixes** (typos, a clear bug, a docs correction) — just send a
+  PR.
+- **Anything larger** (a new feature, a refactor, a new model, a behavior
+  change) — **please open an issue first** so we can agree on the approach
+  before you invest time. SceneWorks has platform-specific engines (MLX on
+  macOS, candle/CUDA on Windows) and a lot of moving parts; a quick conversation
+  up front saves everyone rework.
+
+## Development setup
+
+SceneWorks is a Rust workspace (backend, workers, native inference) plus a
+React + Vite web app, packaged as a Tauri desktop app and an optional Docker
+server. Full instructions live in the
+[README](README.md#development) and, for the desktop app,
+[`apps/desktop/README.md`](apps/desktop/README.md).
+
+**You'll need:**
+
+- A **Rust** toolchain with `rustfmt` and `clippy` (pinned in
+  [`rust-toolchain.toml`](rust-toolchain.toml)).
+- **Node.js ≥ 20** (see [`package.json`](package.json) `engines`).
+- Platform-specific, depending on what you're touching:
+  - **macOS (Apple Silicon)** for the MLX GPU worker,
+  - **Windows (NVIDIA)** for the candle/CUDA worker,
+  - **Docker** for the headless server path.
+
+You can contribute to a lot of the codebase (web UI, Rust API, docs, shared
+crates) without a GPU. Changes to the inference engines are best validated on
+the matching platform — tell us in the PR what you were able to test.
+
+## Running the checks locally
+
+CI runs the same commands, so running them before you push is the fastest way to
+a green PR. From the repo root:
+
+**Rust** (formatting, lints, tests, build — this is the full gate CI runs):
+
+```bash
+npm run rust:check
+```
+
+That expands to `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D
+warnings`, `cargo test`, and `cargo build`. Clippy warnings **fail** the build,
+so keep it clean.
+
+**Web** (from the repo root):
+
+```bash
+npm --prefix apps/web run lint
+npm --prefix apps/web run test
+npm --prefix apps/web run build
+```
+
+**Scaffold / compose sanity checks:**
+
+```bash
+npm run check
+npm run check:compose
+```
+
+**Optional but recommended** — install the local Git hook that auto-formats Rust
+before commits:
+
+```bash
+npm run hooks:install
+```
+
+If your change alters an API response shape, CI's contract/parity snapshot tests
+(run via `pytest -m parity`) may need regenerating — CI will tell you, and a
+maintainer can help if you're unsure.
+
+## Opening a pull request
+
+1. **Fork** the repo and create a branch off `main` with a descriptive name
+   (e.g. `fix/video-export-crash`).
+2. Make your change. Keep the PR **focused** — one logical change per PR is much
+   easier to review than a grab-bag.
+3. Run the [checks above](#running-the-checks-locally).
+4. Push and open a PR. Fill out the PR template — it takes a minute and helps
+   reviewers a lot.
+5. Make sure **CI is green** and address review feedback. Maintainers may ask
+   for changes; that's a normal part of the process, not a rejection.
+
+## Commit messages
+
+SceneWorks uses [Conventional Commits](https://www.conventionalcommits.org/).
+The type and an optional scope prefix the summary:
+
+```
+feat(web): add dark-mode toggle to settings
+fix(worker): guard against zero-length video export
+docs: clarify LoRA training prerequisites
+chore(deps): bump vite to 6.4.2
+```
+
+Common types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `perf`.
+Reference the GitHub issue you're closing in the PR description (e.g.
+`Closes #123`).
+
+## Sign your work (DCO)
+
+SceneWorks uses the [Developer Certificate of Origin](https://developercertificate.org/)
+(DCO) instead of a CLA. It's a lightweight, one-line certification that you wrote
+the patch (or otherwise have the right to submit it under the project's license).
+There's no form to sign — you just add a `Signed-off-by` line to each commit:
+
+```bash
+git commit -s -m "fix(worker): guard against zero-length video export"
+```
+
+The `-s` flag appends a line using your configured Git name and email:
+
+```
+Signed-off-by: Jane Doe <jane@example.com>
+```
+
+By signing off, you certify the four points of the
+[DCO 1.1](https://developercertificate.org/). Every commit in a PR needs a
+sign-off. Forgot one? `git commit --amend -s` (single commit) or an interactive
+rebase / `git rebase --signoff main` (multiple) will fix it up.
+
+## How your contribution is licensed
+
+SceneWorks is licensed under **AGPL-3.0-or-later**, and contributions follow the
+same terms (inbound = outbound). **By submitting a contribution, you agree that
+it is licensed under `AGPL-3.0-or-later`**, the same license as the project, and
+your DCO sign-off certifies you have the right to do so. There is **no separate
+CLA** and no copyright assignment — you keep the copyright to your work.
+
+Note that **model weights are not covered** by this license — SceneWorks
+downloads third-party weights at runtime, and each keeps its own license (see
+[Licensing](README.md#licensing)).
+
+## Reporting security issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+See [SECURITY.md](SECURITY.md) for how to report them privately.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,62 @@
+# Security Policy
+
+Thanks for helping keep SceneWorks and its users safe.
+
+## Supported versions
+
+SceneWorks is pre-1.0 and moves quickly. Security fixes land on `main` and in
+the latest release. Please make sure you can reproduce an issue against the
+**latest release or `main`** before reporting.
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, report privately using either of:
+
+- **GitHub private vulnerability reporting** — go to the repository's
+  **Security** tab → **Report a vulnerability** (preferred; keeps the report
+  attached to the repo). This must be enabled by the maintainer under
+  *Settings → Code security → Private vulnerability reporting*.
+- **Email** — **michael@trefry.net**.
+
+Please include as much of the following as you can:
+
+- A description of the issue and its impact.
+- Steps to reproduce, or a proof of concept.
+- The affected version / commit, and the platform (macOS/MLX, Windows/candle,
+  or Docker server).
+- Any suggested remediation, if you have one.
+
+## What to expect
+
+- We'll acknowledge your report as soon as we can, and aim to give an initial
+  assessment within a few days.
+- We'll keep you updated on progress toward a fix and coordinate on disclosure
+  timing.
+- With your permission, we're happy to credit you when the fix is released.
+
+Please give us a reasonable chance to release a fix before any public
+disclosure.
+
+## Scope notes
+
+A few things are **documented, intentional tradeoffs** rather than
+vulnerabilities — please read these before reporting:
+
+- **Loopback trust on the desktop app.** When LAN remote access is enabled, any
+  local process/user on the same machine can reach the loopback API without the
+  access token. This is a deliberate single-user-desktop tradeoff, described
+  under [Local access control](README.md#local-access-control). Running in
+  remote-access mode on a shared, multi-user host is out of scope unless you've
+  configured it as documented there.
+- **Server credential storage.** On the Docker/server path, credentials are
+  protected by `0600` file mode plus your orchestrator's secret handling, not
+  app-level encryption. This is described in
+  [Service credentials](README.md#service-credentials-api-tokens).
+- **Model weights.** SceneWorks downloads third-party model weights at runtime.
+  Issues in the weights themselves belong to their upstream projects, not here.
+
+If you're unsure whether something is in scope, report it privately anyway and
+we'll figure it out together.


### PR DESCRIPTION
## What does this PR do?

Adds the community-health documents SceneWorks was missing as it opens up to outside contributors, tailored to this repo and consistent with the recent AGPL-3.0-or-later relicense (#1296).

New files:

- **CONTRIBUTING.md** — how to contribute: dev setup (Rust workspace + web + Tauri/Docker), the *actual* CI check commands (`npm run rust:check`, the web lint/test/build trio, `npm run check`), the PR flow, Conventional Commits, and **DCO sign-off** (`git commit -s`). Notes that the internal `sc-####` tracker is private, so GitHub Issues/PRs are the front door for outside work.
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1, enforcement contact `michael@trefry.net`.
- **SECURITY.md** — private disclosure via GitHub vulnerability reporting or email, plus scope notes that pre-empt reports about the *documented, intentional* loopback-trust and server-credential tradeoffs.
- **.github/PULL_REQUEST_TEMPLATE.md** — checklist with the real check commands and platform-tested boxes (macOS/MLX, Windows/candle, Docker).
- **.github/ISSUE_TEMPLATE/** — bug + feature forms with a platform dropdown matching the build split, and a `config.yml` that routes security reports away from public issues.

## Why

First outside contributors need a clear on-ramp, and the AGPL relicense makes now the right time to state the contribution-licensing model explicitly.

## Licensing model

Contributions are **inbound = outbound under AGPL-3.0-or-later** via the **DCO** — no CLA, no copyright assignment; contributors keep copyright to their work. This was a deliberate choice to minimize contributor friction, accepting that a future relicense would require collecting contributor consent.

## Reviewer notes

- Docs/templates only — no code, no runtime surface changed.
- The issue-template YAML was validated with a parser locally.
- Two repo **settings** still need flipping by hand (out of scope for this PR): enable *Private vulnerability reporting* (so SECURITY.md's report button appears), and optionally install the DCO check app to enforce sign-off.