### PR TITLE
fix(models): reconcile derived-family downloads against base architecture (sc-10398)

### DIFF
--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -234,8 +234,23 @@ pub fn reconcile_detected_family(
             // form) against a detected `krea_2` (the catalog/trainer token), or
             // ai-toolkit's separator-less `krea2`. Store the canonical token so the
             // recorded family matches `loraCompatibility.families` exactly.
-            if canonical_lora_family(&supplied) == canonical_lora_family(&detected) {
-                Ok(Some(canonical_lora_family(&detected)))
+            let canonical_supplied = canonical_lora_family(&supplied);
+            let canonical_detected = canonical_lora_family(&detected);
+            // A detected *base architecture* family also satisfies a declared, more specific
+            // model family built on that architecture. A Chroma checkpoint (`chroma`) with no
+            // metadata detects as `flux`; FLUX.2 [klein] / [dev] (`flux2-klein` / `flux2-dev`)
+            // carry no variant signature and detect as the base `flux2`. Without this, every
+            // legitimate Chroma / klein / dev download or import fails as a false mismatch.
+            // Keep the *declared* family — it is the model's true identity (a klein model must
+            // stay `flux2-klein`, a Chroma LoRA `chroma`), and the base is only what the
+            // detector falls back to when the variant shares the base's tensor layout.
+            if canonical_supplied == canonical_detected
+                || detected_base_architecture_satisfies_declared(
+                    &canonical_supplied,
+                    &canonical_detected,
+                )
+            {
+                Ok(Some(canonical_supplied))
             } else {
                 Err(FamilyMismatch { supplied, detected })
             }
@@ -440,6 +455,26 @@ pub fn canonical_lora_family(family: &str) -> String {
         "krea-2" => "krea_2".to_owned(),
         _ => normalized,
     }
+}
+
+/// True when a *detected* base-architecture family legitimately satisfies a declared,
+/// more specific model family — i.e. the declared family's weights share that base
+/// architecture's tensor layout, so [`detect_model_family`] can only report the base.
+/// These are exactly the families that also load the base architecture's LoRAs, so this
+/// consults the same [`extra_compatible_lora_families`] registry to stay in lockstep:
+///
+/// * Chroma (`chroma`) is FLUX.1-schnell-derived; a metadata-less Chroma checkpoint has
+///   byte-for-byte the same tensor keys as FLUX.1, so key detection reports `flux`.
+/// * FLUX.2 [klein] / [dev] (`flux2-klein` / `flux2-dev`) carry no klein/dev-specific
+///   tensor signature, so detection reports the base `flux2`.
+///
+/// The reason such a model accepts the base family's LoRAs is precisely that it *is*
+/// that base architecture, which is why the accept-detection and load-LoRA relations
+/// coincide. Both arguments must already be canonical (see [`canonical_lora_family`]).
+/// Directional on purpose: only a detected *base* satisfies a declared *variant*, never
+/// the reverse, so a genuinely wrong download/import is still a confident mismatch.
+fn detected_base_architecture_satisfies_declared(declared: &str, detected: &str) -> bool {
+    extra_compatible_lora_families(declared).contains(&detected)
 }
 
 fn read_diffusers_model_index_family(dir: &Path) -> Option<String> {
@@ -2505,6 +2540,43 @@ mod tests {
                 supplied: "z-image".to_owned(),
                 detected: "qwen-image".to_owned(),
             }
+        );
+    }
+
+    #[test]
+    fn reconcile_detected_family_accepts_base_architecture_of_derived_families() {
+        // A declared model family whose weights legitimately detect only as a compatible
+        // *base* architecture must reconcile (it previously failed every such download /
+        // import as a false mismatch), keeping the declared family as the model's identity:
+        //   - Chroma (`chroma`) is FLUX.1-derived; metadata-less weights detect as `flux`.
+        //   - FLUX.2 [klein] / [dev] carry no variant signature; weights detect as `flux2`.
+        let cases = [
+            ("chroma", "flux"),
+            ("flux2-klein", "flux2"),
+            ("flux2_klein", "flux2"),
+            ("flux2-dev", "flux2"),
+        ];
+        for (declared, detected) in cases {
+            assert_eq!(
+                reconcile_detected_family(Some(declared.to_owned()), Some(detected.to_owned()))
+                    .unwrap()
+                    .as_deref(),
+                Some(canonical_lora_family(declared).as_str()),
+                "declared {declared:?} vs detected {detected:?} should keep {declared:?}"
+            );
+        }
+        // Directional: the reverse is NOT a variant relationship, so it stays a mismatch —
+        // a plain `flux` weight is not a Chroma, and `flux2` is not FLUX.1 (`flux`).
+        assert!(
+            reconcile_detected_family(Some("flux".to_owned()), Some("chroma".to_owned())).is_err()
+        );
+        assert!(
+            reconcile_detected_family(Some("flux".to_owned()), Some("flux2".to_owned())).is_err()
+        );
+        // An unrelated cross-architecture pair is still a confident mismatch.
+        assert!(
+            reconcile_detected_family(Some("flux2-klein".to_owned()), Some("flux".to_owned()))
+                .is_err()
         );
     }
 

--- a/crates/sceneworks-worker/src/tests/hf_and_family.rs
+++ b/crates/sceneworks-worker/src/tests/hf_and_family.rs
@@ -28,6 +28,39 @@ fn wan_video_safetensors_keys() -> Vec<String> {
     keys
 }
 
+fn flux2_safetensors_keys() -> Vec<String> {
+    // Mirrors the FLUX.2 architecture signature: the top-level shared-modulation
+    // tensors (unique to FLUX.2) plus its double/single stream blocks. klein and dev
+    // weights carry no variant-specific signature, so both detect as the base `flux2`.
+    let mut keys = vec![
+        "double_stream_modulation_img".to_owned(),
+        "double_stream_modulation_txt".to_owned(),
+        "single_stream_modulation.weight".to_owned(),
+    ];
+    for block in 0..8 {
+        keys.push(format!("double_blocks.{block}.img_attn.qkv.weight"));
+        keys.push(format!("double_blocks.{block}.txt_attn.qkv.weight"));
+        keys.push(format!("single_blocks.{block}.linear1.weight"));
+    }
+    keys
+}
+
+fn flux1_no_metadata_safetensors_keys() -> Vec<String> {
+    // FLUX.1 double + single stream blocks. Chroma is FLUX.1-schnell-derived and shares
+    // this exact tensor layout, so a metadata-less Chroma checkpoint key-detects as the
+    // base `flux` (the `single_transformer_blocks.` prefix is the Flux discriminator).
+    let mut keys = Vec::new();
+    for block in 0..8 {
+        for module in ["attn.to_q", "attn.to_k", "attn.to_v", "attn.to_out.0"] {
+            keys.push(format!("transformer.transformer_blocks.{block}.{module}.weight"));
+            keys.push(format!(
+                "transformer.single_transformer_blocks.{block}.{module}.weight"
+            ));
+        }
+    }
+    keys
+}
+
 #[test]
 fn hf_cli_windows_encoding_failures_are_detected() {
     let stderr = "Fetching 28 files: 100%|##########| 28/28 [00:00<00:00, 14016.05it/s]\n\
@@ -211,6 +244,57 @@ fn download_family_check_proceeds_when_detection_matches_catalog() {
     assert!(matches!(
         check_downloaded_model_family(Some("wan-video".to_owned()), dir.path()),
         DownloadFamilyCheck::Proceed
+    ));
+}
+
+#[test]
+fn download_family_check_proceeds_for_derived_family_base_architecture() {
+    // Regression: a catalog entry declares a model family whose downloaded weights detect
+    // only as a compatible *base* architecture. The download guard must treat that as a
+    // match, not a false mismatch that fails the install with e.g. "Downloaded model files
+    // appear to be flux2, but the catalog declared family flux2-klein".
+    //
+    // FLUX.2 [klein] / [dev] (`flux2-klein` / `flux2-dev`) detect as `flux2`; a metadata-
+    // less Chroma checkpoint (`chroma`, FLUX.1-derived) detects as `flux`.
+    let flux2_dir = tempdir().expect("tempdir creates");
+    write_safetensors_with_keys(
+        &flux2_dir.path().join("model.safetensors"),
+        &flux2_safetensors_keys(),
+    );
+    for declared in ["flux2-klein", "flux2-dev", "flux2"] {
+        assert!(
+            matches!(
+                check_downloaded_model_family(Some(declared.to_owned()), flux2_dir.path()),
+                DownloadFamilyCheck::Proceed
+            ),
+            "declared {declared:?} against flux2 weights should proceed"
+        );
+    }
+
+    let chroma_dir = tempdir().expect("tempdir creates");
+    write_safetensors_with_keys(
+        &chroma_dir.path().join("model.safetensors"),
+        &flux1_no_metadata_safetensors_keys(),
+    );
+    for declared in ["chroma", "flux"] {
+        assert!(
+            matches!(
+                check_downloaded_model_family(Some(declared.to_owned()), chroma_dir.path()),
+                DownloadFamilyCheck::Proceed
+            ),
+            "declared {declared:?} against flux weights should proceed"
+        );
+    }
+
+    // A genuinely wrong declaration is still caught: wan-video weights are not flux.
+    let wan_dir = tempdir().expect("tempdir creates");
+    write_safetensors_with_keys(
+        &wan_dir.path().join("model.safetensors"),
+        &wan_video_safetensors_keys(),
+    );
+    assert!(matches!(
+        check_downloaded_model_family(Some("chroma".to_owned()), wan_dir.path()),
+        DownloadFamilyCheck::Mismatch(_)
     ));
 }
 


### PR DESCRIPTION
## Problem

Downloading **FLUX.2 [klein] 9B True V2** (and every klein/dev variant) failed with:

> Downloaded model files appear to be flux2, but the catalog declared family flux2-klein. Fix the catalog entry to family flux2 or correct the download source.

## Root cause

The post-download family guard (`reconcile_downloaded_model_family` → `check_downloaded_model_family`) re-detects the downloaded weights' architecture and reconciles it against the catalog-declared `family`, via the shared `reconcile_detected_family` (`crates/sceneworks-core/src/lora_family.rs`).

The catalog **legitimately** declares the model families `flux2-klein` / `flux2-dev` (`config/manifests/builtin.models.jsonc`), but klein/dev weights carry **no klein/dev-specific tensor signature** — architecturally they are plain FLUX.2, so `detect_model_family` can only ever report the base `flux2` (`Bucket::Flux2`). The reconcile compared canonical tokens **verbatim** (`flux2-klein` != `flux2`) → hard `FamilyMismatch`. Because the policy is shared, this affected model-download, model-import, and LoRA-import.

**Same class — Chroma.** Chroma (`chroma`, FLUX.1-schnell-derived) has byte-identical tensor keys to FLUX.1, so a metadata-less Chroma checkpoint key-detects as `flux` and hit the same false mismatch (latent: masked when the weights carry chroma metadata / a diffusers class).

## Fix

`reconcile_detected_family` now also accepts when the detected family is a **base architecture the declared family is built on**, consulting the existing `extra_compatible_lora_families` registry (chroma→flux, flux2-klein/dev→flux2) — one source of truth, stays in lockstep with LoRA compatibility (the reason such a model accepts the base family's LoRAs is precisely that it *is* that base architecture). It keeps the **declared** (more-specific) family as the model's identity, and is **directional** — only a detected base satisfies a declared variant, so a genuinely wrong download/import is still a confident mismatch.

## Scope

Every builtin catalog `family` was cross-checked against detector output. Confirmed affected + fixed: `chroma`, `flux2-klein`, `flux2-dev`. Everything else either matches its detector output or detects as `None` (inconclusive → proceeds).

Composite native-MLX families (`boogu`/`bernini`/`scail2`) *could* key-detect as a base family too, but that needs weight inspection and a **different** mechanism (they shouldn't load arbitrary base-family LoRAs) — deliberately not bundled here; tracked in sc-10399.

## Tests
- `crates/sceneworks-core/src/lora_family.rs` — `reconcile_detected_family_accepts_base_architecture_of_derived_families` (chroma + klein/dev; directional negative cases).
- `crates/sceneworks-worker/src/tests/hf_and_family.rs` — `download_family_check_proceeds_for_derived_family_base_architecture` (real flux2 + flux1 safetensors headers; wan-video negative control).
- Full `npm run rust:check` (fmt --all + clippy --all-targets -D warnings + test + build) green.

Story: sc-10398 · Follow-up: sc-10399

🤖 Generated with [Claude Code](https://claude.com/claude-code)