### PR TITLE
test(worker): overridable seed on the SDXL q8 smoke (sc-10620)

### DIFF
--- a/crates/sceneworks-worker/src/sdxl_base_q8_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/sdxl_base_q8_mlx_smoke.rs
@@ -19,7 +19,7 @@
 //! Override `SDXL_Q8_DIR` to point at a snapshot root or a `q8/`-bearing dir directly.
 //! ```text
 //! # optional: SDXL_Q8_DIR=/path/to/sdxl-base-mlx  (root containing q8/, or the q8/ dir itself)
-//! # optional: SDXL_STEPS=30 SDXL_W=768 SDXL_H=768 SDXL_PROMPT="..." SDXL_OUT_DIR=/tmp/sdxl_q8_smoke
+//! # optional: SDXL_STEPS=30 SDXL_W=768 SDXL_H=768 SDXL_SEED=42 SDXL_PROMPT="..." SDXL_OUT_DIR=/tmp/sdxl_q8_smoke
 //! cargo test -p sceneworks-worker --release sdxl_base_q8_mlx_gpu_smoke -- --ignored --nocapture
 //! ```
 
@@ -89,6 +89,10 @@ fn sdxl_base_q8_mlx_gpu_smoke() {
     let steps: u32 = env_or("SDXL_STEPS", "30").parse().expect("SDXL_STEPS");
     let w: u32 = env_or("SDXL_W", "768").parse().expect("SDXL_W");
     let h: u32 = env_or("SDXL_H", "768").parse().expect("SDXL_H");
+    // Overridable so a resolution/quality sweep can vary the sample rather than read one draw as if
+    // it were the model's behaviour (sc-10620). Defaults to the pinned 42, so the smoke itself is
+    // unchanged and still deterministic.
+    let seed: u64 = env_or("SDXL_SEED", "42").parse().expect("SDXL_SEED");
     let prompt = env_or(
         "SDXL_PROMPT",
         "a photorealistic portrait of a red fox sitting in a sunlit autumn forest, sharp focus, \
@@ -110,7 +114,7 @@ fn sdxl_base_q8_mlx_gpu_smoke() {
         width: w,
         height: h,
         count: 1,
-        seed: Some(42),
+        seed: Some(seed),
         steps: Some(steps),
         guidance: Some(7.0),
         ..Default::default()


### PR DESCRIPTION
Small harness change, but it changed a product decision.

`sdxl_base_q8_mlx_gpu_smoke` pinned `seed: Some(42)`. Driving the Illustrious resolution bake-off ([sc-10620](https://app.shortcut.com/trefry/story/10620)) with a fixed seed meant one draw per cell — and one draw is not a model's behaviour.

Concretely: **Illustrious v2.0 duplicated the subject at 1536×1536 on seed 42, and rendered a single clean subject on seed 7.** Either sample alone, taken as evidence, would have set the catalog's `limits.resolutions` on a coin flip. With three seeds the real picture emerges: v2 duplicates on 2 of 3 at 1536², v1.0 on 0 of 3.

`SDXL_SEED` defaults to `42`, so the smoke is unchanged and still deterministic when the env var is absent. It only exists so a sweep can vary the sample.

## Verification
- `cargo test -p sceneworks-worker --lib` → 697 passed, 0 failed.
- `cargo fmt --all -- --check` and `cargo clippy -p sceneworks-worker --all-targets -- -D warnings` clean.
- Exercised across 18 real GPU renders at 6 resolutions × 3 seeds × 2 models; the seed override demonstrably changes the draw (per-render `mean`/`std` differ by seed).

Findings go on sc-10620; no catalog change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)