### PR TITLE
polish(training): match select control heights to inputs on Configure Job form

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5094,8 +5094,11 @@ details[open] > summary.lora-scope-group-heading::before,
 
 /* A native <select> renders shorter than a text input even with matching padding.
    Strip the native chrome (so it honors the shared 9px 12px padding + line-height)
-   and add a chevron, so the Scope/Family selects match the URL/Name input height. */
-.models-import-grid select {
+   and add a chevron, so selects match their sibling text/number inputs' height.
+   Covers the LoRA import grid (Scope/Family) and the training config grids. */
+.models-import-grid select,
+.training-config-grid select,
+.training-advanced-grid select {
   appearance: none;
   -webkit-appearance: none;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2.5'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");


### PR DESCRIPTION
## What

On the training **Configure Job** page (and the Advanced options grid), the native `<select>` controls (Target, Preset, Dataset, Output scope, Quality preset, Requested GPU) rendered at a different height than the padded text/number inputs beside them, so the form looked misaligned.

This extends the existing select-normalization CSS rule — previously scoped only to the model-manager LoRA import grid (`.models-import-grid select`) — to also cover `.training-config-grid select` and `.training-advanced-grid select`. Stripping the native chrome (`appearance: none`) lets the selects honor the shared `9px 12px` padding, and the same custom chevron already used elsewhere is applied, giving every control in the grid a uniform height.

## Why

A native `<select>` renders a different height than a text input even with matching padding (notably in the macOS WKWebView the desktop app runs in). The codebase already had a proven fix for this exact problem; it just wasn't applied to the training grids.

## Notes for reviewer

- Reuses the existing rule (adds two selectors) rather than duplicating the chevron data-URI a third time — single source of truth for the normalized-select look.
- One-file, CSS-only change (`apps/web/src/styles.css`), no JSX/markup touched.
- Verified in the web preview by measuring rendered heights: select, disabled input, text input, and number inputs in `.training-config-grid` all render at a uniform 35px, with selects now `appearance: none`.
- Caveat: the height mismatch is WebKit-specific and does not reproduce in the Chromium preview (native selects already honor the padding there), and the live Training Studio form is gated behind an open workspace + backend API, which was offline in the verification environment. Worth a quick visual confirm in the packaged macOS app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)