### PR TITLE
feat(web): Page-Frame standard — Phase 2: Logs + Queue (sc-10437, sc-10438)

### DIFF
--- a/apps/web/src/screens/LogsScreen.jsx
+++ b/apps/web/src/screens/LogsScreen.jsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { apiFetch } from "../api.js";
 import { useAppStatic } from "../context/AppContext.js";
 import { isDesktop, tauriInvoke } from "../runtime.js";
+import { WorkPanel } from "../components/WorkPanel.jsx";
 
 // In-app Logs viewer (sc-3452). Shows the current session's activity — most
 // importantly the GPU routing decisions (`gpu_route_decision`) and claim
@@ -162,8 +163,9 @@ export function LogsScreen() {
   }, [entries, paused]);
 
   return (
-    <section className="main-surface logs-screen">
-      <div className="logs-toolbar" role="toolbar" aria-label="Log filters">
+    <section className="page-frame logs-screen">
+      <WorkPanel eyebrow="Filter the stream">
+        <div className="logs-toolbar" role="toolbar" aria-label="Log filters">
         <div className="segmented-control" role="group" aria-label="Source">
           <button
             type="button"
@@ -218,7 +220,8 @@ export function LogsScreen() {
         >
           {paused ? "Paused" : "● Live"}
         </button>
-      </div>
+        </div>
+      </WorkPanel>
 
       {error ? (
         <p className="logs-error" role="alert">

--- a/apps/web/src/screens/QueueScreen.jsx
+++ b/apps/web/src/screens/QueueScreen.jsx
@@ -4,6 +4,7 @@ import { terminalStatuses } from "../constants.js";
 import { GPU_REQUIRED_JOB_TYPES, NON_GPU_JOB_TYPES } from "../jobTypes.js";
 import { useAppContext } from "../context/AppContext.js";
 import { resolveJobResultAssets } from "../jobResultAssets.js";
+import { WorkPanel } from "../components/WorkPanel.jsx";
 
 function formatJobType(type) {
   return String(type ?? "job").replaceAll("_", " ");
@@ -207,12 +208,11 @@ export function QueueScreen() {
   // contexts that may not yet expose it (test harnesses, etc.).
   const gpuWorkers = useMemo(() => workers.filter(isGpuWorker), [workers]);
   return (
-    <section className="main-surface queue-surface">
-      <div className="queue-header">
-        <div className="section-heading">
-          <p className="eyebrow">Jobs and GPUs</p>
-          <h2>Queue</h2>
-        </div>
+    <section className="page-frame queue-surface">
+      <WorkPanel
+        eyebrow="Add a job"
+        hint="Queue a prompt to a GPU — or Auto to route to the first free worker."
+      >
         <form className="job-composer" onSubmit={createJob}>
           <label htmlFor="queue-job-prompt">Prompt</label>
           <input id="queue-job-prompt" onChange={(event) => setJobPrompt(event.target.value)} value={jobPrompt} />
@@ -228,9 +228,8 @@ export function QueueScreen() {
             Add job
           </button>
         </form>
-      </div>
-
-      <div className="queue-tools">
+        <div className="work-panel-divider" />
+        <div className="queue-tools">
         <label htmlFor="project-filter">Project</label>
         <select id="project-filter" onChange={(event) => setProjectFilter(event.target.value)} value={projectFilter}>
           <option value="all">All projects</option>
@@ -240,7 +239,8 @@ export function QueueScreen() {
             </option>
           ))}
         </select>
-      </div>
+        </div>
+      </WorkPanel>
 
       <div className="worker-grid">
         {gpuWorkers.length === 0 ? (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1063,17 +1063,20 @@ button:focus-visible {
 .workspace > .notice,
 .workspace > section.main-surface,
 .workspace > section[class*="-surface"],
-.workspace > section[class*="-layout"] {
+.workspace > section[class*="-layout"],
+.workspace > .page-frame {
   margin: 0 22px;
 }
 
 .workspace > section.main-surface:first-of-type,
-.workspace > section[class*="-surface"]:first-of-type {
+.workspace > section[class*="-surface"]:first-of-type,
+.workspace > .page-frame:first-of-type {
   margin-top: var(--pad-panel);
 }
 
 .workspace > section.main-surface:last-of-type,
-.workspace > section[class*="-surface"]:last-of-type {
+.workspace > section[class*="-surface"]:last-of-type,
+.workspace > .page-frame:last-of-type {
   margin-bottom: 30px;
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1179,6 +1179,13 @@ button:focus-visible {
   flex-shrink: 0;
 }
 
+/* Hairline separator between grouped rows inside a work-panel (e.g. Queue's
+   composer / project filter). Spans the panel content width. */
+.work-panel-divider {
+  height: 1px;
+  background: var(--border);
+}
+
 /* Advanced section — expands in place BELOW the work-panel, never inside it. */
 .advanced-section {
   border: 1px solid var(--border);
@@ -9925,6 +9932,12 @@ details[open] > summary.lora-scope-group-heading::before,
   grid-template-columns: minmax(180px, 1fr) minmax(108px, 140px) auto;
   gap: 8px;
   align-items: end;
+}
+
+/* Share the one control height so the composer row (input · select · button)
+   sits on a single baseline (Page-Frame standard). */
+.job-composer button {
+  min-height: var(--control-h);
 }
 
 .job-composer label {


### PR DESCRIPTION
## Phase 2 of epic [sc-10433](https://app.shortcut.com/trefry/epic/10433) — Page-Frame Design Standard (direction 1b)

Migrates the two simplest screens onto the frame from Phase 1 (`<WorkPanel>` + `.page-frame`). **Visual/structural only — no control or behavior removed.**

### Logs ([sc-10437](https://app.shortcut.com/trefry/story/10437))
Logs had **no page header at all** — the biggest consistency gap. It now gets its first Purpose zone: the source/level segmented filters, search, and ● Live toggle live in a `<WorkPanel>` ("Filter the stream"); the log stream sits flush on the canvas below (routing events keep their accent highlight, warn/error chips keep their tint). Drops the whole-page `.main-surface` wrap. 2s live poll + client-side search unchanged. Also registers `.page-frame` in the `.workspace` child-margin rules (first consumer) so migrated screens keep the same 22px insets.

### Queue ([sc-10438](https://app.shortcut.com/trefry/story/10438))
Replaces the bespoke header (eyebrow + in-screen "Queue" h2 + inline composer) with the frame — the topbar already names the page, so the duplicate h2 is gone. The job composer (prompt · GPU select · Add job) and the project filter now sit in one `<WorkPanel>` ("Add a job") split by a hairline divider; GPU worker cards + the job list render flush on the canvas. Composer row shares the `--control-h` baseline. All handlers unchanged.

### Verification
- `vite build` ✅ · `eslint` ✅ · **full web suite 105 files / 1371 tests** ✅ (LogsScreen's 10 tests render the real component with the new structure). Queue has no dedicated test; covered by build + the shared WorkerProgressCard/context tests + preview.
- Rendered both screens against the live worktree stylesheet in dark theme (screenshots on the stories). The app's real Logs/Queue components are gated behind the first-run "create workspace" screen when the API is offline, so the visual was verified via the real class structure + the passing component tests.

### Constraint honored
No control removed or hidden — every filter/composer/field is retained, just reorganized into the frame (per the epic's preserve-all-controls constraint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)