### PR TITLE
feat(web): Page-Frame design standard — Phase 1 foundations (sc-10435, sc-10436)

### DIFF
--- a/apps/web/src/components/AdvancedSection.jsx
+++ b/apps/web/src/components/AdvancedSection.jsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { Icon } from "./Icons.jsx";
+
+// AdvancedSection — a bordered, collapsible section that expands IN PLACE below
+// the work-panel (never inside it), so the Purpose zone stays a fixed height
+// no matter how many optional knobs a screen has (Page-Frame standard, direction
+// 1b, epic sc-10433). Controlled via `open` / `onToggle`; presentational only.
+// `actions` (e.g. "Reset to model defaults") sit to the left of the caret and
+// keep their own click handlers.
+export function AdvancedSection({
+  open,
+  onToggle,
+  label = "Advanced",
+  hint,
+  actions,
+  className,
+  children,
+}) {
+  const rootClass = ["advanced-section", open ? "open" : "", className].filter(Boolean).join(" ");
+  return (
+    <section className={rootClass}>
+      <div className="advanced-section-head">
+        <button
+          aria-expanded={Boolean(open)}
+          className="advanced-section-toggle"
+          onClick={onToggle}
+          type="button"
+        >
+          <span className="eyebrow advanced-section-label">{label}</span>
+          {hint ? <span className="advanced-section-hint">{hint}</span> : null}
+        </button>
+        {actions ? <div className="advanced-section-actions">{actions}</div> : null}
+        <button
+          aria-expanded={Boolean(open)}
+          aria-label={open ? "Collapse advanced" : "Expand advanced"}
+          className="advanced-section-caret-btn"
+          onClick={onToggle}
+          type="button"
+        >
+          <Icon.ChevDown className={open ? "advanced-section-caret open" : "advanced-section-caret"} />
+        </button>
+      </div>
+      {open ? <div className="advanced-section-body">{children}</div> : null}
+    </section>
+  );
+}

--- a/apps/web/src/components/AdvancedSection.test.jsx
+++ b/apps/web/src/components/AdvancedSection.test.jsx
@@ -1,0 +1,77 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AdvancedSection } from "./AdvancedSection.jsx";
+
+// AdvancedSection expands in place below the work-panel (sc-10436). Proves the AC:
+// the body only renders when open, the caret/label toggle calls onToggle, and
+// `actions` render alongside their own click handler.
+
+let container;
+let root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function render(ui) {
+  act(() => root.render(ui));
+}
+
+describe("AdvancedSection (sc-10436)", () => {
+  it("hides the body when collapsed and shows it when open", () => {
+    render(
+      <AdvancedSection open={false} onToggle={() => {}}>
+        <div>knobs</div>
+      </AdvancedSection>,
+    );
+    expect(container.querySelector(".advanced-section-body")).toBeNull();
+    expect(container.querySelector(".advanced-section.open")).toBeNull();
+
+    render(
+      <AdvancedSection open onToggle={() => {}}>
+        <div>knobs</div>
+      </AdvancedSection>,
+    );
+    expect(container.querySelector(".advanced-section-body").textContent).toContain("knobs");
+    expect(container.querySelector(".advanced-section.open")).toBeTruthy();
+  });
+
+  it("calls onToggle when the header toggle is clicked", () => {
+    let toggles = 0;
+    render(
+      <AdvancedSection open={false} onToggle={() => (toggles += 1)}>
+        <div>knobs</div>
+      </AdvancedSection>,
+    );
+    act(() => container.querySelector(".advanced-section-toggle").click());
+    act(() => container.querySelector(".advanced-section-caret-btn").click());
+    expect(toggles).toBe(2);
+  });
+
+  it("renders actions with their own handler", () => {
+    let reset = 0;
+    render(
+      <AdvancedSection
+        open
+        onToggle={() => {}}
+        actions={
+          <button type="button" className="reset-defaults" onClick={() => (reset += 1)}>
+            Reset
+          </button>
+        }
+      >
+        <div>knobs</div>
+      </AdvancedSection>,
+    );
+    act(() => container.querySelector(".reset-defaults").click());
+    expect(reset).toBe(1);
+  });
+});

--- a/apps/web/src/components/WorkPanel.jsx
+++ b/apps/web/src/components/WorkPanel.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+// WorkPanel — the one elevated card per page (Page-Frame standard, direction 1b,
+// epic sc-10433). It holds a screen's Purpose zone: its primary controls + tabs.
+// Presentational only — no state. A 3px accent top-rule sits across the top.
+// When `eyebrow` / `hint` / `actions` are omitted the children render directly
+// (so screens that lead with mode-tabs can skip the head).
+export function WorkPanel({ eyebrow, hint, actions, className, children, ...rest }) {
+  const hasHead = eyebrow || hint || actions;
+  return (
+    <div className={className ? `work-panel ${className}` : "work-panel"} {...rest}>
+      <span className="work-panel-rule" aria-hidden="true" />
+      {hasHead ? (
+        <div className="work-panel-head">
+          <div className="work-panel-head-text">
+            {eyebrow ? <p className="eyebrow work-panel-eyebrow">{eyebrow}</p> : null}
+            {hint ? <p className="work-panel-hint">{hint}</p> : null}
+          </div>
+          {actions ? <div className="work-panel-actions">{actions}</div> : null}
+        </div>
+      ) : null}
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/WorkPanel.test.jsx
+++ b/apps/web/src/components/WorkPanel.test.jsx
@@ -1,0 +1,66 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { WorkPanel } from "./WorkPanel.jsx";
+
+// WorkPanel is the one elevated card per page (Page-Frame standard, sc-10436).
+// Proves the AC: it renders its children, always paints the 3px accent top-rule,
+// and only shows the head when an eyebrow/hint/actions is supplied.
+
+let container;
+let root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function render(ui) {
+  act(() => root.render(ui));
+}
+
+describe("WorkPanel (sc-10436)", () => {
+  it("renders children and the accent top-rule", () => {
+    render(
+      <WorkPanel>
+        <button type="button">Generate</button>
+      </WorkPanel>,
+    );
+    const panel = container.querySelector(".work-panel");
+    expect(panel).toBeTruthy();
+    expect(panel.querySelector(".work-panel-rule")).toBeTruthy();
+    expect(panel.textContent).toContain("Generate");
+  });
+
+  it("shows the head with an accent eyebrow only when provided", () => {
+    render(
+      <WorkPanel eyebrow="Add a job" hint="Queue a prompt to a GPU">
+        <div>body</div>
+      </WorkPanel>,
+    );
+    const eyebrow = container.querySelector(".work-panel-eyebrow");
+    expect(eyebrow.textContent).toBe("Add a job");
+    expect(container.querySelector(".work-panel-hint").textContent).toBe("Queue a prompt to a GPU");
+  });
+
+  it("omits the head when no eyebrow/hint/actions is given", () => {
+    render(
+      <WorkPanel>
+        <div>tabs first</div>
+      </WorkPanel>,
+    );
+    expect(container.querySelector(".work-panel-head")).toBeNull();
+  });
+
+  it("passes through className", () => {
+    render(<WorkPanel className="queue-composer">x</WorkPanel>);
+    const panel = container.querySelector(".work-panel");
+    expect(panel.classList.contains("queue-composer")).toBe(true);
+  });
+});

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1110,6 +1110,136 @@ button:focus-visible {
   min-height: 0;
 }
 
+/* ---------- Page-Frame standard (direction 1b, epic sc-10433) ----------
+   Every migrated screen is: a work-panel (Purpose zone) above bare results
+   (Results zone) on the plain canvas. The topbar (global) owns the page name;
+   no screen repeats it. Replaces the per-page hero + whole-page .main-surface
+   card wrap. */
+.page-frame {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-height: 0;
+}
+
+/* The one elevated card per page. 3px accent top-rule; nothing in the results
+   zone gets a card except an optional detail rail. */
+.work-panel {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-3);
+  padding: var(--pad-panel);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  box-shadow: var(--shadow-md);
+  overflow: hidden;
+}
+
+.work-panel-rule {
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--accent), color-mix(in oklch, var(--accent) 30%, transparent));
+}
+
+.work-panel-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--gap-3);
+}
+
+.work-panel-head-text {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.work-panel-eyebrow {
+  color: var(--accent-strong);
+}
+
+.work-panel-hint {
+  margin: 0;
+  font-size: 12.5px;
+  color: var(--text-muted);
+}
+
+.work-panel-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--gap-2);
+  flex-shrink: 0;
+}
+
+/* Advanced section — expands in place BELOW the work-panel, never inside it. */
+.advanced-section {
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+  overflow: hidden;
+}
+
+.advanced-section-head {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-2);
+  padding: 11px 14px;
+  background: var(--surface-2);
+}
+
+.advanced-section.open .advanced-section-head {
+  border-bottom: 1px solid var(--border);
+}
+
+.advanced-section-toggle {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--gap-2);
+  min-width: 0;
+  text-align: left;
+}
+
+.advanced-section-label {
+  color: var(--accent-strong);
+}
+
+.advanced-section-hint {
+  font-size: 11.5px;
+  color: var(--text-faint);
+}
+
+.advanced-section-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--gap-2);
+}
+
+.advanced-section-caret-btn {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-faint);
+}
+
+.advanced-section-caret {
+  transition: transform var(--t-fast) var(--ease-out);
+}
+
+.advanced-section-caret.open {
+  transform: rotate(180deg);
+}
+
+.advanced-section-body {
+  padding: 14px;
+  display: grid;
+  gap: var(--gap-2);
+}
+
 .section-heading {
   display: grid;
   gap: 4px;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -70,6 +70,7 @@
   --pad-tile: 14px;
   --pad-panel: 20px;
   --row-h: 40px;
+  --control-h: 38px;
 
   /* Motion */
   --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
@@ -225,6 +226,7 @@ textarea,
 select {
   width: 100%;
   min-width: 0;
+  box-sizing: border-box;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--r-sm);
@@ -245,6 +247,40 @@ select:focus {
   outline: none;
   border-color: var(--accent);
   box-shadow: var(--shadow-glow);
+}
+
+/* ---------- One control height (Page-Frame standard, sc-10435) ----------
+   A native <select> sizes itself from OS font + chrome, so it never matches an
+   <input> even with identical padding. Lock text-like inputs + selects to one
+   baseline (--control-h) and strip the OS select chrome, supplying our own
+   caret. Scoped to text-like types on purpose — checkbox / radio / range /
+   color / file keep their own sizing. Multiline textarea opts out (it keeps the
+   base padding + its own min-height and is deliberately absent below). */
+input[type="text"],
+input[type="search"],
+input[type="number"],
+input[type="password"],
+input[type="email"],
+input[type="tel"],
+input[type="url"],
+input:not([type]),
+select {
+  height: var(--control-h);
+  padding: 0 12px;
+  font: 500 13px/1 var(--font-ui);
+}
+
+select {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 30px;
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='12'%20height='12'%20viewBox='0%200%2012%2012'%20fill='none'%20stroke='%236b7280'%20stroke-width='1.5'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M3%204.5%206%207.5%209%204.5'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 11px center;
+}
+
+[data-theme="dark"] select {
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='12'%20height='12'%20viewBox='0%200%2012%2012'%20fill='none'%20stroke='%238b95a1'%20stroke-width='1.5'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M3%204.5%206%207.5%209%204.5'/%3E%3C/svg%3E");
 }
 
 button:focus-visible {


### PR DESCRIPTION
## Phase 1 of epic [sc-10433](https://app.shortcut.com/trefry/epic/10433) — SceneWorks Web: Page-Frame Design Standard (direction 1b)

Applies the design-system handoff as a phased rollout. This first PR lands the **foundations** every screen migration builds on — no screens change yet.

### What's here
- **Control-height fix (sc-10435).** A native `<select>` sizes itself from OS font+chrome, so it never matched an `<input>`. Adds `--control-h: 38px` and locks text-like inputs + selects to one baseline (`box-sizing:border-box`, `appearance:none` + a supplied caret). Scoped to text-like input types — checkbox / radio / range / color / file and multiline `textarea` keep their own sizing.
- **Shared primitives (sc-10436).** `<WorkPanel>` (the one elevated card per page, with the 3px accent top-rule), `<AdvancedSection>` (collapsible, expands *below* the panel), and the `.page-frame` layout class. Presentational only — no new global state. The global topbar already owns the page name via `viewTitles`, so no heavy `<PageFrame>` is needed.

### Verification
- `vite build` ✅ · `eslint` ✅ (new files clean)
- **Full web suite: 105 files / 1371 tests pass** ✅ (incl. 7 new tests for WorkPanel/AdvancedSection)
- Verified in the browser preview against the real worktree stylesheet: text/select/number = 38px with the select caret; checkbox (13px), range (36px), color (27px), textarea (116px) correctly keep their own sizing. Work-panel + advanced-section render correctly in **light and dark** with `[data-accent]` recoloring intact.

### Not in this PR
Screen migrations (Logs, Queue, Assets, Model Manager, studios, Data Sets…) land in later phases per the epic. Dead frame CSS (`.surface-header.hero` + orb, whole-page `.main-surface` wrap) is removed in the final cleanup phase once no screen uses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)