### PR TITLE
fix(models): refetch the catalog when a model import completes (sc-10688)

### DIFF
--- a/apps/web/src/App.models.test.jsx
+++ b/apps/web/src/App.models.test.jsx
@@ -263,6 +263,63 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Converted to MLX and ready.");
   });
 
+  it("adds the imported model's row when a model import completes", async () => {
+    // sc-10688, the same gap sc-10679 closed for `model_convert`. A completed model_import upserts
+    // the model into `user.models.jsonc`, and the catalog is derived from that manifest server-side.
+    // Without a refetch on the SSE `job.updated` the Models page never grows the imported row until
+    // the app restarts. (The import route is 403-gated today under sc-7081; this locks the wiring in
+    // so epic 7080's re-enable does not have to rediscover it.)
+    let models = [{ id: "anima_2b", name: "Anima 2B", type: "image", family: "anima", installState: "installed" }];
+    global.fetch.mockImplementation((url) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-1", name: "Noir" }]));
+      }
+      if (path.endsWith("/models")) {
+        return Promise.resolve(response(models));
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+    await act(async () => {
+      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Models").click();
+    });
+    await settle();
+
+    const cardTitles = () => [...container.querySelectorAll(".model-card-title strong")].map((node) => node.textContent);
+    expect(cardTitles()).toEqual(["Anima 2B"]);
+
+    models = [
+      ...models,
+      { id: "imported_checkpoint", name: "Imported Checkpoint", type: "image", family: "anima", installState: "installed" },
+    ];
+    await act(async () => {
+      FakeEventSource.instances[0].listeners["job.updated"]({
+        data: JSON.stringify({
+          id: "import-job-1",
+          type: "model_import",
+          status: "completed",
+          payload: { modelId: "imported_checkpoint", modelName: "Imported Checkpoint" },
+        }),
+      });
+    });
+    await settle();
+    await settle();
+
+    expect(cardTitles()).toEqual(["Anima 2B", "Imported Checkpoint"]);
+  });
+
   it("keeps LoRA imports on the Models page and shows local progress", async () => {
     const createdJobs = [];
     global.fetch.mockImplementation((url, options = {}) => {

--- a/apps/web/src/hooks/useJobEvents.js
+++ b/apps/web/src/hooks/useJobEvents.js
@@ -92,10 +92,19 @@ export function useJobEvents({
         refreshAssetsRef.current?.(job.projectId);
       }
       // A completed download flips the catalog's `installState`; a completed conversion writes the
-      // MLX artifact that flips `mlxConversionState` to "converted". Both are derived server-side
-      // from the filesystem, so the catalog must be refetched or the Models row keeps offering
-      // "Convert to MLX" for an already-converted model until the app is restarted.
-      if (job.status === "completed" && (job.type === "model_download" || job.type === "model_convert")) {
+      // MLX artifact that flips `mlxConversionState` to "converted"; a completed import upserts the
+      // model into `user.models.jsonc` (sc-10688). All three are derived server-side from the
+      // filesystem/manifests, so the catalog must be refetched or the Models page keeps rendering
+      // the pre-job row — still offering "Convert to MLX" for an already-converted model, or
+      // omitting the imported one entirely — until the app is restarted.
+      //
+      // `model_import` cannot fire today: `create_model_import_job` 403s on every platform behind
+      // the sc-7081 kill-switch, so no such job is ever queued. It is wired here so 7080's P5
+      // re-enable flips the feature on complete, not one refresh short.
+      if (
+        job.status === "completed" &&
+        (job.type === "model_download" || job.type === "model_convert" || job.type === "model_import")
+      ) {
         refreshDataRef.current?.();
       }
       // A completed built-in LoRA download (sc-5944) flips the catalog entry to


### PR DESCRIPTION
## Summary

Closes the same catalog-refetch gap [sc-10679](https://app.shortcut.com/trefry/story/10679) fixed for `model_convert`, now for `model_import` ([sc-10688](https://app.shortcut.com/trefry/story/10688)).

`useJobEvents` refetches the model catalog on a completed `model_download` or `model_convert` job, but `model_import` was missing. A completed import upserts the model into `config/manifests/user.models.jsonc`, from which the catalog is derived server-side, so the Models page omitted the imported row until the app restarted.

## Change

- [apps/web/src/hooks/useJobEvents.js](apps/web/src/hooks/useJobEvents.js): add `model_import` to the completed-job catalog refetch.
- [apps/web/src/App.models.test.jsx](apps/web/src/App.models.test.jsx): regression test mirroring the sc-10679 `model_convert` test — asserts the imported model's card appears after the SSE `job.updated` completes. **Confirmed to fail against the unfixed hook** (imported card never appears), and asserts on `.model-card-title strong` so it can't pass off a transient job card.

## Correction to the story's premise

The story argued a LAN client (epic 4484) could hit this live today via `POST /api/v1/models/import`. It can't: `create_model_import_job` returns **403 on every platform** behind the sc-7081 kill-switch (epic 7080), *before* any staging or queueing, and that handler is the only site that constructs a `ModelImport` job. So the branch is **latent, not live** — no path fires it until epic 7080's P5 re-enables the feature.

Per the "answer is always now / don't defer" posture, I implemented the wiring + test now rather than leaving it backlogged, so the re-enable doesn't land one refresh short. The code comment documents that it's currently unreachable and why.

## Testing

- `apps/web`: full vitest suite — 1404 passed (106 files), including the new test.
- `npm run lint` (eslint) — 0 errors (48 pre-existing warnings, none in touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)