### PR TITLE
fix(assets): only request a video poster when one exists (sc-10468)

### DIFF
--- a/apps/web/src/components/assetMedia.jsx
+++ b/apps/web/src/components/assetMedia.jsx
@@ -53,12 +53,27 @@ export function suppressThumbnailContextMenu(event) {
 // Generated videos get a sibling `<name>.poster.jpg` (the worker extracts frame 0).
 // WKWebView won't paint a <video>'s own first frame as a poster, so the UI shows
 // this real image instead — as the thumbnail and as the player's poster attribute.
+//
+// The server attaches `posterUrl` to a normalized asset ONLY when that poster file
+// actually exists on disk (sc-10468). So for a persisted (normalized) asset — which
+// always carries a server-built `url` — the ABSENCE of `posterUrl` means the video
+// has no poster, and we must NOT probe `<name>.poster.jpg` (that 404'd on every
+// render, spamming the log). We only fall back to deriving the poster path for
+// transient/live-job assets the server hasn't normalized yet (no `url`), preserving
+// the in-progress poster behavior in the studios.
 export function posterUrl(asset) {
-  const src = bareAssetUrl(asset);
-  if (!src || !assetCanRenderAsVideo(asset)) {
+  if (!assetCanRenderAsVideo(asset)) {
     return "";
   }
-  return withMediaTicket(src.replace(/\.\w+$/, ".poster.jpg"));
+  if (asset?.posterUrl) {
+    return withMediaTicket(API_BASE_URL + asset.posterUrl);
+  }
+  if (asset?.url) {
+    // Normalized asset with no server-advertised poster ⇒ none exists; don't probe.
+    return "";
+  }
+  const src = bareAssetUrl(asset);
+  return src ? withMediaTicket(src.replace(/\.\w+$/, ".poster.jpg")) : "";
 }
 
 // Placeholder shown when an asset's underlying file can't be loaded — e.g. it

--- a/apps/web/src/components/assetMedia.test.jsx
+++ b/apps/web/src/components/assetMedia.test.jsx
@@ -1,7 +1,7 @@
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { AssetMedia, AssetThumbnail, MissingMedia } from "./assetMedia.jsx";
+import { AssetMedia, AssetThumbnail, MissingMedia, posterUrl } from "./assetMedia.jsx";
 
 const imageAsset = {
   id: "img",
@@ -71,5 +71,40 @@ describe("thumbnail native context-menu suppression (sc-8731)", () => {
     expect(img).not.toBeNull();
     const event = fireContextMenu(img);
     expect(event.defaultPrevented).toBe(false);
+  });
+});
+
+describe("posterUrl poster-existence gating (sc-10468)", () => {
+  it("uses the server-advertised posterUrl when present", () => {
+    const asset = {
+      type: "video",
+      url: "/api/v1/projects/p1/files/assets/clip.mp4",
+      posterUrl: "/api/v1/projects/p1/files/assets/clip.poster.jpg",
+      file: { path: "assets/clip.mp4", mimeType: "video/mp4" },
+      projectId: "p1",
+    };
+    expect(posterUrl(asset)).toContain("/api/v1/projects/p1/files/assets/clip.poster.jpg");
+  });
+
+  it("returns '' for a normalized video with no poster, so it never probes .poster.jpg", () => {
+    // A persisted asset always carries a server `url`; the missing posterUrl means
+    // the poster genuinely does not exist — the source of the startup 404 spam.
+    const asset = {
+      type: "video",
+      url: "/api/v1/projects/p1/files/assets/clip.mp4",
+      file: { path: "assets/clip.mp4", mimeType: "video/mp4" },
+      projectId: "p1",
+    };
+    expect(posterUrl(asset)).toBe("");
+  });
+
+  it("still derives the poster path for a transient asset without a server url", () => {
+    // Live-job assets the server hasn't normalized keep the old behavior.
+    const asset = {
+      type: "video",
+      file: { path: "assets/clip.mp4", mimeType: "video/mp4" },
+      projectId: "p1",
+    };
+    expect(posterUrl(asset)).toContain(".poster.jpg");
   });
 });

--- a/crates/sceneworks-core/src/asset_index.rs
+++ b/crates/sceneworks-core/src/asset_index.rs
@@ -208,6 +208,22 @@ pub(crate) fn normalize_asset_cached(
     }
     if let Some(path) = asset.pointer("/file/path").and_then(Value::as_str) {
         let normalized_path = path.replace('\\', "/");
+        // A generated/rendered video carries a sibling `<name>.poster.jpg` (worker
+        // frame-0 extract) that the web UI shows in place of the <video>'s own first
+        // frame — WKWebView won't paint it. Advertise a `posterUrl` ONLY when that
+        // file actually exists on disk, so the client never requests a poster a video
+        // doesn't have — an imported clip, or a generation where ffmpeg was
+        // unavailable — which would otherwise 404 on every render (sc-10468). Resolved
+        // at read time so it reflects the real on-disk state; images never have one.
+        let poster_url = (asset.get("type").and_then(Value::as_str) == Some("video"))
+            .then(|| Path::new(&normalized_path).with_extension("poster.jpg"))
+            .filter(|poster_rel| project_path.join(poster_rel).is_file())
+            .map(|poster_rel| {
+                format!(
+                    "/api/v1/projects/{project_id}/files/{}",
+                    poster_rel.to_string_lossy().replace('\\', "/")
+                )
+            });
         if let Some(object) = asset.as_object_mut() {
             object.insert(
                 "url".to_owned(),
@@ -215,6 +231,9 @@ pub(crate) fn normalize_asset_cached(
                     "/api/v1/projects/{project_id}/files/{normalized_path}"
                 )),
             );
+            if let Some(poster_url) = poster_url {
+                object.insert("posterUrl".to_owned(), Value::String(poster_url));
+            }
         }
     }
     if let Some(generation_set_id) = asset.get("generationSetId").and_then(Value::as_str) {

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -5599,6 +5599,63 @@ mod tests {
     }
 
     #[test]
+    fn list_assets_advertises_poster_url_only_when_the_poster_exists() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Videos").expect("project creates");
+        let project_path = store.find_project_path(&project.id).expect("project path");
+
+        let video_fact = |id: &str| {
+            json!({
+                "assetId": id,
+                "mediaPath": format!("assets/videos/genset/{id}.mp4"),
+                "mimeType": "video/mp4",
+                "type": "video",
+                "displayName": id,
+                "createdAt": "2026-05-25T00:00:00Z",
+                "mode": "image_to_video",
+                "model": "wan",
+                "adapter": "wan",
+                "prompt": "x",
+            })
+        };
+        store
+            .persist_generated_asset(&project.id, "job-1", "genset", &video_fact("withposter"))
+            .expect("withposter persists");
+        store
+            .persist_generated_asset(&project.id, "job-1", "genset", &video_fact("noposter"))
+            .expect("noposter persists");
+        // Only `withposter` has its `<name>.poster.jpg` sibling on disk.
+        std::fs::write(
+            project_path.join("assets/videos/genset/withposter.poster.jpg"),
+            b"jpg-bytes",
+        )
+        .expect("write poster");
+
+        let assets = store
+            .list_assets(&project.id, true, true, AssetScope::All)
+            .expect("list");
+        let by_id = |id: &str| {
+            assets
+                .iter()
+                .find(|asset| asset["id"] == id)
+                .unwrap_or_else(|| panic!("asset {id} present"))
+        };
+        assert_eq!(
+            by_id("withposter")["posterUrl"],
+            json!(format!(
+                "/api/v1/projects/{}/files/assets/videos/genset/withposter.poster.jpg",
+                project.id
+            )),
+            "posterUrl is advertised when the poster file exists"
+        );
+        assert!(
+            by_id("noposter").get("posterUrl").is_none(),
+            "no posterUrl is advertised when the poster file is absent"
+        );
+    }
+
+    #[test]
     fn build_generated_asset_sidecar_derives_video_type_from_mime() {
         let fact = json!({
             "assetId": "asset_v",


### PR DESCRIPTION
Final follow-up in the `app-startup-404s` group (after #1320 / sc-10465 and #1323 / sc-10467).

## Problem
The web UI rewrote **every** video asset's extension to `<name>.poster.jpg` and requested it (`posterUrl()` in `assetMedia.jsx`, used by `AssetThumbnail`/`VideoPoster` and the `<video poster>` attr). Generated videos get a poster from the worker (`write_poster_frame`), but **imported clips** — and generations where ffmpeg was unavailable — have none, so each one **404'd on every render**. That's the remaining source of the startup 404 spam, now visible as `event=project_file_missing … relative_path=….poster.jpg` (from sc-10465's log enrichment).

## Fix
- **Backend** (`normalize_asset_cached`): attach `posterUrl` to a video asset **only when its `<name>.poster.jpg` sibling exists on disk**, resolved at read time so it reflects real state. Images never get one.
- **Frontend** (`posterUrl()`): use `asset.posterUrl` when present. A normalized asset always carries a server-built `url`; its **absence of `posterUrl` means "no poster — don't probe"**, so no request fires. Only transient/live-job assets (no server `url`) still derive the path, preserving the in-progress poster behavior in the studios.

## Why not gate in the sidecar / worker fact
Read-time resolution needs no schema change, no worker/fact contract change, no migration, and self-corrects if a poster is added/removed later. It also covers imported and legacy videos uniformly.

## No parity drift
The parity golden's video fixtures are built via `persist_generated_asset`, which writes no media/poster files — so `posterUrl` is never emitted for them and the golden is unchanged (same reason sc-10465 didn't drift it).

## Tests
- Backend: `list_assets_advertises_poster_url_only_when_the_poster_exists` (poster present ⇒ `posterUrl` set; absent ⇒ omitted)
- Frontend: 3 `posterUrl` cases (server field used; normalized-no-poster ⇒ `""` no-probe; transient ⇒ derive)
- 404 core lib tests + full web vitest (1374 tests) pass; clippy `-D warnings` + `fmt --all --check` clean

Shortcut: [sc-10468](https://app.shortcut.com/trefry/story/10468)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
