### PR TITLE
feat(models): register Illustrious-XL v1.0 + v2.0 (sc-10615)

### DIFF
--- a/apps/web/public/prompt-guides/illustrious.md
+++ b/apps/web/public/prompt-guides/illustrious.md
@@ -1,0 +1,83 @@
+# Illustrious Prompt Guide
+
+## Best For
+
+Anime and illustration text-to-image. Illustrious-XL (OnomaAI) is a Danbooru-tag SDXL finetune — it shares the SDXL architecture, sdxl-family LoRA support, real CFG + negative prompt, and dual-CLIP text encoding, but is trained for high-resolution illustration rather than photorealism. Two versions are offered as separate models; see **v1.0 vs v2.0** below.
+
+## Prompt Shape
+
+Illustrious is trained on **Danbooru-style tags blended with natural language**. You can prompt with plain English, with comma-separated tags, or with both — tags give you the most precise control over anime-specific attributes.
+
+A reliable structure:
+
+`quality tags + subject count + character/appearance tags + clothing + pose/expression + setting + composition`
+
+The CLIP encoders weight earlier tokens more heavily, so **lead with the quality tags and the subject**.
+
+## Quality Tags
+
+The community convention is to open with a short quality preamble, then the subject:
+
+`masterpiece, best quality, highly detailed, 1girl, solo, ...`
+
+Common openers: `masterpiece`, `best quality`, `highly detailed`, `absurdres`. These are learned tokens, not magic — one or two is plenty.
+
+## Subject Count
+
+Danbooru count tags are load-bearing. State them explicitly:
+
+- `1girl, solo` — a single subject
+- `2girls` / `1boy, 1girl` — multiple subjects
+
+If you want one character, write `1girl, solo` (or `1boy, solo`). See the note under v2.0 about wide frames.
+
+## Build The Prompt
+
+### Appearance
+
+Tag hair, eyes, and distinguishing features:
+
+`silver hair, long hair, blue eyes, hair between eyes, ahoge`
+
+### Clothing
+
+`school uniform, sailor collar, pleated skirt, thighhighs`
+
+### Pose and Expression
+
+`standing, looking at viewer, light smile, arms behind back`
+
+### Setting
+
+`cherry blossom park, outdoors, day, falling petals`
+
+### Composition
+
+`full body`, `upper body`, `cowboy shot`, `from above`, `dutch angle`
+
+## Negative Prompt
+
+Anime models use a different negative-prompt convention than photoreal ones. A practical baseline:
+
+`lowres, bad anatomy, bad hands, missing fingers, extra digits, worst quality, low quality, jpeg artifacts, signature, watermark, username, blurry`
+
+## v1.0 vs v2.0
+
+These are **separate models, not a version upgrade** — pick per job.
+
+- **v1.0** handles wide and large frames well, including up to 1536×1536 and tall non-standard ratios. Reach for it when you want a big or wide composition.
+- **v2.0** (the "STABLE" annealing snapshot) tends to be subtler and more consistent, but it is prone to **duplicating the subject in wide frames** — a `1girl, solo` prompt can render two characters once the frame gets wide. Its resolution picker therefore omits the widest buckets. Prefer square or tall framing with v2.0; if you see an unwanted second character, narrow the frame.
+
+## Settings
+
+- **Steps:** ~30
+- **Guidance (CFG):** ~7.0
+- **Sampler:** the default (Euler) is a good starting point; `dpmpp_2m` with a Karras schedule is a common alternative.
+- **Resolution:** native 1024×1024; see the resolution picker for the safe set per version.
+
+## License
+
+- **v1.0** — SDXL license (CreativeML Open RAIL++-M). Commercial use OK, ungated.
+- **v2.0** — CreativeML OpenRAIL-M. Commercial use OK, ungated.
+
+Both carry behavioral-use restrictions per their respective licenses.

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -373,6 +373,26 @@ export const fallbackModels = [
     },
   },
   {
+    id: "illustrious_xl_v1",
+    name: "Illustrious-XL v1.0 (anime)",
+    type: "image",
+    capabilities: ["text_to_image", "edit_image", "character_image", "style_variations"],
+    ui: {
+      description: "Danbooru-tag anime SDXL finetune from OnomaAI, trained for high-resolution illustration. Same SDXL UNet + dual CLIP, sdxl-family LoRA support, real CFG + negative prompt. Prompts blend Danbooru tags with natural language. Handles wide frames up to 1536x1536. SDXL license (openrail++), commercial use OK, ungated.",
+      promptGuide: { title: "Illustrious Prompt Guide", path: "/prompt-guides/illustrious.md" },
+    },
+  },
+  {
+    id: "illustrious_xl_v2",
+    name: "Illustrious-XL v2.0 (anime)",
+    type: "image",
+    capabilities: ["text_to_image", "edit_image", "character_image", "style_variations"],
+    ui: {
+      description: "The v2.0-STABLE snapshot of Illustrious-XL — subtler and more stable than v1.0, but with a narrower safe frame width (it tends to duplicate the subject in wide compositions, so the widest aspect buckets are not offered — prefer square or tall). Same Danbooru-tag prompting and sdxl-family LoRA support. CreativeML OpenRAIL-M, commercial use OK, ungated.",
+      promptGuide: { title: "Illustrious Prompt Guide", path: "/prompt-guides/illustrious.md" },
+    },
+  },
+  {
     id: "instantid_realvisxl",
     name: "InstantID (RealVisXL)",
     type: "image",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -4733,6 +4733,183 @@
       }
     },
     {
+      "id": "illustrious_xl_v1",
+      "name": "Illustrious-XL v1.0 (anime)",
+      "family": "sdxl",
+      "type": "image",
+      "adapter": "sdxl_diffusers",
+      // Danbooru-tag anime SDXL finetune (OnomaAI). Architecturally vanilla SDXL — identical UNet,
+      // dual CLIP-L + OpenCLIP-bigG, eps-pred, VAE scaling_factor 0.13025 — so it reuses the `sdxl`
+      // engine and the whole sdxl-family LoRA/LoKr stack unchanged (epic 10609).
+      "capabilities": ["text_to_image", "edit_image", "image_inpaint", "image_detail", "character_image", "style_variations"],
+      "downloads": [
+        // SceneWorks turnkey re-host (sc-10611). Upstream OnomaAIResearch/Illustrious-XL-v1.0 ships a
+        // SINGLE-FILE LDM checkpoint, which neither mlx-gen-sdxl nor candle-gen-sdxl can read — it is
+        // converted to a tiered diffusers turnkey offline by `scripts/build_sdxl_turnkey.py`
+        // (sc-10610). Sizes measured on the built trees, not extrapolated.
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/illustrious-xl-v1-mlx",
+          "variant": "q4",
+          "default": true,
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 3911461825,
+          "footprint": { "diskSizeBytes": 3911461825, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/illustrious-xl-v1-mlx",
+          "variant": "q8",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 5385646417,
+          "footprint": { "diskSizeBytes": 5385646417, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/illustrious-xl-v1-mlx",
+          "variant": "bf16",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 7108498305,
+          "footprint": { "diskSizeBytes": 7108498305, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/SceneWorks/illustrious-xl-v1-mlx"
+      },
+      "gated": false,
+      "defaults": {
+        "resolution": "1024x1024",
+        "steps": 30,
+        "guidanceScale": 7.0,
+        "count": 4
+      },
+      "limits": {
+        // MEASURED, not taken from the model card (sc-10620). v1.0 tolerates wide frames: 0/3 seeds
+        // duplicated the subject at 1536x1536, and 1248x1824 rendered cleanly. The card's "native
+        // 1536x1536" claim holds; the checkpoint's own `modelspec.resolution: 1024x1024` is a stale
+        // training-harness stamp. NOTE v2.0 does NOT share this list — see that entry.
+        "resolutions": ["1024x1024", "1152x896", "896x1152", "1216x832", "832x1216", "1344x768", "768x1344", "1536x1536"],
+        "count": [1, 2, 4],
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
+      },
+      "loraCompatibility": {
+        "families": ["sdxl"],
+        "types": ["style", "enhance", "character"]
+      },
+      "mlx": {
+        "quantize": 4,
+        "standardTierLayout": true,
+        "limits": {
+          "guidanceMethods": ["cfg", "cfg_pp"]
+        }
+      },
+      "ui": {
+        "label": "Illustrious-XL v1.0 (anime)",
+        "description": "Danbooru-tag anime SDXL finetune from OnomaAI, trained for high-resolution illustration. Same UNet and dual-CLIP as SDXL, so sdxl-family LoRAs apply and real CFG + negative prompt work as usual. Prompts blend Danbooru tags with natural language. Handles wide frames up to 1536x1536. SDXL license (openrail++), commercial use OK, ungated.",
+        "recommendedFor": ["text_to_image", "style_variations"],
+        "pid": { "checkpointId": "pid_sdxl" },
+        "promptGuide": {
+          "title": "Illustrious Prompt Guide",
+          "path": "/prompt-guides/illustrious.md",
+          "sources": [
+            { "label": "Illustrious-XL v1.0 model card", "url": "https://huggingface.co/OnomaAIResearch/Illustrious-XL-v1.0" },
+            { "label": "SDXL technical report", "url": "https://arxiv.org/abs/2307.01952" }
+          ]
+        }
+      }
+    },
+    {
+      "id": "illustrious_xl_v2",
+      "name": "Illustrious-XL v2.0 (anime)",
+      "family": "sdxl",
+      "type": "image",
+      "adapter": "sdxl_diffusers",
+      // The `v2.0-STABLE` last-annealing-phase snapshot of a cosine-annealing run. A SEPARATE
+      // catalog id, not a replacement for v1.0: upstream describe it as behaviourally distinct, and
+      // it has a materially narrower safe resolution range (see `limits`). Same vanilla-SDXL
+      // architecture, and it ships no checkpoint metadata at all — `prediction_type: epsilon` was
+      // read off the conversion, not the file (epic 10609).
+      "capabilities": ["text_to_image", "edit_image", "image_inpaint", "image_detail", "character_image", "style_variations"],
+      "downloads": [
+        // SceneWorks turnkey re-host (sc-10612). As with v1.0, upstream ships a single-file LDM
+        // checkpoint converted offline by `scripts/build_sdxl_turnkey.py`. v2.0 additionally carries a
+        // stray I64 `position_ids` buffer and a BF16 VAE, both normalized by the conversion.
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/illustrious-xl-v2-mlx",
+          "variant": "q4",
+          "default": true,
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 3911461501,
+          "footprint": { "diskSizeBytes": 3911461501, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/illustrious-xl-v2-mlx",
+          "variant": "q8",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 5385646137,
+          "footprint": { "diskSizeBytes": 5385646137, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/illustrious-xl-v2-mlx",
+          "variant": "bf16",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 7108498177,
+          "footprint": { "diskSizeBytes": 7108498177, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/SceneWorks/illustrious-xl-v2-mlx"
+      },
+      "gated": false,
+      "defaults": {
+        "resolution": "1024x1024",
+        "steps": 30,
+        "guidanceScale": 7.0,
+        "count": 4
+      },
+      "limits": {
+        // DELIBERATELY NARROWER THAN v1.0 — do not "unify" these two lists (sc-10620).
+        // v2.0 duplicates the subject in WIDE frames: a `1girl, solo` prompt renders two girls on
+        // 1/2 seeds at 1344 wide and 3/4 at 1536 wide, while v1.0 is 0/3 at 1536. The failure tracks
+        // horizontal extent, not pixel count — v2 @1536x1024 duplicates while v2 @1024x1536 (same
+        // 1.57 MP) is clean. So `1344x768` (a STOCK SDXL bucket) and `1536x1536` are both omitted,
+        // while the tall `768x1344` is kept: only wide frames fail.
+        "resolutions": ["1024x1024", "1152x896", "896x1152", "1216x832", "832x1216", "768x1344"],
+        "count": [1, 2, 4],
+        "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
+        "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
+      },
+      "loraCompatibility": {
+        "families": ["sdxl"],
+        "types": ["style", "enhance", "character"]
+      },
+      "mlx": {
+        "quantize": 4,
+        "standardTierLayout": true,
+        "limits": {
+          "guidanceMethods": ["cfg", "cfg_pp"]
+        }
+      },
+      "ui": {
+        "label": "Illustrious-XL v2.0 (anime)",
+        "description": "The v2.0-STABLE snapshot of Illustrious-XL — subtler and more stable than v1.0, but with a narrower safe frame width: it tends to duplicate the subject in wide compositions, so the widest aspect buckets are not offered. Prefer square or tall framing. Same Danbooru-tag prompting and sdxl-family LoRA support. CreativeML OpenRAIL-M, commercial use OK, ungated.",
+        "recommendedFor": ["text_to_image", "style_variations"],
+        "pid": { "checkpointId": "pid_sdxl" },
+        "promptGuide": {
+          "title": "Illustrious Prompt Guide",
+          "path": "/prompt-guides/illustrious.md",
+          "sources": [
+            { "label": "Illustrious-XL v2.0 model card", "url": "https://huggingface.co/OnomaAIResearch/Illustrious-XL-v2.0" },
+            { "label": "SDXL technical report", "url": "https://arxiv.org/abs/2307.01952" }
+          ]
+        }
+      }
+    },
+    {
       "id": "instantid_realvisxl",
       "recommended": true,
       "name": "InstantID (RealVisXL)",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -5164,7 +5164,12 @@ mod candle_routing_tests {
         // A pure SDXL/RealVisXL reference (IP-Adapter) job routes to the candle lane (sc-5488) via the
         // bespoke branch, NOT the txt2img `image_request_candle_eligible` gate (which rejects
         // `referenceAssetId`).
-        for model in ["sdxl", "realvisxl"] {
+        for model in [
+            "sdxl",
+            "realvisxl",
+            "illustrious_xl_v1",
+            "illustrious_xl_v2",
+        ] {
             let payload = json!({ "model": model, "referenceAssetId": "asset_1" });
             assert!(sdxl_ipadapter_candle_eligible(&object(payload.clone())));
             assert!(image_job_is_candle_eligible(&image_generate_job(payload)));
@@ -5190,7 +5195,12 @@ mod candle_routing_tests {
         // SDXL/RealVisXL img2img / inpaint / outpaint edit jobs (sc-5487) route to the bespoke candle
         // `SdxlEdit` lane via the new branch, NOT the txt2img `image_request_candle_eligible` gate
         // (which rejects the whole `edit_image` family).
-        for model in ["sdxl", "realvisxl"] {
+        for model in [
+            "sdxl",
+            "realvisxl",
+            "illustrious_xl_v1",
+            "illustrious_xl_v2",
+        ] {
             // img2img (source, no mask).
             let img2img = json!({ "model": model, "mode": "edit_image", "sourceAssetId": "src_1" });
             assert!(sdxl_edit_candle_eligible(&object(img2img.clone())));

--- a/crates/sceneworks-core/src/jobs_store/routing/candle.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/candle.rs
@@ -59,7 +59,7 @@ pub(crate) fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     // txt2img — the `image_request_candle_eligible` gate below rejects the whole `edit_image` family.
     // Branch it out first (disjoint from the IP-Adapter lane below, which is reference-only and not
     // `edit_image`). Mirrors the worker's `sdxl_edit_candle_available` gate.
-    if matches!(model, "sdxl" | "realvisxl") && sdxl_edit_candle_eligible(&job.payload) {
+    if is_sdxl_family_candle_model(model) && sdxl_edit_candle_eligible(&job.payload) {
         return true;
     }
     // FLUX.2-klein reference / img2img edit (sc-5487, epic 5480): a klein-family `edit_image` job with a
@@ -147,7 +147,7 @@ pub(crate) fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     // the `image_request_candle_eligible` gate below rejects `referenceAssetId`. Branch it out first
     // (pure IP only; img2img/inpaint/edit shapes are the SDXL edit lane above). Mirrors the worker's
     // `sdxl_ipadapter_available` gate.
-    if matches!(model, "sdxl" | "realvisxl") && sdxl_ipadapter_candle_eligible(&job.payload) {
+    if is_sdxl_family_candle_model(model) && sdxl_ipadapter_candle_eligible(&job.payload) {
         return true;
     }
     // Kolors IP-Adapter-Plus reference conditioning (sc-5488, epic 5480): the `kolors` family with a
@@ -567,6 +567,20 @@ pub(crate) fn instantid_candle_eligible(payload: &Map<String, Value>) -> bool {
 /// with the FLUX XLabs IP-Adapter lane.
 pub(crate) fn pulid_flux_candle_eligible(payload: &Map<String, Value>) -> bool {
     pulid_flux_mlx_eligible(payload)
+}
+
+/// The SDXL-family model ids whose conditioning shapes have a bespoke candle lane (edit + IP-Adapter).
+///
+/// NOT every id on the `sdxl` engine: `realvisxl_lightning` is txt2img-only (its accel sampler is
+/// engine-incompatible with reference/img2img conditioning) and `instantid_realvisxl` has its own
+/// bespoke lane. Must stay in lockstep with the worker's `is_sdxl_edit_candle_model` /
+/// `is_sdxl_ipadapter_model` — a model the router sends to a lane the worker then rejects fails the
+/// job rather than falling back.
+pub(crate) fn is_sdxl_family_candle_model(model: &str) -> bool {
+    matches!(
+        model,
+        "sdxl" | "realvisxl" | "illustrious_xl_v1" | "illustrious_xl_v2"
+    )
 }
 
 /// SDXL img2img / inpaint / outpaint candle-routing conditions (sc-5487, epic 5480). The candle

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -566,6 +566,10 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
     ModelCaps::new("flux2_dev", true, true, false, false, false),
     ModelCaps::new("sdxl", true, true, false, false, false),
     ModelCaps::new("realvisxl", true, true, false, false, false),
+    // Illustrious-XL v1.0 / v2.0 (epic 10609): vanilla-SDXL anime finetunes on the shared `sdxl`
+    // engine. Same routing surface as `realvisxl` — MLX + candle txt2img, dense (no candle quant).
+    ModelCaps::new("illustrious_xl_v1", true, true, false, false, false),
+    ModelCaps::new("illustrious_xl_v2", true, true, false, false, false),
     // RealVisXL Lightning (MLX sc-6075 / candle sc-7176): standalone few-step distilled SDXL checkpoint
     // on the shared `sdxl` engine, few-step `lightning` accel sampler. **txt2img only** on both backends —
     // edit / reference / mask / pose shapes fall back to torch (accel sampler is conditioning-incompatible).
@@ -917,6 +921,8 @@ mod tests {
         "flux2_dev",
         "sdxl",
         "realvisxl",
+        "illustrious_xl_v1",
+        "illustrious_xl_v2",
         "realvisxl_lightning",
         "instantid_realvisxl",
         "pulid_flux_dev",
@@ -951,6 +957,8 @@ mod tests {
     const EXPECTED_CANDLE_ROUTED_MODELS: &[&str] = &[
         "sdxl",
         "realvisxl",
+        "illustrious_xl_v1",
+        "illustrious_xl_v2",
         "realvisxl_lightning",
         "z_image_turbo",
         "z_image",

--- a/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
@@ -58,7 +58,10 @@ pub(crate) fn image_request_mlx_eligible(model: &str, payload: &Map<String, Valu
         "flux2_klein_9b" | "flux2_klein_9b_kv" | "flux2_klein_9b_true_v2" | "flux2_dev" => {
             flux2_mlx_eligible(payload)
         }
-        "sdxl" | "realvisxl" => sdxl_mlx_eligible(payload),
+        // Illustrious-XL shares the `sdxl` engine and its full conditioning surface (epic 10609).
+        "sdxl" | "realvisxl" | "illustrious_xl_v1" | "illustrious_xl_v2" => {
+            sdxl_mlx_eligible(payload)
+        }
         "realvisxl_lightning" => realvisxl_lightning_mlx_eligible(payload),
         "instantid_realvisxl" => instantid_mlx_eligible(payload),
         "pulid_flux_dev" => pulid_flux_mlx_eligible(payload),
@@ -97,7 +100,10 @@ pub(crate) fn image_detail_mlx_eligible(job: &JobSnapshot) -> bool {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or("realvisxl");
-    matches!(model, "sdxl" | "realvisxl")
+    matches!(
+        model,
+        "sdxl" | "realvisxl" | "illustrious_xl_v1" | "illustrious_xl_v2"
+    )
 }
 
 /// Whether the in-process MLX worker can serve this GPU job (image_generate or image_detail).

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -276,6 +276,31 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
         default_guidance: 7.0,
         adapter_label: "mlx_sdxl",
     },
+    // Illustrious-XL (epic 10609) — Danbooru-tag anime SDXL finetunes from OnomaAI. Architecturally
+    // vanilla SDXL (identical UNet shapes, dual CLIP-L + OpenCLIP-bigG, eps-pred, VAE
+    // scaling_factor 0.13025), so both share the `sdxl` engine via a weights swap. Upstream ships a
+    // SINGLE-FILE LDM checkpoint, which no gen crate can read — the turnkeys are built offline by
+    // `scripts/build_sdxl_turnkey.py` (sc-10610), not converted at install.
+    //
+    // v1.0 and v2.0 are SEPARATE ids, not a version toggle: v2.0 is the `v2.0-STABLE` snapshot of a
+    // cosine-annealing run, behaviourally distinct, and it duplicates the subject in wide frames
+    // where v1.0 does not (sc-10620 — hence their different `limits.resolutions`).
+    ModelRow {
+        sceneworks_id: "illustrious_xl_v1",
+        engine_id: "sdxl",
+        default_repo: "SceneWorks/illustrious-xl-v1-mlx",
+        default_steps: 30,
+        default_guidance: 7.0,
+        adapter_label: "mlx_sdxl",
+    },
+    ModelRow {
+        sceneworks_id: "illustrious_xl_v2",
+        engine_id: "sdxl",
+        default_repo: "SceneWorks/illustrious-xl-v2-mlx",
+        default_steps: 30,
+        default_guidance: 7.0,
+        adapter_label: "mlx_sdxl",
+    },
     // RealVisXL Lightning (sc-6075) — standalone few-step *distilled* sibling of RealVisXL_V5.0.
     // Same SDXL arch, so it shares the `sdxl` engine via a weights swap; differs only in the
     // distilled checkpoint + the few-step recipe: ~5 steps at guidance 1.0 (CFG off). The
@@ -1003,6 +1028,19 @@ mod tests {
             identity_engine: true,
             control_net_pose_repo: None,
         },
+        // Illustrious-XL (epic 10609): character_image via the shared SDXL IP-Adapter lane
+        // (is_sdxl_ipadapter_model), so identity_engine is true, like the rest of the plain SDXL
+        // family. No strict-pose ControlNet.
+        CharacterEngineWiring {
+            sceneworks_id: "illustrious_xl_v1",
+            identity_engine: true,
+            control_net_pose_repo: None,
+        },
+        CharacterEngineWiring {
+            sceneworks_id: "illustrious_xl_v2",
+            identity_engine: true,
+            control_net_pose_repo: None,
+        },
         CharacterEngineWiring {
             sceneworks_id: "kolors",
             identity_engine: true,
@@ -1348,7 +1386,12 @@ mod tests {
     fn sdxl_family_advertises_cfgpp_on_mlx() {
         let manifest = parse_builtin_models();
         let models = manifest["models"].as_array().expect("models array");
-        for id in ["sdxl", "realvisxl"] {
+        for id in [
+            "sdxl",
+            "realvisxl",
+            "illustrious_xl_v1",
+            "illustrious_xl_v2",
+        ] {
             let model = models
                 .iter()
                 .find(|m| m["id"].as_str() == Some(id))
@@ -1591,6 +1634,8 @@ mod tests {
             ("sdxl", "SceneWorks/sdxl-base-mlx"),
             ("realvisxl", "SceneWorks/realvisxl-mlx"),
             ("realvisxl_lightning", "SceneWorks/realvisxl-lightning-mlx"),
+            ("illustrious_xl_v1", "SceneWorks/illustrious-xl-v1-mlx"),
+            ("illustrious_xl_v2", "SceneWorks/illustrious-xl-v2-mlx"),
         ] {
             let row = MODEL_TABLE
                 .iter()

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -3492,6 +3492,10 @@ fn is_candle_engine(model: &str) -> bool {
         model,
         "sdxl"
             | "realvisxl"
+            // Illustrious-XL (epic 10609): vanilla-SDXL anime finetunes on the shared candle `sdxl`
+            // engine. Their turnkeys are tiered, so the dense lanes resolve `bf16/` (dense_tier_subdir).
+            | "illustrious_xl_v1"
+            | "illustrious_xl_v2"
             // RealVisXL Lightning (sc-7176): shares the candle `sdxl` engine via a weights swap; the
             // few-step `lightning` sampler is forced in `generate_candle_stream`. txt2img-only (the
             // router defers its conditioning shapes to torch), so it rides the base candle txt2img lane.
@@ -3694,7 +3698,12 @@ async fn generate_candle_stream(
         .unwrap_or(true);
     match request.model.as_str() {
         // realvisxl_lightning shares the candle `sdxl` engine (sc-7176), so the SDXL flash toggle applies.
-        "sdxl" | "realvisxl" | "realvisxl_lightning" => candle_gen_sdxl::set_flash_attn(flash_attn),
+        // So do the Illustrious-XL finetunes (epic 10609).
+        "sdxl"
+        | "realvisxl"
+        | "realvisxl_lightning"
+        | "illustrious_xl_v1"
+        | "illustrious_xl_v2" => candle_gen_sdxl::set_flash_attn(flash_attn),
         // Base z_image (sc-8679) shares the candle z-image accel-attention toggle with Turbo.
         "z_image_turbo" | "z_image" => candle_gen_z_image::set_accel_attn(flash_attn),
         _ => {}

--- a/crates/sceneworks-worker/src/image_jobs/pid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pid.rs
@@ -88,9 +88,15 @@ fn pid_backbone_for(model: &str) -> Option<&'static str> {
         // sdxl (sc-7848): SDXL base, RealVisXL (+ Lightning), Kolors (reuses the SDXL VAE). InstantID
         // (sc-8370/8371) composes the SDXL VAE too, so its Angles/Poses latents decode through the same
         // `sdxl` PiD student — the engine's `InstantId::with_pid` loads that one checkpoint.
-        "sdxl" | "realvisxl" | "realvisxl_lightning" | "kolors" | "instantid_realvisxl" => {
-            Some("sdxl")
-        }
+        // Illustrious-XL (epic 10609) ships the stock SDXL VAE (scaling_factor 0.13025 — verified on
+        // the converted turnkey), so its latents decode through the same `sdxl` PiD student.
+        "sdxl"
+        | "realvisxl"
+        | "realvisxl_lightning"
+        | "kolors"
+        | "instantid_realvisxl"
+        | "illustrious_xl_v1"
+        | "illustrious_xl_v2" => Some("sdxl"),
         _ => None,
     }
 }

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
@@ -22,15 +22,27 @@ const SDXL_EDIT_CANDLE_DEFAULT_GUIDANCE: f32 = 5.0;
 /// `candle_sdxl` and the `candle_sdxl_ipadapter` lanes).
 const SDXL_EDIT_CANDLE_ENGINE: &str = "candle_sdxl_edit";
 
-/// SDXL model ids the candle edit route accepts (the txt2img-eligible SDXL family).
+/// SDXL model ids the candle edit route accepts (the txt2img-eligible SDXL family). Must stay in
+/// lockstep with `jobs_store::routing::candle::image_request_candle_lane`'s `sdxl_edit_candle_eligible`
+/// guard — a model the router sends here but this rejects lands in a lane that then refuses it.
 fn is_sdxl_edit_candle_model(model: &str) -> bool {
-    matches!(model, "sdxl" | "realvisxl")
+    matches!(
+        model,
+        "sdxl" | "realvisxl" | "illustrious_xl_v1" | "illustrious_xl_v2"
+    )
 }
 
 /// Default SDXL base repo for a model id when the manifest omits `repo`.
+///
+/// `sdxl` and `realvisxl` name FLAT upstream diffusers snapshots. Illustrious has no such upstream —
+/// OnomaAI ship a single-file LDM checkpoint — so it names its tiered turnkey, and
+/// `dense_tier_subdir` descends into the dense `bf16/` tier (sc-10614). This lane is dense-only:
+/// `IMAGE_MODEL_CAPS` marks the whole SDXL family `candle_quant: false`.
 fn sdxl_edit_candle_default_repo(model: &str) -> &'static str {
     match model {
         "realvisxl" => "SG161222/RealVisXL_V5.0",
+        "illustrious_xl_v1" => "SceneWorks/illustrious-xl-v1-mlx",
+        "illustrious_xl_v2" => "SceneWorks/illustrious-xl-v2-mlx",
         _ => "stabilityai/stable-diffusion-xl-base-1.0",
     }
 }

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
@@ -35,15 +35,25 @@ const SDXL_IPADAPTER_DEFAULT_GUIDANCE: f32 = 5.0;
 /// txt2img `candle_sdxl` and the `candle_instantid` lanes).
 const SDXL_IPADAPTER_ENGINE: &str = "candle_sdxl_ipadapter";
 
-/// SDXL model ids the candle IP-Adapter route accepts (the txt2img-eligible SDXL family).
+/// SDXL model ids the candle IP-Adapter route accepts (the txt2img-eligible SDXL family). Must stay
+/// in lockstep with `jobs_store::routing::candle`'s `sdxl_ipadapter_candle_eligible` guard.
 fn is_sdxl_ipadapter_model(model: &str) -> bool {
-    matches!(model, "sdxl" | "realvisxl")
+    matches!(
+        model,
+        "sdxl" | "realvisxl" | "illustrious_xl_v1" | "illustrious_xl_v2"
+    )
 }
 
 /// Default SDXL base repo for a model id when the manifest omits `repo`.
+///
+/// `sdxl` and `realvisxl` name FLAT upstream diffusers snapshots. Illustrious has no such upstream —
+/// OnomaAI ship a single-file LDM checkpoint — so it names its tiered turnkey, and
+/// `dense_tier_subdir` descends into the dense `bf16/` tier (sc-10614).
 fn sdxl_ipadapter_default_repo(model: &str) -> &'static str {
     match model {
         "realvisxl" => "SG161222/RealVisXL_V5.0",
+        "illustrious_xl_v1" => "SceneWorks/illustrious-xl-v1-mlx",
+        "illustrious_xl_v2" => "SceneWorks/illustrious-xl-v2-mlx",
         _ => "stabilityai/stable-diffusion-xl-base-1.0",
     }
 }

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -338,6 +338,9 @@ fn model_table_rows_resolve_and_flags_match_descriptor() {
         ("flux2_dev", true, false),
         ("sdxl", true, true),
         ("realvisxl", true, true),
+        // Illustrious-XL v1.0 / v2.0 (epic 10609): plain SDXL engine, real CFG + negative prompt.
+        ("illustrious_xl_v1", true, true),
+        ("illustrious_xl_v2", true, true),
         // RealVisXL Lightning (sc-6075): shares the `sdxl` engine id, whose descriptor advertises
         // guidance + negative prompt (true, true). The few-step recipe runs CFG-off (guidance 1.0,
         // negative inert) via the worker-forced `lightning` sampler, but that's a recipe default,


### PR DESCRIPTION
Registers the two Illustrious-XL anime SDXL finetunes in the catalog and every routing/engine site. Pure wiring — no engine or gen-crate change, because Illustrious is architecturally vanilla SDXL on the shared `sdxl` engine (verified across epic [sc-10609](https://app.shortcut.com/trefry/epic/10609)).

## What's wired

**Catalog** (`builtin.models.jsonc`): two entries, `family: sdxl`, `adapter: sdxl_diffusers`, three tiers each with **measured** footprint bytes, `mlx.standardTierLayout`, CFG++, `pid_sdxl` decoder.

**Rust**: `ModelRow` ×2 and the character-engine honesty-guard rows (`engines.rs`); `IMAGE_MODEL_CAPS` + the derived-list snapshot (`routing/catalog.rs`); MLX dispatch + `image_detail` eligibility (`routing/mlx.rs`); `is_candle_engine` + flash-attn (`base.rs`); SDXL PiD backbone (`pid.rs`).

**Candle edit + IP-Adapter** — the id-list extension originally scoped to sc-10614, moved here because the ids didn't exist then. `is_sdxl_{edit_candle,ipadapter}_model` accept the new ids, and crucially their `default_repo` returns the tiered **turnkey** (Illustrious has no flat upstream diffusers repo), so `dense_tier_subdir` from #1346 descends into `bf16/`. The router twins in `routing/candle.rs` are factored into a shared `is_sdxl_family_candle_model` so the worker gates and router predicates can't drift — a mismatch would route a job to a lane that then refuses it.

## Two per-version differences held in place

`limits.resolutions` differ (sc-10620): **v1.0** carries the wide buckets + `1536x1536`; **v2.0 omits `1344x768` and `1536x1536`** because it duplicates the subject in wide frames. Both entries carry a prominent do-not-unify comment, because collapsing them into one shared list is the obvious "cleanup" that would reintroduce the bug.

Licenses differ and are recorded per entry: v1.0 OpenRAIL++, v2.0 CreativeML OpenRAIL-M.

## Verification

- core **422** + worker **697** lib tests, web **1403** tests, manifest audit **7** — all pass.
- `cargo fmt --all --check`, `cargo clippy -p sceneworks-core -p sceneworks-worker --all-targets -- -D warnings` clean.
- The extended tests now hold the new ids to the same contracts as the rest of the SDXL family: routed-list membership, CFG++, candle edit/IP-Adapter routing, MODEL_TABLE flag pairs.
- **Drove a real generation** through an install-shaped HF cache snapshot of the built v1 turnkey (symlinked `q4/q8/bf16` under `models--SceneWorks--illustrious-xl-v1-mlx/snapshots/<rev>/`): the resolver descended from the snapshot root into `q8/` and rendered a coherent single-subject anime image. This exercises the seam between the new catalog id and the tier resolver, not just the unit tests.

## Prompt guide

Added `illustrious.md` so the `promptGuide.path` I reference isn't a dangling 404. It covers Danbooru-tag prompting, the v1/v2 wide-frame difference, and the per-version licenses. The `ui.defaultNegativePrompt` wiring remains sc-10621.

## Not in this PR — install cannot be validated until the turnkeys are published

The acceptance line "both models appear in the catalog, **install**, and generate" is met for catalog + generate (via the pre-seeded snapshot), but real **install** needs `SceneWorks/illustrious-xl-v{1,2}-mlx` to exist on HF — sc-10611 / sc-10612, which need Michael's explicit go to publish ~28 GB under the org. The candle edit/IP-Adapter path is compiled + routed + lint-clean but a real candle job on Illustrious still wants a CUDA box + the published repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)