### PR TITLE
polish(ui): remove internal "Rust" from user-facing messaging

### DIFF
--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -1860,7 +1860,7 @@ mod bind_tests {
         // Loopback (OS-assigned) — the default packaged first-run path.
         assert_eq!(
             parse_listening_port(
-                r#"{"message":"SceneWorks Rust API listening","event":"api_listening","address":"127.0.0.1:60294","level":"info","reportedAt":"2026-07-04T15:20:19Z"}"#
+                r#"{"message":"SceneWorks API listening","event":"api_listening","address":"127.0.0.1:60294","level":"info","reportedAt":"2026-07-04T15:20:19Z"}"#
             ),
             Some(60294)
         );

--- a/apps/rust-api/src/server.rs
+++ b/apps/rust-api/src/server.rs
@@ -254,7 +254,7 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
         tracing::info!(
             event = "hf_home_defaulted",
             home = %home.display(),
-            "SceneWorks Rust API defaulting HF_HOME"
+            "SceneWorks API defaulting HF_HOME"
         );
     }
     let settings = Settings::from_env();
@@ -338,7 +338,7 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!(
         event = "api_listening",
         address = %bound,
-        "SceneWorks Rust API listening"
+        "SceneWorks API listening"
     );
 
     let utility_worker = run_utility_inprocess.then(|| spawn_inprocess_utility_worker(port));

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -3956,10 +3956,7 @@ async fn models_catalog_carries_mac_support_and_capabilities_endpoint() {
     let (status, caps) = request(app, "GET", "/api/v1/capabilities/mac", Value::Null).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(caps["macGatingActive"], true);
-    assert_eq!(
-        caps["notAvailableLabel"],
-        "Not available on Mac (Rust/MLX only)"
-    );
+    assert_eq!(caps["notAvailableLabel"], "Not available on Mac (MLX only)");
     // Real-ESRGAN upscaling is ported to the Rust worker (sc-3489) → tool supported, no reason.
     assert_eq!(caps["features"]["imageUpscale"]["supported"], true);
     assert_eq!(caps["features"]["imageUpscale"]["reason"], Value::Null);

--- a/apps/web/src/App.queue.test.jsx
+++ b/apps/web/src/App.queue.test.jsx
@@ -89,7 +89,7 @@ describe("SceneWorks app shell", () => {
             {
               id: "rust-gpu-1",
               gpuId: "1",
-              gpuName: "Rust placeholder GPU",
+              gpuName: "Placeholder GPU",
               status: "idle",
               capabilities: ["placeholder", "gpu", "nvidia"],
             },
@@ -103,7 +103,7 @@ describe("SceneWorks app shell", () => {
             {
               id: "rust-cpu",
               gpuId: "cpu",
-              gpuName: "Rust CPU utility worker",
+              gpuName: "CPU utility worker",
               status: "idle",
               capabilities: ["placeholder", "cpu", "model_download"],
             },
@@ -128,8 +128,8 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("20.0 GB");
     expect(container.textContent).toContain("4.0 GB / 24.0 GB");
     expect(container.textContent).toContain("12%");
-    expect(container.textContent).not.toContain("Rust CPU utility worker");
-    expect(container.textContent).not.toContain("Rust placeholder GPU");
+    expect(container.textContent).not.toContain("CPU utility worker");
+    expect(container.textContent).not.toContain("Placeholder GPU");
     expect(container.textContent).not.toContain("Stale GPU");
     expect([...document.body.querySelector("#queue-gpu").options].map((option) => option.value)).toEqual(["auto", "0"]);
   });

--- a/apps/web/src/App.training.test.jsx
+++ b/apps/web/src/App.training.test.jsx
@@ -133,7 +133,7 @@ describe("SceneWorks app shell", () => {
     });
 
     expect(document.body.querySelector("#training-tab-configure").getAttribute("aria-selected")).toBe("true");
-    expect(container.textContent).toContain("A dry run validates the Rust-resolved training plan");
+    expect(container.textContent).toContain("A dry run validates the training plan");
     expect(document.body.querySelector("#training-tab-dataset")).toBeNull();
     expect(document.body.querySelector("#training-tab-rename-caption")).toBeNull();
     expect(container.textContent).not.toContain("Import images & captions");

--- a/apps/web/src/macGating.js
+++ b/apps/web/src/macGating.js
@@ -7,7 +7,7 @@
 // after submit. On Windows/Linux (and a Mac still in observe mode) `macGatingActive` is false and
 // every helper here is a no-op, so non-Mac pickers are untouched.
 
-export const MAC_NOT_AVAILABLE_LABEL = "Not available on Mac (Rust/MLX only)";
+export const MAC_NOT_AVAILABLE_LABEL = "Not available on Mac (MLX only)";
 
 // The inert default used until the capabilities endpoint responds (and the permanent value on
 // non-Mac / observe-mode deployments). Every helper below short-circuits to "not blocked".

--- a/apps/web/src/macGating.test.js
+++ b/apps/web/src/macGating.test.js
@@ -15,7 +15,7 @@ import {
 const gating = {
   macGatingActive: true,
   platform: "macos",
-  notAvailableLabel: "Not available on Mac (Rust/MLX only)",
+  notAvailableLabel: "Not available on Mac (MLX only)",
   features: {
     imageUpscale: {
       supported: false,
@@ -50,7 +50,7 @@ describe("macGating helpers", () => {
   it("blocks a torch-only model and names its port epic when gating is active", () => {
     const block = macModelBlock(torchModel, gating);
     expect(block?.blocked).toBe(true);
-    expect(block?.text).toContain("Not available on Mac (Rust/MLX only)");
+    expect(block?.text).toContain("Not available on Mac (MLX only)");
     expect(block?.text).toContain("epic 3532");
     expect(macModelBlock(mlxModel, gating)).toBeNull();
   });
@@ -144,6 +144,6 @@ describe("macGating helpers", () => {
   });
 
   it("falls back to the bare label when a reason is missing", () => {
-    expect(macReasonText(gating, null)).toBe("Not available on Mac (Rust/MLX only)");
+    expect(macReasonText(gating, null)).toBe("Not available on Mac (MLX only)");
   });
 });

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -595,7 +595,7 @@ describe("ImageStudio model picker capability gating", () => {
   const MAC_CAPS = {
     macGatingActive: true,
     platform: "darwin",
-    notAvailableLabel: "Not available on Mac (Rust/MLX only)",
+    notAvailableLabel: "Not available on Mac (MLX only)",
     features: {},
     training: { supportedKernels: [], lokrOnWanSupported: false },
   };

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -1458,7 +1458,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
             <p className="view-copy">
               {datasetLibraryMode
                 ? "Create training datasets, manage imported dataset images, and normalize captions in one place."
-                : "Select an existing dataset and prepare a Rust-owned training plan before any ML runtime work begins."}
+                : "Select an existing dataset and prepare a training plan before any ML runtime work begins."}
             </p>
           </div>
           <div className="training-metrics" aria-label="Training workspace summary">

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -743,7 +743,7 @@ describe("VideoStudio Mac mode gating (sc-5716)", () => {
   const MAC_CAPS = {
     macGatingActive: true,
     platform: "darwin",
-    notAvailableLabel: "Not available on Mac (Rust/MLX only)",
+    notAvailableLabel: "Not available on Mac (MLX only)",
     features: {},
     training: { supportedKernels: [], lokrOnWanSupported: false },
   };

--- a/apps/web/src/screens/training/ConfigureJobPanel.jsx
+++ b/apps/web/src/screens/training/ConfigureJobPanel.jsx
@@ -97,7 +97,7 @@ export function ConfigureJobPanel({
                   return (
                     <option key={target.id} value={target.id} disabled={blocked}>
                       {target.ui?.label ?? target.name}
-                      {blocked ? " — not on Mac (Rust/MLX only)" : ""}
+                      {blocked ? " — not on Mac (MLX only)" : ""}
                     </option>
                   );
                 })}
@@ -267,7 +267,7 @@ export function ConfigureJobPanel({
                       return (
                         <option key={option} value={option} disabled={blocked}>
                           {networkTypeLabel(option)}
-                          {blocked ? " — not on Mac (Rust/MLX only)" : ""}
+                          {blocked ? " — not on Mac (MLX only)" : ""}
                         </option>
                       );
                     })}
@@ -467,7 +467,7 @@ export function ConfigureJobPanel({
         </div>
       )}
       <p className="view-copy">
-        A dry run validates the Rust-resolved training plan and dataset on a GPU worker without training. Run training
+        A dry run validates the training plan and dataset on a GPU worker without training. Run training
         (beta) hands the same plan to the worker's Z-Image LoRA kernel to produce a real .safetensors adapter.
       </p>
     </>

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1163,7 +1163,7 @@ impl JobsStore {
                 update jobs
                    set status = 'failed',
                        stage = 'failed',
-                       message = 'Not supported by the Rust/MLX flow on macOS.',
+                       message = 'Not supported by the MLX flow on macOS.',
                        error = ?2,
                        completed_at = ?1,
                        updated_at = ?1,

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -12,7 +12,7 @@ use crate::jobs_store::routing::mlx::{image_request_mlx_eligible, video_mode_is_
 
 /// The user-facing affordance prefix the Mac UI shows in place of a torch-only control
 /// (sc-3486). Centralised so the API, the web client, and the gap docs read identically.
-pub const MAC_NOT_AVAILABLE_LABEL: &str = "Not available on Mac (Rust/MLX only)";
+pub const MAC_NOT_AVAILABLE_LABEL: &str = "Not available on Mac (MLX only)";
 
 /// UI-facing per-model macOS support (sc-3486), derived from the same `*_mlx_eligible` routing
 /// predicates as the [`mac_rust_supported`] job oracle — one source of truth, so what the UI

--- a/crates/sceneworks-core/src/jobs_store/routing/gaps.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/gaps.rs
@@ -230,7 +230,7 @@ impl UnsupportedReason {
             .map(|epic| format!(" [{epic}]"))
             .unwrap_or_default();
         format!(
-            "mlx_unsupported: {feature}{model} is not in the Rust/MLX flow on macOS — {detail}{pointer}",
+            "mlx_unsupported: {feature}{model} is not in the MLX flow on macOS — {detail}{pointer}",
             feature = self.feature,
             detail = self.detail,
         )
@@ -390,7 +390,7 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
                 Err(UnsupportedReason::new(
                     model,
                     "image_upscale (AuraSR)",
-                    "the Rust upscaler runs Real-ESRGAN (+ SeedVR2); the AuraSR engine is dropped as an offered engine (sc-3668 / sc-5499).",
+                    "the upscaler runs Real-ESRGAN (+ SeedVR2); the AuraSR engine is dropped as an offered engine (sc-3668 / sc-5499).",
                     Some("sc-5499"),
                 ))
             }
@@ -420,7 +420,7 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
         JobType::TrainingCaption => Err(UnsupportedReason::new(
             None,
             "dataset captioning",
-            "this dataset captioning job is not in the Rust/MLX JoyCaption flow.",
+            "this dataset captioning job is not in the MLX JoyCaption flow.",
             Some("sc-3556"),
         )),
     }
@@ -632,7 +632,7 @@ pub(crate) fn classify_image_gap(payload: &Map<String, Value>) -> UnsupportedRea
         return UnsupportedReason::new(
             Some(model),
             "unsupported image model",
-            "this model has no Rust/MLX engine and no port epic yet — file a porting epic and drop it on Mac (epic 3482 policy).",
+            "this model has no MLX engine and no port epic yet — file a porting epic and drop it on Mac (epic 3482 policy).",
             None,
         );
     }
@@ -708,7 +708,7 @@ pub(crate) fn classify_image_gap(payload: &Map<String, Value>) -> UnsupportedRea
         _ => UnsupportedReason::new(
             Some(model),
             "unsupported configuration",
-            "this model/feature combination is not in the Rust/MLX flow.",
+            "this model/feature combination is not in the MLX flow.",
             None,
         ),
     }
@@ -725,7 +725,7 @@ pub(crate) fn classify_video_gap(payload: &Map<String, Value>) -> UnsupportedRea
         return UnsupportedReason::new(
             Some(model),
             "unsupported video model",
-            "this video model has no Rust/MLX engine; it is not available in the native flow on Mac.",
+            "this video model has no MLX engine; it is not available in the native flow on Mac.",
             Some("epic 3040"),
         );
     }
@@ -746,7 +746,7 @@ pub(crate) fn classify_video_gap(payload: &Map<String, Value>) -> UnsupportedRea
     UnsupportedReason::new(
         Some(model),
         "unsupported video configuration",
-        "this video configuration is not in the Rust/MLX flow.",
+        "this video configuration is not in the MLX flow.",
         None,
     )
 }
@@ -774,7 +774,7 @@ pub(crate) fn classify_training_gap(payload: &Map<String, Value>) -> Unsupported
         _ => UnsupportedReason::new(
             None,
             "LoRA/LoKr training",
-            "this training kernel has no native mlx-gen Rust trainer.",
+            "this training kernel has no native mlx-gen trainer.",
             Some("epic 3039"),
         ),
     }

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1207,7 +1207,7 @@ fn cpu_utility_worker_does_not_claim_gpu_generation_job() {
         .register_worker(RegisterWorker {
             worker_id: "worker-cpu".to_owned(),
             gpu_id: "cpu".to_owned(),
-            gpu_name: Some("Rust CPU utility worker".to_owned()),
+            gpu_name: Some("CPU utility worker".to_owned()),
             capabilities: vec![
                 WorkerCapability::Cpu,
                 WorkerCapability::ModelDownload,

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -599,7 +599,7 @@ pub(crate) fn visible_gpu_ids(value: Option<&str>) -> Option<Vec<String>> {
 pub(crate) fn cpu_gpu() -> DiscoveredGpu {
     DiscoveredGpu {
         id: "cpu".to_owned(),
-        name: "Rust CPU utility worker".to_owned(),
+        name: "CPU utility worker".to_owned(),
         capabilities: vec![WorkerCapability::Placeholder, WorkerCapability::Cpu],
         utilization: None,
     }

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -1181,7 +1181,7 @@ async fn run_utility_job(
                 let result = fail_job(
                     api,
                     &job.id,
-                    "No Rust utility exists for this job type.",
+                    "No utility exists for this job type.",
                     Some(format!(
                         "Unsupported utility job type: {}",
                         job.job_type.as_str()

--- a/crates/sceneworks-worker/src/sensenova_jobs.rs
+++ b/crates/sceneworks-worker/src/sensenova_jobs.rs
@@ -355,7 +355,7 @@ pub(crate) async fn run_vqa_job(
     _job: &JobSnapshot,
 ) -> WorkerResult<()> {
     Err(WorkerError::InvalidPayload(
-        "image_vqa runs on the macOS MLX worker, the candle (Windows/CUDA) worker, not this Rust worker"
+        "image_vqa runs on the macOS MLX worker, the candle (Windows/CUDA) worker, not this worker"
             .to_owned(),
     ))
 }
@@ -826,7 +826,7 @@ pub(crate) async fn run_interleave_job(
     _job: &JobSnapshot,
 ) -> WorkerResult<()> {
     Err(WorkerError::InvalidPayload(
-        "image_interleave runs on the macOS MLX worker, the candle (Windows/CUDA) worker, not this Rust worker"
+        "image_interleave runs on the macOS MLX worker, the candle (Windows/CUDA) worker, not this worker"
             .to_owned(),
     ))
 }

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -915,7 +915,7 @@ pub(crate) async fn run_image_upscale_job(
         "seedvr2" => "seedvr2",
         other => {
             return Err(WorkerError::InvalidPayload(format!(
-                "Rust upscaler supports engine=real-esrgan or engine=seedvr2 (got {other}); aura-sr is dropped (sc-3668 / sc-5499)."
+                "This upscaler supports engine=real-esrgan or engine=seedvr2 (got {other}); aura-sr is dropped (sc-3668 / sc-5499)."
             )));
         }
     };

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -2085,7 +2085,7 @@ pub(crate) async fn run_video_upscale_job(
     let engine = req.engine.trim().to_ascii_lowercase();
     if !matches!(engine.as_str(), "" | "seedvr2" | "seedvr2_3b") {
         return Err(WorkerError::InvalidPayload(format!(
-            "Rust video upscaler supports only engine=seedvr2 (got {engine})."
+            "This video upscaler supports only engine=seedvr2 (got {engine})."
         )));
     }
     let project_id = req

--- a/tests/fixtures/rust_api_contract_snapshots/snapshots.json
+++ b/tests/fixtures/rust_api_contract_snapshots/snapshots.json
@@ -2175,7 +2175,7 @@
           "reference": false
         },
         "reason": {
-          "detail": "this model has no Rust/MLX engine and no port epic yet \u2014 file a porting epic and drop it on Mac (epic 3482 policy).",
+          "detail": "this model has no MLX engine and no port epic yet \u2014 file a porting epic and drop it on Mac (epic 3482 policy).",
           "feature": "unsupported image model",
           "model": "base-model",
           "suggestedEpic": null


### PR DESCRIPTION
## What & why

Users don't need to know the runtime is Rust — yet several on-screen messages leaked it. This removes the word **"Rust"** from all user-facing copy, rewording each so it still reads naturally. **"MLX" is kept** since it's already house style in the app (`Convert to MLX`, `MLX weights`, `Mac / MLX`, the `MLX` badge).

## Scope — this was bigger than the frontend

The Mac "Not available" label is **backend-owned** (`catalog.rs` `MAC_NOT_AVAILABLE_LABEL`, served via `GET /api/v1/capabilities/mac`); `macGating.js` only holds a fallback. So a frontend-only edit would have left "Rust" on screen for real Mac users. Changed, in lockstep:

- **Gating label:** `Not available on Mac (Rust/MLX only)` → `Not available on Mac (MLX only)` (backend `catalog.rs` + JS fallback)
- **Training copy:** "prepare a **Rust-owned** training plan" / "validates the **Rust-resolved** training plan" → drop "Rust-owned"/"Rust-resolved"
- **Gap reasons** (render on blocked pickers + failed job cards, via `gaps.rs` `UnsupportedReason.detail`): `Rust/MLX flow` → `MLX flow`, `no Rust/MLX engine` → `no MLX engine`, `native mlx-gen Rust trainer` → `native mlx-gen trainer`, etc.
- **Job-failure message** (`jobs_store.rs`): `Not supported by the Rust/MLX flow` → `…MLX flow`
- **Worker errors:** `Rust upscaler` → `This upscaler`, `Rust video upscaler` → `This video upscaler`, `not this Rust worker` → `not this worker`, `No Rust utility exists` → `No utility exists`; device name `Rust CPU utility worker` → `CPU utility worker` (`gpu.rs`)
- **API startup logs** (visible in System → Logs): `SceneWorks Rust API listening` / `…defaulting HF_HOME` → drop "Rust"
- **Tests + parity golden** (`snapshots.json`, `tests.rs`, `*.test.jsx`) updated to match.

**Left untouched:** `//`/`///` code comments, doc-comments, test descriptions, and crate/path names (`rust-api`) — none render on a screen, and they accurately document that the runtime is Rust.

## Verification

- Web: **124** vitest tests pass (these render the components and assert the new copy in the DOM)
- Rust: core **584**, worker **679**, rust-api capabilities test, desktop parse test — **0 failures**
- `cargo fmt --all --check`: clean
- Parity golden: verified the updated `detail` string is byte-for-byte identical to its Rust source literal, with zero "Rust" remaining (parity lane compares parsed JSON, so it will match); the Python parity suite itself runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)