### PR TITLE
feat(presets): add lastUsedAt so "Recently used" sort is real (sc-10520)

### DIFF
--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -232,6 +232,10 @@ pub(crate) async fn apply_recipe_preset_to_image_payload(
         .find(|item| item.get("id").and_then(Value::as_str) == Some(preset_id))
         .ok_or_else(|| ApiError::bad_request("Recipe preset not found"))?;
 
+    // Submitting a job with a preset is the strong "used" signal, and the one place the
+    // backend already sees the resolved preset id — stamp lastUsedAt now (sc-10520).
+    stamp_recipe_preset_used(state, preset_id).await;
+
     let expanded_prompt = preset_prompt(&payload.prompt, preset);
     job_payload.insert("prompt".to_owned(), Value::String(expanded_prompt));
     if payload.model == default_image_model() {
@@ -383,6 +387,10 @@ pub(crate) async fn apply_recipe_preset_to_video_payload(
         .iter()
         .find(|item| item.get("id").and_then(Value::as_str) == Some(preset_id))
         .ok_or_else(|| ApiError::bad_request("Recipe preset not found"))?;
+
+    // Submitting a job with a preset is the strong "used" signal, and the one place the
+    // backend already sees the resolved preset id — stamp lastUsedAt now (sc-10520).
+    stamp_recipe_preset_used(state, preset_id).await;
 
     let expanded_prompt = preset_prompt(&payload.prompt, preset);
     job_payload.insert("prompt".to_owned(), Value::String(expanded_prompt));

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -156,8 +156,9 @@ use dto::{
 };
 mod manifest;
 use manifest::{
-    load_manifest_entries, merge_entries_by_id, merge_object, mutate_manifest_entries,
-    remove_catalog_manifest_entry, ManifestCache,
+    acquire_manifest_file_lock, load_manifest_entries, manifest_write_lock, merge_entries_by_id,
+    merge_object, mutate_manifest_entries, remove_catalog_manifest_entry, write_manifest_atomic,
+    ManifestCache,
 };
 #[cfg(test)]
 use manifest::{strip_jsonc_comments, API_MANAGED_MANIFEST_HEADER};
@@ -186,7 +187,8 @@ mod recipe_presets;
 use recipe_presets::{
     create_recipe_preset, delete_recipe_preset, duplicate_recipe_preset, get_recipe_preset,
     list_recipe_presets, preset_lora_id, preset_lora_weight, preset_prompt, recipe_preset_catalog,
-    recipe_preset_catalog_with, recipe_preset_loras, serialize_preset_lora, update_recipe_preset,
+    recipe_preset_catalog_with, recipe_preset_loras, serialize_preset_lora,
+    stamp_recipe_preset_used, update_recipe_preset,
 };
 mod prompt_batches;
 use prompt_batches::{

--- a/apps/rust-api/src/manifest.rs
+++ b/apps/rust-api/src/manifest.rs
@@ -13,7 +13,7 @@ const MANIFEST_LOCK_POLL: std::time::Duration = std::time::Duration::from_millis
 /// RAII holder for the cross-process advisory exclusive lock on a `<manifest>.lock`
 /// sibling. Released when the file handle drops. Acquired on a blocking thread since
 /// flock is synchronous (see [`acquire_manifest_file_lock`]).
-struct ManifestFileLock {
+pub(crate) struct ManifestFileLock {
     _file: std::fs::File,
 }
 
@@ -27,7 +27,9 @@ fn manifest_lock_path(manifest_path: &FsPath) -> PathBuf {
 }
 
 /// Acquire the cross-process manifest lock, off the async runtime (flock blocks).
-async fn acquire_manifest_file_lock(path: &FsPath) -> Result<ManifestFileLock, ApiError> {
+pub(crate) async fn acquire_manifest_file_lock(
+    path: &FsPath,
+) -> Result<ManifestFileLock, ApiError> {
     if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent).await.map_err(|error| {
             ApiError::internal(format!(

--- a/apps/rust-api/src/recipe_presets.rs
+++ b/apps/rust-api/src/recipe_presets.rs
@@ -281,6 +281,23 @@ pub(crate) async fn recipe_preset_catalog_with(
     for preset in presets.iter_mut() {
         finalize_recipe_preset_entry(preset, models)?;
     }
+    // Overlay `lastUsedAt` from the usage side store (sc-10520). The store is the source
+    // of truth for recency: builtin presets are read-only so their usage can't live in
+    // their manifest, so every scope reads it here. A store value always wins over any
+    // stale `lastUsedAt` carried in a writable manifest.
+    let usage = load_recipe_preset_usage(state).await;
+    if !usage.is_empty() {
+        for preset in presets.iter_mut() {
+            let Some(id) = preset.get("id").and_then(Value::as_str).map(str::to_owned) else {
+                continue;
+            };
+            if let Some(last_used) = usage.get(&id).and_then(Value::as_str) {
+                if let Some(object) = preset.as_object_mut() {
+                    object.insert("lastUsedAt".to_owned(), Value::String(last_used.to_owned()));
+                }
+            }
+        }
+    }
     presets.sort_by(|left, right| {
         let left_key = (
             recipe_preset_scope_order(left.get("scope").and_then(Value::as_str)),
@@ -516,6 +533,9 @@ pub(crate) fn strip_recipe_preset_write_context(payload: &mut Value) {
         object.remove("manifestPath");
         object.remove("builtInLoras");
         object.remove("appliedDefaults");
+        // lastUsedAt is API-managed via the usage side store (sc-10520); a client
+        // echoing it back on update must not be allowed to overwrite it.
+        object.remove("lastUsedAt");
     }
 }
 
@@ -524,6 +544,9 @@ pub(crate) fn strip_recipe_preset_runtime_fields(payload: &mut Value) {
         object.remove("manifestPath");
         object.remove("builtInLoras");
         object.remove("appliedDefaults");
+        // A duplicate is a brand-new, never-used preset — drop the source's recency
+        // so it sorts as unused until applied to a job (sc-10520).
+        object.remove("lastUsedAt");
     }
 }
 
@@ -1044,4 +1067,85 @@ pub(crate) fn preset_name_exists(entries: &[Value], name: &str) -> bool {
     entries
         .iter()
         .any(|entry| entry.get("name").and_then(Value::as_str) == Some(name))
+}
+
+// -- Recipe preset usage side store (sc-10520) ------------------------------------
+//
+// `lastUsedAt` is persisted in a dedicated `recipe-preset-usage.json` keyed by preset
+// id, NOT in the preset manifests, for two reasons: builtin presets are read-only so
+// their usage can't live in `builtin.recipe-presets.jsonc`, and rewriting a JSONC
+// manifest on the generate hot path is too costly. The store is overlaid onto the
+// catalog on read (see `recipe_preset_catalog_with`) so every scope can surface it.
+
+pub(crate) fn recipe_preset_usage_path(state: &AppState) -> PathBuf {
+    state
+        .settings
+        .config_dir
+        .join("manifests")
+        .join("recipe-preset-usage.json")
+}
+
+/// Load the usage side store as an id → RFC3339 map. Best-effort: a missing or malformed
+/// store yields an empty map so a usage-store problem can never fail a catalog read.
+pub(crate) async fn load_recipe_preset_usage(state: &AppState) -> JsonObject {
+    let path = recipe_preset_usage_path(state);
+    let Ok(payload) = tokio::fs::read_to_string(&path).await else {
+        return JsonObject::new();
+    };
+    serde_json::from_str::<Value>(&payload)
+        .ok()
+        .as_ref()
+        .and_then(|value| value.get("lastUsed"))
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default()
+}
+
+/// Record `preset_id` as used at the current instant in the usage side store. Best-effort:
+/// serialized by the shared manifest lock (in-process mutex + cross-process advisory lock)
+/// so concurrent job submits don't clobber one another, but any failure is logged and
+/// swallowed rather than failing the job the user actually asked for.
+pub(crate) async fn stamp_recipe_preset_used(state: &AppState, preset_id: &str) {
+    if let Err(error) = stamp_recipe_preset_used_inner(state, preset_id).await {
+        tracing::warn!(
+            preset_id,
+            error = %error.detail,
+            "failed to stamp recipe preset lastUsedAt"
+        );
+    }
+}
+
+async fn stamp_recipe_preset_used_inner(state: &AppState, preset_id: &str) -> Result<(), ApiError> {
+    let path = recipe_preset_usage_path(state);
+    let lock = manifest_write_lock(state, &path);
+    let _guard = lock.lock().await;
+    let _file_lock = acquire_manifest_file_lock(&path).await?;
+    let mut root = match tokio::fs::read_to_string(&path).await {
+        Ok(payload) => serde_json::from_str::<Value>(&payload)
+            .ok()
+            .and_then(|value| value.as_object().cloned())
+            .unwrap_or_default(),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => JsonObject::new(),
+        Err(error) => {
+            return Err(ApiError::internal(format!(
+                "Failed to read preset usage store {}: {error}",
+                path.display()
+            )))
+        }
+    };
+    let last_used = root
+        .entry("lastUsed".to_owned())
+        .or_insert_with(|| Value::Object(JsonObject::new()));
+    if !last_used.is_object() {
+        *last_used = Value::Object(JsonObject::new());
+    }
+    if let Some(map) = last_used.as_object_mut() {
+        map.insert(preset_id.to_owned(), Value::String(now_rfc3339()));
+    }
+    root.entry("schemaVersion".to_owned())
+        .or_insert_with(|| json!(1));
+    let payload = serde_json::to_string_pretty(&Value::Object(root)).map_err(|error| {
+        ApiError::internal(format!("Failed to encode preset usage store: {error}"))
+    })?;
+    write_manifest_atomic(&path, &format!("{payload}\n")).await
 }

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -5735,6 +5735,36 @@ async fn video_jobs_expand_recipe_presets_server_side() {
         video_job["payload"]["advanced"]["recipePresetId"],
         "dream_motion"
     );
+
+    // sc-10520: submitting the job stamped lastUsedAt into the usage side store, and it
+    // surfaces on the catalog read even though dream_motion is a read-only BUILTIN preset
+    // (its own manifest can't be rewritten). The store lives beside the manifests.
+    assert!(
+        config_dir.join("recipe-preset-usage.json").is_file(),
+        "job submit should create the recipe-preset usage store"
+    );
+    let (status, presets) = request(
+        app.clone(),
+        "GET",
+        &format!("/api/v1/recipe-presets?projectId={project_id}"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let dream = presets
+        .as_array()
+        .expect("presets list")
+        .iter()
+        .find(|preset| preset["id"] == "dream_motion")
+        .expect("dream_motion present");
+    assert_eq!(dream["scope"], "builtin");
+    assert!(
+        dream["lastUsedAt"]
+            .as_str()
+            .is_some_and(|value| !value.is_empty()),
+        "builtin preset should carry lastUsedAt after use, got {:?}",
+        dream["lastUsedAt"]
+    );
 }
 
 #[tokio::test]

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -56,6 +56,7 @@ const imageAspectChoices = ["1024x1024", "1536x1024", "1024x1536", "2048x1152"];
 const videoResolutionChoices = ["768x512", "1280x720", "720x1280"];
 
 const SORT_CHOICES = [
+  ["used", "Recently used"],
   ["updated", "Recently updated"],
   ["name", "Name"],
   ["scope", "Scope"],
@@ -547,6 +548,11 @@ export function PresetManagerScreen() {
       }
       if (sort === "scope") {
         return (scopeRank[a.scope] ?? 1) - (scopeRank[b.scope] ?? 1) || byName(a, b);
+      }
+      if (sort === "used") {
+        // Newest-used first; never-used presets (no lastUsedAt) sink to the bottom
+        // because "" sorts after any real timestamp under a descending compare.
+        return String(b.lastUsedAt ?? "").localeCompare(String(a.lastUsedAt ?? "")) || byName(a, b);
       }
       return String(b.updatedAt ?? "").localeCompare(String(a.updatedAt ?? "")) || byName(a, b);
     });

--- a/apps/web/src/screens/PresetManagerScreen.test.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.test.jsx
@@ -29,6 +29,7 @@ const presets = [
     workflow: "text_to_image",
     model: "z_image_turbo",
     updatedAt: "2026-07-09T00:00:00Z",
+    lastUsedAt: "2026-07-06T00:00:00Z",
     prompt: { prefix: "cinematic portrait of", suffix: ", 85mm" },
     defaults: { resolution: "1024x1024", count: 4, quality: "balanced" },
     loras: [{ id: "global_detail", weight: 0.7 }],
@@ -40,6 +41,7 @@ const presets = [
     workflow: "edit_image",
     model: "z_image_turbo",
     updatedAt: "2026-07-05T00:00:00Z",
+    lastUsedAt: "2026-07-08T00:00:00Z",
     ui: { description: "cel shading" },
   },
   {
@@ -123,8 +125,7 @@ describe("PresetManagerScreen", () => {
     await render();
     const sortSelect = () => container.querySelector("select[aria-label='Sort presets']");
 
-    // Default sort is `updatedAt` descending — there is no lastUsedAt to sort on (sc-10520).
-    // Cinematic 07-09, Anime 07-05, Bridge 07-03.
+    // Default sort is `updatedAt` descending: Cinematic 07-09, Anime 07-05, Bridge 07-03.
     expect(cardNames()).toEqual(["Cinematic Portrait", "Anime Key Visual", "Bridge Clip"]);
 
     await changeField(sortSelect(), "name");
@@ -133,6 +134,16 @@ describe("PresetManagerScreen", () => {
     // global (Bridge, Cinematic) before project (Anime), name-tiebroken within a scope.
     await changeField(sortSelect(), "scope");
     expect(cardNames()).toEqual(["Bridge Clip", "Cinematic Portrait", "Anime Key Visual"]);
+  });
+
+  it("sorts by recently used, sinking never-used presets to the bottom (sc-10520)", async () => {
+    await render();
+    const sortSelect = () => container.querySelector("select[aria-label='Sort presets']");
+
+    // Anime used 07-08, Cinematic used 07-06, Bridge never used (no lastUsedAt) → last,
+    // even though Bridge's ordering differs under `updated`/`name`/`scope`.
+    await changeField(sortSelect(), "used");
+    expect(cardNames()).toEqual(["Anime Key Visual", "Cinematic Portrait", "Bridge Clip"]);
   });
 
   it("hands a preset to the studio that can run it", async () => {

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -1591,6 +1591,12 @@ pub struct RecipePresetManifestEntry {
     pub archived: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub order: Option<i64>,
+    /// RFC3339 timestamp of the last time this preset was applied to a submitted job.
+    /// Powers the Manager's "Recently used" sort. The API sources it from a usage
+    /// side-store and overlays it on read (so read-only builtin presets can carry it
+    /// too); `None` means never used and sorts last.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_used_at: Option<String>,
     pub workflow: RecipePresetWorkflow,
     pub model: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/packages/schemas/recipe-preset.schema.json
+++ b/packages/schemas/recipe-preset.schema.json
@@ -18,6 +18,11 @@
           "name": { "type": "string", "minLength": 1 },
           "scope": { "type": "string", "enum": ["builtin", "global", "project"] },
           "archived": { "type": "boolean" },
+          "lastUsedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "RFC3339 timestamp of the last time this preset was applied to a submitted job, powering the Manager's 'Recently used' sort. API-managed: sourced from a usage side-store and overlaid on read so read-only builtin presets can carry it too. Absent means never used (sorts last)."
+          },
           "order": {
             "type": "integer",
             "description": "Caller-owned display order. Values do not need to be unique; lists sort by scope (builtin, then global, then project), then order, then name."

--- a/tests/fixtures/rust_migration_contracts/sidecars/recipe-preset-manifest-entry.json
+++ b/tests/fixtures/rust_migration_contracts/sidecars/recipe-preset-manifest-entry.json
@@ -4,6 +4,7 @@
   "scope": "global",
   "archived": false,
   "order": 10,
+  "lastUsedAt": "2026-07-09T18:30:00Z",
   "workflow": "text_to_image",
   "model": "z_image_turbo",
   "modes": ["text_to_image"],


### PR DESCRIPTION
## What

Makes the Presets Manager's **Recently used** sort real. Before this, presets carried only `createdAt`/`updatedAt` and the catalog sorted purely by `(scope, order, name)` — there was no recency data source anywhere server-side ([sc-10520](https://app.shortcut.com/trefry/story/10520)).

## How

- **Contract + schema** — add optional `lastUsedAt` (RFC3339) to the recipe-preset entry (`RecipePresetManifestEntry` + `recipe-preset.schema.json`); the round-trip fixture now carries it so the contract test proves it survives.
- **Write path** — stamp `lastUsedAt` on job submit, at the single place the backend already resolves the preset id (`apply_recipe_preset_to_{image,video}_payload`). Persisted in a dedicated **usage side store** (`manifests/recipe-preset-usage.json` keyed by id), *not* the JSONC manifests, because:
  - builtin presets are read-only (`builtin.recipe-presets.jsonc` can't be rewritten), and
  - rewriting a JSONC manifest on the generate hot path is too costly.
  
  The write is best-effort under the shared manifest lock (in-process mutex + cross-process advisory lock); any failure is logged and swallowed rather than failing the user's job.
- **Read path** — overlay the store onto every catalog read (GET + list) so **all** scopes, including read-only builtin, surface `lastUsedAt`. A store value wins over any stale manifest value.
- **API-managed** — `lastUsedAt` is stripped on update (a client echoing it back can't overwrite it) and on duplicate (a copy starts never-used).
- **Web** — add `Recently used` to the Manager sort select; never-used presets sink to the bottom rather than erroring.

## Testing

- `cargo test -p sceneworks-core --test contract_roundtrip` — `lastUsedAt` survives the typed round-trip.
- `cargo test -p sceneworks-rust-api preset` (12 tests) — extended `video_jobs_expand_recipe_presets_server_side` to assert a job submit stamps the store and the value surfaces on the read of a **builtin** (read-only) preset. Existing exact-output parity snapshots confirm the overlay is a no-op when the store is absent.
- `vitest PresetManagerScreen` — new case asserts `Recently used` orders by recency and sinks never-used presets to the bottom.
- `cargo fmt --check` + `cargo clippy` clean on both changed crates.

## Acceptance

- ✅ `lastUsedAt` set on job submit with a preset; survives the round-trip.
- ✅ Manager sort offers `Recently used` and orders correctly.
- ✅ Builtin presets sort sanely (never-used sinks to the bottom rather than erroring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)