### PR TITLE
fix(worker): Anima LoRA/LoKr on the default (quantized) tier — pin mlx-gen a5c1fcd + candle-gen bce6663 (sc-10578)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-gen",
  "image",
@@ -695,7 +695,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -752,7 +752,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -769,7 +769,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -789,7 +789,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -813,7 +813,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -824,7 +824,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd#02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=bce666380b59b407b9b1a7484c9726ab62f96fa4#bce666380b59b407b9b1a7484c9726ab62f96fa4"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -3673,7 +3673,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3687,7 +3687,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "image",
  "inventory",
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "image",
  "inventory",
@@ -3714,7 +3714,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "image",
  "inventory",
@@ -3728,7 +3728,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3742,7 +3742,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3753,7 +3753,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3762,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3771,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3785,7 +3785,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3798,7 +3798,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3811,7 +3811,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3823,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "image",
  "inventory",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "image",
  "inventory",
@@ -3860,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "image",
  "inventory",
@@ -3874,7 +3874,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "image",
  "inventory",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3897,7 +3897,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3909,7 +3909,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3921,7 +3921,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3930,7 +3930,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3939,7 +3939,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3949,7 +3949,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3961,7 +3961,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "image",
  "inventory",
@@ -3976,7 +3976,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "image",
  "inventory",
@@ -3990,7 +3990,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4001,7 +4001,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4013,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4024,7 +4024,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "image",
  "inventory",
@@ -4038,7 +4038,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "image",
  "inventory",
@@ -5872,7 +5872,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=6a10ae11b348d4d08598d3d47cf6caadc951ea53#6a10ae11b348d4d08598d3d47cf6caadc951ea53"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641#a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641"
 dependencies = [
  "core-llm",
  "inventory",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -525,7 +525,16 @@ sceneworks-core = { path = "../sceneworks-core" }
 # block below moves `2fecff1` -> `c556054` IN LOCKSTEP (candle-gen #374: re-pins candle-gen's OWN
 # gen-core ab6b1f4 -> fcf07df, byte-identical) so `--features backend-candle --target all` resolves the
 # SINGLE gen-core rev fcf07df (verified: scripts/check-gen-core-skew.sh reports exactly one).
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+# Bumped mlx-gen + gen-core `6a10ae1` -> `a5c1fcd` (sc-10578, epic 10512; mlx-gen #681 = Anima LoRA/LoKr
+# on a packed q4/q8 tier). `git diff 6a10ae1..a5c1fcd -- gen-core/ gen-core-testkit/` is EMPTY — gen-core
+# BYTE-IDENTICAL; the range is three files (mlx-gen's shared adapter loader, mlx-gen-anima/src/model.rs,
+# a new test binary). The candle-gen pin block below moves `02c0df4` -> `bce6663` IN LOCKSTEP (candle-gen
+# #381: re-pins candle-gen's OWN gen-core 6a10ae1 -> a5c1fcd, byte-identical) so `--features
+# backend-candle --target all` resolves the SINGLE gen-core rev a5c1fcd (scripts/check-gen-core-skew.sh
+# reports exactly one). NOTE: this bump FIXES a live bug — on 6a10ae1, every Anima LoRA/LoKr failed at
+# model load, because the worker defaults spec.quantize to Some(Q8) for every MLX model and mlx-gen-anima
+# rejected quant+adapter together. See test `anima_default_tier_with_adapter_builds_loadable_spec`.
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -882,7 +891,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -898,23 +907,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b34
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -922,7 +931,7 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
 # mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
 # mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
@@ -930,7 +939,7 @@ mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae1
 # conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
 # DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
 # generator-cache load path drives.
-mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # Anima 2B anime t2i provider (native MLX, CircleStone Labs Non-Commercial License v1.2; epic 10512,
 # sc-10523). Same git rev as mlx-gen so MLX builds once. Self-registers `anima_base` / `anima_aesthetic`
 # / `anima_turbo` (Cosmos-Predict2 DiT + Qwen3-0.6B T5-query-token adapter conditioner + Qwen-Image VAE)
@@ -939,59 +948,59 @@ mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae
 # scheduler (sc-10519) and strong prompt-weighting on the T5 query tokens (sc-10566). Carries the
 # install-time q4/q8/bf16 converter the model_jobs.rs Anima path drives (sc-10517). Pinned to merged
 # mlx-gen main 6a10ae1 (PR #680), which carries both the Anima crate and gen-core's is_hidden_file.
-mlx-gen-anima = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-anima = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -1000,19 +1009,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -1021,7 +1030,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10a
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -1029,7 +1038,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -1040,7 +1049,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -1051,7 +1060,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10a
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -1073,7 +1082,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -1084,7 +1093,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a1
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -1116,7 +1125,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10ae11b348d4d08598d3d47cf6caadc951ea53" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a5c1fcd26cde5b5e8aa2961a09b63b3efd8ad641" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1540,15 +1549,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "6a10
 # `5c28c20` -> `09f6ef99` (byte-identical — provider-only) so `--features backend-candle` resolves the
 # SINGLE gen-core rev `09f6ef99` (skew gate green). `536c2ef` is an ancestor of `b20ef5d`, a clean
 # forward move; ALL candle-gen-* move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1562,7 +1571,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1570,17 +1579,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1590,7 +1599,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1598,21 +1607,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1621,17 +1630,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1640,7 +1649,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1673,7 +1682,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1682,12 +1691,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1695,7 +1704,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0d
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1704,7 +1713,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1712,7 +1721,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1726,7 +1735,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1753,7 +1762,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1764,7 +1773,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "02c0df449fa7ebf2394fc3f9ffd08e6fe642cfcd", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "bce666380b59b407b9b1a7484c9726ab62f96fa4", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -4882,6 +4882,83 @@ mod standard_tier_tests {
         );
     }
 
+    /// Regression guard for **sc-10578** (epic 10512), pinning the worker HALF of the fix that mlx-gen
+    /// #681 (this pin bump → `a5c1fcd`) delivered.
+    ///
+    /// The bug: on mlx-gen ≤ `6a10ae1`, `mlx-gen-anima`'s `load` rejected
+    /// `spec.quantize.is_some() && !spec.adapters.is_empty()`. The worker defaults EVERY MLX model's
+    /// tier to Q8 ([`resolve_quant`]'s `None` arm), so `spec.quantize` is `Some(..)` on the default
+    /// path — which meant **every** Anima LoRA/LoKr generation failed at model load, at the DEFAULT
+    /// tier, with no tier selection by the user. The only escape was an explicit bf16 pick
+    /// (`mlxQuantize <= 0`). That combination — default tier + adapter — is exactly what no prior test
+    /// exercised, which is how the model shipped with `supports_lora`, an official style LoRA, and a
+    /// trainer whose output could not be loaded.
+    ///
+    /// This asserts the two worker-owned facts that made the bug fire, so a future change that
+    /// reintroduces either is caught here. The end-to-end proof that the engine now ACCEPTS this spec
+    /// lives in mlx-gen's real-weights `tests/packed_adapters.rs` (a Mac + weights are needed to run it,
+    /// so it cannot live in this crate).
+    #[test]
+    fn anima_default_tier_with_adapter_builds_loadable_spec() {
+        use gen_core::{AdapterKind, AdapterSpec, Quant};
+
+        // 1. A default Anima request IS quantized — the premise that made the guard fire everywhere.
+        let base_default =
+            ImageRequest::from_payload(json!({ "model": "anima_base" }).as_object().unwrap());
+        assert_eq!(
+            resolve_quant(&base_default),
+            (Some(Quant::Q8), Some(8)),
+            "anima_base with no mlxQuantize must default to Q8 — the reason adding an adapter used to \
+             fail at load on the DEFAULT tier"
+        );
+        // aesthetic/turbo ship manifest `mlx.quantize: 4`; still quantized, so still hit the guard.
+        let aesthetic = ImageRequest::from_payload(
+            json!({ "model": "anima_aesthetic", "modelManifestEntry": { "mlx": { "quantize": 4 } } })
+                .as_object()
+                .unwrap(),
+        );
+        assert_eq!(resolve_quant(&aesthetic), (Some(Quant::Q4), Some(4)));
+        // Only an explicit bf16 opt-out escaped the bug.
+        let bf16 = ImageRequest::from_payload(
+            json!({ "model": "anima_base", "advanced": { "mlxQuantize": 0 } })
+                .as_object()
+                .unwrap(),
+        );
+        assert_eq!(resolve_quant(&bf16), (None, None));
+
+        // 2. The LoadSpec the worker hands the engine carries a quant AND the adapter together — the
+        //    exact `quantize.is_some() && !adapters.is_empty()` shape mlx-gen-anima rejected on
+        //    `6a10ae1` and accepts on `a5c1fcd`.
+        let (quant, _) = resolve_quant(&base_default);
+        let adapters = vec![AdapterSpec::new(
+            PathBuf::from("/tmp/anima-style-lora.safetensors"),
+            1.0,
+            AdapterKind::Lora,
+        )];
+        let spec = load_spec(PathBuf::from("/tmp/anima-q8-tier"), quant, adapters, None);
+        assert!(
+            spec.quantize.is_some(),
+            "the default Anima tier is quantized, so the spec carries a quant"
+        );
+        assert!(
+            !spec.adapters.is_empty(),
+            "the adapter is present alongside the quant — the combination that used to fail"
+        );
+        // A dense-tier spec (the bf16 escape hatch) never carried a quant — documents the one path
+        // that worked before the fix.
+        let dense = load_spec(
+            PathBuf::from("/tmp/anima-bf16-tier"),
+            None,
+            vec![AdapterSpec::new(
+                PathBuf::from("/tmp/anima-style-lora.safetensors"),
+                1.0,
+                AdapterKind::Lora,
+            )],
+            None,
+        );
+        assert!(dense.quantize.is_none());
+    }
+
     /// sc-10676: off-Mac candle dense-load resolution. [`anima_dense_split_files_dir`] descends into the
     /// `split_files/` subdir of the HF snapshot (the raw dense DiT tree, NOT a converted q4/q8/bf16 tier),
     /// falling back to the snapshot root when `split_files/` is absent (the candle loader accepts the


### PR DESCRIPTION
Consumes the merged **[sc-10578](https://app.shortcut.com/trefry/story/10578)** fix (epic 10512) into the product. This is the last step; the story moves to `Done` when this merges.

## 🔴 This fixes a live P0, not a version bump

On the current pins, **every Anima LoRA/LoKr generation fails at model load** — at the default tier, with no tier selection by the user:

1. `resolve_quant` defaults every MLX model to `Some(Q8)` (its `None` arm) — Anima is not a dense-TE tier and sets no `mlx.denseTextEncoderTier`.
2. `mlx-gen-anima`'s `load` rejected `spec.quantize.is_some() && !spec.adapters.is_empty()`.

So epic 10512 shipped `supports_lora`, `supports_lokr`, the official 448-target style LoRA, and a whole LoRA/LoKr **trainer** — whose output could not be loaded on the default tier of the model it was trained for. The only escape was an explicit bf16 pick, and the web tier picker only appears when >1 tier is installed. Each capability was validated in isolation; nothing exercised **default tier + adapter** together.

[mlx-gen #681](https://github.com/SceneWorks/mlx-gen/pull/681) removes the rejection: LoRA rides the packed base as an additive branch (`y = xW_packed + scale·(xA)B`, epic 10043), and a deferrable LoKr installs as the structured Kronecker form instead of a ~3.9 GB materialized delta.

## The bump

| | from | to | count |
|---|---|---|---|
| mlx-gen | `6a10ae1` | `a5c1fcd` | 31 |
| candle-gen | `02c0df4` | `bce6663` | 27 |

One PR, because the gen-core skew gate requires both lanes on the same rev. `gen-core` lives in the mlx-gen repo and candle-gen pins it from there; candle-gen #381 already re-pinned its own gen-core to `a5c1fcd`, so both now resolve one rev. **`git diff 6a10ae1..a5c1fcd -- gen-core/ gen-core-testkit/` is EMPTY** — the contract is byte-identical, the merge range is three mlx-gen files, and no worker code needed to change.

## Regression test

`anima_default_tier_with_adapter_builds_loadable_spec` pins the worker half of the fix:
- a default `anima_base` request resolves to `Some(Q8)` (aesthetic/turbo to `Some(Q4)` via manifest) — the premise that made the guard fire on the default path;
- the `LoadSpec` the worker hands the engine carries a quant **and** the adapter together — the exact shape that used to fail;
- only an explicit `mlxQuantize <= 0` yields a dense spec (the one path that worked before).

**Mutation-verified:** flipping `resolve_quant`'s default arm to dense makes the test fail. End-to-end acceptance (the engine now loads this spec, at q4 and q8, and the LoRA is visibly applied) is proven by mlx-gen's real-weights `tests/packed_adapters.rs` — it needs a Mac + weights, so it can't live in this crate.

## Verified locally
- `scripts/check-gen-core-skew.sh` → *"OK: exactly one sceneworks-gen-core … #a5c1fcd2"* (across mlx-gen **and** candle-gen deps, `--target all`).
- `cargo fmt -p sceneworks-worker --check` — clean.
- The new test builds against the bumped pins and passes; mutation check confirms it can fail.

Cargo.lock changes are only the two source revs. Let CI exercise the full worker + candle-worker + parity + web lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)