### PR TITLE
fix(presets): derive editor Aspect/Resolution/Duration/Frames from the model's limits (sc-10589)

### DIFF
--- a/apps/web/src/samplerOptions.js
+++ b/apps/web/src/samplerOptions.js
@@ -87,7 +87,7 @@ function uniqueOrdered(values, order) {
 // `candle.limits` override when present, else the base `limits` (epic 7114 P5
 // per-model-per-backend gating). `backend` is the active worker's backend
 // ("mlx" | "candle"); a null/unknown backend falls back to the base menu.
-function effectiveLimits(model, backend) {
+export function effectiveLimits(model, backend) {
   const override = backend ? model?.[backend]?.limits : null;
   return override ?? model?.limits;
 }

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -16,6 +16,7 @@ import {
 import {
   SAMPLER_LABELS,
   SCHEDULER_LABELS,
+  effectiveLimits,
   samplerOptionsFromModel,
   schedulerOptionsFromModel,
 } from "../samplerOptions.js";
@@ -52,8 +53,37 @@ const CAPABILITY_FLAGS = [
   ["first_last_frame", "first-last"],
 ];
 
-const imageAspectChoices = ["1024x1024", "1536x1024", "1024x1536", "2048x1152"];
-const videoResolutionChoices = ["768x512", "1280x720", "720x1280"];
+// Fallbacks for a model that declares no `limits.resolutions` / `.durations` / `.fps`
+// (e.g. a user-imported checkpoint). A model that DOES declare them drives the menu
+// instead — the studios read the same manifest keys, so the editor must not offer a
+// value the launched studio would silently clamp away (sc-10589).
+const imageAspectFallback = ["1024x1024", "1536x1024", "1024x1536", "2048x1152"];
+const videoResolutionFallback = ["768x512", "1280x720", "720x1280"];
+const durationFallback = [3, 4, 6, 8, 10, 12];
+const fpsFallback = [24, 25, 30];
+
+// The resolution/aspect menu the selected model honors. Reads the model's effective
+// `limits.resolutions` (base `limits`, since a preset is backend-agnostic — it can be
+// launched on either worker), falling back to the static list when the model is silent.
+function resolutionOptionsForModel(model, isVideo) {
+  const values = effectiveLimits(model)?.resolutions;
+  if (Array.isArray(values) && values.length) {
+    return values.map(String);
+  }
+  return isVideo ? videoResolutionFallback : imageAspectFallback;
+}
+
+// Video-only menus. Durations/fps are numbers in the manifest; the form stores them as
+// strings, so keep a numeric list here and stringify at the option boundary.
+function durationOptionsForModel(model) {
+  const values = effectiveLimits(model)?.durations;
+  return Array.isArray(values) && values.length ? values : durationFallback;
+}
+
+function fpsOptionsForModel(model) {
+  const values = effectiveLimits(model)?.fps;
+  return Array.isArray(values) && values.length ? values : fpsFallback;
+}
 
 const SORT_CHOICES = [
   ["updated", "Recently updated"],
@@ -85,6 +115,18 @@ const EDITOR_OWNED_DEFAULTS = [
 
 function segmentByKey(key) {
   return WORKFLOW_SEGMENTS.find((segment) => segment.key === key) ?? WORKFLOW_SEGMENTS[0];
+}
+
+// A stored default the selected model no longer lists (an in-the-wild preset, or a
+// same-type model switch that hasn't cleared yet) still has to be visible and selected
+// so the user sees what the preset carries. Flag it rather than blank the select; the
+// save stays blocked (defaultValueErrors) until they pick a supported option. Returns
+// null when the value is blank or already in the menu.
+function outOfMenuOption(value, menu, format) {
+  if (value === "" || menu.map(String).includes(String(value))) {
+    return null;
+  }
+  return <option value={value}>{format(value)} — not in this model’s list</option>;
 }
 
 // Invert the (workflow, defaults.mode) pair back into the segment the editor shows.
@@ -181,7 +223,11 @@ function loraLabel(lora) {
 // The knobs the backend range-checks (recipe_presets.rs validate_recipe_preset_defaults).
 // Catching them here means the CTA explains itself instead of the save round-tripping
 // into a 400. Blank always means "no default" and is dropped by buildPayload.
-function defaultValueErrors(form, isVideo) {
+//
+// `options` carries the menus the selected model actually honors. A stored value outside
+// its menu is a default the model would silently clamp away, so it blocks the save until
+// the user picks a supported one — the in-menu flag shows what's there but can't be kept.
+function defaultValueErrors(form, isVideo, options) {
   const errors = [];
   const checkNumber = (value, label, { min, max, integer = false }) => {
     if (value === "") {
@@ -192,12 +238,23 @@ function defaultValueErrors(form, isVideo) {
       errors.push(`${label} must be ${integer ? "a whole number " : ""}between ${min} and ${max}.`);
     }
   };
+  const checkInMenu = (value, label, menu) => {
+    if (value === "" || !menu) {
+      return;
+    }
+    if (!menu.map(String).includes(String(value))) {
+      errors.push(`${label} ${value} isn't one this model supports — pick a listed option.`);
+    }
+  };
   checkNumber(form.count, "Variations", { min: 1, max: 8, integer: true });
   checkNumber(form.steps, "Steps", { min: 1, max: 200, integer: true });
   checkNumber(form.guidanceScale, "Guidance", { min: 0, max: 60 });
+  checkInMenu(form.resolution, isVideo ? "Resolution" : "Aspect", options?.resolutions);
   if (isVideo) {
     checkNumber(form.duration, "Duration", { min: 1, max: 120 });
     checkNumber(form.fps, "Frames", { min: 1, max: 240 });
+    checkInMenu(form.duration, "Duration", options?.durations);
+    checkInMenu(form.fps, "Frames", options?.fps);
   }
   return errors;
 }
@@ -260,9 +317,17 @@ export function PresetManagerScreen() {
   const samplerMenu = selectedModel ? samplerOptionsFromModel(selectedModel) : [];
   const schedulerMenu = selectedModel ? schedulerOptionsFromModel(selectedModel) : [];
 
+  // Resolution/duration/fps menus come from the selected model's effective limits, the
+  // same source the studios read — so the editor can't offer a default the studio would
+  // silently clamp away (sc-10589).
+  const resolutionOptions = resolutionOptionsForModel(selectedModel, isVideo);
+  const durationOptions = durationOptionsForModel(selectedModel);
+  const fpsOptions = fpsOptionsForModel(selectedModel);
+  const defaultsOptions = { resolutions: resolutionOptions, durations: durationOptions, fps: fpsOptions };
+
   const validation = presetValidation({ loras: form.loras }, loras, selectedModel);
   const validationMessage = editable ? presetValidationMessage(validation) : "";
-  const valueErrors = defaultValueErrors(form, isVideo);
+  const valueErrors = defaultValueErrors(form, isVideo, defaultsOptions);
   const dirty = editing && !creating && JSON.stringify(form) !== JSON.stringify(baseline);
 
   // Two kinds of "can't save" (sc-10500 split). A REQUIREMENT is an unfilled field the
@@ -325,6 +390,11 @@ export function PresetManagerScreen() {
         const nextSegment = nextSegments.some((segment) => segment.key === current.segment)
           ? previousSegment
           : (nextSegments[0] ?? previousSegment);
+        const nextIsVideo = nextSegment.type === "video";
+        // Only the value survives a model switch if the new model still lists it; an
+        // out-of-menu default (blank untouched) would otherwise persist and be clamped.
+        const keepIfListed = (val, menu) => (val !== "" && menu.map(String).includes(String(val)) ? val : "");
+        const nextResolutions = resolutionOptionsForModel(nextModel, nextIsVideo);
         return {
           ...current,
           model: value,
@@ -341,8 +411,16 @@ export function PresetManagerScreen() {
           scheduler: "",
           // Image and video defaults don't transfer: an image resolution isn't in the
           // video resolution menu (and vice versa), and count/duration/fps are exclusive.
+          // On a same-type switch keep what the new model still lists and drop the rest,
+          // so switching to a model with a narrower menu clears a now-invalid default.
           ...(nextSegment.type === previousSegment.type
-            ? {}
+            ? nextIsVideo
+              ? {
+                  resolution: keepIfListed(current.resolution, nextResolutions),
+                  duration: keepIfListed(current.duration, durationOptionsForModel(nextModel)),
+                  fps: keepIfListed(current.fps, fpsOptionsForModel(nextModel)),
+                }
+              : { resolution: keepIfListed(current.resolution, nextResolutions) }
             : { resolution: "", count: "", duration: "", fps: "" }),
         };
       }
@@ -1018,7 +1096,6 @@ export function PresetManagerScreen() {
   }
 
   function renderDefaults() {
-    const resolutionChoices = isVideo ? videoResolutionChoices : imageAspectChoices;
     return (
       <div className="preset-form-section">
         {renderSectionHead("Defaults", "The settings the Studio starts on. All still editable per run.")}
@@ -1027,7 +1104,8 @@ export function PresetManagerScreen() {
             <span>{isVideo ? "Resolution" : "Aspect"}</span>
             <select disabled={!editable} onChange={(event) => updateField("resolution", event.target.value)} value={form.resolution}>
               <option value="">No default</option>
-              {resolutionChoices.map((value) => (
+              {outOfMenuOption(form.resolution, resolutionOptions, (value) => value.replace("x", " × "))}
+              {resolutionOptions.map((value) => (
                 <option key={value} value={value}>
                   {value.replace("x", " × ")}
                 </option>
@@ -1040,7 +1118,8 @@ export function PresetManagerScreen() {
                 <span>Duration</span>
                 <select disabled={!editable} onChange={(event) => updateField("duration", event.target.value)} value={form.duration}>
                   <option value="">No default</option>
-                  {[3, 4, 6, 8, 10, 12].map((d) => (
+                  {outOfMenuOption(form.duration, durationOptions, (value) => `${value}s`)}
+                  {durationOptions.map((d) => (
                     <option key={d} value={String(d)}>
                       {d}s
                     </option>
@@ -1051,7 +1130,8 @@ export function PresetManagerScreen() {
                 <span>Frames</span>
                 <select disabled={!editable} onChange={(event) => updateField("fps", event.target.value)} value={form.fps}>
                   <option value="">No default</option>
-                  {[24, 25, 30].map((f) => (
+                  {outOfMenuOption(form.fps, fpsOptions, (value) => `${value} fps`)}
+                  {fpsOptions.map((f) => (
                     <option key={f} value={String(f)}>
                       {f} fps
                     </option>

--- a/apps/web/src/screens/PresetManagerScreen.test.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.test.jsx
@@ -13,12 +13,24 @@ const imageModel = {
   downloadSizeLabel: "5.1 GB",
 };
 
+// A second image model whose manifest declares a narrow resolution menu — the source
+// the editor must derive the Aspect list from (sc-10589).
+const fluxModel = {
+  id: "flux_dev",
+  name: "FLUX [dev]",
+  type: "image",
+  family: "flux",
+  capabilities: ["text_to_image"],
+  limits: { resolutions: ["768x768", "1024x1024", "1280x720", "720x1280"] },
+};
+
 const videoModel = {
   id: "ltx_2_3",
   name: "LTX",
   type: "video",
   family: "ltx-video",
   capabilities: ["text_to_video", "image_to_video"],
+  limits: { resolutions: ["768x512", "1280x720"], durations: [4, 6, 8], fps: [24, 25] },
 };
 
 const presets = [
@@ -234,6 +246,70 @@ describe("PresetManagerScreen", () => {
       guidanceMethod: "cfg_pp",
       prompt: "a literal prompt",
     });
+  });
+
+  // sc-10589: the Aspect/Resolution/Duration/Frames menus come from the selected model's
+  // effective limits, so the editor can't offer a default the studio would clamp away.
+  it("derives the Aspect menu from the selected model's limits.resolutions", async () => {
+    await render(baseContext({ imageModels: [imageModel, fluxModel] }));
+    await clickButton("New preset");
+
+    // z_image_turbo declares no limits → the static fallback list.
+    const aspectValues = () => [...field(container, "Aspect").options].map((option) => option.value);
+    expect(aspectValues()).toEqual(["", "1024x1024", "1536x1024", "1024x1536", "2048x1152"]);
+
+    // flux_dev declares a narrower menu — the editor follows it.
+    await changeField(field(container, "Model"), "flux_dev");
+    expect(aspectValues()).toEqual(["", "768x768", "1024x1024", "1280x720", "720x1280"]);
+  });
+
+  it("derives video Resolution/Duration/Frames menus and clears a now-invalid value on switch", async () => {
+    await render();
+    await clickButton("New preset");
+    await changeField(field(container, "Model"), "ltx_2_3");
+
+    // The video model's manifest lists these exactly.
+    expect([...field(container, "Resolution").options].map((o) => o.value)).toEqual(["", "768x512", "1280x720"]);
+    expect([...field(container, "Duration").options].map((o) => o.value)).toEqual(["", "4", "6", "8"]);
+    expect([...field(container, "Frames").options].map((o) => o.value)).toEqual(["", "24", "25"]);
+  });
+
+  it("clears a resolution the newly selected same-type model no longer lists", async () => {
+    await render(baseContext({ imageModels: [imageModel, fluxModel] }));
+    await clickButton("New preset");
+
+    // 1536x1024 is in z_image_turbo's fallback menu but not in flux_dev's.
+    await changeField(field(container, "Aspect"), "1536x1024");
+    expect(field(container, "Aspect").value).toBe("1536x1024");
+
+    await changeField(field(container, "Model"), "flux_dev");
+    expect(field(container, "Aspect").value).toBe("");
+  });
+
+  it("flags an out-of-menu stored resolution and blocks the save until it's fixed", async () => {
+    const stale = {
+      id: "stale",
+      name: "Stale",
+      scope: "global",
+      workflow: "text_to_image",
+      model: "flux_dev",
+      defaults: { resolution: "2048x1152" },
+    };
+    await render(baseContext({ imageModels: [imageModel, fluxModel], presets: [stale] }));
+    await act(async () => {
+      container.querySelector(".preset-card .secondary-action").click();
+    });
+
+    const aspect = field(container, "Aspect");
+    // The stored value is shown and selected, flagged rather than blanked.
+    expect(aspect.value).toBe("2048x1152");
+    expect(aspect.textContent).toContain("not in this model");
+    expect(container.textContent).toContain("isn't one this model supports");
+    expect([...container.querySelectorAll("button[type='submit']")].every((b) => b.disabled)).toBe(true);
+
+    // Picking a supported option unblocks the save.
+    await changeField(aspect, "1024x1024");
+    expect([...container.querySelectorAll("button[type='submit']")].some((b) => !b.disabled)).toBe(true);
   });
 
   it("shows Draft for a new preset and Unsaved changes once an existing one is edited", async () => {


### PR DESCRIPTION
## What

The Preset editor's **Defaults** menus (Aspect/Resolution, Duration, Frames) were module-level constants, independent of the selected model. A preset could therefore store a `defaults.resolution` the pinned model can't render — e.g. a `flux_dev` preset saved at `1024x1536`, which the backend accepts (`validate_recipe_preset_defaults` only shape/range-checks) but Image Studio silently clamps to `1024x1024` on launch. The preset said one thing, the studio did another, and nothing told the user.

## Fix

Derive the menus from the selected model's effective `limits.resolutions` / `.durations` / `.fps` — the same manifest keys the studios read (`effectiveLimits`, now exported from `samplerOptions.js`). A preset is backend-agnostic, so this reads the base `limits` (matching the editor's existing backend-less `samplerOptionsFromModel(model)` call).

- **Menu source** — Aspect/Resolution, Duration, Frames come from the model's effective `limits`, falling back to the prior static lists when the model declares none (a user-imported checkpoint).
- **Re-derive + clear on switch** — a same-type model switch now clears a stored value the new model no longer lists (the redesign already cleared on an image↔video switch; this extends it to same-type switches).
- **Flag, don't blank** — an in-the-wild preset carrying an out-of-menu value shows it as a flagged `… — not in this model's list` option rather than blanking the select, the same treatment the redesign gave an uninstalled pinned model.
- **Block the bad save** — `defaultValueErrors` now rejects an out-of-menu resolution/duration/fps, so the CTA explains itself and no preset can be saved with a default the pinned model won't honor.

## Acceptance (sc-10589)

- [x] Aspect/Resolution, Duration, Frames options come from the selected model's effective `limits`.
- [x] Changing model re-derives them and clears a now-invalid stored value.
- [x] A preset carrying an out-of-menu value shows it, flagged, instead of blanking.
- [x] No preset can be saved with a default the pinned model won't honor.

## Testing

`PresetManagerScreen.test.jsx` — 4 new cases (derive image menu, derive video menus, clear-on-switch, flag+block+unblock) + 8 existing, all green. `ImageStudio` (54), `VideoStudio` (30), `App.videoPresets` (8), `samplerOptions` (12) unaffected. Pre-existing, unrelated: `App.queue`/`vite build` fail on a missing `recharts` dep in the local install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)