### PR TITLE
feat(web): Page-Frame standard — Phase 4: Model Manager (sc-10445)

### DIFF
--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
+import { WorkPanel } from "../components/WorkPanel.jsx";
 import { terminalStatuses } from "../constants.js";
 import { hasPresentCredential, loadCredentials, serverToken } from "../credentials.js";
 import {
@@ -1372,7 +1373,9 @@ export function ModelManagerScreen() {
 
   // A model type panel: an accent Recommended band (when any recommended match) over an
   // "All {type} models" grid of the rest. Both filtered by the active search + family.
-  function renderModelTabPanel(type) {
+  // Filter the catalog for a type by the active search + family, split into the
+  // curated Recommended picks (surfaced in the work-panel) and the rest.
+  function modelTabGroups(type) {
     const activeModels = models
       .filter((model) => model.type === type)
       .filter(modelMatchesQuery)
@@ -1382,19 +1385,36 @@ export function ModelManagerScreen() {
     const typeLabel = { image: "image", video: "video", utility: "utility" }[type] ?? type;
     const othersHeading =
       recommended.length > 0 ? `All ${typeLabel} models` : `${typeLabel.charAt(0).toUpperCase()}${typeLabel.slice(1)} models`;
+    return { recommended, others, othersHeading };
+  }
+
+  // Recommended picks, rendered flush inside the work-panel (Page-Frame standard:
+  // curated getting-started content belongs to the action, not floating on the
+  // canvas). No accent-band card here — the work-panel is already the one card.
+  function renderRecommendedPicks(type) {
+    const { recommended } = modelTabGroups(type);
+    if (!recommended.length) {
+      return null;
+    }
+    return (
+      <div className="models-recommended">
+        <div className="models-accent-band-head">
+          <span className="models-accent-dot" aria-hidden="true" />
+          <p className="eyebrow">Recommended</p>
+          <span className="models-accent-band-count">{recommended.length}</span>
+          <span className="models-accent-band-caption">Curated getting-started picks</span>
+        </div>
+        <div className="models-card-grid">{recommended.map((model) => renderModelCard(model))}</div>
+      </div>
+    );
+  }
+
+  // The catalog grid on the canvas: "All {type} models" (the non-recommended
+  // rest). Recommended picks render separately in the work-panel above.
+  function renderModelTabPanel(type) {
+    const { recommended, others, othersHeading } = modelTabGroups(type);
     return (
       <div className="models-tab-panel">
-        {recommended.length ? (
-          <div className="models-accent-band">
-            <div className="models-accent-band-head">
-              <span className="models-accent-dot" aria-hidden="true" />
-              <p className="eyebrow">Recommended</p>
-              <span className="models-accent-band-count">{recommended.length}</span>
-              <span className="models-accent-band-caption">Curated getting-started picks</span>
-            </div>
-            <div className="models-card-grid">{recommended.map((model) => renderModelCard(model))}</div>
-          </div>
-        ) : null}
         {others.length ? (
           <div className="models-section">
             <div className="models-section-heading">
@@ -1448,8 +1468,9 @@ export function ModelManagerScreen() {
   }
 
   return (
-    <section className="main-surface models-surface">
-      <div className="models-tabbar">
+    <section className="page-frame models-surface">
+      <WorkPanel>
+        <div className="models-tabbar">
         <div className="mode-tabs" role="tablist" aria-label="Model type">
           {tabDefs.map(([key, label, count]) => {
             const active = effectiveTab === key;
@@ -1495,7 +1516,9 @@ export function ModelManagerScreen() {
             ))}
           </select>
         </div>
-      </div>
+        </div>
+        {isModelTab ? renderRecommendedPicks(effectiveTab) : null}
+      </WorkPanel>
 
       {deleteMessage.text ? <p className={deleteMessage.tone === "success" ? "inline-success" : "inline-warning"}>{deleteMessage.text}</p> : null}
 

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -587,7 +587,9 @@ describe("ModelManagerScreen type-grouped layout", () => {
         { id: "flux_dev", name: "FLUX.1 [dev]", type: "image", family: "flux", capabilities: ["text_to_image"], installState: "missing" },
       ],
     });
-    const band = container.querySelector(".models-accent-band");
+    // Recommended picks now render flush inside the work-panel (page-frame
+    // standard) as .models-recommended, above the "All models" catalog on canvas.
+    const band = container.querySelector(".models-recommended");
     expect(band).toBeTruthy();
     expect(band.textContent).toContain("Recommended");
     expect(band.querySelectorAll(".model-card").length).toBe(1);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5766,6 +5766,15 @@ details[open] > summary.lora-scope-group-heading::before,
   align-self: flex-start;
 }
 
+/* Recommended picks flush inside the Model Manager work-panel — same header
+   treatment as the accent band, minus the tinted card (the work-panel is already
+   the one card, so no card-in-card). */
+.models-recommended {
+  display: flex;
+  flex-direction: column;
+  gap: 13px;
+}
+
 /* Plain section (All {type} models, Built-In LoRAs, a User family group, a Search group). */
 .models-section {
   display: flex;


### PR DESCRIPTION
## Phase 4 of epic [sc-10433](https://app.shortcut.com/trefry/epic/10433) — Page-Frame Design Standard (direction 1b)

Migrates **Model Manager** ([sc-10445](https://app.shortcut.com/trefry/story/10445)) — the flagship tabbed screen the handoff detailed.

- Drops the whole-page `.main-surface` card.
- The **tab bar** (Image / Video / Utility / LoRAs with counts), the **search** field + **family filter**, and the curated **Recommended** picks now live in one `<WorkPanel>`.
- Recommended cards render **flush** (`.models-recommended`) — not the tinted accent-band card — so there's no card-in-card inside the panel.
- The full **"All {type} models"** catalog grid renders on the bare canvas below.
- Refactor: extracted `modelTabGroups()` so the panel's Recommended picks and the canvas catalog share one filter pass (search + family).

### Constraint honored (preserve-all-controls)
Every control preserved — tabs, search, family filter, per-card actions (Download / Manage / N tiers / gated → Add token), the GATED badge + credential notice, and the LoRA import form. Only the Recommended container moved (into the panel, flush).

### Verification
- `vite build` ✅ · `eslint` ✅ (no errors) · **full web suite 105 files / 1371 tests** ✅ (37 Model Manager tests). One test queried the Recommended picks by the old `.models-accent-band` class; updated it to the new `.models-recommended` container — the behavioral assertions (recommended model shows with the ★ chip; non-recommended under "All models") are unchanged.
- Rendered against the live worktree stylesheet in dark — matches the handoff mockup (screenshot on the story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)