### PR TITLE
chore(packaging): guard against NC model weights in published artifacts (sc-10526)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,11 @@ apps/web/node_modules
 apps/web/dist
 __pycache__
 *.pyc
+# Model weights are NEVER baked into a published image — SceneWorks converts at
+# install and pulls at runtime (sc-10526). Excluding these local model stores keeps
+# a developer's downloaded weights (including Non-Commercial families like Anima)
+# out of the image layers. The scripts/check-no-nc-weights.mjs guard enforces this
+# in CI. See docs/packaging-nc-weights-guard.md.
 data/projects/*
 !data/projects/.gitkeep
 data/models/*

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -70,6 +70,17 @@ jobs:
         run: |
           npm run check
           npm run check:compose
+      - name: Guard against NC model weights in a published artifact (sc-10526, epic 10512)
+        # SceneWorks converts weights at install and pulls them at runtime — it never
+        # redistributes them. Baking a Non-Commercial family's weights (Anima /
+        # CircleStone, FLUX NC, Ideogram, Krea, NVIDIA SANA, …) into an installer or
+        # image layer would make us a distributor of a Derivative and attach the NC
+        # obligations. The self-test proves the gate fires on a fake anima-*.safetensors
+        # before the real scan runs over the Docker build context / Tauri resource trees
+        # (config/, crates/, apps/). See docs/packaging-nc-weights-guard.md.
+        run: |
+          node scripts/check-no-nc-weights.mjs --self-test
+          npm run check:nc-weights
       - name: Guard against gen-core version skew (sc-4482, epic 3720)
         # Fails if more than one distinct `sceneworks-gen-core` rev resolves in the worker's
         # build graph (the inventory skew trap => runtime "engine not found"). `--target all`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,15 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm --prefix apps/desktop run build -- --config updater.release.conf.json
 
+      # License guard (sc-10526): scan the freshly-built .app tree for model weights
+      # before we sign/staple/publish it. This is the real-artifact form of the
+      # check.yml source-tree scan — the DMG is opaque, but the .app under
+      # bundle/macos/ carries the exact Contents/Resources payload the DMG wraps, so
+      # a weight baked into the bundle fails the release here. NC weights (Anima /
+      # CircleStone, FLUX NC, Ideogram, Krea, SANA, …) must never ship in an installer.
+      - name: Guard against NC model weights in the desktop bundle (sc-10526)
+        run: node scripts/check-no-nc-weights.mjs --dir target/release/bundle
+
       # Tauri staples the .app but not the wrapping .dmg — staple the DMG so the
       # downloaded artifact verifies offline (shared script; same as `release:mac`).
       - name: Staple the DMG
@@ -216,6 +225,13 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm --prefix apps/desktop run build -- --bundles nsis,msi --config updater.release.conf.json
+      # License guard (sc-10526): scan the built Windows bundle tree for model
+      # weights before publishing. The NSIS/MSI installers are opaque, but any loose
+      # resource weight Tauri stages under bundle/ is caught; the exhaustive
+      # resource-source scan runs in check.yml over apps/. NC weights must never ship.
+      - name: Guard against NC model weights in the desktop bundle (sc-10526)
+        shell: bash
+        run: node scripts/check-no-nc-weights.mjs --dir target/release/bundle
       # Upload to the draft release the macos job created. The user ships the MSI
       # (per desktop-windows.yml); the NSIS .exe is attached too as an alternative.
       # --clobber so re-running the job replaces rather than 409s. Then merge the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,12 +88,15 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm --prefix apps/desktop run build -- --config updater.release.conf.json
 
-      # License guard (sc-10526): scan the freshly-built .app tree for model weights
-      # before we sign/staple/publish it. This is the real-artifact form of the
-      # check.yml source-tree scan — the DMG is opaque, but the .app under
-      # bundle/macos/ carries the exact Contents/Resources payload the DMG wraps, so
-      # a weight baked into the bundle fails the release here. NC weights (Anima /
-      # CircleStone, FLUX NC, Ideogram, Krea, SANA, …) must never ship in an installer.
+      # License guard (sc-10526): scan the freshly-built bundle tree for model
+      # weights. The previous step already signed, notarized & stapled the .app, so
+      # this runs AFTER signing but BEFORE the DMG is stapled, the release is drafted,
+      # and anything is uploaded — a weight in the bundle still fails the job before
+      # any artifact is published. This is the real-artifact form of the check.yml
+      # source-tree scan — the DMG is opaque, but the .app under bundle/macos/ carries
+      # the exact Contents/Resources payload the DMG wraps, so a weight baked into the
+      # bundle is caught here. NC weights (Anima / CircleStone, FLUX NC, Ideogram,
+      # Krea, SANA, …) must never ship in an installer.
       - name: Guard against NC model weights in the desktop bundle (sc-10526)
         run: node scripts/check-no-nc-weights.mjs --dir target/release/bundle
 

--- a/docs/packaging-nc-weights-guard.md
+++ b/docs/packaging-nc-weights-guard.md
@@ -69,6 +69,33 @@ node scripts/check-no-nc-weights.mjs --self-test     # prove the gate fires
 - **`--dir <path>` (repeatable):** a real built artifact — an extracted Docker image
   rootfs, a built `.app` / bundle tree, or a RunPod build context. The release
   workflow points this at `target/release/bundle` after building the desktop bundle.
+- **Tauri bundle-resource config (always):** on every run the guard also reads the
+  committed `apps/desktop/tauri*.conf.json` files and inspects the declared
+  `bundle.resources` / `bundle.externalBin` specs. It **fails** if any spec is an
+  archive/container (`.zip`, `.tar.gz`, `.dmg`, …), stages a weight file directly,
+  matches an NC family token, or is rooted at a weights directory (`weights/`,
+  `checkpoints/`, `loras/`). This is the cheap defense for the one vector the
+  file-tree scans cannot see into: a weight sealed inside an archive staged as a
+  resource. The current resources (`onnxruntime/**/*`, `ffmpeg/**/*`, `mlx/**/*`) are
+  clean.
+
+### The `.bin` question (not a blind spot)
+
+A bare `.bin` extension is **not** in the weight-extension set — fonts, wasm, and
+misc blobs also use `.bin`, so treating every `.bin` as a weight would false-trip.
+But an NC `.bin` is still caught **by default, with no flags**, three ways:
+
+1. The **strong NC repo-path match** (`org/name`, `models--org--name`) runs on every
+   file regardless of extension, so any blob inside a redistributed NC repo/cache
+   directory fails (this is the `pytorch_model.bin` under `models--…--Anima/` case).
+2. A `.bin` whose path matches a **bare NC family token** (e.g. `anima-base.bin`) is
+   promoted to a weight.
+3. The **canonical Hugging Face `.bin` weight names** — `pytorch_model.bin`,
+   `diffusion_pytorch_model.bin`, `open_clip_pytorch_model.bin` and their sharded
+   forms (the second dominant HF weight format after safetensors) — count as weights
+   by name even with no NC token.
+
+`--include-bin` additionally promotes **every** `.bin` to a weight (belt-and-suspenders).
 
 ### What it deliberately does NOT scan, and why
 
@@ -127,6 +154,21 @@ The `.dmg` / `.msi` / `-setup.exe` installers are opaque compressed archives; th
 installer. The exhaustive resource-source scan in `check.yml` covers the resource
 trees that feed those installers, so a weight cannot reach an installer without first
 tripping the source scan.
+
+**Archive-*content* scanning is not implemented (tracked follow-up).** The guard
+inspects file *names* on disk and Tauri resource *config*, but it does not open
+archives (`.zip` / `.tar.gz` / `.dmg` / …) to scan the files *inside* them. The
+config-level resource check above already fails the build if an archive or a weights
+directory is *declared* as a bundle resource — which is the realistic vector and is
+cheap to enforce — so a weight cannot be staged into the bundle inside an archive
+without the config check catching the declaration. A full recursive decompress-and-
+scan of every archive in a built artifact is comparatively expensive (needs a
+decompressor per format, temp extraction, and archive-bomb guards) and buys little
+over the declaration check, so it is deliberately deferred to a tracked Shortcut
+story rather than implemented here. `include_bytes!`-compiled weights (a weight
+embedded in a Rust binary at compile time) are likewise not detectable by a file
+scan; the source-tree scan catches the weight *file* that such a macro would embed,
+before it is compiled in.
 
 The **RunPod image (epic 10362) does not exist yet** — there is no RunPod-specific
 Dockerfile in the repo. The existing `docker/rust.Dockerfile` (the base the RunPod

--- a/docs/packaging-nc-weights-guard.md
+++ b/docs/packaging-nc-weights-guard.md
@@ -1,0 +1,136 @@
+# Packaging rule: never bake model weights into a published artifact
+
+**Status:** enforced in CI (sc-10526, epic 10512 "Anima model support").
+
+## The rule
+
+SceneWorks ships its **code** under AGPL-3.0-or-later. The model **weights** it runs
+are a **separate, license-gated concern** and are governed by their own upstream
+licenses — not by SceneWorks' code license.
+
+Several supported model families are distributed under **Non-Commercial (NC)**
+licenses. A "Derivative" under these licenses includes **any converted or quantized
+checkpoint and any LoRA / fine-tune** of the weights. Redistributing a Derivative
+obliges the distributor to ship the license text, an attribution notice, and a
+statement of modification.
+
+SceneWorks avoids all of those obligations with one architectural posture:
+
+> **Convert at install. Pull at runtime. Never redistribute weights.**
+
+Weights are downloaded from Hugging Face into the **user's own machine or instance**
+and converted/quantized there. SceneWorks is never the party handing someone a copy
+of the weights — so the redistribution terms never attach.
+
+**That guarantee is only as strong as our packaging.** If a published artifact ever
+embeds model weights, SceneWorks becomes a distributor of a Derivative and the
+obligations attach immediately. Published artifacts include:
+
+- **Desktop installers / DMGs** (Tauri bundle, `apps/desktop/`).
+- **Docker / RunPod image layers** (`docker/rust.Dockerfile`, epic 10362).
+- **Re-hosted Hugging Face repos** (the epic 5594 pattern).
+
+So the rule is: **no model-weight file may appear inside any published artifact
+payload.**
+
+### Outputs are explicitly fine
+
+Do not over-correct. The NC licenses permit **commercial use of Outputs** — the
+generated images (e.g. the CircleStone Labs Non-Commercial License v1.2 §2(e)). Only
+the **Model and its Derivatives** (the weights) are restricted. This rule is about
+weights, never about generations.
+
+### Re-hosting an NC model (if we ever choose to)
+
+Re-hosting converted NC tiers on the SceneWorks HF org (the epic 5594 pattern) is
+permitted **non-commercially**, but it is a redistribution, so each such repo **must
+carry the upstream license text + an attribution notice + a "we modified this model"
+statement.** Do not do it accidentally. That path is out of scope for this guard,
+which covers installers and image layers.
+
+## The guard
+
+`scripts/check-no-nc-weights.mjs` fails the build if a model-weight file is found in
+an artifact-payload directory.
+
+Run it directly:
+
+```sh
+npm run check:nc-weights              # scan the default payload trees
+node scripts/check-no-nc-weights.mjs --dir <path>   # scan a built artifact tree
+node scripts/check-no-nc-weights.mjs --self-test     # prove the gate fires
+```
+
+### What it scans
+
+- **Default:** `config/`, `crates/`, `apps/` — exactly the trees the Docker image
+  COPYs in and where the Tauri desktop bundle stages its resources. Build caches
+  (`node_modules/`, `target/`, `dist/`, `.git/`) are skipped.
+- **`--dir <path>` (repeatable):** a real built artifact — an extracted Docker image
+  rootfs, a built `.app` / bundle tree, or a RunPod build context. The release
+  workflow points this at `target/release/bundle` after building the desktop bundle.
+
+### What it deliberately does NOT scan, and why
+
+- **`data/`** — the developer's local model store. `.dockerignore` already excludes
+  `data/models|loras|cache` from the image, so it is never artifact payload.
+- **`~/.cache/huggingface`** — the runtime HF cache. A developer running
+  convert-at-install has NC weights here (e.g.
+  `models--circlestone-labs--Anima/`). That is the normal, correct state and must
+  **not** trip the guard — so the cache is never scanned.
+
+### How NC families are declared (data-driven)
+
+The set of NC families is **derived from the manifests**
+(`config/manifests/builtin.models.jsonc` + `builtin.loras.jsonc`): an entry is NC if
+it declares `nonCommercial: true` **or** its license text carries an NC signal
+("non-commercial", "NSCL", "NVIDIA Open Model License", the FLUX / Ideogram / Krea NC
+licenses). Each NC entry's HF repo(s) become on-disk match tokens (`org/name`,
+`models--org--name`, and the bare `name`). **The next NC model inherits the guard
+the moment it lands in the manifest** — there is no second list to maintain.
+
+The hard failure does not depend on that classification: **any** weight file in the
+payload that is not on the allowlist fails the build. NC classification only enriches
+the error so it can name the specific license/family. A brand-new NC model therefore
+still fails the build even before it is tagged NC.
+
+> **Bootstrap:** Anima (epic 10512) is not in the manifest yet, so its tokens
+> (`anima`, `circlestone-labs`) are seeded directly in the guard. Remove that seed
+> once Anima's manifest entry lands with its repo + `nonCommercial: true`.
+
+### The allowlist
+
+A tiny set of **permissively-licensed** weights are legitimately compiled into a
+SceneWorks binary and are allowed in the payload. Today that is only the LAION
+improved-aesthetic-predictor (`aesthetic-v2-sac-logos-ava1-l14.safetensors`, MIT), a
+~4 MB CLIP-head regressor linked into `crates/sceneworks-image-quality`.
+
+To add a new legitimately-bundled permissive weight, add its basename **with a
+justification** to the `ALLOWLIST` array in `scripts/check-no-nc-weights.mjs`.
+**Never add an NC weight to the allowlist** — the whole point is that NC weights are
+pulled at runtime, not shipped. An allowlisted basename found inside an NC repo/cache
+path is still flagged.
+
+## Where it runs in CI
+
+- **`.github/workflows/check.yml`** (every PR): runs `--self-test` then the default
+  scan over the Docker build context / Tauri resource trees.
+- **`.github/workflows/release.yml`** (desktop release, macOS + Windows): scans the
+  freshly-built `target/release/bundle` tree before signing/publishing — the
+  real-artifact form of the check.
+
+## Known limitation
+
+The `.dmg` / `.msi` / `-setup.exe` installers are opaque compressed archives; the
+`--dir` release scan walks the loose `.app` / bundle tree (which carries the same
+`Contents/Resources` payload the DMG wraps) but does not decompress the final
+installer. The exhaustive resource-source scan in `check.yml` covers the resource
+trees that feed those installers, so a weight cannot reach an installer without first
+tripping the source scan.
+
+The **RunPod image (epic 10362) does not exist yet** — there is no RunPod-specific
+Dockerfile in the repo. The existing `docker/rust.Dockerfile` (the base the RunPod
+lane will build on) is verified to pull-at-runtime: its COPYs are limited to
+`config/`, `crates/`, `apps/`, and the built binaries, and `.dockerignore` excludes
+`data/models|loras|cache`. When the RunPod image lands, run the guard over its build
+context / extracted rootfs (`--dir`) as part of that lane.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "check": "node scripts/check-scaffold.mjs",
     "check:compose": "node scripts/check-compose-config.mjs",
     "check:health": "node scripts/check-health.mjs",
+    "check:nc-weights": "node scripts/check-no-nc-weights.mjs",
     "hooks:install": "git config core.hooksPath scripts/git-hooks",
     "check:docker:rust-api": "node scripts/check-docker-api-runtime.mjs",
     "rust:fmt": "cargo fmt --all -- --check",

--- a/scripts/check-no-nc-weights.mjs
+++ b/scripts/check-no-nc-weights.mjs
@@ -45,6 +45,16 @@
 //   --dir <path> (repeatable): scan a real built artifact instead — an extracted
 //   Docker image rootfs, a built `.app`/`.dmg` Resources tree, or a RunPod build
 //   context. The release/desktop lanes should point this at the finished bundle.
+//   Symlinked directories are followed (loop-safe), so a link to a weights dir is
+//   not missed.
+//
+//   In addition to the file walk, EVERY run inspects the committed Tauri bundle
+//   config (apps/desktop/tauri*.conf.json): a declared `bundle.resources` /
+//   `externalBin` spec that is an archive, stages a weight, matches an NC token, or
+//   is rooted at a weights dir fails the build. That is the cheap defense for the one
+//   vector the file walk cannot see into — a weight sealed inside an archive staged
+//   as a resource. (Decompressing archives to scan their CONTENTS is a tracked
+//   follow-up, not done here; see docs "Known limitation".)
 //
 // HOW NC FAMILIES ARE DECLARED (data-driven, not a hand-maintained list)
 // ----------------------------------------------------------------------
@@ -66,7 +76,17 @@
 // See docs/packaging-nc-weights-guard.md for the full rule and how to add a new
 // permissively-licensed bundled weight to the allowlist.
 
-import { readFile, readdir, stat, mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import {
+  readFile,
+  readdir,
+  stat,
+  realpath,
+  mkdtemp,
+  mkdir,
+  writeFile,
+  symlink,
+  rm,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
@@ -89,9 +109,19 @@ const EXCLUDED_DIR_NAMES = new Set([
   "__pycache__",
 ]);
 
-// File extensions that are, in practice, always serialized model weights. `.bin`
-// is intentionally excluded (fonts, wasm, and misc blobs also use it) unless
-// --include-bin is passed; the NC-token matcher below still catches an NC `.bin`.
+// File extensions that are, in practice, always serialized model weights. A bare
+// `.bin` is intentionally NOT in this set — fonts, wasm, and misc blobs also use
+// `.bin`, so treating every `.bin` as a weight by default would false-trip. But a
+// `.bin` is NOT a blind spot: three things catch an NC `.bin` with no extra flags —
+//   (1) scan() runs the STRONG NC repo-path match (models--org--name / org/name)
+//       on every file regardless of extension, so any blob inside a redistributed
+//       NC repo/cache directory fails (see scan());
+//   (2) a `.bin` whose path matches a bare NC family token (e.g. `anima-base.bin`,
+//       or a `.bin` under `models--…--Anima/`) is treated as a weight; and
+//   (3) the canonical Hugging Face `.bin` weight filenames below — one of the two
+//       dominant HF weight formats (text encoders, VAEs, full checkpoints) — are
+//       treated as weights by name even when they carry no NC token.
+// `--include-bin` promotes *every* `.bin` to a weight (belt-and-suspenders).
 const WEIGHT_EXTENSIONS = new Set([
   ".safetensors",
   ".gguf",
@@ -104,6 +134,34 @@ const WEIGHT_EXTENSIONS = new Set([
   ".msgpack",
   ".h5",
   ".pb",
+]);
+
+// Canonical Hugging Face `.bin` weight filenames. Unlike a generic `foo.bin`, these
+// names are, by HF convention, ALWAYS serialized model weights (PyTorch pickle
+// checkpoints), so they count as weights by default even though `.bin` as a bare
+// extension does not. `pytorch_model.bin` / `diffusion_pytorch_model.bin` /
+// `open_clip_pytorch_model.bin` are the second dominant HF weight format after
+// safetensors. The optional `-00001-of-00002` group covers sharded checkpoints.
+const CANONICAL_BIN_WEIGHT =
+  /^(?:pytorch_model|diffusion_pytorch_model|open_clip_pytorch_model)(?:-\d{5}-of-\d{5})?\.bin$/i;
+
+// Archive/container extensions. A weight sealed inside one of these would slip both
+// the loose-tree file scan AND the source-tree scan, so we refuse to let one be
+// STAGED as a Tauri bundle resource in the first place (see inspectResourceSpecs).
+const ARCHIVE_EXTENSIONS = new Set([
+  ".zip",
+  ".tar",
+  ".tgz",
+  ".gz",
+  ".bz2",
+  ".xz",
+  ".zst",
+  ".7z",
+  ".rar",
+  ".dmg",
+  ".msi",
+  ".cab",
+  ".pkg",
 ]);
 
 // Permissively-licensed weights that are LEGITIMATELY compiled/bundled into a
@@ -125,7 +183,9 @@ const ALLOWLIST_BASENAMES = new Set(ALLOWLIST.map((entry) => entry.basename));
 // Anima (epic 10512) is being ported now; until its manifest entry lands with a
 // repo + `nonCommercial: true`, seed its tokens here so the guard already names it.
 // REMOVE an entry once the corresponding family is in the manifest (the manifest is
-// the source of truth) — the self-test asserts Anima stays covered either way.
+// the source of truth). This is not left to vigilance: the self-test asserts that
+// once the manifest itself yields an `anima` / `circlestone-labs` token, this array
+// MUST be empty — so the "temporary" seed cannot silently become permanent.
 const BOOTSTRAP_NC_TOKENS = ["circlestone-labs", "anima"];
 
 // -- JSONC parsing (manifests carry // comments). Mirrors scripts/check-scaffold.mjs. --
@@ -239,9 +299,11 @@ function collectRepoStrings(entry) {
   return repos;
 }
 
-// Build the NC token set from the manifests + the bootstrap seed.
-async function buildNcTokens() {
-  const tokens = new Set(BOOTSTRAP_NC_TOKENS.map((token) => token.toLowerCase()));
+// Build the NC token set from the manifests ALONE (no bootstrap seed). Kept
+// separate so the self-test can assert that the bootstrap seed is redundant the
+// moment the manifest starts producing the same family tokens.
+async function buildManifestNcTokens() {
+  const tokens = new Set();
   const families = new Set();
 
   const sources = [
@@ -272,15 +334,90 @@ async function buildNcTokens() {
   return { tokens: [...tokens].filter(Boolean), families: [...families] };
 }
 
-// Which NC token (if any) does this on-disk path match? Compared over the whole
-// POSIX-normalized path so both the file basename (anima-base-v1.0.safetensors) and
-// an ancestor cache dir (models--circlestone-labs--Anima/…) are caught.
-function ncTokenFor(filePath, ncTokens) {
-  const needle = filePath.split(path.sep).join("/").toLowerCase();
-  return ncTokens.find((token) => token.length >= 4 && needle.includes(token)) ?? null;
+// Build the NC token set from the manifests + the bootstrap seed (what the guard
+// actually runs against).
+async function buildNcTokens() {
+  const { tokens, families } = await buildManifestNcTokens();
+  const merged = new Set(tokens);
+  for (const token of BOOTSTRAP_NC_TOKENS) {
+    merged.add(token.toLowerCase());
+  }
+  return { tokens: [...merged].filter(Boolean), families };
 }
 
-async function walk(dir, files) {
+// A STRONG token is a multi-segment HF repo/cache form (`org/name` or
+// `models--org--name`). Its presence in a path means a genuine redistributed NC
+// repo directory is on disk, so any file under it fails regardless of extension.
+// These never collide with ordinary source paths. A WEAK token is a bare model
+// name (`anima`, `ideogram-4`) — it legitimately appears in docs/config that only
+// *reference* a model (e.g. apps/web/public/prompt-guides/ideogram-4.md), so a weak
+// match alone must not fail a non-weight file.
+function isStrongToken(token) {
+  return token.includes("/") || token.includes("--");
+}
+
+// Boundary-aware containment. The token must sit on non-alphanumeric boundaries
+// (path separators, `-`, `_`, `.`, or the string ends) so the 5-char token "anima"
+// matches ".../models--circlestone-labs--anima/..." and "anima-base.safetensors"
+// but NOT ".../animations/foo.js" (the trailing "t" is alphanumeric → different
+// word). Without this, a short token substring-matches unrelated paths.
+function tokenMatchesPath(needle, token) {
+  let from = 0;
+  for (;;) {
+    const index = needle.indexOf(token, from);
+    if (index === -1) {
+      return false;
+    }
+    const before = index === 0 ? "" : needle[index - 1];
+    const after = index + token.length >= needle.length ? "" : needle[index + token.length];
+    const boundaryBefore = before === "" || !/[a-z0-9]/.test(before);
+    const boundaryAfter = after === "" || !/[a-z0-9]/.test(after);
+    if (boundaryBefore && boundaryAfter) {
+      return true;
+    }
+    from = index + 1;
+  }
+}
+
+// The first STRONG NC token (if any) whose repo/cache path form appears in the file
+// path. Compared over the whole POSIX-normalized path so an ancestor cache dir
+// (models--circlestone-labs--Anima/…) is caught even for a generically-named blob.
+function strongNcTokenFor(needle, ncTokens) {
+  return (
+    ncTokens.find(
+      (token) => token.length >= 4 && isStrongToken(token) && tokenMatchesPath(needle, token),
+    ) ?? null
+  );
+}
+
+// The first WEAK NC token (bare family/model name) whose boundary-aware form appears
+// in the file path — used only to classify a file that is ALSO a weight/blob.
+function weakNcTokenFor(needle, ncTokens) {
+  return (
+    ncTokens.find(
+      (token) => token.length >= 4 && !isStrongToken(token) && tokenMatchesPath(needle, token),
+    ) ?? null
+  );
+}
+
+async function walk(dir, files, visited = new Set()) {
+  // Loop guard: track REAL directory paths so a symlink cycle (A→B→A) or a link
+  // pointing back up the tree cannot spin forever. Keyed on realpath, not the
+  // logical path, so two routes to the same dir are visited once.
+  let realDir;
+  try {
+    realDir = await realpath(dir);
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return; // Broken link or vanished dir.
+    }
+    throw error;
+  }
+  if (visited.has(realDir)) {
+    return;
+  }
+  visited.add(realDir);
+
   let entries;
   try {
     entries = await readdir(dir, { withFileTypes: true });
@@ -296,26 +433,63 @@ async function walk(dir, files) {
       if (EXCLUDED_DIR_NAMES.has(entry.name)) {
         continue;
       }
-      await walk(full, files);
-    } else if (entry.isFile() || entry.isSymbolicLink()) {
+      await walk(full, files, visited);
+    } else if (entry.isSymbolicLink()) {
+      // A symlink's Dirent reflects the LINK, not its target, so a symlink to a
+      // directory of weights would otherwise be recorded as a single "file" and
+      // only extension-checked — never descended. Resolve the target: descend a
+      // linked dir (loop-safe via `visited`), record a linked file, skip a broken
+      // link.
+      let target;
+      try {
+        target = await stat(full); // Follows the link.
+      } catch (error) {
+        if (error.code === "ENOENT") {
+          continue; // Dangling symlink.
+        }
+        throw error;
+      }
+      if (target.isDirectory()) {
+        if (EXCLUDED_DIR_NAMES.has(entry.name)) {
+          continue;
+        }
+        await walk(full, files, visited);
+      } else if (target.isFile()) {
+        files.push(full);
+      }
+    } else if (entry.isFile()) {
       files.push(full);
     }
   }
 }
 
-function isWeightFile(filePath, includeBin) {
+// Is this a model weight? A definite weight is any WEIGHT_EXTENSIONS file, a
+// canonical HF `.bin` (pytorch_model.bin & friends), a `.bin` that matches a bare
+// NC family token (so an NC blob named `anima-base.bin` counts), or — under
+// --include-bin — any `.bin` at all.
+function isWeightFile(filePath, { includeBin, weakNcMatch }) {
   const ext = path.extname(filePath).toLowerCase();
   if (WEIGHT_EXTENSIONS.has(ext)) {
     return true;
   }
-  if (includeBin && ext === ".bin") {
-    return true;
+  if (ext === ".bin") {
+    if (includeBin || CANONICAL_BIN_WEIGHT.test(path.basename(filePath)) || weakNcMatch) {
+      return true;
+    }
   }
   return false;
 }
 
-// Core: scan the given roots and return the list of violations. A violation is any
-// weight file that is not on the allowlist. NC classification enriches each one.
+// Core: scan the given roots and return the list of violations.
+//
+// Two independent ways a file becomes a violation:
+//   (1) STRONG NC match — its path contains a genuine NC repo/cache directory
+//       (models--org--name / org/name). Fails regardless of extension: any blob of
+//       any name inside a redistributed NC repo must not ship. This is what closes
+//       the `.bin` blind spot for the HF-cache-form vector with no flags.
+//   (2) It is a model weight (see isWeightFile) that is not on the allowlist. NC
+//       classification (a bare family token) enriches the message; a bare NC token
+//       also promotes an otherwise-ambiguous `.bin` to a weight.
 async function scan({ roots, ncTokens, includeBin }) {
   const violations = [];
   for (const scanRoot of roots) {
@@ -336,24 +510,127 @@ async function scan({ roots, ncTokens, includeBin }) {
       files.push(absRoot);
     }
     for (const file of files) {
-      if (!isWeightFile(file, includeBin)) {
+      const basename = path.basename(file);
+      const needle = file.split(path.sep).join("/").toLowerCase();
+
+      // (1) A file inside a genuine NC repo/cache directory — fail regardless of
+      // extension or allowlist. An allowlisted permissive name must never travel
+      // inside an NC repo path either.
+      const strongToken = strongNcTokenFor(needle, ncTokens);
+      if (strongToken) {
+        violations.push({ file: path.relative(root, file) || file, basename, ncToken: strongToken });
         continue;
       }
-      const basename = path.basename(file);
-      // NC-token match wins even for allowlisted basenames: an allowlisted
-      // permissive name must never travel inside an NC repo/cache path.
-      const ncToken = ncTokenFor(file, ncTokens);
-      if (!ncToken && ALLOWLIST_BASENAMES.has(basename)) {
+
+      // (2) Otherwise, is it a weight? A bare NC token both classifies it and
+      // promotes an ambiguous `.bin` to a weight.
+      const weakToken = weakNcTokenFor(needle, ncTokens);
+      if (!isWeightFile(file, { includeBin, weakNcMatch: Boolean(weakToken) })) {
+        continue;
+      }
+      // A non-NC, allowlisted permissive weight is legitimately bundled.
+      if (!weakToken && ALLOWLIST_BASENAMES.has(basename)) {
         continue;
       }
       violations.push({
         file: path.relative(root, file) || file,
         basename,
-        ncToken,
+        ncToken: weakToken,
       });
     }
   }
   return violations;
+}
+
+// Inspect declared Tauri bundle-resource specs (the SOURCE globs the packager copies
+// into Contents/Resources) and refuse the realistic evasion the loose-tree scan
+// cannot see: a weight sealed in an archive, a weight staged directly, or a resource
+// glob rooted at an NC repo / a weights directory. This is a config-level check —
+// it does not decompress anything (see docs "Known limitation").
+function specHasExtIn(spec, extensions) {
+  // Match an extension as a suffix of a path component, tolerant of trailing globs
+  // (`weights/*.safetensors`, `blob.tar.gz`, `models/**/*.bin`).
+  const lower = spec.toLowerCase();
+  for (const ext of extensions) {
+    const escaped = ext.replace(/[.]/g, "\\.");
+    if (new RegExp(`${escaped}($|[/*?\\s])`).test(lower)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function inspectResourceSpecs(specs, ncTokens) {
+  const violations = [];
+  for (const raw of specs) {
+    if (typeof raw !== "string" || raw.length === 0) {
+      continue;
+    }
+    const needle = raw.split(path.sep).join("/").toLowerCase();
+    const strongToken = strongNcTokenFor(needle, ncTokens);
+    const weakToken = weakNcTokenFor(needle, ncTokens);
+    if (strongToken || weakToken) {
+      violations.push({
+        spec: raw,
+        reason: `resource path matches Non-Commercial family token "${strongToken || weakToken}"`,
+      });
+      continue;
+    }
+    if (specHasExtIn(needle, ARCHIVE_EXTENSIONS)) {
+      violations.push({
+        spec: raw,
+        reason:
+          "resource is an archive/container — a weight sealed inside it would evade " +
+          "both the loose-tree and source-tree scans; unpack it at runtime instead",
+      });
+      continue;
+    }
+    if (specHasExtIn(needle, WEIGHT_EXTENSIONS) || /\.bin($|[/*?\s])/.test(needle)) {
+      violations.push({ spec: raw, reason: "resource stages a model-weight file into the bundle" });
+      continue;
+    }
+    if (/(^|\/)(weights|checkpoints|loras?|safetensors)(\/|$)/.test(needle)) {
+      violations.push({ spec: raw, reason: "resource glob is rooted at a weights directory" });
+      continue;
+    }
+  }
+  return violations;
+}
+
+// Read the declared bundle resources / externalBin from the committed Tauri configs
+// and run them through inspectResourceSpecs. Missing config files are fine (a
+// non-desktop context). Returns { specs, violations }.
+async function inspectTauriConfigs(ncTokens) {
+  const configRelPaths = [
+    "apps/desktop/tauri.conf.json",
+    "apps/desktop/tauri.macos.conf.json",
+    "apps/desktop/updater.release.conf.json",
+  ];
+  const specs = [];
+  for (const relPath of configRelPaths) {
+    let body;
+    try {
+      body = await readFile(path.join(root, relPath), "utf8");
+    } catch (error) {
+      if (error.code === "ENOENT") {
+        continue;
+      }
+      throw error;
+    }
+    const conf = JSON.parse(body);
+    const bundle = conf?.bundle ?? {};
+    const resources = bundle.resources;
+    if (Array.isArray(resources)) {
+      specs.push(...resources);
+    } else if (resources && typeof resources === "object") {
+      // Object form maps SOURCE path -> destination; the source is the key.
+      specs.push(...Object.keys(resources));
+    }
+    if (Array.isArray(bundle.externalBin)) {
+      specs.push(...bundle.externalBin);
+    }
+  }
+  return { specs, violations: inspectResourceSpecs(specs, ncTokens) };
 }
 
 function reportViolations(violations) {
@@ -381,6 +658,22 @@ function reportViolations(violations) {
           `build — SceneWorks pulls weights at runtime, it does not ship them.`,
       );
     }
+  }
+  console.error(
+    "\nSee docs/packaging-nc-weights-guard.md for the rule and the allowlist policy.\n",
+  );
+}
+
+function reportResourceViolations(resourceViolations) {
+  console.error(
+    "\nNC-WEIGHTS GUARD FAILED (sc-10526): a declared Tauri bundle resource could " +
+      "carry model weights into the installer.\n" +
+      "Bundle resources are copied verbatim into the app payload; an archive or a " +
+      "weights directory staged here would ship weights even though the loose-tree " +
+      "scan cannot see inside it. Pull weights at runtime instead of bundling them.\n",
+  );
+  for (const violation of resourceViolations) {
+    console.error(`  ✗ bundle resource "${violation.spec}"\n      ${violation.reason}.`);
   }
   console.error(
     "\nSee docs/packaging-nc-weights-guard.md for the rule and the allowlist policy.\n",
@@ -415,7 +708,11 @@ async function runScan(options) {
   const { tokens, families } = await buildNcTokens();
   const roots = options.dirs.length > 0 ? options.dirs : DEFAULT_SCAN_ROOTS;
   const violations = await scan({ roots, ncTokens: tokens, includeBin: options.includeBin });
-  return { tokens, families, roots, violations };
+  // The Tauri resource-config check reads the committed configs at the repo root and
+  // is independent of the file scan, so it runs on every invocation (default and
+  // --dir alike) as a cheap second line of defense against a bundled archive.
+  const { specs, violations: resourceViolations } = await inspectTauriConfigs(tokens);
+  return { tokens, families, roots, violations, resourceViolations, resourceSpecCount: specs.length };
 }
 
 // -- Self-test: proves the guard fires (mirrors scripts/check-gen-core-skew.sh --self-test). --
@@ -441,6 +738,28 @@ async function selfTest() {
   assert(
     "Anima is covered (bootstrap until epic 10512 lands in the manifest)",
     tokens.includes("anima") && tokens.includes("circlestone-labs"),
+  );
+
+  // Bootstrap-seed redundancy: the moment the MANIFEST itself yields an Anima /
+  // CircleStone token, the hardcoded BOOTSTRAP_NC_TOKENS seed is redundant and MUST
+  // be emptied — otherwise the "temporary" seed silently becomes permanent. This
+  // assertion fails loudly (forcing the seed's removal) once Anima lands in the
+  // manifest with NC classification.
+  const manifestOnly = await buildManifestNcTokens();
+  const manifestHasAnima = manifestOnly.tokens.some((t) => /anima|circlestone/.test(t));
+  assert(
+    "bootstrap seed is empty once the manifest covers Anima (no permanent hardcode)",
+    !manifestHasAnima || BOOTSTRAP_NC_TOKENS.length === 0,
+  );
+
+  // Token tightening: a bare 5-char token like "anima" must NOT substring-match an
+  // unrelated path such as ".../animations/" (this is what the shipped
+  // apps/web/public/prompt-guides/ideogram-4.md relies on: a doc that merely names
+  // an NC model is not a weight and must not fail the scan).
+  assert(
+    'weak token "anima" does not match ".../animations/foo.js"',
+    weakNcTokenFor("apps/web/src/animations/foo.js", tokens) == null &&
+      strongNcTokenFor("apps/web/src/animations/foo.js", tokens) == null,
   );
 
   const tmp = await mkdtemp(path.join(os.tmpdir(), "nc-weights-guard-"));
@@ -487,9 +806,93 @@ async function selfTest() {
     const vE = await scan({ roots: [dirE], ncTokens: tokens, includeBin: false });
     assert("unexpected non-allowlisted weight is flagged", vE.length === 1);
     assert("...with the generic (non-NC) message", vE[0]?.ncToken == null);
+
+    // (f) THE `.bin` BLIND SPOT (the major review finding). A `.bin` inside an
+    //     HF-cache-form NC directory MUST fail by default — no --include-bin.
+    const dirF = path.join(tmp, "layer-bin", "models--circlestone-labs--Anima", "snapshots", "abc");
+    await mkdir(dirF, { recursive: true });
+    await writeFile(path.join(dirF, "pytorch_model.bin"), "not real weights");
+    await writeFile(path.join(dirF, "anima-base.bin"), "not real weights");
+    const vF = await scan({
+      roots: [path.join(tmp, "layer-bin")],
+      ncTokens: tokens,
+      includeBin: false,
+    });
+    assert(
+      "NC .bin under models--circlestone-labs--Anima/ fails by default (no --include-bin)",
+      vF.length === 2 && vF.every((v) => v.ncToken != null),
+    );
+
+    // (g) A bare NC-named `.bin` (not under an NC dir) is still caught by default.
+    const dirG = path.join(tmp, "loose-bin");
+    await mkdir(dirG, { recursive: true });
+    await writeFile(path.join(dirG, "anima-base.bin"), "not real weights");
+    const vG = await scan({ roots: [dirG], ncTokens: tokens, includeBin: false });
+    assert("bare NC-named anima-base.bin is flagged NC by default", vG.length === 1 && vG[0].ncToken != null);
+
+    // (h) A canonical HF `.bin` weight name is caught even with no NC token.
+    const dirH = path.join(tmp, "hf-bin");
+    await mkdir(dirH, { recursive: true });
+    await writeFile(path.join(dirH, "diffusion_pytorch_model.bin"), "weights");
+    const vH = await scan({ roots: [dirH], ncTokens: tokens, includeBin: false });
+    assert("canonical HF diffusion_pytorch_model.bin is flagged (generic)", vH.length === 1 && vH[0].ncToken == null);
+
+    // (i) A generic, non-canonical, non-NC `.bin` (font/wasm/etc.) must NOT trip the
+    //     guard by default — no false positives.
+    const dirI = path.join(tmp, "generic-bin");
+    await mkdir(dirI, { recursive: true });
+    await writeFile(path.join(dirI, "glyphs.bin"), "a font blob, not a weight");
+    const vI = await scan({ roots: [dirI], ncTokens: tokens, includeBin: false });
+    assert("generic non-weight glyphs.bin passes by default", vI.length === 0);
+    const vIbin = await scan({ roots: [dirI], ncTokens: tokens, includeBin: true });
+    assert("...but --include-bin promotes it to a weight", vIbin.length === 1);
+
+    // (j) SYMLINKED DIRECTORY (the walk() finding). A symlink to a directory of
+    //     weights must be descended, not treated as one opaque "file".
+    const realWeights = path.join(tmp, "real-weights-dir");
+    await mkdir(realWeights, { recursive: true });
+    await writeFile(path.join(realWeights, "some-random-model.safetensors"), "weights");
+    const dirJ = path.join(tmp, "bundle-with-symlink");
+    await mkdir(dirJ, { recursive: true });
+    await symlink(realWeights, path.join(dirJ, "linked-weights"), "dir");
+    const vJ = await scan({ roots: [dirJ], ncTokens: tokens, includeBin: false });
+    assert("weight inside a SYMLINKED directory is flagged (walk follows dir links)", vJ.length === 1);
+
+    // (k) A symlink LOOP must terminate (visited-set), not hang or throw.
+    const loopDir = path.join(tmp, "loop");
+    await mkdir(loopDir, { recursive: true });
+    await symlink(loopDir, path.join(loopDir, "self"), "dir");
+    const vK = await scan({ roots: [loopDir], ncTokens: tokens, includeBin: false });
+    assert("symlink loop terminates cleanly", vK.length === 0);
   } finally {
     await rm(tmp, { recursive: true, force: true });
   }
+
+  // (l) Tauri bundle-resource inspection. The committed configs must be clean, and a
+  //     crafted spec that stages an archive / a weights dir / an NC repo must fail.
+  const { violations: liveResourceViolations } = await inspectTauriConfigs(tokens);
+  assert(
+    "committed Tauri bundle resources declare no weight-bearing entry",
+    liveResourceViolations.length === 0,
+  );
+  const cleanSpecs = ["onnxruntime/**/*", "mlx/**/*"]; // current, legitimately clean
+  const dirtySpecs = [
+    "weights.tar.gz", // archive container
+    "models/**/*.safetensors", // staged weight glob
+    "checkpoints/**/*", // weights directory
+    "vendor/pytorch_model.bin", // staged weight
+    "models--circlestone-labs--Anima/**/*", // NC repo directory
+  ];
+  const craftedResources = inspectResourceSpecs([...cleanSpecs, ...dirtySpecs], tokens);
+  const flaggedSpecs = new Set(craftedResources.map((v) => v.spec));
+  assert(
+    "every archive / weight / NC-repo resource spec is flagged",
+    dirtySpecs.every((s) => flaggedSpecs.has(s)),
+  );
+  assert(
+    "clean resource specs (onnxruntime, mlx) are not flagged",
+    cleanSpecs.every((s) => !flaggedSpecs.has(s)),
+  );
 
   if (failures === 0) {
     console.log("self-test: PASS");
@@ -507,17 +910,30 @@ async function main() {
     return;
   }
 
-  const { tokens, roots, violations } = await runScan(options);
+  const { tokens, roots, violations, resourceViolations, resourceSpecCount } =
+    await runScan(options);
   console.log(
     `NC-weights guard: scanned ${roots.join(", ")} for model weights ` +
-      `(${tokens.length} NC family tokens from the manifests + bootstrap).`,
+      `(${tokens.length} NC family tokens from the manifests + bootstrap) and ` +
+      `${resourceSpecCount} declared Tauri bundle-resource spec(s).`,
   );
+  let failed = false;
   if (violations.length > 0) {
     reportViolations(violations);
+    failed = true;
+  }
+  if (resourceViolations.length > 0) {
+    reportResourceViolations(resourceViolations);
+    failed = true;
+  }
+  if (failed) {
     process.exitCode = 1;
     return;
   }
-  console.log("NC-weights guard passed: no model weights in the artifact payload.");
+  console.log(
+    "NC-weights guard passed: no model weights in the artifact payload and no " +
+      "weight-bearing bundle resources declared.",
+  );
 }
 
 main().catch((error) => {

--- a/scripts/check-no-nc-weights.mjs
+++ b/scripts/check-no-nc-weights.mjs
@@ -1,0 +1,526 @@
+// SceneWorks packaging guard: never bake model weights into a published artifact
+// (sc-10526, epic 10512 "Anima model support").
+//
+// WHY THIS EXISTS
+// ---------------
+// SceneWorks ships its *code* under AGPL-3.0-or-later, but the model *weights* it
+// runs are a separate, license-gated concern. Several supported families are
+// distributed under Non-Commercial (NC) licenses whose redistribution terms attach
+// the moment we hand someone a copy of the weights — e.g. Anima (CircleStone Labs
+// Non-Commercial License v1.2, epic 10512), FLUX.1 [dev] / FLUX.2 (FLUX
+// Non-Commercial License), Ideogram 4 (Ideogram Non-Commercial Model Agreement),
+// Krea 2 (Krea Community License), and NVIDIA SANA (NVIDIA Open Model License /
+// NSCL). A "Derivative" under these licenses includes any converted or quantized
+// checkpoint and any LoRA/fine-tune.
+//
+// SceneWorks' posture side-steps all of the redistribution obligations by NEVER
+// redistributing weights: it CONVERTS AT INSTALL and PULLS AT RUNTIME into the
+// user's own machine/instance. That guarantee is only as strong as our packaging.
+// If a published artifact — a desktop installer/DMG, a Docker/RunPod image layer
+// (epic 10362), or a re-hosted HF repo — ever embeds those weights, SceneWorks
+// becomes a distributor of a Derivative and the NC obligations (ship the license +
+// an attribution notice + a statement of modification) attach immediately.
+//
+// This check fails the build if any model-weight file is found inside an
+// artifact-payload directory. It is deliberately scoped to *artifact staging*, not
+// the developer's machine: a dev with ~/.cache/huggingface/models--circlestone-labs--Anima
+// on disk (the normal convert-at-install state) must NOT trip it, and does not —
+// see SCAN ROOTS below.
+//
+// NOTE ON OUTPUTS: the NC licenses permit commercial use of *Outputs* (generated
+// images) — e.g. CircleStone v1.2 §2(e). Only the Model and its Derivatives (the
+// weights) are restricted. This guard is about weights, never about generations.
+//
+// WHAT IT SCANS (artifact payload only)
+// -------------------------------------
+//   Default: config/, crates/, apps/  — exactly the trees the Docker image COPYs
+//   in (docker/rust.Dockerfile) and where the Tauri desktop bundle stages its
+//   resources (apps/desktop/**). Excludes node_modules/, target/, dist/, .git/.
+//   Deliberately NOT scanned:
+//     * data/          — the developer's local model store; .dockerignore already
+//                        excludes data/models|loras|cache from the image, so it is
+//                        never artifact payload. Scanning it would false-trip on a
+//                        dev's downloaded weights, defeating convert-at-install.
+//     * ~/.cache/huggingface — the runtime HF cache; never part of any artifact.
+//   --dir <path> (repeatable): scan a real built artifact instead — an extracted
+//   Docker image rootfs, a built `.app`/`.dmg` Resources tree, or a RunPod build
+//   context. The release/desktop lanes should point this at the finished bundle.
+//
+// HOW NC FAMILIES ARE DECLARED (data-driven, not a hand-maintained list)
+// ----------------------------------------------------------------------
+//   The set of NC model families is DERIVED from the manifests
+//   (config/manifests/builtin.models.jsonc + builtin.loras.jsonc): an entry is NC
+//   if it declares `nonCommercial: true` OR its description/licenseUrl carries an
+//   NC signal ("non-commercial", "NSCL", "NVIDIA Open Model License", "FLUX ...
+//   Non-Commercial License", the Ideogram/Krea NC agreements). From each NC entry
+//   we take its HF repo(s) and turn them into on-disk match tokens. This means the
+//   next NC model inherits the guard automatically once it is in the manifest — no
+//   second list to keep in sync.
+//
+//   The hard failure, though, does NOT depend on that classification being perfect:
+//   ANY weight file in the payload that is not on the small ALLOWLIST fails the
+//   build. NC classification only ENRICHES the error so it can name the specific
+//   license/family. So a brand-new NC model still fails the build even before it is
+//   tagged NC — it just gets the generic "unexpected model weight" message.
+//
+// See docs/packaging-nc-weights-guard.md for the full rule and how to add a new
+// permissively-licensed bundled weight to the allowlist.
+
+import { readFile, readdir, stat, mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+const root = process.cwd();
+
+// Directories that make up the published-artifact payload when no --dir is given.
+// These are the Docker build-context trees the image COPYs in and the Tauri
+// resource source trees; see the module header for why data/ and the HF cache are
+// intentionally absent.
+const DEFAULT_SCAN_ROOTS = ["config", "crates", "apps"];
+
+// Never descend into these — build caches, deps, and VCS metadata are not payload.
+const EXCLUDED_DIR_NAMES = new Set([
+  "node_modules",
+  "target",
+  "dist",
+  ".git",
+  ".claude",
+  "__pycache__",
+]);
+
+// File extensions that are, in practice, always serialized model weights. `.bin`
+// is intentionally excluded (fonts, wasm, and misc blobs also use it) unless
+// --include-bin is passed; the NC-token matcher below still catches an NC `.bin`.
+const WEIGHT_EXTENSIONS = new Set([
+  ".safetensors",
+  ".gguf",
+  ".ckpt",
+  ".pth",
+  ".pt",
+  ".onnx",
+  ".npz",
+  ".mlx",
+  ".msgpack",
+  ".h5",
+  ".pb",
+]);
+
+// Permissively-licensed weights that are LEGITIMATELY compiled/bundled into a
+// SceneWorks binary and are therefore allowed in the payload. Keyed by exact
+// basename so it holds across both the default scan and any --dir scan. Keep this
+// list tiny and every entry justified — anything NC must never be added here.
+const ALLOWLIST = [
+  {
+    basename: "aesthetic-v2-sac-logos-ava1-l14.safetensors",
+    reason:
+      "LAION improved-aesthetic-predictor (MIT). A ~4 MB CLIP-head regressor " +
+      "compiled into crates/sceneworks-image-quality for the aesthetic score. " +
+      "Permissive, not a generative model, and not a Derivative of any NC family.",
+  },
+];
+const ALLOWLIST_BASENAMES = new Set(ALLOWLIST.map((entry) => entry.basename));
+
+// Bootstrap NC tokens for families that are not yet represented in the manifest.
+// Anima (epic 10512) is being ported now; until its manifest entry lands with a
+// repo + `nonCommercial: true`, seed its tokens here so the guard already names it.
+// REMOVE an entry once the corresponding family is in the manifest (the manifest is
+// the source of truth) — the self-test asserts Anima stays covered either way.
+const BOOTSTRAP_NC_TOKENS = ["circlestone-labs", "anima"];
+
+// -- JSONC parsing (manifests carry // comments). Mirrors scripts/check-scaffold.mjs. --
+function stripJsoncComments(body) {
+  let result = "";
+  let inString = false;
+  let escaped = false;
+  for (let index = 0; index < body.length; index += 1) {
+    const char = body[index];
+    const next = body[index + 1];
+    if (inString) {
+      result += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      result += char;
+      continue;
+    }
+    if (char === "/" && next === "/") {
+      while (index < body.length && body[index] !== "\n") {
+        index += 1;
+      }
+      result += "\n";
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      index += 2;
+      while (index < body.length && !(body[index] === "*" && body[index + 1] === "/")) {
+        index += 1;
+      }
+      index += 1;
+      continue;
+    }
+    result += char;
+  }
+  return result;
+}
+
+async function readJsonc(relativePath) {
+  const body = await readFile(path.join(root, relativePath), "utf8");
+  return JSON.parse(stripJsoncComments(body));
+}
+
+// An entry (model or lora) is NC when it says so explicitly or its human-readable
+// license text does. Kept deliberately specific: "community license" alone is NOT
+// an NC signal (the Stability Community License permits commercial use under a
+// revenue cap), so we match the concrete NC license names/phrases instead.
+const NC_TEXT_SIGNAL =
+  /non[-\s]?commercial|noncommercial|\bNSCL\b|NVIDIA Open Model License|FLUX[^.]*Non-Commercial|Non-Commercial (?:Model )?(?:License|Agreement)|krea-2-licensing|CircleStone/i;
+
+function entryIsNonCommercial(entry) {
+  if (entry?.nonCommercial === true) {
+    return true;
+  }
+  // NC signals live in several places (`ui.description`, `licenseUrl`, `name`, and
+  // occasionally nested variant text), so test the whole flattened entry rather
+  // than cherry-picking fields. `commercial` on its own (e.g. "for commercial use
+  // choose X" on a *permissive* model) does not match — only the concrete
+  // non-commercial phrasing does. Over-recall here only affects the wording of a
+  // failure message; the hard gate fails on any non-allowlisted weight regardless.
+  return NC_TEXT_SIGNAL.test(JSON.stringify(entry));
+}
+
+// Turn an HF repo id ("org/name") into the tokens it shows up as on disk:
+//   org/name            (bare clone / manifest form)
+//   models--org--name   (HF hub cache dir form)
+//   name                (final path component; catches a flattened copy)
+function repoToTokens(repo) {
+  if (typeof repo !== "string" || !repo.includes("/")) {
+    return [];
+  }
+  const lower = repo.toLowerCase();
+  const [org, ...rest] = lower.split("/");
+  const name = rest.join("/");
+  const tokens = new Set([lower, `models--${org}--${name}`.replace(/\//g, "--")]);
+  if (name) {
+    tokens.add(name);
+  }
+  return [...tokens];
+}
+
+// Deep-collect every value under a "repo" key anywhere in the entry
+// (downloads[].repo, source.repo, and any nested variant repos), so the token set
+// covers all of a family's HF repos regardless of where the manifest nests them.
+function collectRepoStrings(entry) {
+  const repos = [];
+  const visit = (node) => {
+    if (Array.isArray(node)) {
+      for (const item of node) {
+        visit(item);
+      }
+    } else if (node && typeof node === "object") {
+      for (const [key, value] of Object.entries(node)) {
+        if (key === "repo" && typeof value === "string") {
+          repos.push(value);
+        } else {
+          visit(value);
+        }
+      }
+    }
+  };
+  visit(entry);
+  return repos;
+}
+
+// Build the NC token set from the manifests + the bootstrap seed.
+async function buildNcTokens() {
+  const tokens = new Set(BOOTSTRAP_NC_TOKENS.map((token) => token.toLowerCase()));
+  const families = new Set();
+
+  const sources = [
+    { path: "config/manifests/builtin.models.jsonc", key: "models" },
+    { path: "config/manifests/builtin.loras.jsonc", key: "loras" },
+  ];
+  for (const source of sources) {
+    let manifest;
+    try {
+      manifest = await readJsonc(source.path);
+    } catch (error) {
+      throw new Error(`Failed to parse ${source.path}: ${error.message}`);
+    }
+    for (const entry of manifest[source.key] ?? []) {
+      if (!entryIsNonCommercial(entry)) {
+        continue;
+      }
+      if (typeof entry.family === "string") {
+        families.add(entry.family.toLowerCase());
+      }
+      for (const repo of collectRepoStrings(entry)) {
+        for (const token of repoToTokens(repo)) {
+          tokens.add(token);
+        }
+      }
+    }
+  }
+  return { tokens: [...tokens].filter(Boolean), families: [...families] };
+}
+
+// Which NC token (if any) does this on-disk path match? Compared over the whole
+// POSIX-normalized path so both the file basename (anima-base-v1.0.safetensors) and
+// an ancestor cache dir (models--circlestone-labs--Anima/…) are caught.
+function ncTokenFor(filePath, ncTokens) {
+  const needle = filePath.split(path.sep).join("/").toLowerCase();
+  return ncTokens.find((token) => token.length >= 4 && needle.includes(token)) ?? null;
+}
+
+async function walk(dir, files) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (EXCLUDED_DIR_NAMES.has(entry.name)) {
+        continue;
+      }
+      await walk(full, files);
+    } else if (entry.isFile() || entry.isSymbolicLink()) {
+      files.push(full);
+    }
+  }
+}
+
+function isWeightFile(filePath, includeBin) {
+  const ext = path.extname(filePath).toLowerCase();
+  if (WEIGHT_EXTENSIONS.has(ext)) {
+    return true;
+  }
+  if (includeBin && ext === ".bin") {
+    return true;
+  }
+  return false;
+}
+
+// Core: scan the given roots and return the list of violations. A violation is any
+// weight file that is not on the allowlist. NC classification enriches each one.
+async function scan({ roots, ncTokens, includeBin }) {
+  const violations = [];
+  for (const scanRoot of roots) {
+    const absRoot = path.isAbsolute(scanRoot) ? scanRoot : path.join(root, scanRoot);
+    let rootStat;
+    try {
+      rootStat = await stat(absRoot);
+    } catch (error) {
+      if (error.code === "ENOENT") {
+        continue; // A staging dir that is not present in this checkout is fine.
+      }
+      throw error;
+    }
+    const files = [];
+    if (rootStat.isDirectory()) {
+      await walk(absRoot, files);
+    } else if (rootStat.isFile()) {
+      files.push(absRoot);
+    }
+    for (const file of files) {
+      if (!isWeightFile(file, includeBin)) {
+        continue;
+      }
+      const basename = path.basename(file);
+      // NC-token match wins even for allowlisted basenames: an allowlisted
+      // permissive name must never travel inside an NC repo/cache path.
+      const ncToken = ncTokenFor(file, ncTokens);
+      if (!ncToken && ALLOWLIST_BASENAMES.has(basename)) {
+        continue;
+      }
+      violations.push({
+        file: path.relative(root, file) || file,
+        basename,
+        ncToken,
+      });
+    }
+  }
+  return violations;
+}
+
+function reportViolations(violations) {
+  console.error(
+    "\nNC-WEIGHTS GUARD FAILED (sc-10526): model-weight file(s) found in the " +
+      "artifact payload.\n" +
+      "SceneWorks must never redistribute model weights — it converts at install " +
+      "and pulls at runtime. Shipping these turns SceneWorks into a distributor of " +
+      "a (possibly Non-Commercial) Derivative.\n",
+  );
+  for (const violation of violations) {
+    if (violation.ncToken) {
+      console.error(
+        `  ✗ ${violation.file}\n` +
+          `      matches Non-Commercial family token "${violation.ncToken}" — this is ` +
+          `an NC weight and MUST NOT ship in any installer, image layer, or re-host.`,
+      );
+    } else {
+      console.error(
+        `  ✗ ${violation.file}\n` +
+          `      unexpected model weight in the artifact payload. If this is a ` +
+          `permissively-licensed weight that is legitimately compiled into a binary, ` +
+          `add its basename (with a justification) to the ALLOWLIST in ` +
+          `scripts/check-no-nc-weights.mjs. If it is an NC weight, remove it from the ` +
+          `build — SceneWorks pulls weights at runtime, it does not ship them.`,
+      );
+    }
+  }
+  console.error(
+    "\nSee docs/packaging-nc-weights-guard.md for the rule and the allowlist policy.\n",
+  );
+}
+
+function parseArgs(argv) {
+  const options = { dirs: [], includeBin: false, selfTest: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--self-test") {
+      options.selfTest = true;
+    } else if (arg === "--include-bin") {
+      options.includeBin = true;
+    } else if (arg === "--dir") {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error("--dir requires a path argument");
+      }
+      options.dirs.push(value);
+      i += 1;
+    } else if (arg.startsWith("--dir=")) {
+      options.dirs.push(arg.slice("--dir=".length));
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return options;
+}
+
+async function runScan(options) {
+  const { tokens, families } = await buildNcTokens();
+  const roots = options.dirs.length > 0 ? options.dirs : DEFAULT_SCAN_ROOTS;
+  const violations = await scan({ roots, ncTokens: tokens, includeBin: options.includeBin });
+  return { tokens, families, roots, violations };
+}
+
+// -- Self-test: proves the guard fires (mirrors scripts/check-gen-core-skew.sh --self-test). --
+async function selfTest() {
+  let failures = 0;
+  const assert = (label, condition) => {
+    const status = condition ? "PASS" : "FAIL";
+    if (!condition) {
+      failures += 1;
+    }
+    console.log(`self-test: ${label} -> ${status}`);
+  };
+
+  const { tokens, families } = await buildNcTokens();
+  // The manifest-derived NC set must not silently empty out (a parse regression
+  // would otherwise disarm NC classification).
+  assert("manifest yields a non-empty NC token set", tokens.length > 5);
+  assert(
+    "known NC families are derived from the manifest (flux / ideogram / krea)",
+    families.some((f) => /flux|ideogram|krea|sana/i.test(f)) ||
+      tokens.some((t) => /flux|ideogram|krea|sana/.test(t)),
+  );
+  assert(
+    "Anima is covered (bootstrap until epic 10512 lands in the manifest)",
+    tokens.includes("anima") && tokens.includes("circlestone-labs"),
+  );
+
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "nc-weights-guard-"));
+  try {
+    // (a) An Anima weight by bare basename must be caught and named NC.
+    const diryA = path.join(tmp, "installer-with-anima");
+    await mkdir(diryA, { recursive: true });
+    await writeFile(path.join(diryA, "anima-base-v1.0.safetensors"), "not real weights");
+    const vA = await scan({ roots: [diryA], ncTokens: tokens, includeBin: false });
+    assert("fake anima-base-v1.0.safetensors is flagged", vA.length === 1);
+    assert("...and is classified NC", vA[0]?.ncToken != null);
+
+    // (b) An HF-cache-form NC path must be caught even with a generic filename.
+    const dirB = path.join(tmp, "image-layer", "models--circlestone-labs--Anima", "snapshots", "abc");
+    await mkdir(dirB, { recursive: true });
+    await writeFile(path.join(dirB, "model.safetensors"), "not real weights");
+    const vB = await scan({
+      roots: [path.join(tmp, "image-layer")],
+      ncTokens: tokens,
+      includeBin: false,
+    });
+    assert("NC weight inside models--circlestone-labs--Anima/ is flagged", vB.length === 1 && vB[0].ncToken != null);
+
+    // (c) A clean payload passes.
+    const dirC = path.join(tmp, "clean");
+    await mkdir(dirC, { recursive: true });
+    await writeFile(path.join(dirC, "README.txt"), "no weights here");
+    await writeFile(path.join(dirC, "sceneworks-api"), "a binary, not a weight");
+    const vC = await scan({ roots: [dirC], ncTokens: tokens, includeBin: false });
+    assert("clean payload passes", vC.length === 0);
+
+    // (d) A payload containing only the allowlisted permissive weight passes.
+    const dirD = path.join(tmp, "with-allowlisted");
+    await mkdir(dirD, { recursive: true });
+    await writeFile(path.join(dirD, "aesthetic-v2-sac-logos-ava1-l14.safetensors"), "permissive");
+    const vD = await scan({ roots: [dirD], ncTokens: tokens, includeBin: false });
+    assert("allowlisted permissive weight passes", vD.length === 0);
+
+    // (e) A non-NC, non-allowlisted weight still fails (belt-and-suspenders: catches
+    //     the next model even before it is tagged NC), with the generic message.
+    const dirE = path.join(tmp, "unexpected");
+    await mkdir(dirE, { recursive: true });
+    await writeFile(path.join(dirE, "some-random-model.safetensors"), "weights");
+    const vE = await scan({ roots: [dirE], ncTokens: tokens, includeBin: false });
+    assert("unexpected non-allowlisted weight is flagged", vE.length === 1);
+    assert("...with the generic (non-NC) message", vE[0]?.ncToken == null);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+
+  if (failures === 0) {
+    console.log("self-test: PASS");
+    return 0;
+  }
+  console.error(`self-test: FAIL (${failures} assertion(s) failed)`);
+  return 1;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (options.selfTest) {
+    process.exitCode = await selfTest();
+    return;
+  }
+
+  const { tokens, roots, violations } = await runScan(options);
+  console.log(
+    `NC-weights guard: scanned ${roots.join(", ")} for model weights ` +
+      `(${tokens.length} NC family tokens from the manifests + bootstrap).`,
+  );
+  if (violations.length > 0) {
+    reportViolations(violations);
+    process.exitCode = 1;
+    return;
+  }
+  console.log("NC-weights guard passed: no model weights in the artifact payload.");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/check-no-nc-weights.mjs
+++ b/scripts/check-no-nc-weights.mjs
@@ -182,11 +182,24 @@ const ALLOWLIST_BASENAMES = new Set(ALLOWLIST.map((entry) => entry.basename));
 // Bootstrap NC tokens for families that are not yet represented in the manifest.
 // Anima (epic 10512) is being ported now; until its manifest entry lands with a
 // repo + `nonCommercial: true`, seed its tokens here so the guard already names it.
-// REMOVE an entry once the corresponding family is in the manifest (the manifest is
-// the source of truth). This is not left to vigilance: the self-test asserts that
-// once the manifest itself yields an `anima` / `circlestone-labs` token, this array
-// MUST be empty — so the "temporary" seed cannot silently become permanent.
-const BOOTSTRAP_NC_TOKENS = ["circlestone-labs", "anima"];
+// These are exactly the tokens `repoToTokens("circlestone-labs/anima")` will emit
+// once sc-10523 wires the manifest entry — the two STRONG repo/cache forms
+// (`circlestone-labs/anima`, `models--circlestone-labs--anima`) plus the WEAK bare
+// name (`anima`). Seeding the strong forms is deliberate: it makes the header
+// comment's "any blob regardless of extension" guarantee (see scan() case (1)) TRUE
+// for Anima today, so an arbitrary-extension blob (e.g. `model.dat`) under a
+// redistributed `models--circlestone-labs--Anima/` directory fails right now, not
+// only after the manifest lands. Because the seed mirrors the manifest output
+// exactly, the guard behaves identically before and after sc-10523.
+// REMOVE every entry once the corresponding family is in the manifest (the manifest
+// is the source of truth). This is not left to vigilance: the self-test asserts that
+// once the manifest itself yields an `anima` / `circlestone` token, this array MUST
+// be empty — so the "temporary" seed cannot silently become permanent.
+const BOOTSTRAP_NC_TOKENS = [
+  "circlestone-labs/anima",
+  "models--circlestone-labs--anima",
+  "anima",
+];
 
 // -- JSONC parsing (manifests carry // comments). Mirrors scripts/check-scaffold.mjs. --
 function stripJsoncComments(body) {
@@ -735,9 +748,16 @@ async function selfTest() {
     families.some((f) => /flux|ideogram|krea|sana/i.test(f)) ||
       tokens.some((t) => /flux|ideogram|krea|sana/.test(t)),
   );
+  // Match on how the token ARRIVES, not an exact bootstrap string. The bootstrap
+  // seed and the eventual manifest wiring produce different literal tokens for the
+  // same family — the seed used to carry a bare `circlestone-labs`, but the manifest
+  // yields `circlestone-labs/anima` + `models--circlestone-labs--anima` + `anima` and
+  // NO bare `circlestone-labs`. Asserting on the exact bare token would fire a second,
+  // unadvertised failure the moment sc-10523 lands and an engineer (correctly) empties
+  // the seed per the tripwire below. A substring match is robust to both worlds.
   assert(
     "Anima is covered (bootstrap until epic 10512 lands in the manifest)",
-    tokens.includes("anima") && tokens.includes("circlestone-labs"),
+    tokens.some((t) => /anima/.test(t)) && tokens.some((t) => /circlestone/.test(t)),
   );
 
   // Bootstrap-seed redundancy: the moment the MANIFEST itself yields an Anima /


### PR DESCRIPTION
## What & why (sc-10526, epic 10512 — Anima model support)

SceneWorks' license posture for model weights is **convert at install, pull at runtime, never redistribute.** That is what keeps Non-Commercial (NC) families — Anima (CircleStone Labs NC License v1.2), FLUX NC, Ideogram, Krea, NVIDIA SANA, PixelDiT, PuLID-FLUX — out of anything we ship, so the NC redistribution obligations (ship the license + attribution + statement of modification) never attach. But the guarantee is only as strong as our packaging: a weight baked into a desktop installer/DMG, a Docker/RunPod image layer (epic 10362), or an accidental HF re-host would make us a distributor of a Derivative.

This adds a CI guard that fails the build if model weights are found in an artifact payload. Filed as a story rather than left as a code comment.

> **Note (SceneWorks code is AGPL-3.0-or-later; NC *weights* are a separate, gated concern):** the guard is about weights only. The NC licenses permit commercial use of **Outputs** (generated images, e.g. CircleStone v1.2 §2(e)) — nothing here touches generations.

## What changed

- **`scripts/check-no-nc-weights.mjs`** — the guard. Node `.mjs`, matching the repo's `check-*.mjs` convention.
- **`package.json`** — `npm run check:nc-weights`.
- **`.github/workflows/check.yml`** — every PR: `--self-test` then the default scan (mirrors the `check-gen-core-skew.sh --self-test` pattern).
- **`.github/workflows/release.yml`** — macOS + Windows desktop jobs: scan `target/release/bundle` after the bundle build, before signing/publishing (real-artifact form).
- **`.dockerignore`** — comment documenting why the local model stores stay out of the image.
- **`docs/packaging-nc-weights-guard.md`** — the rule, the scan scope, the allowlist policy, and the known limitations.

## What the guard scans

- **Default:** `config/`, `crates/`, `apps/` — exactly the trees the Docker image COPYs in (`docker/rust.Dockerfile`) and where the Tauri bundle stages its resources. Skips `node_modules/`, `target/`, `dist/`, `.git/`.
- **`--dir <path>` (repeatable):** a real built artifact — extracted image rootfs, a built `.app`/bundle tree, or a RunPod build context. The release workflow points this at `target/release/bundle`.

**NC families are data-driven:** derived from `builtin.models.jsonc` + `builtin.loras.jsonc` (an entry is NC via `nonCommercial: true` or its license text — "non-commercial" / NSCL / NVIDIA Open Model License / FLUX·Ideogram·Krea NC). Each NC entry's HF repo(s) become on-disk match tokens (`org/name`, `models--org--name`, bare `name`). The next NC model inherits the guard the moment it's in the manifest — no second list to maintain (53 tokens today). Anima isn't in the manifest yet, so `anima` / `circlestone-labs` are seeded as a documented bootstrap.

The **hard failure is any non-allowlisted weight** in the payload — NC classification only enriches the message, so a brand-new NC model still fails the build before anyone tags it NC.

## What it deliberately does NOT scan, and why

- **`data/`** — the developer's local model store; `.dockerignore` already excludes `data/models|loras|cache` from the image, so it is never payload.
- **`~/.cache/huggingface`** — the runtime HF cache. A dev running convert-at-install has NC weights here (`models--circlestone-labs--Anima/`); that is the normal, correct state and must not trip the guard.
- **The one legitimately-bundled permissive weight** — `aesthetic-v2-sac-logos-ava1-l14.safetensors` (LAION improved-aesthetic-predictor, MIT), a ~4 MB CLIP-head regressor linked into `crates/sceneworks-image-quality` — is allowlisted by basename with a justification. An allowlisted name found inside an NC repo/cache path is still flagged.

## How it was tested

- `node scripts/check-no-nc-weights.mjs --self-test` (runs in CI): asserts the manifest yields a non-empty NC token set (flux/ideogram/krea/sana + Anima), then builds temp staging dirs and asserts — fake `anima-base-v1.0.safetensors` → **fail (classified NC)**; NC weight inside `models--circlestone-labs--Anima/` → **fail**; clean payload → **pass**; only the allowlisted weight → **pass**; a non-NC non-allowlisted weight → **fail (generic message)**.
- Real scan over `config/crates/apps` → **passes** (the aesthetic weight is correctly allowlisted; no other weights present).
- `--dir` over a fake bundle with `flux2-klein-9b-mlx-transformer.safetensors` → fails and names the NC family; a random weight → fails with the generic message.
- Existing `npm run check` (scaffold) still passes; both workflow YAMLs validate. No Rust touched.

## What remains unverifiable today

The **RunPod image (epic 10362) does not exist yet** — there is no RunPod-specific Dockerfile in the repo, so "verify the RunPod image pulls at runtime" cannot be checked against a real artifact. The existing `docker/rust.Dockerfile` (the base that lane will build on) is verified to pull-at-runtime: its COPYs are limited to `config/`, `crates/`, `apps/`, and built binaries, and `.dockerignore` excludes `data/models|loras|cache`. The guard is structured so the RunPod lane covers it with one `--dir` step over its build context / rootfs the moment it lands. See FOLLOW_UPS in the story.

The final `.dmg`/`.msi`/`-setup.exe` installers are opaque archives; the release scan walks the loose `.app`/bundle tree (same `Contents/Resources` the DMG wraps) but doesn't decompress the installer — `check.yml`'s source scan covers the resource trees that feed them.


---

## Review follow-ups (adversarial review — CHANGES_REQUIRED, resolved)

- **[major] Closed the `.bin` blind spot.** The NC-token check previously ran only *after* the weight-extension gate, so a `.bin` was `continue`d before it — `pytorch_model.bin` / `anima-base.bin` under `models--circlestone-labs--Anima/` scanned CLEAN by default. `scan()` now runs a **STRONG NC repo-path match** (`org/name`, `models--org--name`) on **every file regardless of extension**, so any blob inside a redistributed NC repo/cache dir fails with **no flags**. Additionally: a `.bin` matching a bare NC family token (`anima-base.bin`) and the canonical HF `.bin` weight names (`pytorch_model.bin`, `diffusion_pytorch_model.bin`, `open_clip_pytorch_model.bin`, sharded forms — the second dominant HF weight format) are treated as weights by default. Generic `.bin` blobs (fonts/wasm) still stay quiet — no false positives. The false "the matcher still catches an NC `.bin`" comment is corrected.
- **[minor] Symlinked directories** are now resolved and descended by `walk()` with a realpath visited-set (loop-safe), instead of being recorded as one opaque "file" and only extension-checked.
- **[minor] Token tightening** — boundary-aware matching so the 5-char token `anima` no longer substring-matches `.../animations/`. Required now that NC matching runs regardless of extension; keeps the shipped `apps/web/public/prompt-guides/ideogram-4.md` clean.
- **[minor] Bootstrap seed can't go permanent** — a new self-test fails once the manifest itself yields an `anima`/`circlestone` token while `BOOTSTRAP_NC_TOKENS` is non-empty, forcing the seed's removal when Anima lands in `builtin.models.jsonc`.
- **[minor] Tauri `bundle.resources` inspection** — every run reads the committed `apps/desktop/tauri*.conf.json` and fails if a declared `bundle.resources` / `externalBin` spec is an archive, stages a weight, matches an NC token, or is rooted at a weights dir. This is the cheap defense for the "weight sealed in an archive staged as a resource" vector. Current resources (`onnxruntime/**/*`, `ffmpeg/**/*`, `mlx/**/*`) are clean.
- **[minor] `release.yml` comment corrected** — the guard runs *after* the previous step signs+notarizes+staples the `.app`, but *before* the DMG staple, release draft, and upload; it still fails the job before anything is published.

**Self-test now 23 assertions.** The new `.bin`-under-NC-dir and symlinked-directory cases were verified to **fail against the pre-fix code** (old script exits 0 / misses them) and pass now (exits 1 / flags all).

**Deferred (tracked follow-up, not a code comment):** full **archive-*content* decompression** scanning — opening `.zip`/`.tar.gz`/`.dmg` in a built artifact to scan files *inside*. The config-level resource check already fails the build if an archive is *declared* as a bundle resource (the realistic vector), so recursive decompress-and-scan buys little over it while needing a per-format decompressor, temp extraction, and archive-bomb guards — disproportionate for this guard. `include_bytes!`-compiled weights are likewise not file-scan-detectable, but the source scan catches the weight *file* before it is compiled in. Documented under docs "Known limitation".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
