### PR TITLE
feat(web): Page-Frame standard — Phase 3: Assets + library-family (sc-10439..44)

### DIFF
--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -11,6 +11,7 @@ import {
   editableLora,
 } from "./characterPanels.jsx";
 import { CompactSelector } from "../components/CompactSelector.jsx";
+import { WorkPanel } from "../components/WorkPanel.jsx";
 import { assetMatchesCharacter } from "../characterMembership.js";
 import { extractFamilies } from "../presetUtils.js";
 import { loadStudioSettings, useStudioSettingsWriter } from "../hooks/useStudioSettings.js";
@@ -492,12 +493,8 @@ export function CharacterStudio() {
   }
 
   return (
-    <section className="main-surface character-studio">
-      <div className="surface-header">
-        <div className="section-heading">
-          <p className="eyebrow">Character Studio</p>
-          <h2>{activeProject ? activeProject.name : "Create a project"}</h2>
-        </div>
+    <section className="page-frame character-studio">
+      <WorkPanel>
         <CompactSelector
           createLabel="New character"
           disabled={!activeProject}
@@ -512,7 +509,7 @@ export function CharacterStudio() {
           placeholder="Select a character"
           selectedId={selectedCharacter?.id ?? ""}
         />
-      </div>
+      </WorkPanel>
 
       <div className="character-layout">
         {!selectedCharacter ? (

--- a/apps/web/src/screens/KeyPointLibraryScreen.jsx
+++ b/apps/web/src/screens/KeyPointLibraryScreen.jsx
@@ -5,6 +5,7 @@ import { terminalStatuses } from "../jobTypes.js";
 import { KpsOverlay } from "../components/KpsOverlay.jsx";
 import { DatasetAddDialog } from "../components/DatasetAddDialog.jsx";
 import { assetUrl } from "../components/assetMedia.jsx";
+import { WorkPanel } from "../components/WorkPanel.jsx";
 import {
   BUILTIN_DEFAULT_COLLECTION_ID,
   GLOBAL_KEYPOINTS_PROJECT_ID,
@@ -584,16 +585,8 @@ export function KeyPointLibraryScreen() {
   );
 
   return (
-    <section className="main-surface library-surface keypoint-library-surface">
-      <div className="surface-header hero">
-        <div className="section-heading">
-          <p className="eyebrow">Key Point Library</p>
-          <h2>Face angles</h2>
-          <p className="hero-blurb">
-            Capture face-angle framing presets from photos and compose them into angle-set collections. The default
-            collection drives Character Studio’s “Generate angle set”.
-          </p>
-        </div>
+    <section className="page-frame library-surface keypoint-library-surface">
+      <WorkPanel>
         <div className="segmented-control" role="tablist" aria-label="Key Point Library sections">
           {TABS.map(([id, label]) => (
             <button
@@ -610,7 +603,7 @@ export function KeyPointLibraryScreen() {
             </button>
           ))}
         </div>
-      </div>
+      </WorkPanel>
 
       <KeypointLibraryPanel
         hidden={activeTab !== "library"}

--- a/apps/web/src/screens/LibraryScreen.jsx
+++ b/apps/web/src/screens/LibraryScreen.jsx
@@ -4,6 +4,7 @@ import { foldUpscaledAssetVariants } from "../assetVariants.js";
 import { AssetDetail, AssetGrid, emptyTrash } from "../components/assetPanels.jsx";
 import { isLibraryAsset, terminalStatuses } from "../constants.js";
 import { useAppContext } from "../context/AppContext.js";
+import { WorkPanel } from "../components/WorkPanel.jsx";
 
 export function LibraryScreen() {
   const {
@@ -117,15 +118,8 @@ export function LibraryScreen() {
   const availableTags = [...new Set(libraryAssets.flatMap((asset) => (Array.isArray(asset.tags) ? asset.tags : [])))].sort();
 
   return (
-    <section className="main-surface library-surface">
-      <div className="surface-header hero">
-        <div className="section-heading">
-          <p className="eyebrow">Project assets</p>
-          <h2>Assets</h2>
-          <p className="hero-blurb">
-            Browse stills and clips across {activeProject?.name ?? "your project"} — pick a recent render to drop into the editor, or send one back to a studio for another pass.
-          </p>
-        </div>
+    <section className="page-frame library-surface">
+      <WorkPanel>
         <div className="toolbar">
           <label className="file-upload-button">
             <input accept="image/*,video/*" disabled={isImporting} onChange={handleImport} type="file" />
@@ -169,25 +163,25 @@ export function LibraryScreen() {
             </button>
           ) : null}
         </div>
-        <div className="hero-stats">
-          <div className="hero-stat">
-            <span className="hero-stat-label">Project</span>
-            <span className="hero-stat-value">{activeProject?.name ?? "—"}</span>
+        <div className="stat-strip">
+          <div className="stat-chip">
+            <span className="stat-chip-label">Project</span>
+            <span className="stat-chip-value">{activeProject?.name ?? "—"}</span>
           </div>
-          <div className="hero-stat">
-            <span className="hero-stat-label">Assets</span>
-            <span className="hero-stat-value">{libraryAssets.length} total</span>
+          <div className="stat-chip">
+            <span className="stat-chip-label">Assets</span>
+            <span className="stat-chip-value">{libraryAssets.length} total</span>
           </div>
-          <div className="hero-stat">
-            <span className="hero-stat-label">Images</span>
-            <span className="hero-stat-value">{imageCount}</span>
+          <div className="stat-chip">
+            <span className="stat-chip-label">Images</span>
+            <span className="stat-chip-value">{imageCount}</span>
           </div>
-          <div className="hero-stat">
-            <span className="hero-stat-label">Clips</span>
-            <span className="hero-stat-value">{videoCount + uploadCount}</span>
+          <div className="stat-chip">
+            <span className="stat-chip-label">Clips</span>
+            <span className="stat-chip-value">{videoCount + uploadCount}</span>
           </div>
         </div>
-      </div>
+      </WorkPanel>
 
       <AssetSelectionBar batch={batch} showDiscard={assetMode === "assets"} />
 

--- a/apps/web/src/screens/PoseLibraryScreen.jsx
+++ b/apps/web/src/screens/PoseLibraryScreen.jsx
@@ -7,6 +7,7 @@ import { useAppContext, useAppStatic } from "../context/AppContext.js";
 import { DEFAULT_MAC_CAPABILITIES, macFeatureBlock } from "../macGating.js";
 import { terminalStatuses } from "../jobTypes.js";
 import { GLOBAL_POSES_PROJECT_ID } from "../poseLibrary.js";
+import { WorkPanel } from "../components/WorkPanel.jsx";
 
 // The Pose Library screen (epic 2282). Two tabs:
 //  - "Poses": manage the global pose store — user-created type:"pose" assets in the
@@ -526,16 +527,8 @@ export function PoseLibraryScreen() {
   }, [visible]);
 
   return (
-    <section className="main-surface library-surface pose-library-surface">
-      <div className="surface-header hero">
-        <div className="section-heading">
-          <p className="eyebrow">Pose Library</p>
-          <h2>Poses</h2>
-          <p className="hero-blurb">
-            Manage your whole-body pose skeletons — discard, restore, tag, and categorize. Create new poses from photos
-            in the Create tab.
-          </p>
-        </div>
+    <section className="page-frame library-surface pose-library-surface">
+      <WorkPanel>
         <div className="segmented-control" role="tablist" aria-label="Pose Library sections">
           {TABS.map(([id, label]) => {
             const macBlock = id === "create" ? macPoseDetectBlock : null;
@@ -557,7 +550,7 @@ export function PoseLibraryScreen() {
             );
           })}
         </div>
-      </div>
+      </WorkPanel>
 
       <div
         aria-labelledby="pose-library-tab-poses"

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { LoraKeywordSummary } from "../components/LoraKeywordSummary.jsx";
 import { Icon } from "../components/Icons.jsx";
+import { WorkPanel } from "../components/WorkPanel.jsx";
 import {
   MAX_PRESET_LORAS,
   compactModeList,
@@ -376,12 +377,8 @@ export function PresetManagerScreen() {
   }
 
   return (
-    <section className="main-surface preset-manager">
-      <div className="surface-header">
-        <div className="section-heading">
-          <p className="eyebrow">Preset Manager</p>
-          <h2>{activeProject ? activeProject.name : "Global presets"}</h2>
-        </div>
+    <section className="page-frame preset-manager">
+      <WorkPanel eyebrow="Preset Manager">
         <div className="toolbar">
           <button onClick={startNewPreset} type="button">
             New Preset
@@ -393,7 +390,7 @@ export function PresetManagerScreen() {
             Archive
           </button>
         </div>
-      </div>
+      </WorkPanel>
 
       <div className={creating ? "preset-layout creating" : "preset-layout"}>
         <section className="preset-list" aria-label="Presets">

--- a/apps/web/src/screens/StatsScreen.jsx
+++ b/apps/web/src/screens/StatsScreen.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from "react";
+import { WorkPanel } from "../components/WorkPanel.jsx";
 import {
   Bar,
   BarChart,
@@ -294,38 +295,28 @@ export function StatsScreen() {
   };
 
   return (
-    <section className="main-surface stats-surface">
-      <div className="surface-header hero">
-        <div className="section-heading">
-          <p className="eyebrow">System</p>
-          <h2>Generation stats</h2>
-          <p className="hero-blurb">
-            Compare runs by model, quant, and settings — with per-phase timing, peak memory, and GPU load
-            for every job.
-          </p>
+    <section className="page-frame stats-surface">
+      <WorkPanel>
+        <div className="stat-strip">
+          <div className="stat-chip">
+            <span className="stat-chip-label">Runs</span>
+            <span className="stat-chip-value">{kpis.runs}</span>
+          </div>
+          <div className="stat-chip">
+            <span className="stat-chip-label">Median total</span>
+            <span className="stat-chip-value">{formatMs(kpis.medianTotalMs)}</span>
+          </div>
+          <div className="stat-chip">
+            <span className="stat-chip-label">Median peak mem</span>
+            <span className="stat-chip-value">{formatPercent(kpis.medianPeakMemPct)}</span>
+          </div>
+          <div className="stat-chip">
+            <span className="stat-chip-label">Fastest quant</span>
+            <span className="stat-chip-value">{kpis.fastestQuant ?? "—"}</span>
+          </div>
         </div>
-      </div>
 
-      <div className="hero-stats">
-        <div className="hero-stat">
-          <span className="hero-stat-label">Runs</span>
-          <span className="hero-stat-value">{kpis.runs}</span>
-        </div>
-        <div className="hero-stat">
-          <span className="hero-stat-label">Median total</span>
-          <span className="hero-stat-value">{formatMs(kpis.medianTotalMs)}</span>
-        </div>
-        <div className="hero-stat">
-          <span className="hero-stat-label">Median peak mem</span>
-          <span className="hero-stat-value">{formatPercent(kpis.medianPeakMemPct)}</span>
-        </div>
-        <div className="hero-stat">
-          <span className="hero-stat-label">Fastest quant</span>
-          <span className="hero-stat-value">{kpis.fastestQuant ?? "—"}</span>
-        </div>
-      </div>
-
-      <div className="stats-filters">
+        <div className="stats-filters">
         <FilterSelect
           label="Job type"
           value={filters.type}
@@ -358,7 +349,8 @@ export function StatsScreen() {
         <button type="button" className="stats-refresh" onClick={refresh} disabled={loading}>
           {loading ? "Loading…" : "Refresh"}
         </button>
-      </div>
+        </div>
+      </WorkPanel>
 
       {error ? <p className="stats-error">{error}</p> : null}
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1186,6 +1186,42 @@ button:focus-visible {
   background: var(--border);
 }
 
+/* Compact stat strip — small inset chips for at-a-glance counts inside a
+   work-panel (replaces the old hero-stats row). Reused across library-family
+   screens (Assets, Stats, …). */
+.stat-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap-2);
+}
+
+.stat-chip {
+  display: grid;
+  gap: 1px;
+  padding: 6px 12px;
+  min-width: 96px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+}
+
+.stat-chip-label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.stat-chip-value {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Advanced section — expands in place BELOW the work-panel, never inside it. */
 .advanced-section {
   border: 1px solid var(--border);
@@ -1590,6 +1626,16 @@ label {
   flex-wrap: wrap;
   gap: 10px;
   align-items: center;
+}
+
+/* Filter-toolbar controls size to content (not the base width:100%) so they sit
+   inline in a full-width work-panel instead of each stretching to its own row. */
+.toolbar select,
+.toolbar input[type="search"],
+.toolbar input[type="text"],
+.toolbar input[type="number"] {
+  width: auto;
+  min-width: 140px;
 }
 
 .editor-header,


### PR DESCRIPTION
## Phase 3 of epic [sc-10433](https://app.shortcut.com/trefry/epic/10433) — Page-Frame Design Standard (direction 1b)

Migrates the six library/grid-family screens onto the frame. **Visual/structural only — no control or behavior removed.** Every screen: hero + whole-page `.main-surface` card dropped → purpose in a `<WorkPanel>` → results/detail flush on the canvas. The topbar already names each page, so the in-screen titles/blurbs are gone.

| Story | Screen | Purpose zone | Results |
|---|---|---|---|
| [sc-10439](https://app.shortcut.com/trefry/story/10439) | **Assets** | import + type/tag filters + Rejected + Assets/Trashcan + compact stat-strip | asset grid + detail rail |
| [sc-10440](https://app.shortcut.com/trefry/story/10440) | **Pose Library** | section tablist | pose grids + detail + Create panel |
| [sc-10441](https://app.shortcut.com/trefry/story/10441) | **Key Point Library** | section tablist | library / capture / collections panels |
| [sc-10442](https://app.shortcut.com/trefry/story/10442) | **Character Studio** | character picker | mode-tabs + generation tabpanels (untouched) |
| [sc-10443](https://app.shortcut.com/trefry/story/10443) | **Presets** | New / Duplicate / Archive | preset list + editor |
| [sc-10444](https://app.shortcut.com/trefry/story/10444) | **Generation Stats** | KPI stat-strip + Job/Model/Quant/Status filters | charts + run table |

### Shared additions
- `.stat-strip` / `.stat-chip` — compact inset counts replacing the old `hero-stats` (reused by Assets + Stats).
- Filter-toolbar `select`/`input` constrained to inline-compact widths so they sit on one row in a full-width panel instead of stretching to 100% (caught during preview).

### Constraint honored (preserve-all-controls)
Characters and Presets are **outer-frame swaps only** — the generation tabpanels and the preset editor (and all their fields) are byte-for-byte unchanged. No control removed or hidden on any screen.

### Verification
- `vite build` ✅ · `eslint` ✅ (no errors) · **full web suite 105 files / 1371 tests** ✅. One test (`App.models` — Preset Manager screen presence) asserted the removed in-screen title; kept it green by giving the Presets work-panel a "Preset Manager" eyebrow rather than weakening the test.
- Rendered the migrated frames against the live worktree stylesheet in dark theme (screenshots on the stories). Live screens are gated behind the first-run "create workspace" screen when the API is offline, so verified via real class structure + passing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)