### PR TITLE
feat(anima): route Anima to the candle lane off-Mac (sc-10676)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -4152,9 +4152,11 @@
       // Anima 2B (epic 10512 / sc-10523) — CircleStone Labs' anime text-to-image model, ported natively
       // to mlx-gen (engine id `anima_base`). The Cosmos-Predict2 `CosmosTransformer3DModel` DiT (28
       // layers, 17-channel patch-embed, 3-axis NTK RoPE) + the bundled `AnimaTextConditioner` (T5 query
-      // tokens cross-attending Qwen3-0.6B states) + the Qwen-Image VAE. Native MLX only (mlx-gen-anima;
-      // the candle port sc-10525 exists + is CPU-numerically-validated but has never run on real CUDA, so
-      // it is NOT catalog-routed yet) → macOnly. True-CFG text-to-image (30 steps / guidance 4.5).
+      // tokens cross-attending Qwen3-0.6B states) + the Qwen-Image VAE. Runs on MLX (macOS) AND the candle
+      // off-Mac lane (Windows/Linux CUDA): the candle port sc-10525 is now GPU-validated on real CUDA
+      // (sc-10625) and catalog-routed off-Mac (sc-10676), so `macOnly: false` — availability is driven by
+      // the routing tables (`MLX_ROUTED_MODELS` / `CANDLE_ROUTED_MODELS`), not this flag. True-CFG
+      // text-to-image (30 steps / guidance 4.5).
       //
       // Non-commercial: distributed under the CircleStone Labs Non-Commercial License v1.2. The source
       // repo `circlestone-labs/Anima` is UN-gated (freely downloadable) but NC — generations are for
@@ -4174,13 +4176,14 @@
       "type": "image",
       "adapter": "mlx_anima",
       "capabilities": ["text_to_image"],
-      "macOnly": true,
+      "macOnly": false,
       "nonCommercial": true,
       "gated": false,
       "downloads": [
         {
-          // The base variant's Cosmos DiT (the convert source). Pulling just this file (plus the two
-          // shared components below) avoids the ~30 GB whole-repo pull (7 bf16 DiTs).
+          // macOS convert source (sc-10517): the base variant's Cosmos DiT + the two shared components.
+          // Pulling just these three files avoids the ~30 GB whole-repo pull (7 bf16 DiTs). On macOS the
+          // worker packs this ON-DEVICE into the q4/q8/bf16 tier matrix (convert-at-install).
           "provider": "huggingface",
           "repo": "circlestone-labs/Anima",
           "files": [
@@ -4189,6 +4192,23 @@
             "split_files/vae/qwen_image_vae.safetensors"
           ],
           "platforms": ["macos"],
+          "estimatedSizeBytes": 5690000000
+        },
+        {
+          // Non-mac dense bf16 (sc-10676): the SAME three exact `split_files/` paths, for the candle
+          // off-Mac lane. There is NO convert-at-install off-Mac (the `anima_quant` converter is
+          // macOS-only), so the candle loader dense-loads bf16 straight from this raw `split_files/`
+          // tree (`candle_gen_anima::loader::resolve_split_files` → `diffusion_models/ text_encoders/
+          // vae/`). Mirrors the mac entry's "3 exact paths, never the bare repo" guard — enumerating
+          // the variant DiT + shared Qwen3 TE + Qwen-Image VAE, never the ~30 GB bare repo.
+          "provider": "huggingface",
+          "repo": "circlestone-labs/Anima",
+          "files": [
+            "split_files/diffusion_models/anima-base-v1.0.safetensors",
+            "split_files/text_encoders/qwen_3_06b_base.safetensors",
+            "split_files/vae/qwen_image_vae.safetensors"
+          ],
+          "platforms": ["windows", "linux"],
           "estimatedSizeBytes": 5690000000
         }
       ],
@@ -4253,19 +4273,20 @@
     {
       "id": "anima_aesthetic",
       // Anima 2B Aesthetic (epic 10512 / sc-10523) — the aesthetic fine-tune of Anima 2B. Same
-      // architecture, sampler/scheduler menu, convert-at-install flow, and NC posture as `anima_base`;
-      // differs only in the DiT weights file + (nothing else — same 30 steps / guidance 4.5).
+      // architecture, sampler/scheduler menu, convert-at-install (mac) / dense candle (off-Mac) flow, and
+      // NC posture as `anima_base`; differs only in the DiT weights file (same 30 steps / guidance 4.5).
       "autoDownload": false,
       "name": "Anima 2B Aesthetic",
       "family": "anima",
       "type": "image",
       "adapter": "mlx_anima",
       "capabilities": ["text_to_image"],
-      "macOnly": true,
+      "macOnly": false,
       "nonCommercial": true,
       "gated": false,
       "downloads": [
         {
+          // macOS convert source (sc-10517).
           "provider": "huggingface",
           "repo": "circlestone-labs/Anima",
           "files": [
@@ -4274,6 +4295,19 @@
             "split_files/vae/qwen_image_vae.safetensors"
           ],
           "platforms": ["macos"],
+          "estimatedSizeBytes": 5690000000
+        },
+        {
+          // Non-mac dense bf16 (sc-10676) — the candle off-Mac lane loads these raw `split_files/` paths
+          // directly (no convert-at-install off-Mac). Same 3-exact-paths guard as the mac entry.
+          "provider": "huggingface",
+          "repo": "circlestone-labs/Anima",
+          "files": [
+            "split_files/diffusion_models/anima-aesthetic-v1.0.safetensors",
+            "split_files/text_encoders/qwen_3_06b_base.safetensors",
+            "split_files/vae/qwen_image_vae.safetensors"
+          ],
+          "platforms": ["windows", "linux"],
           "estimatedSizeBytes": 5690000000
         }
       ],
@@ -4331,11 +4365,12 @@
       "type": "image",
       "adapter": "mlx_anima",
       "capabilities": ["text_to_image"],
-      "macOnly": true,
+      "macOnly": false,
       "nonCommercial": true,
       "gated": false,
       "downloads": [
         {
+          // macOS convert source (sc-10517).
           "provider": "huggingface",
           "repo": "circlestone-labs/Anima",
           "files": [
@@ -4344,6 +4379,19 @@
             "split_files/vae/qwen_image_vae.safetensors"
           ],
           "platforms": ["macos"],
+          "estimatedSizeBytes": 5690000000
+        },
+        {
+          // Non-mac dense bf16 (sc-10676) — the candle off-Mac lane loads these raw `split_files/` paths
+          // directly (no convert-at-install off-Mac). Same 3-exact-paths guard as the mac entry.
+          "provider": "huggingface",
+          "repo": "circlestone-labs/Anima",
+          "files": [
+            "split_files/diffusion_models/anima-turbo-v1.0.safetensors",
+            "split_files/text_encoders/qwen_3_06b_base.safetensors",
+            "split_files/vae/qwen_image_vae.safetensors"
+          ],
+          "platforms": ["windows", "linux"],
           "estimatedSizeBytes": 5690000000
         }
       ],

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -656,16 +656,21 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
     // SANA 1600M + SANA-Sprint (epic 8485 / sc-8489 / sc-8490): MLX-only txt2img (no torch/candle backend).
     ModelCaps::new("sana_1600m", true, false, false, false, false),
     ModelCaps::new("sana_sprint_1600m", true, false, false, false, false),
-    // Anima base / aesthetic / turbo (epic 10512 / sc-10523): native-MLX anime txt2img. MLX-routed with
-    // install-time Q4/Q8 quant + inference LoRA/LoKr (advertised via the engine descriptor + manifest;
-    // quant+LoRA TOGETHER is unsupported, tracked sc-10578 — the engine `load()` errors on the combo).
-    // `candle_routed = false`: the candle port (sc-10525) is numerically CPU-validated but has NEVER been
-    // generated on real CUDA hardware, so no candle lane is advertised (all candle_* columns false, which
-    // also keeps the sc-9495 superset invariant trivially satisfied). Re-evaluate once sc-10525's
-    // hardware-gated acceptance passes on the NVIDIA rig.
-    ModelCaps::new("anima_base", true, false, false, false, false),
-    ModelCaps::new("anima_aesthetic", true, false, false, false, false),
-    ModelCaps::new("anima_turbo", true, false, false, false, false),
+    // Anima base / aesthetic / turbo (epic 10512): anime txt2img on BOTH backends — native-MLX (macOS,
+    // install-time Q4/Q8 quant) and the candle off-Mac lane (sc-10676), which sc-10625 GPU-validated on
+    // real CUDA (candle-gen #380). `candle_routed = true`; `candle_lora = true` because the candle engine
+    // dense-folds a LoRA/LoKr onto the split_files/ DiT (descriptor `supports_lora`/`supports_lokr`,
+    // validated in the anima GPU smoke). `candle_quant = false`: there is NO packed Q4/Q8 tier off-Mac —
+    // the `anima_quant` converter is macOS-only and the NC license bars publishing one, and the candle
+    // loader only CONSUMES an MLX-packed tier (it hard-rejects a quant request against the dense DiT). So
+    // a deliberate `mlxQuantize` request stays off candle (defers rather than silently running dense —
+    // the sc-10515 anti-lie posture); the worker also force-dense-loads Anima regardless of the manifest
+    // default. `candle_quant_lora = false`: quant+LoRA together is unsupported on both lanes (sc-10578 —
+    // folding an adapter into u32-packed codes is a separate additive-branch job). candle_lora ⟹
+    // candle_routed keeps the sc-9495 superset invariant satisfied.
+    ModelCaps::new("anima_base", true, true, false, true, false),
+    ModelCaps::new("anima_aesthetic", true, true, false, true, false),
+    ModelCaps::new("anima_turbo", true, true, false, true, false),
 ];
 
 /// The one-row-per-model VIDEO routing table (sc-9495) — the single source the video list constants
@@ -981,6 +986,9 @@ mod tests {
         "sd3_5_large",
         "sd3_5_large_turbo",
         "sd3_5_medium",
+        "anima_base",
+        "anima_aesthetic",
+        "anima_turbo",
     ];
 
     // sc-9983: Krea joins Lens as a BOTH-quant-and-LoRA candle family (sc-9607 flipped its
@@ -1002,8 +1010,10 @@ mod tests {
         "boogu_image_edit",
     ];
 
-    // sc-9983: Krea moved to CANDLE_QUANT_LORA_MODELS (BOTH), so the LoRA-only list is now empty.
-    const EXPECTED_CANDLE_LORA_MODELS: &[&str] = &[];
+    // sc-9983: Krea moved to CANDLE_QUANT_LORA_MODELS (BOTH). sc-10676: Anima is the LoRA-only candle
+    // family — the off-Mac engine dense-folds a LoRA/LoKr onto the split_files/ DiT, but advertises NO
+    // candle quant (no packed tier off-Mac), so it is LoRA-only rather than BOTH.
+    const EXPECTED_CANDLE_LORA_MODELS: &[&str] = &["anima_base", "anima_aesthetic", "anima_turbo"];
 
     const EXPECTED_CANDLE_VIDEO_ROUTED_MODELS: &[&str] = &[
         "wan_2_2",

--- a/crates/sceneworks-worker/src/anima_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/anima_gpu_smoke.rs
@@ -234,3 +234,104 @@ fn anima_candle_gpu_smoke() {
         png.display()
     );
 }
+
+/// sc-10676 worker-lane E2E: drive the ACTUAL worker weight-resolution + dense-load + render for all
+/// three Anima variants on real CUDA — the piece the engine-seam [`anima_candle_gpu_smoke`] above does
+/// NOT cover. Unlike that smoke (which hands the engine a hand-built `split_files/` path), this calls
+/// the WORKER's [`crate::image_jobs::resolve_weights_dir`] the way `generate_candle_stream` does, asserts
+/// it returns the dense `split_files/` dir off-Mac (NOT a converted q4/q8/bf16 tier), then loads DENSE
+/// (Quant `None` — the decision `generate_candle_stream` forces for Anima; passing a quant would hit the
+/// loader's dense-DiT reject) and renders a coherent image. Point the HF cache env at the real Anima
+/// snapshot — no `ANIMA_DIR` (the resolver finds it):
+/// ```text
+/// $env:HF_HUB_CACHE="D:\.cache\huggingface\hub"
+/// $env:ANIMA_OUT_DIR="D:\sceneworks-anima-validate"
+/// cargo test -p sceneworks-worker --no-default-features --features backend-candle --release \
+///   anima_worker_lane_gpu_smoke -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore = "real-weight worker-lane GPU smoke; needs the circlestone-labs/Anima snapshot in the HF cache \
+            (HF_HUB_CACHE/HF_HOME) + a CUDA device (cap=120)"]
+fn anima_worker_lane_gpu_smoke() {
+    use crate::image_jobs::resolve_weights_dir;
+    use crate::settings::Settings;
+    use gen_core::GenerationRequest;
+    use sceneworks_core::image_request::ImageRequest;
+    use serde_json::json;
+
+    let out_dir = PathBuf::from(env_or("ANIMA_OUT_DIR", "/tmp/anima_smoke"));
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+    let settings = Settings::from_env();
+    let prompt = "masterpiece, best quality, 1girl, silver hair, blue eyes, kimono, \
+                  cherry blossoms, standing, looking at viewer, detailed background";
+    let negative = "worst quality, low quality, blurry, jpeg artifacts";
+
+    // (id, steps, guidance, uses_cfg) — turbo is the merged CFG-free student (no negative / guidance).
+    for (id, steps, guidance, uses_cfg) in [
+        ("anima_base", 30u32, 4.5f32, true),
+        ("anima_aesthetic", 30, 4.5, true),
+        ("anima_turbo", 10, 1.0, false),
+    ] {
+        // A minimal job payload — resolve_weights_dir keys off `model` (+ absent modelPath), the exact
+        // shape the router hands `generate_candle_stream`. No `mlxQuantize`: the web UI never sends it.
+        let payload = json!({ "model": id, "prompt": prompt, "width": 1024, "height": 1024 });
+        let request = ImageRequest::from_payload(payload.as_object().unwrap());
+
+        // THE worker resolver (my sc-10676 change): off-Mac Anima → the dense `split_files/` tree, never
+        // a converted tier (there is none off-Mac). This is the seam the engine-only smoke skips.
+        let dir = resolve_weights_dir(&request, &settings)
+            .expect("resolve_weights_dir")
+            .unwrap_or_else(|| {
+                panic!("{id}: Anima snapshot not in the HF cache — set HF_HUB_CACHE/HF_HOME")
+            });
+        assert!(
+            dir.ends_with("split_files") && dir.join("diffusion_models").is_dir(),
+            "{id}: worker must resolve the dense split_files/ dir, got {}",
+            dir.display()
+        );
+        println!(
+            "[worker-smoke] {id}: resolve_weights_dir -> {}",
+            dir.display()
+        );
+
+        // DENSE load (Quant None) — exactly what generate_candle_stream forces for Anima.
+        let spec = LoadSpec::new(WeightsSource::Dir(dir));
+        let generator = gen_core::load(id, &spec).unwrap_or_else(|e| panic!("load {id}: {e}"));
+        let req = GenerationRequest {
+            prompt: prompt.to_string(),
+            negative_prompt: uses_cfg.then(|| negative.to_string()),
+            width: 1024,
+            height: 1024,
+            count: 1,
+            seed: Some(42),
+            steps: Some(steps),
+            guidance: uses_cfg.then_some(guidance),
+            ..Default::default()
+        };
+        println!("[worker-smoke] {id}: rendering 1024x1024 @ {steps} steps ...");
+        let output = generator
+            .generate(&req, &mut |_| {})
+            .unwrap_or_else(|e| panic!("{id} generate: {e}"));
+        let image = match output {
+            GenerationOutput::Images(mut images) => images.pop().expect("engine returned no image"),
+            other => panic!("expected Images output, got {other:?}"),
+        };
+        let std = image_std(&image);
+        let png = out_dir.join(format!("{id}_worker_lane_1024.png"));
+        save_png(&image, &png);
+        println!(
+            "[worker-smoke] {id}: {}x{} mean {:.2} std {:.2} -> {}",
+            image.width,
+            image.height,
+            image_mean(&image),
+            std,
+            png.display()
+        );
+        assert_eq!((image.width, image.height), (1024, 1024));
+        assert!(
+            std > DEGENERATE_STD_FLOOR_DEFAULT,
+            "{id} render looks degenerate (std {std:.2})"
+        );
+    }
+    println!("[worker-smoke] DONE: all three Anima variants rendered through the worker resolver + dense lane");
+}

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -485,6 +485,19 @@ pub(crate) fn resolve_weights_dir(
     if request.model == "krea_2_turbo" || request.model == "krea_2_raw" {
         return Ok(snapshot.map(|root| krea_model_subdir(&root, request)));
     }
+    // Anima off-Mac (candle, sc-10676): dense bf16, NOT convert-at-install. There is no converted tier
+    // artifact off-Mac (the `anima_quant` converter is macOS-only), so point at the raw
+    // `circlestone-labs/Anima` `split_files/` root the candle loader reads directly (its DiT +
+    // `text_encoders/qwen_3_06b_base` + `vae/qwen_image_vae`, the exact dir the GPU-validated anima smoke
+    // used) and SKIP `anima_tier_subdir` — there are no bf16/q8/q4 tier subdirs off-Mac. The candle
+    // loader's `resolve_split_files` also accepts the snapshot parent, so fall back to the snapshot root
+    // if `split_files/` is somehow absent (a partial download then surfaces a loud load error, not a
+    // silently-wrong dir). macOS never reaches here: a converted Anima install injects `modelPath` and
+    // returns early via the `is_anima_model` tier-descent branch at the top of this fn.
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    if is_anima_model(&request.model) {
+        return Ok(snapshot.map(anima_dense_split_files_dir));
+    }
     // Catalog-wide quant-matrix models (sc-8513, epic 8506) ship as SceneWorks pre-quantized
     // turnkeys with self-contained `q4/` (default) + `q8/` + `bf16/` subdirs (replacing any
     // install-time convert); point the engine at the chosen tier's subdir rather than the repo root.
@@ -748,6 +761,23 @@ fn anima_tier_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
         .or_else(|| present("q8"))
         .or_else(|| present("bf16"))
         .unwrap_or_else(|| root.to_path_buf())
+}
+
+/// The candle off-Mac Anima weights dir (sc-10676): the `split_files/` subdir of the HF snapshot `root`
+/// when it holds `diffusion_models/` (the dense DiT tree `candle_gen_anima::loader::resolve_split_files`
+/// reads — the exact dir the GPU-validated anima smoke used), else `root` itself. The candle loader also
+/// accepts the snapshot parent, so falling back to `root` keeps a partial download a loud load error, not
+/// a silently-wrong dir. Anima has NO convert-at-install tier off-Mac (the `anima_quant` converter is
+/// macOS-only), so this deliberately SKIPS [`anima_tier_subdir`]'s bf16/q8/q4 tier descent — off-Mac is
+/// always dense bf16.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn anima_dense_split_files_dir(root: PathBuf) -> PathBuf {
+    let split = root.join("split_files");
+    if split.join("diffusion_models").is_dir() {
+        split
+    } else {
+        root
+    }
 }
 
 /// The Ideogram 4 tier subdir a `mlxQuantize` request needs fetched ON DEMAND — `Some("q8")` when the
@@ -3555,6 +3585,16 @@ fn is_candle_engine(model: &str) -> bool {
             | "sd3_5_large"
             | "sd3_5_large_turbo"
             | "sd3_5_medium"
+            // Anima 2B base / aesthetic / turbo (sc-10676, epic 10512): the candle port (sc-10525,
+            // GPU-validated sc-10625) rides the generic candle txt2img lane off-Mac. `generate_candle_\
+            // stream` dense-loads bf16 from the raw `circlestone-labs/Anima` split_files/ tree (no
+            // convert-at-install off-Mac) and FORCES the load Quant to None — the descriptor advertises
+            // Q4/Q8 but there is no packed tier off-Mac, and the loader rejects a quant against the dense
+            // DiT. Inference LoRA/LoKr folds onto the dense DiT (`supports_lora`/`supports_lokr`); quant +
+            // LoRA together stays rejected (sc-10578). Pure txt2img (no edit/reference/control shapes).
+            | "anima_base"
+            | "anima_aesthetic"
+            | "anima_turbo"
     )
 }
 
@@ -3585,6 +3625,9 @@ fn candle_adapter_label(model: &str) -> &'static str {
         "krea_2_turbo" | "krea_2_raw" => "candle_krea",
         // Stable Diffusion 3.5 (sc-7880): Large / Large Turbo / Medium share the candle SD3.5 engine.
         "sd3_5_large" | "sd3_5_large_turbo" | "sd3_5_medium" => "candle_sd3",
+        // Anima 2B (sc-10676): base / aesthetic / turbo share the candle Anima engine (the off-Mac
+        // sibling of the `mlx_anima` label).
+        "anima_base" | "anima_aesthetic" | "anima_turbo" => "candle_anima",
         // sdxl / realvisxl share the candle "sdxl" engine.
         _ => CANDLE_ADAPTER,
     }
@@ -3708,6 +3751,17 @@ async fn generate_candle_stream(
         // INT8-ConvRot (sc-9300): the int8 DiT replaces the dense transformer wholesale — a bits-based
         // load-time `Quant` is meaningless (and the candle-gen krea engine rejects a quant overlay on
         // the ConvRot path). Force dense-None; the recipe records no `mlxQuantize` bits for this tier.
+        (None, None)
+    } else if is_anima_model(&request.model) {
+        // Anima off-Mac (sc-10676): the descriptor advertises Q4/Q8, but there is NO packed tier off-Mac
+        // — the `anima_quant` converter is macOS-only and the NC license bars publishing one, and the
+        // candle loader only CONSUMES an MLX-packed tier (it hard-rejects a quant request against the
+        // dense split_files/ DiT: "the DiT checkpoint is DENSE … load the dense tier"). So force dense
+        // bf16 here, IGNORING the manifest `mlx.quantize: 4` default that `resolve_quant` would otherwise
+        // apply — else every plain candle Anima job would fail the loader's packed-detect. The router
+        // keeps `candle_quant = false`, so a deliberate `advanced.mlxQuantize > 0` never reaches this lane
+        // (it defers rather than silently running dense); this arm handles the default-quant case the
+        // router doesn't strip. A dense DiT + LoRA/LoKr still folds (Quant None ⇒ no sc-10578 reject).
         (None, None)
     } else if model.supports_quant() {
         resolve_quant(request)
@@ -4434,6 +4488,10 @@ mod candle_label_tests {
         assert_eq!(candle_adapter_label("sd3_5_large"), "candle_sd3");
         assert_eq!(candle_adapter_label("sd3_5_large_turbo"), "candle_sd3");
         assert_eq!(candle_adapter_label("sd3_5_medium"), "candle_sd3");
+        // Anima 2B (sc-10676): the candle asset stamp, the off-Mac sibling of `mlx_anima`.
+        assert_eq!(candle_adapter_label("anima_base"), "candle_anima");
+        assert_eq!(candle_adapter_label("anima_aesthetic"), "candle_anima");
+        assert_eq!(candle_adapter_label("anima_turbo"), "candle_anima");
     }
 
     #[test]
@@ -4475,6 +4533,10 @@ mod candle_label_tests {
             "sd3_5_large",
             "sd3_5_large_turbo",
             "sd3_5_medium",
+            // Anima 2B (sc-10676): base / aesthetic / turbo dense-load bf16 on the generic candle lane.
+            "anima_base",
+            "anima_aesthetic",
+            "anima_turbo",
         ] {
             assert!(is_candle_engine(model), "{model} should be a candle engine");
         }
@@ -4808,6 +4870,33 @@ mod standard_tier_tests {
         assert_eq!(
             anima_tier_subdir(tmp3.path(), &anima_request(json!(null))),
             tmp3.path().to_path_buf()
+        );
+    }
+
+    /// sc-10676: off-Mac candle dense-load resolution. [`anima_dense_split_files_dir`] descends into the
+    /// `split_files/` subdir of the HF snapshot (the raw dense DiT tree, NOT a converted q4/q8/bf16 tier),
+    /// falling back to the snapshot root when `split_files/` is absent (the candle loader accepts the
+    /// parent; a partial download stays a loud load error). This is the off-Mac counterpart to the mac
+    /// convert-at-install [`anima_tier_subdir`] — there are no tier subdirs off-Mac.
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    #[test]
+    fn anima_dense_split_files_dir_descends_into_split_files_else_root() {
+        // Snapshot holds `split_files/diffusion_models/...` → resolve there (the loader reads it directly).
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("split_files").join("diffusion_models")).unwrap();
+        assert_eq!(
+            anima_dense_split_files_dir(root.to_path_buf()),
+            root.join("split_files"),
+            "descends into split_files/ when present"
+        );
+        // No `split_files/` yet (partial/absent download) → the snapshot root; the loader surfaces a
+        // clear "not an Anima split_files dir" error rather than this silently pointing at a wrong dir.
+        let tmp2 = tempfile::tempdir().unwrap();
+        assert_eq!(
+            anima_dense_split_files_dir(tmp2.path().to_path_buf()),
+            tmp2.path().to_path_buf(),
+            "falls back to the snapshot root when split_files/ is absent"
         );
     }
 


### PR DESCRIPTION
Extracted from sc-10625 (the GPU-validation is merged: candle-gen #380 `02c0df4`, worker #1349). The engine runs on real CUDA, but flipping `macOnly`/`candle_routed` needed distinct routing wiring.

## What changed

**Manifest** (`builtin.models.jsonc`, all 3 Anima entries)
- `macOnly: false`.
- A **non-mac dense bf16 download** (`platforms: ["windows","linux"]`) enumerating the 3 exact `split_files/` paths — variant DiT + shared Qwen3 TE + Qwen-Image VAE — never the ~30GB bare repo. The mac convert-source entry stays.

**Worker** (`image_jobs/base.rs`)
- Add the anima ids to `is_candle_engine` (→ generic candle txt2img lane) and `candle_adapter_label` (→ `candle_anima`).
- `resolve_weights_dir` dense-loads bf16 straight from the raw `split_files/` tree via the new `anima_dense_split_files_dir`, **skipping** the macOS-only `anima_tier_subdir` tier descent (there are no q4/q8/bf16 tier subdirs off-Mac).
- `generate_candle_stream` **forces the load Quant to `None`** for Anima. The descriptor advertises `supported_quants: [Q4,Q8]`, so `resolve_quant` would apply the manifest `quantize: 4` default — but there is no packed tier off-Mac and the candle loader hard-rejects a quant against the dense DiT ("the DiT checkpoint is DENSE … load the dense tier"). Without this, every plain candle job would fail the packed-detect.

**Routing** (`routing/catalog.rs`)
- `ModelCaps("anima_*", mlx=true, candle_routed=true, candle_quant=false, candle_lora=true, candle_quant_lora=false)`.
- `candle_lora=true`: the engine dense-folds a LoRA/LoKr onto the split_files/ DiT (validated in the anima GPU smoke). `candle_quant=false`: no packed tier off-Mac, so a deliberate `mlxQuantize>0` defers rather than silently running dense (sc-10515 anti-lie). `candle_quant_lora=false`: quant+LoRA together stays rejected (sc-10578).
- Updated `EXPECTED_CANDLE_ROUTED_MODELS` + `EXPECTED_CANDLE_LORA_MODELS`.

## Out of scope / blocked
- **q4/q8 on candle off-Mac** stays `candle_quant=false` — no packed Anima tier is producible (converter is macOS-only) or publishable (NC license). Needs a Mac-produced tier or a Windows quantizer.
- **Quant + LoRA together** stays rejected — sc-10578.

## Tests
- Core routing snapshots + superset invariant: green.
- Full candle worker lib suite (`--features backend-candle`): **491 passed, 0 failed** — includes the updated `is_candle_engine`/`candle_adapter_label` coverage, the new `anima_dense_split_files_dir` test, and the builtin-manifest parse tests.
- `cargo fmt` clean.

## Remaining acceptance (task #4)
Full-worker E2E on the NVIDIA rig (download dense bf16 + generate all 3 variants through the routed lane). The **engine + dense split_files load + LoRA fold are already GPU-validated** via the anima smoke, which drives the exact `WeightsSource::Dir(<snapshot>/split_files)` the worker now resolves; the remaining gap is only the shared job-plumbing.

Relates to sc-10625.

🤖 Generated with [Claude Code](https://claude.com/claude-code)