### PR TITLE
chore(dev): reproduce CI 'neither' build locally to catch cfg/dead-code traps (sc-10463)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,35 @@ That expands to `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D
 warnings`, `cargo test`, and `cargo build`. Clippy warnings **fail** the build,
 so keep it clean.
 
+**The "neither" build** — CI's `parity` lane runs the Rust clippy on **Linux with
+default features (no `backend-candle`)**. The worker's generation harness
+(`crates/sceneworks-worker/src/image_jobs/base.rs`) is compiled only on macOS **or** the
+`backend-candle` lane, so anything used *only* by that gated code is dead on this "neither
+backend" build and fails `-D warnings`. Reproduce it locally with:
+
+```bash
+npm run rust:check:neither
+```
+
+On Linux/Windows that's a native clippy — the host already *is* the neither build. On
+macOS it runs the same clippy inside a Linux Docker container, because a native macOS
+clippy always compiles `base.rs` and can never see the trap. It's also wired into the
+optional pre-push hook (installed by `npm run hooks:install`; skip a run with
+`SKIP_NEITHER_CHECK=1` or `git push --no-verify`).
+
+> **The base.rs / candle cfg rule.** Any `sceneworks-worker` item — a `use`, struct, or
+> helper fn — used **only** by `base.rs` or other candle-only code MUST carry the same cfg
+> as `base.rs`, or it's dead code on the neither build:
+>
+> ```rust
+> #[cfg(any(target_os = "macos", all(not(target_os = "macos"), feature = "backend-candle")))]
+> ```
+>
+> `npm run rust:check` on **macOS cannot catch a violation** (there `target_os` is always
+> `macos`, so `base.rs` always compiles) — use `npm run rust:check:neither`, the pre-push
+> hook, or the CI parity lane. This trap has bitten sc-10404 (`PhaseTimer`) and sc-8390
+> (`run_blocking_with_heartbeat`).
+
 **Web** (from the repo root):
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "rust:test": "cargo test",
     "rust:build": "cargo build",
     "rust:check": "npm run rust:fmt && npm run rust:lint && npm run rust:test && npm run rust:build",
+    "rust:check:neither": "node scripts/check-neither-build.mjs",
     "desktop:build": "cargo build -p sceneworks-desktop",
     "desktop:check": "cargo clippy -p sceneworks-desktop --all-targets -- -D warnings",
     "web:build": "npm --prefix apps/web run build",

--- a/scripts/check-neither-build.mjs
+++ b/scripts/check-neither-build.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// sc-10463: reproduce the CI "parity" lane's Rust build locally — Linux with default features and
+// NO `backend-candle` (the "neither backend" config) — so the cfg/dead-code trap that only surfaces
+// there is caught before pushing, not after a full CI round-trip.
+//
+// The trap: `sceneworks-worker`'s generation harness (`src/image_jobs/base.rs` and the code it pulls
+// in) is `include!`d only under
+//     any(target_os = "macos", all(not(target_os = "macos"), feature = "backend-candle"))
+// so on the neither build (`not(macos)` + candle off, which is the default) that whole harness is
+// absent. Anything used *only* by it — a `use`, a struct, a helper fn — is then dead, and
+// `cargo clippy -- -D warnings` fails ("never constructed" / "unused import"). This has bitten
+// sc-10404 (`PhaseTimer`) and sc-8390 (`run_blocking_with_heartbeat`). See CONTRIBUTING.md
+// ("The base.rs / candle cfg rule") for the fix pattern.
+//
+// Reproduction is host-dependent because the gate keys off `target_os`, which a native build cannot
+// change:
+//   * Non-macOS host (Linux, Windows): `target_os != "macos"` already, and candle is off by default,
+//     so the plain default-feature clippy below IS the neither build. Run it natively — no Docker,
+//     no extra toolchain.
+//   * macOS host: `target_os` is pinned to "macos", so a native clippy ALWAYS compiles `base.rs` and
+//     can never see the trap. Run the identical clippy inside a Linux `rust` container instead.
+//
+// Either way the lint is `cargo clippy -p sceneworks-worker -p sceneworks-rust-api --all-targets --
+// -D warnings` — the parity lane's clippy, scoped to the two crates that carry the gated code
+// (`sceneworks-worker` holds the whole trap class; `sceneworks-rust-api` is included as belt-and-
+// suspenders since it links the same contract types).
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// The parity lane's clippy, scoped to the crates that carry the macOS/candle-gated code.
+const CLIPPY_ARGS = [
+  "clippy",
+  "-p",
+  "sceneworks-worker",
+  "-p",
+  "sceneworks-rust-api",
+  "--all-targets",
+  "--",
+  "-D",
+  "warnings",
+];
+
+// Official Debian-based Rust image (buildpack-deps lineage → ships gcc/pkg-config/libssl the native
+// worker deps need). It uses the *minimal* rustup profile, so clippy must be added in-container
+// (CI does the same via `components: clippy`). Overridable for a pinned/mirrored tag.
+const RUST_IMAGE = process.env.SCENEWORKS_NEITHER_IMAGE || "rust:bookworm";
+
+function hasDocker() {
+  const res = spawnSync("docker", ["--version"], { stdio: "ignore" });
+  return !res.error && res.status === 0;
+}
+
+function runNative() {
+  console.log(
+    `[neither] host is ${process.platform} (not macOS): the default-feature build already excludes\n` +
+      "          base.rs, so this native clippy IS the parity 'neither' build.\n" +
+      `          cargo ${CLIPPY_ARGS.join(" ")}\n`,
+  );
+  const res = spawnSync("cargo", CLIPPY_ARGS, { stdio: "inherit", cwd: repoRoot });
+  if (res.error) {
+    if (res.error.code === "ENOENT") {
+      console.error("[neither] cargo not found on PATH. Install Rust (https://rustup.rs) and retry.");
+      return 1;
+    }
+    throw res.error;
+  }
+  return res.status ?? 1;
+}
+
+function runDocker() {
+  if (!hasDocker()) {
+    console.error(
+      "[neither] macOS host: a native clippy always compiles the macOS-only base.rs, so it CANNOT\n" +
+        "          reproduce the Linux 'neither' build. This check needs Docker here.\n" +
+        "          • Install Docker Desktop, or\n" +
+        "          • run this on a Linux or Windows box, where `npm run rust:check` already is the\n" +
+        "            neither build.\n" +
+        "          (SCENEWORKS_NEITHER_IMAGE overrides the container image.)",
+    );
+    return 1;
+  }
+  // Named volumes prepopulate from the image on first use and then cache the toolchain, crate
+  // registry, and target dir across runs, so only the first invocation is cold.
+  const dockerArgs = [
+    "run",
+    "--rm",
+    "-v",
+    `${repoRoot}:/workspace`,
+    "-w",
+    "/workspace",
+    "-v",
+    "sceneworks-neither-rustup:/usr/local/rustup",
+    "-v",
+    "sceneworks-neither-registry:/usr/local/cargo/registry",
+    "-v",
+    "sceneworks-neither-target:/workspace/target",
+    RUST_IMAGE,
+    "bash",
+    "-euc",
+    // rust-toolchain.toml pins `stable`; add clippy to it (no-op if already present) then lint.
+    `rustup component add clippy && exec cargo ${CLIPPY_ARGS.join(" ")}`,
+  ];
+  console.log(
+    `[neither] macOS host: reproducing the Linux 'neither' build in ${RUST_IMAGE}.\n` +
+      `          docker ${dockerArgs.join(" ")}\n`,
+  );
+  const res = spawnSync("docker", dockerArgs, { stdio: "inherit", cwd: repoRoot });
+  if (res.error) throw res.error;
+  return res.status ?? 1;
+}
+
+if (process.argv.includes("--help") || process.argv.includes("-h")) {
+  console.log(
+    "Reproduce the CI 'parity' (Linux, no backend-candle) Rust clippy locally.\n\n" +
+      "  node scripts/check-neither-build.mjs        # or: npm run rust:check:neither\n\n" +
+      "Non-macOS hosts run it natively; macOS hosts run it in a Linux Docker container.\n" +
+      "Env: SCENEWORKS_NEITHER_IMAGE overrides the container image (default rust:bookworm).",
+  );
+  process.exit(0);
+}
+
+process.exit(process.platform === "darwin" ? runDocker() : runNative());

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,0 +1,55 @@
+#!/bin/sh
+# sc-10463: before pushing Rust changes, run the "neither" build (Linux, no backend-candle) locally
+# so the cfg/dead-code trap that only surfaces in CI's parity lane is caught here instead of after a
+# full CI round-trip. Only runs when the pushed commits touch Rust; skip with SKIP_NEITHER_CHECK=1 or
+# `git push --no-verify`. See CONTRIBUTING.md ("The base.rs / candle cfg rule").
+set -eu
+
+if [ "${SKIP_NEITHER_CHECK:-0}" = "1" ]; then
+  exit 0
+fi
+
+zero="0000000000000000000000000000000000000000"
+rust_changed=0
+
+# stdin: "<local ref> <local sha> <remote ref> <remote sha>" per ref being pushed.
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+  [ "$local_sha" = "$zero" ] && continue # branch deletion — nothing to lint.
+
+  if [ "$remote_sha" = "$zero" ]; then
+    # New remote branch: diff from the parent of the oldest not-yet-pushed commit.
+    oldest="$(git rev-list "$local_sha" --not --remotes 2>/dev/null | tail -n 1)"
+    if [ -n "$oldest" ]; then
+      base="$(git rev-parse "$oldest^" 2>/dev/null || git hash-object -t tree /dev/null)"
+      diff_range="$base..$local_sha"
+    else
+      diff_range="$local_sha"
+    fi
+  else
+    diff_range="$remote_sha..$local_sha"
+  fi
+
+  if git diff --name-only "$diff_range" 2>/dev/null \
+    | grep -Eq '(^|/)([^/]+\.rs|Cargo\.(toml|lock)|rustfmt\.toml)$|^\.cargo/.*\.toml$'; then
+    rust_changed=1
+  fi
+done
+
+[ "$rust_changed" = "0" ] && exit 0
+
+echo "Running the 'neither' build (Linux, no backend-candle) for pushed Rust changes..."
+echo "(skip with SKIP_NEITHER_CHECK=1 or 'git push --no-verify')"
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm is required to run the neither-build check. Install Node/npm or add it to PATH."
+  exit 1
+fi
+
+if ! npm run --silent rust:check:neither; then
+  echo
+  echo "The neither build failed: an item used only by base.rs / candle-only code is dead on the"
+  echo "Linux no-candle build. Gate it with the same cfg as base.rs:"
+  echo '  #[cfg(any(target_os = "macos", all(not(target_os = "macos"), feature = "backend-candle")))]'
+  echo "See CONTRIBUTING.md ('The base.rs / candle cfg rule')."
+  exit 1
+fi


### PR DESCRIPTION
## What

Gives developers a single local command that reproduces CI's **parity** lane — the Linux, no-`backend-candle` "neither backend" build — so the cfg/dead-code trap that only surfaces there is caught before pushing.

**The trap:** the worker's generation harness (`crates/sceneworks-worker/src/image_jobs/base.rs`) is `include!`d only under `any(target_os = "macos", all(not(target_os = "macos"), feature = "backend-candle"))`. On the neither build that harness is absent, so anything used **only** by it (a `use`, a struct, a helper) is dead under `clippy -D warnings`. `npm run rust:check` on **macOS can't catch it** (`target_os` is always `macos`, so `base.rs` always compiles), so it only shows up after a full CI round-trip. It bit sc-10404 (`PhaseTimer`) and sc-8390 (`run_blocking_with_heartbeat`).

## Key insight

Reproduction is **host-dependent**, not "Linux-magic": the gate keys off `target_os`, and a native build can't change that.
- **Non-macOS host (Linux, Windows):** `target_os != "macos"` already + candle off by default → the plain default-feature clippy **is** the neither build. Run it natively — no Docker, no cross-target.
- **macOS host:** `target_os` is pinned to `macos` → run the identical clippy in a Linux container.

## Changes

- **`scripts/check-neither-build.mjs`** + **`npm run rust:check:neither`** — native clippy on non-mac; Linux Docker container on mac (adds the `clippy` component the minimal `rust` image omits — caught during validation). Scoped to `sceneworks-worker` + `sceneworks-rust-api` (the crates carrying the gated code; `sceneworks-core`'s macOS cfgs are plain platform paths, not this trap).
- **`scripts/git-hooks/pre-push`** — opt-in (active only after `npm run hooks:install`), runs the check when the pushed commits touch Rust; skip with `SKIP_NEITHER_CHECK=1` or `git push --no-verify`.
- **`CONTRIBUTING.md`** — documents the command and the **base.rs / candle cfg rule**.

## Verification (on the Windows box)

- Clean tree: `npm run rust:check:neither` → **passes** (exit 0, ~16s warm).
- Acceptance test: re-introduced a `PhaseTimer`-style ungated `struct` used only from `base.rs` → shipped command **fails** with `error: struct ` + "` is never constructed`" (exit 101). Reverted; tree clean.
- Validated the macOS Docker path's prerequisites: `rust:bookworm` ships gcc/pkg-config but **not** clippy (minimal profile) → the script adds it, mirroring CI's `components: clippy`.

Chore sc-10463. Relates to sc-10404, sc-8390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)