### PR TITLE
feat(web): Page-Frame standard — Phase 7: Data Sets dataset row (sc-10448)

### DIFF
--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -1449,7 +1449,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
       onOpenModels={() => setActiveView("Models")}
       onOpenQueue={() => setActiveView("Queue")}
     >
-    <section className="main-surface training-studio">
+    <section className="page-frame training-studio">
       <div className="training-studio-shell">
         <div className="training-summary-band">
           <div className="section-heading">

--- a/apps/web/src/screens/training/DatasetEditorPanel.jsx
+++ b/apps/web/src/screens/training/DatasetEditorPanel.jsx
@@ -5,6 +5,7 @@ import { CompactSelector } from "../../components/CompactSelector.jsx";
 import { DatasetAddDialog } from "../../components/DatasetAddDialog.jsx";
 import { DatasetCaptionDialog } from "../../components/DatasetCaptionDialog.jsx";
 import { Icon } from "../../components/Icons.jsx";
+import { WorkPanel } from "../../components/WorkPanel.jsx";
 import {
   DatasetDoctorDistributions,
   DatasetDoctorReadout,
@@ -174,58 +175,63 @@ export function DatasetEditorPanel({
           <div className="empty-panel compact-panel">No training datasets yet — use “New” to start one.</div>
         ) : null}
         <div className="training-dataset-editor">
-          <div className="training-dataset-fields">
-            <label className="field-name">
-              Dataset name
-              <input
-                onChange={(event) => setDraftName(event.target.value)}
-                placeholder="Character portrait set"
-                value={draftName}
-              />
-            </label>
-            <span className="field-version">
-              {dirty ? "Unsaved changes" : activeDataset ? `Version ${activeDataset.version}` : "Draft"}
-            </span>
-            <button className="primary-action field-add" onClick={() => setAddDialogOpen(true)} type="button">
-              <Icon.Plus size={14} />
-              Add images
-            </button>
-
-            <label className="field-prefix">
-              Name prefix
-              <input
-                onChange={(event) => setRenamePrefix(event.target.value)}
-                placeholder="item"
-                value={renamePrefix}
-              />
-            </label>
-            <button
-              className="primary-action field-apply"
-              disabled={!activeDataset?.id || renaming || !memberAssets.length}
-              onClick={applyOrderedNames}
-              type="button"
-            >
-              <Icon.Sliders size={14} />
-              {renaming ? "Renaming…" : "Apply ordered names"}
-            </button>
-            <button
-              className="primary-action field-caption"
-              disabled={!memberAssets.length}
-              onClick={() => setCaptionDialog({ type: "all" })}
-              type="button"
-            >
-              <Icon.Sliders size={14} />
-              Caption all
-            </button>
-          </div>
-          <DatasetHealth
-            health={health}
-            action={
-              <button className="primary-action" disabled={!canSave} onClick={saveDataset} type="button">
+          <WorkPanel className="dataset-work-panel">
+            <div className="dataset-primary-row">
+              <label className="dataset-field">
+                <span>Dataset name</span>
+                <input
+                  onChange={(event) => setDraftName(event.target.value)}
+                  placeholder="Character portrait set"
+                  value={draftName}
+                />
+              </label>
+              <label className="dataset-field">
+                <span>Name prefix</span>
+                <input
+                  onChange={(event) => setRenamePrefix(event.target.value)}
+                  placeholder="item"
+                  value={renamePrefix}
+                />
+              </label>
+              <span className="dataset-version">
+                {dirty ? "Unsaved changes" : activeDataset ? `Version ${activeDataset.version}` : "Draft"}
+              </span>
+              <button className="primary-action dataset-save" disabled={!canSave} onClick={saveDataset} type="button">
                 {savingDataset ? "Saving" : activeDataset ? "Save dataset" : "Create dataset"}
               </button>
-            }
-          />
+            </div>
+            <div className="dataset-utility-row">
+              <span className="dataset-count">
+                {health.itemCount} image{health.itemCount === 1 ? "" : "s"} ·{" "}
+                {Math.max(0, health.itemCount - health.missingCaptions)} captioned
+              </span>
+              <span className="dataset-utility-actions">
+                <button className="secondary-action" onClick={() => setAddDialogOpen(true)} type="button">
+                  <Icon.Plus size={14} />
+                  Add images
+                </button>
+                <button
+                  className="secondary-action"
+                  disabled={!activeDataset?.id || renaming || !memberAssets.length}
+                  onClick={applyOrderedNames}
+                  type="button"
+                >
+                  <Icon.Sliders size={14} />
+                  {renaming ? "Renaming…" : "Apply ordered names"}
+                </button>
+                <button
+                  className="secondary-action"
+                  disabled={!memberAssets.length}
+                  onClick={() => setCaptionDialog({ type: "all" })}
+                  type="button"
+                >
+                  <Icon.Sliders size={14} />
+                  Caption all
+                </button>
+              </span>
+            </div>
+          </WorkPanel>
+          <DatasetHealth health={health} />
           <div className="training-validity">
             <span className={health.valid ? "training-valid-dot valid" : "training-valid-dot"} />
             <span>{health.valid ? "Dataset is ready for downstream steps" : "Add image assets to build this dataset"}</span>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3477,6 +3477,61 @@ label {
 /* Dataset header fields aligned to the 4 health columns (sc-2025 polish):
    row 1 = name | version | Add images, row 2 = prefix | Apply names | Caption all;
    the health grid below (row 3) shares the same 4-column geometry. */
+/* Dataset editor controls (sc-10448) — replaces the crammed equal-weight
+   .training-dataset-fields grid: a primary row (the two inputs + the one filled
+   Save CTA) over a de-emphasized utility row (add / rename / caption + a live
+   count), inside a work-panel. */
+.dataset-primary-row {
+  display: flex;
+  gap: 10px;
+  align-items: end;
+  flex-wrap: wrap;
+}
+
+.dataset-field {
+  display: grid;
+  gap: 6px;
+  flex: 1 1 220px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+
+.dataset-version {
+  align-self: center;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-faint);
+  white-space: nowrap;
+}
+
+.dataset-save {
+  flex: 0 0 auto;
+  min-height: var(--control-h);
+}
+
+.dataset-utility-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
+.dataset-count {
+  font-size: 12.5px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+.dataset-utility-actions {
+  display: inline-flex;
+  gap: 8px;
+  margin-left: auto;
+  flex-wrap: wrap;
+}
+
 .training-dataset-fields {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));


### PR DESCRIPTION
## Phase 7 of epic [sc-10433](https://app.shortcut.com/trefry/epic/10433) — Page-Frame Design Standard (direction 1b)

Fixes the flagged "horrendous" dataset row ([sc-10448](https://app.shortcut.com/trefry/story/10448)) and drops Training Studio's card-in-card.

**Before:** two inputs crammed with three **equal-weight filled** buttons (Add images / Apply ordered names / Caption all), with Save off in the health grid — everything competing for attention.

**After:** the dataset controls live in a `<WorkPanel>`:
- **Primary row** — Dataset name + Name prefix inputs + version + the **one** filled `Save dataset` CTA.
- **Utility row** (below a divider) — a live **"N images · M captioned"** count on the left; the three utilities (Add images / Apply ordered names / Caption all) as **de-emphasized secondary** buttons on the right.

Also: `TrainingStudio` `section.main-surface` → `.page-frame` (removes the whole-page card wrap).

### Constraint honored (preserve-all-controls)
Every field + action is retained — the two inputs, Save, Add images, Apply ordered names, Caption all (and the Add-images dialog's import path) all work exactly as before; only the layout/weighting changed. Save moved from the health grid's `action` slot into the primary row.

### Notes / scope
The dual-mode summary-band (Data Sets vs Training) + workflow tabs are kept as the screen's dashboard header — folding those into a work-panel is a possible follow-up, not a dropped control.

### Verification
- `vite build` ✅ · `eslint` ✅ (no errors) · **full web suite 105 files / 1374 tests** ✅ (TrainingStudio + DatasetAddDialog/Caption tests).
- Before/after rendered against the live worktree stylesheet in dark (screenshot on the story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)