### PR TITLE
fix(desktop): set PMETAL_METALLIB_PATH on the Metal GPU preflight probe too; release 0.7.3 (sc-10349 follow-up)

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -2,7 +2,7 @@
 
 SceneWorks Desktop packages the full SceneWorks AI image and video studio as a
 single native application — no Docker, no terminal, no Python to install. It is a
-[Tauri](https://tauri.app) shell (`net.trefry.sceneworks`, v0.7.2) that bundles
+[Tauri](https://tauri.app) shell (`net.trefry.sceneworks`, v0.7.3) that bundles
 the SceneWorks API and runs generation on a native, platform-specific engine:
 
 - **macOS** runs on Apple's **MLX** engine (Apple Silicon only).

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/desktop",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/desktop",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/desktop",
   "private": true,
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "SceneWorks desktop shell (Tauri).",
   "scripts": {
     "dev": "tauri dev",

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -1553,11 +1553,23 @@ fn cuda_preflight() -> Result<(), String> {
 /// (relayed verbatim onto the setup screen), or a fallback if the probe produced none.
 #[cfg(target_os = "macos")]
 async fn metal_preflight(app: &AppHandle) -> Result<(), String> {
-    let output = app
+    let mut command = app
         .shell()
         .sidecar("sceneworks-api")
         .map_err(|error| format!("locate api for GPU check: {error}"))?
-        .env("SCENEWORKS_GPU_CHECK", "1")
+        .env("SCENEWORKS_GPU_CHECK", "1");
+    // The probe's `astype`+`eval` dispatches a real MLX kernel, which loads MLX's
+    // Metal shader library — so it needs the bundled metallib just like the API
+    // sidecar and MLX worker spawns (sc-10349). This runs FIRST on startup, before
+    // spawn_api/gate_window, so on a clean Mac (no ~/.cache/pmetal, no build tree) a
+    // preflight without this env fails with "Failed to load the default metallib.
+    // library not found" and the setup screen relays it — stranding every fresh
+    // install on the first screen (sc-10353). Keeps the probe's spawn context
+    // identical to the worker's, as this fn's own contract states.
+    if let Some(metallib) = resolve_bundled_metallib(app) {
+        command = command.env("PMETAL_METALLIB_PATH", metallib);
+    }
+    let output = command
         .output()
         .await
         .map_err(|error| format!("run GPU check: {error}"))?;

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SceneWorks",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "identifier": "net.trefry.sceneworks",
   "build": {
     "frontendDist": "ui",

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/web",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/web",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "dependencies": {
         "konva": "^9.3.22",
         "react": "18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/web",
   "private": true,
-  "version": "0.7.2",
+  "version": "0.7.3",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sceneworks",
   "private": true,
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Local AI image and video generation studio runtime skeleton.",
   "license": "AGPL-3.0-or-later",
   "scripts": {


### PR DESCRIPTION
Follow-up to #1295 (sc-10349). 0.7.2 still fails for real users — **5 clean Macs, all stuck on the first setup screen** with the identical `Failed to load the default metallib. library not found ×5 … array.cpp:232` error.

## Root cause — a third MLX spawn my 0.7.2 fix missed
0.7.2 bundled `mlx.metallib` and set `PMETAL_METALLIB_PATH` on `spawn_api` and `supervise_mlx_worker`. But **`metal_preflight`** (sc-8411) — the Apple-Silicon GPU check that re-launches the sidecar in `SCENEWORKS_GPU_CHECK=1` mode — runs an `astype`+`eval` probe that **dispatches a real MLX kernel and loads the metallib**. It set only `SCENEWORKS_GPU_CHECK`, not the metallib env, and it runs **first**, before `spawn_api`/`gate_window`.

So on a genuinely clean Mac (no `~/.cache/pmetal`, no build tree) the preflight fails with the users' exact error, and `run_startup` emits it to the setup screen — stranding every fresh install on the first screen. The **×5** count is diagnostic: the env-override candidate is null (unset) so only the five *file* candidates report "library not found"; a set-but-missing env would be ×6.

## Fix
Pass `PMETAL_METALLIB_PATH` to the GPU-check spawn via `resolve_bundled_metallib` — the identical line already in `spawn_api`/`supervise_mlx_worker`.

## Reproduced (cleanly this time)
The **released** `sceneworks-api` GPU-check binary, under an isolated empty `HOME`:
- **without** `PMETAL_METALLIB_PATH` → `Failed to load the default metallib. library not found ×5 … array.cpp:232` (exit 255) — the users' exact error.
- **with** `PMETAL_METALLIB_PATH=<bundled>` → exit 0.

Why 0.7.2's testing missed it: a concurrent MLX build in another worktree kept repopulating `~/.cache/pmetal`, so every "clean" test with the real `HOME` was silently rescued by the cache fallback — the false negative that made me wrongly revert this exact change during 0.7.2. Isolating `HOME` removes that confound.

Cuts **0.7.3**. `cargo check -p sceneworks-desktop` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)