### PR TITLE
fix(web): Image/Video Studio Advanced — nest it in the work-panel, drop the grid-offsetting hint (sc-10490, sc-10493)

### DIFF
--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -2599,305 +2599,304 @@ export function ImageStudio() {
             presetPromptParts={presetPromptParts}
             presetLoraDetails={presetLoraDetails}
           />
-        </WorkPanel>
 
-        <AdvancedSection
-          hint="cleared values → model default"
-          onToggle={() => setAdvancedOpen((value) => !value)}
-          open={advancedOpen}
-        >
-              <div className="advanced-panel">
+          <AdvancedSection
+            hint="cleared values → model default"
+            onToggle={() => setAdvancedOpen((value) => !value)}
+            open={advancedOpen}
+          >
+            <div className="advanced-panel">
+              <label>
+                GPU
+                <select onChange={(event) => setRequestedGpu(event.target.value)} value={requestedGpu}>
+                  {gpuOptions.map((gpu) => (
+                    <option key={gpu} value={gpu}>
+                      {gpu === "auto" ? "Auto" : gpu}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Seed
+                <input onChange={(event) => setSeed(event.target.value)} placeholder="Random" type="number" value={seed} />
+              </label>
+              <label>
+                Width override
+                <input
+                  min="256"
+                  max="4096"
+                  onChange={(event) => setWidthOverride(event.target.value)}
+                  placeholder={String(dropdownWidth)}
+                  type="number"
+                  value={widthOverride}
+                />
+              </label>
+              <label>
+                Height override
+                <input
+                  min="256"
+                  max="4096"
+                  onChange={(event) => setHeightOverride(event.target.value)}
+                  placeholder={String(dropdownHeight)}
+                  type="number"
+                  value={heightOverride}
+                />
+              </label>
+              <span className="field-hint">
+                Custom size overrides the Aspect dropdown (256–4096 per side; leave blank to use it).
+              </span>
+              {showSamplerPicker ? (
                 <label>
-                  GPU
-                  <select onChange={(event) => setRequestedGpu(event.target.value)} value={requestedGpu}>
-                    {gpuOptions.map((gpu) => (
-                      <option key={gpu} value={gpu}>
-                        {gpu === "auto" ? "Auto" : gpu}
+                  Sampler
+                  <select onChange={(event) => setSampler(event.target.value)} value={sampler}>
+                    {samplerOptions.map((key) => (
+                      <option key={key} value={key}>
+                        {SAMPLER_LABELS[key] ?? key}
                       </option>
                     ))}
                   </select>
                 </label>
+              ) : null}
+              {showSchedulerPicker ? (
                 <label>
-                  Seed
-                  <input onChange={(event) => setSeed(event.target.value)} placeholder="Random" type="number" value={seed} />
+                  Scheduler
+                  <select onChange={(event) => setScheduler(event.target.value)} value={scheduler}>
+                    {schedulerOptions.map((key) => (
+                      <option key={key} value={key}>
+                        {SCHEDULER_LABELS[key] ?? key}
+                      </option>
+                    ))}
+                  </select>
                 </label>
+              ) : null}
+              {showSchedulerPicker && scheduler !== "default" ? (
                 <label>
-                  Width override
+                  Schedule shift
                   <input
-                    min="256"
-                    max="4096"
-                    onChange={(event) => setWidthOverride(event.target.value)}
-                    placeholder={String(dropdownWidth)}
-                    type="number"
-                    value={widthOverride}
-                  />
-                </label>
-                <label>
-                  Height override
-                  <input
-                    min="256"
-                    max="4096"
-                    onChange={(event) => setHeightOverride(event.target.value)}
-                    placeholder={String(dropdownHeight)}
-                    type="number"
-                    value={heightOverride}
-                  />
-                </label>
-                <span className="field-hint">
-                  Custom size overrides the Aspect dropdown (256–4096 per side; leave blank to use it).
-                </span>
-                {showSamplerPicker ? (
-                  <label>
-                    Sampler
-                    <select onChange={(event) => setSampler(event.target.value)} value={sampler}>
-                      {samplerOptions.map((key) => (
-                        <option key={key} value={key}>
-                          {SAMPLER_LABELS[key] ?? key}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                ) : null}
-                {showSchedulerPicker ? (
-                  <label>
-                    Scheduler
-                    <select onChange={(event) => setScheduler(event.target.value)} value={scheduler}>
-                      {schedulerOptions.map((key) => (
-                        <option key={key} value={key}>
-                          {SCHEDULER_LABELS[key] ?? key}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                ) : null}
-                {showSchedulerPicker && scheduler !== "default" ? (
-                  <label>
-                    Schedule shift
-                    <input
-                      max="10"
-                      min="0.1"
-                      onChange={(event) => setSchedulerShift(Number(event.target.value))}
-                      step="0.1"
-                      type="number"
-                      value={schedulerShift}
-                    />
-                  </label>
-                ) : null}
-                <label>
-                  Steps
-                  <input
-                    min="1"
-                    max="80"
-                    onChange={(event) => setStepsOverride(event.target.value)}
-                    placeholder={String(stepsDefaultFromModel(selectedModel) ?? "")}
-                    type="number"
-                    value={stepsOverride}
-                  />
-                </label>
-                <label>
-                  Guidance
-                  <input
-                    min="0"
-                    max="30"
-                    onChange={(event) => setGuidanceOverride(event.target.value)}
-                    placeholder={(() => {
-                      const value = guidanceDefaultFromModel(selectedModel);
-                      return value == null ? "" : String(value);
-                    })()}
+                    max="10"
+                    min="0.1"
+                    onChange={(event) => setSchedulerShift(Number(event.target.value))}
                     step="0.1"
                     type="number"
-                    value={guidanceOverride}
+                    value={schedulerShift}
                   />
                 </label>
-                {showGuidanceMethodPicker ? (
-                  <label>
-                    Guidance method
-                    <select
-                      onChange={(event) => setGuidanceMethod(event.target.value)}
-                      value={guidanceMethod}
-                    >
-                      {guidanceMethodOptions.map((key) => (
-                        <option key={key} value={key}>
-                          {GUIDANCE_METHOD_LABELS[key] ?? key}
-                        </option>
-                      ))}
-                    </select>
-                    {guidanceMethod === "cfg_pp" ? (
-                      <span className="field-hint">
-                        CFG++ reparameterizes guidance — use a low CFG (~1.5–2.5); high
-                        values over-saturate.
-                      </span>
-                    ) : null}
-                  </label>
-                ) : null}
+              ) : null}
+              <label>
+                Steps
+                <input
+                  min="1"
+                  max="80"
+                  onChange={(event) => setStepsOverride(event.target.value)}
+                  placeholder={String(stepsDefaultFromModel(selectedModel) ?? "")}
+                  type="number"
+                  value={stepsOverride}
+                />
+              </label>
+              <label>
+                Guidance
+                <input
+                  min="0"
+                  max="30"
+                  onChange={(event) => setGuidanceOverride(event.target.value)}
+                  placeholder={(() => {
+                    const value = guidanceDefaultFromModel(selectedModel);
+                    return value == null ? "" : String(value);
+                  })()}
+                  step="0.1"
+                  type="number"
+                  value={guidanceOverride}
+                />
+              </label>
+              {showGuidanceMethodPicker ? (
+                <label>
+                  Guidance method
+                  <select
+                    onChange={(event) => setGuidanceMethod(event.target.value)}
+                    value={guidanceMethod}
+                  >
+                    {guidanceMethodOptions.map((key) => (
+                      <option key={key} value={key}>
+                        {GUIDANCE_METHOD_LABELS[key] ?? key}
+                      </option>
+                    ))}
+                  </select>
+                  {guidanceMethod === "cfg_pp" ? (
+                    <span className="field-hint">
+                      CFG++ reparameterizes guidance — use a low CFG (~1.5–2.5); high
+                      values over-saturate.
+                    </span>
+                  ) : null}
+                </label>
+              ) : null}
+              <label
+                className="checkline flash-attn-toggle"
+                title="Fused flash-attention on the candle (Windows/CUDA) SDXL backend — faster and lower VRAM. Ignored on other backends."
+              >
+                <input
+                  checked={flashAttn}
+                  onChange={(event) => setFlashAttn(event.target.checked)}
+                  type="checkbox"
+                />
+                Flash attention
+              </label>
+              {promptEnhance ? (
                 <label
-                  className="checkline flash-attn-toggle"
-                  title="Fused flash-attention on the candle (Windows/CUDA) SDXL backend — faster and lower VRAM. Ignored on other backends."
+                  className="checkline prompt-enhance-toggle"
+                  title="Have FLUX.2-dev's built-in LLM rewrite (upsample) your prompt before generating — text-only for new images, and reference-aware when editing. Distinct from the Refine button; off by default."
                 >
                   <input
-                    checked={flashAttn}
-                    onChange={(event) => setFlashAttn(event.target.checked)}
+                    checked={enhancePrompt}
+                    onChange={(event) => setEnhancePrompt(event.target.checked)}
                     type="checkbox"
                   />
-                  Flash attention
+                  Enhance prompt
                 </label>
-                {promptEnhance ? (
+              ) : null}
+              {showTierPicker ? (
+                <label className="quant-tier-picker" title="Switch which installed quant tier generates, for A/B comparison. Higher precision = larger memory footprint; switching a heavy tier reloads it before the next generation.">
+                  Quant tier
+                  <select
+                    onChange={(event) => handleTierChange(event.target.value)}
+                    value={quantTier}
+                  >
+                    {availableTiers.map((tier) => (
+                      <option key={tier} value={tier}>
+                        {tierLabel(tier)}
+                      </option>
+                    ))}
+                  </select>
+                  {tierSwitching ? (
+                    <span className="field-hint" role="status">
+                      Loading {tierLabel(tierSwitching)}…
+                    </span>
+                  ) : null}
+                </label>
+              ) : null}
+              {precisionToggle && !showTierPicker ? (
+                <label
+                  className="checkline boogu-precision-toggle"
+                  title="Use the full-precision bf16 build instead of the default Q8. Higher fidelity, but a much larger download (~38 GB per variant, fetched on demand) that needs a larger Mac (≈96 GB unified memory). Off = the Q8 default (~23 GB, 64 GB-class Mac)."
+                >
+                  <input
+                    checked={bf16Precision}
+                    onChange={(event) => setBf16Precision(event.target.checked)}
+                    type="checkbox"
+                  />
+                  Full precision (bf16)
+                </label>
+              ) : null}
+              {showPidToggle ? (
+                <>
                   <label
-                    className="checkline prompt-enhance-toggle"
-                    title="Have FLUX.2-dev's built-in LLM rewrite (upsample) your prompt before generating — text-only for new images, and reference-aware when editing. Distinct from the Refine button; off by default."
+                    className="checkline pid-decoder-toggle"
+                    title="Decode this generation through NVIDIA's PiD pixel-diffusion decoder instead of the model's VAE: it decodes and super-resolves in one pass to 2K or 4K (pick the tier at right — sharper detail, but slower and more memory). Non-commercial use only — PiD output is licensed for research/evaluation, unlike the rest of the pipeline. Off = the model's native VAE at the selected resolution."
                   >
                     <input
-                      checked={enhancePrompt}
-                      onChange={(event) => setEnhancePrompt(event.target.checked)}
+                      checked={usePid}
+                      disabled={upscaleEnabled}
+                      onChange={(event) => setUsePid(event.target.checked)}
                       type="checkbox"
                     />
-                    Enhance prompt
+                    PiD decoder <span className="badge badge-nc">Non-Commercial</span>
                   </label>
-                ) : null}
-                {showTierPicker ? (
-                  <label className="quant-tier-picker" title="Switch which installed quant tier generates, for A/B comparison. Higher precision = larger memory footprint; switching a heavy tier reloads it before the next generation.">
-                    Quant tier
-                    <select
-                      onChange={(event) => handleTierChange(event.target.value)}
-                      value={quantTier}
-                    >
-                      {availableTiers.map((tier) => (
-                        <option key={tier} value={tier}>
-                          {tierLabel(tier)}
-                        </option>
-                      ))}
-                    </select>
-                    {tierSwitching ? (
-                      <span className="field-hint" role="status">
-                        Loading {tierLabel(tierSwitching)}…
-                      </span>
-                    ) : null}
-                  </label>
-                ) : null}
-                {precisionToggle && !showTierPicker ? (
-                  <label
-                    className="checkline boogu-precision-toggle"
-                    title="Use the full-precision bf16 build instead of the default Q8. Higher fidelity, but a much larger download (~38 GB per variant, fetched on demand) that needs a larger Mac (≈96 GB unified memory). Off = the Q8 default (~23 GB, 64 GB-class Mac)."
-                  >
-                    <input
-                      checked={bf16Precision}
-                      onChange={(event) => setBf16Precision(event.target.checked)}
-                      type="checkbox"
-                    />
-                    Full precision (bf16)
-                  </label>
-                ) : null}
-                {showPidToggle ? (
-                  <>
+                  {usePid ? (
                     <label
-                      className="checkline pid-decoder-toggle"
-                      title="Decode this generation through NVIDIA's PiD pixel-diffusion decoder instead of the model's VAE: it decodes and super-resolves in one pass to 2K or 4K (pick the tier at right — sharper detail, but slower and more memory). Non-commercial use only — PiD output is licensed for research/evaluation, unlike the rest of the pipeline. Off = the model's native VAE at the selected resolution."
+                      className="pid-target-select"
+                      title="PiD super-resolves the base render 4×, so this sets the output size: 4K (~4096px, max detail) or 2K (~2048px, faster and less GPU memory). Both are super-resolved from the model's latent."
                     >
-                      <input
-                        checked={usePid}
-                        disabled={upscaleEnabled}
-                        onChange={(event) => setUsePid(event.target.checked)}
-                        type="checkbox"
-                      />
-                      PiD decoder <span className="badge badge-nc">Non-Commercial</span>
-                    </label>
-                    {usePid ? (
-                      <label
-                        className="pid-target-select"
-                        title="PiD super-resolves the base render 4×, so this sets the output size: 4K (~4096px, max detail) or 2K (~2048px, faster and less GPU memory). Both are super-resolved from the model's latent."
+                      Output
+                      <select
+                        onChange={(event) => setPidTarget(event.target.value)}
+                        value={pidTarget}
                       >
-                        Output
-                        <select
-                          onChange={(event) => setPidTarget(event.target.value)}
-                          value={pidTarget}
-                        >
-                          <option value="4k">4K · max detail</option>
-                          <option value="2k">2K · faster</option>
-                        </select>
-                      </label>
-                    ) : null}
-                  </>
-                ) : null}
-                <label
-                  className="checkline upscale-toggle"
-                  title={usePid ? "Disabled while the PiD decoder is on — PiD already super-resolves to 2K/4K." : undefined}
-                >
+                        <option value="4k">4K · max detail</option>
+                        <option value="2k">2K · faster</option>
+                      </select>
+                    </label>
+                  ) : null}
+                </>
+              ) : null}
+              <label
+                className="checkline upscale-toggle"
+                title={usePid ? "Disabled while the PiD decoder is on — PiD already super-resolves to 2K/4K." : undefined}
+              >
+                <input
+                  checked={upscaleEnabled}
+                  disabled={usePid}
+                  onChange={(event) => setUpscaleEnabled(event.target.checked)}
+                  type="checkbox"
+                />
+                Upscale
+              </label>
+              <label>
+                Scale
+                <select disabled={!upscaleEnabled || usePid} onChange={(event) => setUpscaleFactor(Number(event.target.value))} value={upscaleFactor}>
+                  {upscaleFactorsForEngine(upscaleEngine).map((factor) => (
+                    <option key={factor} value={factor}>
+                      {factor}x
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Engine
+                <select disabled={!upscaleEnabled || usePid} onChange={(event) => handleUpscaleEngineChange(event.target.value)} value={upscaleEngine}>
+                  {availableUpscaleEngines.map((engine) => (
+                    <option key={engine.key} value={engine.key}>
+                      {engine.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              {upscaleEngineHasSoftness(upscaleEngine) ? (
+                <label title="Higher restores more detail from a degraded source; 0 keeps it faithful.">
+                  Detail
                   <input
-                    checked={upscaleEnabled}
-                    disabled={usePid}
-                    onChange={(event) => setUpscaleEnabled(event.target.checked)}
-                    type="checkbox"
+                    aria-label="SeedVR2 detail (softness)"
+                    disabled={!upscaleEnabled || usePid}
+                    max="1"
+                    min="0"
+                    onChange={(event) => setUpscaleSoftness(Number(event.target.value))}
+                    step="0.05"
+                    type="range"
+                    value={upscaleSoftness}
                   />
-                  Upscale
+                  <span>{upscaleSoftness.toFixed(2)}</span>
                 </label>
-                <label>
-                  Scale
-                  <select disabled={!upscaleEnabled || usePid} onChange={(event) => setUpscaleFactor(Number(event.target.value))} value={upscaleFactor}>
-                    {upscaleFactorsForEngine(upscaleEngine).map((factor) => (
-                      <option key={factor} value={factor}>
-                        {factor}x
-                      </option>
-                    ))}
-                  </select>
-                </label>
-                <label>
-                  Engine
-                  <select disabled={!upscaleEnabled || usePid} onChange={(event) => handleUpscaleEngineChange(event.target.value)} value={upscaleEngine}>
-                    {availableUpscaleEngines.map((engine) => (
-                      <option key={engine.key} value={engine.key}>
-                        {engine.label}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-                {upscaleEngineHasSoftness(upscaleEngine) ? (
-                  <label title="Higher restores more detail from a degraded source; 0 keeps it faithful.">
-                    Detail
-                    <input
-                      aria-label="SeedVR2 detail (softness)"
-                      disabled={!upscaleEnabled || usePid}
-                      max="1"
-                      min="0"
-                      onChange={(event) => setUpscaleSoftness(Number(event.target.value))}
-                      step="0.05"
-                      type="range"
-                      value={upscaleSoftness}
-                    />
-                    <span>{upscaleSoftness.toFixed(2)}</span>
-                  </label>
-                ) : null}
-                <label className="prompt-field">
-                  Negative prompt
-                  <textarea onChange={(event) => setNegativePrompt(event.target.value)} value={negativePrompt} />
-                </label>
-                <LoraPickerSection
-                  selectedModel={selectedModel}
-                  selectedLoras={selectedLoras}
-                  selectedLoraIds={selectedLoraIds}
-                  compatibleLoras={compatibleLoras}
-                  userSelectedLoraCount={userSelectedLoraCount}
-                  showIncompatibleLoras={showIncompatibleLoras}
-                  setShowIncompatibleLoras={setShowIncompatibleLoras}
-                  toggleLora={toggleLora}
-                  effectiveLoraWeight={effectiveLoraWeight}
-                  setLoraWeight={setLoraWeight}
-                  loraEmptyMessage={loraEmptyMessage}
-                />
-                {/* Save-as-preset folds into Advanced with the rest of the power-user
-                    knobs (UI-refinement 2b). */}
-                <SavePresetPanel
-                  presetName={presetName}
-                  setPresetName={setPresetName}
-                  savingPreset={savingPreset}
-                  presetSaveMessage={presetSaveMessage}
-                  setPresetSaveMessage={setPresetSaveMessage}
-                  onSave={handleSaveAsPreset}
-                  presetScope={presetScope}
-                  setPresetScope={setPresetScope}
-                  activeProject={activeProject}
-                />
-              </div>
-        </AdvancedSection>
+              ) : null}
+              <label className="prompt-field">
+                Negative prompt
+                <textarea onChange={(event) => setNegativePrompt(event.target.value)} value={negativePrompt} />
+              </label>
+              <LoraPickerSection
+                selectedModel={selectedModel}
+                selectedLoras={selectedLoras}
+                selectedLoraIds={selectedLoraIds}
+                compatibleLoras={compatibleLoras}
+                userSelectedLoraCount={userSelectedLoraCount}
+                showIncompatibleLoras={showIncompatibleLoras}
+                setShowIncompatibleLoras={setShowIncompatibleLoras}
+                toggleLora={toggleLora}
+                effectiveLoraWeight={effectiveLoraWeight}
+                setLoraWeight={setLoraWeight}
+                loraEmptyMessage={loraEmptyMessage}
+              />
+              {/* Save-as-preset folds into Advanced with the rest of the power-user
+                  knobs (UI-refinement 2b). */}
+              <SavePresetPanel
+                presetName={presetName}
+                setPresetName={setPresetName}
+                savingPreset={savingPreset}
+                presetSaveMessage={presetSaveMessage}
+                setPresetSaveMessage={setPresetSaveMessage}
+                onSave={handleSaveAsPreset}
+                presetScope={presetScope}
+                setPresetScope={setPresetScope}
+                activeProject={activeProject}
+              />
+            </div>
+          </AdvancedSection>
 
           <PresetValidationWarnings presetValidationResult={presetValidationResult} selectedModel={selectedModel} />
           {selectedLoraValidationResult.incompatible.length ? (
@@ -2905,6 +2904,8 @@ export function ImageStudio() {
               Generate is blocked because these selected LoRAs are incompatible with {selectedModel?.name ?? "the selected model"}: {selectedLoraValidationResult.incompatible.join(", ")}.
             </p>
           ) : null}
+
+        </WorkPanel>
 
         <div className="studio-results">
           <section className="review-panel">

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -2642,9 +2642,6 @@ export function ImageStudio() {
                   value={heightOverride}
                 />
               </label>
-              <span className="field-hint">
-                Custom size overrides the Aspect dropdown (256–4096 per side; leave blank to use it).
-              </span>
               {showSamplerPicker ? (
                 <label>
                   Sampler

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -101,6 +101,16 @@ describe("ImageStudio Save as Preset", () => {
     await act(async () => {}); // flush mount effects (pose loaders, etc.)
   }
 
+  // The Advanced disclosure belongs INSIDE the work-panel, not floating beneath it:
+  // the Purpose zone is one elevated card. It shipped detached in sc-10476 and was
+  // pulled back in by sc-10490 — assert the nesting so it cannot drift again.
+  it("nests the Advanced disclosure inside the work-panel", async () => {
+    await render(baseContext());
+
+    expect(document.body.querySelector(".work-panel .advanced-section")).toBeTruthy();
+    expect(document.body.querySelector(".studio-shell > .advanced-section")).toBeNull();
+  });
+
   it("snapshots the current config into a preset payload without the seed", async () => {
     const context = baseContext();
     await render(context);

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -111,6 +111,17 @@ describe("ImageStudio Save as Preset", () => {
     expect(document.body.querySelector(".studio-shell > .advanced-section")).toBeNull();
   });
 
+  // `.advanced-panel` is a 3-column grid, so a bare hint span is a grid ITEM: it eats a
+  // cell and shifts every control after it into the wrong column (sc-10493). Hints belong
+  // inside the <label> they describe.
+  it("puts no bare hint spans in the advanced grid", async () => {
+    await render(baseContext());
+    await click(document.body.querySelector(".advanced-section-toggle"));
+
+    expect(document.body.querySelector(".advanced-panel > .field-hint")).toBeNull();
+    expect(document.body.textContent).not.toContain("Custom size overrides the Aspect dropdown");
+  });
+
   it("snapshots the current config into a preset payload without the seed", async () => {
     const context = baseContext();
     await render(context);

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -1154,13 +1154,12 @@ export function VideoStudio() {
           />
 
           {durationHint ? <p className="helper-copy">{durationHint}</p> : null}
-        </WorkPanel>
 
-        <AdvancedSection
-          hint="cleared values → model default"
-          onToggle={() => setAdvancedOpen((value) => !value)}
-          open={advancedOpen}
-        >
+          <AdvancedSection
+            hint="cleared values → model default"
+            onToggle={() => setAdvancedOpen((value) => !value)}
+            open={advancedOpen}
+          >
             <div className="advanced-panel">
               <label>
                 Frames
@@ -1456,7 +1455,7 @@ export function VideoStudio() {
                 videoAssets={videoAssets}
               />
             </div>
-        </AdvancedSection>
+          </AdvancedSection>
 
           <PresetValidationWarnings presetValidationResult={presetValidationResult} selectedModel={selectedModel} />
           {blockedMessage ? <p className="inline-warning">{blockedMessage}</p> : null}
@@ -1465,6 +1464,8 @@ export function VideoStudio() {
               Generate is blocked because these selected LoRAs are incompatible with {selectedModel?.name ?? "the selected model"}: {selectedLoraValidationResult.incompatible.join(", ")}.
             </p>
           ) : null}
+
+        </WorkPanel>
 
         <div className="studio-results">
           <section className="review-panel">

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -111,6 +111,16 @@ describe("VideoStudio Save as Preset", () => {
     await act(async () => {});
   }
 
+  // The Advanced disclosure belongs INSIDE the work-panel, not floating beneath it:
+  // the Purpose zone is one elevated card. It shipped detached in sc-10477 and was
+  // pulled back in by sc-10490 — assert the nesting so it cannot drift again.
+  it("nests the Advanced disclosure inside the work-panel", async () => {
+    await render(baseContext());
+
+    expect(document.body.querySelector(".work-panel .advanced-section")).toBeTruthy();
+    expect(document.body.querySelector(".studio-shell > .advanced-section")).toBeNull();
+  });
+
   it("snapshots the video config into a text_to_video preset without the seed", async () => {
     const context = baseContext();
     await render(context);


### PR DESCRIPTION
Michael, on the merged P9 work: *"You didn't quite get there with the Image Studio and Video Studio. The Advanced section is still separate from the Hero."*

He's right. [sc-10490](https://app.shortcut.com/trefry/story/10490).

## What was wrong

#1328 (sc-10476 / sc-10477) correctly swapped the floating `.advanced-toggle` button for the canonical `<AdvancedSection>`. But it left the disclosure a **sibling** of `<WorkPanel>`:

```jsx
  </WorkPanel>

  <AdvancedSection …>   {/* floats on the canvas below the hero card */}
```

`.studio-shell` is a grid with `gap: var(--gap-4)`, and `.advanced-section` is its own bordered `--surface-2` block. So Advanced rendered as a *second card* detached from the hero — exactly the "two disconnected things" the frame spec rejects, just with a nicer header.

Training Studio (`ConfigureJobPanel.jsx`) nests it **inside** the panel. Image and Video were the outliers, so the spec's "one pattern across all studios" action item didn't actually hold. (Character Studio isn't comparable — `characterPanels.jsx` has no `WorkPanel` at all.)

## Why it happened

Both stories specified the wrong placement in their own text:

> sc-10476: *"Placement stays directly below the WorkPanel (the panel must not balloon)."*

The implementation followed the story. The spec is genuinely ambiguous — `SceneWorks Frame Spec.dc.html` says *"Advanced opens as a section directly beneath — the panel never balloons"* and also, of the disclosure, *"…inside the same bordered block."* That second sentence describes the disclosure's own header+body, not its relationship to the work-panel.

The ballooning worry is already solved by the disclosure itself: collapsed, it's header-only and reserves no space. So there was never a reason to push it outside the card.

## The change

Move `</WorkPanel>` down so it closes after the disclosure and the trailing validation warnings. **One line moved per file.**

The warnings were already indented as panel children — they'd been orphaned outside the panel by the original move, which is a good tell that inside was the original intent.

No CSS changes: `.work-panel` is `display: flex; flex-direction: column; gap: var(--gap-3)`, so the moved children inherit correct spacing.

> **Review with `git diff -w`.** `ImageStudio.jsx` shows ~500 changed lines only because its advanced body is dedented two spaces to match its new depth. Ignoring whitespace, the whole PR is **24 insertions, 2 deletions** — 1 moved line per screen, plus the two guards.

No control is added, removed, reordered, or regrouped.

## Verification

Driven in the running app, not just asserted in jsdom. I stood up the rust-api against a sandboxed `HOME` so nothing touched real app data, pointed `HF_HOME` at the existing model cache (read-only) so the studios would render past their "no model installed" empty state, and drove both screens:

| Check | Image Studio | Video Studio |
|---|---|---|
| `.advanced-section` parent | `work-panel studio-work-panel` | `work-panel studio-work-panel` |
| `.work-panel .advanced-section` | ✅ | ✅ |
| `.studio-shell > .advanced-section` | none | none |
| Inset from card edges (L/R/bottom) | 21px / 21px / 21px | 21px / 21px / 21px |
| Expanded, still inside card | ✅ (17 controls) | ✅ |

21px is exactly `--pad-panel`, i.e. the disclosure sits within the card's padding box. Checked collapsed and expanded, in **dark and light** — `.advanced-section` keeps its `--surface-2` fill against the panel's `--surface`, so it stays legible as a distinct block inside the card rather than melting into it.

- **Regression guards** in `ImageStudio.test.jsx` / `VideoStudio.test.jsx` assert `.work-panel .advanced-section` matches and `.studio-shell > .advanced-section` doesn't. Mutation-checked: reinstating the early `</WorkPanel>` fails both.
- `npm --prefix apps/web run lint` → 0 errors (47 pre-existing warnings). `… run test` → 1379 passed / 105 files (+2). `… run build` → clean. `npm run check` → passed.
- No Rust touched, so no `rust:check` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## sc-10493 — drop the custom-size hint (added to this PR)

Michael, on seeing the Advanced section in the screenshots above:

> *"That line is awkwardly placed and takes up a column that offsets all of the following controls. Let's remove it. I don't think it adds anything."*

`.advanced-panel` is a **two-column grid**, so this bare span between the Height-override label and the Sampler picker is a grid **item** — it eats a cell and shifts every control after it one column over:

```jsx
  </label>
  <span className="field-hint">
    Custom size overrides the Aspect dropdown (256–4096 per side; leave blank to use it).
  </span>
```

Measured in the running app at 1600px, **before**:

| col 1 | col 2 |
|---|---|
| GPU | Seed |
| Width override | Height override |
| **the hint** | Sampler ← offset starts |
| Scheduler | Steps |
| Guidance | … |

**After** — the intended pairs line up: `GPU\|Seed`, `Width\|Height`, `Sampler\|Scheduler`, `Steps\|Guidance`.

**Nothing is lost.** Both override inputs already carry `min="256" max="4096"`, and each one's `placeholder` shows the dimension the Aspect dropdown would use — which is precisely what "leave blank to use it" was telling you.

The file's two other `.field-hint` spans (the CFG++ guidance note, the quant-tier loading status) sit **inside** their `<label>`, so they aren't grid items. This was the only offender, and `.field-hint` is still used by `characterPanels.jsx`.

New guard: `puts no bare hint spans in the advanced grid` asserts `.advanced-panel > .field-hint` is null. Mutation-checked — restoring the span fails it. The invariant is reusable: **hints belong inside the `<label>` they describe.**

### Why it's in this PR

The edit lands inside the very advanced body that sc-10490 (above) relocates and re-indents. Basing it on `main` would guarantee a merge conflict with this branch, so it ships here as its own commit — one commit per story, both scoped to the Image/Video Studio Advanced section.

Web suite now 1380 passed / 105 files; lint 0 errors; build clean.
