### PR TITLE
feat(web): Page-Frame standard — Phase 6: Video Studio (sc-10447)

### DIFF
--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -5,6 +5,7 @@ import { FitModeControl, effectiveFitMode } from "../components/FitModeControl.j
 import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
 import { Icon } from "../components/Icons.jsx";
+import { WorkPanel } from "../components/WorkPanel.jsx";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { PromptGuideModal } from "../components/PromptGuideModal.jsx";
 import { RefinePromptControl } from "../components/RefinePromptControl.jsx";
@@ -818,9 +819,9 @@ export function VideoStudio() {
       onOpenQueue={onOpenQueue}
       onCancelJob={onCancelJob}
     >
-    <section className="main-surface video-studio">
+    <section className="page-frame video-studio">
       <form className="studio-shell" onSubmit={submit}>
-        <div className="surface-header hero studio-prompt-hero">
+        <WorkPanel className="studio-work-panel">
           <div className="prompt-hero-top">
             <div className="mode-tabs mode-control" role="tablist" aria-label="Video mode">
               {modeOptions.map(([value, label]) => {
@@ -1152,8 +1153,9 @@ export function VideoStudio() {
           />
 
           {durationHint ? <p className="helper-copy">{durationHint}</p> : null}
+        </WorkPanel>
 
-          <button className="advanced-toggle" onClick={() => setAdvancedOpen((value) => !value)} type="button">
+        <button className="advanced-toggle" onClick={() => setAdvancedOpen((value) => !value)} type="button">
             <Icon.ChevDown className={advancedOpen ? "chev-rotate open" : "chev-rotate"} size={14} />
             {advancedOpen ? "Hide advanced" : "Advanced"}
           </button>
@@ -1463,7 +1465,6 @@ export function VideoStudio() {
               Generate is blocked because these selected LoRAs are incompatible with {selectedModel?.name ?? "the selected model"}: {selectedLoraValidationResult.incompatible.join(", ")}.
             </p>
           ) : null}
-        </div>
 
         <div className="studio-results">
           <section className="review-panel">


### PR DESCRIPTION
## Phase 6 of epic [sc-10433](https://app.shortcut.com/trefry/epic/10433) — Page-Frame Design Standard (direction 1b)

Migrates **Video Studio** ([sc-10447](https://app.shortcut.com/trefry/story/10447)), mirroring the Image Studio migration.

- Drops the whole-page `.main-surface` card + the `studio-prompt-hero`.
- **Purpose zone → one WorkPanel**: mode tabs (Text→Video / Image→Video / Upscale), Prompt guide / Saved presets links, the prompt field + Generate, the control row, and the duration hint.
- **Advanced moves below the panel**; the latest-batch results + comparison grid render on the bare canvas.

### Constraint honored (preserve-all-controls) — verified
You flagged this as the highest-risk screen. Wrapper-only change: **control count before = after: 13 selects / 10 inputs / 2 textareas**, including every mode/model/pipeline permutation (text→video vs image→video vs upscale, per-model fields, comparison mode). No conditional-render logic touched — nothing dropped or hidden. Advanced toggle keeps its behavior + persistence.

### Verification
- `vite build` ✅ · `eslint` ✅ (no errors) · **full web suite 105 files / 1371 tests** ✅ (Video Studio tests incl. mode/comparison flows).
- Rendered against the live worktree stylesheet in dark — work-panel + advanced-below + comparison grid on canvas (screenshot on the story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)