### PR TITLE
fix(models): refresh the catalog when an MLX conversion completes (sc-10679)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,8 +210,10 @@ tempCodeRunnerFile.py
 .ruff_cache/
 
 # Node / web
-node_modules/
-apps/web/node_modules/
+# No trailing slash: a git worktree commonly symlinks node_modules back to the main
+# checkout, and git sees a symlink as a file — `node_modules/` would not match it.
+node_modules
+apps/web/node_modules
 apps/web/dist/
 
 # Tauri desktop shell generated artifacts

--- a/apps/web/src/App.models.test.jsx
+++ b/apps/web/src/App.models.test.jsx
@@ -197,6 +197,72 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).not.toContain("Jobs and GPUs");
   });
 
+  it("flips the MLX button to ready when a model conversion completes", async () => {
+    // `mlxConversionState` is derived server-side from the converted artifact on disk, so the
+    // Models row only learns the conversion landed if the catalog is refetched when the
+    // model_convert job completes. Without that refetch the button stays on "Convert to MLX"
+    // until the app restarts.
+    let conversionState = "needs_conversion";
+    global.fetch.mockImplementation((url) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-1", name: "Noir" }]));
+      }
+      if (path.endsWith("/models")) {
+        return Promise.resolve(
+          response([
+            {
+              id: "anima_2b",
+              name: "Anima 2B",
+              type: "image",
+              family: "anima",
+              installState: "installed",
+              mlxConversionState: conversionState,
+            },
+          ]),
+        );
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+    await act(async () => {
+      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Models").click();
+    });
+    await settle();
+
+    const mlxButton = () => [...container.querySelectorAll(".mlx-status button")][0];
+    expect(mlxButton().textContent).toBe("Convert to MLX");
+
+    conversionState = "converted";
+    await act(async () => {
+      FakeEventSource.instances[0].listeners["job.updated"]({
+        data: JSON.stringify({
+          id: "convert-job-1",
+          type: "model_convert",
+          status: "completed",
+          payload: { modelId: "anima_2b", modelName: "Anima 2B" },
+        }),
+      });
+    });
+    await settle();
+    await settle();
+
+    expect(mlxButton().textContent).toBe("MLX ready");
+    expect(mlxButton().disabled).toBe(true);
+    expect(container.textContent).toContain("Converted to MLX and ready.");
+  });
+
   it("keeps LoRA imports on the Models page and shows local progress", async () => {
     const createdJobs = [];
     global.fetch.mockImplementation((url, options = {}) => {

--- a/apps/web/src/hooks/useJobEvents.js
+++ b/apps/web/src/hooks/useJobEvents.js
@@ -91,7 +91,11 @@ export function useJobEvents({
       if (job.status === "completed" && job.projectId && job.type === "person_detect") {
         refreshAssetsRef.current?.(job.projectId);
       }
-      if (job.status === "completed" && job.type === "model_download") {
+      // A completed download flips the catalog's `installState`; a completed conversion writes the
+      // MLX artifact that flips `mlxConversionState` to "converted". Both are derived server-side
+      // from the filesystem, so the catalog must be refetched or the Models row keeps offering
+      // "Convert to MLX" for an already-converted model until the app is restarted.
+      if (job.status === "completed" && (job.type === "model_download" || job.type === "model_convert")) {
         refreshDataRef.current?.();
       }
       // A completed built-in LoRA download (sc-5944) flips the catalog entry to


### PR DESCRIPTION
Fixes [sc-10679](https://app.shortcut.com/trefry/story/10679).

## Symptom

Running **Convert to MLX** on an Anima model: the worker starts, converts, and exits. The Models row still renders the **Convert to MLX** button, so the conversion looks like it failed. Restarting the app shows **MLX ready**.

Not Anima-specific — every convert-required model is affected. It is just most visible on Anima because its conversion is a fast force-link rather than a long re-serialization, so the worker appears and disappears almost instantly.

## Root cause

`ModelManagerScreen` renders the button from `model.mlxConversionState`, which `GET /api/v1/models` derives server-side by probing the filesystem for the converted artifact. That field only changes when the frontend refetches the catalog.

In the SSE handler (`apps/web/src/hooks/useJobEvents.js`), a completed job triggers a catalog refetch for `model_download`, `lora_download`, `lora_import`, and `lora_train` — but **`model_convert` was missing from that list**. When the convert job finished, the progress card vanished (it only renders non-terminal jobs) and the button fell back to the stale `needs_conversion` state.

## Fix

Refetch the catalog on a completed `model_convert`, exactly as already done for `model_download`.

I checked the two things that could defeat that refetch in production but not in a test:

- The worker atomically renames the converted directory into place **before** emitting `completed` (`crates/sceneworks-worker/src/model_jobs.rs`), so there is no read-before-write race when the refetch lands.
- `GET /api/v1/models` rebuilds and re-probes the filesystem on every call — no memoization or ETag layer. Only Hugging Face *size* estimates are cached, which does not touch `mlxConversionState`.

## Also in this change

`.gitignore` used `node_modules/` with a trailing slash, which matches directories only. Git classifies a symlink as a file, so the `node_modules` symlink a worktree needs in order to run the web tests was never ignored. Dropping the trailing slash covers both forms. Confirmed no tracked file is newly swallowed by the broader pattern.

## Validation

- New regression test in `apps/web/src/App.models.test.jsx` renders the real `App`, serves a model in `needs_conversion`, fires an actual `job.updated` SSE event for a completed `model_convert`, and asserts the button flips to "MLX ready" and goes disabled.
- Mutation-checked: with the fix reverted the new test fails; restored, it passes.
- Full web suite green (1403 tests) on the merged tree. `npm run lint` reports no findings on the touched files.
- I did **not** drive a physical Anima conversion end-to-end — reproducing the precondition means deleting an existing converted artifact, which I did not want to do unasked. The test drives the real `App` through the actual SSE handler, and the backend ordering guarantee above is read-verified.

## Known gap (not fixed here)

`model_import` has the identical staleness gap in the same handler. Left alone because the import UI is hidden and disabled repo-wide under epic 7080, so no live path fires it — though the POST endpoint still exists, so a LAN client calling it directly would see the same stale row. Happy to fold it in if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)