### PR TITLE
fix(web): render Logs timestamps in the local timezone, not UTC

### DIFF
--- a/apps/web/src/screens/LogsScreen.jsx
+++ b/apps/web/src/screens/LogsScreen.jsx
@@ -256,9 +256,19 @@ export function LogsScreen() {
   );
 }
 
+const TIME_FORMAT = new Intl.DateTimeFormat(undefined, {
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hour12: false,
+});
+
 function shortTime(timestamp) {
   if (!timestamp) return "";
-  // ISO 8601 → HH:MM:SS (drop date + zone for a compact column).
+  // ISO 8601 (UTC, trailing Z) → HH:MM:SS in the system's local timezone.
+  const date = new Date(timestamp);
+  if (!Number.isNaN(date.getTime())) return TIME_FORMAT.format(date);
+  // Fall back to the raw HH:MM:SS substring if the value can't be parsed.
   const match = /T(\d{2}:\d{2}:\d{2})/.exec(timestamp);
   return match ? match[1] : timestamp;
 }

--- a/apps/web/src/screens/LogsScreen.test.jsx
+++ b/apps/web/src/screens/LogsScreen.test.jsx
@@ -94,6 +94,20 @@ describe("LogsScreen", () => {
     expect(container.textContent).toContain("image_inference_failed");
   });
 
+  it("renders timestamps in the local timezone, not the raw UTC substring", async () => {
+    await render();
+    // Row 0's timestamp is 2026-06-07T01:02:00Z (UTC). The time column must be
+    // the viewer's local wall-clock time, parsed from the ISO string — not the
+    // raw "01:02:00" substring lifted out of the UTC value.
+    const expected = new Intl.DateTimeFormat(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    }).format(new Date("2026-06-07T01:02:00Z"));
+    expect(container.querySelector(".logs-time").textContent).toBe(expected);
+  });
+
   it("highlights routing-decision events", async () => {
     await render();
     const highlighted = container.querySelector(".logs-row.highlighted");


### PR DESCRIPTION
## What

The **Logs** page rendered each entry's time in UTC. This changes the time column to display in the viewer's **system (local) timezone**.

## Why

`shortTime()` in `LogsScreen.jsx` regex-extracted the `HH:MM:SS` substring straight out of the raw ISO-8601 UTC string (`…THH:MM:SSZ`) and never applied a timezone offset — so the column always showed UTC wall-clock time.

## How

- Parse the timestamp into a `Date` (which correctly reads the trailing `Z` as UTC), then format it in the local timezone via `Intl.DateTimeFormat(undefined, …)`, keeping the compact 24-hour `HH:MM:SS` column.
- Falls back to the old substring extraction if a value ever fails to parse.
- Mirrors the existing `new Date()` + `Intl.DateTimeFormat(undefined, …)` convention already used by `compactDate()` in `AssetPicker.jsx` (there's no shared date util, so the formatter is kept local to the file).

## Reviewer notes

- Backend timestamps are whole-second UTC (`YYYY-MM-DDTHH:MM:SSZ`), so the column shows seconds only — same granularity as before.
- Added a test that pins local-time rendering; it derives the expected value from the same ISO string and **fails against the old UTC-substring behavior in any non-UTC timezone**.
- All 10 `LogsScreen` tests pass, verified both in the default env and under `TZ=America/Chicago`.

## Test plan

- [x] `npm test` (LogsScreen suite) — 10/10 pass
- [x] Re-ran under `TZ=America/Chicago` to confirm the offset is actually applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)