### PR TITLE
feat(loras): reuse LoRAs from an existing ComfyUI models folder (sc-10452)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,21 @@ SCENEWORKS_CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 SCENEWORKS_DATA_DIR=data
 SCENEWORKS_CONFIG_DIR=config
 
+# Reuse model weights you already have — point this at an existing ComfyUI
+# `models/` directory and its `loras/` subtree is scanned (recursively) and listed
+# alongside the built-in catalog. Files are read IN PLACE: nothing is copied,
+# nothing is re-downloaded, and SceneWorks will never modify or delete them.
+#
+# OS-native path list: `;`-separated on Windows, `:`-separated on Linux. Entries
+# must be absolute. Unset (the default) disables the feature entirely, and it is
+# always disabled on macOS.
+#
+# Widening this admits its contents to the worker's adapter-load path, so it is an
+# operator/deployment setting and is never accepted from an API request.
+#   Windows: SCENEWORKS_EXTERNAL_MODEL_ROOTS=C:\Users\you\ComfyUI\models
+#   Linux:   SCENEWORKS_EXTERNAL_MODEL_ROOTS=/home/you/ComfyUI/models
+# SCENEWORKS_EXTERNAL_MODEL_ROOTS=
+
 # Host paths mounted by Docker Compose. Defaults preserve the repository data
 # and config folders; override only for isolated checks or alternate storage.
 SCENEWORKS_DATA_BIND=./data

--- a/apps/rust-api/src/external_loras.rs
+++ b/apps/rust-api/src/external_loras.rs
@@ -1,0 +1,610 @@
+//! Surface the LoRA adapters already sitting in an operator's ComfyUI `models/`
+//! tree, read in place (epic 10451 / sc-10452).
+//!
+//! Every other LoRA in the catalog is *manifest-declared*: `lora_catalog` merges
+//! `builtin.loras.jsonc`, `user.loras.jsonc` and a project manifest, and a LoRA
+//! that no manifest names simply does not exist. Nothing scans a directory. That
+//! is exactly why "just point at my ComfyUI folder" needs new code rather than a
+//! config tweak — this module is that scan, producing synthetic catalog rows for
+//! the adapters it finds.
+//!
+//! The rows are deliberately second-class:
+//! * `scope: "external"` — `delete_lora` / `update_lora` reject the scope, and
+//!   `lora_catalog` marks them `removable: false`. **We never offer to mutate or
+//!   delete a file the user owns and we merely borrowed.**
+//! * ids are namespaced `external_…` so a scanned adapter can never collide with,
+//!   or shadow, a manifest entry.
+//! * nothing is copied. `source.path` points straight at the operator's file; the
+//!   worker's `normalize_app_managed_lora_path` admits it because the same root
+//!   list is configured there.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use sceneworks_core::external_roots::comfyui_lora_dirs;
+use sceneworks_core::lora_family::{detect_lora_family, read_safetensors_header};
+use sceneworks_core::slug::slugify;
+use serde_json::{json, Value};
+
+/// Catalog `scope` for a scanned, externally-owned adapter.
+pub(crate) const EXTERNAL_SCOPE: &str = "external";
+
+/// Prefix on every synthesized id, so an external row can never collide with a
+/// manifest-declared LoRA (whose ids are `<family>_<slug>`).
+const EXTERNAL_ID_PREFIX: &str = "external_";
+
+/// Directory nesting we will descend below `<root>/loras`. The real trees nest a
+/// level or two (`loras/Wan/…`, `loras/Ltx2.3/…`); this is a runaway guard against
+/// a pathological tree, not a real limit.
+const MAX_SCAN_DEPTH: usize = 8;
+
+/// Upper bound on adapters surfaced from one root. A user with a runaway directory
+/// should get a truncated list rather than a stalled API.
+const MAX_ADAPTERS_PER_ROOT: usize = 4096;
+
+/// Memo of the family detected for each adapter, keyed by its identity on disk.
+///
+/// `lora_catalog` is rebuilt on **every job-create**, and family detection means
+/// parsing a safetensors header — for a real Wan adapter that is a ~1200-entry JSON
+/// blob. A user with a large ComfyUI collection (the very user this feature targets)
+/// would otherwise re-parse every header before every generation. The walk and the
+/// `stat` stay cheap and always run, so added, removed, or *modified* files are
+/// picked up immediately; only the header read is skipped, and only when size and
+/// mtime both match what was parsed last time.
+#[derive(Default)]
+pub(crate) struct ExternalLoraCache {
+    entries: HashMap<PathBuf, CachedAdapter>,
+}
+
+#[derive(Clone)]
+struct CachedAdapter {
+    modified: Option<SystemTime>,
+    size: u64,
+    /// `None` = header parsed fine but no family could be identified. Cached too,
+    /// so an unidentifiable adapter is not re-parsed on every catalog build.
+    family: Option<String>,
+}
+
+impl ExternalLoraCache {
+    /// The cached family for `path` when the file is byte-identical (same size and
+    /// mtime) to the one we parsed. Outer `None` = cache miss, parse the header.
+    fn get(&self, path: &Path, modified: Option<SystemTime>, size: u64) -> Option<Option<String>> {
+        let entry = self.entries.get(path)?;
+        // A file whose mtime is unavailable can never be proven unchanged.
+        let modified = modified?;
+        let cached_modified = entry.modified?;
+        (entry.size == size && cached_modified == modified).then(|| entry.family.clone())
+    }
+
+    fn insert(
+        &mut self,
+        path: PathBuf,
+        modified: Option<SystemTime>,
+        size: u64,
+        family: Option<String>,
+    ) {
+        self.entries.insert(
+            path,
+            CachedAdapter {
+                modified,
+                size,
+                family,
+            },
+        );
+    }
+
+    /// Drop memos for adapters that are no longer on disk, so a long-lived process
+    /// that watches a churning directory does not grow without bound.
+    fn retain_seen(&mut self, seen: &HashSet<PathBuf>) {
+        self.entries.retain(|path, _| seen.contains(path));
+    }
+}
+
+/// Scan each configured root's `loras/` subdirectory and return synthesized catalog
+/// rows, one per `.safetensors` adapter found. Returns empty when no roots are
+/// configured (the default), which keeps the catalog byte-identical for every
+/// install that has not opted in.
+///
+/// Blocking filesystem work — call from `spawn_blocking`, as `lora_catalog` does for
+/// the manifest normalize sweep.
+pub(crate) fn scan_external_loras(roots: &[PathBuf], cache: &mut ExternalLoraCache) -> Vec<Value> {
+    let mut rows = Vec::new();
+    let mut used_ids = HashSet::new();
+    let mut seen = HashSet::new();
+    for lora_dir in comfyui_lora_dirs(roots) {
+        // Canonicalize once: every candidate must stay under this, so a symlink
+        // inside the tree cannot walk us out of the root the operator declared.
+        let Ok(canonical_root) = std::fs::canonicalize(&lora_dir) else {
+            continue;
+        };
+        let adapters = collect_adapters(&canonical_root);
+        let found = adapters.len();
+        let mut detected = 0_usize;
+        for adapter in adapters {
+            match external_lora_row(&canonical_root, &adapter, &mut used_ids, cache) {
+                Some(row) => {
+                    if row.get("family").is_some() {
+                        detected += 1;
+                    }
+                    seen.insert(adapter);
+                    rows.push(row);
+                }
+                None => {
+                    tracing::debug!(
+                        path = %adapter.display(),
+                        "skipping external LoRA with an unreadable safetensors header"
+                    );
+                }
+            }
+        }
+        tracing::info!(
+            root = %lora_dir.display(),
+            found,
+            detected_family = detected,
+            "scanned external LoRA root"
+        );
+    }
+    cache.retain_seen(&seen);
+    rows
+}
+
+/// Depth-bounded walk of `root` returning every `.safetensors` file whose
+/// canonical path is still under `root`.
+///
+/// Symlinks are *followed*, then re-checked for containment: multi-install ComfyUI
+/// setups routinely symlink a shared weights directory in, so refusing to follow
+/// would hide legitimate files. A link that escapes the root is dropped instead —
+/// which keeps this scan consistent with the worker's confinement check, where such
+/// a path would be rejected at generation time anyway. Surfacing a row the worker
+/// will later refuse to load would be worse than not surfacing it.
+fn collect_adapters(root: &Path) -> Vec<PathBuf> {
+    let mut adapters = Vec::new();
+    let mut stack = vec![(root.to_path_buf(), 0_usize)];
+    while let Some((dir, depth)) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if adapters.len() >= MAX_ADAPTERS_PER_ROOT {
+                tracing::warn!(
+                    root = %root.display(),
+                    limit = MAX_ADAPTERS_PER_ROOT,
+                    "external LoRA scan hit its per-root cap; remaining files ignored"
+                );
+                return adapters;
+            }
+            let path = entry.path();
+            // `canonicalize` resolves any symlink and proves existence; anything that
+            // lands outside the declared root is not ours to read.
+            let Ok(canonical) = std::fs::canonicalize(&path) else {
+                continue;
+            };
+            if !canonical.starts_with(root) {
+                continue;
+            }
+            if canonical.is_dir() {
+                if depth < MAX_SCAN_DEPTH {
+                    stack.push((canonical, depth + 1));
+                }
+            } else if has_safetensors_extension(&canonical) {
+                adapters.push(canonical);
+            }
+        }
+    }
+    adapters
+}
+
+fn has_safetensors_extension(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("safetensors"))
+}
+
+/// Build one catalog row for `adapter`. `None` when the file has no readable
+/// safetensors header (truncated, or not actually safetensors) — such a file cannot
+/// be loaded, so listing it would only produce a confusing failure later.
+///
+/// A readable header whose *family* the detector cannot identify still yields a row,
+/// with `family` absent: the adapter is real and the user can see we found it. It
+/// simply will not pass any model's compatibility gate, which is the honest outcome —
+/// quietly dropping it would look like the scan had missed the file.
+fn external_lora_row(
+    root: &Path,
+    adapter: &Path,
+    used_ids: &mut HashSet<String>,
+    cache: &mut ExternalLoraCache,
+) -> Option<Value> {
+    let metadata = std::fs::metadata(adapter).ok()?;
+    let size = metadata.len();
+    let modified = metadata.modified().ok();
+
+    let family = match cache.get(adapter, modified, size) {
+        Some(family) => family,
+        None => {
+            // Cache miss (new, changed, or mtime-less file): parse the header. A file
+            // that will not parse is dropped entirely — and deliberately not memoized,
+            // so a partially-written download is retried on the next catalog build
+            // rather than being remembered as broken.
+            let header = read_safetensors_header(adapter).ok()?;
+            let family = detect_lora_family(&header);
+            cache.insert(adapter.to_path_buf(), modified, size, family.clone());
+            family
+        }
+    };
+
+    let relative = adapter.strip_prefix(root).unwrap_or(adapter);
+    let display_name = relative_display_name(relative);
+    let id = unique_id(&display_name, used_ids);
+    let file_name = adapter.file_name()?.to_str()?.to_owned();
+
+    let mut row = json!({
+        "id": id,
+        "name": display_name,
+        "scope": EXTERNAL_SCOPE,
+        "source": { "path": adapter.display().to_string() },
+        "files": [file_name],
+        // The scan proved the file exists and parsed its header, so it is installed by
+        // construction. There is no manifest behind it.
+        "installedPath": adapter.display().to_string(),
+        "installState": "installed",
+        "manifestPath": Value::Null,
+    });
+    if let Some(family) = family {
+        row["family"] = Value::String(family);
+    }
+    Some(row)
+}
+
+/// A stable, human-meaningful name from the adapter's path relative to `loras/`:
+/// `Wan/detailz-wan.safetensors` → `Wan/detailz-wan`. Keeping the subdirectory
+/// distinguishes same-named adapters filed under different families.
+fn relative_display_name(relative: &Path) -> String {
+    let without_extension = relative.with_extension("");
+    without_extension
+        .components()
+        .filter_map(|component| match component {
+            std::path::Component::Normal(value) => value.to_str(),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// `external_<slug>`, suffixed on collision so two adapters that slugify alike keep
+/// distinct ids (the id is the catalog's primary key and the deletion/selection handle).
+fn unique_id(display_name: &str, used_ids: &mut HashSet<String>) -> String {
+    let base = format!(
+        "{EXTERNAL_ID_PREFIX}{}",
+        slugify(display_name, "lora", Some(80))
+    );
+    let mut candidate = base.clone();
+    let mut suffix = 2_usize;
+    while used_ids.contains(&candidate) {
+        candidate = format!("{base}_{suffix}");
+        suffix += 1;
+    }
+    used_ids.insert(candidate.clone());
+    candidate
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Map;
+
+    /// Write a syntactically valid safetensors file whose header declares `keys`.
+    /// Only the header is ever read, but the declared tensor data must actually be
+    /// present or `read_safetensors_header` rejects the file as truncated (sc-6072).
+    fn write_safetensors(path: &Path, keys: &[&str]) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("parent dir");
+        }
+        let mut header = Map::new();
+        for (index, key) in keys.iter().enumerate() {
+            let start = index * 4;
+            header.insert(
+                (*key).to_owned(),
+                json!({ "dtype": "F32", "shape": [1], "data_offsets": [start, start + 4] }),
+            );
+        }
+        let header_bytes = serde_json::to_vec(&Value::Object(header)).expect("header json");
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(header_bytes.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(&header_bytes);
+        bytes.extend(std::iter::repeat(0_u8).take(keys.len() * 4));
+        std::fs::write(path, bytes).expect("write safetensors");
+    }
+
+    /// Key layout taken verbatim from a real ComfyUI Wan adapter
+    /// (`wan2.2_t2v_lightx2v_4steps_lora_v1.1_high_noise.safetensors`).
+    fn wan_keys() -> Vec<&'static str> {
+        vec![
+            "diffusion_model.blocks.0.cross_attn.k.lora_down.weight",
+            "diffusion_model.blocks.0.cross_attn.k.lora_up.weight",
+            "diffusion_model.blocks.0.cross_attn.v.lora_down.weight",
+            "diffusion_model.blocks.0.cross_attn.v.lora_up.weight",
+            "diffusion_model.blocks.0.self_attn.q.lora_down.weight",
+            "diffusion_model.blocks.0.self_attn.q.lora_up.weight",
+            "diffusion_model.blocks.0.ffn.0.lora_down.weight",
+            "diffusion_model.blocks.0.ffn.0.lora_up.weight",
+        ]
+    }
+
+    fn comfy_root(temp: &Path) -> PathBuf {
+        temp.join("ComfyUI").join("models")
+    }
+
+    /// Scan with a throwaway cache. Cache behaviour is asserted separately.
+    fn scan(roots: &[PathBuf]) -> Vec<Value> {
+        scan_external_loras(roots, &mut ExternalLoraCache::default())
+    }
+
+    #[test]
+    fn no_roots_configured_yields_no_rows() {
+        assert!(scan(&[]).is_empty());
+    }
+
+    #[test]
+    fn a_root_without_a_loras_dir_is_skipped() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = comfy_root(temp.path());
+        std::fs::create_dir_all(root.join("checkpoints")).expect("mkdir");
+        assert!(scan(&[root]).is_empty());
+    }
+
+    /// The real tree nests adapters under `loras/Wan/` and `loras/Ltx2.3/`, so a flat
+    /// glob would miss most of them.
+    #[test]
+    fn scan_recurses_into_subdirectories_and_names_rows_by_relative_path() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = comfy_root(temp.path());
+        let loras = root.join("loras");
+        write_safetensors(&loras.join("top-level.safetensors"), &wan_keys());
+        write_safetensors(
+            &loras.join("Wan").join("detailz-wan.safetensors"),
+            &wan_keys(),
+        );
+
+        let rows = scan(&[root]);
+        assert_eq!(rows.len(), 2, "both the flat and the nested adapter appear");
+
+        let names: HashSet<&str> = rows
+            .iter()
+            .filter_map(|row| row.get("name").and_then(Value::as_str))
+            .collect();
+        assert!(names.contains("top-level"));
+        assert!(
+            names.contains("Wan/detailz-wan"),
+            "subdir is kept in the name"
+        );
+    }
+
+    /// Rows must be inert: namespaced id, external scope, no manifest, and a
+    /// `source.path` pointing at the operator's own file (never a copy).
+    #[test]
+    fn rows_are_external_scoped_and_point_at_the_original_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = comfy_root(temp.path());
+        let adapter = root.join("loras").join("detailz-wan.safetensors");
+        write_safetensors(&adapter, &wan_keys());
+
+        let rows = scan(&[root]);
+        let row = rows.first().expect("one row");
+
+        assert_eq!(row["scope"], EXTERNAL_SCOPE);
+        assert_eq!(row["installState"], "installed");
+        assert_eq!(row["manifestPath"], Value::Null);
+        assert!(row["id"]
+            .as_str()
+            .expect("id")
+            .starts_with(EXTERNAL_ID_PREFIX));
+        assert_eq!(row["files"], json!(["detailz-wan.safetensors"]));
+
+        let source = row["source"]["path"].as_str().expect("source path");
+        let canonical = adapter.canonicalize().expect("canonicalize");
+        assert_eq!(Path::new(source), canonical.as_path());
+        assert_eq!(
+            row["installedPath"].as_str().expect("installedPath"),
+            source
+        );
+    }
+
+    /// The detector recognizes a real ComfyUI Wan key layout, so the row is
+    /// compatibility-gated like any manifest LoRA. Guards the scanner against
+    /// regressing into "everything is family-less".
+    #[test]
+    fn a_real_wan_key_layout_detects_its_family() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = comfy_root(temp.path());
+        write_safetensors(&root.join("loras").join("wan.safetensors"), &wan_keys());
+
+        let rows = scan(&[root]);
+        assert_eq!(
+            rows[0].get("family").and_then(Value::as_str),
+            Some("wan-video")
+        );
+    }
+
+    /// A readable adapter whose family we cannot infer is still listed (with no
+    /// `family`), rather than silently vanishing from a folder the user pointed us at.
+    #[test]
+    fn an_undetectable_family_still_yields_a_row_without_family() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = comfy_root(temp.path());
+        write_safetensors(
+            &root.join("loras").join("mystery.safetensors"),
+            &["some.unknown.tensor"],
+        );
+
+        let rows = scan(&[root]);
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].get("family").is_none());
+        assert_eq!(rows[0]["installState"], "installed");
+    }
+
+    /// A file that is not safetensors (or is truncated) cannot be loaded, so it is
+    /// dropped instead of becoming a row that fails at generation time.
+    #[test]
+    fn unreadable_headers_are_dropped() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = comfy_root(temp.path());
+        let loras = root.join("loras");
+        std::fs::create_dir_all(&loras).expect("mkdir");
+        std::fs::write(loras.join("garbage.safetensors"), b"not safetensors").expect("write");
+        // A non-safetensors extension is not even considered.
+        std::fs::write(loras.join("notes.txt"), b"hello").expect("write");
+
+        assert!(scan(&[root]).is_empty());
+    }
+
+    /// Two adapters in different subdirectories can slugify identically; ids are the
+    /// catalog's primary key, so they must stay distinct.
+    #[test]
+    fn colliding_slugs_get_distinct_ids() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = comfy_root(temp.path());
+        let loras = root.join("loras");
+        write_safetensors(&loras.join("a").join("style.safetensors"), &wan_keys());
+        write_safetensors(&loras.join("b").join("style.safetensors"), &wan_keys());
+
+        let rows = scan(&[root]);
+        assert_eq!(rows.len(), 2);
+        let ids: HashSet<&str> = rows
+            .iter()
+            .filter_map(|row| row.get("id").and_then(Value::as_str))
+            .collect();
+        assert_eq!(ids.len(), 2, "slug collision must not merge two adapters");
+    }
+
+    /// A cache entry is only reused when BOTH size and mtime match — the file we
+    /// parsed is the file on disk. Anything else is a miss, so an edited adapter is
+    /// re-read rather than served from a stale memo.
+    #[test]
+    fn cache_hits_require_matching_size_and_mtime() {
+        let now = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_000);
+        let later = now + std::time::Duration::from_secs(1);
+        let path = PathBuf::from("adapter.safetensors");
+
+        let mut cache = ExternalLoraCache::default();
+        cache.insert(path.clone(), Some(now), 100, Some("wan-video".to_owned()));
+
+        assert_eq!(
+            cache.get(&path, Some(now), 100),
+            Some(Some("wan-video".to_owned())),
+            "identical size + mtime is a hit"
+        );
+        assert_eq!(
+            cache.get(&path, Some(later), 100),
+            None,
+            "newer mtime misses"
+        );
+        assert_eq!(
+            cache.get(&path, Some(now), 101),
+            None,
+            "changed size misses"
+        );
+        assert_eq!(
+            cache.get(&path, None, 100),
+            None,
+            "a file with no mtime can never be proven unchanged"
+        );
+        assert_eq!(cache.get(Path::new("other"), Some(now), 100), None);
+    }
+
+    /// A `None` family (parsed fine, unidentifiable) is memoized too — otherwise every
+    /// catalog build would re-parse the adapters that can never be identified.
+    #[test]
+    fn cache_memoizes_an_undetected_family() {
+        let now = SystemTime::UNIX_EPOCH;
+        let path = PathBuf::from("mystery.safetensors");
+        let mut cache = ExternalLoraCache::default();
+        cache.insert(path.clone(), Some(now), 7, None);
+        assert_eq!(cache.get(&path, Some(now), 7), Some(None));
+    }
+
+    /// The cache fills on scan and drops adapters that have disappeared, so a
+    /// long-lived process watching a churning directory does not grow unbounded.
+    #[test]
+    fn scan_populates_then_prunes_the_cache() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = comfy_root(temp.path());
+        let adapter = root.join("loras").join("wan.safetensors");
+        write_safetensors(&adapter, &wan_keys());
+
+        let mut cache = ExternalLoraCache::default();
+        let rows = scan_external_loras(std::slice::from_ref(&root), &mut cache);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(cache.entries.len(), 1, "the adapter is memoized");
+
+        // A second scan of the unchanged tree yields the same rows, now from cache.
+        let again = scan_external_loras(std::slice::from_ref(&root), &mut cache);
+        assert_eq!(again, rows);
+        assert_eq!(cache.entries.len(), 1);
+
+        std::fs::remove_file(&adapter).expect("remove adapter");
+        let empty = scan_external_loras(&[root], &mut cache);
+        assert!(empty.is_empty());
+        assert!(cache.entries.is_empty(), "vanished adapters are pruned");
+    }
+
+    /// Manual smoke against a real ComfyUI tree — the only test that exercises the
+    /// actual key conventions users ship. Ignored by default (no such tree in CI):
+    ///
+    /// ```text
+    /// SCENEWORKS_EXTERNAL_MODEL_ROOTS='C:\Users\Michael\ComfyUI-Shared\models' \
+    ///   cargo test -p sceneworks-rust-api --lib external_loras::tests::real_comfyui_tree -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "requires a real ComfyUI models tree via SCENEWORKS_EXTERNAL_MODEL_ROOTS"]
+    fn real_comfyui_tree_smoke() {
+        let roots = sceneworks_core::external_roots::parse_external_model_roots(
+            std::env::var("SCENEWORKS_EXTERNAL_MODEL_ROOTS")
+                .ok()
+                .as_deref(),
+        );
+        assert!(!roots.is_empty(), "set SCENEWORKS_EXTERNAL_MODEL_ROOTS");
+
+        let rows = scan(&roots);
+        println!("\n{} adapters surfaced:", rows.len());
+        let mut without_family = 0;
+        for row in &rows {
+            let family = row.get("family").and_then(Value::as_str);
+            if family.is_none() {
+                without_family += 1;
+            }
+            println!(
+                "  {:<12} {:<10} {}",
+                family.unwrap_or("(none)"),
+                row["scope"].as_str().unwrap_or_default(),
+                row["name"].as_str().unwrap_or_default(),
+            );
+        }
+        println!(
+            "\n{without_family} of {} lack a detected family\n",
+            rows.len()
+        );
+        assert!(!rows.is_empty(), "the real tree should surface adapters");
+    }
+
+    /// A symlink escaping the declared root is dropped: the worker's confinement would
+    /// reject that path at generation time, so surfacing it would only promise a load
+    /// that cannot happen.
+    #[cfg(unix)]
+    #[test]
+    fn symlinks_escaping_the_root_are_not_surfaced() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = comfy_root(temp.path());
+        let loras = root.join("loras");
+        std::fs::create_dir_all(&loras).expect("mkdir");
+        let outside = temp.path().join("outside");
+        write_safetensors(&outside.join("escape.safetensors"), &wan_keys());
+        std::os::unix::fs::symlink(
+            outside.join("escape.safetensors"),
+            loras.join("escape.safetensors"),
+        )
+        .expect("symlink");
+
+        assert!(scan(&[root]).is_empty());
+    }
+}

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -172,6 +172,7 @@ use models::{
     merge_model_manifest_entry, mlx_catalog_status, model_co_requisite_downloads, model_download,
     retain_downloads_for_os,
 };
+mod external_loras;
 mod loras;
 use loras::{
     create_lora_download_job, create_lora_import_job, delete_lora, list_loras, lora_catalog,
@@ -841,6 +842,7 @@ pub(crate) fn create_app_with_state(
         manifest_cache: Arc::new(Mutex::new(ManifestCache::default())),
         manifest_write_locks: Arc::new(Mutex::new(HashMap::new())),
         model_size_cache: Arc::new(Mutex::new(ModelSizeCache::default())),
+        external_lora_cache: Arc::new(Mutex::new(external_loras::ExternalLoraCache::default())),
         http_client: reqwest::Client::new(),
         interrupted_jobs_on_startup,
     };

--- a/apps/rust-api/src/loras.rs
+++ b/apps/rust-api/src/loras.rs
@@ -180,6 +180,14 @@ pub(crate) async fn delete_lora(
             vec![state.settings.data_dir.join("loras")],
             state.settings.data_dir.clone(),
         ),
+        // sc-10452: the file lives in the operator's own external tree (e.g. ComfyUI).
+        // We read it in place and never took ownership, so deletion is not ours to do.
+        crate::external_loras::EXTERNAL_SCOPE => {
+            return Err(ApiError::bad_request(
+                "This LoRA lives in an external model folder and is read-only. \
+                 Delete it from that folder directly.",
+            ));
+        }
         _ => return Err(ApiError::bad_request("Unsupported LoRA scope")),
     };
     let permanent = query.permanent.unwrap_or(false);
@@ -293,6 +301,13 @@ pub(crate) async fn update_lora(
         "builtin" => {
             return Err(ApiError::bad_request(
                 "Built-in LoRA metadata is read-only. Import a copy to add trigger keywords or notes.",
+            ));
+        }
+        // sc-10452: no manifest backs an external row, so there is nothing to write to.
+        crate::external_loras::EXTERNAL_SCOPE => {
+            return Err(ApiError::bad_request(
+                "LoRAs discovered in an external model folder are read-only. \
+                 Import a copy to add trigger keywords or notes.",
             ));
         }
         _ => return Err(ApiError::bad_request("Unsupported LoRA scope")),
@@ -527,6 +542,12 @@ pub(crate) async fn lora_catalog(
     let user_manifest = manifest_dir.join("user.loras.jsonc");
     // sc-4202 (F-API-3): normalize_lora_entry probes the filesystem for installed
     // artifact paths; run the builtin+user normalize off the async executor.
+    // Epic 10451 / sc-10452: adapters an operator already has on disk (a ComfyUI
+    // `models/loras` tree). Empty unless `SCENEWORKS_EXTERNAL_MODEL_ROOTS` is set, so
+    // the default catalog is unchanged. Scanned inside the same blocking task as the
+    // manifest normalize sweep — both are filesystem-bound.
+    let external_roots = state.settings.external_model_roots.clone();
+    let external_cache = state.external_lora_cache.clone();
     let mut loras = {
         let data_dir = data_dir.clone();
         tokio::task::spawn_blocking(move || -> Result<Vec<Value>, ApiError> {
@@ -546,7 +567,16 @@ pub(crate) async fn lora_catalog(
                     normalize_lora_entry(lora, "global", &user_manifest, &data_dir, &data_dir)
                 })
                 .collect::<Result<Vec<_>, _>>()?;
-            Ok(merge_entries_by_id(loras, user))
+            let loras = merge_entries_by_id(loras, user);
+            // External rows carry their own `installedPath`/`installState` (the scan
+            // proved the file exists), so they skip `normalize_lora_entry` — there is no
+            // manifest behind them to resolve a relative path against. Merged last of the
+            // global sources; their `external_…` ids cannot collide with a manifest entry.
+            let external = {
+                let mut cache = external_cache.lock();
+                crate::external_loras::scan_external_loras(&external_roots, &mut cache)
+            };
+            Ok(merge_entries_by_id(loras, external))
         })
         .await
         .map_err(|err| ApiError::internal(format!("LoRA catalog normalize task failed: {err}")))??
@@ -588,10 +618,17 @@ pub(crate) async fn lora_catalog(
             .get("installState")
             .and_then(Value::as_str)
             .is_some_and(|state| state == "installed");
-        object.insert(
-            "removable".to_owned(),
-            Value::Bool(scope != "builtin" || installed),
-        );
+        let removable = match scope {
+            // An external adapter lives in the user's own ComfyUI tree; we borrowed it,
+            // we do not own it. `delete_lora` refuses the scope, so a Delete button here
+            // could only ever 400 — and offering to remove someone else's file at all is
+            // the wrong promise (epic 10451 / sc-10452).
+            crate::external_loras::EXTERNAL_SCOPE => false,
+            // A built-in is only removable once its weights are actually on disk.
+            "builtin" => installed,
+            _ => true,
+        };
+        object.insert("removable".to_owned(), Value::Bool(removable));
     }
     loras.sort_by(|left, right| {
         let left_key = (

--- a/apps/rust-api/src/server.rs
+++ b/apps/rust-api/src/server.rs
@@ -28,6 +28,7 @@ use sceneworks_core::project_store::ProjectStore;
 
 use crate::auth::AuthThrottle;
 use crate::events::EventHub;
+use crate::external_loras::ExternalLoraCache;
 use crate::manifest::ManifestCache;
 use crate::models::ModelSizeCache;
 use crate::tickets::TicketStore;
@@ -108,6 +109,14 @@ pub struct Settings {
     /// `SCENEWORKS_MCP_JOB_TIMEOUT` (whole seconds); defaults to the
     /// `JobWaitConfig` default (30 min). Clamped to ≥ the poll interval.
     pub mcp_job_timeout: Duration,
+    /// Epic 10451 (sc-10452) — operator-configured directories outside the app data dir
+    /// that hold model weights the user already has, typically a ComfyUI `models/` tree.
+    /// The API scans each root's `loras/` subdirectory to surface those adapters in the
+    /// LoRA catalog (read in place, never copied); the worker holds the same list and
+    /// admits it in its adapter-path confinement. Read from
+    /// `SCENEWORKS_EXTERNAL_MODEL_ROOTS`; empty (feature off) by default and always empty
+    /// on macOS — see `sceneworks_core::external_roots`.
+    pub external_model_roots: Vec<PathBuf>,
 }
 
 impl Settings {
@@ -178,6 +187,7 @@ impl Settings {
                 "SCENEWORKS_MCP_JOB_TIMEOUT",
                 sceneworks_mcp::JobWaitConfig::default().timeout,
             ),
+            external_model_roots: sceneworks_core::external_roots::external_model_roots_from_env(),
         }
     }
 
@@ -238,6 +248,11 @@ pub struct AppState {
     pub(crate) manifest_cache: Arc<Mutex<ManifestCache>>,
     pub(crate) manifest_write_locks: Arc<Mutex<HashMap<PathBuf, Arc<AsyncMutex<()>>>>>,
     pub(crate) model_size_cache: Arc<Mutex<ModelSizeCache>>,
+    /// sc-10452 — memoized family detection for adapters scanned out of the operator's
+    /// external model roots, keyed by each file's size + mtime. `lora_catalog` runs on
+    /// every job-create; without this, every generation would re-parse every ComfyUI
+    /// adapter's safetensors header.
+    pub(crate) external_lora_cache: Arc<Mutex<ExternalLoraCache>>,
     pub(crate) http_client: reqwest::Client,
     pub(crate) interrupted_jobs_on_startup: usize,
 }

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -12924,3 +12924,42 @@ fn external_lora_family_is_detected_and_gates_model_compatibility() {
         error.detail
     );
 }
+
+/// sc-10452: an adapter whose family the detector cannot identify (in the real tree:
+/// an LLM LoRA, and the ComfyUI Qwen-Image adapters of sc-10506) is still LISTED —
+/// the user pointed us at the folder and deserves to see we found the file — but the
+/// API **fails closed** when one is attached to a generation. We will not guess a
+/// family and load arbitrary tensors into a model.
+#[test]
+fn external_lora_without_a_detected_family_is_refused_at_job_create() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let comfy_root = temp_dir.path().join("models");
+    let adapter = comfy_root.join("loras").join("mystery.safetensors");
+    std::fs::create_dir_all(adapter.parent().expect("parent")).expect("mkdir");
+    write_test_safetensors_with_keys(&adapter, &["some.unknown.tensor".to_owned()]);
+
+    let mut cache = crate::external_loras::ExternalLoraCache::default();
+    let catalog =
+        crate::external_loras::scan_external_loras(std::slice::from_ref(&comfy_root), &mut cache);
+
+    // Listed, installed, but carrying no family.
+    let lora = catalog.first().expect("the adapter is still surfaced");
+    assert_eq!(lora["installState"], "installed");
+    assert!(lora.get("family").is_none(), "no family could be detected");
+
+    let attached = vec![json!({ "id": lora["id"].as_str().expect("id"), "weight": 0.8 })];
+    let models = vec![json!({
+        "id": "wan_2_2",
+        "loraCompatibility": { "families": ["wan-video"], "types": ["style"] }
+    })];
+
+    let error = super::validate_lora_specs_for_model(
+        &models, &catalog, "wan_2_2", &attached, false, "LoRA",
+    )
+    .expect_err("an unidentifiable adapter must not be loaded into a model");
+    assert!(
+        error.detail.contains("no declared family"),
+        "the refusal explains why: {}",
+        error.detail
+    );
+}

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -12867,3 +12867,60 @@ async fn no_external_roots_leaves_the_lora_catalog_unchanged() {
         "no external rows without an operator-configured root"
     );
 }
+
+/// sc-10452: the whole point of detecting a family on a scanned adapter is that the
+/// existing compatibility gate then treats it exactly like a manifest LoRA. Nothing
+/// declares `families` on an external row — `families_from_value_chain` falls back to
+/// the singular `family` key and normalizes it — so assert the gate end-to-end rather
+/// than trusting that fallback to survive a refactor.
+#[test]
+fn external_lora_family_is_detected_and_gates_model_compatibility() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let comfy_root = temp_dir.path().join("models");
+    write_comfy_wan_adapter(
+        &comfy_root
+            .join("loras")
+            .join("Wan")
+            .join("detailz-wan.safetensors"),
+    );
+
+    let mut cache = crate::external_loras::ExternalLoraCache::default();
+    let catalog =
+        crate::external_loras::scan_external_loras(std::slice::from_ref(&comfy_root), &mut cache);
+    let lora = catalog.first().expect("one scanned adapter");
+    // Read from the tensor keys, not the filename or folder.
+    assert_eq!(lora["family"], "wan-video");
+
+    let lora_id = lora["id"].as_str().expect("id").to_owned();
+    let attached = vec![json!({ "id": lora_id, "weight": 0.8 })];
+
+    // A Wan model accepts it: the detected family matches `loraCompatibility.families`.
+    let wan = vec![json!({
+        "id": "wan_2_2",
+        "loraCompatibility": { "families": ["wan-video"], "types": ["style"] }
+    })];
+    let accepted =
+        super::validate_lora_specs_for_model(&wan, &catalog, "wan_2_2", &attached, false, "LoRA")
+            .expect("a wan-video adapter is compatible with a wan-video model");
+    assert_eq!(accepted.len(), 1);
+
+    // A Z-Image model rejects the same adapter, naming the detected family.
+    let z_image = vec![json!({
+        "id": "z_image_turbo",
+        "loraCompatibility": { "families": ["z-image"], "types": ["style"] }
+    })];
+    let error = super::validate_lora_specs_for_model(
+        &z_image,
+        &catalog,
+        "z_image_turbo",
+        &attached,
+        false,
+        "LoRA",
+    )
+    .expect_err("a wan-video adapter is not compatible with a z-image model");
+    assert!(
+        error.detail.contains("wan-video"),
+        "the rejection names the detected family: {}",
+        error.detail
+    );
+}

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -291,6 +291,7 @@ fn test_settings(temp_dir: &tempfile::TempDir) -> Settings {
         mcp_api_url: "http://127.0.0.1:0".to_owned(),
         mcp_job_poll_interval: sceneworks_mcp::JobWaitConfig::default().poll_interval,
         mcp_job_timeout: sceneworks_mcp::JobWaitConfig::default().timeout,
+        external_model_roots: Vec::new(),
     }
 }
 
@@ -12761,4 +12762,108 @@ async fn update_lora_edits_trigger_words_and_notes() {
         .expect("seeded LoRA present");
     assert_eq!(entry["triggerWords"], json!(["fresh", "tokens"]));
     assert_eq!(entry["notes"], "revised note");
+}
+
+/// A ComfyUI-style Wan adapter (keys taken from a real
+/// `wan2.2_t2v_lightx2v_*.safetensors`) written at `path`, parent dirs included.
+fn write_comfy_wan_adapter(path: &std::path::Path) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("adapter parent dir");
+    }
+    let keys: Vec<String> = [
+        "diffusion_model.blocks.0.cross_attn.k.lora_down.weight",
+        "diffusion_model.blocks.0.cross_attn.k.lora_up.weight",
+        "diffusion_model.blocks.0.cross_attn.v.lora_down.weight",
+        "diffusion_model.blocks.0.cross_attn.v.lora_up.weight",
+        "diffusion_model.blocks.0.self_attn.q.lora_down.weight",
+        "diffusion_model.blocks.0.self_attn.q.lora_up.weight",
+        "diffusion_model.blocks.0.ffn.0.lora_down.weight",
+        "diffusion_model.blocks.0.ffn.0.lora_up.weight",
+    ]
+    .iter()
+    .map(|key| (*key).to_owned())
+    .collect();
+    write_test_safetensors_with_keys(path, &keys);
+}
+
+/// epic 10451 / sc-10452: with an operator-configured external root, the LoRAs in a
+/// ComfyUI `models/loras` tree are surfaced by `GET /api/v1/loras` — read in place,
+/// never copied — and are read-only: not removable, and `DELETE` refuses them. We
+/// borrowed the user's file; we must not offer to destroy it.
+#[tokio::test]
+async fn external_root_loras_are_listed_read_only() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let comfy_root = temp_dir.path().join("ComfyUI").join("models");
+    // Nested, like the real tree (`loras/Wan/…`).
+    let adapter = comfy_root
+        .join("loras")
+        .join("Wan")
+        .join("detailz-wan.safetensors");
+    write_comfy_wan_adapter(&adapter);
+
+    let mut settings = test_settings(&temp_dir);
+    settings.external_model_roots = vec![comfy_root];
+    let app = create_app(settings).expect("app creates");
+
+    let (status, loras) = request(app.clone(), "GET", "/api/v1/loras", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    let external = loras
+        .as_array()
+        .expect("loras array")
+        .iter()
+        .find(|lora| lora["scope"] == "external")
+        .expect("the ComfyUI adapter is surfaced");
+
+    assert_eq!(external["name"], "Wan/detailz-wan");
+    assert_eq!(external["family"], "wan-video");
+    assert_eq!(external["installState"], "installed");
+    // Read in place: the catalog points at the operator's own file, not a copy.
+    assert_eq!(
+        external["installedPath"].as_str().expect("installedPath"),
+        adapter
+            .canonicalize()
+            .expect("canonicalize")
+            .display()
+            .to_string()
+    );
+    // Never offer to delete a file we do not own.
+    assert_eq!(external["removable"], false);
+
+    let id = external["id"].as_str().expect("id");
+    assert!(id.starts_with("external_"), "ids are namespaced: {id}");
+
+    let (status, _) = request(
+        app,
+        "DELETE",
+        &format!("/api/v1/loras/{id}?scope=external"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "deleting an external LoRA must be refused"
+    );
+}
+
+/// The feature is off unless an operator opts in: with no external roots configured
+/// (the default), the catalog is exactly what the manifests declare.
+#[tokio::test]
+async fn no_external_roots_leaves_the_lora_catalog_unchanged() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let comfy_root = temp_dir.path().join("ComfyUI").join("models");
+    write_comfy_wan_adapter(&comfy_root.join("loras").join("ignored.safetensors"));
+
+    // Settings default to no external roots; the tree above is simply not looked at.
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (status, loras) = request(app, "GET", "/api/v1/loras", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        !loras
+            .as_array()
+            .expect("loras array")
+            .iter()
+            .any(|lora| lora["scope"] == "external"),
+        "no external rows without an operator-configured root"
+    );
 }

--- a/crates/sceneworks-core/src/external_roots.rs
+++ b/crates/sceneworks-core/src/external_roots.rs
@@ -1,0 +1,181 @@
+//! Operator-configured external model roots (epic 10451 / sc-10452).
+//!
+//! Users arrive with gigabytes of weights already on disk — most often a ComfyUI
+//! `models/` tree — and re-downloading them into the Hugging Face cache is the
+//! single loudest complaint about install. An external root lets the app *read*
+//! those files in place, with no copy and no re-download.
+//!
+//! Two properties make this safe enough to ship:
+//!
+//! 1. **Operator-set, never payload-derived.** The roots come from the process
+//!    environment (`SCENEWORKS_EXTERNAL_MODEL_ROOTS`), so a job payload can never
+//!    introduce one. The jobs API is LAN-exposed (epic 4484), and an unconfined
+//!    weight path is an arbitrary-file-read primitive; widening the allow-list is
+//!    a deployment decision, not a request-time one. Payload paths are still
+//!    confined — they must resolve *under* an allowed root
+//!    (`sceneworks-worker`'s `normalize_app_managed_lora_path`).
+//! 2. **Off by default, and off on macOS.** Unset means the empty list, i.e.
+//!    byte-identical prior behaviour. The ComfyUI single-file ecosystem is
+//!    overwhelmingly CUDA, so the feature is gated to Windows/Linux rather than
+//!    widening the Mac/MLX default for no user benefit.
+
+use std::path::PathBuf;
+
+/// The environment variable holding the operator's external model roots, as an
+/// OS-native path list (`;`-separated on Windows, `:`-separated elsewhere —
+/// parsed by [`std::env::split_paths`], so a Windows `C:\…` drive letter is not
+/// mistaken for a separator).
+pub const EXTERNAL_MODEL_ROOTS_ENV: &str = "SCENEWORKS_EXTERNAL_MODEL_ROOTS";
+
+/// The ComfyUI subdirectory holding single-file LoRA adapters, relative to a
+/// configured root. A root is expected to be a ComfyUI-style `models/` directory.
+pub const COMFYUI_LORA_SUBDIR: &str = "loras";
+
+/// Parse an OS path-list into external model roots.
+///
+/// Entries must be **absolute**: a root is a deployment-level declaration, and a
+/// relative path would silently resolve against whatever working directory the
+/// binary happened to start in. Blank entries are dropped and duplicates are
+/// removed, preserving the operator's ordering.
+///
+/// Existence is deliberately *not* required — a root may live on a drive that is
+/// not mounted yet — so callers must tolerate a missing directory. Nor is the
+/// path canonicalized here: that needs the path to exist, and the confinement
+/// checks canonicalize at use time.
+pub fn parse_external_model_roots(raw: Option<&str>) -> Vec<PathBuf> {
+    let Some(raw) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Vec::new();
+    };
+    let mut roots = Vec::new();
+    for path in std::env::split_paths(raw) {
+        if path.as_os_str().is_empty() || !path.is_absolute() {
+            continue;
+        }
+        if !roots.contains(&path) {
+            roots.push(path);
+        }
+    }
+    roots
+}
+
+/// The external model roots for this process: [`parse_external_model_roots`] over
+/// [`EXTERNAL_MODEL_ROOTS_ENV`], **always empty on macOS** (see the module docs —
+/// the feature is Windows/Linux-gated).
+///
+/// Read once at binary startup and stored on each `Settings`, so the API and the
+/// worker cannot disagree about the allow-list.
+pub fn external_model_roots_from_env() -> Vec<PathBuf> {
+    if cfg!(target_os = "macos") {
+        return Vec::new();
+    }
+    parse_external_model_roots(std::env::var(EXTERNAL_MODEL_ROOTS_ENV).ok().as_deref())
+}
+
+/// The `loras` directory under each configured root that actually exists.
+/// Non-existent roots (unmounted drive, typo) contribute nothing rather than
+/// erroring — a misconfigured root must not take the catalog down.
+pub fn comfyui_lora_dirs(roots: &[PathBuf]) -> Vec<PathBuf> {
+    roots
+        .iter()
+        .map(|root| root.join(COMFYUI_LORA_SUBDIR))
+        .filter(|dir| dir.is_dir())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    /// Build an OS-native path list the same way an operator's shell would.
+    fn joined(paths: &[&str]) -> String {
+        std::env::join_paths(paths.iter().map(Path::new))
+            .expect("join_paths")
+            .into_string()
+            .expect("utf-8")
+    }
+
+    #[cfg(windows)]
+    const ABS_A: &str = r"C:\models\a";
+    #[cfg(windows)]
+    const ABS_B: &str = r"D:\weights\b";
+    #[cfg(not(windows))]
+    const ABS_A: &str = "/models/a";
+    #[cfg(not(windows))]
+    const ABS_B: &str = "/weights/b";
+
+    #[test]
+    fn unset_or_blank_yields_no_roots() {
+        assert!(parse_external_model_roots(None).is_empty());
+        assert!(parse_external_model_roots(Some("")).is_empty());
+        assert!(parse_external_model_roots(Some("   ")).is_empty());
+    }
+
+    #[test]
+    fn parses_an_os_path_list_of_absolute_roots() {
+        let raw = joined(&[ABS_A, ABS_B]);
+        assert_eq!(
+            parse_external_model_roots(Some(&raw)),
+            vec![PathBuf::from(ABS_A), PathBuf::from(ABS_B)]
+        );
+    }
+
+    /// A Windows root carries a `C:` drive letter; naive `split(':')` would shear
+    /// it in half. `split_paths` is OS-aware, so the drive letter survives.
+    #[cfg(windows)]
+    #[test]
+    fn windows_drive_letters_survive_splitting() {
+        let roots = parse_external_model_roots(Some(r"C:\models\a;D:\weights\b"));
+        assert_eq!(
+            roots,
+            vec![
+                PathBuf::from(r"C:\models\a"),
+                PathBuf::from(r"D:\weights\b")
+            ]
+        );
+    }
+
+    /// A relative root would resolve against the process working directory —
+    /// non-deterministic across the API and the worker, which start differently.
+    #[test]
+    fn relative_entries_are_rejected() {
+        assert!(parse_external_model_roots(Some("models/loras")).is_empty());
+        assert!(parse_external_model_roots(Some("../escape")).is_empty());
+    }
+
+    #[test]
+    fn duplicates_collapse_and_order_is_preserved() {
+        let raw = joined(&[ABS_B, ABS_A, ABS_B]);
+        assert_eq!(
+            parse_external_model_roots(Some(&raw)),
+            vec![PathBuf::from(ABS_B), PathBuf::from(ABS_A)]
+        );
+    }
+
+    #[test]
+    fn comfyui_lora_dirs_skips_missing_roots() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let present = temp.path().join("present");
+        std::fs::create_dir_all(present.join(COMFYUI_LORA_SUBDIR)).expect("mkdir");
+        let absent = temp.path().join("absent");
+
+        let dirs = comfyui_lora_dirs(&[present.clone(), absent]);
+        assert_eq!(dirs, vec![present.join(COMFYUI_LORA_SUBDIR)]);
+    }
+
+    /// macOS is gated off entirely, so the env var must not introduce roots there.
+    /// Off-Mac the var is honored. Asserted against the same process env.
+    #[test]
+    fn env_reader_is_macos_gated() {
+        // Safety: single-threaded test, restored immediately.
+        std::env::set_var(EXTERNAL_MODEL_ROOTS_ENV, ABS_A);
+        let roots = external_model_roots_from_env();
+        std::env::remove_var(EXTERNAL_MODEL_ROOTS_ENV);
+
+        if cfg!(target_os = "macos") {
+            assert!(roots.is_empty(), "macOS must never expose external roots");
+        } else {
+            assert_eq!(roots, vec![PathBuf::from(ABS_A)]);
+        }
+    }
+}

--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod character_store;
 pub mod contracts;
 pub mod credentials;
 pub mod dataset_quality;
+pub mod external_roots;
 pub mod hf_home;
 pub mod ideogram_caption;
 pub mod image_request;

--- a/crates/sceneworks-worker/src/caption_jobs.rs
+++ b/crates/sceneworks-worker/src/caption_jobs.rs
@@ -694,6 +694,7 @@ mod tests {
             backend_mlx_enabled: true,
             backend_candle_enabled: false,
             gpu_memory_limit_bytes: 0,
+            external_model_roots: Vec::new(),
         }
     }
 

--- a/crates/sceneworks-worker/src/dataset_analysis_jobs.rs
+++ b/crates/sceneworks-worker/src/dataset_analysis_jobs.rs
@@ -432,6 +432,7 @@ mod tests {
             backend_mlx_enabled: true,
             backend_candle_enabled: false,
             gpu_memory_limit_bytes: 0,
+            external_model_roots: Vec::new(),
         }
     }
 

--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -1436,6 +1436,7 @@ mod ensure_cached_file_tests {
             backend_mlx_enabled: true,
             backend_candle_enabled: false,
             gpu_memory_limit_bytes: 0,
+            external_model_roots: Vec::new(),
         };
         let api = ApiClient::new(&settings);
         let context = DownloadContext {

--- a/crates/sceneworks-worker/src/paths.rs
+++ b/crates/sceneworks-worker/src/paths.rs
@@ -195,7 +195,15 @@ pub(crate) fn normalize_app_managed_model_path(
 /// a project tree under `<data>`; HF-cached adapters live in the hub cache).
 /// Without this a crafted payload could point a LoRA at any `.safetensors` on the
 /// host, giving the worker an arbitrary-file read primitive across the API boundary.
-/// Mirrors `normalize_app_managed_model_path` (model weights share the same roots).
+///
+/// Additionally admits `settings.external_model_roots` (epic 10451 / sc-10452) — an
+/// operator's existing ComfyUI `models/` tree, read in place. Those roots come only
+/// from the process environment, never from a payload, so a LAN caller (epic 4484)
+/// still cannot widen the allow-list; they merely name directories the deployment
+/// has already declared readable. The list is empty by default and on macOS, so the
+/// confinement is unchanged for every install that has not opted in. Unlike
+/// `normalize_app_managed_model_path` (base weights, unchanged in Phase 1), adapters
+/// are single files we load directly, which is why only this lane widens.
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub(crate) fn normalize_app_managed_lora_path(
     settings: &Settings,
@@ -206,13 +214,21 @@ pub(crate) fn normalize_app_managed_lora_path(
     let hf_cache = normalize_absolute_path(&huggingface_hub_cache_dir(&settings.data_dir))?;
     let canonical_hf_cache =
         normalize_existing_or_absolute(&huggingface_hub_cache_dir(&settings.data_dir))?;
+    let mut roots = vec![data_dir, canonical_data_dir, hf_cache, canonical_hf_cache];
+    // Both the lexical and canonical form of each external root, matching the posture
+    // above: `resolved` is canonical, and a canonical path never `starts_with` a
+    // lexical root when the two differ (a symlinked or `..`-bearing root, macOS
+    // `/var` -> `/private/var`). A root that cannot be canonicalized (unmounted drive)
+    // contributes its lexical form only, and simply never matches.
+    for root in &settings.external_model_roots {
+        roots.push(normalize_absolute_path(root)?);
+        if let Ok(canonical) = normalize_existing_or_absolute(root) {
+            roots.push(canonical);
+        }
+    }
     let normalized = normalize_absolute_path(path)?;
     let resolved = normalize_existing_or_absolute(&normalized)?;
-    ensure_path_under(
-        resolved,
-        &[data_dir, canonical_data_dir, hf_cache, canonical_hf_cache],
-        "LoRA path",
-    )
+    ensure_path_under(resolved, &roots, "LoRA path")
 }
 
 pub(crate) fn normalize_existing_or_absolute(path: &Path) -> WorkerResult<PathBuf> {

--- a/crates/sceneworks-worker/src/pose_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/pose_jobs/tests.rs
@@ -285,6 +285,7 @@ fn pose_test_settings(data_dir: &Path) -> Settings {
         backend_mlx_enabled: true,
         backend_candle_enabled: false,
         gpu_memory_limit_bytes: 0,
+        external_model_roots: Vec::new(),
     }
 }
 

--- a/crates/sceneworks-worker/src/settings.rs
+++ b/crates/sceneworks-worker/src/settings.rs
@@ -39,6 +39,14 @@ pub struct Settings {
     /// env var still overrides either way (set `0` to force a candle build back onto the Python
     /// torch fallback during a staged rollout).
     pub backend_candle_enabled: bool,
+    /// Operator-configured directories outside the app data dir and the Hugging Face cache
+    /// that may be read for model weights — typically an existing ComfyUI `models/` tree
+    /// (epic 10451, sc-10452). Widens the confinement allow-list in
+    /// [`crate::paths::normalize_app_managed_lora_path`] **only**; it is never derived from a
+    /// job payload, so the LAN-exposed jobs API (epic 4484) cannot introduce a root. Empty
+    /// (feature off) unless `SCENEWORKS_EXTERNAL_MODEL_ROOTS` is set, and always empty on
+    /// macOS — see `sceneworks_core::external_roots`.
+    pub external_model_roots: Vec<PathBuf>,
     /// Soft ceiling, in bytes, on the shared/unified GPU memory the MLX runtime may use, from
     /// `SCENEWORKS_GPU_MEMORY_LIMIT_BYTES` (epic 7819, sc-7820). `0` (the default / unset) leaves
     /// MLX at its own budget — byte-identical to prior behavior. When non-zero it is applied
@@ -107,6 +115,7 @@ impl Settings {
                 cfg!(feature = "backend-candle"),
             ),
             gpu_memory_limit_bytes: env_u64_any(&["SCENEWORKS_GPU_MEMORY_LIMIT_BYTES"], 0),
+            external_model_roots: sceneworks_core::external_roots::external_model_roots_from_env(),
         }
     }
 }

--- a/crates/sceneworks-worker/src/tests/media_and_paths.rs
+++ b/crates/sceneworks-worker/src/tests/media_and_paths.rs
@@ -252,6 +252,85 @@ fn lora_paths_resolve_symlinks_before_root_check() {
     assert!(error.to_string().contains("LoRA path must be inside"));
 }
 
+/// epic 10451 / sc-10452: an operator-configured external root (a ComfyUI `models/`
+/// tree) is readable for adapters, in place — no copy into `<data>/loras`. The same
+/// path is rejected when no root is configured, which is the default and therefore
+/// the behaviour every existing install keeps.
+#[test]
+fn lora_paths_admit_operator_configured_external_roots() {
+    let temp = tempdir().expect("tempdir creates");
+    let data_dir = temp.path().join("data");
+    std::fs::create_dir_all(data_dir.join("loras")).expect("lora dir creates");
+    // Mimic the real tree: nested subdirectory under `<root>/loras`.
+    let comfy_root = temp.path().join("ComfyUI").join("models");
+    let comfy_loras = comfy_root.join("loras").join("Wan");
+    std::fs::create_dir_all(&comfy_loras).expect("comfy lora dir creates");
+    let adapter = comfy_loras.join("detailz-wan.safetensors");
+    std::fs::write(&adapter, b"adapter").expect("adapter writes");
+
+    let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+    settings.data_dir = data_dir;
+
+    // Default (no external roots): the ComfyUI file is outside every managed root.
+    let error = super::normalize_app_managed_lora_path(&settings, &adapter)
+        .expect_err("external path rejects while the feature is off");
+    assert!(error.to_string().contains("LoRA path must be inside"));
+
+    // Operator opts in: the very same path now resolves, canonicalized.
+    settings.external_model_roots = vec![comfy_root];
+    let normalized = super::normalize_app_managed_lora_path(&settings, &adapter)
+        .expect("adapter under an external root is accepted");
+    assert_eq!(
+        normalized,
+        adapter.canonicalize().expect("adapter canonicalizes")
+    );
+}
+
+/// Configuring an external root must widen the allow-list to *that root only* — a
+/// sibling directory stays rejected. Without this, "point at my ComfyUI folder"
+/// would quietly become "read anything on the host", which is the arbitrary-file-read
+/// primitive the confinement exists to close (epic 4484).
+#[test]
+fn external_roots_do_not_admit_paths_outside_them() {
+    let temp = tempdir().expect("tempdir creates");
+    let data_dir = temp.path().join("data");
+    std::fs::create_dir_all(data_dir.join("loras")).expect("lora dir creates");
+    let comfy_root = temp.path().join("comfy");
+    std::fs::create_dir_all(comfy_root.join("loras")).expect("comfy dir creates");
+    let secrets = temp.path().join("secrets");
+    std::fs::create_dir_all(&secrets).expect("secrets dir creates");
+    let stolen = secrets.join("id_rsa");
+    std::fs::write(&stolen, b"secret").expect("secret writes");
+
+    let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+    settings.data_dir = data_dir;
+    settings.external_model_roots = vec![comfy_root];
+
+    let error = super::normalize_app_managed_lora_path(&settings, &stolen)
+        .expect_err("a sibling of the external root is still rejected");
+    assert!(error.to_string().contains("LoRA path must be inside"));
+}
+
+/// A configured root that does not exist (unmounted drive, typo) must not error the
+/// whole confinement check — it simply never matches.
+#[test]
+fn missing_external_root_is_inert_rather_than_fatal() {
+    let temp = tempdir().expect("tempdir creates");
+    let data_dir = temp.path().join("data");
+    let lora_dir = data_dir.join("loras");
+    std::fs::create_dir_all(&lora_dir).expect("lora dir creates");
+    let managed = lora_dir.join("safe.safetensors");
+    std::fs::write(&managed, b"safe").expect("safe lora writes");
+
+    let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+    settings.data_dir = data_dir;
+    settings.external_model_roots = vec![temp.path().join("not-mounted")];
+
+    // The managed path still resolves; the absent root neither errors nor admits.
+    super::normalize_app_managed_lora_path(&settings, &managed)
+        .expect("a missing external root leaves managed roots working");
+}
+
 // sc-8877 / F-075: the write-target confinement helpers must canonicalize before the
 // root check so a symlink planted under a managed root can't smuggle a write outside
 // via a purely-lexical `starts_with`. Covers all five that used the weaker check.

--- a/crates/sceneworks-worker/src/tests/support_stubs.rs
+++ b/crates/sceneworks-worker/src/tests/support_stubs.rs
@@ -354,6 +354,7 @@ fn test_settings(huggingface_base_url: String, huggingface_token: Option<&str>) 
         backend_mlx_enabled: true,
         backend_candle_enabled: false,
         gpu_memory_limit_bytes: 0,
+        external_model_roots: Vec::new(),
     }
 }
 

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -1516,6 +1516,7 @@ mod tests {
             backend_mlx_enabled: true,
             backend_candle_enabled: false,
             gpu_memory_limit_bytes: 0,
+            external_model_roots: Vec::new(),
         }
     }
 

--- a/crates/sceneworks-worker/src/upscale_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs/tests.rs
@@ -472,6 +472,7 @@ fn upscale_test_settings(data_dir: &std::path::Path) -> crate::Settings {
         backend_mlx_enabled: true,
         backend_candle_enabled: false,
         gpu_memory_limit_bytes: 0,
+        external_model_roots: Vec::new(),
     }
 }
 


### PR DESCRIPTION
Closes sc-10452 (epic 10451).

## Why

The loudest install complaint: *"I already have gigabytes of models downloaded — just let me point at my ComfyUI folder."* Today every weight resolves under the app data dir or the HF hub cache, so a user's existing ComfyUI tree is unreachable and everything is re-downloaded.

This makes the **LoRAs** in that tree usable, read in place — no copy, no re-download.

```bash
# Windows
SCENEWORKS_EXTERNAL_MODEL_ROOTS=C:\Users\you\ComfyUI\models
# Linux
SCENEWORKS_EXTERNAL_MODEL_ROOTS=/home/you/ComfyUI/models
```

Off-Mac (Windows/Linux) and **off by default**. Unset → the catalog is byte-identical to before. `external_model_roots_from_env` returns empty on macOS unconditionally.

## Scope corrected during implementation

The epic originally promised LoRA + VAE + ControlNet + embeddings. Mapping the code showed three of those have **no surface to hang anything on**, so they were cut and filed rather than faked:

| assumed | reality | filed |
|---|---|---|
| per-generation VAE override | does not exist (only PiD's super-res *decoder* swap) | sc-10504 |
| textual-inversion embeddings | not a concept anywhere in the codebase | sc-10505 |
| ControlNet reuse | `advanced.controlWeights` is **HF repo + plain filename**, cannot take a local path | sc-10503 |
| "just widen the confinement root" | LoRA discovery is **manifest-only** — nothing ever enumerated a directory | (this PR: net-new scan) |

So `external_loras` adds a **fourth catalog source** to `lora_catalog`, next to the builtin/user/project manifests.

## Safety

The jobs API is LAN-exposed (epic 4484), so an unconfined weight path is an arbitrary-file-read primitive. Accordingly:

- **Roots are operator-set, never payload-derived.** `normalize_app_managed_lora_path` still confines every payload path; it merely gains the operator's declared roots (lexical + canonical, preserving the sc-8877/F-075 symlink posture). A sibling directory of a configured root stays rejected.
- **Read-only rows.** `scope: "external"`, `removable: false`, and both `delete_lora` and `update_lora` refuse the scope. *We never offer to delete a file we do not own.*
- **Symlinks** are followed but dropped when their canonical path escapes the root — matching what the worker would reject at generation time, so we never surface a row that cannot load.
- Ids are namespaced `external_…` and cannot shadow a manifest entry. Walk is depth- and count-bounded.

## Performance

`lora_catalog` rebuilds on **every job-create**, and family detection parses a safetensors header (~1200 entries for a real Wan adapter). Family is memoized per file by size + mtime, so a large collection does not re-parse before every generation. The walk and `stat` always run, so added / changed / removed files are picked up immediately; the memo is pruned of vanished files.

## Verification

Real tree (`C:\Users\Michael\ComfyUI-Shared\models`) via the `--ignored` smoke test:

```
18 adapters surfaced   (incl. nested Wan/ and Ltx2.3/ subdirectories)
3 of 18 lack a detected family
```

The three: one gemma **LLM** LoRA (correctly not an image/video adapter), and two ComfyUI **Qwen-Image** adapters the family detector misses — a pre-existing detector gap, filed as **sc-10506**, not a scanner bug.

- `cargo test -p sceneworks-core` — 398 pass
- `cargo test -p sceneworks-worker --lib` — 270 pass
- `cargo test -p sceneworks-worker --lib --features backend-candle` — **480 pass** (the lane CI never runs; it compiles the candle path that calls the widened confinement)
- `cargo test -p sceneworks-rust-api` — 230 pass
- `cargo clippy --all-targets -- -D warnings` — clean (this is the "neither" build on Windows)
- `cargo fmt --all -- --check`, `npm run check` — clean

> Note: 8 rust-api model-catalog tests fail on any dev machine that exports `HF_HOME`. Pre-existing (reproduced with this branch stashed), environment-only, invisible in CI. Filed as **sc-10508**.

## Not in this PR

Base checkpoints. Inspecting a real tree revised that problem too: modern ComfyUI stores components **separately** (`diffusion_models/` + `text_encoders/` + `vae/`), not fused — so Phase 2 is "assemble a virtual snapshot", not "split a checkpoint". Scoping spike is sc-10453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
