### PR TITLE
feat(web): Data Sets page redesign + dead training CSS sweep (sc-10481, sc-10497)

### DIFF
--- a/apps/web/src/components/Icons.jsx
+++ b/apps/web/src/components/Icons.jsx
@@ -52,5 +52,8 @@ export const Icon = {
   Wand: (p) => <I {...p} d="M15 4l5 5L9 20l-5-5zM14 5l5 5M3 14l3 3" />,
   Star: ({ filled = false, ...p }) => <I {...p} fill={filled} d="M12 2l2.4 7.4H22l-6.2 4.5L18 21l-6-4.4L6 21l2.2-7.1L2 9.4h7.6z" />,
   Stars: (p) => <I {...p} fill d="M12 2l2.4 7.4H22l-6.2 4.5L18 21l-6-4.4L6 21l2.2-7.1L2 9.4h7.6z" />,
+  Refresh: (p) => <I {...p} d="M21 12a9 9 0 11-3-6.7L21 8M21 3v5h-5" />,
+  Pencil: (p) => <I {...p} d="M12 20h9M16.5 3.5a2.12 2.12 0 013 3L7 19l-4 1 1-4z" />,
+  Stethoscope: (p) => <I {...p} d="M6 3v5a4 4 0 008 0V3M10 15v-3M10 15a5 5 0 0010 0v-2M18 11a2 2 0 100-4 2 2 0 000 4z" />,
 };
 

--- a/apps/web/src/main.testSupport.jsx
+++ b/apps/web/src/main.testSupport.jsx
@@ -203,9 +203,21 @@ export async function settle() {
   });
 }
 
+// Find a control by its visible <label>, falling back to an aria-label for the controls
+// that carry no visible label — e.g. the Data Sets name field, which reads as the page's
+// heading rather than a labelled input (sc-10481).
 export function field(container, labelText) {
   const label = [...container.querySelectorAll("label")].find((item) => item.childNodes[0]?.textContent.trim() === labelText);
-  return label?.querySelector("input, select, textarea");
+  const labelled = label?.querySelector("input, select, textarea");
+  if (labelled) {
+    return labelled;
+  }
+  // `?? undefined` keeps the "not found" value what callers already assert on.
+  return (
+    container.querySelector(
+      `input[aria-label="${labelText}"], select[aria-label="${labelText}"], textarea[aria-label="${labelText}"]`,
+    ) ?? undefined
+  );
 }
 
 export function loraPanel(container) {

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -23,7 +23,6 @@ import {
   imageAssetName,
   normalizeDatasetAssetIds,
   selectionAfterDuplicateRemoval,
-  summarizeDatasets,
 } from "../training/datasetHelpers.js";
 import {
   captionHash,
@@ -392,7 +391,6 @@ export function TrainingStudio({ mode = "training" } = {}) {
   const [trainingRunMode, setTrainingRunMode] = useState("dry_run");
   const configBasisRef = useRef("");
 
-  const datasetSummary = useMemo(() => summarizeDatasets(datasets), [datasets]);
   const datasetAssets = useMemo(
     () => datasetOwnedAssets(activeDataset, activeProject?.id, assets),
     [activeDataset, activeProject?.id, assets],
@@ -1425,34 +1423,8 @@ export function TrainingStudio({ mode = "training" } = {}) {
     >
     <section className="page-frame training-studio">
       <div className="training-studio-shell">
-        {/* Data Sets keeps its own header band; the Training Studio is named by the
-            topbar and leads straight into its work-panel (page-frame standard). */}
-        {datasetLibraryMode ? (
-          <div className="training-summary-band">
-            <div className="section-heading">
-              <p className="eyebrow">Library</p>
-              <h2>Data Sets</h2>
-              <p className="view-copy">
-                Create training datasets, manage imported dataset images, and normalize captions in one place.
-              </p>
-            </div>
-            <div className="training-metrics" aria-label="Training workspace summary">
-              <div>
-                <strong>{activeProject?.name ?? "No workspace"}</strong>
-                <span>Project</span>
-              </div>
-              <div>
-                <strong>{datasets.length}</strong>
-                <span>Datasets</span>
-              </div>
-              <div>
-                <strong>{datasetSummary.items}</strong>
-                <span>Items</span>
-              </div>
-            </div>
-          </div>
-        ) : null}
-
+        {/* Both modes are named by the topbar and lead straight into their work-panel
+            (page-frame standard, sc-10481). */}
         {!authenticated ? (
           <div className="training-empty-state" role="status">
             <Icon.Train size={24} />
@@ -1472,63 +1444,63 @@ export function TrainingStudio({ mode = "training" } = {}) {
         ) : (
           <>
             {datasetLibraryMode ? (
-              <section className="training-panel">
-                <DatasetEditorPanel
-                  loadingDatasets={loadingDatasets}
-                  onRefreshDatasets={onRefreshDatasets}
-                  busyDatasetId={busyDatasetId}
-                  datasetThumbAsset={datasetThumbAsset}
-                  datasets={datasets}
-                  startNewDataset={startNewDataset}
-                  openDataset={openDataset}
-                  activeDataset={activeDataset}
-                  selectedDatasetId={selectedDatasetId}
-                  datasetsError={datasetsError}
-                  datasetError={datasetError}
-                  datasetMessage={datasetMessage}
-                  draftName={draftName}
-                  setDraftName={setDraftName}
-                  dirty={dirty}
-                  setAddDialogOpen={setAddDialogOpen}
-                  renamePrefix={renamePrefix}
-                  setRenamePrefix={setRenamePrefix}
-                  renaming={renaming}
-                  memberAssets={memberAssets}
-                  applyOrderedNames={applyOrderedNames}
-                  setCaptionDialog={setCaptionDialog}
-                  health={health}
-                  datasetDoctor={datasetDoctor}
-                  readinessByKey={readinessByKey}
-                  onToggleItemAck={toggleItemQualityAck}
-                  canSave={canSave}
-                  saveDataset={saveDataset}
-                  savingDataset={savingDataset}
-                  unavailableAssetIds={unavailableAssetIds}
-                  removeUnavailableAsset={removeUnavailableAsset}
-                  captionDraftById={captionDraftById}
-                  onPreview={onPreview}
-                  updateCaption={updateCaption}
-                  captioning={captioning}
-                  addDialogOpen={addDialogOpen}
-                  imageAssets={imageAssets}
-                  characters={characters}
-                  importingAssets={importingAssets}
-                  selectedAssetIds={selectedAssetIds}
-                  addAssets={addAssets}
-                  handleImport={handleImport}
-                  captionDialog={captionDialog}
-                  gpuOptions={gpuOptions}
-                  updateCaptionSetting={updateCaptionSetting}
-                  runCaptionJob={runCaptionJob}
-                  toggleCaptionExtraOption={toggleCaptionExtraOption}
-                  displayedCaptionPrompt={displayedCaptionPrompt}
-                  captionSettings={captionSettings}
-                  captionModelMissing={captionModelMissing}
-                  onDownloadCaptionModel={onDownloadCaptionModel}
-                  captionModelSizeLabel={captionModelSizeLabel}
-                  captionModelName={captionModel?.name ?? "JoyCaption"}
-                />
-              </section>
+              <DatasetEditorPanel
+                loadingDatasets={loadingDatasets}
+                onRefreshDatasets={onRefreshDatasets}
+                busyDatasetId={busyDatasetId}
+                datasetThumbAsset={datasetThumbAsset}
+                datasets={datasets}
+                startNewDataset={startNewDataset}
+                openDataset={openDataset}
+                activeDataset={activeDataset}
+                selectedDatasetId={selectedDatasetId}
+                datasetsError={datasetsError}
+                datasetError={datasetError}
+                datasetMessage={datasetMessage}
+                draftName={draftName}
+                setDraftName={setDraftName}
+                dirty={dirty}
+                setAddDialogOpen={setAddDialogOpen}
+                renamePrefix={renamePrefix}
+                setRenamePrefix={setRenamePrefix}
+                renaming={renaming}
+                memberAssets={memberAssets}
+                applyOrderedNames={applyOrderedNames}
+                setCaptionDialog={setCaptionDialog}
+                health={health}
+                datasetDoctor={datasetDoctor}
+                readinessByKey={readinessByKey}
+                onToggleItemAck={toggleItemQualityAck}
+                canSave={canSave}
+                saveDataset={saveDataset}
+                savingDataset={savingDataset}
+                unavailableAssetIds={unavailableAssetIds}
+                removeUnavailableAsset={removeUnavailableAsset}
+                captionDraftById={captionDraftById}
+                onPreview={onPreview}
+                updateCaption={updateCaption}
+                captioning={captioning}
+                addDialogOpen={addDialogOpen}
+                imageAssets={imageAssets}
+                characters={characters}
+                associatedCharacterId={associatedCharacterId}
+                setActiveView={setActiveView}
+                importingAssets={importingAssets}
+                selectedAssetIds={selectedAssetIds}
+                addAssets={addAssets}
+                handleImport={handleImport}
+                captionDialog={captionDialog}
+                gpuOptions={gpuOptions}
+                updateCaptionSetting={updateCaptionSetting}
+                runCaptionJob={runCaptionJob}
+                toggleCaptionExtraOption={toggleCaptionExtraOption}
+                displayedCaptionPrompt={displayedCaptionPrompt}
+                captionSettings={captionSettings}
+                captionModelMissing={captionModelMissing}
+                onDownloadCaptionModel={onDownloadCaptionModel}
+                captionModelSizeLabel={captionModelSizeLabel}
+                captionModelName={captionModel?.name ?? "JoyCaption"}
+              />
             ) : (
               <>
                 <ConfigureJobPanel

--- a/apps/web/src/screens/training/DatasetEditorPanel.jsx
+++ b/apps/web/src/screens/training/DatasetEditorPanel.jsx
@@ -27,7 +27,23 @@ function captionSourceLabel(source) {
   return "Manual";
 }
 
-function DatasetHealth({ health, action }) {
+// Character kinds arrive lowercase ("person" / "style" / "object"); the chip shows them capitalized.
+function characterKindLabel(type) {
+  return type ? type.charAt(0).toUpperCase() + type.slice(1) : "";
+}
+
+// A member has an unresolved finding when the readiness report flags it at warn/fatal
+// and the user hasn't dismissed that flag. Same predicate the per-thumbnail badge reads,
+// so the "Flagged" filter and the badges never disagree.
+function hasActiveFlags(entry) {
+  return (entry?.flags ?? []).some(
+    (flag) => !flag.acknowledged && (flag.severity === "warn" || flag.severity === "fatal"),
+  );
+}
+
+// Health rail (sc-10481): the three counts the design calls out, plus a wide tile carrying
+// the readiness dot + sentence that used to live in a separate `.training-validity` row.
+function DatasetHealth({ health }) {
   return (
     <div className="training-health-grid" aria-label="Dataset health">
       <div>
@@ -42,7 +58,12 @@ function DatasetHealth({ health, action }) {
         <strong>{health.duplicateFilenames}</strong>
         <span>Duplicate filenames</span>
       </div>
-      {action ? <div className="training-health-action">{action}</div> : null}
+      <div className="training-health-status">
+        <span className={health.valid ? "training-valid-dot valid" : "training-valid-dot"} />
+        <span className="training-health-status-text">
+          {health.valid ? "Dataset is ready for downstream steps" : "Add image assets to build this dataset"}
+        </span>
+      </div>
     </div>
   );
 }
@@ -50,7 +71,12 @@ function DatasetHealth({ health, action }) {
 // Dataset-editor panel (sc-4199): extracted verbatim from TrainingStudio so the
 // dataset name/prefix fields, health summary, caption grid, and the add/caption
 // dialogs live in their own component. All state and handlers are owned by the
-// TrainingStudio screen and passed in as props — behavior is unchanged.
+// TrainingStudio screen and passed in as props.
+//
+// sc-10481 re-cuts it onto the page-frame standard: one WorkPanel is the Purpose
+// zone (identity + tools + health + Dataset Doctor, separated by hairlines), and the
+// caption grid becomes a bare Results zone beneath it. The topbar names the page, so
+// the panel carries no title of its own.
 export function DatasetEditorPanel({
   loadingDatasets,
   onRefreshDatasets,
@@ -95,6 +121,8 @@ export function DatasetEditorPanel({
   addDialogOpen,
   imageAssets,
   characters,
+  associatedCharacterId,
+  setActiveView,
   importingAssets,
   selectedAssetIds,
   addAssets,
@@ -114,6 +142,10 @@ export function DatasetEditorPanel({
   // Local aliases for the doctor readout's report/loading, still referenced directly by
   // the distributions block and the per-card readiness badges below.
   const { report: readiness = null, loading: readinessLoading = false } = datasetDoctor ?? {};
+  // The pencil button next to a saved dataset's name is a rename affordance: it focuses
+  // the (otherwise chrome-less) name input rather than opening anything.
+  const nameInputRef = React.useRef(null);
+  const [captionFilter, setCaptionFilter] = React.useState("all");
   // sc-8564: resolve a near-dup cluster's item ids (server dataset-item ids — the readiness report's
   // `itemId` / flag `peers`) back to member assets, so the cluster view can render each sibling's
   // thumbnail. `activeDataset.items` carry both the server `id` and the `assetId` (the member-asset key).
@@ -136,162 +168,286 @@ export function DatasetEditorPanel({
       <span className="dataset-doctor-nearup-thumb-missing" title={itemId} aria-hidden />
     );
   };
+
+  // sc-2022: the dataset's owning character, shown as a chip beside the name so the set's
+  // subject (and the readiness kind it drives) is visible without opening Characters.
+  const associatedCharacter = associatedCharacterId
+    ? (characters ?? []).find((character) => character.id === associatedCharacterId)
+    : null;
+
+  const captionedCount = Math.max(0, health.itemCount - health.missingCaptions);
+  const isMissingCaption = (asset) => !String(captionDraftById[asset.id]?.text ?? "").trim();
+  const isFlagged = (asset) => hasActiveFlags(readinessByKey?.get(asset.id));
+  const visibleAssets = memberAssets.filter((asset) => {
+    if (captionFilter === "missing") {
+      return isMissingCaption(asset);
+    }
+    if (captionFilter === "flagged") {
+      return isFlagged(asset);
+    }
+    return true;
+  });
+  // Only derivable once the report exists — an item with no entry is "not assessed yet",
+  // never silently ready (sc-6534).
+  const readyCount = readiness ? memberAssets.filter((asset) => !isFlagged(asset)).length : 0;
+
+  const statusPill = dirty ? (
+    <span className="dataset-status-pill unsaved">
+      <span className="dataset-status-dot" aria-hidden="true" />
+      Unsaved changes
+    </span>
+  ) : activeDataset ? (
+    <span className="dataset-status-pill">Version {activeDataset.version}</span>
+  ) : (
+    <span className="dataset-status-pill">Draft</span>
+  );
+
   return (
     <>
-      <div className="training-panel-head">
-        <div>
-          <p className="eyebrow">Dataset</p>
-          <h3>Dataset management</h3>
-        </div>
-        <div className="training-head-actions">
-          <button className="secondary-action" disabled={loadingDatasets} onClick={onRefreshDatasets} type="button">
-            <Icon.Search size={14} />
-            {loadingDatasets ? "Refreshing" : "Refresh"}
-          </button>
-          <CompactSelector
-            busyId={busyDatasetId}
-            createLabel="New dataset"
-            getSubtitle={(dataset) => {
-              const count = datasetItemCount(dataset);
-              return `${count} item${count === 1 ? "" : "s"}`;
-            }}
-            getThumbAsset={datasetThumbAsset}
-            items={datasets}
-            label="Select dataset"
-            onCreate={startNewDataset}
-            onSelect={(dataset) => openDataset(dataset.id)}
-            placeholder={activeDataset ? activeDataset.name : "New dataset"}
-            selectedId={selectedDatasetId}
-          />
-        </div>
-      </div>
       {datasetsError ? <p className="inline-warning">{datasetsError}</p> : null}
       {datasetError ? <p className="inline-warning">{datasetError}</p> : null}
       {datasetMessage ? <p className="inline-success">{datasetMessage}</p> : null}
-      <div className="training-dataset-workspace">
-        {loadingDatasets ? <div className="empty-panel compact-panel">Loading training datasets</div> : null}
-        {!loadingDatasets && datasets.length === 0 ? (
-          <div className="empty-panel compact-panel">No training datasets yet — use “New” to start one.</div>
-        ) : null}
-        <div className="training-dataset-editor">
-          <WorkPanel className="dataset-work-panel">
-            <div className="dataset-primary-row">
-              <label className="dataset-field">
-                <span>Dataset name</span>
+
+      <WorkPanel className="dataset-work-panel">
+        <div className="dataset-identity-row">
+          <div className="dataset-identity">
+            <p className="eyebrow work-panel-eyebrow">Build &amp; caption</p>
+            <div className="dataset-name-row">
+              {activeDataset ? (
+                <span className="dataset-name-inline">
+                  <input
+                    aria-label="Dataset name"
+                    className="dataset-name-input"
+                    onChange={(event) => setDraftName(event.target.value)}
+                    placeholder="Character portrait set"
+                    ref={nameInputRef}
+                    value={draftName}
+                  />
+                  <button
+                    className="dataset-rename-button"
+                    onClick={() => nameInputRef.current?.focus()}
+                    title="Rename dataset"
+                    type="button"
+                  >
+                    <Icon.Pencil size={14} />
+                  </button>
+                </span>
+              ) : (
                 <input
+                  aria-label="Dataset name"
+                  className="dataset-name-input boxed"
                   onChange={(event) => setDraftName(event.target.value)}
-                  placeholder="Character portrait set"
+                  placeholder="Name this dataset…"
                   value={draftName}
                 />
-              </label>
-              <label className="dataset-field">
-                <span>Name prefix</span>
-                <input
-                  onChange={(event) => setRenamePrefix(event.target.value)}
-                  placeholder="item"
-                  value={renamePrefix}
-                />
-              </label>
-              <span className="dataset-version">
-                {dirty ? "Unsaved changes" : activeDataset ? `Version ${activeDataset.version}` : "Draft"}
-              </span>
-              <button className="primary-action dataset-save" disabled={!canSave} onClick={saveDataset} type="button">
-                {savingDataset ? "Saving" : activeDataset ? "Save dataset" : "Create dataset"}
+              )}
+              {associatedCharacter ? (
+                <span className="dataset-character-chip">
+                  {associatedCharacter.type ? `${characterKindLabel(associatedCharacter.type)} · ` : ""}
+                  {associatedCharacter.name}
+                </span>
+              ) : null}
+            </div>
+            <p className="dataset-identity-copy">
+              Curate the images and captions that teach this LoRA. Fix flags below, then train from the{" "}
+              <button className="link-button" onClick={() => setActiveView?.("Train")} type="button">
+                Training Studio
+              </button>
+              .
+            </p>
+          </div>
+          <div className="dataset-identity-actions">
+            <div className="dataset-identity-controls">
+              <CompactSelector
+                busyId={busyDatasetId}
+                createLabel="New dataset"
+                getSubtitle={(dataset) => {
+                  const count = datasetItemCount(dataset);
+                  return `${count} item${count === 1 ? "" : "s"}`;
+                }}
+                getThumbAsset={datasetThumbAsset}
+                items={datasets}
+                label="Select dataset"
+                onCreate={startNewDataset}
+                onSelect={(dataset) => openDataset(dataset.id)}
+                placeholder={activeDataset ? activeDataset.name : "New dataset"}
+                selectedId={selectedDatasetId}
+              />
+              <button className="secondary-action" disabled={loadingDatasets} onClick={onRefreshDatasets} type="button">
+                <Icon.Refresh size={14} />
+                {loadingDatasets ? "Refreshing" : "Refresh"}
               </button>
             </div>
-            <div className="dataset-utility-row">
-              <span className="dataset-count">
-                {health.itemCount} image{health.itemCount === 1 ? "" : "s"} ·{" "}
-                {Math.max(0, health.itemCount - health.missingCaptions)} captioned
-              </span>
-              <span className="dataset-utility-actions">
-                <button className="secondary-action" onClick={() => setAddDialogOpen(true)} type="button">
-                  <Icon.Plus size={14} />
-                  Add images
-                </button>
-                <button
-                  className="secondary-action"
-                  disabled={!activeDataset?.id || renaming || !memberAssets.length}
-                  onClick={applyOrderedNames}
-                  type="button"
-                >
-                  <Icon.Sliders size={14} />
-                  {renaming ? "Renaming…" : "Apply ordered names"}
-                </button>
-                <button
-                  className="secondary-action"
-                  disabled={!memberAssets.length}
-                  onClick={() => setCaptionDialog({ type: "all" })}
-                  type="button"
-                >
-                  <Icon.Sliders size={14} />
-                  Caption all
-                </button>
-              </span>
-            </div>
-          </WorkPanel>
-          <DatasetHealth health={health} />
-          <div className="training-validity">
-            <span className={health.valid ? "training-valid-dot valid" : "training-valid-dot"} />
-            <span>{health.valid ? "Dataset is ready for downstream steps" : "Add image assets to build this dataset"}</span>
+            <button className="primary-action dataset-save" disabled={!canSave} onClick={saveDataset} type="button">
+              {savingDataset ? "Saving" : activeDataset ? "Save dataset" : "Create dataset"}
+            </button>
+            {statusPill}
           </div>
-          <DatasetDoctorReadout
-            {...datasetDoctor}
-            onRecaptionFlagged={(itemIds) => setCaptionDialog({ type: "flagged", itemIds })}
-          />
-          <NearDuplicateClusters
-            report={readiness}
-            renderThumbnail={renderClusterThumbnail}
-            onRemoveDuplicates={datasetDoctor?.onRemoveDuplicates}
-          />
-          {readiness?.distributions ? (
-            <details className="dataset-doctor-advanced">
-              <summary>Metric distributions (advanced)</summary>
-              <DatasetDoctorDistributions report={readiness} />
-            </details>
-          ) : null}
-          {unavailableAssetIds.length ? (
-            <div className="training-unavailable-list" aria-label="Unavailable dataset items">
-              {unavailableAssetIds.map((assetId) => (
-                <div className="training-unavailable-item" key={assetId}>
-                  <div>
-                    <strong>{assetId}</strong>
-                    <span>Asset is no longer available</span>
-                  </div>
-                  <button className="secondary-action" onClick={() => removeUnavailableAsset(assetId)} type="button">
-                    Remove
-                  </button>
-                </div>
-              ))}
+        </div>
+
+        <div className="work-panel-divider" />
+
+        <div className="dataset-tools-row">
+          <label className="dataset-field dataset-prefix-field">
+            <span>Name prefix</span>
+            <input onChange={(event) => setRenamePrefix(event.target.value)} placeholder="item" value={renamePrefix} />
+          </label>
+          <span className="dataset-tools-actions">
+            <button className="secondary-action strong" onClick={() => setAddDialogOpen(true)} type="button">
+              <Icon.Plus size={14} />
+              Add images
+            </button>
+            <button
+              className="secondary-action"
+              disabled={!memberAssets.length}
+              onClick={() => setCaptionDialog({ type: "all" })}
+              type="button"
+            >
+              <Icon.Sliders size={14} />
+              Caption all
+            </button>
+            <button
+              className="secondary-action"
+              disabled={!activeDataset?.id || renaming || !memberAssets.length}
+              onClick={applyOrderedNames}
+              type="button"
+            >
+              <Icon.Sliders size={14} />
+              {renaming ? "Renaming…" : "Apply ordered names"}
+            </button>
+          </span>
+        </div>
+
+        <div className="work-panel-divider" />
+
+        <DatasetHealth health={health} />
+
+        {readiness || readinessLoading ? (
+          <>
+            <div className="work-panel-divider" />
+            <div className="dataset-doctor-band">
+              <div className="dataset-doctor-band-head">
+                <span className="dataset-doctor-band-icon" aria-hidden="true">
+                  <Icon.Stethoscope size={18} />
+                </span>
+                <strong>Dataset Doctor</strong>
+                {readiness ? (
+                  <span className="dataset-doctor-band-count">
+                    {readyCount} of {health.itemCount} items ready
+                  </span>
+                ) : null}
+              </div>
+              <DatasetDoctorReadout
+                {...datasetDoctor}
+                onRecaptionFlagged={(itemIds) => setCaptionDialog({ type: "flagged", itemIds })}
+              />
+              <NearDuplicateClusters
+                report={readiness}
+                renderThumbnail={renderClusterThumbnail}
+                onRemoveDuplicates={datasetDoctor?.onRemoveDuplicates}
+              />
+              {readiness?.distributions ? (
+                <details className="dataset-doctor-advanced">
+                  <summary>Metric distributions (advanced)</summary>
+                  <DatasetDoctorDistributions report={readiness} />
+                </details>
+              ) : null}
             </div>
-          ) : null}
-          <div className="training-caption-grid" aria-label="Dataset images and captions">
-            {memberAssets.length ? (
-              memberAssets.map((asset) => {
-                const disabled = asset.status?.rejected || asset.status?.trashed;
-                const draft = captionDraftById[asset.id] ?? {};
-                const source = draft.source ?? "manual";
-                const name = asset.displayName ?? imageAssetName(asset);
-                const readinessEntry = readinessByKey?.get(asset.id);
-                return (
-                  <article
-                    className={["training-caption-card", disabled ? "disabled" : ""].filter(Boolean).join(" ")}
-                    key={asset.id}
-                  >
-                    <div className="training-caption-card-head">
-                      <button className="training-caption-card-thumb" onClick={() => onPreview(asset, memberAssets)} type="button">
-                        <AssetThumbnail asset={asset} />
-                        {/* Only flash pending on the first load — during an ack-triggered refetch the
-                            prior report's badges hold steady rather than blinking to "·". */}
-                        <ReadinessBadge entry={readinessEntry} loading={readinessLoading && !readiness} />
-                      </button>
-                      <div className="training-caption-card-meta">
-                        <strong title={name}>{name}</strong>
-                        <span className={`training-caption-source source-${source}`}>{captionSourceLabel(source)}</span>
-                        {disabled ? (
-                          <span className="training-asset-badge">{asset.status?.trashed ? "Trashed" : "Rejected"}</span>
-                        ) : null}
-                      </div>
+          </>
+        ) : null}
+      </WorkPanel>
+
+      {loadingDatasets ? <div className="empty-panel compact-panel">Loading training datasets</div> : null}
+      {!loadingDatasets && datasets.length === 0 ? (
+        <div className="empty-panel compact-panel">
+          No training datasets yet — open the dataset selector and pick “New dataset” to start one.
+        </div>
+      ) : null}
+
+      {unavailableAssetIds.length ? (
+        <div className="training-unavailable-list" aria-label="Unavailable dataset items">
+          {unavailableAssetIds.map((assetId) => (
+            <div className="training-unavailable-item" key={assetId}>
+              <div>
+                <strong>{assetId}</strong>
+                <span>Asset is no longer available</span>
+              </div>
+              <button className="secondary-action" onClick={() => removeUnavailableAsset(assetId)} type="button">
+                Remove
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      <section className="dataset-results">
+        <div className="dataset-results-head">
+          <div className="section-heading">
+            <p className="eyebrow">Results</p>
+            <h2>Images &amp; captions</h2>
+          </div>
+          <span className="dataset-count">
+            {health.itemCount} image{health.itemCount === 1 ? "" : "s"} · {captionedCount} captioned
+          </span>
+          <div className="segmented-control" role="group" aria-label="Filter images">
+            <button
+              className={captionFilter === "all" ? "active" : ""}
+              onClick={() => setCaptionFilter("all")}
+              type="button"
+            >
+              All
+            </button>
+            <button
+              className={captionFilter === "missing" ? "active" : ""}
+              onClick={() => setCaptionFilter("missing")}
+              type="button"
+            >
+              Missing
+            </button>
+            <button
+              className={captionFilter === "flagged" ? "active" : ""}
+              onClick={() => setCaptionFilter("flagged")}
+              type="button"
+            >
+              Flagged
+            </button>
+          </div>
+        </div>
+
+        <div className="training-caption-grid" aria-label="Dataset images and captions">
+          {!memberAssets.length ? (
+            <div className="empty-panel compact-panel">No images yet — use “Add images” to build this dataset.</div>
+          ) : !visibleAssets.length ? (
+            <div className="empty-panel compact-panel">
+              {captionFilter === "missing"
+                ? "Every image has a caption."
+                : "No images carry an unresolved quality finding."}
+            </div>
+          ) : (
+            visibleAssets.map((asset) => {
+              const disabled = asset.status?.rejected || asset.status?.trashed;
+              const draft = captionDraftById[asset.id] ?? {};
+              const source = draft.source ?? "manual";
+              const name = asset.displayName ?? imageAssetName(asset);
+              const readinessEntry = readinessByKey?.get(asset.id);
+              return (
+                <article
+                  className={["training-caption-card", disabled ? "disabled" : ""].filter(Boolean).join(" ")}
+                  key={asset.id}
+                >
+                  <button className="training-caption-card-thumb" onClick={() => onPreview(asset, memberAssets)} type="button">
+                    <AssetThumbnail asset={asset} />
+                    {/* Only flash pending on the first load — during an ack-triggered refetch the
+                        prior report's badges hold steady rather than blinking to "·". */}
+                    <ReadinessBadge entry={readinessEntry} loading={readinessLoading && !readiness} />
+                  </button>
+                  <div className="training-caption-card-body">
+                    <div className="training-caption-card-meta">
+                      <strong title={name}>{name}</strong>
+                      <span className={`training-caption-source source-${source}`}>{captionSourceLabel(source)}</span>
+                      {disabled ? (
+                        <span className="training-asset-badge">{asset.status?.trashed ? "Trashed" : "Rejected"}</span>
+                      ) : null}
                     </div>
                     <ReadinessFlagDetails
                       entry={readinessEntry}
@@ -303,7 +459,12 @@ export function DatasetEditorPanel({
                     />
                     <textarea
                       aria-label={`Caption for ${name}`}
-                      className="training-caption-card-text"
+                      className={[
+                        "training-caption-card-text",
+                        isMissingCaption(asset) ? "is-empty" : "",
+                      ]
+                        .filter(Boolean)
+                        .join(" ")}
                       onChange={(event) => updateCaption(asset.id, event.target.value)}
                       placeholder="Describe this image…"
                       rows={3}
@@ -320,7 +481,7 @@ export function DatasetEditorPanel({
                       </button>
                       <button
                         aria-label={`Re-caption ${name}`}
-                        className="secondary-action"
+                        className="secondary-action strong"
                         disabled={captioning}
                         onClick={() => setCaptionDialog({ type: "item", member: asset })}
                         type="button"
@@ -328,55 +489,54 @@ export function DatasetEditorPanel({
                         Re-Caption
                       </button>
                     </div>
-                  </article>
-                );
-              })
-            ) : (
-              <div className="empty-panel compact-panel">No images yet — use “Add images” to build this dataset.</div>
-            )}
-          </div>
-          {addDialogOpen ? (
-            <DatasetAddDialog
-              assets={imageAssets}
-              characters={characters}
-              importing={importingAssets}
-              memberIds={selectedAssetIds}
-              onAdd={addAssets}
-              onClose={() => setAddDialogOpen(false)}
-              onImport={handleImport}
-            />
-          ) : null}
-          {captionDialog ? (
-            <DatasetCaptionDialog
-              captionLengths={joyCaptionLengths}
-              captionTypes={joyCaptionTypes}
-              extraOptions={joyCaptionExtraOptions}
-              gpuOptions={gpuOptions}
-              onChange={updateCaptionSetting}
-              onClose={() => setCaptionDialog(null)}
-              onRun={runCaptionJob}
-              onToggleExtra={toggleCaptionExtraOption}
-              promptValue={displayedCaptionPrompt}
-              running={captioning}
-              modelMissing={captionModelMissing}
-              onDownloadModel={onDownloadCaptionModel}
-              modelSizeLabel={captionModelSizeLabel}
-              modelName={captionModelName}
-              scope={
-                captionDialog.type === "item"
-                  ? {
-                      type: "item",
-                      name: captionDialog.member.displayName ?? imageAssetName(captionDialog.member),
-                    }
-                  : captionDialog.type === "flagged"
-                    ? { type: "flagged", count: captionDialog.itemIds?.length ?? 0 }
-                    : { type: "all" }
-              }
-              settings={captionSettings}
-            />
-          ) : null}
+                  </div>
+                </article>
+              );
+            })
+          )}
         </div>
-      </div>
+      </section>
+
+      {addDialogOpen ? (
+        <DatasetAddDialog
+          assets={imageAssets}
+          characters={characters}
+          importing={importingAssets}
+          memberIds={selectedAssetIds}
+          onAdd={addAssets}
+          onClose={() => setAddDialogOpen(false)}
+          onImport={handleImport}
+        />
+      ) : null}
+      {captionDialog ? (
+        <DatasetCaptionDialog
+          captionLengths={joyCaptionLengths}
+          captionTypes={joyCaptionTypes}
+          extraOptions={joyCaptionExtraOptions}
+          gpuOptions={gpuOptions}
+          onChange={updateCaptionSetting}
+          onClose={() => setCaptionDialog(null)}
+          onRun={runCaptionJob}
+          onToggleExtra={toggleCaptionExtraOption}
+          promptValue={displayedCaptionPrompt}
+          running={captioning}
+          modelMissing={captionModelMissing}
+          onDownloadModel={onDownloadCaptionModel}
+          modelSizeLabel={captionModelSizeLabel}
+          modelName={captionModelName}
+          scope={
+            captionDialog.type === "item"
+              ? {
+                  type: "item",
+                  name: captionDialog.member.displayName ?? imageAssetName(captionDialog.member),
+                }
+              : captionDialog.type === "flagged"
+                ? { type: "flagged", count: captionDialog.itemIds?.length ?? 0 }
+                : { type: "all" }
+          }
+          settings={captionSettings}
+        />
+      ) : null}
     </>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3172,16 +3172,13 @@ label {
   align-content: start;
 }
 
-.training-empty-state,
-.training-step-block {
+.training-empty-state {
   border: 1px solid var(--border);
   border-radius: var(--r-sm);
   background: var(--surface-2);
 }
 
-.training-step-block span,
-.training-empty-state span,
-.training-tabs small {
+.training-empty-state span {
   color: var(--text-muted);
   font-size: 12px;
 }
@@ -3197,39 +3194,6 @@ label {
 .training-empty-state > div {
   display: grid;
   gap: 4px;
-}
-
-.training-tabs {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 8px;
-}
-
-.training-tabs button {
-  display: grid;
-  min-height: 66px;
-  gap: 4px;
-  padding: 10px 12px;
-  text-align: left;
-  border: 1px solid var(--border);
-  border-radius: var(--r-sm);
-  background: var(--surface-2);
-  color: var(--text);
-}
-
-.training-tabs button:hover {
-  border-color: var(--border-strong);
-  background: var(--surface-hover);
-}
-
-.training-tabs button.active {
-  border-color: color-mix(in oklch, var(--accent) 55%, var(--border));
-  background: var(--surface);
-  box-shadow: var(--shadow-sm);
-}
-
-.training-tabs span {
-  font-weight: 700;
 }
 
 /* Results zone: the live runs sit flush on the workspace canvas — only the
@@ -3278,20 +3242,11 @@ label {
   font-weight: 700;
 }
 
-.training-dataset-list,
-.training-workflow-grid,
-.training-config-preview,
 .training-config-form,
 .training-config-grid,
 .training-advanced-grid {
   display: grid;
   gap: 10px;
-}
-
-.training-step-block {
-  display: grid;
-  gap: 4px;
-  min-width: 0;
 }
 
 /* ---------- Data Sets hero (sc-10481) ----------
@@ -3501,74 +3456,17 @@ input.dataset-name-input.boxed:focus {
   font-weight: 600;
 }
 
-.training-dataset-fields {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 8px;
-  align-items: end;
-}
-
-.field-name,
-.field-prefix {
+/* The Preset editor's Name field — sole survivor of the old 4-column dataset header
+   grid, whose other cells died with it (sc-10497). Its `grid-column: 1 / span 2` went
+   with them: .preset-section-body is a single-column grid, so spanning two columns had
+   been opening an implicit second one that the other .field siblings auto-placed into.
+   The preset sections now stack, which the Presets redesign will settle properly. */
+.field-name {
   display: grid;
   gap: 7px;
-  grid-column: 1 / span 2;
   font-size: 12px;
   font-weight: 700;
   color: var(--text-muted);
-}
-
-.field-name {
-  grid-row: 1;
-}
-
-.field-prefix {
-  grid-row: 2;
-}
-
-.field-version {
-  grid-row: 1;
-  grid-column: 3;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 44px;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-muted);
-}
-
-.field-add {
-  grid-row: 1;
-  grid-column: 4;
-}
-
-.field-apply {
-  grid-row: 2;
-  grid-column: 3;
-}
-
-.field-caption {
-  grid-row: 2;
-  grid-column: 4;
-}
-
-/* Split the difference: inputs grow a touch (larger font), buttons shrink, both
-   land on a shared 44px control height. */
-.training-dataset-fields input {
-  height: 44px;
-  font-size: 15px;
-}
-
-.training-dataset-fields .primary-action {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  width: 100%;
-  height: 44px;
-  padding-top: 0;
-  padding-bottom: 0;
 }
 
 /* Health rail (sc-10481): three counts plus a wide tile carrying the readiness dot
@@ -3681,19 +3579,6 @@ input.dataset-name-input.boxed:focus {
   font-weight: 700;
 }
 
-.training-workflow-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.training-step-block {
-  padding: 14px;
-}
-
-.training-config-preview {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.training-config-preview label,
 .training-config-grid label,
 .training-advanced-grid label {
   display: grid;
@@ -10381,12 +10266,8 @@ details[open] > summary.lora-scope-group-heading::before,
   .media-grid,
   .library-layout,
   .studio-layout,
-  .training-tabs,
-  .training-dataset-fields,
   .training-health-grid,
   .training-caption-card,
-  .training-workflow-grid,
-  .training-config-preview,
   .training-config-grid,
   .training-advanced-grid,
   .preset-layout,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3172,46 +3172,13 @@ label {
   align-content: start;
 }
 
-.training-summary-band {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(300px, 420px);
-  gap: 18px;
-  align-items: stretch;
-}
-
-.training-metrics {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 10px;
-}
-
-.training-metrics > div,
 .training-empty-state,
-.training-panel,
-.training-step-block,
-.training-dataset-editor {
+.training-step-block {
   border: 1px solid var(--border);
   border-radius: var(--r-sm);
   background: var(--surface-2);
 }
 
-.training-metrics > div {
-  display: grid;
-  align-content: center;
-  gap: 4px;
-  min-height: 84px;
-  padding: 12px;
-}
-
-.training-metrics strong {
-  overflow-wrap: anywhere;
-  color: var(--text);
-  font-size: 18px;
-  font-weight: 700;
-  line-height: 1.2;
-}
-
-.training-metrics span,
 .training-step-block span,
 .training-empty-state span,
 .training-tabs small {
@@ -3299,31 +3266,6 @@ label {
   gap: 10px;
 }
 
-.training-panel {
-  display: grid;
-  gap: 14px;
-  padding: 16px;
-}
-
-.training-panel-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.training-head-actions {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.training-panel-head h3 {
-  margin: 2px 0 0;
-  font-size: 18px;
-}
-
 .training-status-pill {
   display: inline-flex;
   align-items: center;
@@ -3346,36 +3288,176 @@ label {
   gap: 10px;
 }
 
-.training-dataset-workspace {
-  display: grid;
-  gap: 14px;
-  align-items: start;
-}
-
-.training-dataset-editor {
-  display: grid;
-  gap: 10px;
-  min-width: 0;
-  padding: 12px;
-}
-
 .training-step-block {
   display: grid;
   gap: 4px;
   min-width: 0;
 }
 
-/* Dataset header fields aligned to the 4 health columns (sc-2025 polish):
-   row 1 = name | version | Add images, row 2 = prefix | Apply names | Caption all;
-   the health grid below (row 3) shares the same 4-column geometry. */
-/* Dataset editor controls (sc-10448) — replaces the crammed equal-weight
-   .training-dataset-fields grid: a primary row (the two inputs + the one filled
-   Save CTA) over a de-emphasized utility row (add / rename / caption + a live
-   count), inside a work-panel. */
-.dataset-primary-row {
+/* ---------- Data Sets hero (sc-10481) ----------
+   The Purpose zone of the Data Sets page: one work-panel whose rows — identity,
+   tools, health rail, Dataset Doctor — are separated by .work-panel-divider
+   hairlines. The dataset name is the panel's most prominent element; the selector
+   and Refresh sit above the Save CTA, with the save-state pill below it. */
+.dataset-identity-row {
   display: flex;
-  gap: 10px;
-  align-items: end;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--gap-4);
+  flex-wrap: wrap;
+}
+
+.dataset-identity {
+  flex: 1 1 280px;
+  min-width: 0;
+}
+
+.dataset-name-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+
+.dataset-name-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1 1 320px;
+  min-width: 0;
+  max-width: 560px;
+}
+
+/* Saved dataset: the name reads as a heading, not a form field, until focused.
+   Qualified with `input` so it outweighs the base `input:not([type])` control rule
+   (height / padding / 13px font), which is (0,1,1) — a bare class would lose. */
+input.dataset-name-input {
+  height: auto;
+  width: 100%;
+  min-width: 0;
+  padding: 2px 0;
+  border: none;
+  border-bottom: 1.5px solid transparent;
+  border-radius: 0;
+  background: transparent;
+  color: var(--text);
+  font: 600 22px/1.2 var(--font-ui);
+  letter-spacing: -0.01em;
+  transition: border-color var(--t-fast) var(--ease-out);
+}
+
+input.dataset-name-input:focus {
+  border-bottom-color: var(--accent);
+  outline: none;
+}
+
+/* Draft dataset: a boxed input, because there is nothing there to read yet. */
+input.dataset-name-input.boxed {
+  width: min(420px, 100%);
+  padding: 11px 15px;
+  border: 1px solid var(--border);
+  border-radius: 11px;
+  background: var(--surface-2);
+  font-size: 18px;
+}
+
+input.dataset-name-input.boxed:focus {
+  border-color: var(--accent);
+}
+
+.dataset-rename-button {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-xs);
+  background: var(--surface-2);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color var(--t-fast), border-color var(--t-fast);
+}
+
+.dataset-rename-button:hover {
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+.dataset-character-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 11px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-pill);
+  background: var(--surface-2);
+  color: var(--text-muted);
+  font-size: 11.5px;
+}
+
+.dataset-identity-copy {
+  margin: 8px 0 0;
+  max-width: 62ch;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.dataset-identity-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 9px;
+}
+
+.dataset-identity-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--gap-2);
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.dataset-save {
+  flex: 0 0 auto;
+  min-height: var(--control-h);
+  padding: 11px 22px;
+  border-radius: 11px;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.dataset-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-pill);
+  background: var(--surface-2);
+  color: var(--text-muted);
+  font-size: 11.5px;
+  font-weight: 600;
+}
+
+.dataset-status-pill.unsaved {
+  border-color: transparent;
+  background: var(--warn-soft);
+  color: color-mix(in oklch, var(--warn) 78%, var(--text));
+}
+
+.dataset-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--warn);
+}
+
+.dataset-tools-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
   flex-wrap: wrap;
 }
 
@@ -3388,39 +3470,35 @@ label {
   color: var(--text-muted);
 }
 
-.dataset-version {
-  align-self: center;
-  font-size: 12px;
-  font-weight: 600;
+.dataset-prefix-field {
+  flex: 0 0 180px;
+}
+
+.dataset-prefix-field > span {
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
   color: var(--text-faint);
-  white-space: nowrap;
 }
 
-.dataset-save {
-  flex: 0 0 auto;
-  min-height: var(--control-h);
-}
-
-.dataset-utility-row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
-  padding-top: 12px;
-  border-top: 1px solid var(--border);
-}
-
-.dataset-count {
-  font-size: 12.5px;
-  color: var(--text-muted);
+.dataset-prefix-field input {
   font-family: var(--font-mono);
+  font-size: 13px;
 }
 
-.dataset-utility-actions {
+.dataset-tools-actions {
   display: inline-flex;
   gap: 8px;
   margin-left: auto;
   flex-wrap: wrap;
+}
+
+/* A secondary button carrying primary weight — the recommended next action in a
+   row of equals (Add images; Re-Caption on a card). */
+.secondary-action.strong {
+  color: var(--text);
+  font-weight: 600;
 }
 
 .training-dataset-fields {
@@ -3493,69 +3571,71 @@ label {
   padding-bottom: 0;
 }
 
+/* Health rail (sc-10481): three counts plus a wide tile carrying the readiness dot
+   and sentence, which used to sit in a separate row below the grid. */
 .training-health-grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 8px;
+  grid-template-columns: repeat(3, minmax(0, 1fr)) minmax(230px, auto);
+  gap: 12px;
+  align-items: stretch;
 }
 
 .training-health-grid > div {
   display: grid;
-  gap: 3px;
-  min-height: 62px;
+  gap: 2px;
   align-content: center;
-  padding: 10px;
+  padding: 13px 16px;
   border: 1px solid var(--border);
-  border-radius: var(--r-sm);
-  background: var(--surface);
+  border-radius: var(--r-md);
+  background: var(--surface-2);
 }
 
 .training-health-grid strong {
-  font-size: 18px;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
 }
 
-.training-health-grid span,
-.training-validity {
+.training-health-grid span {
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: 11.5px;
 }
 
 .training-health-grid .needs-attention {
-  border-color: color-mix(in oklch, var(--danger) 42%, var(--border));
-  background: color-mix(in oklch, var(--danger) 8%, var(--surface));
+  border-color: color-mix(in oklch, var(--warn) 40%, var(--border));
 }
 
-/* Save lives in the health row (sc-2025) so a small edit needs no scroll. */
-/* Save sits in the health row's 4th column (sc-2025): no card chrome, button
-   bottom-aligned with the stat cards, same size as Add images / Caption all. */
-.training-health-action {
-  border: none !important;
-  background: none !important;
-  padding: 0 !important;
-  align-content: end !important;
+.training-health-grid .needs-attention strong {
+  color: color-mix(in oklch, var(--warn) 80%, var(--text));
 }
 
-.training-health-action button {
-  width: 100%;
-  height: 44px;
-  justify-content: center;
-}
-
-.training-validity {
+/* Vertical padding so the tile keeps its height when the rail stacks to one column
+   on narrow viewports; at rail width it stretches to match the stat tiles anyway. */
+.training-health-grid > div.training-health-status {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 11px;
+  padding: 13px 20px;
+}
+
+.training-health-grid .training-health-status-text {
+  color: var(--text);
+  font-size: 12.5px;
+  line-height: 1.35;
 }
 
 .training-valid-dot {
+  flex: none;
   width: 9px;
   height: 9px;
   border-radius: 50%;
-  background: var(--danger);
+  background: var(--warn);
+  box-shadow: 0 0 0 4px color-mix(in oklch, var(--warn) 20%, transparent);
 }
 
 .training-valid-dot.valid {
   background: var(--success);
+  box-shadow: 0 0 0 4px color-mix(in oklch, var(--success) 20%, transparent);
 }
 
 .training-unavailable-list {
@@ -9305,19 +9385,49 @@ details[open] > summary.lora-scope-group-heading::before,
 
 /* Unified image + caption cards (sc-2025): thumbnail + read-only name/source,
    editable caption underneath, actions at the bottom. Responsive auto-fill. */
-.training-caption-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 12px;
+/* ---------- Data Sets results zone (sc-10481) ---------- */
+.dataset-results {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-3);
+  min-width: 0;
 }
 
+.dataset-results-head {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-3);
+  flex-wrap: wrap;
+}
+
+.dataset-results-head .section-heading {
+  margin-right: auto;
+}
+
+.dataset-results-head .section-heading h2 {
+  font-size: 16px;
+}
+
+.dataset-count {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.training-caption-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: var(--gap-3);
+}
+
+/* The card splits in half: image left, everything about it right (sc-10481). */
 .training-caption-card {
   display: grid;
-  gap: 8px;
-  align-content: start;
-  padding: 10px;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  align-items: stretch;
+  padding: 12px;
   border: 1px solid var(--border);
-  border-radius: var(--r-md);
+  border-radius: var(--r-lg);
   background: var(--surface);
 }
 
@@ -9325,28 +9435,30 @@ details[open] > summary.lora-scope-group-heading::before,
   opacity: 0.6;
 }
 
-.training-caption-card-head {
-  display: grid;
-  grid-template-columns: 72px minmax(0, 1fr);
-  gap: 10px;
-  align-items: center;
-}
-
 .training-caption-card-thumb {
   position: relative;
+  display: block;
+  min-height: 150px;
   padding: 0;
   border: none;
-  background: none;
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--bg-2);
   cursor: pointer;
 }
 
 .training-caption-card-thumb img,
 .training-caption-card-thumb video {
-  width: 72px;
-  height: 72px;
+  width: 100%;
+  height: 100%;
   object-fit: cover;
-  border-radius: var(--r-sm);
-  background: var(--bg-2);
+}
+
+.training-caption-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
 }
 
 .training-caption-card-meta {
@@ -9357,47 +9469,124 @@ details[open] > summary.lora-scope-group-heading::before,
 
 .training-caption-card-meta strong {
   overflow: hidden;
-  font-size: 13px;
+  font-size: 12.5px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+/* Caption provenance (sc-2025): Manual reads neutral, Auto is accented because the
+   model wrote it, Imported recedes. */
 .training-caption-source {
   justify-self: start;
-  padding: 1px 8px;
-  border-radius: 999px;
-  font-size: 11px;
-  font-weight: 600;
-  background: var(--surface-hover);
+  padding: 2px 7px;
+  border-radius: 5px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: var(--surface-2);
   color: var(--text-muted);
 }
 
-.training-caption-source.source-imported {
-  background: color-mix(in oklch, var(--accent) 16%, transparent);
+.training-caption-source.source-auto {
+  background: var(--accent-soft);
   color: var(--accent-strong);
 }
 
-.training-caption-source.source-auto {
-  background: color-mix(in oklch, var(--warm) 22%, transparent);
+.training-caption-source.source-imported {
+  color: var(--text-faint);
 }
 
 .training-caption-card-text {
   width: 100%;
+  min-height: 56px;
+  padding: 9px 11px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--bg);
+  font-size: 12px;
+  line-height: 1.5;
   resize: vertical;
+}
+
+/* An uncaptioned image is the one thing the page wants you to fix. */
+.training-caption-card-text.is-empty {
+  border-style: dashed;
+  border-color: color-mix(in oklch, var(--warn) 45%, var(--border));
+}
+
+.training-caption-card-text.is-empty::placeholder {
+  font-style: italic;
 }
 
 .training-caption-card-actions {
   display: flex;
   gap: 8px;
+  margin-top: auto;
 }
 
+/* The card's right half is only ~170px wide, so these two must not wrap. */
 .training-caption-card-actions button {
   flex: 1;
+  height: 32px;
+  min-height: 0;
+  padding: 0 8px;
+  justify-content: center;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+/* Quality findings sit in that same narrow column, so they read as compact chips
+   rather than the full-width rows they'd be at panel width. */
+.training-caption-card .dataset-doctor-flags li {
+  padding: 4px 7px;
+  font-size: 10.5px;
+}
+
+.training-caption-card .dataset-doctor-flags li.tone-warn {
+  background: var(--warn-soft);
 }
 
 /* Dataset Doctor — pre-training quality readout + per-thumbnail badges (sc-6534).
    Tone vocabulary: good = success, warn = amber (no global token), fatal = danger,
    pending = muted. Amber is defined inline so it reads on both light/dark surfaces. */
+/* Doctor band (sc-10481): the readout, near-duplicate clusters and the metric
+   distributions grouped under one labelled header inside the hero work-panel. */
+.dataset-doctor-band {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+
+.dataset-doctor-band-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.dataset-doctor-band-head strong {
+  font-size: 13.5px;
+  font-weight: 600;
+}
+
+.dataset-doctor-band-icon {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 34px;
+  height: 34px;
+  border-radius: 9px;
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.dataset-doctor-band-count {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
 .dataset-doctor {
   --dd-tone: var(--text-muted);
   display: grid;
@@ -10192,12 +10381,10 @@ details[open] > summary.lora-scope-group-heading::before,
   .media-grid,
   .library-layout,
   .studio-layout,
-  .training-summary-band,
   .training-tabs,
-  .training-metrics,
-  .training-dataset-workspace,
   .training-dataset-fields,
   .training-health-grid,
+  .training-caption-card,
   .training-workflow-grid,
   .training-config-preview,
   .training-config-grid,

--- a/apps/web/src/training/datasetHelpers.js
+++ b/apps/web/src/training/datasetHelpers.js
@@ -13,10 +13,6 @@ export function datasetItemCount(dataset) {
   return Number.isFinite(value) ? value : 0;
 }
 
-export function summarizeDatasets(datasets) {
-  return datasets.reduce((summary, dataset) => ({ items: summary.items + datasetItemCount(dataset) }), { items: 0 });
-}
-
 export function captionText(item) {
   return String(item?.caption?.text ?? "").trim();
 }


### PR DESCRIPTION
Implements the `design/Dataset Design.zip` handoff for the **Data Sets** screen, then sweeps the CSS it orphaned. Closes the last open page-frame story of epic 10433.

Two commits, one per story.

## sc-10481 — Data Sets redesign

The screen no longer names itself. The `.training-summary-band` (eyebrow "Library" + `<h2>Data Sets</h2>` + Project/Datasets/Items metrics), the `.training-panel` wrapper that boxed a `WorkPanel` inside another card, and `DatasetEditorPanel`'s own `<h3>Dataset management</h3>` head are all gone — the topbar already carried the title and blurb.

What's left is one `WorkPanel` (the Purpose zone), its rows split by `.work-panel-divider` hairlines:

- **identity** — the dataset name as the panel's heading (borderless with a pencil that focuses it when saved, boxed when a draft), the owning character chip, and a right column with the dataset selector + Refresh **above** the Save/Create CTA and the save-state pill **below** it
- **tools** — name prefix, Add images, Caption all, Apply ordered names
- **health rail** — Items / Missing captions / Duplicate filenames, plus a wide tile carrying the readiness dot and sentence that used to sit in its own row
- **Dataset Doctor**, under a labelled band header

Below it, a bare Results zone: an "Images & captions" header with a live count and a new client-side **All / Missing / Flagged** filter, then the caption grid. Cards now split in half — thumbnail fills the left, metadata/findings/caption/actions stack on the right.

**No control was lost.** The Doctor keeps all four meters, its summary, gate counts and six fix actions, plus `NearDuplicateClusters` and the metric-distributions disclosure. Cards keep their readiness badges, per-finding Dismiss/Undo, rejected/trashed badges and thumbnail preview.

### Deviations from the prototype (agreed with Michael)

- **Accent rule on top**, not down the left edge — the shipped `WorkPanel` treatment, consistent with the seven merged phases of this epic.
- **Selector + Refresh live in the panel**, not the global topbar, which has no per-screen actions slot.
- **The Doctor keeps its full surface** rather than shrinking to the prototype's single progress bar.

## sc-10497 — Dead training CSS

Audited every `.training-*` / `.dataset-*` / `.field-*` selector against all of `apps/web/src` and deleted what had no JSX consumer: `.training-dataset-fields` and its cells (`.field-prefix`, `.field-version`, `.field-add`, `.field-apply`, `.field-caption`), `.training-step-block` (three separate rules), `.training-tabs` (six rules), `.training-workflow-grid`, `.training-config-preview`, `.training-dataset-list`, and the now-orphaned entries in the `max-width: 860px` single-column list. **127 lines removed.**

## What a reviewer should know

**`.field-name`'s grid placement was load-bearing by accident.** It survives (only `PresetManagerScreen.jsx` renders it), but its `grid-column: 1 / span 2` addressed the deleted 4-column grid and looked like obvious cruft. It wasn't: `.preset-section-body` is a *single-column* grid, so spanning two columns opened an implicit second column that the sibling `.field` elements auto-placed into. That one declaration was the only reason the Preset editor laid out two-up. **The preset sections now stack.** Michael's call — the Presets redesign is next and will settle that layout deliberately.

The suite passed 1380/1380 and lint was clean *both with and without* that regression; neither can see layout. It was caught by rendering the Preset form and diffing child bounding boxes with the declarations injected back.

**`input.dataset-name-input` is qualified with `input` on purpose.** The base `input:not([type])` control rule is specificity (0,1,1) and would otherwise beat a bare class, pinning the hero name to 13px. Same family as the checkbox trap in sc-10492.

**`field()` in `main.testSupport.jsx` gained an `aria-label` fallback**, because the name input no longer has a visible `<label>`. It returns `?? undefined` since callers assert `toBeUndefined()`.

Also drops `summarizeDatasets()`, orphaned with the metrics band, and adds `Icon.Refresh` / `Icon.Pencil` / `Icon.Stethoscope`.

## Verification

Driven in a real browser against a mock API, not just asserted in tests:

- **All / Missing / Flagged** — Missing returns the 1 uncaptioned item, Flagged exactly the 2 with unresolved warn flags, All returns 6
- pencil focuses the name; editing it flips the pill to "Unsaved changes" and enables Save
- **draft state** — boxed 18px input, "Name this dataset…" placeholder, `Draft` pill, `Create dataset` CTA, zeroed health, no Doctor band, no character chip
- **saved state** — 22px/600 borderless name, `Person · Aurora` chip, `Version 3` pill
- light and dark themes both read correctly; no horizontal overflow at 768px
- after the CSS sweep: Data Sets pixel-unchanged, Presets renders correctly stacked

`npm test` 1380/1380 · `npm run lint` 0 errors (46 pre-existing warnings, unchanged) · `vite build` clean.

## Follow-up filed

- **sc-10498** — below 860px the sticky topbar overlaps page content. Pre-existing and app-wide; reproduced identically on the untouched Assets screen. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)