### PR TITLE
Generation Stats: record image count + normalize timing per image (sc-10426)

### DIFF
--- a/apps/web/src/screens/StatsScreen.jsx
+++ b/apps/web/src/screens/StatsScreen.jsx
@@ -83,6 +83,7 @@ const COLUMNS = [
   { key: "scheduler", label: "sched", get: (r) => r.metrics?.scheduler ?? "—" },
   { key: "cfg", label: "cfg", numeric: true, get: (r) => num1(r.metrics?.guidanceScale) },
   { key: "steps", label: "steps", numeric: true, get: (r) => r.metrics?.steps ?? "—" },
+  { key: "images", label: "imgs", numeric: true, get: (r) => r.metrics?.imageCount ?? "—" },
   { key: null, label: "PiD", get: (r) => pidLabel(r.metrics) },
   { key: "load", label: "load", numeric: true, get: (r) => formatMs(r.metrics?.loadMs) },
   { key: "sample", label: "sample", numeric: true, get: (r) => formatMs(r.metrics?.sampleMs) },
@@ -112,6 +113,8 @@ function FilterSelect({ label, value, onChange, options, render = (v) => v, allL
 
 function RunDetail({ row, onClose }) {
   const m = row.metrics ?? {};
+  const count = Math.max(1, Number(m.imageCount) || 1);
+  const perImage = (ms) => formatMs(ms != null && Number.isFinite(Number(ms)) ? Number(ms) / count : null);
   const items = [
     ["Job", `${typeLabel(row.type)} · ${row.jobId}`],
     ["Model", m.model ?? "—"],
@@ -130,6 +133,7 @@ function RunDetail({ row, onClose }) {
       }${m.trueCfgScale != null ? ` · trueCfg ${num1(m.trueCfgScale)}` : ""}`,
     ],
     ["Steps", m.steps ?? "—"],
+    ["Images", m.imageCount ?? "—"],
     ["PiD", pidLabel(m)],
     ["Size", m.width && m.height ? `${m.width}×${m.height}` : "—"],
     ["Seed", m.seed ?? "—"],
@@ -139,6 +143,10 @@ function RunDetail({ row, onClose }) {
       `${formatMs(m.loadMs)} / ${formatMs(m.sampleMs)} / ${formatMs(m.decodeMs)}`,
     ],
     ["Total time", formatMs(m.totalMs)],
+    [
+      "Per image",
+      `${perImage(m.totalMs)} total · ${perImage(m.sampleMs)} sample · ${perImage(m.decodeMs)} decode`,
+    ],
     ["Peak memory", `${formatPercent(m.peakMemoryPct)} (${formatBytes(m.peakMemoryBytes)})`],
     ["Peak GPU load", formatPercent(m.peakGpuLoadPct)],
     ["Created", formatDate(row.createdAt)],
@@ -185,7 +193,7 @@ function StatsCharts({ rows }) {
     <div className="stats-charts">
       <div className="stats-chart-card">
         <div className="stats-chart-head">
-          <span className="stats-chart-title">Median phase time (s) — group by</span>
+          <span className="stats-chart-title">Median per-image time (s) — group by</span>
           <select value={groupBy} onChange={(event) => setGroupBy(event.target.value)}>
             {Object.entries(GROUP_BY_LABELS).map(([key, label]) => (
               <option key={key} value={key}>
@@ -220,7 +228,7 @@ function StatsCharts({ rows }) {
 
       <div className="stats-chart-card">
         <div className="stats-chart-head">
-          <span className="stats-chart-title">Steps vs total time (s), by quant</span>
+          <span className="stats-chart-title">Steps vs per-image time (s), by quant</span>
         </div>
         {scatterData.length ? (
           <ResponsiveContainer width="100%" height={240}>

--- a/apps/web/src/screens/StatsScreen.test.jsx
+++ b/apps/web/src/screens/StatsScreen.test.jsx
@@ -21,6 +21,7 @@ vi.mock("../hooks/useGenerationMetrics.js", () => ({
           scheduler: "default",
           guidanceScale: 4.0,
           steps: 20,
+          imageCount: 2,
           totalMs: 9400,
           loadMs: 2100,
           sampleMs: 6400,
@@ -93,5 +94,6 @@ describe("StatsScreen", () => {
     expect(container.querySelector(".stats-detail")).not.toBeNull();
     expect(container.textContent).toContain("Run detail");
     expect(container.textContent).toContain("mlx"); // backend surfaced in detail
+    expect(container.textContent).toContain("Per image"); // per-image breakdown (sc-10426)
   });
 });

--- a/apps/web/src/statsData.js
+++ b/apps/web/src/statsData.js
@@ -18,6 +18,7 @@ export const SORT_ACCESSORS = {
   scheduler: (r) => r.metrics?.scheduler ?? "",
   cfg: (r) => num(r.metrics?.guidanceScale),
   steps: (r) => num(r.metrics?.steps),
+  images: (r) => num(r.metrics?.imageCount),
   load: (r) => num(r.metrics?.loadMs),
   sample: (r) => num(r.metrics?.sampleMs),
   decode: (r) => num(r.metrics?.decodeMs),
@@ -143,9 +144,12 @@ export function groupPhaseTimings(rows, groupKey) {
       groups.set(group, { load: [], sample: [], decode: [], count: 0 });
     }
     const bucket = groups.get(group);
-    push(bucket.load, r.metrics?.loadMs);
-    push(bucket.sample, r.metrics?.sampleMs);
-    push(bucket.decode, r.metrics?.decodeMs);
+    // Amortize per image so batch sizes compare fairly (sc-10426): the timings
+    // are batch totals, so a 4-image job's phases divide by its image count.
+    const per = Math.max(1, Number(r.metrics?.imageCount) || 1);
+    push(bucket.load, Number(r.metrics?.loadMs) / per);
+    push(bucket.sample, Number(r.metrics?.sampleMs) / per);
+    push(bucket.decode, Number(r.metrics?.decodeMs) / per);
     bucket.count += 1;
   }
   return [...groups.entries()]
@@ -167,7 +171,8 @@ export function scatterByQuant(rows) {
     if (!isGenerationRow(r)) continue;
     const quant = r.metrics?.quantLabel ?? "unknown";
     const steps = Number(r.metrics?.steps);
-    const total = Number(r.metrics?.totalMs);
+    const per = Math.max(1, Number(r.metrics?.imageCount) || 1);
+    const total = Number(r.metrics?.totalMs) / per; // per-image (sc-10426)
     if (!Number.isFinite(steps) || !Number.isFinite(total)) continue;
     if (!byQuant.has(quant)) byQuant.set(quant, []);
     byQuant.get(quant).push({ steps, total: msToSeconds(total) });

--- a/apps/web/src/statsData.test.js
+++ b/apps/web/src/statsData.test.js
@@ -141,6 +141,37 @@ describe("scatterByQuant", () => {
   });
 });
 
+describe("per-image normalization (sc-10426)", () => {
+  it("divides phase timings by imageCount in groupPhaseTimings", () => {
+    const rows = [
+      row("m1", "image_generate", "completed", "2026-07-05T10:00:00Z", {
+        quantLabel: "q8", loadMs: 2000, sampleMs: 8000, decodeMs: 4000, totalMs: 14000,
+        imageCount: 4, steps: 20,
+      }),
+    ];
+    const [g] = groupPhaseTimings(rows, "quant");
+    expect(g.load).toBe(0.5); // 2000/4 = 500ms
+    expect(g.sample).toBe(2); // 8000/4 = 2000ms
+    expect(g.decode).toBe(1); // 4000/4 = 1000ms
+  });
+  it("divides total by imageCount in scatterByQuant", () => {
+    const rows = [
+      row("m1", "image_generate", "completed", "2026-07-05T10:00:00Z", {
+        quantLabel: "q8", totalMs: 14000, steps: 20, imageCount: 4,
+      }),
+    ];
+    expect(scatterByQuant(rows)[0].points[0].total).toBe(3.5); // 14000/4
+  });
+  it("treats a missing imageCount as 1 (no division)", () => {
+    const rows = [
+      row("m1", "image_generate", "completed", "2026-07-05T10:00:00Z", {
+        quantLabel: "q8", sampleMs: 6000, totalMs: 9000, steps: 20,
+      }),
+    ];
+    expect(groupPhaseTimings(rows, "quant")[0].sample).toBe(6);
+  });
+});
+
 describe("computeKpis", () => {
   it("counts runs, medians, and the fastest quant tier", () => {
     const kpis = computeKpis(ROWS);

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -943,6 +943,12 @@ pub struct GenerationMetrics {
     pub scheduler_shift: Option<ContractNumber>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub steps: Option<u32>,
+    /// Number of images this job produced (a batch of N). The phase timings
+    /// below are batch totals — `sampleMs`/`decodeMs` sum across all N images
+    /// (`loadMs` is one-time) — so a fair per-image comparison divides them by
+    /// this count (epic 10402, sc-10426). Video = 1.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_count: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub guidance_scale: Option<ContractNumber>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -432,6 +432,7 @@ impl JobsStore {
               scheduler text,
               scheduler_shift real,
               steps integer,
+              image_count integer,
               guidance_scale real,
               true_cfg_scale real,
               guidance_method text,
@@ -458,6 +459,9 @@ impl JobsStore {
               on generation_metrics(quant_label);
             ",
         )?;
+        // Batch size per job (epic 10402, sc-10426) — added after the table shipped,
+        // so back-fill the column on existing generation_metrics tables.
+        ensure_column(&transaction, "generation_metrics", "image_count", "integer")?;
         transaction.commit()?;
         Ok(())
     }
@@ -713,10 +717,10 @@ impl JobsStore {
                 guidance_method, use_pid, pid_target, width, height, seed,
                 loras_json, load_ms, sample_ms, decode_ms, total_ms,
                 peak_memory_bytes, peak_memory_pct, peak_gpu_load_pct, backend,
-                updated_at
+                image_count, updated_at
             ) values (
                 ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
-                ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26
+                ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27
             )
             on conflict(job_id) do update set
                 model = coalesce(excluded.model, generation_metrics.model),
@@ -743,6 +747,7 @@ impl JobsStore {
                 peak_memory_pct = coalesce(excluded.peak_memory_pct, generation_metrics.peak_memory_pct),
                 peak_gpu_load_pct = coalesce(excluded.peak_gpu_load_pct, generation_metrics.peak_gpu_load_pct),
                 backend = coalesce(excluded.backend, generation_metrics.backend),
+                image_count = coalesce(excluded.image_count, generation_metrics.image_count),
                 updated_at = excluded.updated_at
             ",
             params![
@@ -771,6 +776,7 @@ impl JobsStore {
                 metrics.peak_memory_pct.as_ref().and_then(Number::as_f64),
                 metrics.peak_gpu_load_pct.as_ref().and_then(Number::as_f64),
                 metrics.backend,
+                metrics.image_count,
                 now,
             ],
         )?;
@@ -2112,6 +2118,7 @@ fn row_to_generation_metrics(row: &Row<'_>) -> rusqlite::Result<GenerationMetric
         scheduler: row.get("scheduler")?,
         scheduler_shift: scheduler_shift.map(number_from_f64),
         steps: row.get("steps")?,
+        image_count: row.get("image_count")?,
         guidance_scale: guidance_scale.map(number_from_f64),
         true_cfg_scale: true_cfg_scale.map(number_from_f64),
         guidance_method: row.get("guidance_method")?,

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -71,6 +71,7 @@ fn generation_metrics_upsert_get_list_and_merge() {
         sampler: Some("euler".to_owned()),
         scheduler: Some("karras".to_owned()),
         steps: Some(20),
+        image_count: Some(4),
         guidance_scale: serde_json::Number::from_f64(4.0),
         use_pid: Some(false),
         width: Some(1024),
@@ -98,6 +99,7 @@ fn generation_metrics_upsert_get_list_and_merge() {
     assert_eq!(read.model.as_deref(), Some("qwen_image"));
     assert_eq!(read.quant_label.as_deref(), Some("q8"));
     assert_eq!(read.steps, Some(20));
+    assert_eq!(read.image_count, Some(4));
     assert_eq!(read.use_pid, Some(false));
     assert_eq!(read.seed, Some(42));
     assert_eq!(read.loras.as_deref(), Some(&["style-a".to_owned()][..]));

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1907,8 +1907,9 @@ mod metrics_settings_tests {
             "width": 1024, "height": 1024, "seed": 42
         }));
         let metrics =
-            image_settings_metrics(&req, Some(20), Some(4.0), Some("q8".to_owned()), Some(8));
+            image_settings_metrics(&req, Some(20), Some(4.0), Some("q8".to_owned()), Some(8), 4);
         assert_eq!(metrics.model.as_deref(), Some("qwen_image"));
+        assert_eq!(metrics.image_count, Some(4));
         assert_eq!(metrics.quant_label.as_deref(), Some("q8"));
         assert_eq!(metrics.quant_bits, Some(8));
         // A default run is not blank — sampler/scheduler/method carry the effective default.
@@ -1937,7 +1938,7 @@ mod metrics_settings_tests {
                 "usePid": true, "pidTarget": "2k", "guidanceMethod": "cfgpp"
             }
         }));
-        let metrics = image_settings_metrics(&req, Some(30), None, Some("bf16".to_owned()), None);
+        let metrics = image_settings_metrics(&req, Some(30), None, Some("bf16".to_owned()), None, 1);
         assert_eq!(metrics.sampler.as_deref(), Some("dpmpp_2m"));
         assert_eq!(metrics.scheduler.as_deref(), Some("karras"));
         assert_eq!(
@@ -3900,6 +3901,7 @@ fn image_settings_metrics(
     effective_guidance: Option<f32>,
     quant_label: Option<String>,
     quant_bits: Option<i64>,
+    image_count: u32,
 ) -> GenerationMetrics {
     let adv = &request.advanced;
     let string_or = |key: &str, default: &str| -> Option<String> {
@@ -3924,6 +3926,7 @@ fn image_settings_metrics(
         scheduler: string_or("scheduler", "default"),
         scheduler_shift: number_field("schedulerShift"),
         steps: effective_steps,
+        image_count: Some(image_count),
         guidance_scale: effective_guidance
             .map(|scale| scale as f64)
             .and_then(serde_json::Number::from_f64),
@@ -3977,17 +3980,32 @@ fn effective_quant_label(request: &ImageRequest) -> (Option<String>, Option<i64>
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
-fn build_image_metrics(request: &ImageRequest, effective_steps: Option<u32>) -> GenerationMetrics {
+fn build_image_metrics(
+    request: &ImageRequest,
+    effective_steps: Option<u32>,
+    image_count: u32,
+) -> GenerationMetrics {
     let (quant_label, quant_bits) = effective_quant_label(request);
     let guidance = mlx_model(&request.model).and_then(|model| resolve_guidance(request, &model));
-    image_settings_metrics(request, effective_steps, guidance, quant_label, quant_bits)
+    image_settings_metrics(
+        request,
+        effective_steps,
+        guidance,
+        quant_label,
+        quant_bits,
+        image_count,
+    )
 }
 #[cfg(not(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 )))]
-fn build_image_metrics(request: &ImageRequest, effective_steps: Option<u32>) -> GenerationMetrics {
-    image_settings_metrics(request, effective_steps, None, None, None)
+fn build_image_metrics(
+    request: &ImageRequest,
+    effective_steps: Option<u32>,
+    image_count: u32,
+) -> GenerationMetrics {
+    image_settings_metrics(request, effective_steps, None, None, None, image_count)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -4242,7 +4260,7 @@ async fn consume_gen_events(
     // Post the effective-settings + per-phase timing block (epic 10402,
     // sc-10405/sc-10406). Best-effort; coalesce-merges with the S2 hardware block
     // (which owns totalMs/backend/peaks) server-side.
-    let mut metrics = build_image_metrics(&plan.request, effective_steps);
+    let mut metrics = build_image_metrics(&plan.request, effective_steps, total as u32);
     if let Some(phase) = phase_timer.into_metrics(Instant::now()) {
         metrics.load_ms = phase.load_ms;
         metrics.sample_ms = phase.sample_ms;

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -4229,6 +4229,7 @@ async fn generate_video(
         .and_then(|value| value.as_str())
         .map(str::to_owned);
     metrics.steps = video_effective_steps;
+    metrics.image_count = Some(1); // one video output per job (sc-10426)
     crate::job_metrics::post_generation_metrics(api, &job.id, &metrics).await;
     result
 }


### PR DESCRIPTION
## Summary

Follow-up to epic 10402 (Michael's on-device feedback): a `generation_metrics` row is per **job**, but a job can produce N images — so `totalMs`/`sampleMs`/`decodeMs` were **batch sums**, making a 4-image job not comparable to a 1-image job (which defeats the comparison charts). This records the batch size and normalizes the comparison **per image**.

Peak memory is unchanged — images generate serially, so it's already a per-image peak.

## Changes

**Backend**
- Add `imageCount` to `GenerationMetrics` + the `generation_metrics` table (new column + `ensure_column` migration so existing DBs back-fill). Populated from the batch size in `consume_gen_events` (image lane); video = 1.

**Web (Stats screen)**
- New `imgs` column + **Images** and **Per image** rows in the run-detail panel (per-image total/sample/decode).
- Charts normalize **per image**: the median phase-time bars and the steps-vs-time scatter divide by `imageCount` (a missing count = 1), so different batch sizes line up. Labels updated ("Median per-image time", "Steps vs per-image time").

## Verification

- **Live 4-image MLX generation**: `imageCount=4`; per-image sample/decode/total = batch totals ÷ 4 (285 / 753 / 1749 ms). GPU load + peak memory still captured.
- Core + worker tests pass (incl. updated round-trip + settings tests); **17 web tests** (added per-image normalization + detail assertions); fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)