### PR TITLE
feat(desktop): offline GPU-runtime provisioning + air-gapped install docs (sc-10354)

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -118,6 +118,13 @@ On first launch a setup screen reports progress. What happens differs by platfor
    connection (typically a few minutes on a fast link).
 3. **Engine starts.** The API starts and the candle/CUDA worker registers.
 
+> **No internet on the target machine?** The GPU runtime can be pre-staged so first
+> run completes fully offline — copy an already-provisioned machine's
+> `%APPDATA%\SceneWorks\gpu-runtime` folder across, or stage the redist and point
+> `SCENEWORKS_GPU_RUNTIME_DIR` at it. See
+> [Offline / air-gapped install](docs/offline-install.md). (Model weights are a
+> separate download — that guide covers seeding them too.)
+
 ### macOS (first run)
 
 There is no runtime download. The MLX engine is linked into the app, so it starts
@@ -290,10 +297,11 @@ is no CPU or AMD fallback. A supported NVIDIA GPU is required.
 Your driver is below the floor for the bundled CUDA 12.9 runtime. Update your
 NVIDIA driver from the GeForce/Studio app or nvidia.com, then relaunch.
 
-**Windows: "GPU runtime download failed."**
+**Windows: "GPU runtime setup failed."**
 The first-run CUDA runtime download did not complete (network/disk). Check your
 connection and free space, then retry from the setup screen. The download resumes
-into `%APPDATA%\SceneWorks\gpu-runtime`.
+into `%APPDATA%\SceneWorks\gpu-runtime`. On a machine with no internet access, pre-stage
+the runtime instead — see [Offline / air-gapped install](docs/offline-install.md).
 
 **"The local API did not start in time."**
 The bundled API didn't become healthy within the startup window. Retry from the

--- a/apps/desktop/docs/offline-install.md
+++ b/apps/desktop/docs/offline-install.md
@@ -1,0 +1,190 @@
+# Offline / air-gapped install (Windows)
+
+SceneWorks Desktop on Windows needs ~2.7 GB of NVIDIA CUDA runtime, cuDNN, and the
+ONNX Runtime GPU provider at runtime. These are **not** in the installer (the set
+exceeds the NSIS installer format's datablock limit), so a normal first run
+**downloads** them once into `%APPDATA%\SceneWorks\gpu-runtime` — see
+[First run](../README.md#first-run).
+
+On a machine with no internet access that download fails and startup stops. This
+guide covers how to **pre-stage** the runtime so first run completes fully offline.
+
+> This only makes *startup* work offline. Generation also needs model weights, which
+> download from Hugging Face on first use — see [Model weights](#model-weights-are-separate)
+> at the end.
+
+---
+
+## Which method to use
+
+| Your situation | Use |
+| --- | --- |
+| You have a connected Windows machine you can run SceneWorks on first | [Method 1 — copy a provisioned folder](#method-1-copy-a-provisioned-folder-easiest) (easiest) |
+| You can reach the internet to download files, but not from the target machine | [Method 2 — stage a redist bundle](#method-2-stage-a-redist-bundle) |
+| You are scripting an enterprise / MSI rollout | [Method 2](#method-2-stage-a-redist-bundle) with `SCENEWORKS_GPU_RUNTIME_DIR` |
+
+All methods land the same files in the same place. Under the hood the app skips the
+download whenever the runtime is already present (`apps/desktop/src/cuda_provision.rs`).
+
+---
+
+## Method 1 — copy a provisioned folder (easiest)
+
+If you have another Windows machine (same or newer NVIDIA driver) that can reach the
+internet:
+
+1. Install and launch SceneWorks on the **connected** machine and let first run
+   finish the GPU-runtime download.
+2. Copy its entire runtime folder to the **offline** machine, to the same path:
+
+   ```
+   %APPDATA%\SceneWorks\gpu-runtime
+   ```
+
+   That folder contains `cuda\`, `onnxruntime\`, and a `.redist-marker` file. Copy all
+   of it (the marker tells the app it is already provisioned).
+3. Install SceneWorks on the offline machine and launch it. First run detects the
+   existing runtime and skips the download.
+
+That is the whole procedure — no environment variables needed.
+
+---
+
+## Method 2 — stage a redist bundle
+
+Use this when the target machine can never reach the internet and you cannot run
+SceneWorks online first. You will assemble the DLLs from the pinned PyPI wheels on a
+connected machine, then hand the bundle to the target.
+
+### 2a. Download the wheels
+
+Download each wheel below on a connected machine. Every entry is version-pinned; the
+SHA-256 lets you verify each download. (This table mirrors the `COMPONENTS` manifest in
+[`apps/desktop/src/cuda_provision.rs`](../src/cuda_provision.rs) — if it ever drifts,
+the source is authoritative.)
+
+| Component | Wheel | Approx | SHA-256 |
+| --- | --- | --- | --- |
+| CUDA runtime | [`nvidia_cuda_runtime_cu12-12.9.79`](https://files.pythonhosted.org/packages/59/df/e7c3a360be4f7b93cee39271b792669baeb3846c58a4df6dfcf187a7ffab/nvidia_cuda_runtime_cu12-12.9.79-py3-none-win_amd64.whl) | 3 MB | `8e018af8fa02363876860388bd10ccb89eb9ab8fb0aa749aaf58430a9f7c4891` |
+| cuBLAS | [`nvidia_cublas_cu12-12.9.1.4`](https://files.pythonhosted.org/packages/45/a1/a17fade6567c57452cfc8f967a40d1035bb9301db52f27808167fbb2be2f/nvidia_cublas_cu12-12.9.1.4-py3-none-win_amd64.whl) | 530 MB | `1e5fee10662e6e52bd71dec533fbbd4971bb70a5f24f3bc3793e5c2e9dc640bf` |
+| cuRAND | [`nvidia_curand_cu12-10.3.10.19`](https://files.pythonhosted.org/packages/e5/98/1bd66fd09cbe1a5920cb36ba87029d511db7cca93979e635fd431ad3b6c0/nvidia_curand_cu12-10.3.10.19-py3-none-win_amd64.whl) | 66 MB | `e8129e6ac40dc123bd948e33d3e11b4aa617d87a583fa2f21b3210e90c743cde` |
+| NVRTC | [`nvidia_cuda_nvrtc_cu12-12.9.86`](https://files.pythonhosted.org/packages/52/de/823919be3b9d0ccbf1f784035423c5f18f4267fb0123558d58b813c6ec86/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-win_amd64.whl) | 73 MB | `72972ebdcf504d69462d3bcd67e7b81edd25d0fb85a2c46d3ea3517666636349` |
+| cuDNN | [`nvidia_cudnn_cu12-9.23.0.39`](https://files.pythonhosted.org/packages/b7/ec/d95cc4204dd45f40f2d1512f8ff0d4c3fb1810a893fecc79fcea05dfec0e/nvidia_cudnn_cu12-9.23.0.39-py3-none-win_amd64.whl) | 660 MB | `357e5d59a1b79d27eef754aa79b3d9e7adf11baf86dc928dc114df0033c2c912` |
+| cuFFT | [`nvidia_cufft_cu12-11.4.1.4`](https://files.pythonhosted.org/packages/20/ee/29955203338515b940bd4f60ffdbc073428f25ef9bfbce44c9a066aedc5c/nvidia_cufft_cu12-11.4.1.4-py3-none-win_amd64.whl) | 190 MB | `8e5bfaac795e93f80611f807d42844e8e27e340e0cde270dcb6c65386d795b80` |
+| nvJitLink | [`nvidia_nvjitlink_cu12-12.9.86`](https://files.pythonhosted.org/packages/dd/7e/2eecb277d8a98184d881fb98a738363fd4f14577a4d2d7f8264266e82623/nvidia_nvjitlink_cu12-12.9.86-py3-none-win_amd64.whl) | 34 MB | `cc6fcec260ca843c10e34c936921a1c426b351753587fdd638e8cff7b16bb9db` |
+| ONNX Runtime (GPU) | [`onnxruntime_gpu-1.26.0-cp312`](https://files.pythonhosted.org/packages/a4/e4/9b378a5466ea0bed65e5beb8e09254973c580a6522810a38afbcc45e5105/onnxruntime_gpu-1.26.0-cp312-cp312-win_amd64.whl) | 216 MB | `5f49c44689894650990e4c8a857d2edafc276fbd79bba57ceb224bd18d25d491` |
+
+Verify a download's hash in PowerShell:
+
+```powershell
+Get-FileHash .\nvidia_cudnn_cu12-9.23.0.39-py3-none-win_amd64.whl -Algorithm SHA256
+```
+
+### 2b. Extract the DLLs into a bundle
+
+A wheel is just a ZIP. Build a bundle folder with two subdirectories, `cuda` and
+`onnxruntime`:
+
+```
+gpu-runtime-bundle\
+  cuda\           <- every *.dll from the 7 nvidia_*-cu12 wheels
+  onnxruntime\    <- three DLLs from the onnxruntime_gpu wheel
+```
+
+- From each of the **seven `nvidia_*-cu12`** wheels, copy **every `*.dll`** (they live
+  under `nvidia\<component>\bin\` inside the wheel) into `cuda\`.
+- From the **`onnxruntime_gpu`** wheel (DLLs under `onnxruntime\capi\`), copy exactly
+  these three into `onnxruntime\`:
+  - `onnxruntime.dll`
+  - `onnxruntime_providers_cuda.dll`
+  - `onnxruntime_providers_shared.dll`
+
+A PowerShell sketch (run in a folder holding all eight `.whl` files):
+
+```powershell
+$bundle = "$PWD\gpu-runtime-bundle"
+New-Item -ItemType Directory -Force "$bundle\cuda", "$bundle\onnxruntime" | Out-Null
+
+foreach ($whl in Get-ChildItem *.whl) {
+  $zip = "$($whl.FullName).zip"
+  Copy-Item $whl.FullName $zip
+  $out = Join-Path $env:TEMP ("whl-" + $whl.BaseName)
+  Expand-Archive -Force $zip $out
+  if ($whl.Name -like 'onnxruntime_gpu*') {
+    'onnxruntime.dll','onnxruntime_providers_cuda.dll','onnxruntime_providers_shared.dll' |
+      ForEach-Object { Copy-Item (Get-ChildItem -Recurse -Filter $_ $out).FullName "$bundle\onnxruntime" }
+  } else {
+    Get-ChildItem -Recurse -Filter *.dll $out | Copy-Item -Destination "$bundle\cuda"
+  }
+  Remove-Item $zip; Remove-Item -Recurse -Force $out
+}
+```
+
+Sanity-check the bundle carries the key libraries: `cuda\` should contain
+`cudart64_12.dll`, `cublas64_12.dll`, `curand64_10.dll`, an `nvrtc64_*.dll`,
+`cudnn64_9.dll`, `cufft64_11.dll`, and an `nvJitLink_*.dll`; `onnxruntime\` should hold
+the three DLLs above. (These are exactly the sentinels the app checks — an incomplete
+bundle is rejected with a clear error, not silently accepted.)
+
+### 2c. Point SceneWorks at the bundle
+
+Copy `gpu-runtime-bundle` to the offline machine, then set the environment variable
+**before launching SceneWorks** so it installs from the bundle instead of downloading:
+
+```powershell
+setx SCENEWORKS_GPU_RUNTIME_DIR "C:\path\to\gpu-runtime-bundle"
+```
+
+(`setx` persists it for future launches; open a new session for it to take effect. For
+a machine-wide rollout, set it as a system environment variable.)
+
+On first launch the app copies the bundle's DLLs into `%APPDATA%\SceneWorks\gpu-runtime`,
+verifies the set is complete, marks the runtime provisioned, and starts — with no network
+access. If the bundle is missing a subdirectory or a required DLL, setup stops with an
+actionable message rather than starting a broken worker.
+
+Once installed, `SCENEWORKS_GPU_RUNTIME_DIR` is no longer consulted (the provisioned
+copy is marked complete), so you can leave it set or remove it.
+
+---
+
+## Manual fallback (marker file)
+
+If you prefer not to set an environment variable, you can place the DLLs directly and
+let the app adopt them:
+
+1. Copy the bundle's `cuda\` and `onnxruntime\` folders into
+   `%APPDATA%\SceneWorks\gpu-runtime\` so you have
+   `%APPDATA%\SceneWorks\gpu-runtime\cuda\...` and `...\onnxruntime\...`.
+2. Launch SceneWorks. It detects the complete DLL set and skips the download.
+
+You do **not** need to hand-write the `.redist-marker` file — the app writes it once it
+confirms the set is complete. (Older instructions that had you create the marker by hand
+still work, but the DLL detection above is the supported path.)
+
+---
+
+## Model weights are separate
+
+Pre-staging the GPU runtime gets the app to **start** offline. The first time you
+generate with a given model, its weights download from Hugging Face into the model
+cache (`%USERPROFILE%\.cache\huggingface`, overridable with `HF_HOME`). For a fully
+offline workstation you must also pre-seed that cache:
+
+- Point `HF_HOME` at a folder you have pre-populated (copy `~/.cache/huggingface`, or a
+  subset, from a connected machine that already downloaded the models you need), or
+- Download the models through **Model Manager** on a connected machine first, then copy
+  the cache across.
+
+Only the runtime DLLs are covered by this guide; the model cache is standard Hugging
+Face layout and can be seeded with any of the usual tooling.
+
+---
+
+## See also
+
+- [First run](../README.md#first-run) — the normal (online) provisioning flow.
+- [`apps/desktop/src/cuda_provision.rs`](../src/cuda_provision.rs) — the pinned manifest
+  and the offline install logic (authoritative source for the versions/hashes above).
+- [sc-5560 CUDA bundling](../../../docs/sc-5560/cuda-bundling.md) — provenance and
+  licensing of the redistributable CUDA runtime.

--- a/apps/desktop/src/cuda_provision.rs
+++ b/apps/desktop/src/cuda_provision.rs
@@ -37,6 +37,15 @@ use crate::setup::{app_support_dir, emit};
 /// marker already equals this string skips the download entirely.
 const REDIST_VERSION: &str = "cuda12.9-ort1.26.0-cudnn9.23-1";
 
+/// `SCENEWORKS_GPU_RUNTIME_DIR` — an optional pre-extracted redist dir to install from
+/// instead of downloading (sc-10354, offline install). It mirrors the provisioned
+/// root's layout: a `cuda\` + `onnxruntime\` pair of subdirs holding the extracted
+/// DLLs (e.g. a copy of another machine's `%APPDATA%\SceneWorks\gpu-runtime`, or a
+/// bundle staged per the offline-install guide). When set, `provision` copies it into
+/// place and skips the multi-GB PyPI download entirely, so a disconnected machine can
+/// complete first run. See `docs/offline-install.md`.
+const GPU_RUNTIME_DIR_ENV: &str = "SCENEWORKS_GPU_RUNTIME_DIR";
+
 /// Which provisioned subdir a component's DLLs land in. `Cuda` is the cudarc +
 /// onnxruntime CUDA-dep dir (cudart/cublas/curand/nvrtc + cuDNN/cuFFT/nvJitLink);
 /// `Onnxruntime` holds onnxruntime's own three DLLs.
@@ -192,6 +201,131 @@ fn already_provisioned(root: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// One sentinel per pinned CUDA component whose presence in the `cuda\` dir marks a
+/// complete CUDA redist. Matched case-insensitively by *prefix* so a CUDA point-release
+/// (`cudart64_12` → `cudart64_13`) still resolves — the version-agnostic match the
+/// sc-5560 bundling resolver used. `cublasLt` ships inside the cuBLAS wheel, so
+/// `cublas64_` covers it.
+const CUDA_DLL_SENTINELS: &[&str] = &[
+    "cudart64_", // CUDA runtime
+    "cublas64_", // cuBLAS (+ cublasLt)
+    "curand64_", // cuRAND
+    "nvrtc64_",  // NVRTC
+    "cudnn64_",  // cuDNN
+    "cufft64_",  // cuFFT
+    "nvjitlink", // nvJitLink (nvJitLink_120_0.dll)
+];
+
+/// The three onnxruntime DLLs the worker dlopens — exact names (no version suffix).
+const ORT_DLL_SENTINELS: &[&str] = &[
+    "onnxruntime.dll",
+    "onnxruntime_providers_cuda.dll",
+    "onnxruntime_providers_shared.dll",
+];
+
+/// True when `dir` holds a `*.dll` matching `needle`: an exact filename check when
+/// `needle` ends in `.dll`, else a case-insensitive prefix match (version-agnostic).
+fn dir_has_dll(dir: &Path, needle: &str) -> bool {
+    if needle.ends_with(".dll") {
+        return dir.join(needle).is_file();
+    }
+    let needle = needle.to_ascii_lowercase();
+    let Ok(entries) = fs::read_dir(dir) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        entry
+            .file_name()
+            .to_str()
+            .map(|name| {
+                let name = name.to_ascii_lowercase();
+                name.starts_with(&needle) && name.ends_with(".dll")
+            })
+            .unwrap_or(false)
+    })
+}
+
+/// True when both provisioned dirs hold the full sentinel set — i.e. a pre-staged redist
+/// is complete enough to run without downloading. Deliberately stricter than the single-
+/// DLL `*_if_present` resolver probes (which only gate the candle lane): a partial stage
+/// that passed a one-DLL probe but was missing cuDNN/nvJitLink would hard-fail at load.
+fn is_staged_complete(cuda: &Path, ort: &Path) -> bool {
+    CUDA_DLL_SENTINELS.iter().all(|dll| dir_has_dll(cuda, dll))
+        && ORT_DLL_SENTINELS.iter().all(|dll| dir_has_dll(ort, dll))
+}
+
+/// Copy every `*.dll` from `src` into `dst` (flat). Returns how many were copied. Used
+/// to install a pre-staged redist subdir into the provisioned location.
+fn copy_dlls(src: &Path, dst: &Path) -> Result<usize, String> {
+    fs::create_dir_all(dst).map_err(|error| format!("create {}: {error}", dst.display()))?;
+    let mut copied = 0usize;
+    for entry in fs::read_dir(src).map_err(|error| format!("read {}: {error}", src.display()))? {
+        let entry = entry.map_err(|error| format!("read {}: {error}", src.display()))?;
+        let path = entry.path();
+        let is_dll = path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| ext.eq_ignore_ascii_case("dll"))
+            .unwrap_or(false);
+        if !is_dll || !path.is_file() {
+            continue;
+        }
+        let Some(name) = path.file_name() else {
+            continue;
+        };
+        fs::copy(&path, dst.join(name))
+            .map_err(|error| format!("copy {}: {error}", name.to_string_lossy()))?;
+        copied += 1;
+    }
+    Ok(copied)
+}
+
+/// Install a pre-extracted redist from `source` (a `cuda\` + `onnxruntime\` pair) into
+/// the provisioned dirs by copying every DLL across, then verify the full sentinel set
+/// landed. Errors clearly if the expected subdirs/DLLs are missing so a mis-staged
+/// override doesn't masquerade as success (and silently leave the candle lane broken).
+fn install_from_staged(source: &Path, cuda: &Path, ort: &Path) -> Result<(), String> {
+    if !source.is_dir() {
+        return Err(format!(
+            "{GPU_RUNTIME_DIR_ENV} points at a missing directory: {}",
+            source.display()
+        ));
+    }
+    let src_cuda = source.join("cuda");
+    let src_ort = source.join("onnxruntime");
+    if !src_cuda.is_dir() || !src_ort.is_dir() {
+        return Err(format!(
+            "{GPU_RUNTIME_DIR_ENV} ({}) must contain `cuda` and `onnxruntime` subdirectories of \
+             extracted DLLs — see docs/offline-install.md",
+            source.display()
+        ));
+    }
+    let copied_cuda = copy_dlls(&src_cuda, cuda)?;
+    let copied_ort = copy_dlls(&src_ort, ort)?;
+    if copied_cuda == 0 || copied_ort == 0 {
+        return Err(format!(
+            "{GPU_RUNTIME_DIR_ENV} ({}) had no DLLs to install (cuda: {copied_cuda}, \
+             onnxruntime: {copied_ort})",
+            source.display()
+        ));
+    }
+    if !is_staged_complete(cuda, ort) {
+        return Err(format!(
+            "pre-staged GPU runtime from {} is incomplete — one or more required CUDA/onnxruntime \
+             DLLs are missing; see docs/offline-install.md for the full redist set",
+            source.display()
+        ));
+    }
+    Ok(())
+}
+
+/// Write the success marker so a fully provisioned root short-circuits `already_provisioned`
+/// on later launches.
+fn write_marker(root: &Path) -> Result<(), String> {
+    fs::write(root.join(".redist-marker"), REDIST_VERSION)
+        .map_err(|error| format!("write marker: {error}"))
+}
+
 /// Hex-encode a sha256 digest for comparison against the pinned value.
 fn hex(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{b:02x}")).collect()
@@ -326,6 +460,48 @@ pub(crate) async fn provision(app: &AppHandle) -> Result<(), String> {
     for dir in [&cuda, &ort] {
         fs::create_dir_all(dir).map_err(|error| format!("create {}: {error}", dir.display()))?;
     }
+
+    // Offline install (sc-10354): if the redist is pre-staged, skip the multi-GB PyPI
+    // download entirely so a disconnected machine can complete first run.
+    //
+    // 1. Explicit override — `SCENEWORKS_GPU_RUNTIME_DIR` points at a pre-extracted
+    //    redist (a `cuda\` + `onnxruntime\` pair). Honor it or fail clearly: a typo'd
+    //    path silently downloading 2.7 GB — or failing offline with a generic error —
+    //    would be baffling on an air-gapped box, so `install_from_staged` errors on a
+    //    missing/incomplete source rather than falling through to the network.
+    if let Ok(value) = std::env::var(GPU_RUNTIME_DIR_ENV) {
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            let source = PathBuf::from(trimmed);
+            emit(
+                app,
+                "provision",
+                format!(
+                    "Installing pre-staged GPU runtime from {}…",
+                    source.display()
+                ),
+                false,
+            );
+            install_from_staged(&source, &cuda, &ort)?;
+            write_marker(&root)?;
+            emit(app, "provision", "GPU runtime ready (pre-staged).", false);
+            return Ok(());
+        }
+    }
+
+    // 2. Implicit — a user (or a prior install) already populated the target dirs with
+    //    the full DLL set. Adopt them as-is; no network.
+    if is_staged_complete(&cuda, &ort) {
+        write_marker(&root)?;
+        emit(
+            app,
+            "provision",
+            "Found a pre-staged GPU runtime; skipping download.",
+            false,
+        );
+        return Ok(());
+    }
+
     let tmp_dir = root.join(".download-tmp");
     fs::create_dir_all(&tmp_dir).map_err(|error| format!("create temp dir: {error}"))?;
 
@@ -383,8 +559,7 @@ pub(crate) async fn provision(app: &AppHandle) -> Result<(), String> {
     outcome?;
 
     // Mark success last so a partial/aborted run re-provisions next launch.
-    fs::write(root.join(".redist-marker"), REDIST_VERSION)
-        .map_err(|error| format!("write marker: {error}"))?;
+    write_marker(&root)?;
     emit(app, "provision", "GPU runtime ready.", false);
     Ok(())
 }
@@ -423,6 +598,135 @@ mod tests {
                 "{}: sha256 must be lowercase hex",
                 component.label
             );
+        }
+    }
+
+    /// A fresh, unique temp dir for a test (offline; cleaned by the caller).
+    fn scratch(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("sw-offline-{tag}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create scratch");
+        dir
+    }
+
+    /// Drop empty files named `names` into `dir` (stand-ins for the real DLLs).
+    fn touch(dir: &Path, names: &[&str]) {
+        fs::create_dir_all(dir).expect("create dir");
+        for name in names {
+            fs::write(dir.join(name), b"").expect("touch dll");
+        }
+    }
+
+    /// The DLL basenames a complete stage carries (mirrors what the wheels extract):
+    /// versioned CUDA libs + the three exact-named onnxruntime DLLs.
+    const STAGED_CUDA_DLLS: &[&str] = &[
+        "cudart64_12.dll",
+        "cublas64_12.dll",
+        "cublasLt64_12.dll",
+        "curand64_10.dll",
+        "nvrtc64_120_0.dll",
+        "cudnn64_9.dll",
+        "cufft64_11.dll",
+        "nvJitLink_120_0.dll",
+    ];
+    const STAGED_ORT_DLLS: &[&str] = &[
+        "onnxruntime.dll",
+        "onnxruntime_providers_cuda.dll",
+        "onnxruntime_providers_shared.dll",
+    ];
+
+    /// `dir_has_dll` matches exact `.dll` names directly and everything else by
+    /// case-insensitive prefix (so a CUDA point-release still resolves).
+    #[test]
+    fn dir_has_dll_exact_and_prefix() {
+        let dir = scratch("has-dll");
+        touch(&dir, &["cudart64_13.dll", "onnxruntime.dll", "notes.txt"]);
+
+        // Exact name (ends in .dll).
+        assert!(dir_has_dll(&dir, "onnxruntime.dll"));
+        assert!(!dir_has_dll(&dir, "onnxruntime_providers_cuda.dll"));
+        // Version-agnostic prefix: a 13.x cudart still satisfies the `cudart64_` sentinel.
+        assert!(dir_has_dll(&dir, "cudart64_"));
+        // Case-insensitive.
+        assert!(dir_has_dll(&dir, "CUDART64_"));
+        // Absent component.
+        assert!(!dir_has_dll(&dir, "cudnn64_"));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// `is_staged_complete` requires the FULL sentinel set in both dirs — a stage
+    /// missing even one component (here cuDNN) is rejected, unlike the one-DLL probes.
+    #[test]
+    fn is_staged_complete_requires_full_set() {
+        let root = scratch("complete");
+        let cuda = root.join("cuda");
+        let ort = root.join("onnxruntime");
+        touch(&cuda, STAGED_CUDA_DLLS);
+        touch(&ort, STAGED_ORT_DLLS);
+        assert!(is_staged_complete(&cuda, &ort));
+
+        // Remove cuDNN — a one-DLL `cudart64_12` probe would still pass, but the full
+        // completeness check must not.
+        fs::remove_file(cuda.join("cudnn64_9.dll")).expect("rm cudnn");
+        assert!(cuda.join("cudart64_12.dll").is_file());
+        assert!(!is_staged_complete(&cuda, &ort));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// `install_from_staged` copies a well-formed `cuda\` + `onnxruntime\` source into
+    /// the provisioned dirs and reports complete.
+    #[test]
+    fn install_from_staged_copies_full_set() {
+        let src = scratch("stage-src");
+        touch(&src.join("cuda"), STAGED_CUDA_DLLS);
+        touch(&src.join("onnxruntime"), STAGED_ORT_DLLS);
+
+        let dest = scratch("stage-dest");
+        let cuda = dest.join("cuda");
+        let ort = dest.join("onnxruntime");
+
+        install_from_staged(&src, &cuda, &ort).expect("install succeeds");
+        assert!(cuda.join("cudart64_12.dll").is_file());
+        assert!(ort.join("onnxruntime_providers_cuda.dll").is_file());
+        assert!(is_staged_complete(&cuda, &ort));
+
+        let _ = fs::remove_dir_all(&src);
+        let _ = fs::remove_dir_all(&dest);
+    }
+
+    /// A source missing the `cuda\`/`onnxruntime\` subdirs, or missing a component, is
+    /// rejected with an actionable error rather than a silent partial install.
+    #[test]
+    fn install_from_staged_rejects_bad_source() {
+        // No cuda/onnxruntime subdirs at all.
+        let flat = scratch("stage-flat");
+        touch(&flat, STAGED_CUDA_DLLS);
+        let dest = scratch("stage-flat-dest");
+        let error = install_from_staged(&flat, &dest.join("cuda"), &dest.join("onnxruntime"))
+            .expect_err("must reject a source without cuda/onnxruntime subdirs");
+        assert!(
+            error.contains("subdirectories"),
+            "unexpected error: {error}"
+        );
+
+        // Subdirs present but incomplete (cuDNN missing).
+        let partial = scratch("stage-partial");
+        let incomplete: Vec<&str> = STAGED_CUDA_DLLS
+            .iter()
+            .copied()
+            .filter(|dll| *dll != "cudnn64_9.dll")
+            .collect();
+        touch(&partial.join("cuda"), &incomplete);
+        touch(&partial.join("onnxruntime"), STAGED_ORT_DLLS);
+        let dest2 = scratch("stage-partial-dest");
+        let error = install_from_staged(&partial, &dest2.join("cuda"), &dest2.join("onnxruntime"))
+            .expect_err("must reject an incomplete source");
+        assert!(error.contains("incomplete"), "unexpected error: {error}");
+
+        for dir in [&flat, &dest, &partial, &dest2] {
+            let _ = fs::remove_dir_all(dir);
         }
     }
 

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -1611,7 +1611,11 @@ async fn run_startup(app: AppHandle) {
         emit(
             &app,
             "error",
-            format!("GPU runtime download failed: {error}"),
+            format!(
+                "GPU runtime setup failed: {error}. To install on a disconnected machine, \
+                 pre-stage the runtime and set SCENEWORKS_GPU_RUNTIME_DIR — see \
+                 docs/offline-install.md."
+            ),
             true,
         );
         return;


### PR DESCRIPTION
## What & why

Windows first run downloads ~2.7 GB of CUDA/cuDNN/onnxruntime-gpu wheels into `%APPDATA%\SceneWorks\gpu-runtime`. On a disconnected machine that download aborts startup with no supported alternative. A user asked for an offline install path. This adds one — the real fix (skip the download when the redist is pre-staged) plus the docs to use it (folded in from the deferred doc story). Story sc-10354 under epic 5558.

## Changes

- **`SCENEWORKS_GPU_RUNTIME_DIR`** — point at a pre-extracted `cuda\` + `onnxruntime\` bundle; `provision` copies it into place, verifies completeness, writes the marker, and skips the download. A missing/incomplete source **fails clearly** instead of silently downloading 2.7 GB or half-installing a broken worker.
- **Probe-based skip** — if the target dirs already hold the full DLL set (e.g. a copied `gpu-runtime` folder from another machine), adopt them as-is; no network.
- **Completeness check** is deliberately stricter than the one-DLL `*_if_present` resolver probes: a full per-component sentinel set, matched case-insensitively by version-agnostic prefix (mirrors the sc-5560 bundling resolver), so a partial stage can't pass the probe and then hard-fail at load.
- **Setup abort message** now points at the offline-install guide (`GPU runtime download failed` → `GPU runtime setup failed: … see docs/offline-install.md`).
- **Docs** — new `apps/desktop/docs/offline-install.md` (pinned wheel manifest with URLs + sha256, bundle-build steps, env-var + manual paths, and the HF model-cache caveat for fully-offline generation); README first-run note + troubleshooting entry link to it.

## Testing

- `cargo test -p sceneworks-desktop` — 35 pass / 1 ignored (network smoke). New tests: `dir_has_dll` exact/prefix, `is_staged_complete` full-set requirement, `install_from_staged` copy + bad-source (no-subdirs / incomplete) rejection.
- `cargo clippy -p sceneworks-desktop --all-targets` — clean.
- Not yet GPU-validated on a real disconnected box — follow-up.

## Notes

- macOS/Linux unaffected (macOS bundles the CoreML onnxruntime dylib at build time; no Linux desktop path).
- Only covers the GPU-runtime redist; fully offline *generation* also needs a pre-seeded HF cache — documented in the guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)