### PR TITLE
fix(web): swallow file drops outside dropzones so they don't replace the UI (#1308)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -34,6 +34,7 @@ import { useModelsAndLoras } from "./hooks/useModelsAndLoras.js";
 import { usePersonTracks } from "./hooks/usePersonTracks.js";
 import { useTimelines } from "./hooks/useTimelines.js";
 import { useAccessGate } from "./hooks/useAccessGate.js";
+import { useDropNavigationGuard } from "./hooks/useDropNavigationGuard.js";
 import { useJobEvents } from "./hooks/useJobEvents.js";
 import { AppStaticContext, AppLiveContext } from "./context/AppContext.js";
 import { DEFAULT_MAC_CAPABILITIES } from "./macGating.js";
@@ -434,6 +435,9 @@ export function App() {
     saveToken,
     lockRemote,
   } = useAccessGate({ setError, pushNotice, dismissNoticeKind });
+  // Stop a file dropped outside a real dropzone from navigating the webview to
+  // the image and replacing the whole UI (issue #1308).
+  useDropNavigationGuard();
   const [theme, setTheme] = useState(readStoredTheme);
   // Apply a theme and persist it through the API. localStorage gives an instant
   // initial paint, but on the desktop shell the UI runs at the API's per-launch

--- a/apps/web/src/hooks/useDropNavigationGuard.js
+++ b/apps/web/src/hooks/useDropNavigationGuard.js
@@ -1,0 +1,45 @@
+import { useEffect } from "react";
+
+// Swallows file drops that no in-app dropzone claimed (issue #1308).
+//
+// The desktop shell runs the webview with Tauri's `dragDropEnabled: false`
+// (apps/desktop/tauri.conf.json) so the real dropzones — AssetPicker, the
+// dataset upload dialog, the Image Editor canvas — receive genuine
+// `dataTransfer.files`. The tradeoff is that a file dropped *anywhere else*
+// falls through to the webview's default handler, which navigates to the file
+// and replaces the whole UI with the image. A plain browser tab behaves the
+// same way. This installs a window-level fallback that accepts and then
+// discards those stray drags so nothing navigates.
+//
+// Real dropzones keep working untouched: each already calls preventDefault()
+// on its own `dragover`/`drop` as the event bubbles through it, so by the time
+// the event reaches this window listener `defaultPrevented` is already true and
+// the guard bows out. It only acts on drags nothing else claimed, where it
+// prevents the default navigation and marks the drop as "not allowed" so the
+// cursor reads as a rejection rather than a copy affordance.
+export function useDropNavigationGuard() {
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+    const swallowStrayDrag = (event) => {
+      if (event.defaultPrevented) {
+        // A registered dropzone already claimed this drag; leave it alone.
+        return;
+      }
+      // Preventing the default on `dragover` is what makes the window a valid
+      // drop target, so the `drop` event fires here (instead of navigating);
+      // preventing it on `drop` is what stops the navigation itself.
+      event.preventDefault();
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = "none";
+      }
+    };
+    window.addEventListener("dragover", swallowStrayDrag);
+    window.addEventListener("drop", swallowStrayDrag);
+    return () => {
+      window.removeEventListener("dragover", swallowStrayDrag);
+      window.removeEventListener("drop", swallowStrayDrag);
+    };
+  }, []);
+}

--- a/apps/web/src/hooks/useDropNavigationGuard.test.jsx
+++ b/apps/web/src/hooks/useDropNavigationGuard.test.jsx
@@ -1,0 +1,86 @@
+// Issue #1308: a file dropped outside a real dropzone must not navigate the
+// webview to the image (replacing the whole UI). The guard installs a
+// window-level fallback that swallows any drag no in-app dropzone claimed.
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { useDropNavigationGuard } from "./useDropNavigationGuard.js";
+
+function Harness() {
+  useDropNavigationGuard();
+  return null;
+}
+
+// jsdom's Event has no dataTransfer; attach a minimal writable stand-in so we
+// can observe the dropEffect the guard sets.
+function dragEvent(type, { defaultPrevented = false } = {}) {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  event.dataTransfer = { dropEffect: "copy" };
+  if (defaultPrevented) {
+    event.preventDefault();
+  }
+  return event;
+}
+
+describe("useDropNavigationGuard", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    act(() => {
+      root = createRoot(container);
+      root.render(<Harness />);
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("swallows an unclaimed drop so the browser never navigates to the file", () => {
+    const event = dragEvent("drop");
+    window.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+    expect(event.dataTransfer.dropEffect).toBe("none");
+  });
+
+  it("marks an unclaimed dragover as not-allowed and prevents its default", () => {
+    const event = dragEvent("dragover");
+    window.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+    expect(event.dataTransfer.dropEffect).toBe("none");
+  });
+
+  it("leaves a drag a real dropzone already claimed untouched", () => {
+    // A dropzone calls preventDefault() as the event bubbles through it; by the
+    // time it reaches window `defaultPrevented` is already true and the guard
+    // must bow out rather than override the dropzone's copy affordance.
+    const event = dragEvent("drop", { defaultPrevented: true });
+    window.dispatchEvent(event);
+    expect(event.dataTransfer.dropEffect).toBe("copy");
+  });
+
+  it("removes its window listeners on unmount", () => {
+    act(() => {
+      root.unmount();
+    });
+    root = null;
+    const event = dragEvent("drop");
+    window.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(false);
+    expect(event.dataTransfer.dropEffect).toBe("copy");
+
+    // Re-establish a root so the shared afterEach unmount stays valid.
+    act(() => {
+      root = createRoot(container);
+      root.render(<Harness />);
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Stops a file dropped **outside** a real dropzone from replacing the whole UI with the image.

The desktop shell runs the webview with `"dragDropEnabled": false` in `apps/desktop/tauri.conf.json` — intentionally, so the in-app dropzones (AssetPicker, the dataset upload dialog, the Image Editor canvas) receive genuine HTML5 `dataTransfer.files`. The side effect is that a file dropped anywhere else falls through to the webview's default handler, which navigates to the file and replaces the entire UI with the image. A plain browser tab behaves the same way. There was no global guard for unclaimed drops.

This adds a small window-level fallback:

- New hook **`useDropNavigationGuard`** (`apps/web/src/hooks/useDropNavigationGuard.js`) installs `dragover`/`drop` listeners on `window`. It acts **only** when `event.defaultPrevented` is still false — i.e. no in-app dropzone claimed the drag — where it `preventDefault()`s to suppress the navigation and sets `dropEffect = "none"` so inert areas show a "not-allowed" cursor.
- Wired into `App` (`apps/web/src/App.jsx`) with a single call alongside the other top-level hooks.

The `defaultPrevented` gate is what keeps existing dropzones working untouched: each already prevents default as the event bubbles through it, so by the time the event reaches the window listener the guard bows out.

## Related issue

Closes #1308

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

## How was this tested?

- New unit test `apps/web/src/hooks/useDropNavigationGuard.test.jsx` — 4 cases: unclaimed drop, unclaimed dragover, a dropzone-claimed drag left untouched, and listener cleanup on unmount.
- Full web suite: **103 files / 1361 tests passing**; `lint` clean; `build` succeeds.
- Real browser (Vite dev server, confirmed serving this branch): a synthetic file `drop` on an inert area returns `defaultPrevented: true` (navigation suppressed) while a dropzone-claimed drag is left alone. Note: synthetic events are `isTrusted: false` so they don't trigger the actual OS-file navigation and Chromium ignores `dropEffect` writes on them — the `dropEffect` path is covered authoritatively by the jsdom unit test, where the write sticks. A manual drag-from-Finder in the packaged app is the remaining last-mile check.

- [x] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [x] Not platform-specific (web UI, docs, shared crate)

## Checklist

- [ ] I ran `npm run rust:check` (if I touched Rust) and it passed — n/a, no Rust changes
- [x] I ran `npm --prefix apps/web run lint && npm --prefix apps/web run test && npm --prefix apps/web run build` (if I touched the web app)
- [ ] I ran `npm run check` (scaffold checks)
- [ ] I updated documentation where relevant — n/a
- [x] All my commits are signed off (`git commit -s`)
- [x] My PR is focused on a single logical change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
