### PR TITLE
feat(web): page-frame the last screens + delete the dead hero CSS (sc-10449, sc-10450)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -2310,7 +2310,7 @@ export function App() {
         ) : null}
 
         {activeView === "ImageEditor" ? (
-          <React.Suspense fallback={<section className="main-surface">Loading editor…</section>}>
+          <React.Suspense fallback={<section className="page-frame">Loading editor…</section>}>
             <ImageEditor key={activeProject?.id ?? "default"} />
           </React.Suspense>
         ) : null}

--- a/apps/web/src/screens/DocumentStudio.jsx
+++ b/apps/web/src/screens/DocumentStudio.jsx
@@ -3,6 +3,7 @@ import { AssetPickerField } from "../components/AssetPicker.jsx";
 import { DocumentView } from "../components/DocumentView.jsx";
 import { ModelAvailabilityGate } from "../components/ModelAvailabilityGate.jsx";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
+import { WorkPanel } from "../components/WorkPanel.jsx";
 import {
   DEFAULT_INTERLEAVE_RESOLUTION,
   DEFAULT_INTERLEAVE_SYSTEM_MESSAGE,
@@ -141,7 +142,11 @@ export function DocumentStudio() {
       onOpenQueue={onOpenQueue}
       onCancelJob={onCancelJob}
     >
-    <section className="main-surface document-studio">
+    <section className="page-frame document-studio">
+      <WorkPanel
+        eyebrow="Compose a document"
+        hint="Describe the document; the model interleaves prose with the images it generates."
+      >
       <form className="studio-form" onSubmit={submit}>
         <label className="field">
           <span>Prompt</span>
@@ -232,6 +237,7 @@ export function DocumentStudio() {
           {submitting ? "Submitting…" : "Compose document"}
         </button>
       </form>
+      </WorkPanel>
 
       <section className="studio-results">
         {localJobs.length ? (

--- a/apps/web/src/screens/EditorScreen.jsx
+++ b/apps/web/src/screens/EditorScreen.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { AssetMedia, assetCanRenderAsImage, assetCanRenderAsVideo } from "../components/assetMedia.jsx";
+import { WorkPanel } from "../components/WorkPanel.jsx";
 import { formatSeconds } from "../formatting.js";
 import {
   aspectOptions,
@@ -404,27 +405,32 @@ export function EditorScreen() {
 
   if (!activeProject) {
     return (
-      <section className="main-surface">
-        <div className="section-heading">
-          <p className="eyebrow">Video Editor</p>
-          <h2>Create a project</h2>
-        </div>
+      <section className="page-frame">
         <div className="empty-panel">Open a project before assembling a timeline.</div>
       </section>
     );
   }
 
   return (
-    <section className="main-surface editor-surface">
-      <div className="surface-header editor-header hero">
-        <div className="section-heading">
-          <p className="eyebrow">Video Editor</p>
-          <h2>{activeTimeline?.name ?? "Timelines"}</h2>
-          <p className="hero-blurb">
-            Sequence clips on the timeline, scrub through the preview, and export when the cut feels right.
-          </p>
-        </div>
-        <div className="editor-actions">
+    <section className="page-frame editor-surface">
+      <WorkPanel
+        eyebrow={activeTimeline?.name ?? "Timelines"}
+        hint="Sequence clips on the timeline, scrub through the preview, and export when the cut feels right."
+        actions={
+          <>
+            <button disabled={!activeTimeline} onClick={() => saveTimeline(activeTimeline)} type="button">
+              Save
+            </button>
+            <button disabled={!history.length} onClick={undo} type="button">
+              Undo
+            </button>
+            <button disabled={!future.length} onClick={redo} type="button">
+              Redo
+            </button>
+          </>
+        }
+      >
+        <div className="editor-header">
           <select onChange={(event) => setSelectedTimelineId(event.target.value)} value={selectedTimelineId ?? ""}>
             <option value="">Select timeline</option>
             {timelines.map((timeline) => (
@@ -433,35 +439,26 @@ export function EditorScreen() {
               </option>
             ))}
           </select>
-          <button disabled={!activeTimeline} onClick={() => saveTimeline(activeTimeline)} type="button">
-            Save
-          </button>
-          <button disabled={!history.length} onClick={undo} type="button">
-            Undo
-          </button>
-          <button disabled={!future.length} onClick={redo} type="button">
-            Redo
-          </button>
         </div>
-      </div>
 
-      <form className="timeline-create" onSubmit={submitNewTimeline}>
-        <label>
-          Timeline
-          <input onChange={(event) => setNewTimelineName(event.target.value)} value={newTimelineName} />
-        </label>
-        <label>
-          Aspect
-          <select onChange={(event) => setNewAspectRatio(event.target.value)} value={newAspectRatio}>
-            {Object.entries(aspectOptions).map(([value, option]) => (
-              <option key={value} value={value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
-        </label>
-        <button type="submit">New Timeline</button>
-      </form>
+        <form className="timeline-create" onSubmit={submitNewTimeline}>
+          <label>
+            Timeline
+            <input onChange={(event) => setNewTimelineName(event.target.value)} value={newTimelineName} />
+          </label>
+          <label>
+            Aspect
+            <select onChange={(event) => setNewAspectRatio(event.target.value)} value={newAspectRatio}>
+              {Object.entries(aspectOptions).map(([value, option]) => (
+                <option key={value} value={value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button type="submit">New Timeline</button>
+        </form>
+      </WorkPanel>
 
       {activeTimeline ? (
         <div className="editor-layout">

--- a/apps/web/src/screens/EditorScreen.jsx
+++ b/apps/web/src/screens/EditorScreen.jsx
@@ -418,13 +418,13 @@ export function EditorScreen() {
         hint="Sequence clips on the timeline, scrub through the preview, and export when the cut feels right."
         actions={
           <>
-            <button disabled={!activeTimeline} onClick={() => saveTimeline(activeTimeline)} type="button">
+            <button className="secondary-action" disabled={!activeTimeline} onClick={() => saveTimeline(activeTimeline)} type="button">
               Save
             </button>
-            <button disabled={!history.length} onClick={undo} type="button">
+            <button className="secondary-action" disabled={!history.length} onClick={undo} type="button">
               Undo
             </button>
-            <button disabled={!future.length} onClick={redo} type="button">
+            <button className="secondary-action" disabled={!future.length} onClick={redo} type="button">
               Redo
             </button>
           </>

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -3498,7 +3498,7 @@ export function ImageEditor() {
   );
 
   return (
-    <section className="main-surface image-editor-surface ie-shell" data-ie-layout={layout}>
+    <section className="image-editor-surface ie-shell" data-ie-layout={layout}>
       <header className="ie-topbar">
         <div className="ie-brand">
           <div className="ie-brand-mark">

--- a/apps/web/src/screens/LicensesScreen.jsx
+++ b/apps/web/src/screens/LicensesScreen.jsx
@@ -26,7 +26,7 @@ export function LicensesScreen() {
 
   if (!selected) {
     return (
-      <section className="main-surface licenses-screen">
+      <section className="page-frame licenses-screen">
         <p className="licenses-empty">No bundled third-party components are recorded.</p>
       </section>
     );
@@ -35,7 +35,7 @@ export function LicensesScreen() {
   const activeDoc = selected.documents[docIndex] ?? selected.documents[0];
 
   return (
-    <section className="main-surface licenses-screen">
+    <section className="page-frame licenses-screen">
       {licensesIntro ? <p className="licenses-intro">{licensesIntro}</p> : null}
 
       <div className="licenses-layout">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1061,20 +1061,17 @@ button:focus-visible {
 /* ---------- Main content surface ---------- */
 .workspace > .auth-band,
 .workspace > .notice,
-.workspace > section.main-surface,
 .workspace > section[class*="-surface"],
 .workspace > section[class*="-layout"],
 .workspace > .page-frame {
   margin: 0 22px;
 }
 
-.workspace > section.main-surface:first-of-type,
 .workspace > section[class*="-surface"]:first-of-type,
 .workspace > .page-frame:first-of-type {
   margin-top: var(--pad-panel);
 }
 
-.workspace > section.main-surface:last-of-type,
 .workspace > section[class*="-surface"]:last-of-type,
 .workspace > .page-frame:last-of-type {
   margin-bottom: 30px;
@@ -1101,7 +1098,6 @@ button:focus-visible {
 }
 
 /* Cards / surfaces shared by screens */
-.main-surface,
 .auth-band {
   display: grid;
   align-content: start;
@@ -1351,7 +1347,6 @@ label {
 .form-row button,
 .queue-chip,
 .job-composer button,
-.editor-actions button,
 .timeline-create button,
 .playback-bar button,
 .bin-actions button,
@@ -1394,7 +1389,6 @@ label {
 .form-row button:hover:not(:disabled),
 .queue-chip:hover:not(:disabled),
 .job-composer button:hover:not(:disabled),
-.editor-actions button:hover:not(:disabled),
 .timeline-create button:hover:not(:disabled),
 .playback-bar button:hover:not(:disabled),
 .bin-actions button:hover:not(:disabled),
@@ -1626,7 +1620,6 @@ label {
 .review-actions,
 .detail-actions,
 .preview-actions,
-.editor-actions,
 .timeline-create,
 .playback-bar,
 .bin-actions,
@@ -1701,120 +1694,9 @@ label {
   transform: translateY(1px);
 }
 
-.surface-header {
-  display: flex;
-  justify-content: space-between;
-  gap: 18px;
-  align-items: flex-end;
-}
-
-/* Hero strip — gradient background + decorative orb. Used as a modifier on
-   surface-header for the welcome / studio screens. Switches to grid so an
-   optional `.hero-stats` row can wrap below the title + actions. */
-.surface-header.hero {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 16px 24px;
-  align-items: end;
-  position: relative;
-  overflow: hidden;
-  padding: 22px;
-  border: 1px solid var(--border);
-  border-radius: var(--r-xl);
-  background: linear-gradient(
-    135deg,
-    color-mix(in oklch, var(--accent-soft) 70%, var(--surface)),
-    var(--surface) 60%
-  );
-}
-
-[data-theme="dark"] .surface-header.hero {
-  background: linear-gradient(135deg, color-mix(in oklch, var(--accent) 12%, var(--surface)), var(--surface) 65%);
-}
-
-.surface-header.hero::after {
-  content: "";
-  position: absolute;
-  right: -80px;
-  top: -80px;
-  width: 280px;
-  height: 280px;
-  border-radius: 50%;
-  background: radial-gradient(circle, color-mix(in oklch, var(--warm) 35%, transparent), transparent 70%);
-  pointer-events: none;
-  z-index: 0;
-}
-
-.surface-header.hero > * {
-  position: relative;
-  z-index: 1;
-}
-
-.surface-header.hero .section-heading h2 {
-  font-size: 24px;
-  letter-spacing: -0.015em;
-}
-
-.hero-blurb {
-  margin: 4px 0 0;
-  color: var(--text-muted);
-  font-size: 13.5px;
-  line-height: 1.5;
-  max-width: 60ch;
-}
-
-.hero-stats {
-  grid-column: 1 / -1;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin-top: 4px;
-}
-
-.hero-stat {
-  display: grid;
-  gap: 2px;
-  padding: 8px 14px;
-  min-width: 140px;
-  background: color-mix(in oklch, var(--surface) 88%, transparent);
-  border: 1px solid var(--border);
-  border-radius: var(--r-md);
-  backdrop-filter: blur(6px);
-}
-
-.hero-stat-label {
-  font-size: 10.5px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-faint);
-}
-
-.hero-stat-value {
-  font-size: 13.5px;
-  font-weight: 600;
-  color: var(--text);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-@media (max-width: 720px) {
-  .surface-header.hero {
-    grid-template-columns: 1fr;
-    align-items: start;
-  }
-}
-
-/* ---------- Studio prompt hero (Image Studio) ----------
-   A vertically-stacked hero: mode tabs + saved-presets link on top,
-   prompt textarea + Generate CTA, then suggestion chips. */
-.surface-header.hero.studio-prompt-hero {
-  grid-template-columns: minmax(0, 1fr);
-  gap: 14px;
-  padding: 18px 22px;
-}
-
+/* ---------- Studio prompt rows (Image / Video Studio work-panels) ----------
+   Mode tabs + prompt-guide / saved-presets links on top, then the prompt
+   textarea + Generate CTA. Lives inside the work-panel (sc-10446/10447). */
 .prompt-hero-top {
   display: flex;
   align-items: center;
@@ -2671,10 +2553,10 @@ label {
   align-items: start;
 }
 
-/* Document Studio (interleaved text-image) — sc-1607/1608. The screen wraps in
-   .main-surface (edge margin + padded card, like Video/Image Studio); these rules
-   give the form/fields rhythm since the generic .field / .field-row class names
-   only carry layout inside preset/ImageStudio scopes. */
+/* Document Studio (interleaved text-image) — sc-1607/1608. The compose form is the
+   screen's work-panel; these rules give the form/fields rhythm since the generic
+   .field / .field-row class names only carry layout inside preset/ImageStudio
+   scopes. */
 .document-studio .studio-form {
   display: grid;
   gap: var(--gap-4);
@@ -8194,14 +8076,12 @@ details[open] > summary.lora-scope-group-heading::before,
 
 /* Full-bleed: drop the card chrome + workspace gutter so the canvas fills the
    whole content area (the screen title already lives in the top page header). */
-.workspace > section.main-surface.image-editor-surface {
+/* The editor is a full-bleed canvas app: cancel the workspace edge margin the
+   `[class*="-surface"]` rules apply to every other screen. */
+.workspace > section.image-editor-surface {
   flex: 1 1 auto;
   min-height: 0;
   margin: 0;
-  padding: 0;
-  border: none;
-  border-radius: 0;
-  background: transparent;
 }
 
 /* Keyboard-shortcut quick-reference overlay (sc-6111). */
@@ -10342,7 +10222,6 @@ details[open] > summary.lora-scope-group-heading::before,
     flex-wrap: wrap;
   }
 
-  .surface-header,
   .lora-panel-header {
     align-items: flex-start;
     flex-direction: column;


### PR DESCRIPTION
Closes out epic sc-10433. The last three screens leave the whole-page card, and the hero CSS the standard replaced is deleted now that nothing renders it.

## sc-10449 — Document, Licenses, Editor

- **Document Studio**: the compose form becomes the work-panel; its results render bare beneath it.
- **Licenses**: a reader with no purpose zone, so it just sheds the `.main-surface` card.
- **Editor**: the hero collapses into a work-panel holding the timeline picker, the create form, and Save/Undo/Redo. The preview + timeline stay on the canvas.
- **Settings** needed nothing — already a header-less card stack.

## sc-10450 — dead CSS

Deleted, all at zero JSX consumers: `.surface-header`, `.surface-header.hero` (+ its gradient, its `::after` orb, its dark-theme and responsive variants), `.hero-blurb`, `.hero-stats` / `.hero-stat` / `.hero-stat-label` / `.hero-stat-value`, `.studio-prompt-hero`, and `.editor-actions`.

`.main-surface` is gone as well. Its two remaining consumers gained nothing from it:

- **Image Editor** (excluded from the redesign) had a sibling rule — `.workspace > section.main-surface.image-editor-surface` — that reset its padding, border, radius and background back to nothing. Dropping the class changes no computed style; I verified the shell still resolves `display: grid` with its `--ie-*` grid areas and background.
- The editor's **Suspense fallback** only ever wanted a `<section>`.

`.main-surface` also *matches* `[class*="-surface"]`, so its entries in the three `.workspace > section` margin rules were redundant from the start. The padded-card rule survives for `.auth-band`, its only genuine user.

## Two corrections to the story's plan

1. sc-10450 listed `.prompt-hero-*` as dead. **They are not** — Image Studio and Video Studio still render `.prompt-hero-top`, `.prompt-hero-links`, and `.hero-link` inside their work-panels. Kept, with the comment updated to describe what they are now.
2. It assumed `.main-surface` could only go once ImageEditor migrated. It turned out ImageEditor never used it in any meaningful sense, so the class died without touching the editor's design.

## Regression caught in review

Retiring the `.editor-actions` wrapper would have stripped Save/Undo/Redo of their styling — `.editor-actions button` was an entry in the shared button grouping. They now carry `.secondary-action`, the standard class for that slot. Tests don't cover styling, so this would have shipped silently.

## Verification

- `npx vitest run` — **1375 passed** (105 files)
- `npx vite build` clean; `npx eslint` 0 errors
- Browser preview against the live worktree stylesheet, asserting computed styles rather than screenshots: `.main-surface` now resolves to an unstyled block (`border 0`, `padding 0`); `.surface-header.hero` has `background-image: none`, `padding: 0`; `.auth-band` keeps its card (1px border, 20px padding, 16px radius); `.image-editor-surface.ie-shell` still resolves `display: grid` with `"top top" "canvas insp" …`; `.page-frame` intact at `flex` / `gap: 18px`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)