### PR TITLE
test(worker): candle Anima GPU smoke + re-pin to the bf16 fix (sc-10625)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-gen",
  "image",
@@ -695,7 +695,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -752,7 +752,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -769,7 +769,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -789,7 +789,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -813,7 +813,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -824,7 +824,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=88b86ff86a48cbba78100257699df43d47c42cb4#88b86ff86a48cbba78100257699df43d47c42cb4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-gen",
  "image",
@@ -695,7 +695,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -752,7 +752,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -769,7 +769,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -789,7 +789,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -813,7 +813,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -824,7 +824,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=b93008150030720943e23ac9bff5713e1ed04ffb#b93008150030720943e23ac9bff5713e1ed04ffb"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1540,26 +1540,30 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10
 # `5c28c20` -> `09f6ef99` (byte-identical — provider-only) so `--features backend-candle` resolves the
 # SINGLE gen-core rev `09f6ef99` (skew gate green). `536c2ef` is an ancestor of `b20ef5d`, a clean
 # forward move; ALL candle-gen-* move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
-# The candle port is numerically CPU-validated but has NEVER been run on real CUDA hardware, so the
-# catalog leaves `candle_routed = false` (unadvertised) even though the crate links — the registration
-# must survive for the future hardware-gated bring-up (sc-10525 acceptance). Pinned to candle-gen branch
-# claude/sc-10525-candle-anima head 88b86ff (PR #379), which has candle-gen main (#378) merged and re-pins
-# its OWN gen-core to the merged mlx-gen main 6a10ae1 — the SAME rev as every mlx-gen pin above. So the
-# `--features backend-candle --target all` skew lane resolves a SINGLE gen-core rev (6a10ae1), matching
-# the mlx lane; the gen-core skew gate stays green on both lanes.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+# GPU-VALIDATED on an RTX PRO 6000 Blackwell (sm_120), sc-10625: base/aesthetic/turbo render coherent at
+# bf16, 512²–1536², plus the 448-target (DiT-only) and 508-target (DiT+conditioner) official LoRA folds —
+# proven via the `anima_gpu_smoke` harness. That bring-up surfaced a bf16-only bug (the sampler mixed a
+# bf16 latent with an f32 velocity, panicking on step 1 — invisible on the CPU-f32 goldens); this pin is
+# the fix. Pinned to candle-gen branch claude/anima-bf16-noise-fix head b930081 (PR #380) = the previous
+# head 88b86ff (candle-gen main #378 merged) + the one-line f32-latent fix, so its OWN gen-core pin is
+# unchanged at the merged mlx-gen main 6a10ae1 — the SAME rev as every mlx-gen pin above, keeping the
+# `--features backend-candle --target all` skew lane on a SINGLE gen-core rev. PROVISIONAL: re-bump all 27
+# candle-gen-* to the merged-to-main SHA once PR #380 lands. The catalog still leaves `candle_routed =
+# false` — routing the app lane additionally needs a non-mac dense download + dense-load path (Anima's
+# convert-at-install converter is macOS-only), tracked on sc-10625.
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1567,17 +1571,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1587,7 +1591,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1595,21 +1599,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1618,17 +1622,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1637,7 +1641,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1670,7 +1674,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1679,12 +1683,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1692,7 +1696,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1701,7 +1705,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1709,7 +1713,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1723,7 +1727,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1750,7 +1754,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1761,7 +1765,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "88b86ff86a48cbba78100257699df43d47c42cb4", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1540,30 +1540,29 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10
 # `5c28c20` -> `09f6ef99` (byte-identical — provider-only) so `--features backend-candle` resolves the
 # SINGLE gen-core rev `09f6ef99` (skew gate green). `536c2ef` is an ancestor of `b20ef5d`, a clean
 # forward move; ALL candle-gen-* move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
 # GPU-VALIDATED on an RTX PRO 6000 Blackwell (sm_120), sc-10625: base/aesthetic/turbo render coherent at
 # bf16, 512²–1536², plus the 448-target (DiT-only) and 508-target (DiT+conditioner) official LoRA folds —
 # proven via the `anima_gpu_smoke` harness. That bring-up surfaced a bf16-only bug (the sampler mixed a
-# bf16 latent with an f32 velocity, panicking on step 1 — invisible on the CPU-f32 goldens); this pin is
-# the fix. Pinned to candle-gen branch claude/anima-bf16-noise-fix head b930081 (PR #380) = the previous
-# head 88b86ff (candle-gen main #378 merged) + the one-line f32-latent fix, so its OWN gen-core pin is
-# unchanged at the merged mlx-gen main 6a10ae1 — the SAME rev as every mlx-gen pin above, keeping the
-# `--features backend-candle --target all` skew lane on a SINGLE gen-core rev. PROVISIONAL: re-bump all 27
-# candle-gen-* to the merged-to-main SHA once PR #380 lands. The catalog still leaves `candle_routed =
-# false` — routing the app lane additionally needs a non-mac dense download + dense-load path (Anima's
-# convert-at-install converter is macOS-only), tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+# bf16 latent with an f32 velocity, panicking on step 1 — invisible on the CPU-f32 goldens); this pin
+# carries the fix. Pinned to candle-gen main 02c0df4, which MERGED PR #380 (the one-line f32-latent fix;
+# b930081 is an ancestor). Its OWN gen-core pin is the merged mlx-gen main 6a10ae1 — the SAME rev as
+# every mlx-gen pin above, keeping the `--features backend-candle --target all` skew lane on a SINGLE
+# gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
+# needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
+# tracked on sc-10625.
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1571,17 +1570,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1591,7 +1590,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1599,21 +1598,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1622,17 +1621,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1641,7 +1640,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1674,7 +1673,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1683,12 +1682,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1696,7 +1695,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b9300
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1705,7 +1704,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1713,7 +1712,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1727,7 +1726,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1754,7 +1753,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1765,7 +1764,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b93008150030720943e23ac9bff5713e1ed04ffb", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/anima_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/anima_gpu_smoke.rs
@@ -1,0 +1,236 @@
+//! Local real-weight GPU smoke for the candle **Anima 2B** worker lane (epic 10512, sc-10625 — the
+//! hardware-gated acceptance extracted from sc-10525). `#[ignore]`d — run by hand on the RTX PRO 6000.
+//! It drives the real candle Anima engine via `gen_core::load("anima_{base,aesthetic,turbo}")` with a
+//! `LoadSpec` pointed at the ungated `circlestone-labs/Anima` `split_files/` snapshot — the exact
+//! runtime seam `generate_candle_stream` uses (minus the API/job plumbing) once the router routes Anima
+//! to candle off-Mac.
+//!
+//! This is the "the candle lane has actually been RUN on real CUDA" evidence that unblocks flipping
+//! `macOnly: false` / `candle_routed = true` (the whole point of sc-10625): the candle port landed
+//! CPU-validated against sc-10524's framework-independent goldens but had NEVER been generated on a
+//! GPU, because the dev machine was an Apple M5 Max.
+//!
+//! Build with `CUDA_COMPUTE_CAP=120` (native Blackwell sm_120).
+//!
+//! Weight layout — the candle loader wants `<root>/{diffusion_models,text_encoders,vae}/...`, which is
+//! exactly the raw HF repo's `split_files/` tree (the loader also accepts a dir whose child is
+//! `split_files/`). Point `ANIMA_DIR` at the snapshot dir (the parent of `split_files/`) OR at
+//! `split_files/` itself.
+//!
+//! Setup (PowerShell):
+//! ```text
+//! $env:ANIMA_DIR="D:\.cache\huggingface\hub\models--circlestone-labs--Anima\snapshots\<hash>"
+//! $env:ANIMA_OUT_DIR="D:\sceneworks-anima-validate"
+//! # optional: ANIMA_VARIANT=base|aesthetic|turbo  ANIMA_W=1024 ANIMA_H=1024 ANIMA_STEPS=..
+//! #           ANIMA_GUIDANCE=..  ANIMA_SEED=42  ANIMA_PROMPT="..."  ANIMA_NEG="..."
+//! #           ANIMA_LORA=<path.safetensors>  ANIMA_LORA_KIND=lora|lokr  ANIMA_LORA_SCALE=1.0
+//! cargo test -p sceneworks-worker --no-default-features --features backend-candle --release \
+//!   anima_candle_gpu_smoke -- --ignored --nocapture
+//! ```
+
+use std::path::PathBuf;
+
+use gen_core::{
+    AdapterKind, AdapterSpec, GenerationOutput, GenerationRequest, LoadSpec, WeightsSource,
+};
+
+use super::smoke_support::{env_or, image_mean, image_std, save_png, DEGENERATE_STD_FLOOR_DEFAULT};
+
+/// Resolve the Anima variant → engine id + its shipped defaults (steps/guidance). Turbo is the merged
+/// CFG-free student (guidance forced 1.0 inside the engine); base/aesthetic run true CFG.
+fn resolve_variant(raw: &str) -> (&'static str, u32, f32) {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "base" => ("anima_base", 30, 4.5),
+        "aesthetic" => ("anima_aesthetic", 30, 4.5),
+        "turbo" => ("anima_turbo", 10, 1.0),
+        other => panic!("ANIMA_VARIANT must be base|aesthetic|turbo, got {other:?}"),
+    }
+}
+
+#[cfg(test)]
+mod variant_tests {
+    use super::resolve_variant;
+
+    #[test]
+    fn resolve_variant_maps_the_three_ids() {
+        assert_eq!(resolve_variant("base").0, "anima_base");
+        assert_eq!(resolve_variant("AESTHETIC").0, "anima_aesthetic");
+        assert_eq!(resolve_variant(" turbo ").0, "anima_turbo");
+    }
+
+    #[test]
+    #[should_panic(expected = "ANIMA_VARIANT must be base|aesthetic|turbo")]
+    fn resolve_variant_rejects_unknown() {
+        let _ = resolve_variant("preview");
+    }
+}
+
+/// The optional LoRA/LoKr adapter from env (`ANIMA_LORA` path + `ANIMA_LORA_KIND` + `ANIMA_LORA_SCALE`).
+/// Returns the built `AdapterSpec` and a filename-safe tag; `None` when `ANIMA_LORA` is unset/empty.
+fn adapter_from_env() -> Option<(AdapterSpec, String)> {
+    let path = std::env::var("ANIMA_LORA")
+        .ok()
+        .map(|p| p.trim().to_string());
+    let path = path.filter(|p| !p.is_empty())?;
+    let lora_path = PathBuf::from(&path);
+    assert!(
+        lora_path.is_file(),
+        "ANIMA_LORA is set but not a file: {}",
+        lora_path.display()
+    );
+    let kind = match env_or("ANIMA_LORA_KIND", "lora")
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "lora" => AdapterKind::Lora,
+        "lokr" => AdapterKind::Lokr,
+        other => panic!("ANIMA_LORA_KIND must be lora|lokr, got {other:?}"),
+    };
+    let scale: f32 = env_or("ANIMA_LORA_SCALE", "1.0")
+        .parse()
+        .expect("ANIMA_LORA_SCALE");
+    let stem = lora_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("lora")
+        .replace(['.', ' '], "_");
+    let tag = format!("{stem}_{:?}", kind).to_ascii_lowercase();
+    Some((AdapterSpec::new(lora_path, scale, kind), tag))
+}
+
+#[test]
+#[ignore = "real-weight GPU smoke; needs the circlestone-labs/Anima split_files snapshot + a CUDA device (cap=120)"]
+fn anima_candle_gpu_smoke() {
+    let root = PathBuf::from(
+        std::env::var("ANIMA_DIR")
+            .expect("set $ANIMA_DIR to the Anima snapshot dir (parent of split_files/)")
+            .trim(),
+    );
+    // Accept either the snapshot dir (child split_files/) or the split_files/ dir directly.
+    let split = if root.join("diffusion_models").is_dir() {
+        root.clone()
+    } else if root.join("split_files").join("diffusion_models").is_dir() {
+        root.join("split_files")
+    } else {
+        panic!(
+            "ANIMA_DIR has no diffusion_models/ or split_files/diffusion_models/: {}",
+            root.display()
+        );
+    };
+    assert!(
+        split
+            .join("text_encoders/qwen_3_06b_base.safetensors")
+            .is_file(),
+        "missing shared Qwen3 TE under {}",
+        split.display()
+    );
+    assert!(
+        split.join("vae/qwen_image_vae.safetensors").is_file(),
+        "missing shared Qwen-Image VAE under {}",
+        split.display()
+    );
+
+    let out_dir = PathBuf::from(env_or("ANIMA_OUT_DIR", "/tmp/anima_smoke"));
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+
+    let variant_raw = env_or("ANIMA_VARIANT", "base");
+    let (id, def_steps, def_guidance) = resolve_variant(&variant_raw);
+    let steps: u32 = env_or("ANIMA_STEPS", &def_steps.to_string())
+        .parse()
+        .expect("ANIMA_STEPS");
+    let w: u32 = env_or("ANIMA_W", "1024").parse().expect("ANIMA_W");
+    let h: u32 = env_or("ANIMA_H", "1024").parse().expect("ANIMA_H");
+    let guidance: f32 = env_or("ANIMA_GUIDANCE", &def_guidance.to_string())
+        .parse()
+        .expect("ANIMA_GUIDANCE");
+    let seed: u64 = env_or("ANIMA_SEED", "42").parse().expect("ANIMA_SEED");
+    let prompt = env_or(
+        "ANIMA_PROMPT",
+        "masterpiece, best quality, score_7, safe, 1girl, silver hair, blue eyes, kimono, \
+         cherry blossoms, standing, looking at viewer, detailed background",
+    );
+    let negative = env_or(
+        "ANIMA_NEG",
+        "worst quality, low quality, score_1, score_2, score_3, artist name, blurry, \
+         jpeg artifacts, chromatic aberration",
+    );
+
+    // Point `WeightsSource::Dir` at the split_files root; the candle loader resolves the variant DiT
+    // + shared TE/VAE from it (dense bf16 — the candle lane has no Windows path to a packed tier, since
+    // the q4/q8 converter is macOS-only and Anima's NC posture means no packed tier is published).
+    let mut spec = LoadSpec::new(WeightsSource::Dir(split.clone()));
+    let adapter = adapter_from_env();
+    if let Some((a, _)) = &adapter {
+        spec = spec.with_adapters(vec![a.clone()]);
+    }
+
+    let adapter_tag = adapter
+        .as_ref()
+        .map(|(_, t)| format!("_{t}"))
+        .unwrap_or_default();
+    println!(
+        "[smoke] loading {id} (bf16{}) from {} ...",
+        adapter
+            .as_ref()
+            .map(|(_, t)| format!(", +{t}"))
+            .unwrap_or_default(),
+        split.display()
+    );
+    let generator = gen_core::load(id, &spec).unwrap_or_else(|e| panic!("load candle {id}: {e}"));
+
+    // Turbo is the merged CFG-free student — its descriptor advertises `supports_negative_prompt: false`
+    // and `supports_guidance: false`, so passing either is (correctly) rejected by `validate`. Only the
+    // CFG variants (base/aesthetic) carry a negative prompt + guidance.
+    let uses_cfg = id != "anima_turbo";
+    let req = GenerationRequest {
+        prompt: prompt.clone(),
+        negative_prompt: uses_cfg.then(|| negative.clone()),
+        width: w,
+        height: h,
+        count: 1,
+        seed: Some(seed),
+        steps: Some(steps),
+        guidance: uses_cfg.then_some(guidance),
+        ..Default::default()
+    };
+    println!(
+        "[smoke] rendering {id} {w}x{h} @ {steps} steps, guidance {guidance}, seed {seed} ..."
+    );
+    let mut last = String::new();
+    let output = generator
+        .generate(&req, &mut |p| {
+            let s = format!("{p:?}");
+            if s != last {
+                println!("[progress] {s}");
+                last = s;
+            }
+        })
+        .unwrap_or_else(|e| panic!("{id} generate: {e}"));
+    let image = match output {
+        GenerationOutput::Images(mut images) => images.pop().expect("engine returned no image"),
+        other => panic!("expected Images output, got {other:?}"),
+    };
+
+    let mean = image_mean(&image);
+    let std = image_std(&image);
+    let png = out_dir.join(format!("{id}_bf16_{w}x{h}_{steps}step{adapter_tag}.png"));
+    save_png(&image, &png);
+    println!(
+        "[smoke] {id} {}x{} mean {:.2} std {:.2} -> {}",
+        image.width,
+        image.height,
+        mean,
+        std,
+        png.display()
+    );
+    assert_eq!((image.width, image.height), (w, h));
+    assert!(
+        std > DEGENERATE_STD_FLOOR_DEFAULT,
+        "{id} render looks degenerate (std {std:.2}) — possible NaN / all-black decode \
+         (check CUDA_COMPUTE_CAP=120)"
+    );
+    println!(
+        "[smoke] DONE: {id} bf16 render coherent at {steps} steps (eyeball {})",
+        png.display()
+    );
+}

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -203,6 +203,13 @@ mod sdxl_edit_pid_gpu_smoke;
 // dense diffusers snapshot — the worker-lane validation backing the off-Mac candle routing wire.
 #[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
 mod flux2_dev_gpu_smoke;
+// Real-weight GPU smoke for the candle Anima 2B lane (epic 10512, sc-10625 — the hardware-gated
+// acceptance extracted from sc-10525). Test-only + candle-only; drives `gen_core::load("anima_base" |
+// "anima_aesthetic" | "anima_turbo")` against the dense bf16 circlestone-labs/Anima split_files
+// snapshot (± an official LoRA/LoKr), proving the candle Anima port renders coherently on real CUDA —
+// the evidence that unblocks flipping `macOnly: false` / `candle_routed = true` (sc-10625).
+#[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
+mod anima_gpu_smoke;
 // Real-weight GPU smoke for the candle InstantID + PiD super-resolving decode (epic 7840, sc-8386).
 // Test-only + candle-only; drives the bespoke `candle_gen_instantid::InstantId` provider across
 // Identity/Angle/Pose with the `pid_sdxl` student attached, asserting the PiD decode 4×-super-resolves


### PR DESCRIPTION
## Summary

GPU-validates the **candle Anima 2B** lane on real CUDA — the acceptance [sc-10525](https://app.shortcut.com/trefry/story/10525) deferred because the dev machine was an Apple M5 Max. Tracked as [sc-10625](https://app.shortcut.com/trefry/story/10625) (epic 10512).

Adds `crates/sceneworks-worker/src/anima_gpu_smoke.rs` — an `#[ignore]`d real-weight smoke that drives the exact `gen_core::load("anima_*")` seam (± an official LoRA/LoKr) and asserts a non-degenerate decode, mirroring the sibling `*_gpu_smoke.rs` harnesses. Re-pins all 27 `candle-gen-*` deps to the fix below.

## The bug this found (candle-gen [PR #380](https://github.com/SceneWorks/candle-gen/pull/380))

Running the smoke on an **RTX PRO 6000 Blackwell (sm_120)** immediately panicked on step 1:

```
anima_base generate: dtype mismatch in add, lhs: BF16, rhs: F32
```

`candle-gen-anima` cast the initial noise latent to the compute dtype (**bf16** on GPU), but the sampler integrates in **f32**. On the CPU parity lane `compute_dtype()` is f32, so the framework-independent goldens **could not** catch it — it only bit on real GPU hardware. Fixed in #380 (keep latents f32; the DiT casts internally). This PR re-pins `88b86ff → b930081` (the fix head).

## Validated — bf16 dense, all eyeballed (not just std floor)

| variant / config | result |
|---|---|
| `anima_base` 1024² · `anima_aesthetic` 1024² · `anima_turbo` 1024² (CFG-free) | ✅ coherent |
| `anima_base` 512² (min) · 1536² (RoPE ceiling) | ✅ coherent, no flat bands |
| `anima_base` + style LoRA (448 DiT-only) · + turbo LoRA v0.2 (508 DiT+conditioner) | ✅ folds + renders |

LoKr fold is CPU-identical (loader folds on CPU f32) + bit-exact validated in candle-gen #379.

## What this PR deliberately does NOT do

- **No `candle_routed` / `macOnly` flip.** The manifest download is `platforms:["macos"]` and the worker's `anima_tier_subdir` expects the mac converter's tier layout, so routing the app lane needs a non-mac dense download + dense-load path first (Anima's converter is macOS-only). Flipping now would advertise a lane that fails at weight resolution.
- **No q4/q8 GPU run.** No packed Anima tier is obtainable off-Mac (converter is macOS-only; NC-unpublished). Remaining work tracked on sc-10625.

## Notes
- 🔴 **Provisional pin.** `b930081` is the #380 branch head; re-bump all 27 `candle-gen-*` to the merged-to-main SHA once #380 lands (single gen-core rev preserved — the fix doesn't touch Cargo.toml).
- The smoke is `#[cfg(all(test, not(target_os="macos"), feature="backend-candle"))]` + `#[ignore]`d, so it's excluded from the parity/neither lane and never auto-runs in CI. Run: `cargo test -p sceneworks-worker --no-default-features --features backend-candle --release anima_candle_gpu_smoke -- --ignored --nocapture`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)