### PR TITLE
fix(routing): claim Anima jobs on the mlx worker — missing dispatch arm (sc-10693)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
@@ -75,7 +75,9 @@ pub(crate) fn image_request_mlx_eligible(model: &str, payload: &Map<String, Valu
         "krea_2_turbo" | "krea_2_raw" => krea_mlx_eligible(payload),
         "sd3_5_large" | "sd3_5_large_turbo" | "sd3_5_medium" => sd3_5_mlx_eligible(payload),
         "sana_1600m" | "sana_sprint_1600m" => sana_mlx_eligible(payload),
-        // Every model in MLX_ROUTED_MODELS must have an arm.
+        "anima_base" | "anima_aesthetic" | "anima_turbo" => anima_mlx_eligible(payload),
+        // Every model in MLX_ROUTED_MODELS must have an arm — enforced by
+        // `every_mlx_routed_model_has_a_dispatch_arm` below, not just by this comment.
         _ => false,
     }
 }
@@ -452,6 +454,20 @@ pub(crate) fn sana_mlx_eligible(payload: &Map<String, Value>) -> bool {
     payload.get("mode").and_then(Value::as_str) != Some("edit_image")
 }
 
+/// Anima base / aesthetic / turbo (epic 10512 / sc-10523) MLX-eligibility. The native `mlx-gen-anima`
+/// engine serves the **text-to-image** surface only — the manifest declares `capabilities:
+/// ["text_to_image"]` and the Cosmos-Predict2 DiT has no source/reference/edit path — so an
+/// `edit_image` request is rejected, the same defensive shape SANA / SD3.5 / Krea / Lens use. All
+/// three variants share the engine and differ only in checkpoint + step/guidance defaults.
+///
+/// Anima is `mlx_routed` with `candle_routed = false`, so this predicate is the ONLY thing that can
+/// make an Anima job claimable: the mlx worker refuses a job it is not eligible for
+/// (`worker_supports_job`) and no candle/torch lane advertises the family. A missing arm here left
+/// every Anima job queued on "Waiting for an available worker." forever.
+pub(crate) fn anima_mlx_eligible(payload: &Map<String, Value>) -> bool {
+    payload.get("mode").and_then(Value::as_str) != Some("edit_image")
+}
+
 /// Epic 3018 routing (sc-3036, the video sibling of [`image_job_is_mlx_eligible`]):
 /// does this video job belong on the in-process Rust MLX worker? Encodes today's
 /// Python `create_video_adapter` MLX-eligibility (video_adapters.py) at the claim
@@ -706,4 +722,54 @@ pub(crate) fn training_plan_is_lokr(plan: &Map<String, Value>) -> bool {
         .and_then(|advanced| advanced.get("networkType"))
         .and_then(Value::as_str)
         .is_some_and(|value| value.trim().eq_ignore_ascii_case("lokr"))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{json, Map, Value};
+
+    use super::{image_request_mlx_eligible, MLX_ROUTED_MODELS};
+
+    /// Every id in [`MLX_ROUTED_MODELS`] must have a real arm in [`image_request_mlx_eligible`]'s
+    /// dispatch. An id that falls through to the `_ => false` catch-all is never MLX-eligible for
+    /// ANY payload, so the mlx worker refuses to claim it (`worker_supports_job`) — and for an
+    /// `mlx_routed`-only family (no candle/torch lane) the job then sits on "Waiting for an
+    /// available worker." forever. That is exactly how three Anima ids shipped in sc-10523: the
+    /// caps table gained `mlx_routed = true` rows, but `image_request_mlx_eligible` gained no arm,
+    /// and only a prose comment guarded the invariant.
+    ///
+    /// Encoded as reachability rather than by inspecting the `match`: a model HAS an arm iff some
+    /// payload makes it eligible. The probes below cover every conditioning shape the arms gate on
+    /// (plain t2i, edit + source, character + reference), so a model that answers `false` to all
+    /// three has no arm — or has one that can never fire, which strands jobs just as badly.
+    #[test]
+    fn every_mlx_routed_model_has_a_dispatch_arm() {
+        let probes = |model: &str| -> Vec<Map<String, Value>> {
+            let shapes = [
+                json!({ "model": model, "mode": "text_to_image" }),
+                json!({ "model": model, "mode": "edit_image", "sourceAssetId": "asset-1" }),
+                json!({ "model": model, "mode": "character_image", "referenceAssetId": "asset-1" }),
+            ];
+            shapes
+                .into_iter()
+                .map(|shape| shape.as_object().expect("probe is an object").clone())
+                .collect()
+        };
+
+        let stranded: Vec<&str> = MLX_ROUTED_MODELS
+            .iter()
+            .copied()
+            .filter(|model| {
+                !probes(model)
+                    .iter()
+                    .any(|payload| image_request_mlx_eligible(model, payload))
+            })
+            .collect();
+
+        assert!(
+            stranded.is_empty(),
+            "MLX_ROUTED_MODELS ids with no reachable arm in `image_request_mlx_eligible` — the mlx \
+             worker can never claim these, so their jobs queue forever: {stranded:?}"
+        );
+    }
 }

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -5780,3 +5780,88 @@ fn progress_from_non_owner_worker_is_rejected() {
         .expect_err("ownerless report on an owned job is rejected");
     assert!(matches!(error, JobsStoreError::NotJobOwner { .. }));
 }
+
+/// Regression for the Anima routing gap (epic 10512 / sc-10523): `anima_base`/`anima_aesthetic`/
+/// `anima_turbo` shipped as `mlx_routed = true` rows in `IMAGE_MODEL_CAPS`, but
+/// `image_request_mlx_eligible` had no dispatch arm for them, so they fell through to `_ => false`.
+/// The mlx worker then refused to claim them (`worker_supports_job`), and because Anima advertises
+/// no candle/torch lane (`candle_routed = false`, macOnly) NOTHING could claim the job — every
+/// Anima generation sat on "Waiting for an available worker." forever.
+#[test]
+fn mlx_worker_claims_anima_text_to_image_jobs() {
+    for model in ["anima_base", "anima_aesthetic", "anima_turbo"] {
+        // A fresh store + worker per model: a worker that claims a job goes `busy` and holds a
+        // `current_job_id`, so it cannot claim a second job in the same store.
+        let store = store(&format!("anima-claim-{model}"));
+        store
+            .register_worker(RegisterWorker {
+                worker_id: "mlx-worker".to_owned(),
+                gpu_id: "mlx".to_owned(),
+                gpu_name: Some("Apple Silicon (MLX)".to_owned()),
+                capabilities: vec![
+                    WorkerCapability::Gpu,
+                    WorkerCapability::ImageGenerate,
+                    WorkerCapability::ImageDetail,
+                ],
+                loaded_models: Vec::new(),
+                utilization: None,
+            })
+            .expect("mlx worker registers");
+
+        let mut payload = Map::new();
+        payload.insert("model".to_owned(), Value::String(model.to_owned()));
+        payload.insert("mode".to_owned(), Value::String("text_to_image".to_owned()));
+        let job = store.create_job(image_job(payload)).expect("job created");
+
+        let claimed = store
+            .claim_next_job("mlx-worker")
+            .expect("claim ok")
+            .unwrap_or_else(|| {
+                panic!(
+                    "{model}: mlx worker must claim the Anima job, but nothing claimed it \
+                     (job {} sits on 'Waiting for an available worker.')",
+                    job.id
+                )
+            });
+        assert_eq!(claimed.id, job.id, "{model}: claimed the wrong job");
+        assert_eq!(
+            claimed.assigned_gpu.as_deref(),
+            Some("mlx"),
+            "{model}: Anima must land on the mlx worker"
+        );
+    }
+}
+
+/// Anima has no edit path (`capabilities: ["text_to_image"]`), so an `edit_image` request must NOT
+/// be MLX-eligible — the defensive shape SANA / SD3.5 / Krea / Lens use.
+#[test]
+fn mlx_worker_refuses_anima_edit_image_jobs() {
+    let store = store("anima-refuses-edit");
+    store
+        .register_worker(RegisterWorker {
+            worker_id: "mlx-worker".to_owned(),
+            gpu_id: "mlx".to_owned(),
+            gpu_name: Some("Apple Silicon (MLX)".to_owned()),
+            capabilities: vec![WorkerCapability::Gpu, WorkerCapability::ImageGenerate],
+            loaded_models: Vec::new(),
+            utilization: None,
+        })
+        .expect("mlx worker registers");
+
+    let mut payload = Map::new();
+    payload.insert("model".to_owned(), Value::String("anima_base".to_owned()));
+    payload.insert("mode".to_owned(), Value::String("edit_image".to_owned()));
+    payload.insert(
+        "sourceAssetId".to_owned(),
+        Value::String("asset-1".to_owned()),
+    );
+    store.create_job(image_job(payload)).expect("job created");
+
+    assert!(
+        store
+            .claim_next_job("mlx-worker")
+            .expect("claim ok")
+            .is_none(),
+        "an Anima edit_image job must not be claimed by the mlx worker"
+    );
+}


### PR DESCRIPTION
## Symptom

Generating with **any** Anima model (`anima_base` / `anima_aesthetic` / `anima_turbo`) **on macOS** sits on **"Waiting for an available worker."** forever. The job is created, never claimed, never starts.

## Root cause

sc-10523 (`9cfdde84`) added the three Anima rows to `IMAGE_MODEL_CAPS` with `mlx_routed = true`, so they joined the derived `MLX_ROUTED_MODELS`. But `image_request_mlx_eligible` gates on **two** things:

```rust
if !MLX_ROUTED_MODELS.contains(&model) { return false; }   // gate 1: membership — Anima passed
match model {
    "sana_1600m" | "sana_sprint_1600m" => sana_mlx_eligible(payload),
    // ...no anima arm existed...
    _ => false,                                             // gate 2: Anima fell here
}
```

Membership is **necessary but not sufficient** — eligibility is decided by the per-model `match` arm (which is also where a model expresses per-mode nuance like "t2i yes, `edit_image` no"). Anima had no arm, so every request returned `false`.

That is fatal on **macOS specifically**: the in-process `mlx` worker is the only generation lane, and it refuses a job it isn't eligible for (`worker_supports_job`). Anima has no torch adapter, and the candle lane never runs on a Mac. ⇒ no registered worker can claim the job.

## Fix (`crates/sceneworks-core/src/jobs_store/routing/mlx.rs`)

1. Add `anima_mlx_eligible` + its dispatch arm. Anima's manifest declares `capabilities: ["text_to_image"]` and the Cosmos-Predict2 DiT has no source/reference/edit path, so it admits every mode except `edit_image` — the same defensive shape SANA / SD3.5 / Krea / Lens use.
2. Replace the prose invariant (`// Every model in MLX_ROUTED_MODELS must have an arm.`) with a real **reachability** test, `every_mlx_routed_model_has_a_dispatch_arm`: for every id in `MLX_ROUTED_MODELS`, some payload must make `image_request_mlx_eligible` return true. A model with no arm answers `false` to all probes and is named in the failure. Catches the whole bug class, not just Anima.

## Verification

Wrote the failing reproduction **first**, then mutation-checked every test:

| Mutation | Result |
|---|---|
| Remove the dispatch arm | `mlx_worker_claims_anima_text_to_image_jobs` FAILS; guard names all 3 ids |
| Make `anima_mlx_eligible` always `true` | `mlx_worker_refuses_anima_edit_image_jobs` FAILS |

- New tests in `tests/jobs_store.rs`: `mlx_worker_claims_anima_text_to_image_jobs` (asserts `assigned_gpu == "mlx"` for all three ids), `mlx_worker_refuses_anima_edit_image_jobs`.
- Anima's `model_mac_support` output is now **byte-identical to SANA's** (`supported=true pose=true reference=true edit=false`) — its closest t2i-only precedent.
- Full `sceneworks-core` suite green; `npm run rust:check` exits 0.
- Anima is in **no** API contract snapshot, so nothing needed re-baselining.
- **Video table checked** — safe. `video_mode_is_mlx_eligible` dispatches on *mode* and defaults `text_to_video | image_to_video => true` (deny-safe). Only the image table denies by default, so only it has the strand hazard.

## Relationship to sc-10676 / #1354

[#1354](https://github.com/SceneWorks/SceneWorks/pull/1354) routes Anima to the **off-Mac candle lane** (`macOnly: false`, `candle_routed = true`). It does **not** touch `routing/mlx.rs` and keeps `mlx_routed = true`, so it does **not** fix the macOS hang. The two are complementary and non-conflicting (no shared files): #1354 = Windows/Linux; this PR = macOS. Both are needed for Anima to run everywhere.

Fixes sc-10693.

🤖 Generated with [Claude Code](https://claude.com/claude-code)