### PR TITLE
polish(models): remove redundant in-page "Runtime assets / Models" heading

### DIFF
--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -1449,11 +1449,6 @@ export function ModelManagerScreen() {
 
   return (
     <section className="main-surface models-surface">
-      <div className="section-heading">
-        <p className="eyebrow">Runtime assets</p>
-        <h2>Models</h2>
-      </div>
-
       <div className="models-tabbar">
         <div className="mode-tabs" role="tablist" aria-label="Model type">
           {tabDefs.map(([key, label, count]) => {


### PR DESCRIPTION
## What

Removes the in-page `section-heading` block at the top of the Model Manager screen:

```jsx
<div className="section-heading">
  <p className="eyebrow">Runtime assets</p>
  <h2>Models</h2>
</div>
```

The page now opens directly into the tab bar.

## Why

The title bar already renders `<h1>Models</h1>` for this view (via the `viewTitles` map in `App.jsx`), so the page showed "Models" twice. Other content screens (e.g. Image Studio) open straight into their surface with no in-page title block — the Model Manager was the odd one out. This makes it consistent.

## Verification

- `ModelManagerScreen.test.jsx` — **37/37 pass** (no test referenced the removed heading).
- Browser preview was not used: in this repo `preview_start` serves the main checkout rather than the worktree, so it can't exercise the branch change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)