### PR TITLE
fix(web): unclip WorkPanel dropdowns — Characters selector (sc-10473)

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1137,7 +1137,9 @@ button:focus-visible {
   border: 1px solid var(--border);
   border-radius: var(--r-lg);
   box-shadow: var(--shadow-md);
-  overflow: hidden;
+  /* No `overflow: hidden` here — it would clip custom popovers that open inside
+     the panel (e.g. the CompactSelector dropdown, sc-10473). The accent top-rule
+     rounds its own top corners instead so it still hugs the panel. */
 }
 
 .work-panel-rule {
@@ -1146,6 +1148,7 @@ button:focus-visible {
   top: 0;
   right: 0;
   height: 3px;
+  border-radius: var(--r-lg) var(--r-lg) 0 0;
   background: linear-gradient(90deg, var(--accent), color-mix(in oklch, var(--accent) 30%, transparent));
 }
 


### PR DESCRIPTION
Fixes [sc-10473](https://app.shortcut.com/trefry/story/10473): the **Characters** character selector stopped dropping down.

### Cause
The P3 Characters migration wrapped the `CompactSelector` in a `<WorkPanel>`. `.work-panel` has `overflow: hidden` (added in P1 to clip the 3px accent top-rule to the rounded corners), which also clipped the selector's `position:absolute` menu — it opens *below* the pill and extends past the panel, so it was invisible.

### Fix
Drop `overflow: hidden` from `.work-panel` and instead round the `.work-panel-rule`'s own top corners (`border-radius: var(--r-lg) var(--r-lg) 0 0`) so the accent bar still hugs the panel. This unclips **every** custom popover that opens inside a work-panel, not just the Characters picker.

### Verification
Reproduced + confirmed fixed in the browser preview (dark): the dropdown now opens fully (New character / Ada / Boone / Cleo visible, escaping the panel bottom) and the top-rule still looks clean at the rounded corners. `vite build` ✅ · **full web suite 1374 tests** ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)