### PR TITLE
feat(training): Illustrious-XL v1/v2 LoRA + LoKr training — targets, presets, and E2E validation (sc-10617, sc-10618)

### DIFF
--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -12040,13 +12040,23 @@ fn sdxl_family_tiered_turnkey_trains_on_its_bf16_unet_tier() {
     let temp = tempfile::tempdir().expect("tempdir");
     let data_dir = temp.path().join("data");
 
-    let mut target = super::builtin_training_targets()
+    // sc-10617: the real `illustrious_xl_v1_lora` registry target now bakes in the tiered-turnkey
+    // repo, so assert the registry entry itself — not a synthetic override — resolves to bf16 and
+    // gates on that tier. This pins that the shipped training target is training-ready off its turnkey.
+    let target = super::builtin_training_targets()
         .targets
         .into_iter()
-        .find(|t| t.base_model == "sdxl")
-        .expect("sdxl target");
-    // Repoint at the tiered-turnkey shape every SceneWorks SDXL re-host uses.
-    target.base_model_repo = Some("SceneWorks/illustrious-xl-v1-mlx".to_owned());
+        .find(|t| t.base_model == "illustrious_xl_v1")
+        .expect("illustrious_xl_v1 target");
+    assert_eq!(
+        target.base_model_repo.as_deref(),
+        Some("SceneWorks/illustrious-xl-v1-mlx"),
+        "the Illustrious v1 training target points at its tiered-turnkey re-host"
+    );
+    assert_eq!(
+        target.kernel, "sdxl_lora",
+        "Illustrious reuses the SDXL kernel"
+    );
     let repo = target.base_model_repo.clone().expect("repo set");
 
     let repo_root = huggingface_repo_cache_path(&data_dir, &repo).expect("repo cache path");

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -424,6 +424,8 @@ pub fn builtin_training_targets() -> TrainingTargetRegistry {
         targets: vec![
             z_image_turbo_lora_target(),
             sdxl_lora_target(),
+            illustrious_xl_v1_lora_target(),
+            illustrious_xl_v2_lora_target(),
             kolors_lora_target(),
             lens_turbo_lora_target(),
             krea_raw_lora_target(),
@@ -443,6 +445,8 @@ pub fn builtin_training_targets() -> TrainingTargetRegistry {
 pub fn builtin_training_presets() -> TrainingPresetRegistry {
     let target = z_image_turbo_lora_target();
     let sdxl_target = sdxl_lora_target();
+    let illustrious_v1_target = illustrious_xl_v1_lora_target();
+    let illustrious_v2_target = illustrious_xl_v2_lora_target();
     let kolors_target = kolors_lora_target();
     let krea_target = krea_raw_lora_target();
     let anima_target = anima_base_lora_target();
@@ -630,6 +634,138 @@ pub fn builtin_training_presets() -> TrainingPresetRegistry {
                 },
                 object(json!({
                     "description": "768px preset for tighter-VRAM SDXL training.",
+                    "order": 40
+                })),
+            ),
+            // Illustrious v1.0/v2.0 reuse the SDXL preset recipe wholesale — same UNet,
+            // same `sdxl_lora` kernel — differing only in the base model they train against.
+            // Built through the same `sdxl_preset` helper; training quality tiers derive from
+            // this preset registry, they are not a separate axis.
+            sdxl_preset(
+                &illustrious_v1_target,
+                "illustrious_xl_v1_lora.character.adamw8bit.balanced",
+                "Character balanced",
+                &["character"],
+                ("adamw8bit", "balanced"),
+                |config| config,
+                object(json!({
+                    "description": "Balanced first run for 12-25 clean character images on Illustrious v1.0.",
+                    "default": true,
+                    "order": 10
+                })),
+            ),
+            sdxl_preset(
+                &illustrious_v1_target,
+                "illustrious_xl_v1_lora.character.adamw8bit.conservative",
+                "Character conservative",
+                &["character"],
+                ("adamw8bit", "conservative"),
+                |mut config| {
+                    config.rank = 8;
+                    config.alpha = 8;
+                    config.learning_rate = number(0.00005);
+                    config
+                },
+                object(json!({
+                    "description": "Lower-rank, lower-LR character preset for tight identity datasets.",
+                    "order": 20
+                })),
+            ),
+            sdxl_preset(
+                &illustrious_v1_target,
+                "illustrious_xl_v1_lora.style.adamw8bit.balanced",
+                "Style balanced",
+                &["style"],
+                ("adamw8bit", "balanced"),
+                |mut config| {
+                    config.rank = 32;
+                    config.alpha = 16;
+                    config
+                },
+                object(json!({
+                    "description": "Higher-capacity style LoRA defaults for anime look and texture transfer.",
+                    "order": 30
+                })),
+            ),
+            sdxl_preset(
+                &illustrious_v1_target,
+                "illustrious_xl_v1_lora.character.adamw8bit.low_vram",
+                "Low VRAM character",
+                &["character"],
+                ("adamw8bit", "low_vram"),
+                |mut config| {
+                    config.rank = 8;
+                    config.alpha = 8;
+                    config.resolution = 768;
+                    config.steps = 1200;
+                    config
+                },
+                object(json!({
+                    "description": "768px preset for tighter-VRAM Illustrious v1.0 training.",
+                    "order": 40
+                })),
+            ),
+            sdxl_preset(
+                &illustrious_v2_target,
+                "illustrious_xl_v2_lora.character.adamw8bit.balanced",
+                "Character balanced",
+                &["character"],
+                ("adamw8bit", "balanced"),
+                |config| config,
+                object(json!({
+                    "description": "Balanced first run for 12-25 clean character images on Illustrious v2.0.",
+                    "default": true,
+                    "order": 10
+                })),
+            ),
+            sdxl_preset(
+                &illustrious_v2_target,
+                "illustrious_xl_v2_lora.character.adamw8bit.conservative",
+                "Character conservative",
+                &["character"],
+                ("adamw8bit", "conservative"),
+                |mut config| {
+                    config.rank = 8;
+                    config.alpha = 8;
+                    config.learning_rate = number(0.00005);
+                    config
+                },
+                object(json!({
+                    "description": "Lower-rank, lower-LR character preset for tight identity datasets.",
+                    "order": 20
+                })),
+            ),
+            sdxl_preset(
+                &illustrious_v2_target,
+                "illustrious_xl_v2_lora.style.adamw8bit.balanced",
+                "Style balanced",
+                &["style"],
+                ("adamw8bit", "balanced"),
+                |mut config| {
+                    config.rank = 32;
+                    config.alpha = 16;
+                    config
+                },
+                object(json!({
+                    "description": "Higher-capacity style LoRA defaults for anime look and texture transfer.",
+                    "order": 30
+                })),
+            ),
+            sdxl_preset(
+                &illustrious_v2_target,
+                "illustrious_xl_v2_lora.character.adamw8bit.low_vram",
+                "Low VRAM character",
+                &["character"],
+                ("adamw8bit", "low_vram"),
+                |mut config| {
+                    config.rank = 8;
+                    config.alpha = 8;
+                    config.resolution = 768;
+                    config.steps = 1200;
+                    config
+                },
+                object(json!({
+                    "description": "768px preset for tighter-VRAM Illustrious v2.0 training.",
                     "order": 40
                 })),
             ),
@@ -1895,6 +2031,158 @@ fn sdxl_lora_target() -> TrainingTarget {
         ui: object(json!({
             "label": "Stable Diffusion XL LoRA",
             "description": "Train an image LoRA for Stable Diffusion XL. The generic SDXL-UNet trainer and the shared foundation for SDXL-family models.",
+            "recommendedFor": ["character", "style"]
+        })),
+        extra: ExtraFields::new(),
+    }
+}
+
+/// Illustrious-XL v1.0 LoRA training target (epic 10609).
+///
+/// Illustrious-XL is a Danbooru-tag anime finetune of **vanilla SDXL** (OnomaAI) —
+/// identical U-Net + dual-CLIP shapes and the same eps objective as the base, so it
+/// reuses the SDXL trainer wholesale through the **same `sdxl_lora` kernel** (unlike
+/// Kolors, which needs its own kernel to swap the ChatGLM3 encoder). `engine_trainer_id`
+/// keys on that kernel and already maps `"sdxl_lora" => "sdxl"`, so no kernel or engine
+/// wiring changes: only `base_model_repo` differs, pointing the SDXL trainer at the
+/// Illustrious turnkey instead of stock SDXL. The output registers as an `sdxl` family
+/// LoRA the shared `sdxl_diffusers` adapter loads back at generation.
+///
+/// `base_model_repo` is the tiered-turnkey re-host (upstream ships a single-file LDM
+/// checkpoint the trainer can't read); `resolve_base_model_path` descends into its dense
+/// `bf16/` tier — never q4/q8 — and `training_base_model_installed` gates on that tier's
+/// component tree via the `bf16_component_tree_present` fix (sc-10613).
+fn illustrious_xl_v1_lora_target() -> TrainingTarget {
+    TrainingTarget {
+        id: "illustrious_xl_v1_lora".to_owned(),
+        name: "Illustrious-XL v1.0 LoRA".to_owned(),
+        modality: TrainingModality::Image,
+        output_kind: TrainingOutputKind::Lora,
+        family: "sdxl".to_owned(),
+        base_model: "illustrious_xl_v1".to_owned(),
+        base_model_repo: Some("SceneWorks/illustrious-xl-v1-mlx".to_owned()),
+        kernel: "sdxl_lora".to_owned(),
+        defaults: TrainingConfig {
+            rank: 16,
+            alpha: 16,
+            learning_rate: ContractNumber::from_f64(0.0001).expect("0.0001 is finite"),
+            steps: 1500,
+            batch_size: 1,
+            gradient_accumulation: 1,
+            resolution: 1024,
+            save_every: 250,
+            seed: 42,
+            optimizer: "adamw8bit".to_owned(),
+            trigger_word: None,
+            advanced: object(json!({
+                "mixedPrecision": "bf16",
+                "cacheLatents": true,
+                "cacheTextEmbeddings": true,
+                "gradientCheckpointing": true,
+                "networkType": "lora",
+                "lossType": "mse",
+                "weightDecay": 0.0001,
+                "lrScheduler": "constant",
+                // Same SDXL UNet attention modules as the base target.
+                "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
+                // Real CFG (not a distilled base): previews at positive guidance.
+                "sampleEvery": 250,
+                "sampleSteps": 30,
+                "sampleGuidanceScale": 7.0,
+                "qualityPreset": "balanced",
+                "outputScope": "project",
+                "requestedGpu": "auto"
+            })),
+            extra: ExtraFields::new(),
+        },
+        limits: object(json!({
+            "rank": [4, 128],
+            "alpha": [1, 128],
+            "steps": [200, 6000],
+            // MEASURED, not from the model card (sc-10620): v1.0 renders cleanly at 1536x1536
+            // (0/3 seeds duplicated), so it earns the high-res training option the base SDXL
+            // target omits. v2.0 does NOT — see that target; do not unify the two lists.
+            "resolutions": [768, 1024, 1536],
+            "batchSize": [1, 4],
+            "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
+            "networkTypes": ["lora", "lokr"],
+            "lrSchedulers": ["constant", "linear", "cosine"],
+            "outputScopes": ["project", "global"]
+        })),
+        ui: object(json!({
+            "label": "Illustrious-XL v1.0 LoRA",
+            "description": "Train an anime image LoRA for Illustrious-XL v1.0 (Danbooru-tag SDXL finetune). Shares the SDXL UNet trainer, so the output is an sdxl-family LoRA. Supports high-res 1536 training.",
+            "recommendedFor": ["character", "style"]
+        })),
+        extra: ExtraFields::new(),
+    }
+}
+
+/// Illustrious-XL v2.0 LoRA training target (epic 10609).
+///
+/// v2.0 is the `v2.0-STABLE` cosine-annealing snapshot — behaviourally distinct from
+/// v1.0 but architecturally the same vanilla SDXL, so it reuses the `sdxl_lora` kernel
+/// exactly as [`illustrious_xl_v1_lora_target`] does. The only per-version difference is
+/// `base_model_repo` and the training-resolution ceiling: v2.0 duplicates the subject in
+/// wide/large frames (sc-10620), so — unlike v1.0 — it does **not** advertise 1536.
+fn illustrious_xl_v2_lora_target() -> TrainingTarget {
+    TrainingTarget {
+        id: "illustrious_xl_v2_lora".to_owned(),
+        name: "Illustrious-XL v2.0 LoRA".to_owned(),
+        modality: TrainingModality::Image,
+        output_kind: TrainingOutputKind::Lora,
+        family: "sdxl".to_owned(),
+        base_model: "illustrious_xl_v2".to_owned(),
+        base_model_repo: Some("SceneWorks/illustrious-xl-v2-mlx".to_owned()),
+        kernel: "sdxl_lora".to_owned(),
+        defaults: TrainingConfig {
+            rank: 16,
+            alpha: 16,
+            learning_rate: ContractNumber::from_f64(0.0001).expect("0.0001 is finite"),
+            steps: 1500,
+            batch_size: 1,
+            gradient_accumulation: 1,
+            resolution: 1024,
+            save_every: 250,
+            seed: 42,
+            optimizer: "adamw8bit".to_owned(),
+            trigger_word: None,
+            advanced: object(json!({
+                "mixedPrecision": "bf16",
+                "cacheLatents": true,
+                "cacheTextEmbeddings": true,
+                "gradientCheckpointing": true,
+                "networkType": "lora",
+                "lossType": "mse",
+                "weightDecay": 0.0001,
+                "lrScheduler": "constant",
+                "loraTargetModules": ["to_q", "to_k", "to_v", "to_out.0"],
+                "sampleEvery": 250,
+                "sampleSteps": 30,
+                "sampleGuidanceScale": 7.0,
+                "qualityPreset": "balanced",
+                "outputScope": "project",
+                "requestedGpu": "auto"
+            })),
+            extra: ExtraFields::new(),
+        },
+        limits: object(json!({
+            "rank": [4, 128],
+            "alpha": [1, 128],
+            "steps": [200, 6000],
+            // DELIBERATELY NARROWER THAN v1.0 — do not unify (sc-10620). v2.0 duplicates the
+            // subject once the frame gets large: 3/4 seeds render two girls at 1536x1536, so
+            // 1536 is withheld as a training resolution (its previews would duplicate too).
+            "resolutions": [768, 1024],
+            "batchSize": [1, 4],
+            "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
+            "networkTypes": ["lora", "lokr"],
+            "lrSchedulers": ["constant", "linear", "cosine"],
+            "outputScopes": ["project", "global"]
+        })),
+        ui: object(json!({
+            "label": "Illustrious-XL v2.0 LoRA",
+            "description": "Train an anime image LoRA for Illustrious-XL v2.0 (the more stable v2.0-STABLE snapshot). Shares the SDXL UNet trainer, so the output is an sdxl-family LoRA. Trains at 768/1024 (v2.0 duplicates the subject in larger frames).",
             "recommendedFor": ["character", "style"]
         })),
         extra: ExtraFields::new(),

--- a/crates/sceneworks-core/tests/training_contracts.rs
+++ b/crates/sceneworks-core/tests/training_contracts.rs
@@ -133,6 +133,10 @@ fn builtin_targets_gate_network_types() {
         [
             "z_image_turbo_lora",
             "sdxl_lora",
+            // Illustrious v1.0/v2.0 are vanilla-SDXL anime finetunes sharing the `sdxl_lora`
+            // kernel; both advertise native-MLX LoKr through the same SDXL trainer (epic 10609).
+            "illustrious_xl_v1_lora",
+            "illustrious_xl_v2_lora",
             "kolors_lora",
             "lens_turbo_lora",
             "krea_2_raw_lora",

--- a/crates/sceneworks-worker/src/illustrious_train_apply_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/illustrious_train_apply_mlx_smoke.rs
@@ -1,0 +1,453 @@
+//! sc-10618 — real-weight MLX **train → apply** smoke for the Illustrious-XL SDXL-family lane.
+//!
+//! This is the E2E evidence the epic 10609 training half demands: not "a registry entry + a green
+//! unit test" but an actual round-trip on real weights. One `#[ignore]`d test, driven by env, that for
+//! one `(model, network_type)` cell:
+//!   1. loads the **native-MLX SDXL trainer** (`mlx_gen_sdxl::load_trainer`) from the Illustrious
+//!      turnkey's **dense `bf16/` tier** — the exact tier `resolve_base_model_path` hands the worker
+//!      (`tiered_turnkey_train_dir` descends to `bf16/`), never a quantized tier,
+//!   2. trains a tiny LoRA or LoKr adapter over a small synthetic dataset (few steps — the point is the
+//!      seam, not convergence),
+//!   3. inspects the emitted `.safetensors` — the dual-text-encoder key signature that makes it an
+//!      `sdxl`-family adapter, and (for LoKr) that **no `mid_block` factors were emitted** (sc-2640: the
+//!      SDXL LoKr surface is down/up attention only, so `mid_block` factors would be dead weight),
+//!   4. renders the SAME prompt/seed WITHOUT and WITH the adapter applied (`LoadSpec::with_adapters`)
+//!      and asserts the adapter **visibly changes the output** — the step that catches a trainer
+//!      emitting keys no inference path reads (a zero delta), and
+//!   5. records wall-clock + peak MLX memory for the manifest footprint record.
+//!
+//! Direct provider constructors (`mlx_gen_sdxl::load{,_trainer}`), NOT the `gen_core` registry: the
+//! worker test build links a candle-backed `sdxl` **trainer stub** (engines.rs, exercises the candle
+//! training gate) and an `sdxl` generator, so the first-wins registry could resolve the stub. The
+//! direct constructors are the same trainer/generator the registry resolves on the real app, minus the
+//! id lookup — the same sidestep `lora_train_driver` makes with `mlx_gen_z_image::load`.
+//!
+//! macOS/Metal + `RUST_TEST_THREADS=1` (MLX is `!Send`). Run one cell per invocation (each loads the
+//! full SDXL model), e.g. the v1 LoRA cell from the scratch-built turnkey, applying on the dense tier:
+//! ```sh
+//! ILL_BF16_DIR=/path/to/ill-v1-fixed/bf16 ILL_MODEL=illustrious_xl_v1 ILL_NETWORK=lora \
+//!   RUST_TEST_THREADS=1 cargo test -p sceneworks-worker --release --lib \
+//!   illustrious_train_apply_mlx_smoke -- --ignored --nocapture
+//! ```
+//! Knobs: `ILL_STEPS` `ILL_RANK` `ILL_RES` `ILL_SEED` `ILL_SCALE` `ILL_OUT_DIR`.
+//!
+//! Apply tier — this smoke applies on the DENSE tier (`ILL_GEN_QUANT` defaults to `bf16`). Applying on a
+//! packed tier (`ILL_GEN_QUANT=q8`/`q4`) currently fails at load: mlx-gen-sdxl applies a LoRA by MERGING
+//! the delta into the base (`merge_dense_delta`), which requires a dense base and rejects a quantized one
+//! ("a LoRA must be merged before quantization"). That is a pre-existing SDXL-family limitation (not
+//! Illustrious-specific) and belongs to the LoRA-inference story (sc-10616), not this training E2E — so
+//! the packed knob exists for that investigation but is expected to fail until sc-10616 addresses it.
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use gen_core::{
+    AdapterKind, AdapterSpec, CancelFlag, GenerationOutput, GenerationRequest, Image, LoadSpec,
+    NetworkType, Quant, TrainingConfig, TrainingItem, TrainingProgress, TrainingRequest,
+    WeightsSource,
+};
+
+use super::smoke_support::{env_or, image_std, is_all_zero, save_png, DEGENERATE_STD_FLOOR_TIGHT};
+
+/// A distinct anime-styled swatch dataset: `n` procedurally-varied images so the tiny run has real
+/// (non-flat) gradient signal to bias the output, captioned with a shared trigger token. Deterministic.
+fn write_synthetic_dataset(dir: &Path, n: u32, res: u32, trigger: &str) -> Vec<TrainingItem> {
+    std::fs::create_dir_all(dir).expect("dataset dir");
+    let caption = format!("{trigger}, 1girl, solo, anime, vibrant, masterpiece");
+    (0..n)
+        .map(|i| {
+            let phase = i as f32 * 1.7;
+            let path = dir.join(format!("swatch_{i:02}.png"));
+            image::RgbImage::from_fn(res, res, |x, y| {
+                let fx = x as f32 / res as f32;
+                let fy = y as f32 / res as f32;
+                // Per-image varied bands + a bright focal blob — distinct across the set, not a flat fill.
+                let r = ((fx * 6.0 + phase).sin() * 0.5 + 0.5) * 255.0;
+                let g = ((fy * 5.0 + phase * 1.3).cos() * 0.5 + 0.5) * 255.0;
+                let d = ((fx - 0.5).powi(2) + (fy - 0.5).powi(2)).sqrt();
+                let b = ((1.0 - d).max(0.0) * 255.0).min(255.0);
+                image::Rgb([r as u8, g as u8, b as u8])
+            })
+            .save(&path)
+            .expect("write swatch");
+            TrainingItem {
+                image_path: path,
+                caption: caption.clone(),
+            }
+        })
+        .collect()
+}
+
+/// Tensor names inside a `.safetensors` file, read straight from the header (8-byte LE length prefix +
+/// JSON map of `name -> {...}`, plus an optional `__metadata__`). Dependency-free so the smoke inspects
+/// exactly what the trainer wrote, without a model load.
+fn safetensors_tensor_names(path: &Path) -> Vec<String> {
+    let bytes = std::fs::read(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    assert!(bytes.len() >= 8, "safetensors {} too short", path.display());
+    let header_len = u64::from_le_bytes(bytes[..8].try_into().unwrap()) as usize;
+    let header: serde_json::Value = serde_json::from_slice(&bytes[8..8 + header_len])
+        .unwrap_or_else(|e| panic!("parse safetensors header {}: {e}", path.display()));
+    header
+        .as_object()
+        .expect("safetensors header is an object")
+        .keys()
+        .filter(|k| k.as_str() != "__metadata__")
+        .cloned()
+        .collect()
+}
+
+/// Load the SDXL generator from `dir` at the requested quant and render one image for `prompt`/`seed`,
+/// optionally with `adapter` applied. Each call loads + drops its own model (MLX cache cleared after) so
+/// the baseline and adapter renders don't co-reside.
+fn render(
+    dir: &Path,
+    quant: Option<Quant>,
+    adapter: Option<AdapterSpec>,
+    prompt: &str,
+    seed: u64,
+    res: u32,
+) -> Image {
+    let mut spec = LoadSpec::new(WeightsSource::Dir(dir.to_path_buf()));
+    if let Some(q) = quant {
+        spec = spec.with_quant(q);
+    }
+    if let Some(a) = adapter {
+        spec = spec.with_adapters(vec![a]);
+    }
+    let generator = mlx_gen_sdxl::load(&spec).expect("load mlx sdxl generator");
+    let req = GenerationRequest {
+        prompt: prompt.to_owned(),
+        negative_prompt: Some("blurry, low quality, deformed, watermark".to_owned()),
+        width: res,
+        height: res,
+        count: 1,
+        seed: Some(seed),
+        steps: Some(
+            env_or("ILL_GEN_STEPS", "24")
+                .parse()
+                .expect("ILL_GEN_STEPS"),
+        ),
+        guidance: Some(7.0),
+        ..Default::default()
+    };
+    let output = generator
+        .generate(&req, &mut |_p| {})
+        .expect("sdxl generate");
+    mlx_rs::memory::clear_cache();
+    match output {
+        GenerationOutput::Images(mut images) => images.pop().expect("engine returned an image"),
+        other => panic!("expected Images output, got {other:?}"),
+    }
+}
+
+/// Mean absolute per-byte difference between two same-shape RGB images (0–255 scale).
+fn mean_abs_delta(a: &Image, b: &Image) -> f64 {
+    assert_eq!(
+        (a.width, a.height, a.pixels.len()),
+        (b.width, b.height, b.pixels.len()),
+        "before/after images must share dimensions"
+    );
+    let n = a.pixels.len() as f64;
+    if n == 0.0 {
+        return 0.0;
+    }
+    a.pixels
+        .iter()
+        .zip(&b.pixels)
+        .map(|(&x, &y)| (x as i32 - y as i32).unsigned_abs() as f64)
+        .sum::<f64>()
+        / n
+}
+
+fn quant_from_env() -> (Option<Quant>, &'static str) {
+    match env_or("ILL_GEN_QUANT", "none").as_str() {
+        "q8" => (Some(Quant::Q8), "q8"),
+        "q4" => (Some(Quant::Q4), "q4"),
+        _ => (None, "bf16"),
+    }
+}
+
+#[test]
+#[ignore = "real-weight MLX train→apply smoke (sc-10618); needs an Illustrious turnkey bf16 tier + an Apple-Silicon Mac. Set ILL_BF16_DIR"]
+fn illustrious_train_apply_mlx_smoke() {
+    let bf16_dir = PathBuf::from(
+        std::env::var("ILL_BF16_DIR")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or_else(|| {
+                panic!(
+                    "set ILL_BF16_DIR to the Illustrious turnkey's dense bf16 tier \
+                     (e.g. .../illustrious-xl-v1-mlx/bf16 — the tier resolve_base_model_path trains from)"
+                )
+            })
+            .trim(),
+    );
+    assert!(
+        bf16_dir.join("unet").is_dir(),
+        "ILL_BF16_DIR must be a diffusers component tree with unet/ (the dense bf16 tier); got {}",
+        bf16_dir.display()
+    );
+
+    let model = env_or("ILL_MODEL", "illustrious");
+    let network_str = env_or("ILL_NETWORK", "lora");
+    let network = NetworkType::parse(&network_str);
+    let is_lokr = matches!(network, NetworkType::Lokr);
+    let gen_dir = std::env::var("ILL_GEN_DIR")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .map(|v| PathBuf::from(v.trim()))
+        .unwrap_or_else(|| bf16_dir.clone());
+    let (gen_quant, gen_quant_label) = quant_from_env();
+
+    let steps: u32 = env_or("ILL_STEPS", "24").parse().expect("ILL_STEPS");
+    let rank: u32 = env_or("ILL_RANK", "8").parse().expect("ILL_RANK");
+    let res: u32 = env_or("ILL_RES", "768").parse().expect("ILL_RES");
+    let seed: u64 = env_or("ILL_SEED", "7").parse().expect("ILL_SEED");
+    let scale: f32 = env_or("ILL_SCALE", "1.4").parse().expect("ILL_SCALE");
+    let out_dir = PathBuf::from(env_or("ILL_OUT_DIR", "/tmp/ill_train_smoke"));
+    std::fs::create_dir_all(&out_dir).expect("out dir");
+
+    let trigger = "sks_ill";
+    let data_dir = out_dir.join(format!("{model}_{network_str}_data"));
+    let items = write_synthetic_dataset(&data_dir, 6, res, trigger);
+    let file_name = format!("{model}_{network_str}.safetensors");
+
+    // ── 1. TRAIN on the dense bf16 tier ────────────────────────────────────────────────────────────
+    let config = TrainingConfig {
+        rank,
+        alpha: rank as f32,
+        learning_rate: 1e-4,
+        steps,
+        batch_size: 1,
+        gradient_accumulation: 1,
+        gradient_checkpointing: false,
+        train_dtype: "bf16".to_owned(),
+        resolution: res,
+        save_every: 0,
+        seed,
+        optimizer: "adamw".to_owned(),
+        weight_decay: 0.0,
+        network_type: network,
+        // -1 = the trainer's auto Kronecker block-split for LoKr (ignored for LoRA).
+        decompose_factor: -1,
+        // SDXL attention projections — the sdxl_lora target's loraTargetModules (sc-10617).
+        lora_target_modules: vec![
+            "to_q".to_owned(),
+            "to_k".to_owned(),
+            "to_v".to_owned(),
+            "to_out.0".to_owned(),
+        ],
+        loss_type: "mse".to_owned(),
+        trigger_word: Some(trigger.to_owned()),
+        // A mid-run preview at POSITIVE guidance — SDXL uses real CFG (acceptance #6), unlike a
+        // distilled base sampling at 0.0. `sample_every` must land on a NON-final step: the engine
+        // skips sampling on the final step (the candle sample-count finding), so `sample_every = steps`
+        // never previews. Half-way through fires at least once mid-run.
+        sample_every: (steps / 2).max(1),
+        sample_prompts: vec![format!("{trigger}, 1girl, solo, anime portrait")],
+        sample_steps: 8,
+        sample_guidance_scale: 7.0,
+        ..Default::default()
+    };
+    let request = TrainingRequest {
+        items,
+        config,
+        output_dir: out_dir.clone(),
+        file_name: file_name.clone(),
+        trigger_words: vec![trigger.to_owned()],
+        cancel: CancelFlag::new(),
+    };
+
+    println!(
+        "[ill-train {model}/{network_str}] loading SDXL trainer from bf16 tier {} ...",
+        bf16_dir.display()
+    );
+    mlx_rs::memory::clear_cache();
+    mlx_rs::memory::reset_peak_memory();
+    let t0 = Instant::now();
+    let mut trainer =
+        mlx_gen_sdxl::load_trainer(&LoadSpec::new(WeightsSource::Dir(bf16_dir.clone())))
+            .expect("mlx sdxl trainer loads from the Illustrious bf16 tier");
+    trainer
+        .validate(&request)
+        .expect("trainer accepts the Illustrious training plan");
+    let mut last_loss = f32::NAN;
+    let mut sample_count = 0u32;
+    let mut first_sample: Option<Image> = None;
+    let output = trainer
+        .train(&request, &mut |progress| match progress {
+            TrainingProgress::Training { step, total, loss } => {
+                last_loss = loss;
+                if step == 1 || step % 5 == 0 || step == total {
+                    println!("[ill-train {model}/{network_str}] step {step}/{total} loss {loss:.4}");
+                }
+            }
+            // The trainer streams in-training previews as events carrying a decoded RGB bitmap (the
+            // worker persists them via `write_training_sample`); capture the first to validate #6.
+            TrainingProgress::Sample {
+                step,
+                prompt,
+                image,
+                ..
+            } => {
+                sample_count += 1;
+                if first_sample.is_none() {
+                    println!(
+                        "[ill-train {model}/{network_str}] preview sample @ step {step} prompt {prompt:?}"
+                    );
+                    first_sample = Some(image);
+                }
+            }
+            _ => {}
+        })
+        .expect("training runs to completion");
+    let train_secs = t0.elapsed().as_secs_f64();
+    let train_peak_gb = mlx_rs::memory::get_peak_memory() as f64 / 1e9;
+    drop(trainer);
+    mlx_rs::memory::clear_cache();
+
+    let adapter_path = output.adapter_path.clone();
+    println!(
+        "[ill-train {model}/{network_str}] DONE steps={} final_loss={} last={last_loss:.4} \
+         wall={train_secs:.1}s peak={train_peak_gb:.1}GB adapter={}",
+        output.steps,
+        output.final_loss,
+        adapter_path.display()
+    );
+    assert!(output.steps >= 1, "at least one training step ran");
+    assert!(output.final_loss.is_finite(), "final loss is finite");
+    assert!(last_loss.is_finite(), "a per-step loss was observed");
+    assert!(
+        adapter_path.exists(),
+        "trained adapter written at {}",
+        adapter_path.display()
+    );
+
+    // In-training preview at POSITIVE guidance (acceptance #6): SDXL uses real CFG (guidance 7.0),
+    // unlike a distilled base sampling at 0.0. The trainer emitted TrainingProgress::Sample event(s);
+    // assert at least one fired and rendered a non-degenerate image at the configured positive guidance.
+    let preview = first_sample.expect(
+        "no TrainingProgress::Sample emitted — expected an in-training preview at positive guidance \
+         (sample_every>0, sample_prompts set)",
+    );
+    let preview_std = image_std(&preview);
+    let preview_png = out_dir.join(format!("{model}_{network_str}_preview.png"));
+    save_png(&preview, &preview_png);
+    println!(
+        "[ill-train {model}/{network_str}] {sample_count} positive-guidance preview(s); first std {preview_std:.1} -> {}",
+        preview_png.display()
+    );
+    assert!(
+        preview_std > DEGENERATE_STD_FLOOR_TIGHT && !is_all_zero(&preview),
+        "in-training preview at positive guidance looks degenerate (std {preview_std:.1})"
+    );
+
+    // ── 2. INSPECT the adapter: sdxl-family signature + (LoKr) no dead mid_block factors ────────────
+    let names = safetensors_tensor_names(&adapter_path);
+    assert!(!names.is_empty(), "adapter carries tensors");
+    let has_te1 = names
+        .iter()
+        .any(|k| k.contains("te1") || k.contains("text_encoder."));
+    let has_te2 = names
+        .iter()
+        .any(|k| k.contains("te2") || k.contains("text_encoder_2"));
+    let has_unet = names
+        .iter()
+        .any(|k| k.contains("unet") || k.contains("down_blocks") || k.contains("up_blocks"));
+    let mid_block_keys: Vec<&String> = names.iter().filter(|k| k.contains("mid_block")).collect();
+    let mut prefixes: Vec<String> = names
+        .iter()
+        .map(|k| k.split(['.', '_']).take(3).collect::<Vec<_>>().join("_"))
+        .collect();
+    prefixes.sort();
+    prefixes.dedup();
+    println!(
+        "[ill-inspect {model}/{network_str}] {} tensors; te1={has_te1} te2={has_te2} unet={has_unet} \
+         mid_block_keys={} sample_prefixes={:?}",
+        names.len(),
+        mid_block_keys.len(),
+        prefixes.iter().take(8).collect::<Vec<_>>()
+    );
+    assert!(
+        (has_te1 && has_te2) || has_unet,
+        "adapter must carry the SDXL dual-text-encoder or UNet key signature (family=sdxl); prefixes: {prefixes:?}"
+    );
+    if is_lokr {
+        // sc-2640: the SDXL LoKr inference surface is down/up attention only; emitting mid_block LoKr
+        // factors would produce weights no inference path reads. Confirm the trainer honors that.
+        assert!(
+            mid_block_keys.is_empty(),
+            "LoKr adapter emitted {} mid_block factor(s) — sc-2640 says the SDXL LoKr surface excludes \
+             mid_block, so these would be dead weight: {mid_block_keys:?}",
+            mid_block_keys.len()
+        );
+    }
+
+    // ── 3. APPLY back at generation: same seed/prompt, without vs with the adapter ──────────────────
+    let gen_prompt = format!("{trigger}, 1girl, solo, anime portrait, detailed, sharp focus");
+    println!(
+        "[ill-apply {model}/{network_str}] rendering baseline (no adapter) from {} tier {} ...",
+        gen_quant_label,
+        gen_dir.display()
+    );
+    let baseline = render(&gen_dir, gen_quant, None, &gen_prompt, seed, res);
+    save_png(
+        &baseline,
+        &out_dir.join(format!("{model}_{network_str}_baseline.png")),
+    );
+
+    println!("[ill-apply {model}/{network_str}] rendering WITH adapter (scale {scale}) ...");
+    let with_adapter = render(
+        &gen_dir,
+        gen_quant,
+        Some(AdapterSpec::new(
+            adapter_path.clone(),
+            scale,
+            if is_lokr {
+                AdapterKind::Lokr
+            } else {
+                AdapterKind::Lora
+            },
+        )),
+        &gen_prompt,
+        seed,
+        res,
+    );
+    let after_png = out_dir.join(format!("{model}_{network_str}_with_adapter.png"));
+    save_png(&with_adapter, &after_png);
+
+    let base_std = image_std(&baseline);
+    let after_std = image_std(&with_adapter);
+    let delta = mean_abs_delta(&baseline, &with_adapter);
+    println!(
+        "[ill-apply {model}/{network_str}] base_std={base_std:.1} after_std={after_std:.1} \
+         mean_abs_delta={delta:.2} -> {}",
+        after_png.display()
+    );
+
+    // Both renders must be alive (a broken decode / all-zero would trivially "differ" or "match").
+    assert!(
+        !is_all_zero(&baseline),
+        "baseline render is all-zero (broken decode)"
+    );
+    assert!(
+        !is_all_zero(&with_adapter),
+        "adapter render is all-zero (broken decode)"
+    );
+    assert!(
+        base_std > DEGENERATE_STD_FLOOR_TIGHT && after_std > DEGENERATE_STD_FLOOR_TIGHT,
+        "a render looks degenerate (base_std {base_std:.1}, after_std {after_std:.1})"
+    );
+    // The load-bearing assertion: the adapter is actually READ at inference. A trainer that emits keys
+    // no inference path consumes yields an identical image (delta ~0). Same seed + same prompt isolate
+    // the adapter as the only variable, so any real applied adapter moves the pixels well clear of noise.
+    assert!(
+        delta > 1.0,
+        "adapter did not change the output (mean_abs_delta {delta:.2} on 0–255) — the trained {network_str} \
+         adapter is not being applied at inference (keys the loader doesn't read?)"
+    );
+    println!(
+        "[ill-DONE {model}/{network_str}] train→apply CLOSED: trained on bf16, adapter applies on {gen_quant_label}, \
+         family=sdxl, delta={delta:.2}, train {train_secs:.1}s peak {train_peak_gb:.1}GB"
+    );
+}

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -246,6 +246,14 @@ mod sd3_5_mlx_smoke;
 // non-degenerate AND specifically NOT all-zero (the retired Apple recipe's exact failure signature).
 #[cfg(all(test, target_os = "macos"))]
 mod sdxl_base_q8_mlx_smoke;
+// Real-weight MLX train→apply smoke for the Illustrious-XL SDXL-family lane (sc-10618, epic 10609).
+// Test-only + macOS-only; drives `mlx_gen_sdxl::load_trainer` from the Illustrious turnkey's dense
+// `bf16/` tier, trains a tiny LoRA/LoKr, then renders WITHOUT vs WITH the adapter via
+// `mlx_gen_sdxl::load(...).with_adapters` and asserts it visibly changes the output — the E2E evidence
+// (not a registry entry + a green unit test) the training half of the epic demands. For LoKr it also
+// asserts no `mid_block` factors were emitted (sc-2640: the SDXL LoKr surface is down/up attention only).
+#[cfg(all(test, target_os = "macos"))]
+mod illustrious_train_apply_mlx_smoke;
 // Real-weight MLX smoke for the Lens-Turbo Q4 worker lane (sc-8763, epic 8506 Group-B). Test-only +
 // macOS-only; drives `gen_core::load("lens_turbo")` with a Q4 LoadSpec against the packed `q4/` turnkey
 // subdir. On-device evidence that the SceneWorks/lens-turbo-mlx pre-quantized q4 tier loads through the

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -2056,6 +2056,11 @@ mod tests {
         let cases: &[(&str, &str, Option<&str>)] = &[
             ("z_image_lora", "z_image_turbo", Some("z_image_turbo")),
             ("sdxl_lora", "sdxl", Some("sdxl")),
+            // Illustrious v1.0/v2.0 (epic 10609) share the `sdxl_lora` kernel — vanilla SDXL —
+            // so both base models resolve to the `sdxl` engine trainer with no branch here,
+            // unlike `sd3_lora`/`anima_lora` which split on base_model. Pin that.
+            ("sdxl_lora", "illustrious_xl_v1", Some("sdxl")),
+            ("sdxl_lora", "illustrious_xl_v2", Some("sdxl")),
             ("ltx_mlx_lora", "ltx_2_3", Some("ltx_2_3")),
             ("wan_lora", "wan_2_2", Some("wan2_2_ti2v_5b")),
             ("wan_moe_lora", "wan_2_2_t2v_14b", Some("wan2_2_t2v_14b")),

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -2926,6 +2926,37 @@ mod tests {
         );
     }
 
+    /// sc-10618 — the candle (CUDA) twin of the macOS Illustrious train smoke. Points the config-blind
+    /// `load_trainer("sdxl", …)` at an Illustrious turnkey's dense `bf16/` tier (the tier
+    /// `resolve_base_model_path` trains from) and runs a LoRA micro-step, proving the candle SDXL trainer
+    /// trains the Illustrious base on CUDA exactly as it trains stock SDXL — Illustrious differs only in
+    /// its base weights (the gen crates are config-blind). Upstream ships a single-file LDM (no plain
+    /// diffusers repo), so point `ILL_CANDLE_BF16_DIR` at the turnkey's `bf16/` tier on the RTX box:
+    /// `ILL_CANDLE_BF16_DIR=/hfcache/models--SceneWorks--illustrious-xl-v1-mlx/snapshots/<rev>/bf16 \
+    ///   cargo test -p sceneworks-worker --lib --features backend-candle --release -- \
+    ///   --ignored candle_illustrious_real_weights --nocapture`.
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    #[test]
+    #[ignore = "needs an Illustrious turnkey bf16 tier + a CUDA device; set ILL_CANDLE_BF16_DIR"]
+    fn candle_illustrious_real_weights_trains_a_lora_step() {
+        let Some(dir) = std::env::var_os("ILL_CANDLE_BF16_DIR")
+            .map(std::path::PathBuf::from)
+            .filter(|p| p.join("unet").is_dir())
+        else {
+            eprintln!(
+                "ILL_CANDLE_BF16_DIR unset or missing unet/ — skipping candle Illustrious smoke"
+            );
+            return;
+        };
+        candle_real_weights_smoke(
+            "sdxl",
+            &dir,
+            512,
+            false,
+            "candle_illustrious_lora.safetensors",
+        );
+    }
+
     /// sc-7817 — the candle Z-Image training smoke. Loads `load_trainer("z_image_turbo", …)` from the
     /// installed `Tongyi-MAI/Z-Image-Turbo` snapshot and trains two LoRA micro-steps with
     /// **gradient checkpointing ON** — REQUIRED on candle: the Z-Image DiT's dense backward OOMs even

--- a/tests/fixtures/rust_migration_contracts/training/preset-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/preset-registry.json
@@ -484,6 +484,400 @@
       }
     },
     {
+      "id": "illustrious_xl_v1_lora.character.adamw8bit.balanced",
+      "version": 1,
+      "targetId": "illustrious_xl_v1_lora",
+      "name": "Character balanced",
+      "recommendedFor": [
+        "character"
+      ],
+      "optimizer": "adamw8bit",
+      "qualityPreset": "balanced",
+      "config": {
+        "rank": 16,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 1500,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 7.0,
+          "sampleSteps": 30,
+          "weightDecay": 0.0001
+        }
+      },
+      "ui": {
+        "default": true,
+        "description": "Balanced first run for 12-25 clean character images on Illustrious v1.0.",
+        "order": 10
+      }
+    },
+    {
+      "id": "illustrious_xl_v1_lora.character.adamw8bit.conservative",
+      "version": 1,
+      "targetId": "illustrious_xl_v1_lora",
+      "name": "Character conservative",
+      "recommendedFor": [
+        "character"
+      ],
+      "optimizer": "adamw8bit",
+      "qualityPreset": "conservative",
+      "config": {
+        "rank": 8,
+        "alpha": 8,
+        "learningRate": 0.00005,
+        "steps": 1500,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "conservative",
+          "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 7.0,
+          "sampleSteps": 30,
+          "weightDecay": 0.0001
+        }
+      },
+      "ui": {
+        "description": "Lower-rank, lower-LR character preset for tight identity datasets.",
+        "order": 20
+      }
+    },
+    {
+      "id": "illustrious_xl_v1_lora.style.adamw8bit.balanced",
+      "version": 1,
+      "targetId": "illustrious_xl_v1_lora",
+      "name": "Style balanced",
+      "recommendedFor": [
+        "style"
+      ],
+      "optimizer": "adamw8bit",
+      "qualityPreset": "balanced",
+      "config": {
+        "rank": 32,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 1500,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 7.0,
+          "sampleSteps": 30,
+          "weightDecay": 0.0001
+        }
+      },
+      "ui": {
+        "description": "Higher-capacity style LoRA defaults for anime look and texture transfer.",
+        "order": 30
+      }
+    },
+    {
+      "id": "illustrious_xl_v1_lora.character.adamw8bit.low_vram",
+      "version": 1,
+      "targetId": "illustrious_xl_v1_lora",
+      "name": "Low VRAM character",
+      "recommendedFor": [
+        "character"
+      ],
+      "optimizer": "adamw8bit",
+      "qualityPreset": "low_vram",
+      "config": {
+        "rank": 8,
+        "alpha": 8,
+        "learningRate": 0.0001,
+        "steps": 1200,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 768,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "low_vram",
+          "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 7.0,
+          "sampleSteps": 30,
+          "weightDecay": 0.0001
+        }
+      },
+      "ui": {
+        "description": "768px preset for tighter-VRAM Illustrious v1.0 training.",
+        "order": 40
+      }
+    },
+    {
+      "id": "illustrious_xl_v2_lora.character.adamw8bit.balanced",
+      "version": 1,
+      "targetId": "illustrious_xl_v2_lora",
+      "name": "Character balanced",
+      "recommendedFor": [
+        "character"
+      ],
+      "optimizer": "adamw8bit",
+      "qualityPreset": "balanced",
+      "config": {
+        "rank": 16,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 1500,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 7.0,
+          "sampleSteps": 30,
+          "weightDecay": 0.0001
+        }
+      },
+      "ui": {
+        "default": true,
+        "description": "Balanced first run for 12-25 clean character images on Illustrious v2.0.",
+        "order": 10
+      }
+    },
+    {
+      "id": "illustrious_xl_v2_lora.character.adamw8bit.conservative",
+      "version": 1,
+      "targetId": "illustrious_xl_v2_lora",
+      "name": "Character conservative",
+      "recommendedFor": [
+        "character"
+      ],
+      "optimizer": "adamw8bit",
+      "qualityPreset": "conservative",
+      "config": {
+        "rank": 8,
+        "alpha": 8,
+        "learningRate": 0.00005,
+        "steps": 1500,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "conservative",
+          "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 7.0,
+          "sampleSteps": 30,
+          "weightDecay": 0.0001
+        }
+      },
+      "ui": {
+        "description": "Lower-rank, lower-LR character preset for tight identity datasets.",
+        "order": 20
+      }
+    },
+    {
+      "id": "illustrious_xl_v2_lora.style.adamw8bit.balanced",
+      "version": 1,
+      "targetId": "illustrious_xl_v2_lora",
+      "name": "Style balanced",
+      "recommendedFor": [
+        "style"
+      ],
+      "optimizer": "adamw8bit",
+      "qualityPreset": "balanced",
+      "config": {
+        "rank": 32,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 1500,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 7.0,
+          "sampleSteps": 30,
+          "weightDecay": 0.0001
+        }
+      },
+      "ui": {
+        "description": "Higher-capacity style LoRA defaults for anime look and texture transfer.",
+        "order": 30
+      }
+    },
+    {
+      "id": "illustrious_xl_v2_lora.character.adamw8bit.low_vram",
+      "version": 1,
+      "targetId": "illustrious_xl_v2_lora",
+      "name": "Low VRAM character",
+      "recommendedFor": [
+        "character"
+      ],
+      "optimizer": "adamw8bit",
+      "qualityPreset": "low_vram",
+      "config": {
+        "rank": 8,
+        "alpha": 8,
+        "learningRate": 0.0001,
+        "steps": 1200,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 768,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "low_vram",
+          "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 7.0,
+          "sampleSteps": 30,
+          "weightDecay": 0.0001
+        }
+      },
+      "ui": {
+        "description": "768px preset for tighter-VRAM Illustrious v2.0 training.",
+        "order": 40
+      }
+    },
+    {
       "id": "kolors_lora.character.adamw8bit.balanced",
       "version": 1,
       "targetId": "kolors_lora",

--- a/tests/fixtures/rust_migration_contracts/training/target-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/target-registry.json
@@ -187,6 +187,195 @@
       }
     },
     {
+      "id": "illustrious_xl_v1_lora",
+      "name": "Illustrious-XL v1.0 LoRA",
+      "modality": "image",
+      "outputKind": "lora",
+      "family": "sdxl",
+      "baseModel": "illustrious_xl_v1",
+      "baseModelRepo": "SceneWorks/illustrious-xl-v1-mlx",
+      "kernel": "sdxl_lora",
+      "defaults": {
+        "rank": 16,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 1500,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 7.0,
+          "sampleSteps": 30,
+          "weightDecay": 0.0001
+        }
+      },
+      "limits": {
+        "alpha": [
+          1,
+          128
+        ],
+        "batchSize": [
+          1,
+          4
+        ],
+        "lrSchedulers": [
+          "constant",
+          "linear",
+          "cosine"
+        ],
+        "networkTypes": [
+          "lora",
+          "lokr"
+        ],
+        "optimizers": [
+          "adamw8bit",
+          "adamw",
+          "adam",
+          "prodigyopt",
+          "rose"
+        ],
+        "outputScopes": [
+          "project",
+          "global"
+        ],
+        "rank": [
+          4,
+          128
+        ],
+        "resolutions": [
+          768,
+          1024,
+          1536
+        ],
+        "steps": [
+          200,
+          6000
+        ]
+      },
+      "ui": {
+        "description": "Train an anime image LoRA for Illustrious-XL v1.0 (Danbooru-tag SDXL finetune). Shares the SDXL UNet trainer, so the output is an sdxl-family LoRA. Supports high-res 1536 training.",
+        "label": "Illustrious-XL v1.0 LoRA",
+        "recommendedFor": [
+          "character",
+          "style"
+        ]
+      }
+    },
+    {
+      "id": "illustrious_xl_v2_lora",
+      "name": "Illustrious-XL v2.0 LoRA",
+      "modality": "image",
+      "outputKind": "lora",
+      "family": "sdxl",
+      "baseModel": "illustrious_xl_v2",
+      "baseModelRepo": "SceneWorks/illustrious-xl-v2-mlx",
+      "kernel": "sdxl_lora",
+      "defaults": {
+        "rank": 16,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 1500,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "loraTargetModules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0"
+          ],
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 250,
+          "sampleGuidanceScale": 7.0,
+          "sampleSteps": 30,
+          "weightDecay": 0.0001
+        }
+      },
+      "limits": {
+        "alpha": [
+          1,
+          128
+        ],
+        "batchSize": [
+          1,
+          4
+        ],
+        "lrSchedulers": [
+          "constant",
+          "linear",
+          "cosine"
+        ],
+        "networkTypes": [
+          "lora",
+          "lokr"
+        ],
+        "optimizers": [
+          "adamw8bit",
+          "adamw",
+          "adam",
+          "prodigyopt",
+          "rose"
+        ],
+        "outputScopes": [
+          "project",
+          "global"
+        ],
+        "rank": [
+          4,
+          128
+        ],
+        "resolutions": [
+          768,
+          1024
+        ],
+        "steps": [
+          200,
+          6000
+        ]
+      },
+      "ui": {
+        "description": "Train an anime image LoRA for Illustrious-XL v2.0 (the more stable v2.0-STABLE snapshot). Shares the SDXL UNet trainer, so the output is an sdxl-family LoRA. Trains at 768/1024 (v2.0 duplicates the subject in larger frames).",
+        "label": "Illustrious-XL v2.0 LoRA",
+        "recommendedFor": [
+          "character",
+          "style"
+        ]
+      }
+    },
+    {
       "id": "kolors_lora",
       "name": "Kolors LoRA",
       "modality": "image",


### PR DESCRIPTION
The **training half** of Illustrious support (epic 10609), two commits (one per story):

## sc-10617 — training targets + presets
- `illustrious_xl_v1_lora` + `illustrious_xl_v2_lora` in `crates/sceneworks-core/src/training.rs`, each with the full four-preset set built through the shared `sdxl_preset` helper.
- Both reuse the `sdxl_lora` kernel outright (`engine_trainer_id` maps it to the `sdxl` trainer with no branch); only `base_model_repo` differs, pointing at the turnkey re-host. Output LoRAs register as `family: sdxl`.
- `resolve_base_model_path` descends to the dense `bf16/` tier via the sc-10613 readiness fix — asserted against the **real** registry target.
- Training resolutions gated on the sc-10620 bake-off: v1 `[768,1024,1536]`, v2 `[768,1024]` (v2 duplicates in large frames). Not unified.

## sc-10618 — E2E train→apply validation (real weights)
New `#[ignore]` macOS smoke `illustrious_train_apply_mlx_smoke`: loads the SDXL trainer from the turnkey `bf16/` tier, trains a LoRA/LoKr, inspects the adapter, then renders the same seed **without vs with** the adapter and asserts it visibly changes output. Plus a candle (CUDA) twin ready for the RTX box.

**Validated on-device (Apple Silicon, 4 cells, 768², 20 steps):**

| cell | mid_block | Δ (0–255) | train | peak |
|---|---|---|---|---|
| v1 LoRA | 240 | 53.76 | 23s | 14.1 GB |
| v1 LoKr | **0** ✓ sc-2640 | 12.16 | 26s | 17.2 GB |
| v2 LoRA | 240 | 20.37 | 24s | 14.1 GB |
| v2 LoKr | **0** ✓ sc-2640 | 6.62 | 29s | 17.2 GB |

Every cell: trained on `bf16`, `family=sdxl`, coherent single-subject anime render that visibly shifts under the adapter, valid positive-guidance (7.0) in-training preview. LoKr correctly emits **zero** `mid_block` factors (sc-2640); LoRA emits the full surface.

## Scope notes
- **candle/CUDA half (4 cells) is hardware-gated** — no NVIDIA GPU on the dev Mac. The candle SDXL trainer is config-blind + already GPU-validated; a ready-to-run smoke is included. Execution filed as **sc-10710**.
- **Finding filed on sc-10616:** applying an SDXL LoRA on a *packed* (q4/q8) tier fails `merge_dense_delta: base is quantized` — mlx-gen-sdxl merges the LoRA into the base (needs dense). Pre-existing + family-wide, not Illustrious-specific. This smoke applies on the dense tier.

## Verified locally
`cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean (core/worker/rust-api); `training_contracts` 32/32; `engine_trainer_id` + rust-api readiness tests green; the 4-cell MLX matrix above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)