### PR TITLE
feat(web): Training Studio redesign + one Advanced disclosure everywhere (sc-10474..8)

### DIFF
--- a/apps/web/src/App.character.test.jsx
+++ b/apps/web/src/App.character.test.jsx
@@ -856,7 +856,7 @@ describe("SceneWorks app shell", () => {
 
     // The Identity-structure slider seeds from angleSetDefault, not the 0.80 single-image default.
     await act(async () => {
-      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Advanced")?.click();
+      document.body.querySelector(".advanced-section-toggle")?.click();
     });
     const lockSlider = [...document.body.querySelectorAll(".reference-strength")].find((label) =>
       label.textContent.includes("Identity structure"),

--- a/apps/web/src/App.imageGeneration.test.jsx
+++ b/apps/web/src/App.imageGeneration.test.jsx
@@ -2019,7 +2019,7 @@ describe("SceneWorks app shell", () => {
       [...document.body.querySelectorAll(".mode-control button")].find((button) => button.textContent === "Text → Video").click();
     });
     await act(async () => {
-      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Advanced").click();
+      document.body.querySelector(".advanced-section-toggle").click();
     });
 
     const quantSelect = field(container, "Quantization");
@@ -2098,7 +2098,7 @@ describe("SceneWorks app shell", () => {
     await settle();
 
     await act(async () => {
-      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Advanced").click();
+      document.body.querySelector(".advanced-section-toggle").click();
     });
     await settle();
 

--- a/apps/web/src/App.imageGeneration.test.jsx
+++ b/apps/web/src/App.imageGeneration.test.jsx
@@ -612,7 +612,7 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).not.toContain("Missing LoRA");
 
     await act(async () => {
-      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Advanced").click();
+      document.body.querySelector(".advanced-section-toggle").click();
     });
 
     // Add-on-demand LoRA picker (UI-refinement 3b): open the "Add LoRA" dropdown and click a
@@ -704,7 +704,7 @@ describe("SceneWorks app shell", () => {
     });
 
     await act(async () => {
-      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Advanced").click();
+      document.body.querySelector(".advanced-section-toggle").click();
     });
     // Open the Add-LoRA dropdown to inspect which LoRAs the model offers as compatible.
     await act(async () => {
@@ -743,7 +743,7 @@ describe("SceneWorks app shell", () => {
     });
 
     await act(async () => {
-      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Advanced").click();
+      document.body.querySelector(".advanced-section-toggle").click();
     });
     // Reveal the incompatible LoRA in the dropdown, then add it via its Add row.
     await act(async () => {
@@ -764,11 +764,11 @@ describe("SceneWorks app shell", () => {
     expect(generate.disabled).toBe(true);
 
     await act(async () => {
-      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Hide advanced").click();
+      document.body.querySelector(".advanced-section-toggle").click();
     });
     await settle();
 
-    expect([...document.body.querySelectorAll("button")].some((button) => button.textContent === "Hide advanced")).toBe(true);
+    expect(document.body.querySelector(".advanced-section.open")).toBeTruthy();
     expect(container.textContent).toContain("Qwen Only");
 
     await act(async () => {
@@ -1052,7 +1052,7 @@ describe("SceneWorks app shell", () => {
     expect(field(container, "Variations").value).toBe("4");
 
     await act(async () => {
-      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Advanced").click();
+      document.body.querySelector(".advanced-section-toggle").click();
     });
 
     expect(field(container, "GPU")).not.toBeUndefined();
@@ -1100,7 +1100,7 @@ describe("SceneWorks app shell", () => {
     });
 
     await act(async () => {
-      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Advanced").click();
+      document.body.querySelector(".advanced-section-toggle").click();
     });
 
     expect(document.body.querySelector('.upscale-toggle input[type="checkbox"]').checked).toBe(false);
@@ -1519,9 +1519,9 @@ describe("SceneWorks app shell", () => {
     });
     await settle();
 
-    // The toggle lives in the (collapsed-by-default) Advanced panel — open it first.
+    // The toggle lives in the (collapsed-by-default) Advanced disclosure — open it first.
     await act(async () => {
-      document.body.querySelector(".advanced-toggle").click();
+      document.body.querySelector(".advanced-section-toggle").click();
     });
 
     // The manifest-driven "Enhance prompt" toggle renders for flux2_dev (off by default).
@@ -1874,7 +1874,7 @@ describe("SceneWorks app shell", () => {
     expect(createImageJob).not.toHaveBeenCalled();
 
     await act(async () => {
-      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Advanced").click();
+      document.body.querySelector(".advanced-section-toggle").click();
     });
     await changeField(field(container, "Model"), "qwen_image");
     await settle();

--- a/apps/web/src/App.training.test.jsx
+++ b/apps/web/src/App.training.test.jsx
@@ -2,7 +2,7 @@ import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "./main.jsx";
-import { withTrainingStudioContext, withTrainingDataSetsLibraryContext, FakeEventSource, response, settle, field, buttonInside, zImageTrainingTarget, zImageTrainingPresets, changeField } from "./main.testSupport.jsx";
+import { withTrainingStudioContext, withTrainingDataSetsLibraryContext, FakeEventSource, response, settle, field, buttonInside, openAdvancedSection, zImageTrainingTarget, zImageTrainingPresets, changeField } from "./main.testSupport.jsx";
 
 describe("SceneWorks app shell", () => {
   let container;
@@ -114,7 +114,7 @@ describe("SceneWorks app shell", () => {
     await settle();
 
     expect(container.textContent).toContain("Training Studio");
-    expect(container.textContent).toContain("Configure Job");
+    expect(container.textContent).toContain("Configure the run");
     expect(container.textContent).toContain("Data Sets");
     expect(container.textContent).not.toContain("Rename & Caption");
     expect([...document.body.querySelectorAll("button")].some((button) => /queue training/i.test(button.textContent))).toBe(false);
@@ -132,10 +132,11 @@ describe("SceneWorks app shell", () => {
       );
     });
 
-    expect(document.body.querySelector("#training-tab-configure").getAttribute("aria-selected")).toBe("true");
+    // The Training Studio is a single work-panel — no tablist, and dataset building
+    // lives in the separate Data Sets library (sc-10475).
+    expect(container.querySelector(".training-config-panel")).toBeTruthy();
+    expect(document.body.querySelector("[role='tablist']")).toBeNull();
     expect(container.textContent).toContain("A dry run validates the training plan");
-    expect(document.body.querySelector("#training-tab-dataset")).toBeNull();
-    expect(document.body.querySelector("#training-tab-rename-caption")).toBeNull();
     expect(container.textContent).not.toContain("Import images & captions");
   });
 
@@ -755,7 +756,6 @@ describe("SceneWorks app shell", () => {
     expect(field(container, "Trigger phrase").value).toBe("Portrait Set");
 
     await changeField(field(container, "Trigger phrase"), "manualTrigger");
-    expect(document.body.querySelector("#training-tab-rename-caption")).toBeNull();
     expect(field(container, "Trigger phrase").value).toBe("manualTrigger");
   });
 
@@ -836,13 +836,13 @@ describe("SceneWorks app shell", () => {
     });
     await settle();
 
-    await act(async () => {
-      document.body.querySelector("#training-tab-configure").click();
-    });
     await changeField(field(container, "Dataset"), "dataset-a");
     await settle();
     await changeField(field(container, "Trigger phrase"), "miraStyle");
 
+    // Everything outside the twelve basic plan fields lives in the Advanced
+    // disclosure, which unmounts its body while collapsed (sc-10475).
+    await openAdvancedSection(container);
     expect(field(container, "Target").value).toBe("z_image_turbo_lora");
     expect(field(container, "Base model").value).toBe("z_image_turbo");
     expect(field(container, "Guidance scale").value).toBe("1");
@@ -918,14 +918,12 @@ describe("SceneWorks app shell", () => {
     });
     await settle();
 
-    await act(async () => {
-      document.body.querySelector("#training-tab-configure").click();
-    });
     await changeField(field(container, "Dataset"), "dataset-a");
     await settle();
 
     expect(field(container, "Preset").value).toBe("z_image_turbo_lora.character.adamw8bit.balanced");
     expect(container.textContent).toContain("Character balanced");
+    await openAdvancedSection(container);
     await changeField(field(container, "Optimizer"), "prodigyopt");
     expect(field(container, "Preset").value).toBe("z_image_turbo_lora.character.prodigyopt.balanced");
     expect(field(container, "Learning rate").value).toBe("1");
@@ -983,14 +981,12 @@ describe("SceneWorks app shell", () => {
     });
     await settle();
 
-    await act(async () => {
-      document.body.querySelector("#training-tab-configure").click();
-    });
     await changeField(field(container, "Dataset"), "dataset-a");
     await settle();
 
     // The selector appears for Z-Image-Turbo and normalizes the preset's legacy
     // "v2-default" value to "v2".
+    await openAdvancedSection(container);
     const adapterSelect = field(container, "De-distill adapter");
     expect(adapterSelect).toBeTruthy();
     expect(adapterSelect.value).toBe("v2");
@@ -1030,9 +1026,7 @@ describe("SceneWorks app shell", () => {
     });
     await settle();
 
-    await act(async () => {
-      document.body.querySelector("#training-tab-configure").click();
-    });
+    await openAdvancedSection(container);
     await changeField(field(container, "Rank"), "24");
 
     expect(container.textContent).toContain("Customized: Rank");
@@ -1070,9 +1064,6 @@ describe("SceneWorks app shell", () => {
     });
     await settle();
 
-    await act(async () => {
-      document.body.querySelector("#training-tab-configure").click();
-    });
     await changeField(field(container, "Dataset"), "dataset-a");
     await settle();
     await changeField(field(container, "Trigger phrase"), "miraStyle");
@@ -1127,9 +1118,6 @@ describe("SceneWorks app shell", () => {
     });
     await settle();
 
-    await act(async () => {
-      document.body.querySelector("#training-tab-configure").click();
-    });
     await changeField(field(container, "Dataset"), "dataset-a");
     await settle();
     await changeField(field(container, "Trigger phrase"), "miraStyle");
@@ -1185,12 +1173,10 @@ describe("SceneWorks app shell", () => {
       render(["auto", "0"]);
     });
     await settle();
-    await act(async () => {
-      document.body.querySelector("#training-tab-configure").click();
-    });
     await changeField(field(container, "Dataset"), "dataset-a");
     await settle();
     await changeField(field(container, "Trigger phrase"), "miraStyle");
+    await openAdvancedSection(container);
     await changeField(field(container, "Rank"), "24");
     await changeField(field(container, "Requested GPU"), "0");
 
@@ -1243,9 +1229,6 @@ describe("SceneWorks app shell", () => {
       );
     });
     await settle();
-    await act(async () => {
-      document.body.querySelector("#training-tab-configure").click();
-    });
 
     expect(container.textContent).toContain("Select a saved dataset");
     expect(container.textContent).toContain("Add a trigger phrase");

--- a/apps/web/src/App.training.test.jsx
+++ b/apps/web/src/App.training.test.jsx
@@ -840,11 +840,11 @@ describe("SceneWorks app shell", () => {
     await settle();
     await changeField(field(container, "Trigger phrase"), "miraStyle");
 
+    expect(field(container, "Target").value).toBe("z_image_turbo_lora");
+
     // Everything outside the twelve basic plan fields lives in the Advanced
     // disclosure, which unmounts its body while collapsed (sc-10475).
     await openAdvancedSection(container);
-    expect(field(container, "Target").value).toBe("z_image_turbo_lora");
-    expect(field(container, "Base model").value).toBe("z_image_turbo");
     expect(field(container, "Guidance scale").value).toBe("1");
     expect(field(container, "Rank").value).toBe("16");
     expect(field(container, "Precision").value).toBe("bf16");

--- a/apps/web/src/App.videoPresets.test.jsx
+++ b/apps/web/src/App.videoPresets.test.jsx
@@ -278,7 +278,7 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).not.toContain("LTX Motion");
 
     await act(async () => {
-      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Advanced").click();
+      document.body.querySelector(".advanced-section-toggle").click();
     });
     await changeField(field(container, "Model"), "wan_2_2");
     await settle();

--- a/apps/web/src/components/AdvancedSection.jsx
+++ b/apps/web/src/components/AdvancedSection.jsx
@@ -1,12 +1,17 @@
 import React from "react";
 import { Icon } from "./Icons.jsx";
 
-// AdvancedSection — a bordered, collapsible section that expands IN PLACE below
-// the work-panel (never inside it), so the Purpose zone stays a fixed height
-// no matter how many optional knobs a screen has (Page-Frame standard, direction
-// 1b, epic sc-10433). Controlled via `open` / `onToggle`; presentational only.
-// `actions` (e.g. "Reset to model defaults") sit to the left of the caret and
-// keep their own click handlers.
+// AdvancedSection — the one canonical "Advanced" disclosure (Page-Frame standard,
+// direction 1b, epic sc-10433). A bordered, header-labelled block whose controls
+// open contiguously beneath its own header, inside the same block: the header row
+// IS the toggle, so collapsed it is header-only and reserves no space no matter
+// how many optional knobs a screen has (sc-10474).
+//
+// Deliberately NOT a floating full-width button that spawns a separate container
+// below it — the button and the panel it revealed read as two disconnected things.
+//
+// Controlled via `open` / `onToggle`; presentational only. `actions` (e.g. "Reset
+// to model defaults") sit to the left of the caret and keep their own handlers.
 export function AdvancedSection({
   open,
   onToggle,
@@ -37,6 +42,7 @@ export function AdvancedSection({
           onClick={onToggle}
           type="button"
         >
+          <span className="advanced-section-caret-label">{open ? "Hide" : "Show"}</span>
           <Icon.ChevDown className={open ? "advanced-section-caret open" : "advanced-section-caret"} />
         </button>
       </div>

--- a/apps/web/src/components/AdvancedSection.test.jsx
+++ b/apps/web/src/components/AdvancedSection.test.jsx
@@ -3,8 +3,10 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AdvancedSection } from "./AdvancedSection.jsx";
 
-// AdvancedSection expands in place below the work-panel (sc-10436). Proves the AC:
-// the body only renders when open, the caret/label toggle calls onToggle, and
+// AdvancedSection is the canonical Advanced disclosure (sc-10436, sc-10474): a
+// bordered block whose header row is the toggle and whose controls open
+// contiguously beneath that header. Proves the AC: the body only renders when
+// open, both header affordances call onToggle, the Show/Hide label flips, and
 // `actions` render alongside their own click handler.
 
 let container;
@@ -54,6 +56,22 @@ describe("AdvancedSection (sc-10436)", () => {
     act(() => container.querySelector(".advanced-section-toggle").click());
     act(() => container.querySelector(".advanced-section-caret-btn").click());
     expect(toggles).toBe(2);
+  });
+
+  it("flips the Show/Hide label with the open state", () => {
+    render(
+      <AdvancedSection open={false} onToggle={() => {}}>
+        <div>knobs</div>
+      </AdvancedSection>,
+    );
+    expect(container.querySelector(".advanced-section-caret-label").textContent).toBe("Show");
+
+    render(
+      <AdvancedSection open onToggle={() => {}}>
+        <div>knobs</div>
+      </AdvancedSection>,
+    );
+    expect(container.querySelector(".advanced-section-caret-label").textContent).toBe("Hide");
   });
 
   it("renders actions with their own handler", () => {

--- a/apps/web/src/components/CharacterAdvancedOptions.jsx
+++ b/apps/web/src/components/CharacterAdvancedOptions.jsx
@@ -1,4 +1,6 @@
 import React from "react";
+
+import { AdvancedSection } from "./AdvancedSection.jsx";
 import {
   SAMPLER_LABELS,
   SCHEDULER_LABELS,
@@ -219,10 +221,7 @@ export function CharacterAdvancedOptions({ state }) {
 
   return (
     <div className="character-advanced">
-      <button className="advanced-toggle" onClick={() => setOpen((value) => !value)} type="button">
-        {open ? "Hide advanced" : "Advanced"}
-      </button>
-      {open ? (
+      <AdvancedSection hint="cleared values → model default" onToggle={() => setOpen((value) => !value)} open={open}>
         <div className="advanced-panel">
           <label className="reference-strength">
             {referenceStrengthCfg?.label ??
@@ -355,7 +354,7 @@ export function CharacterAdvancedOptions({ state }) {
             </>
           ) : null}
         </div>
-      ) : null}
+      </AdvancedSection>
     </div>
   );
 }

--- a/apps/web/src/main.testSupport.jsx
+++ b/apps/web/src/main.testSupport.jsx
@@ -212,6 +212,18 @@ export function loraPanel(container) {
   return container.querySelector("form[aria-label='Import LoRA']");
 }
 
+// The AdvancedSection disclosure unmounts its body when collapsed (sc-10474), so a
+// test that touches an override field has to expand it first — unlike the `<details>`
+// element it replaced, which kept its contents in the DOM.
+export async function openAdvancedSection(scope = document.body) {
+  const toggle = scope.querySelector(".advanced-section-toggle");
+  if (toggle?.getAttribute("aria-expanded") === "false") {
+    await act(async () => {
+      toggle.click();
+    });
+  }
+}
+
 // The Model Manager is a tabbed interface (epic 10309): Image / Video / Utility / LoRAs.
 // A model card or the LoRA import form is only mounted while its tab is active, so tests
 // switch tabs after opening the Models page. The tab button text carries a trailing count

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -3,6 +3,7 @@ import { AssetPickerField, ImageEditSourcePickerField } from "../components/Asse
 import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia, assetUrl } from "../components/assetMedia.jsx";
 import { Icon } from "../components/Icons.jsx";
+import { AdvancedSection } from "../components/AdvancedSection.jsx";
 import { WorkPanel } from "../components/WorkPanel.jsx";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { PromptGuideModal } from "../components/PromptGuideModal.jsx";
@@ -2600,12 +2601,11 @@ export function ImageStudio() {
           />
         </WorkPanel>
 
-        <button className="advanced-toggle" onClick={() => setAdvancedOpen((value) => !value)} type="button">
-            <Icon.ChevDown className={advancedOpen ? "chev-rotate open" : "chev-rotate"} size={14} />
-            {advancedOpen ? "Hide advanced" : "Advanced"}
-          </button>
-
-            {advancedOpen ? (
+        <AdvancedSection
+          hint="cleared values → model default"
+          onToggle={() => setAdvancedOpen((value) => !value)}
+          open={advancedOpen}
+        >
               <div className="advanced-panel">
                 <label>
                   GPU
@@ -2897,7 +2897,7 @@ export function ImageStudio() {
                   activeProject={activeProject}
                 />
               </div>
-            ) : null}
+        </AdvancedSection>
 
           <PresetValidationWarnings presetValidationResult={presetValidationResult} selectedModel={selectedModel} />
           {selectedLoraValidationResult.incompatible.length ? (

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -106,7 +106,7 @@ describe("ImageStudio Save as Preset", () => {
     await render(context);
 
     // Save-as-preset now lives inside the Advanced panel (UI-refinement 2b).
-    await click([...document.body.querySelectorAll("button")].find((b) => b.textContent === "Advanced"));
+    await click(document.body.querySelector(".advanced-section-toggle"));
     const input = nameInput(container);
     expect(input).toBeTruthy();
     await act(async () => setInput(input, "Atrium Look"));
@@ -142,7 +142,7 @@ describe("ImageStudio Save as Preset", () => {
     });
     await render(context);
 
-    await click([...document.body.querySelectorAll("button")].find((b) => b.textContent === "Advanced"));
+    await click(document.body.querySelector(".advanced-section-toggle"));
     await act(async () => setInput(nameInput(container), "Atrium Look"));
     await click(saveButton(container));
 
@@ -225,7 +225,7 @@ describe("ImageStudio advanced model defaults", () => {
       }),
     );
 
-    await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Advanced"));
+    await click(document.body.querySelector(".advanced-section-toggle"));
     await act(async () => setSelect(field(container, "Sampler"), "euler"));
     await act(async () => setSelect(field(container, "Scheduler"), "shift"));
     await act(async () => setInput(field(container, "Schedule shift"), "7.7"));
@@ -296,7 +296,7 @@ describe("ImageStudio guidance method picker (epic 7434, sc-7449)", () => {
   };
 
   const openAdvanced = async () =>
-    click([...document.body.querySelectorAll("button")].find((b) => b.textContent === "Advanced"));
+    click(document.body.querySelector(".advanced-section-toggle"));
   const generate = async () =>
     click([...document.body.querySelectorAll("button")].find((b) => b.textContent === "Generate"));
 
@@ -737,7 +737,7 @@ describe("ImageStudio model picker capability gating", () => {
   const precisionLabel = (root) =>
     root.querySelector("label.boogu-precision-toggle");
   const openAdvanced = async (root) =>
-    click([...root.querySelectorAll("button")].find((b) => b.textContent === "Advanced"));
+    click(root.querySelector(".advanced-section-toggle"));
 
   it("exposes the Full-precision (bf16) toggle for Boogu in Advanced when ui.precisionToggle is set (sc-6568)", async () => {
     await render(
@@ -1332,7 +1332,7 @@ describe("ImageStudio PiD decoder toggle (sc-7851)", () => {
   const PID_CKPT = (installState) => ({ id: "pid_qwenimage", type: "utility", installState });
 
   const openAdvanced = async () =>
-    click([...document.body.querySelectorAll("button")].find((b) => b.textContent === "Advanced"));
+    click(document.body.querySelector(".advanced-section-toggle"));
   const pidLabel = () =>
     [...document.body.querySelectorAll("label")].find((l) => l.textContent.includes("PiD decoder"));
   const generateButton = () =>

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -54,10 +54,6 @@ import { DatasetEditorPanel } from "./training/DatasetEditorPanel.jsx";
 // screen; the implementations now live in ../training/trainingConfig.js (sc-4199).
 export { configDraftFromTarget, trainingConfigSnapshot };
 
-const trainingTabs = [
-  { id: "configure", label: "Configure Job", title: "Configure training job", status: "Queue dry run" },
-];
-
 const IMPORT_IMAGE_EXTENSIONS = new Set(["png", "jpg", "jpeg", "webp", "bmp", "gif", "tif", "tiff"]);
 
 function uploadFileBaseName(name) {
@@ -255,7 +251,7 @@ function TrainingLiveProgress({ jobs, projectId, onCancel, onPreview }) {
     <section className="training-live-panel" aria-label="Active training progress">
       <div className="training-live-title">
         <div>
-          <p className="eyebrow">Live training</p>
+          <p className="eyebrow">Runs</p>
           <h3>Training in progress</h3>
         </div>
         <span>{jobs.length} active</span>
@@ -341,8 +337,6 @@ export function TrainingStudio({ mode = "training" } = {}) {
   const createCaptionJob = createTrainingDatasetCaptionJob;
   const trainingPresets = trainingPresetsCatalog?.presets ?? [];
   const trainingTargets = trainingTargetsCatalog?.targets ?? [];
-  const workflowTabs = datasetLibraryMode ? [] : trainingTabs;
-  const [activeTab, setActiveTab] = useState(datasetLibraryMode ? "dataset" : "configure");
   const [activeDataset, setActiveDataset] = useState(null);
   const [datasetError, setDatasetError] = useState("");
   const [datasetMessage, setDatasetMessage] = useState("");
@@ -395,10 +389,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
   // the plan to the worker's Z-Image LoRA kernel. Default to the safe dry run.
   const [trainingRunMode, setTrainingRunMode] = useState("dry_run");
   const configBasisRef = useRef("");
-  const tabRefs = useRef({});
 
-  const activeIndex = workflowTabs.findIndex((tab) => tab.id === activeTab);
-  const active = workflowTabs[activeIndex] ?? { id: activeTab, title: datasetLibraryMode ? "Dataset management" : "Configure training job" };
   const datasetSummary = useMemo(() => summarizeDatasets(datasets), [datasets]);
   const datasetAssets = useMemo(
     () => datasetOwnedAssets(activeDataset, activeProject?.id, assets),
@@ -719,10 +710,6 @@ export function TrainingStudio({ mode = "training" } = {}) {
     configBasisRef.current = "";
   }, [activeProject?.id]);
 
-  useEffect(() => {
-    setActiveTab(datasetLibraryMode ? "dataset" : "configure");
-  }, [datasetLibraryMode]);
-
   // sc-2022: open a dataset requested from elsewhere (Character Studio's
   // "Open" action hands off via studioLaunch). Keyed on the launch id so a
   // repeat request for the same dataset re-opens it.
@@ -819,34 +806,6 @@ export function TrainingStudio({ mode = "training" } = {}) {
       return { ...current, requestedGpu: gpuOptions[0] ?? "" };
     });
   }, [gpuOptionsKey]);
-
-  function focusTab(index) {
-    if (!workflowTabs.length) {
-      return;
-    }
-    const next = workflowTabs[(index + workflowTabs.length) % workflowTabs.length];
-    setActiveTab(next.id);
-    window.requestAnimationFrame(() => tabRefs.current[next.id]?.focus());
-  }
-
-  function onTabKeyDown(event) {
-    if (event.key === "ArrowRight") {
-      event.preventDefault();
-      focusTab(activeIndex + 1);
-    }
-    if (event.key === "ArrowLeft") {
-      event.preventDefault();
-      focusTab(activeIndex - 1);
-    }
-    if (event.key === "Home") {
-      event.preventDefault();
-      focusTab(0);
-    }
-    if (event.key === "End") {
-      event.preventDefault();
-      focusTab(workflowTabs.length - 1);
-    }
-  }
 
   async function openDataset(datasetId) {
     if (!datasetId) {
@@ -1451,39 +1410,33 @@ export function TrainingStudio({ mode = "training" } = {}) {
     >
     <section className="page-frame training-studio">
       <div className="training-studio-shell">
-        <div className="training-summary-band">
-          <div className="section-heading">
-            <p className="eyebrow">{datasetLibraryMode ? "Library" : "Training Studio"}</p>
-            <h2>{datasetLibraryMode ? "Data Sets" : "Native LoRA training workflow"}</h2>
-            <p className="view-copy">
-              {datasetLibraryMode
-                ? "Create training datasets, manage imported dataset images, and normalize captions in one place."
-                : "Select an existing dataset and prepare a training plan before any ML runtime work begins."}
-            </p>
+        {/* Data Sets keeps its own header band; the Training Studio is named by the
+            topbar and leads straight into its work-panel (page-frame standard). */}
+        {datasetLibraryMode ? (
+          <div className="training-summary-band">
+            <div className="section-heading">
+              <p className="eyebrow">Library</p>
+              <h2>Data Sets</h2>
+              <p className="view-copy">
+                Create training datasets, manage imported dataset images, and normalize captions in one place.
+              </p>
+            </div>
+            <div className="training-metrics" aria-label="Training workspace summary">
+              <div>
+                <strong>{activeProject?.name ?? "No workspace"}</strong>
+                <span>Project</span>
+              </div>
+              <div>
+                <strong>{datasets.length}</strong>
+                <span>Datasets</span>
+              </div>
+              <div>
+                <strong>{datasetSummary.items}</strong>
+                <span>Items</span>
+              </div>
+            </div>
           </div>
-          <div className="training-metrics" aria-label="Training workspace summary">
-            <div>
-              <strong>{activeProject?.name ?? "No workspace"}</strong>
-              <span>Project</span>
-            </div>
-            <div>
-              <strong>{datasets.length}</strong>
-              <span>Datasets</span>
-            </div>
-            <div>
-              <strong>{datasetSummary.items}</strong>
-              <span>Items</span>
-            </div>
-          </div>
-        </div>
-        {datasetLibraryMode ? null : (
-          <TrainingLiveProgress
-            jobs={activeTrainingJobs}
-            projectId={activeProject?.id}
-            onCancel={jobAction ? (job) => jobAction(job, "cancel") : undefined}
-            onPreview={setPreviewAsset}
-          />
-        )}
+        ) : null}
 
         {!authenticated ? (
           <div className="training-empty-state" role="status">
@@ -1503,40 +1456,9 @@ export function TrainingStudio({ mode = "training" } = {}) {
           </div>
         ) : (
           <>
-            {workflowTabs.length ? (
-            <div className="training-tabs" role="tablist" aria-label="Training workflow">
-              {workflowTabs.map((tab) => (
-                <button
-                  aria-controls={activeTab === tab.id ? `training-panel-${tab.id}` : undefined}
-                  aria-selected={activeTab === tab.id}
-                  className={activeTab === tab.id ? "active" : ""}
-                  id={`training-tab-${tab.id}`}
-                  key={tab.id}
-                  onClick={() => setActiveTab(tab.id)}
-                  onKeyDown={onTabKeyDown}
-                  ref={(node) => {
-                    tabRefs.current[tab.id] = node;
-                  }}
-                  role="tab"
-                  tabIndex={activeTab === tab.id ? 0 : -1}
-                  type="button"
-                >
-                  <span>{tab.label}</span>
-                  <small>{tab.status}</small>
-                </button>
-              ))}
-            </div>
-            ) : null}
-
-            <section
-              aria-labelledby={workflowTabs.length ? `training-tab-${active.id}` : undefined}
-              className="training-panel"
-              id={`training-panel-${active.id}`}
-              role="tabpanel"
-            >
-              {datasetLibraryMode || activeTab === "dataset" ? (
+            {datasetLibraryMode ? (
+              <section className="training-panel">
                 <DatasetEditorPanel
-                  active={active}
                   loadingDatasets={loadingDatasets}
                   onRefreshDatasets={onRefreshDatasets}
                   busyDatasetId={busyDatasetId}
@@ -1591,11 +1513,10 @@ export function TrainingStudio({ mode = "training" } = {}) {
                   captionModelSizeLabel={captionModelSizeLabel}
                   captionModelName={captionModel?.name ?? "JoyCaption"}
                 />
-              ) : null}
-
-              {activeTab === "configure" ? (
+              </section>
+            ) : (
+              <>
                 <ConfigureJobPanel
-                  active={active}
                   setActiveView={setActiveView}
                   configReady={configReady}
                   trainingTargetsError={trainingTargetsError}
@@ -1639,8 +1560,14 @@ export function TrainingStudio({ mode = "training" } = {}) {
                   datasetDoctor={datasetDoctor}
                   readinessBlocksTraining={readinessBlocksTraining}
                 />
-              ) : null}
-            </section>
+                <TrainingLiveProgress
+                  jobs={activeTrainingJobs}
+                  projectId={activeProject?.id}
+                  onCancel={jobAction ? (job) => jobAction(job, "cancel") : undefined}
+                  onPreview={setPreviewAsset}
+                />
+              </>
+            )}
           </>
         )}
       </div>

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -5,6 +5,7 @@ import { FitModeControl, effectiveFitMode } from "../components/FitModeControl.j
 import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
 import { Icon } from "../components/Icons.jsx";
+import { AdvancedSection } from "../components/AdvancedSection.jsx";
 import { WorkPanel } from "../components/WorkPanel.jsx";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { PromptGuideModal } from "../components/PromptGuideModal.jsx";
@@ -1155,12 +1156,11 @@ export function VideoStudio() {
           {durationHint ? <p className="helper-copy">{durationHint}</p> : null}
         </WorkPanel>
 
-        <button className="advanced-toggle" onClick={() => setAdvancedOpen((value) => !value)} type="button">
-            <Icon.ChevDown className={advancedOpen ? "chev-rotate open" : "chev-rotate"} size={14} />
-            {advancedOpen ? "Hide advanced" : "Advanced"}
-          </button>
-
-          {advancedOpen ? (
+        <AdvancedSection
+          hint="cleared values → model default"
+          onToggle={() => setAdvancedOpen((value) => !value)}
+          open={advancedOpen}
+        >
             <div className="advanced-panel">
               <label>
                 Frames
@@ -1456,7 +1456,7 @@ export function VideoStudio() {
                 videoAssets={videoAssets}
               />
             </div>
-          ) : null}
+        </AdvancedSection>
 
           <PresetValidationWarnings presetValidationResult={presetValidationResult} selectedModel={selectedModel} />
           {blockedMessage ? <p className="inline-warning">{blockedMessage}</p> : null}

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -76,12 +76,10 @@ const buttonWithText = (root, text) =>
 const saveButton = (container) =>
   [...container.querySelectorAll("button")].find((b) => b.textContent.includes("Save as Preset"));
 const nameInput = (container) => container.querySelector('input[aria-label="Preset name"]');
-// Save-as-Preset folds into the Advanced panel (collapsed by default), matching Image
-// Studio's single-column layout — open it before touching the preset controls.
+// Save-as-Preset folds into the Advanced disclosure (collapsed by default), matching
+// Image Studio — open it before touching the preset controls.
 const openAdvanced = async (container) => {
-  const toggle = [...container.querySelectorAll("button.advanced-toggle")].find((b) =>
-    b.textContent.includes("Advanced"),
-  );
+  const toggle = container.querySelector(".advanced-section-toggle");
   if (toggle) {
     await click(toggle);
   }
@@ -915,9 +913,9 @@ describe("VideoStudio Lightning toggle (sc-10048)", () => {
     await act(async () => {});
   }
 
-  // Open the Advanced panel where the toggle + steps/guidance live.
+  // Open the Advanced disclosure where the toggle + steps/guidance live.
   const openAdvanced = async () => {
-    await click(buttonWithText(container, "Advanced"));
+    await click(container.querySelector(".advanced-section-toggle"));
   };
   const lightningLabel = () =>
     [...container.querySelectorAll(".lightning-toggle label")].find((el) =>

--- a/apps/web/src/screens/training/ConfigureJobPanel.jsx
+++ b/apps/web/src/screens/training/ConfigureJobPanel.jsx
@@ -1,6 +1,8 @@
 import React from "react";
 
+import { AdvancedSection } from "../../components/AdvancedSection.jsx";
 import { Icon } from "../../components/Icons.jsx";
+import { WorkPanel } from "../../components/WorkPanel.jsx";
 import { DatasetDoctorReadout } from "./DatasetDoctor.jsx";
 import {
   lossTypeOptions,
@@ -12,12 +14,15 @@ import {
   trainingAdapterVersionLabels,
 } from "../../training/trainingConfig.js";
 
-// Configure-training-job panel (sc-4199): extracted verbatim from TrainingStudio
-// so the target/preset/dataset selectors, the advanced config grid, and the
-// run-mode actions live in their own component. All state and handlers are owned
-// by the TrainingStudio screen and passed in as props — behavior is unchanged.
+// Configure-training-job panel. The Purpose zone of the Training Studio under the
+// page-frame standard (sc-10475): one work-panel holding the twelve basic plan
+// fields, the Advanced disclosure with every remaining knob, and the actions row.
+// All state and handlers are owned by the TrainingStudio screen and passed in.
+//
+// The basic grid is the twelve fields the design calls out, in its order. Its
+// "Base model" slot is our `Target` select — the real base+kernel picker; the
+// read-only base-model echo lives in Advanced with everything else.
 export function ConfigureJobPanel({
-  active,
   setActiveView,
   configReady,
   trainingTargetsError,
@@ -65,21 +70,24 @@ export function ConfigureJobPanel({
   datasetDoctor,
   readinessBlocksTraining = false,
 }) {
+  const resolvedGpu = configDraft.requestedGpu === "auto" || !configDraft.requestedGpu
+    ? "Auto"
+    : `GPU ${configDraft.requestedGpu}`;
   return (
-    <>
-      <div className="training-panel-head">
-        <div>
-          <p className="eyebrow">Configure Job</p>
-          <h3>{active.title}</h3>
-        </div>
-        <div className="training-head-actions">
+    <WorkPanel
+      className="training-config-panel"
+      eyebrow="Configure the run"
+      hint="Pick a captioned dataset from the Data Sets library, choose a target and a preset, then queue the plan."
+      actions={
+        <>
           <button className="secondary-action" onClick={() => setActiveView?.("LibraryDataSets")} type="button">
             <Icon.Library size={14} />
             Data Sets
           </button>
           <span className="training-status-pill">{configReady ? "Ready" : "Needs input"}</span>
-        </div>
-      </div>
+        </>
+      }
+    >
       {trainingTargetsError ? <p className="inline-warning">{trainingTargetsError}</p> : null}
       {trainingPresetsError ? <p className="inline-warning">{trainingPresetsError}</p> : null}
       {configError ? <p className="inline-warning">{configError}</p> : null}
@@ -89,6 +97,17 @@ export function ConfigureJobPanel({
       ) : (
         <div className="training-config-form" aria-label="Training job configuration">
           <div className="training-config-grid">
+            <label>
+              Dataset
+              <select onChange={(event) => openDataset(event.target.value)} value={activeDataset?.id ?? ""}>
+                <option value="">Select a saved dataset</option>
+                {datasets.map((dataset) => (
+                  <option key={dataset.id} value={dataset.id}>
+                    {dataset.name ?? dataset.id}
+                  </option>
+                ))}
+              </select>
+            </label>
             <label>
               Target
               <select onChange={(event) => setSelectedTargetId(event.target.value)} value={selectedTarget.id}>
@@ -115,29 +134,6 @@ export function ConfigureJobPanel({
               </select>
             </label>
             <label>
-              Base model
-              <input disabled readOnly value={selectedTarget.baseModel ?? ""} />
-            </label>
-            <label>
-              Dataset
-              <select onChange={(event) => openDataset(event.target.value)} value={activeDataset?.id ?? ""}>
-                <option value="">Select a saved dataset</option>
-                {datasets.map((dataset) => (
-                  <option key={dataset.id} value={dataset.id}>
-                    {dataset.name ?? dataset.id}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label>
-              LoRA name
-              <input onChange={(event) => updateConfigDraft("outputName", event.target.value)} value={configDraft.outputName ?? ""} />
-            </label>
-            <label>
-              Trigger phrase
-              <input onChange={(event) => updateConfigDraft("triggerWord", event.target.value)} value={configDraft.triggerWord ?? ""} />
-            </label>
-            <label>
               Output scope
               <select onChange={(event) => updateConfigDraft("outputScope", event.target.value)} value={configDraft.outputScope ?? ""}>
                 {outputScopes.length ? null : <option value={configDraft.outputScope ?? ""}>{configDraft.outputScope || "Default"}</option>}
@@ -148,22 +144,28 @@ export function ConfigureJobPanel({
                 ))}
               </select>
             </label>
+
             <label>
-              Quality preset
-              <select
-                onChange={(event) => updateConfigDraft("qualityPreset", event.target.value)}
-                value={configDraft.qualityPreset ?? ""}
-              >
-                {visibleQualityPresets.length ? null : (
-                  <option value={configDraft.qualityPreset ?? ""}>{configDraft.qualityPreset || "Default"}</option>
-                )}
-                {visibleQualityPresets.map((preset) => (
-                  <option key={preset} value={preset}>
-                    {preset}
-                  </option>
-                ))}
-              </select>
+              LoRA name
+              <input onChange={(event) => updateConfigDraft("outputName", event.target.value)} value={configDraft.outputName ?? ""} />
             </label>
+            <label>
+              Trigger phrase
+              <input onChange={(event) => updateConfigDraft("triggerWord", event.target.value)} value={configDraft.triggerWord ?? ""} />
+            </label>
+            <label>
+              Steps
+              <input onChange={(event) => updateConfigDraft("steps", event.target.value)} type="number" value={configDraft.steps ?? ""} />
+            </label>
+            <label>
+              Checkpoint cadence
+              <input
+                onChange={(event) => updateConfigDraft("saveEvery", event.target.value)}
+                type="number"
+                value={configDraft.saveEvery ?? ""}
+              />
+            </label>
+
             <label>
               Requested GPU
               <select onChange={(event) => updateConfigDraft("requestedGpu", event.target.value)} value={configDraft.requestedGpu ?? ""}>
@@ -175,11 +177,12 @@ export function ConfigureJobPanel({
               </select>
             </label>
             <label>
-              Sample cadence
+              Sample count
               <input
-                onChange={(event) => updateConfigDraft("sampleEvery", event.target.value)}
+                min="0"
+                onChange={(event) => updateConfigDraft("sampleCount", event.target.value)}
                 type="number"
-                value={configDraft.sampleEvery ?? ""}
+                value={configDraft.sampleCount ?? ""}
               />
             </label>
             <label>
@@ -191,62 +194,41 @@ export function ConfigureJobPanel({
               />
             </label>
             <label>
-              Guidance scale
+              Sample cadence
               <input
-                onChange={(event) => updateConfigDraft("sampleGuidanceScale", event.target.value)}
-                step="0.1"
+                onChange={(event) => updateConfigDraft("sampleEvery", event.target.value)}
                 type="number"
-                value={configDraft.sampleGuidanceScale ?? ""}
-              />
-            </label>
-            <label>
-              Sample count
-              <input
-                min="0"
-                onChange={(event) => updateConfigDraft("sampleCount", event.target.value)}
-                type="number"
-                value={configDraft.sampleCount ?? ""}
+                value={configDraft.sampleEvery ?? ""}
               />
             </label>
           </div>
 
-          <label className="training-sample-prompts">
-            Sample prompts
-            <textarea
-              onChange={(event) => updateConfigDraft("samplePrompts", event.target.value)}
-              placeholder="One prompt per line. Leave blank to use the trigger-phrase defaults."
-              rows={4}
-              value={configDraft.samplePrompts ?? ""}
-            />
-            <span className="training-field-hint">
-              One prompt per line. Renders one preview per prompt, up to the sample count.
-            </span>
-          </label>
-
-          {selectedPreset ? (
-            <div className="training-preset-summary" aria-label="Preset values">
-              <span>{selectedPreset.name}</span>
-              <span>Rank {configDraft.rank || "-"}</span>
-              <span>LR {configDraft.learningRate || "-"}</span>
-              <span>{optimizerLabel(configDraft.optimizer)}</span>
-              <span>{configDraft.steps || "-"} steps</span>
-              <span>{configDraft.resolution || "-"}px</span>
-              {customizedConfigLabels.length ? (
-                <span>Customized: {customizedConfigLabels.join(", ")}</span>
-              ) : null}
-            </div>
-          ) : null}
-
-          <details
-            className="training-advanced-panel"
-            onToggle={(event) => setShowAdvancedConfig(event.currentTarget.open)}
+          <AdvancedSection
+            hint="cleared values → preset default"
+            onToggle={() => setShowAdvancedConfig(!showAdvancedConfig)}
             open={showAdvancedConfig}
           >
-            <summary>
-              <Icon.Sliders size={14} />
-              Advanced
-            </summary>
             <div className="training-advanced-grid">
+              <label>
+                Base model
+                <input disabled readOnly value={selectedTarget.baseModel ?? ""} />
+              </label>
+              <label>
+                Quality preset
+                <select
+                  onChange={(event) => updateConfigDraft("qualityPreset", event.target.value)}
+                  value={configDraft.qualityPreset ?? ""}
+                >
+                  {visibleQualityPresets.length ? null : (
+                    <option value={configDraft.qualityPreset ?? ""}>{configDraft.qualityPreset || "Default"}</option>
+                  )}
+                  {visibleQualityPresets.map((preset) => (
+                    <option key={preset} value={preset}>
+                      {preset}
+                    </option>
+                  ))}
+                </select>
+              </label>
               <label>
                 Rank
                 <input onChange={(event) => updateConfigDraft("rank", event.target.value)} type="number" value={configDraft.rank ?? ""} />
@@ -314,9 +296,24 @@ export function ConfigureJobPanel({
                   value={configDraft.weightDecay ?? ""}
                 />
               </label>
-              <label>
-                Steps
-                <input onChange={(event) => updateConfigDraft("steps", event.target.value)} type="number" value={configDraft.steps ?? ""} />
+              <label title="Learning-rate scheduler (not the timestep/noise scheduler). Constant holds the LR fixed for the whole run; linear and cosine decay it toward zero over the run.">
+                LR scheduler
+                <select onChange={(event) => updateConfigDraft("lrScheduler", event.target.value)} value={configDraft.lrScheduler ?? ""}>
+                  {visibleLrSchedulerOptions.map((option) => (
+                    <option key={option} value={option}>
+                      {optionLabel(option)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label title="Optional linear warmup: number of steps to ramp the LR up from zero before the scheduler body runs. 0 disables warmup.">
+                LR warmup steps
+                <input
+                  min="0"
+                  onChange={(event) => updateConfigDraft("lrWarmupSteps", event.target.value)}
+                  type="number"
+                  value={configDraft.lrWarmupSteps ?? ""}
+                />
               </label>
               <label>
                 Timestep type
@@ -348,25 +345,6 @@ export function ConfigureJobPanel({
                   ))}
                 </select>
               </label>
-              <label title="Learning-rate scheduler (not the timestep/noise scheduler). Constant holds the LR fixed for the whole run; linear and cosine decay it toward zero over the run.">
-                LR scheduler
-                <select onChange={(event) => updateConfigDraft("lrScheduler", event.target.value)} value={configDraft.lrScheduler ?? ""}>
-                  {visibleLrSchedulerOptions.map((option) => (
-                    <option key={option} value={option}>
-                      {optionLabel(option)}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label title="Optional linear warmup: number of steps to ramp the LR up from zero before the scheduler body runs. 0 disables warmup.">
-                LR warmup steps
-                <input
-                  min="0"
-                  onChange={(event) => updateConfigDraft("lrWarmupSteps", event.target.value)}
-                  type="number"
-                  value={configDraft.lrWarmupSteps ?? ""}
-                />
-              </label>
               {showTrainingAdapter ? (
                 <label title="ostris de-distill adapter for the step-distilled Z-Image-Turbo base. Fused in for training, removed at inference. v1 is stable; v2 is a heavier, experimental de-distill.">
                   De-distill adapter
@@ -397,6 +375,31 @@ export function ConfigureJobPanel({
                 Precision
                 <input onChange={(event) => updateConfigDraft("precision", event.target.value)} value={configDraft.precision ?? ""} />
               </label>
+              <label>
+                Guidance scale
+                <input
+                  onChange={(event) => updateConfigDraft("sampleGuidanceScale", event.target.value)}
+                  step="0.1"
+                  type="number"
+                  value={configDraft.sampleGuidanceScale ?? ""}
+                />
+              </label>
+            </div>
+
+            <label className="training-sample-prompts">
+              Sample prompts
+              <textarea
+                onChange={(event) => updateConfigDraft("samplePrompts", event.target.value)}
+                placeholder="One prompt per line. Leave blank to use the trigger-phrase defaults."
+                rows={4}
+                value={configDraft.samplePrompts ?? ""}
+              />
+              <span className="training-field-hint">
+                One prompt per line. Renders one preview per prompt, up to the sample count.
+              </span>
+            </label>
+
+            <div className="training-advanced-toggles">
               <label className="training-checkbox-field">
                 <input
                   checked={Boolean(configDraft.gradientCheckpointing)}
@@ -405,16 +408,22 @@ export function ConfigureJobPanel({
                 />
                 Gradient checkpointing
               </label>
-              <label>
-                Checkpoint cadence
-                <input
-                  onChange={(event) => updateConfigDraft("saveEvery", event.target.value)}
-                  type="number"
-                  value={configDraft.saveEvery ?? ""}
-                />
-              </label>
             </div>
-          </details>
+          </AdvancedSection>
+
+          {selectedPreset ? (
+            <div className="training-preset-summary" aria-label="Preset values">
+              <span>{selectedPreset.name}</span>
+              <span>Rank {configDraft.rank || "-"}</span>
+              <span>LR {configDraft.learningRate || "-"}</span>
+              <span>{optimizerLabel(configDraft.optimizer)}</span>
+              <span>{configDraft.steps || "-"} steps</span>
+              <span>{configDraft.resolution || "-"}px</span>
+              {customizedConfigLabels.length ? (
+                <span>Customized: {customizedConfigLabels.join(", ")}</span>
+              ) : null}
+            </div>
+          ) : null}
 
           {configWarnings.length ? (
             <div className="training-config-warnings" aria-label="Configuration warnings">
@@ -447,6 +456,7 @@ export function ConfigureJobPanel({
                 <option value="real">Run training (beta)</option>
               </select>
             </label>
+            <span className="training-run-note">Runs locally · {resolvedGpu}</span>
             <button className="secondary-action" onClick={resetConfigDefaults} type="button">
               Reset defaults
             </button>
@@ -470,6 +480,6 @@ export function ConfigureJobPanel({
         A dry run validates the training plan and dataset on a GPU worker without training. Run training
         (beta) hands the same plan to the worker's Z-Image LoRA kernel to produce a real .safetensors adapter.
       </p>
-    </>
+    </WorkPanel>
   );
 }

--- a/apps/web/src/screens/training/ConfigureJobPanel.jsx
+++ b/apps/web/src/screens/training/ConfigureJobPanel.jsx
@@ -19,10 +19,12 @@ import {
 // fields, the Advanced disclosure with every remaining knob, and the actions row.
 // All state and handlers are owned by the TrainingStudio screen and passed in.
 //
-// The basic grid is the twelve fields the design calls out, in its order. Its
-// "Base model" slot is our `Target` select: every target maps 1:1 to a base model
-// and names it in its own label, and the job payload carries `targetId` alone —
-// the server resolves the base from the registry.
+// The basic grid holds the twelve fields the design calls out. Two deviations from
+// its literal ordering: the "Base model" slot is our `Target` select (every target
+// maps 1:1 to a base model and names it in its own label; the payload carries
+// `targetId` alone and the server resolves the base), and `Quality` sits beside
+// `Preset` because it is a tier OF the preset, not an independent axis. GPU is a
+// runtime routing knob rather than part of the plan, so it lives in Advanced.
 export function ConfigureJobPanel({
   setActiveView,
   configReady,
@@ -134,13 +136,21 @@ export function ConfigureJobPanel({
                 ))}
               </select>
             </label>
+            {/* Quality is a tier OF the preset (preset ids are
+                <target>.<recipe>.<optimizer>.<quality>), so it sits beside Preset.
+                Selecting a tier does not yet swap the preset — sc-10483 wires it. */}
             <label>
-              Output scope
-              <select onChange={(event) => updateConfigDraft("outputScope", event.target.value)} value={configDraft.outputScope ?? ""}>
-                {outputScopes.length ? null : <option value={configDraft.outputScope ?? ""}>{configDraft.outputScope || "Default"}</option>}
-                {outputScopes.map((scope) => (
-                  <option key={scope} value={scope}>
-                    {scope}
+              Quality
+              <select
+                onChange={(event) => updateConfigDraft("qualityPreset", event.target.value)}
+                value={configDraft.qualityPreset ?? ""}
+              >
+                {visibleQualityPresets.length ? null : (
+                  <option value={configDraft.qualityPreset ?? ""}>{configDraft.qualityPreset || "Default"}</option>
+                )}
+                {visibleQualityPresets.map((preset) => (
+                  <option key={preset} value={preset}>
+                    {preset}
                   </option>
                 ))}
               </select>
@@ -168,11 +178,12 @@ export function ConfigureJobPanel({
             </label>
 
             <label>
-              Requested GPU
-              <select onChange={(event) => updateConfigDraft("requestedGpu", event.target.value)} value={configDraft.requestedGpu ?? ""}>
-                {gpuOptions.map((gpu) => (
-                  <option key={gpu} value={gpu}>
-                    {gpu === "auto" ? "Auto" : `GPU ${gpu}`}
+              Output scope
+              <select onChange={(event) => updateConfigDraft("outputScope", event.target.value)} value={configDraft.outputScope ?? ""}>
+                {outputScopes.length ? null : <option value={configDraft.outputScope ?? ""}>{configDraft.outputScope || "Default"}</option>}
+                {outputScopes.map((scope) => (
+                  <option key={scope} value={scope}>
+                    {scope}
                   </option>
                 ))}
               </select>
@@ -211,17 +222,11 @@ export function ConfigureJobPanel({
           >
             <div className="training-advanced-grid">
               <label>
-                Quality preset
-                <select
-                  onChange={(event) => updateConfigDraft("qualityPreset", event.target.value)}
-                  value={configDraft.qualityPreset ?? ""}
-                >
-                  {visibleQualityPresets.length ? null : (
-                    <option value={configDraft.qualityPreset ?? ""}>{configDraft.qualityPreset || "Default"}</option>
-                  )}
-                  {visibleQualityPresets.map((preset) => (
-                    <option key={preset} value={preset}>
-                      {preset}
+                Requested GPU
+                <select onChange={(event) => updateConfigDraft("requestedGpu", event.target.value)} value={configDraft.requestedGpu ?? ""}>
+                  {gpuOptions.map((gpu) => (
+                    <option key={gpu} value={gpu}>
+                      {gpu === "auto" ? "Auto" : `GPU ${gpu}`}
                     </option>
                   ))}
                 </select>

--- a/apps/web/src/screens/training/ConfigureJobPanel.jsx
+++ b/apps/web/src/screens/training/ConfigureJobPanel.jsx
@@ -20,8 +20,9 @@ import {
 // All state and handlers are owned by the TrainingStudio screen and passed in.
 //
 // The basic grid is the twelve fields the design calls out, in its order. Its
-// "Base model" slot is our `Target` select — the real base+kernel picker; the
-// read-only base-model echo lives in Advanced with everything else.
+// "Base model" slot is our `Target` select: every target maps 1:1 to a base model
+// and names it in its own label, and the job payload carries `targetId` alone —
+// the server resolves the base from the registry.
 export function ConfigureJobPanel({
   setActiveView,
   configReady,
@@ -209,10 +210,6 @@ export function ConfigureJobPanel({
             open={showAdvancedConfig}
           >
             <div className="training-advanced-grid">
-              <label>
-                Base model
-                <input disabled readOnly value={selectedTarget.baseModel ?? ""} />
-              </label>
               <label>
                 Quality preset
                 <select

--- a/apps/web/src/screens/training/DatasetEditorPanel.jsx
+++ b/apps/web/src/screens/training/DatasetEditorPanel.jsx
@@ -52,7 +52,6 @@ function DatasetHealth({ health, action }) {
 // dialogs live in their own component. All state and handlers are owned by the
 // TrainingStudio screen and passed in as props — behavior is unchanged.
 export function DatasetEditorPanel({
-  active,
   loadingDatasets,
   onRefreshDatasets,
   busyDatasetId,
@@ -142,7 +141,7 @@ export function DatasetEditorPanel({
       <div className="training-panel-head">
         <div>
           <p className="eyebrow">Dataset</p>
-          <h3>{active.title}</h3>
+          <h3>Dataset management</h3>
         </div>
         <div className="training-head-actions">
           <button className="secondary-action" disabled={loadingDatasets} onClick={onRefreshDatasets} type="button">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4480,7 +4480,6 @@ label {
 .review-card,
 .asset-detail,
 .preview-button,
-.advanced-panel,
 .studio-controls,
 .review-panel {
   border: 1px solid var(--border);
@@ -7278,12 +7277,10 @@ details[open] > summary.lora-scope-group-heading::before,
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+/* Every Advanced panel now renders inside an `.advanced-section` disclosure, which
+   owns the bordered block. What is left here is only the override grid (sc-10478). */
 .advanced-panel {
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  padding: 12px;
-  background: var(--surface-2);
-  border-radius: var(--r-md);
-  border: 1px solid var(--border);
 }
 
 /* Uniform control height so every select and number/text field in the panel lines up
@@ -7323,15 +7320,6 @@ details[open] > summary.lora-scope-group-heading::before,
   grid-column: 1 / -1;
 }
 
-/* Inside the disclosure the block's chrome belongs to `.advanced-section`, so the
-   panel is just a grid. CharacterAdvancedOptions still renders `.advanced-panel`
-   standalone with its own card; this override drops out with it (sc-10478). */
-.advanced-section-body .advanced-panel {
-  padding: 0;
-  background: none;
-  border: 0;
-  border-radius: 0;
-}
 
 .video-preset-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1225,11 +1225,13 @@ button:focus-visible {
   white-space: nowrap;
 }
 
-/* Advanced section — expands in place BELOW the work-panel, never inside it. */
+/* Advanced section — the one canonical disclosure. A bordered, header-labelled
+   block whose controls open contiguously beneath its own header, inside the same
+   block (sc-10474). Collapsed it is header-only, so it reserves no space. */
 .advanced-section {
   border: 1px solid var(--border);
   border-radius: var(--r-md);
-  background: var(--surface);
+  background: var(--surface-2);
   overflow: hidden;
 }
 
@@ -1238,7 +1240,7 @@ button:focus-visible {
   align-items: center;
   gap: var(--gap-2);
   padding: 11px 14px;
-  background: var(--surface-2);
+  cursor: pointer;
 }
 
 .advanced-section.open .advanced-section-head {
@@ -1272,7 +1274,12 @@ button:focus-visible {
 .advanced-section-caret-btn {
   display: inline-flex;
   align-items: center;
+  gap: 6px;
   color: var(--text-faint);
+}
+
+.advanced-section-caret-label {
+  font-size: 11px;
 }
 
 .advanced-section-caret {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3306,10 +3306,8 @@ label {
 .training-metrics > div,
 .training-empty-state,
 .training-panel,
-.training-live-panel,
 .training-step-block,
-.training-dataset-editor,
-.training-advanced-panel {
+.training-dataset-editor {
   border: 1px solid var(--border);
   border-radius: var(--r-sm);
   background: var(--surface-2);
@@ -3385,10 +3383,11 @@ label {
   font-weight: 700;
 }
 
+/* Results zone: the live runs sit flush on the workspace canvas — only the
+   WorkerProgressCard rows carry their own borders (page-frame standard). */
 .training-live-panel {
   display: grid;
   gap: 12px;
-  padding: 14px;
 }
 
 /* .training-live-title remains because TrainingStudio.jsx still renders it as the
@@ -3747,32 +3746,22 @@ label {
   grid-template-columns: repeat(4, minmax(150px, 1fr));
 }
 
-.training-advanced-panel {
-  padding: 12px;
-  background: var(--surface);
-}
-
-.training-advanced-panel summary {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  cursor: pointer;
-  color: var(--text);
-  font-weight: 700;
-}
-
 .training-advanced-grid {
   grid-template-columns: repeat(4, minmax(120px, 1fr));
-  margin-top: 12px;
 }
 
-.training-advanced-grid .training-checkbox-field {
+.training-advanced-grid .training-checkbox-field,
+.training-advanced-toggles .training-checkbox-field {
+  display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
   align-content: center;
   gap: 8px;
-  min-height: 58px;
+  min-height: var(--control-h);
+  min-width: 0;
   color: var(--text);
+  font-size: 12.5px;
+  font-weight: 500;
 }
 
 .training-config-warnings {
@@ -3808,19 +3797,39 @@ label {
   font-weight: 700;
 }
 
+/* Toggles close the Advanced disclosure, divided from the override grid above
+   them (design handoff: "a grouped grid of override fields, then a toggles row"). */
+.training-advanced-toggles {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(120px, 1fr));
+  gap: 10px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
+/* Actions close the work-panel: the run-mode note on the left, one filled
+   primary on the right, divided from the config above. */
 .training-config-actions {
   display: flex;
   justify-content: flex-end;
   flex-wrap: wrap;
   gap: 8px;
   align-items: flex-end;
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
+}
+
+.training-run-note {
+  margin-right: auto;
+  align-self: center;
+  color: var(--text-faint);
+  font-size: 11.5px;
 }
 
 .training-run-mode {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  margin-right: auto;
   font-size: 0.78rem;
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7323,6 +7323,16 @@ details[open] > summary.lora-scope-group-heading::before,
   grid-column: 1 / -1;
 }
 
+/* Inside the disclosure the block's chrome belongs to `.advanced-section`, so the
+   panel is just a grid. CharacterAdvancedOptions still renders `.advanced-panel`
+   standalone with its own card; this override drops out with it (sc-10478). */
+.advanced-section-body .advanced-panel {
+  padding: 0;
+  background: none;
+  border: 0;
+  border-radius: 0;
+}
+
 .video-preset-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }

--- a/apps/web/src/training/trainingConfig.js
+++ b/apps/web/src/training/trainingConfig.js
@@ -47,7 +47,7 @@ export const configFieldLabels = {
   outputName: "LoRA name",
   triggerWord: "Trigger phrase",
   outputScope: "Output scope",
-  qualityPreset: "Quality preset",
+  qualityPreset: "Quality",
   requestedGpu: "Requested GPU",
   rank: "Rank",
   alpha: "Alpha",


### PR DESCRIPTION
Applies the second design handoff (`design/Training Design.zip`) — the Training Studio redesign, plus the Advanced-disclosure pattern it establishes, rolled out to the Image and Video studios as the spec's closing action item requires.

## What the handoff changed

The spec **supersedes** the earlier Advanced description. The canonical treatment is a **bordered, header-labelled block whose controls open contiguously beneath its own header, inside the same block**. It is explicitly *not* a floating full-width button that spawns a separate container below it — "the button and the panel it reveals read as two disconnected things; here the header *is* the panel."

## Commits

| Story | Change |
|---|---|
| sc-10474 | `AdvancedSection` → the spec'd disclosure: `--surface-2` block, header row is the toggle (eyebrow + hint + Show/Hide + caret), body attaches beneath it |
| sc-10475 | Training Studio configure panel redesign |
| sc-10476 | Image Studio Advanced → the disclosure |
| sc-10477 | Video Studio Advanced → the disclosure |
| sc-10478 | Character advanced options → the disclosure; `.advanced-panel` sheds its card |

## Training Studio

One work-panel holds the **twelve basic plan fields** the design enumerates, in its order:

- Dataset · Target · Preset · Quality
- LoRA name · Trigger phrase · Steps · Checkpoint cadence
- Output scope · Sample count · Sample steps · Sample cadence

`Steps` and `Checkpoint cadence` are promoted out of Advanced to reach that set. The design's **"Base model" slot maps to our `Target` select**, and the old read-only `Base model` field is **deleted**: it was `<input disabled readOnly>`, never submitted (the payload carries `targetId`; the server resolves the base from the registry), and all 11 targets map 1:1 to a base model their own label already names. It was a control-shaped echo of the Target select, not a control.

`Quality` (was "Quality preset") moves up beside `Preset`: it is a tier *of* the preset — ids are `<target>.<recipe>.<optimizer>.<quality>` — not an independent axis. `Requested GPU` moves down into Advanced, since it routes the run rather than describing the plan. `Quality` remains inert until [sc-10483](https://app.shortcut.com/trefry/story/10483) wires it to the preset registry and fixes its option vocabulary (`limits.qualityPresets` offers `speed/balanced/quality` while presets emit `balanced/conservative/low_vram`).

Per Michael's instruction, **anything not in the twelve basics goes under Advanced rather than being dropped or hidden**: Quality preset, Guidance scale, Rank, Alpha, Network type\*, LoKr factor\*, Optimizer, Learning rate, Weight decay, LR scheduler, LR warmup steps, Timestep type, Timestep bias, Loss type, De-distill adapter\*, Resolution, Precision, the full-width Sample prompts textarea, and the Gradient-checkpointing toggle row. (\* = existing conditional renders, conditions intact.)

The actions row closes the panel (run-mode select + resolved-GPU note left, Reset defaults + one filled primary right). The live runs drop their wrapping card and sit on the canvas. The single-item "Configure Job" tablist goes with the hero band — datasets are built in the separate Data Sets library, so there is nothing to tab between.

## Preserve-all-controls

Verified by before/after control counts against `origin/main`:

- **ConfigureJobPanel**: 15 selects / 16 inputs / 1 textarea / 3 buttons / 32 labels, vs 15/17/1/3/33 before. The single delta is the deleted disabled-readonly `Base model` echo (the Quality/GPU/Output-scope moves are relocations, not removals); every interactive control survives, and all 28 `updateConfigDraft` field keys are unchanged (diffed, zero delta).
- **ImageStudio**: 13 selects / 18 inputs / 2 textareas / 32 labels — identical (one fewer `<button>`: the retired floating toggle, now inside the component).
- **VideoStudio**: 13 selects / 10 inputs / 2 textareas / 25 labels — identical, incl. Lightning, the per-model conditionals, and the full-width upscale card.

## Verification

- `npx vitest run` — **1375 passed** (105 files), up 1 from the new Show/Hide test
- `npx vite build` — clean; `npx eslint` — 0 errors
- Browser preview against the live worktree stylesheet, light + dark: collapsed disclosure is header-only (40px, no body in the DOM), expanded gets the 1px header divider, 4-col basic + advanced grids, every control on `--control-h` (38px), toggles + actions rows top-bordered, `.advanced-panel` renders as a bare 2-col grid with no nested card. `work-panel` `overflow: visible` preserved (the sc-10473 dropdown fix). No console errors.

## Note

Tests that read an override field now expand Advanced first (`openAdvancedSection` helper): the disclosure unmounts its body when collapsed, unlike the `<details>` element it replaced in the Training Studio.

Data Sets keeps its own header band and card for now — the page-frame cleanup there is tracked separately and was not in this handoff's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

