### PR TITLE
feat(training): wire the Anima LoRA/LoKr trainer + presets (sc-10522)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -816,6 +816,9 @@ pub(crate) const MLX_ROUTED_TRAINING_KERNELS: &[&str] = &[
     "wan_lora",
     "wan_moe_lora",
     "ltx_mlx_lora",
+    // Anima (epic 10512, sc-10522): the native `mlx-gen-anima` LoRA/LoKr trainer (DiT + `llm_adapter`
+    // conditioner). No torch path, so it is also in `MLX_ONLY_TRAINING_KERNELS`.
+    "anima_lora",
 ];
 
 /// SceneWorks training kernels with a native candle trainer that needs no base-model disambiguation
@@ -842,7 +845,8 @@ pub(crate) const CANDLE_ROUTED_TRAINING_KERNELS: &[&str] =
 /// [`CANDLE_ROUTED_TRAINING_KERNELS`]), while torch is still refused. `sd3_lora` (epic 7841 T3
 /// sc-7884) is MLX-native with no torch trainer and no candle trainer yet (the off-Mac/candle SD3.5
 /// trainer is epic 7982), so — like LTX — only an mlx worker runs it today.
-pub(crate) const MLX_ONLY_TRAINING_KERNELS: &[&str] = &["ltx_mlx_lora", "krea_lora", "sd3_lora"];
+pub(crate) const MLX_ONLY_TRAINING_KERNELS: &[&str] =
+    &["ltx_mlx_lora", "krea_lora", "sd3_lora", "anima_lora"];
 
 #[cfg(test)]
 mod tests {
@@ -1023,12 +1027,14 @@ mod tests {
         "wan_lora",
         "wan_moe_lora",
         "ltx_mlx_lora",
+        "anima_lora",
     ];
 
     const EXPECTED_CANDLE_ROUTED_TRAINING_KERNELS: &[&str] =
         &["z_image_lora", "sdxl_lora", "lens_lora", "krea_lora"];
 
-    const EXPECTED_MLX_ONLY_TRAINING_KERNELS: &[&str] = &["ltx_mlx_lora", "krea_lora", "sd3_lora"];
+    const EXPECTED_MLX_ONLY_TRAINING_KERNELS: &[&str] =
+        &["ltx_mlx_lora", "krea_lora", "sd3_lora", "anima_lora"];
 
     #[test]
     fn routed_model_lists_match_snapshot() {

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -2272,7 +2272,9 @@ fn validate_lr_scheduler(config: &TrainingConfig) -> Result<(), TrainingPlanErro
 /// `apply_anima_adapters`. The native `mlx-gen-anima` trainer trains the 448 DiT targets **and** the
 /// 60 `llm_adapter` conditioner targets (508 total). mlx-only (no torch/candle Anima trainer). NB the
 /// `mlx-gen-anima` trainer does not yet honor gradient checkpointing or preview sampling (dense-only,
-/// no in-training previews), so those advanced knobs default off here.
+/// no in-training previews), so those advanced knobs default off here — that parity work (gradient
+/// checkpointing + OOM guard, in-training preview, mid-run resume, and the >1024 resolution ceiling)
+/// is tracked in sc-10576, not deferred in prose.
 fn anima_base_lora_target() -> TrainingTarget {
     TrainingTarget {
         id: "anima_base_lora".to_owned(),
@@ -2303,7 +2305,8 @@ fn anima_base_lora_target() -> TrainingTarget {
                 "cacheLatents": true,
                 "cacheTextEmbeddings": true,
                 // Dense-only for now (the mlx-gen-anima trainer does not implement block
-                // checkpointing yet — a follow-up); keep it off so the UI does not advertise a no-op.
+                // checkpointing yet — tracked in sc-10576); keep it off so the UI does not advertise
+                // a no-op.
                 "gradientCheckpointing": false,
                 "networkType": "lora",
                 // Flow-match noising: sigmoid timestep with a high-noise tilt, MSE on the velocity
@@ -2314,7 +2317,7 @@ fn anima_base_lora_target() -> TrainingTarget {
                 "weightDecay": 0.0001,
                 "lrScheduler": "constant",
                 // In-training preview sampling is not implemented in the mlx-gen-anima trainer yet
-                // (a follow-up), so sampling defaults off.
+                // (tracked in sc-10576), so sampling defaults off.
                 "sampleEvery": 0,
                 "sampleSteps": 10,
                 "sampleGuidanceScale": 4.5,
@@ -2329,7 +2332,7 @@ fn anima_base_lora_target() -> TrainingTarget {
             "alpha": [1, 128],
             "steps": [200, 6000],
             // Dense-only training (no memory guard/checkpointing yet), so the training-resolution
-            // ceiling stays at 1024 even though inference supports up to 1536 (a follow-up).
+            // ceiling stays at 1024 even though inference supports up to 1536 (tracked in sc-10576).
             "resolutions": [512, 768, 1024],
             "batchSize": [1, 4],
             "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -429,6 +429,7 @@ pub fn builtin_training_targets() -> TrainingTargetRegistry {
             krea_raw_lora_target(),
             sd3_large_lora_target(),
             sd3_medium_lora_target(),
+            anima_base_lora_target(),
             ltx_video_lora_target(),
             wan_lora_target(),
             wan_t2v_14b_lora_target(),
@@ -444,6 +445,7 @@ pub fn builtin_training_presets() -> TrainingPresetRegistry {
     let sdxl_target = sdxl_lora_target();
     let kolors_target = kolors_lora_target();
     let krea_target = krea_raw_lora_target();
+    let anima_target = anima_base_lora_target();
     let wan_target = wan_lora_target();
     let wan_t2v_14b_target = wan_t2v_14b_lora_target();
     let wan_i2v_14b_target = wan_i2v_14b_lora_target();
@@ -842,6 +844,57 @@ pub fn builtin_training_presets() -> TrainingPresetRegistry {
                 object(json!({
                     "description": "Higher-step style LoRA for Wan2.2 14B I2V.",
                     "order": 20
+                })),
+            ),
+            anima_preset(
+                &anima_target,
+                "anima_base_lora.character.adamw8bit.balanced",
+                "Character balanced",
+                &["character"],
+                ("adamw8bit", "balanced"),
+                |mut config| {
+                    config.steps = 3000;
+                    config
+                },
+                object(json!({
+                    "description": "Balanced first run for 12-25 clean character images on the Anima base model (trains the DiT + llm_adapter conditioner).",
+                    "default": true,
+                    "order": 10
+                })),
+            ),
+            anima_preset(
+                &anima_target,
+                "anima_base_lora.character.adamw8bit.conservative",
+                "Character conservative",
+                &["character"],
+                ("adamw8bit", "conservative"),
+                |mut config| {
+                    config.rank = 8;
+                    config.alpha = 8;
+                    config.learning_rate = number(0.00005);
+                    config.steps = 3000;
+                    config
+                },
+                object(json!({
+                    "description": "Lower-rank, lower-LR Anima character preset for tight identity datasets.",
+                    "order": 20
+                })),
+            ),
+            anima_preset(
+                &anima_target,
+                "anima_base_lora.style.adamw8bit.balanced",
+                "Style balanced",
+                &["style"],
+                ("adamw8bit", "balanced"),
+                |mut config| {
+                    config.rank = 32;
+                    config.alpha = 16;
+                    config.steps = 3000;
+                    config
+                },
+                object(json!({
+                    "description": "Higher-capacity Anima style LoRA for anime texture and visual-language transfer.",
+                    "order": 30
                 })),
             ),
         ],
@@ -2211,6 +2264,126 @@ fn validate_lr_scheduler(config: &TrainingConfig) -> Result<(), TrainingPlanErro
         }
     }
     Ok(())
+}
+
+/// The Anima (Cosmos-Predict2 DiT + `AnimaTextConditioner`) image LoRA/LoKr training target (epic
+/// 10512, sc-10522). Trained on the undistilled `anima_base` (like Krea Raw→Turbo / SD3 Large→turbo);
+/// the family-arch-identical aesthetic/turbo variants apply the same adapter back via
+/// `apply_anima_adapters`. The native `mlx-gen-anima` trainer trains the 448 DiT targets **and** the
+/// 60 `llm_adapter` conditioner targets (508 total). mlx-only (no torch/candle Anima trainer). NB the
+/// `mlx-gen-anima` trainer does not yet honor gradient checkpointing or preview sampling (dense-only,
+/// no in-training previews), so those advanced knobs default off here.
+fn anima_base_lora_target() -> TrainingTarget {
+    TrainingTarget {
+        id: "anima_base_lora".to_owned(),
+        name: "Anima LoRA".to_owned(),
+        modality: TrainingModality::Image,
+        output_kind: TrainingOutputKind::Lora,
+        family: "anima".to_owned(),
+        base_model: "anima_base".to_owned(),
+        base_model_repo: Some("circlestone-labs/Anima".to_owned()),
+        kernel: "anima_lora".to_owned(),
+        defaults: TrainingConfig {
+            rank: 16,
+            alpha: 16,
+            learning_rate: ContractNumber::from_f64(0.0001).expect("0.0001 is finite"),
+            steps: 3000,
+            batch_size: 1,
+            gradient_accumulation: 1,
+            resolution: 1024,
+            save_every: 250,
+            seed: 42,
+            optimizer: "adamw8bit".to_owned(),
+            trigger_word: None,
+            advanced: object(json!({
+                // Anima's base is bf16 on disk; the trainer runs bf16 mixed-precision (frozen base +
+                // activations bf16, trainable factors/optimizer f32). VAE latents + the Qwen3
+                // conditioner inputs are cached; the trained conditioner is re-run per step.
+                "mixedPrecision": "bf16",
+                "cacheLatents": true,
+                "cacheTextEmbeddings": true,
+                // Dense-only for now (the mlx-gen-anima trainer does not implement block
+                // checkpointing yet — a follow-up); keep it off so the UI does not advertise a no-op.
+                "gradientCheckpointing": false,
+                "networkType": "lora",
+                // Flow-match noising: sigmoid timestep with a high-noise tilt, MSE on the velocity
+                // target (ε − x0), static schedule shift 3.0 baked into the trainer.
+                "timestepType": "sigmoid",
+                "timestepBias": "high_noise",
+                "lossType": "mse",
+                "weightDecay": 0.0001,
+                "lrScheduler": "constant",
+                // In-training preview sampling is not implemented in the mlx-gen-anima trainer yet
+                // (a follow-up), so sampling defaults off.
+                "sampleEvery": 0,
+                "sampleSteps": 10,
+                "sampleGuidanceScale": 4.5,
+                "qualityPreset": "balanced",
+                "outputScope": "project",
+                "requestedGpu": "auto"
+            })),
+            extra: ExtraFields::new(),
+        },
+        limits: object(json!({
+            "rank": [4, 128],
+            "alpha": [1, 128],
+            "steps": [200, 6000],
+            // Dense-only training (no memory guard/checkpointing yet), so the training-resolution
+            // ceiling stays at 1024 even though inference supports up to 1536 (a follow-up).
+            "resolutions": [512, 768, 1024],
+            "batchSize": [1, 4],
+            "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
+            // The native mlx-gen-anima trainer reports `supports_lokr`; the inference loader applies
+            // LoKr through the shared `apply_anima_adapters` seam (sc-10521).
+            "networkTypes": ["lora", "lokr"],
+            "lrSchedulers": ["constant", "linear", "cosine"],
+            "outputScopes": ["project", "global"]
+        })),
+        ui: object(json!({
+            "label": "Anima LoRA",
+            "description": "Train an anime image LoRA for the Anima base model (Cosmos-Predict2 DiT + text conditioner).",
+            "recommendedFor": ["character", "style"]
+        })),
+        extra: ExtraFields::new(),
+    }
+}
+
+/// Build an Anima image LoRA/LoKr preset. The flow-match sampling + caching knobs live on the target
+/// defaults, so the preset overrides only the optimizer + quality label and whatever the `mutate`
+/// closure tweaks (rank/alpha/steps/LR).
+fn anima_preset<F>(
+    target: &TrainingTarget,
+    id: &str,
+    name: &str,
+    recommended_for: &[&str],
+    optimizer_quality: (&str, &str),
+    mutate: F,
+    ui: JsonObject,
+) -> TrainingPreset
+where
+    F: FnOnce(TrainingConfig) -> TrainingConfig,
+{
+    let (optimizer, quality_preset) = optimizer_quality;
+    let mut config = mutate(target.defaults.clone());
+    config.optimizer = optimizer.to_owned();
+    config
+        .advanced
+        .insert("qualityPreset".to_owned(), json!(quality_preset));
+    TrainingPreset {
+        id: id.to_owned(),
+        version: 1,
+        target_id: target.id.clone(),
+        name: name.to_owned(),
+        recommended_for: recommended_for
+            .iter()
+            .map(|value| (*value).to_owned())
+            .collect(),
+        optimizer: optimizer.to_owned(),
+        quality_preset: quality_preset.to_owned(),
+        config,
+        ui,
+        extra: ExtraFields::new(),
+    }
 }
 
 #[cfg(test)]

--- a/crates/sceneworks-core/tests/training_contracts.rs
+++ b/crates/sceneworks-core/tests/training_contracts.rs
@@ -138,6 +138,7 @@ fn builtin_targets_gate_network_types() {
             "krea_2_raw_lora",
             "sd3_5_large_lora",
             "sd3_5_medium_lora",
+            "anima_base_lora",
             "wan_lora"
         ]
     );

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -648,6 +648,13 @@ pub(crate) const TRAINER_IDS: &[&str] = &[
     "wan2_2_ti2v_5b",
     "wan2_2_t2v_14b",
     "wan2_2_i2v_14b",
+    // Anima (Cosmos-Predict2 DiT + AnimaTextConditioner; epic 10512, sc-10522): the `mlx-gen-anima`
+    // trainer registers LoRA/LoKr under the same ids as the inference generators of the three variants
+    // (base/aesthetic/turbo). mlx-only (no candle/torch Anima trainer). The trained adapter targets the
+    // DiT AND the bundled `llm_adapter` conditioner (508 targets), applying back via `apply_anima_adapters`.
+    "anima_base",
+    "anima_aesthetic",
+    "anima_turbo",
 ];
 
 /// A [`ModelRow`] paired with the linked gen_core descriptor for its engine id — the merged

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -350,6 +350,15 @@ fn engine_trainer_id(plan: &TrainingPlan) -> Option<&'static str> {
             "wan_2_2_i2v_14b" => Some("wan2_2_i2v_14b"),
             _ => None,
         },
+        // Anima (epic 10512, sc-10522): the `mlx-gen-anima` LoRA/LoKr trainer registers under the same
+        // id as the inference generator of the training base. All three variants share one architecture,
+        // so a LoRA trained on any applies back to every variant via `apply_anima_adapters`; the base
+        // model selects which variant's dense weights the trainer loads (default `anima_base`).
+        "anima_lora" => match plan.target.base_model.as_str() {
+            "anima_aesthetic" => Some("anima_aesthetic"),
+            "anima_turbo" => Some("anima_turbo"),
+            _ => Some("anima_base"),
+        },
         _ => None,
     }
 }
@@ -2064,6 +2073,11 @@ mod tests {
             // registers under the inference-generator id of each base.
             ("sd3_lora", "sd3_5_large", Some("sd3_5_large")),
             ("sd3_lora", "sd3_5_medium", Some("sd3_5_medium")),
+            // Anima (sc-10522): the `anima_lora` kernel maps to the trainer registered under the
+            // inference-generator id of the training-base variant; `anima_base` is the default.
+            ("anima_lora", "anima_base", Some("anima_base")),
+            ("anima_lora", "anima_aesthetic", Some("anima_aesthetic")),
+            ("anima_lora", "anima_turbo", Some("anima_turbo")),
             // Unknown SD3.5 base model variant (e.g. Turbo is NOT a training base).
             ("sd3_lora", "sd3_5_large_turbo", None),
             // Unknown A14B base model variant.

--- a/tests/fixtures/rust_migration_contracts/training/preset-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/preset-registry.json
@@ -1186,6 +1186,142 @@
         "description": "Higher-step style LoRA for Wan2.2 14B I2V.",
         "order": 20
       }
+    },
+    {
+      "id": "anima_base_lora.character.adamw8bit.balanced",
+      "version": 1,
+      "targetId": "anima_base_lora",
+      "name": "Character balanced",
+      "recommendedFor": [
+        "character"
+      ],
+      "optimizer": "adamw8bit",
+      "qualityPreset": "balanced",
+      "config": {
+        "rank": 16,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 3000,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": false,
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 0,
+          "sampleGuidanceScale": 4.5,
+          "sampleSteps": 10,
+          "timestepBias": "high_noise",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
+        }
+      },
+      "ui": {
+        "default": true,
+        "description": "Balanced first run for 12-25 clean character images on the Anima base model (trains the DiT + llm_adapter conditioner).",
+        "order": 10
+      }
+    },
+    {
+      "id": "anima_base_lora.character.adamw8bit.conservative",
+      "version": 1,
+      "targetId": "anima_base_lora",
+      "name": "Character conservative",
+      "recommendedFor": [
+        "character"
+      ],
+      "optimizer": "adamw8bit",
+      "qualityPreset": "conservative",
+      "config": {
+        "rank": 8,
+        "alpha": 8,
+        "learningRate": 0.00005,
+        "steps": 3000,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": false,
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "conservative",
+          "requestedGpu": "auto",
+          "sampleEvery": 0,
+          "sampleGuidanceScale": 4.5,
+          "sampleSteps": 10,
+          "timestepBias": "high_noise",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
+        }
+      },
+      "ui": {
+        "description": "Lower-rank, lower-LR Anima character preset for tight identity datasets.",
+        "order": 20
+      }
+    },
+    {
+      "id": "anima_base_lora.style.adamw8bit.balanced",
+      "version": 1,
+      "targetId": "anima_base_lora",
+      "name": "Style balanced",
+      "recommendedFor": [
+        "style"
+      ],
+      "optimizer": "adamw8bit",
+      "qualityPreset": "balanced",
+      "config": {
+        "rank": 32,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 3000,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": false,
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 0,
+          "sampleGuidanceScale": 4.5,
+          "sampleSteps": 10,
+          "timestepBias": "high_noise",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
+        }
+      },
+      "ui": {
+        "description": "Higher-capacity Anima style LoRA for anime texture and visual-language transfer.",
+        "order": 30
+      }
     }
   ]
 }

--- a/tests/fixtures/rust_migration_contracts/training/target-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/target-registry.json
@@ -689,6 +689,97 @@
       }
     },
     {
+      "id": "anima_base_lora",
+      "name": "Anima LoRA",
+      "modality": "image",
+      "outputKind": "lora",
+      "family": "anima",
+      "baseModel": "anima_base",
+      "baseModelRepo": "circlestone-labs/Anima",
+      "kernel": "anima_lora",
+      "defaults": {
+        "rank": 16,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 3000,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": false,
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 0,
+          "sampleGuidanceScale": 4.5,
+          "sampleSteps": 10,
+          "timestepBias": "high_noise",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
+        }
+      },
+      "limits": {
+        "alpha": [
+          1,
+          128
+        ],
+        "batchSize": [
+          1,
+          4
+        ],
+        "lrSchedulers": [
+          "constant",
+          "linear",
+          "cosine"
+        ],
+        "networkTypes": [
+          "lora",
+          "lokr"
+        ],
+        "optimizers": [
+          "adamw8bit",
+          "adamw",
+          "adam",
+          "prodigyopt",
+          "rose"
+        ],
+        "outputScopes": [
+          "project",
+          "global"
+        ],
+        "rank": [
+          4,
+          128
+        ],
+        "resolutions": [
+          512,
+          768,
+          1024
+        ],
+        "steps": [
+          200,
+          6000
+        ]
+      },
+      "ui": {
+        "description": "Train an anime image LoRA for the Anima base model (Cosmos-Predict2 DiT + text conditioner).",
+        "label": "Anima LoRA",
+        "recommendedFor": [
+          "character",
+          "style"
+        ]
+      }
+    },
+    {
       "id": "ltx_video_lora",
       "name": "LTX-2.3 Video LoRA",
       "modality": "video",


### PR DESCRIPTION
## sc-10522 — SceneWorks wiring for the Anima trainer (epic 10512)

Static training-routing + preset wiring for the native `mlx-gen-anima` LoRA/LoKr trainer (mlx-gen PR SceneWorks/mlx-gen#678). **No `mlx-gen` rev bump and no MODEL_TABLE / IMAGE_MODEL_CAPS / manifest rows** — sc-10523 owns those.

### Changes
- **`TRAINER_IDS`** (`engines.rs`): add `anima_base` / `anima_aesthetic` / `anima_turbo` — training capability lights up per-variant once the mlx backend registers the Anima trainer.
- **`engine_trainer_id`** (`training_jobs.rs`): map the `anima_lora` kernel → the trainer id of the training-base variant (default `anima_base`), + test coverage. One architecture across variants, so the adapter applies back via `apply_anima_adapters`.
- **Routing** (`catalog.rs`): `anima_lora` added to `MLX_ROUTED_TRAINING_KERNELS` and `MLX_ONLY_TRAINING_KERNELS` (Rust-native, no torch/candle path); order-pinned `EXPECTED_*` snapshots updated.
- **Preset registry** (`training.rs`): new `anima_base_lora` image LoRA/LoKr target (family `anima`, base `anima_base`, `networkTypes: [lora, lokr]`) + three presets (character balanced [default], character conservative, style balanced). Regenerated `target-registry.json` / `preset-registry.json`. Quality stays a preset tier, not a free axis (sc-10483). Dense-only defaults + res capped at 1024 match the current trainer (gradient checkpointing / memory guard / preview sampling are follow-ups).

### Checks
`fmt --all --check`, `clippy --all-targets -D warnings`, and the touched crates' tests all green: `sceneworks-core` (training_contracts 32, `routed_model_lists_match_snapshot`, `builtin_targets_gate_network_types`, jobs_store 138), `sceneworks-worker` (`engine_trainer_id`), `sceneworks-rust-api` (training targets/presets routes). Full workspace `cargo test` not run exhaustively (build-disk/time), but every crate this change touches is green.

⚠️ **sc-10523 also edits `engines.rs`** (adds the Anima MODEL_TABLE rows + bumps the mlx-gen `rev` to include the trainer) and will need to rebase on this branch.

**DO NOT MERGE.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)