### PR TITLE
ci: add timeout-minutes guardrails to CI jobs (sc-10420)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   web:
     runs-on: ubuntu-latest
+    # Guardrail so a wedged step fails fast instead of riding GitHub's 6-hour
+    # default (sc-10420). Well above the healthy ~5-8 min of ci+lint+test+build.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -28,6 +31,13 @@ jobs:
 
   parity:
     runs-on: ubuntu-latest
+    # A stalled step (e.g. a transient `docker compose up --build` layer/registry
+    # hang in the Docker smoke) otherwise rides GitHub's 6-hour default timeout,
+    # blocking the PR and holding a runner for hours — this bit PR #1300 / sc-10354
+    # for ~4 h. Cap well above the healthy ~12-15 min parity duration so healthy
+    # runs are unaffected but a wedge fails in minutes with a clear timeout
+    # (sc-10420).
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -49,6 +49,12 @@ jobs:
     # windows-2022 ships VS2022 with an MSVC 14.4x toolset; CUDA 12.9's nvcc rejects
     # VS2026's 14.51 (sc-3676), so pin the older image rather than windows-latest.
     runs-on: windows-2022
+    # Guardrail so a wedged step fails fast instead of riding GitHub's 6-hour
+    # default (sc-10420). This is the heavy candle CUDA release build (nvcc
+    # compiles every provider's kernels), so a cold-cache run is legitimately
+    # long — cap generously at 2 h to avoid false-failing real builds while still
+    # cutting a genuine hang to a third of the default.
+    timeout-minutes: 120
     env:
       # compute_80 PTX the driver JITs forward to sm_120 — one binary covers
       # Ampere->Blackwell (sc-3676); build-sidecar.mjs defaults this too.


### PR DESCRIPTION
## What
Adds job-level `timeout-minutes` to the CI jobs scoped by [sc-10420](https://app.shortcut.com/trefry/story/10420) so a stalled step fails fast instead of riding GitHub's **6-hour** default job timeout.

| Workflow | Job | Cap | Healthy duration |
|---|---|---|---|
| `check.yml` | `parity` | **30 min** | ~12–15 min |
| `check.yml` | `web` | **20 min** | ~5–8 min |
| `desktop-windows.yml` | `build-windows` | **120 min** | heavy candle CUDA build — generous headroom |

## Why
On [#1300](https://github.com/SceneWorks/SceneWorks/pull/1300) (sc-10354) a transient `docker compose up --build` hang in the parity job's "Smoke default Rust API Docker runtime" step left the run **IN_PROGRESS for ~4 hours**, blocking the PR and pinning a runner. The smoke's own health poll already bounds `waitForHealth` at 120s (`scripts/check-docker-api-runtime.mjs`); the hang was **upstream** in the image build, which nothing capped. The smoke itself isn't broken — recent `main` runs pass — the gap was purely the missing guardrail.

The `build-windows` cap is deliberately generous: it's the real candle CUDA release build (nvcc compiles every provider's kernels), so a cold-cache run is legitimately long — a tight cap would false-fail real builds. 120 min still cuts a genuine hang to a third of the default.

## Scope / follow-up
sc-10420 scoped exactly these three jobs (`parity` primary; `web` + `build-windows` audited "while in the file"). While auditing, four more jobs across `release.yml`, `macos-mlx.yml`, `windows-candle.yml`, and `server-candle-linux.yml` were found to also lack `timeout-minutes` — those need per-lane duration analysis (a too-tight cap on a real release build would break a release), tracked separately as [sc-10424](https://app.shortcut.com/trefry/story/10424).

## Verification
Both workflow files parse as valid YAML; all three caps confirmed as integers at the job level. Changes are declarative CI config only (no runtime code touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)