### PR TITLE
feat(web): Page-Frame standard — Phase 5: Image Studio (sc-10446)

### DIFF
--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -3,6 +3,7 @@ import { AssetPickerField, ImageEditSourcePickerField } from "../components/Asse
 import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia, assetUrl } from "../components/assetMedia.jsx";
 import { Icon } from "../components/Icons.jsx";
+import { WorkPanel } from "../components/WorkPanel.jsx";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { PromptGuideModal } from "../components/PromptGuideModal.jsx";
 import { PoseLibraryPicker } from "../components/PoseLibraryPicker.jsx";
@@ -1915,9 +1916,9 @@ export function ImageStudio() {
       onOpenQueue={onOpenQueue}
       onCancelJob={onCancelJob}
     >
-    <section className="main-surface image-studio">
+    <section className="page-frame image-studio">
       <form className="studio-shell" onSubmit={submit}>
-        <div className="surface-header hero studio-prompt-hero">
+        <WorkPanel className="studio-work-panel">
           <div className="prompt-hero-top">
             <div className="mode-tabs" role="tablist" aria-label="Image mode">
               {[
@@ -2597,8 +2598,9 @@ export function ImageStudio() {
             presetPromptParts={presetPromptParts}
             presetLoraDetails={presetLoraDetails}
           />
+        </WorkPanel>
 
-          <button className="advanced-toggle" onClick={() => setAdvancedOpen((value) => !value)} type="button">
+        <button className="advanced-toggle" onClick={() => setAdvancedOpen((value) => !value)} type="button">
             <Icon.ChevDown className={advancedOpen ? "chev-rotate open" : "chev-rotate"} size={14} />
             {advancedOpen ? "Hide advanced" : "Advanced"}
           </button>
@@ -2903,7 +2905,6 @@ export function ImageStudio() {
               Generate is blocked because these selected LoRAs are incompatible with {selectedModel?.name ?? "the selected model"}: {selectedLoraValidationResult.incompatible.join(", ")}.
             </p>
           ) : null}
-        </div>
 
         <div className="studio-results">
           <section className="review-panel">


### PR DESCRIPTION
## Phase 5 of epic [sc-10433](https://app.shortcut.com/trefry/epic/10433) — Page-Frame Design Standard (direction 1b)

Migrates **Image Studio** ([sc-10446](https://app.shortcut.com/trefry/story/10446)) — the largest control surface in the app.

- Drops the whole-page `.main-surface` card + the `studio-prompt-hero`.
- **Purpose zone → one WorkPanel**: mode tabs (Text / Edit / With character), Prompt guide / Saved presets links, the prompt field + Generate, suggestion chips, the 3-up prompt-tools row, and the Model / Aspect / Variations / Style control row.
- **Advanced moves below the panel** (its toggle + the full override grid: negative prompt, steps, guidance, guidance method, sampler, scheduler, scheduler shift, seed, width×height, LoRAs, toggles) so the Purpose zone stays a fixed height.
- Latest-batch results (Favorite / Reject tiles) render on the bare canvas.

### Constraint honored (preserve-all-controls) — verified
Wrapper-only change. **Control count before = after: 13 selects / 18 inputs / 2 textareas.** No control, model-specific field, tab branch, or advanced knob removed or hidden. The advanced toggle keeps its existing behavior + `saved.advancedOpen` persistence.

I reused Image Studio's existing `advanced-toggle`/`advanced-panel` (now correctly positioned below the work-panel) rather than swapping in the `<AdvancedSection>` component — that keeps the complex panel and its 52 tests intact. Converting it to the bordered `<AdvancedSection>` is an available follow-up refinement (cosmetic; deferred to avoid destabilizing the tests).

### Verification
- `vite build` ✅ · `eslint` ✅ (no errors) · **full web suite 105 files / 1371 tests** ✅, incl. all **52 Image Studio tests** (generate / favorite / reject / advanced open+persist / prompt-tools).
- Rendered against the live worktree stylesheet in dark — work-panel purpose zone + advanced-below + results on canvas (screenshot on the story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)