### PR TITLE
feat(api): scan ComfyUI base subtrees + assemble virtual external models (sc-10667)

### DIFF
--- a/apps/rust-api/src/external_base_models.rs
+++ b/apps/rust-api/src/external_base_models.rs
@@ -1,0 +1,782 @@
+//! Surface the **base** weights sitting in an operator's ComfyUI `models/` tree as
+//! assembled virtual models, read in place (epic 10451 Phase 2, sc-10667).
+//!
+//! Phase 1 (sc-10452, [`crate::external_loras`]) scans only `<root>/loras`. Phase 2
+//! adds the sibling base subtrees — `diffusion_models/`, `unet/`, `text_encoders/`,
+//! `vae/`, `checkpoints/` — and assembles a **virtual model** from the separate
+//! component files, because modern ComfyUI does not fuse them: the diffusion
+//! transformer, the prompt encoders, and the VAE are distinct files. A legacy
+//! all-in-one `checkpoints/` file is a virtual model on its own.
+//!
+//! Each file is classified header-only by the sc-10662 detector
+//! ([`sceneworks_core::base_weights`]) into `(family, component, quant)`. A model is
+//! **anchored** by a transformer (`diffusion_models/`, `unet/`) or an all-in-one
+//! checkpoint (`checkpoints/`); the text encoders and VAEs in the tree are matched
+//! in as components.
+//!
+//! The rows mirror the external-LoRA posture and are deliberately second-class:
+//! * `catalogScope: "external"` + `removable: false` — read in place, never copied,
+//!   never offered for deletion.
+//! * ids are namespaced `external_base_…` so they can never collide with a
+//!   manifest model id.
+//! * **`usable: false` for now.** The per-family remap/dequant loaders are the
+//!   downstream slices (sc-10668+); until one lands, an assembled external model is
+//!   surfaced with an `unusableReason` (the sc-10509 fail-closed-with-reason
+//!   posture) rather than offered as a generation target. `assembly` +
+//!   `components` record what was found so the loader slice and the UI can use it.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use sceneworks_core::base_weights::{
+    detect_base_weight_file, BaseWeightDetection, ComponentRole, QuantFormat,
+};
+use sceneworks_core::external_roots::comfyui_base_dirs;
+use sceneworks_core::lora_family::is_hidden_file;
+use sceneworks_core::slug::slugify;
+use serde_json::{json, Value};
+
+/// Catalog `catalogScope` for a scanned, externally-owned base model. Models use
+/// `catalogScope` (not the LoRA `scope`); `"external"` is new here (manifest models
+/// are only ever `"builtin"` or `"user"`).
+pub(crate) const EXTERNAL_SCOPE: &str = "external";
+
+/// Prefix on every synthesized id, distinct from the external-LoRA `external_`
+/// prefix so a base model and an adapter can never collide.
+const EXTERNAL_ID_PREFIX: &str = "external_base_";
+
+/// Reason attached to every assembled external base model until a per-family
+/// load-in-place loader exists (sc-10668+). Even a fully-assembled model is not yet
+/// runnable, so it is surfaced fail-closed rather than offered for generation.
+const LOADER_PENDING_REASON: &str =
+    "External ComfyUI base-model loading is not yet implemented (epic 10451 Phase 2).";
+
+/// Directory nesting descended below each base subtree — the real trees are mostly
+/// flat, but a couple nest a level; this is a runaway guard, not a real limit.
+const MAX_SCAN_DEPTH: usize = 8;
+
+/// Upper bound on files inspected per base subtree, so a pathological directory
+/// yields a truncated list rather than a stalled API.
+const MAX_FILES_PER_DIR: usize = 4096;
+
+/// The base subtrees that **anchor** a virtual model — a file here is a model the
+/// user would pick. `text_encoders/` and `vae/` are component pools, never anchors.
+const ANCHOR_SUBDIRS: &[&str] = &["diffusion_models", "unet", "checkpoints"];
+
+/// Memo of the detection for each file, keyed by path + identity on disk (size +
+/// mtime). `model_catalog` rebuilds on every job-create; classifying a 20 GB base
+/// file means parsing a safetensors header that can be a multi-thousand-entry JSON
+/// blob, so — exactly as [`crate::external_loras::ExternalLoraCache`] does for
+/// adapters — the walk and `stat` always run (added/changed/removed files appear at
+/// once) but the header parse is skipped when size and mtime both match.
+#[derive(Default)]
+pub(crate) struct ExternalBaseModelCache {
+    entries: HashMap<PathBuf, CachedDetection>,
+}
+
+#[derive(Clone)]
+struct CachedDetection {
+    modified: Option<SystemTime>,
+    size: u64,
+    detection: BaseWeightDetection,
+}
+
+impl ExternalBaseModelCache {
+    fn get(
+        &self,
+        path: &Path,
+        modified: Option<SystemTime>,
+        size: u64,
+    ) -> Option<BaseWeightDetection> {
+        let entry = self.entries.get(path)?;
+        let modified = modified?;
+        let cached_modified = entry.modified?;
+        (entry.size == size && cached_modified == modified).then(|| entry.detection.clone())
+    }
+
+    fn insert(
+        &mut self,
+        path: PathBuf,
+        modified: Option<SystemTime>,
+        size: u64,
+        detection: BaseWeightDetection,
+    ) {
+        self.entries.insert(
+            path,
+            CachedDetection {
+                modified,
+                size,
+                detection,
+            },
+        );
+    }
+
+    fn retain_seen(&mut self, seen: &HashSet<PathBuf>) {
+        self.entries.retain(|path, _| seen.contains(path));
+    }
+}
+
+/// A single classified base-weight file found on disk.
+struct DetectedFile {
+    /// Canonical path to the file (the operator's own file — never copied).
+    path: PathBuf,
+    /// Which base subtree it was found in (`diffusion_models`, `vae`, …).
+    subdir: &'static str,
+    /// Display name relative to the subtree, e.g. `Wan/high_noise` — kept so files
+    /// filed under a nested folder stay distinguishable.
+    name: String,
+    detection: BaseWeightDetection,
+}
+
+impl DetectedFile {
+    fn verdict(&self) -> Option<(&Option<String>, ComponentRole, QuantFormat)> {
+        match &self.detection {
+            BaseWeightDetection::Recognized(v) => Some((&v.family, v.component, v.quant)),
+            BaseWeightDetection::Unrecognized { .. } => None,
+        }
+    }
+
+    fn component_json(&self) -> Value {
+        let (family, role, quant) = match &self.detection {
+            BaseWeightDetection::Recognized(v) => (
+                v.family.clone(),
+                Some(v.component.as_str()),
+                Some(v.quant.as_str()),
+            ),
+            BaseWeightDetection::Unrecognized { .. } => (None, None, None),
+        };
+        json!({
+            "name": self.name,
+            "subdir": self.subdir,
+            "role": role,
+            "family": family,
+            "quant": quant,
+            "path": self.path.display().to_string(),
+        })
+    }
+}
+
+/// Scan each configured root's base subtrees and return synthesized model-catalog
+/// rows, one per assembled virtual model (a transformer + its matched components,
+/// or an all-in-one checkpoint). Returns empty when no roots are configured — the
+/// default — keeping the catalog byte-identical for every install that has not
+/// opted in.
+///
+/// Blocking filesystem work — call from `spawn_blocking`, as `model_catalog` does
+/// for the manifest install-state sweep.
+pub(crate) fn scan_external_base_models(
+    roots: &[PathBuf],
+    cache: &mut ExternalBaseModelCache,
+) -> Vec<Value> {
+    let mut detected: Vec<DetectedFile> = Vec::new();
+    let mut seen = HashSet::new();
+
+    for (subdir, dir) in comfyui_base_dirs(roots) {
+        // Canonicalize once: every file must stay under this, so a symlink inside
+        // the subtree cannot walk the scan out of the operator's declared root.
+        let Ok(canonical_dir) = std::fs::canonicalize(&dir) else {
+            continue;
+        };
+        for file in collect_weight_files(&canonical_dir) {
+            let Some(detection) = classify(&file, cache) else {
+                continue;
+            };
+            seen.insert(file.clone());
+            let name = relative_display_name(file.strip_prefix(&canonical_dir).unwrap_or(&file));
+            detected.push(DetectedFile {
+                path: file,
+                subdir,
+                name,
+                detection,
+            });
+        }
+    }
+    cache.retain_seen(&seen);
+
+    assemble_models(detected)
+}
+
+/// Depth-bounded walk returning every `.safetensors`/`.gguf` file whose canonical
+/// path is still under `root`. Hidden entries are skipped (an external ComfyUI
+/// folder is a prime home for macOS AppleDouble `._x` sidecars). Symlinks are
+/// followed then re-checked for containment, matching the worker's confinement — a
+/// link escaping the root is dropped, since a row the worker would refuse to load
+/// is worse than no row. Mirrors [`crate::external_loras::collect_adapters`].
+fn collect_weight_files(root: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let mut stack = vec![(root.to_path_buf(), 0_usize)];
+    while let Some((dir, depth)) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if files.len() >= MAX_FILES_PER_DIR {
+                tracing::warn!(
+                    root = %root.display(),
+                    limit = MAX_FILES_PER_DIR,
+                    "external base-model scan hit its per-dir cap; remaining files ignored"
+                );
+                return files;
+            }
+            let path = entry.path();
+            if is_hidden_file(&path) {
+                continue;
+            }
+            let Ok(canonical) = std::fs::canonicalize(&path) else {
+                continue;
+            };
+            if !canonical.starts_with(root) {
+                continue;
+            }
+            if canonical.is_dir() {
+                if depth < MAX_SCAN_DEPTH {
+                    stack.push((canonical, depth + 1));
+                }
+            } else if has_weight_extension(&canonical) {
+                files.push(canonical);
+            }
+        }
+    }
+    files
+}
+
+/// True when `path` names a base-weight container: a `.safetensors` or a `.gguf`
+/// (case-insensitively — re-hosted checkpoints ship `.SAFETENSORS`). GGUF content
+/// is confirmed by magic in [`detect_base_weight_file`]; the extension only decides
+/// what to hand the detector.
+fn has_weight_extension(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            extension.eq_ignore_ascii_case("safetensors") || extension.eq_ignore_ascii_case("gguf")
+        })
+}
+
+/// Classify a file, using the memo when size + mtime match. `None` when the file
+/// vanished between the walk and the `stat`, or its header could not be read at all
+/// (a truncated download) — such a file is dropped and, deliberately, **not**
+/// memoized, so a still-downloading file is retried on the next build.
+fn classify(path: &Path, cache: &mut ExternalBaseModelCache) -> Option<BaseWeightDetection> {
+    let metadata = std::fs::metadata(path).ok()?;
+    let size = metadata.len();
+    let modified = metadata.modified().ok();
+    if let Some(detection) = cache.get(path, modified, size) {
+        return Some(detection);
+    }
+    let detection = detect_base_weight_file(path).ok()?;
+    cache.insert(path.to_path_buf(), modified, size, detection.clone());
+    Some(detection)
+}
+
+/// A stable, human-meaningful name from a file's path relative to its subtree:
+/// `Wan/high_noise.safetensors` → `Wan/high_noise`.
+fn relative_display_name(relative: &Path) -> String {
+    let without_extension = relative.with_extension("");
+    without_extension
+        .components()
+        .filter_map(|component| match component {
+            std::path::Component::Normal(value) => value.to_str(),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// Group detected files into virtual models: each transformer/checkpoint anchor
+/// becomes one row, with text encoders and VAEs matched in from the pools.
+fn assemble_models(detected: Vec<DetectedFile>) -> Vec<Value> {
+    // Component pools: everything the detector calls a text encoder / VAE, wherever
+    // it was filed (usually `text_encoders/` and `vae/`).
+    let text_encoders: Vec<&DetectedFile> = detected
+        .iter()
+        .filter(|file| matches!(file.verdict(), Some((_, ComponentRole::TextEncoder, _))))
+        .collect();
+    let vaes: Vec<&DetectedFile> = detected
+        .iter()
+        .filter(|file| matches!(file.verdict(), Some((_, ComponentRole::Vae, _))))
+        .collect();
+
+    let mut rows = Vec::new();
+    let mut used_ids = HashSet::new();
+    for anchor in &detected {
+        // Only files in an anchor subtree seed a model; a text encoder or VAE is a
+        // component, never a standalone model.
+        if !ANCHOR_SUBDIRS.contains(&anchor.subdir) {
+            continue;
+        }
+        if let Some(row) = assemble_one(anchor, &text_encoders, &vaes, &mut used_ids) {
+            rows.push(row);
+        }
+    }
+    rows
+}
+
+/// Text-encoder families that satisfy a given DiT family (best-effort labels from
+/// the base-weight detector), and whether the family needs a VAE. `None` for a
+/// family we do not yet model — its anchor is still surfaced, but as `unassemblable`.
+///
+/// Deliberately conservative and grounded in what SceneWorks ships: precise
+/// component pairing (exactly which encoder/VAE snapshot a family loads) is the
+/// loader slice's job (sc-10668+); here we only decide "are the raw materials
+/// present". VAE families are intentionally not pinned — the Wan and Qwen 3D VAEs
+/// are byte-identical by key, so the detector returns no VAE family, and requiring
+/// one would false-negative every assembly.
+fn required_text_encoders(family: &str) -> Option<&'static [&'static str]> {
+    match family {
+        // Z-Image pairs with Qwen3-4B; Wan with UMT5 (a T5 encoder); FLUX.2 with
+        // Mistral-3 — all reliably labelled by the detector.
+        "z-image" => Some(&["qwen3"]),
+        "wan-video" => Some(&["t5"]),
+        "flux2" => Some(&["mistral"]),
+        // Qwen-Image uses Qwen2.5-VL, which the detector does not yet label (it is
+        // neither the Qwen3 q_norm/k_norm shape nor a tagged vision tower). Left out
+        // deliberately rather than mis-pairing it with the Qwen3 encoder — its anchor
+        // is still surfaced, as `unassemblable`, until the encoder detection lands.
+        _ => None,
+    }
+}
+
+/// Map a detected family to a catalog `type` so external rows group with the
+/// manifest models of the same modality.
+fn model_type_for_family(family: &str) -> &'static str {
+    match family {
+        "wan-video" | "ltx-video" => "video",
+        _ => "image",
+    }
+}
+
+fn assemble_one(
+    anchor: &DetectedFile,
+    text_encoders: &[&DetectedFile],
+    vaes: &[&DetectedFile],
+    used_ids: &mut HashSet<String>,
+) -> Option<Value> {
+    let id = unique_id(&anchor.name, used_ids);
+    let mut components = vec![anchor.component_json()];
+
+    // `assembly` records completeness; `usable` stays false regardless (no loader
+    // yet). `reason` prefers the most actionable message.
+    let (family, assembly, reason): (Option<String>, &str, String) = match anchor.verdict() {
+        // An unreadable/unclassifiable anchor: surfaced so the user sees we found a
+        // file we could not use, with the detector's reason (sc-10509 posture).
+        None => {
+            let detail = match &anchor.detection {
+                BaseWeightDetection::Unrecognized { reason } => reason.clone(),
+                BaseWeightDetection::Recognized(_) => String::new(),
+            };
+            (
+                None,
+                "unrecognized",
+                format!("Unrecognized base weight: {detail}"),
+            )
+        }
+        // An all-in-one checkpoint carries every role itself — complete standalone.
+        Some((family, ComponentRole::Checkpoint, _)) => {
+            (family.clone(), "complete", LOADER_PENDING_REASON.to_owned())
+        }
+        // A VAE or text encoder filed in an anchor subtree is a component, not a
+        // model; skip it rather than surfacing a bogus row.
+        Some((_, ComponentRole::Vae | ComponentRole::TextEncoder, _)) => return None,
+        // A transformer needs its companion encoder + VAE matched in from the tree.
+        Some((family, ComponentRole::Transformer, _)) => {
+            let Some(family_name) = family.clone() else {
+                return Some(finish_row(
+                    id,
+                    anchor,
+                    None,
+                    "unrecognized",
+                    "Unrecognized diffusion-transformer architecture.".to_owned(),
+                    components,
+                ));
+            };
+            match required_text_encoders(&family_name) {
+                None => (
+                    Some(family_name),
+                    "unassemblable",
+                    "Component assembly for this family is not yet modeled.".to_owned(),
+                ),
+                Some(accepted) => {
+                    let matched_encoder = text_encoders.iter().find(|encoder| {
+                        matches!(encoder.verdict(), Some((Some(fam), _, _)) if accepted.contains(&fam.as_str()))
+                    });
+                    if let Some(encoder) = matched_encoder {
+                        components.push(encoder.component_json());
+                    }
+                    // VAE families are byte-identical across model families (the Wan and
+                    // Qwen 3D VAEs share every key), so the detector cannot label them.
+                    // Completeness only requires that *a* VAE is present; a specific one
+                    // is listed as a component only when the tree is unambiguous (exactly
+                    // one). The loader slice resolves the exact VAE per family (sc-10668+).
+                    let vae_present = !vaes.is_empty();
+                    if let [only_vae] = vaes {
+                        components.push(only_vae.component_json());
+                    }
+                    if matched_encoder.is_some() && vae_present {
+                        (
+                            Some(family_name),
+                            "complete",
+                            LOADER_PENDING_REASON.to_owned(),
+                        )
+                    } else {
+                        let mut missing = Vec::new();
+                        if matched_encoder.is_none() {
+                            missing.push(format!("a {} text encoder", accepted.join("/")));
+                        }
+                        if !vae_present {
+                            missing.push("a VAE".to_owned());
+                        }
+                        (
+                            Some(family_name),
+                            "incomplete",
+                            format!(
+                                "Incomplete: no {} found in the tree.",
+                                missing.join(" and ")
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+    };
+
+    Some(finish_row(id, anchor, family, assembly, reason, components))
+}
+
+fn finish_row(
+    id: String,
+    anchor: &DetectedFile,
+    family: Option<String>,
+    assembly: &str,
+    reason: String,
+    components: Vec<Value>,
+) -> Value {
+    let quant = match &anchor.detection {
+        BaseWeightDetection::Recognized(v) => Some(v.quant.as_str()),
+        BaseWeightDetection::Unrecognized { .. } => None,
+    };
+    let mut row = json!({
+        "id": id,
+        "name": format!("{} (ComfyUI)", anchor.name),
+        "type": family.as_deref().map(model_type_for_family).unwrap_or("image"),
+        "catalogScope": EXTERNAL_SCOPE,
+        "removable": false,
+        "downloadable": false,
+        "downloads": [],
+        "installState": "installed",
+        "installedPath": anchor.path.display().to_string(),
+        "manifestPath": Value::Null,
+        "source": { "path": anchor.path.display().to_string() },
+        // Fail closed: every external base model is surfaced but not yet runnable
+        // (the per-family loaders are sc-10668+). The web picker must not offer it.
+        "usable": false,
+        "unusableReason": reason,
+        "assembly": assembly,
+        "components": components,
+    });
+    if let Some(family) = family {
+        row["family"] = Value::String(family);
+    }
+    if let Some(quant) = quant {
+        row["quant"] = Value::String(quant.to_owned());
+    }
+    row
+}
+
+/// `external_base_<slug>`, suffixed on collision so two anchors that slugify alike
+/// keep distinct ids (the id is the catalog's primary key).
+fn unique_id(display_name: &str, used_ids: &mut HashSet<String>) -> String {
+    let base = format!(
+        "{EXTERNAL_ID_PREFIX}{}",
+        slugify(display_name, "model", Some(80))
+    );
+    let mut candidate = base.clone();
+    let mut suffix = 2_usize;
+    while used_ids.contains(&candidate) {
+        candidate = format!("{base}_{suffix}");
+        suffix += 1;
+    }
+    used_ids.insert(candidate.clone());
+    candidate
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Map;
+
+    /// Write a safetensors file whose header declares `(name, dtype)` tensors. Only
+    /// the header is read, but the declared data must be present or the header is
+    /// rejected as truncated (sc-6072).
+    fn write_safetensors(path: &Path, entries: &[(&str, &str)]) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("parent dir");
+        }
+        let mut header = Map::new();
+        for (index, (key, dtype)) in entries.iter().enumerate() {
+            let start = index * 4;
+            header.insert(
+                (*key).to_owned(),
+                json!({ "dtype": dtype, "shape": [1], "data_offsets": [start, start + 4] }),
+            );
+        }
+        let header_bytes = serde_json::to_vec(&Value::Object(header)).expect("header json");
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(header_bytes.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(&header_bytes);
+        bytes.extend(std::iter::repeat(0_u8).take(entries.len() * 4));
+        std::fs::write(path, bytes).expect("write safetensors");
+    }
+
+    fn z_image_keys() -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("cap_embedder.0.weight", "BF16"),
+            ("noise_refiner.0.attention.qkv.weight", "BF16"),
+            ("layers.0.attention.qkv.weight", "BF16"),
+            ("layers.0.feed_forward.w1.weight", "BF16"),
+        ]
+    }
+    fn qwen3_encoder_keys() -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("model.embed_tokens.weight", "BF16"),
+            ("model.layers.0.self_attn.q_proj.weight", "BF16"),
+            ("model.layers.0.self_attn.q_norm.weight", "BF16"),
+            ("model.layers.0.self_attn.k_norm.weight", "BF16"),
+            ("model.layers.0.mlp.gate_proj.weight", "BF16"),
+        ]
+    }
+    fn vae_keys() -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("encoder.conv_in.weight", "F32"),
+            ("encoder.down.0.block.0.conv1.weight", "F32"),
+            ("decoder.conv_out.weight", "F32"),
+            ("decoder.up.0.block.0.conv1.weight", "F32"),
+        ]
+    }
+
+    fn models_root(temp: &Path) -> PathBuf {
+        temp.join("ComfyUI").join("models")
+    }
+
+    fn scan(roots: &[PathBuf]) -> Vec<Value> {
+        scan_external_base_models(roots, &mut ExternalBaseModelCache::default())
+    }
+
+    #[test]
+    fn no_roots_configured_yields_no_rows() {
+        assert!(scan(&[]).is_empty());
+    }
+
+    #[test]
+    fn a_root_without_base_subtrees_is_empty() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = models_root(temp.path());
+        std::fs::create_dir_all(root.join("loras")).expect("mkdir");
+        assert!(scan(&[root]).is_empty());
+    }
+
+    #[test]
+    fn z_image_with_encoder_and_vae_assembles_complete_but_unusable() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = models_root(temp.path());
+        write_safetensors(
+            &root.join("unet").join("z_image_turbo_bf16.safetensors"),
+            &z_image_keys(),
+        );
+        write_safetensors(
+            &root.join("text_encoders").join("qwen_3_4b.safetensors"),
+            &qwen3_encoder_keys(),
+        );
+        write_safetensors(&root.join("vae").join("ae.safetensors"), &vae_keys());
+
+        let rows = scan(&[root]);
+        assert_eq!(
+            rows.len(),
+            1,
+            "one anchored model, encoder+vae folded in as components"
+        );
+        let row = &rows[0];
+        assert_eq!(row["family"], "z-image");
+        assert_eq!(row["type"], "image");
+        assert_eq!(row["catalogScope"], EXTERNAL_SCOPE);
+        assert_eq!(row["removable"], false);
+        assert_eq!(row["assembly"], "complete");
+        // Fail-closed regardless of completeness: no loader exists yet.
+        assert_eq!(row["usable"], false);
+        assert!(row["unusableReason"]
+            .as_str()
+            .unwrap()
+            .contains("not yet implemented"));
+        assert_eq!(row["components"].as_array().unwrap().len(), 3);
+        assert!(row["id"].as_str().unwrap().starts_with(EXTERNAL_ID_PREFIX));
+    }
+
+    #[test]
+    fn z_image_without_encoder_is_incomplete_with_reason() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = models_root(temp.path());
+        write_safetensors(
+            &root.join("unet").join("z_image_turbo_bf16.safetensors"),
+            &z_image_keys(),
+        );
+        write_safetensors(&root.join("vae").join("ae.safetensors"), &vae_keys());
+        // No text_encoders/ at all.
+
+        let rows = scan(&[root]);
+        let row = &rows[0];
+        assert_eq!(row["assembly"], "incomplete");
+        assert_eq!(row["usable"], false);
+        let reason = row["unusableReason"].as_str().unwrap();
+        assert!(reason.contains("text encoder"), "reason: {reason}");
+        // The VAE it did find is still listed as a component.
+        assert_eq!(row["components"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn all_in_one_checkpoint_is_complete_standalone() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = models_root(temp.path());
+        // LTX all-in-one: DiT + an embedded audio_vae → ComponentRole::Checkpoint.
+        write_safetensors(
+            &root.join("checkpoints").join("ltx.safetensors"),
+            &[
+                ("model.diffusion_model.scale_shift_table", "F32"),
+                ("model.diffusion_model.patchify_proj.weight", "BF16"),
+                (
+                    "model.diffusion_model.transformer_blocks.0.attn1.to_q.weight",
+                    "BF16",
+                ),
+                ("audio_vae.encoder.conv_in.conv.weight", "F32"),
+                ("audio_vae.decoder.conv_out.conv.weight", "F32"),
+            ],
+        );
+
+        let rows = scan(&[root]);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["family"], "ltx-video");
+        assert_eq!(rows[0]["type"], "video");
+        assert_eq!(rows[0]["assembly"], "complete");
+        // No component pool needed: the checkpoint carries every role.
+        assert_eq!(rows[0]["components"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn text_encoders_and_vaes_are_components_never_anchors() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = models_root(temp.path());
+        // Only encoders + VAEs, no transformer/checkpoint → nothing to anchor a model.
+        write_safetensors(
+            &root.join("text_encoders").join("qwen_3_4b.safetensors"),
+            &qwen3_encoder_keys(),
+        );
+        write_safetensors(&root.join("vae").join("ae.safetensors"), &vae_keys());
+        assert!(scan(&[root]).is_empty());
+    }
+
+    #[test]
+    fn unrecognized_family_transformer_is_surfaced_unusable() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = models_root(temp.path());
+        write_safetensors(
+            &root.join("diffusion_models").join("mystery.safetensors"),
+            &[("some.unknown.tensor", "BF16"), ("another.mystery", "BF16")],
+        );
+        let rows = scan(&[root]);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["usable"], false);
+        assert_eq!(rows[0]["assembly"], "unrecognized");
+        assert!(rows[0].get("family").is_none());
+    }
+
+    #[test]
+    fn a_family_without_a_component_spec_is_unassemblable_but_listed() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = models_root(temp.path());
+        // Ideogram is a recognized DiT family with no component spec here yet.
+        write_safetensors(
+            &root.join("diffusion_models").join("ideo.safetensors"),
+            &[
+                ("embed_image_indicator.weight", "BF16"),
+                ("layers.0.attention.qkv.weight", "BF16"),
+                ("layers.0.adaln_modulation.weight", "BF16"),
+            ],
+        );
+        let rows = scan(&[root]);
+        assert_eq!(rows[0]["family"], "ideogram");
+        assert_eq!(rows[0]["assembly"], "unassemblable");
+        assert_eq!(rows[0]["usable"], false);
+    }
+
+    #[test]
+    fn gguf_anchor_is_surfaced() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = models_root(temp.path());
+        let unet = root.join("unet");
+        std::fs::create_dir_all(&unet).expect("mkdir");
+        // GGUF magic + padding; detected by magic, classified quant=gguf.
+        std::fs::write(unet.join("wan_Q4_K_S.gguf"), b"GGUF\x00\x00\x00\x00padding")
+            .expect("write");
+        let rows = scan(&[root]);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["quant"], "gguf");
+        assert_eq!(rows[0]["usable"], false);
+    }
+
+    #[test]
+    fn scan_populates_then_prunes_the_cache() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = models_root(temp.path());
+        let anchor = root.join("unet").join("z_image_turbo_bf16.safetensors");
+        write_safetensors(&anchor, &z_image_keys());
+
+        let mut cache = ExternalBaseModelCache::default();
+        let rows = scan_external_base_models(std::slice::from_ref(&root), &mut cache);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(cache.entries.len(), 1);
+
+        let again = scan_external_base_models(std::slice::from_ref(&root), &mut cache);
+        assert_eq!(
+            again, rows,
+            "unchanged tree yields identical rows from cache"
+        );
+
+        std::fs::remove_file(&anchor).expect("remove");
+        assert!(scan_external_base_models(&[root], &mut cache).is_empty());
+        assert!(cache.entries.is_empty(), "vanished files pruned");
+    }
+
+    /// Manual smoke against a real ComfyUI tree — the only test over real key
+    /// conventions. Ignored by default:
+    ///
+    /// ```text
+    /// SCENEWORKS_EXTERNAL_MODEL_ROOTS='C:\Users\Michael\ComfyUI-Shared\models' \
+    ///   cargo test -p sceneworks-rust-api --lib external_base_models::tests::real_comfyui_base_tree -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "requires a real ComfyUI models tree via SCENEWORKS_EXTERNAL_MODEL_ROOTS"]
+    fn real_comfyui_base_tree_smoke() {
+        let roots = sceneworks_core::external_roots::parse_external_model_roots(
+            std::env::var("SCENEWORKS_EXTERNAL_MODEL_ROOTS")
+                .ok()
+                .as_deref(),
+        );
+        assert!(!roots.is_empty(), "set SCENEWORKS_EXTERNAL_MODEL_ROOTS");
+        let rows = scan(&roots);
+        println!("\n{} external base models assembled:", rows.len());
+        for row in &rows {
+            println!(
+                "  {:<10} {:<14} {:<8} {}",
+                row.get("family")
+                    .and_then(Value::as_str)
+                    .unwrap_or("(none)"),
+                row["assembly"].as_str().unwrap_or_default(),
+                row.get("quant").and_then(Value::as_str).unwrap_or("-"),
+                row["name"].as_str().unwrap_or_default(),
+            );
+        }
+        assert!(
+            !rows.is_empty(),
+            "the real tree should assemble base models"
+        );
+    }
+}

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -173,6 +173,7 @@ use models::{
     merge_model_manifest_entry, mlx_catalog_status, model_co_requisite_downloads, model_download,
     retain_downloads_for_os,
 };
+mod external_base_models;
 mod external_loras;
 mod loras;
 use loras::{
@@ -864,6 +865,9 @@ pub(crate) fn create_app_with_state(
         manifest_write_locks: Arc::new(Mutex::new(HashMap::new())),
         model_size_cache: Arc::new(Mutex::new(ModelSizeCache::default())),
         external_lora_cache: Arc::new(Mutex::new(external_loras::ExternalLoraCache::default())),
+        external_base_model_cache: Arc::new(Mutex::new(
+            external_base_models::ExternalBaseModelCache::default(),
+        )),
         http_client: reqwest::Client::new(),
         interrupted_jobs_on_startup,
     };

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1346,6 +1346,11 @@ async fn model_catalog_inner(
     .await;
 
     let data_dir = state.settings.data_dir.clone();
+    // sc-10667: surface assembled external ComfyUI base models alongside the manifest
+    // catalog. Cloned before the blocking closure, mirroring the external-LoRA merge in
+    // `lora_catalog`; the scan is filesystem-bound and runs on the blocking pool below.
+    let external_roots = state.settings.external_model_roots.clone();
+    let external_base_cache = state.external_base_model_cache.clone();
     // sc-4202 (F-API-3): the per-model install-state probes below hit the filesystem
     // (huggingface_cache_health snapshot walks, model_is_installed, mlx_catalog_status)
     // for every model. Assemble the catalog on the blocking pool so these synchronous
@@ -1458,6 +1463,16 @@ async fn model_catalog_inner(
             apply_gating_fields(object);
             apply_mac_and_mlx_fields(object, &data_dir);
         }
+        // Append assembled external base models (empty unless external roots are
+        // configured; always empty on macOS). They carry their own catalogScope /
+        // installState / usable fields and deliberately skip the manifest
+        // install-state sweep above, exactly as external LoRAs skip
+        // `normalize_lora_entry` in `lora_catalog`.
+        let external = {
+            let mut cache = external_base_cache.lock();
+            crate::external_base_models::scan_external_base_models(&external_roots, &mut cache)
+        };
+        models.extend(external);
         models.sort_by(|left, right| {
             let left_key = (
                 left.get("type").and_then(Value::as_str).unwrap_or_default(),

--- a/apps/rust-api/src/server.rs
+++ b/apps/rust-api/src/server.rs
@@ -28,6 +28,7 @@ use sceneworks_core::project_store::ProjectStore;
 
 use crate::auth::AuthThrottle;
 use crate::events::EventHub;
+use crate::external_base_models::ExternalBaseModelCache;
 use crate::external_loras::ExternalLoraCache;
 use crate::manifest::ManifestCache;
 use crate::models::ModelSizeCache;
@@ -253,6 +254,11 @@ pub struct AppState {
     /// every job-create; without this, every generation would re-parse every ComfyUI
     /// adapter's safetensors header.
     pub(crate) external_lora_cache: Arc<Mutex<ExternalLoraCache>>,
+    /// sc-10667 — memoized base-weight detection for the transformer/encoder/VAE
+    /// files scanned out of the external roots' base subtrees, keyed by size +
+    /// mtime. `model_catalog` runs on every job-create; without this, every
+    /// generation would re-parse every ComfyUI base file's safetensors header.
+    pub(crate) external_base_model_cache: Arc<Mutex<ExternalBaseModelCache>>,
     pub(crate) http_client: reqwest::Client,
     pub(crate) interrupted_jobs_on_startup: usize,
 }

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -701,12 +701,20 @@ export function App() {
     createVideoJob,
   });
 
+  // `usable !== false` fails closed on external ComfyUI base models (sc-10667): they
+  // are surfaced in the catalog with a reason but not yet runnable (the per-family
+  // loaders are sc-10668+), so they must not be offered as a generation target.
+  // Manifest models never set `usable`, so they are unaffected.
   const imageModels = useMemo(() => {
-    const items = models.filter((model) => model.type === "image" && model.installState !== "missing");
+    const items = models.filter(
+      (model) => model.type === "image" && model.installState !== "missing" && model.usable !== false,
+    );
     return items.length || models.length ? items : fallbackModels.filter((model) => model.type === "image");
   }, [models]);
   const videoModels = useMemo(() => {
-    const items = models.filter((model) => model.type === "video" && model.installState !== "missing");
+    const items = models.filter(
+      (model) => model.type === "video" && model.installState !== "missing" && model.usable !== false,
+    );
     return items.length || models.length ? items : fallbackModels.filter((model) => model.type === "video");
   }, [models]);
   const selectedAsset = useMemo(

--- a/apps/web/src/modelEligibility.js
+++ b/apps/web/src/modelEligibility.js
@@ -143,7 +143,11 @@ export function characterModelUsable(model, caps) {
 // installState !== "missing"), so a screen is never gated while its picker still shows a
 // model. Only a fully-missing catalog gates the screen.
 export function hasUsableModelFor(models, predicate, caps) {
-  return (models ?? []).some((model) => model?.installState !== "missing" && predicate(model, caps));
+  // `usable !== false` keeps the screen-gate in lockstep with the pickers, which
+  // exclude not-yet-runnable external base models (sc-10667).
+  return (models ?? []).some(
+    (model) => model?.installState !== "missing" && model?.usable !== false && predicate(model, caps),
+  );
 }
 
 // The models to OFFER for download when a screen is gated: catalog models usable on the

--- a/crates/sceneworks-core/src/external_roots.rs
+++ b/crates/sceneworks-core/src/external_roots.rs
@@ -31,6 +31,20 @@ pub const EXTERNAL_MODEL_ROOTS_ENV: &str = "SCENEWORKS_EXTERNAL_MODEL_ROOTS";
 /// configured root. A root is expected to be a ComfyUI-style `models/` directory.
 pub const COMFYUI_LORA_SUBDIR: &str = "loras";
 
+/// The ComfyUI subdirectories holding **base** weights (epic 10451 Phase 2,
+/// sc-10667), relative to a configured root. Modern ComfyUI does not fuse
+/// components: the diffusion transformer lives in `diffusion_models/` or `unet/`,
+/// the prompt encoders in `text_encoders/`, the VAE in `vae/`. Only legacy
+/// SD1.5/SDXL-era all-in-one checkpoints sit in `checkpoints/`. All five are
+/// scanned so a virtual model can be assembled from the separate component files.
+pub const COMFYUI_BASE_SUBDIRS: &[&str] = &[
+    "diffusion_models",
+    "unet",
+    "text_encoders",
+    "vae",
+    "checkpoints",
+];
+
 /// Parse an OS path-list into external model roots.
 ///
 /// Entries must be **absolute**: a root is a deployment-level declaration, and a
@@ -80,6 +94,25 @@ pub fn comfyui_lora_dirs(roots: &[PathBuf]) -> Vec<PathBuf> {
         .map(|root| root.join(COMFYUI_LORA_SUBDIR))
         .filter(|dir| dir.is_dir())
         .collect()
+}
+
+/// The existing base-weight subdirectories ([`COMFYUI_BASE_SUBDIRS`]) under each
+/// configured root, each paired with the subdirectory name it came from (so a
+/// scanner can record which component bucket a file was found in). Missing
+/// subdirectories contribute nothing — a tree with only some of the buckets, or a
+/// root on an unmounted drive, must not error. Order follows the roots, then
+/// [`COMFYUI_BASE_SUBDIRS`].
+pub fn comfyui_base_dirs(roots: &[PathBuf]) -> Vec<(&'static str, PathBuf)> {
+    let mut dirs = Vec::new();
+    for root in roots {
+        for subdir in COMFYUI_BASE_SUBDIRS {
+            let dir = root.join(subdir);
+            if dir.is_dir() {
+                dirs.push((*subdir, dir));
+            }
+        }
+    }
+    dirs
 }
 
 #[cfg(test)]
@@ -161,6 +194,25 @@ mod tests {
 
         let dirs = comfyui_lora_dirs(&[present.clone(), absent]);
         assert_eq!(dirs, vec![present.join(COMFYUI_LORA_SUBDIR)]);
+    }
+
+    #[test]
+    fn comfyui_base_dirs_returns_only_existing_buckets_tagged_by_name() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join("models");
+        std::fs::create_dir_all(root.join("diffusion_models")).expect("mkdir");
+        std::fs::create_dir_all(root.join("vae")).expect("mkdir");
+        // `unet`, `text_encoders`, `checkpoints` absent → contribute nothing.
+
+        let dirs = comfyui_base_dirs(std::slice::from_ref(&root));
+        assert_eq!(
+            dirs,
+            vec![
+                ("diffusion_models", root.join("diffusion_models")),
+                ("vae", root.join("vae")),
+            ],
+            "only existing buckets, tagged by subdir name, in COMFYUI_BASE_SUBDIRS order"
+        );
     }
 
     /// macOS is gated off entirely, so the env var must not introduce roots there.


### PR DESCRIPTION
## What

Phase 2 foundation for epic 10451. Phase 1 (sc-10452) scanned only `<root>/loras`; this adds the **base** subtrees — `diffusion_models/`, `unet/`, `text_encoders/`, `vae/`, `checkpoints/` — and assembles a **virtual model** from the separate ComfyUI component files (modern ComfyUI does not fuse them). Each file is classified header-only by the sc-10662 detector into `(family, component, quant)`; a model is anchored by a transformer or an all-in-one checkpoint, with text encoders + VAEs matched in as components.

The plumbing, **not** the loaders — every external base model is surfaced fail-closed (`usable: false` + reason) because the per-family remap/dequant loaders are the downstream slices (sc-10668/10670/10671/10680/10681/10672).

## Changes
- **core**: `COMFYUI_BASE_SUBDIRS` + `comfyui_base_dirs()` (existing buckets, tagged by name).
- **`apps/rust-api/external_base_models.rs`** (new): depth-bounded, symlink-contained, AppleDouble-skipping scan reusing the Phase 1 posture; a size+mtime detection memo (`ExternalBaseModelCache`); per-family component assembly; external catalog rows.
- Rows: `catalogScope:"external"`, `removable:false`, read in place, ids `external_base_*`, `usable:false` + `unusableReason`, `assembly` (complete/incomplete/unassemblable/unrecognized), `components[]`. Wired into `model_catalog_inner` (mirrors the external-LoRA merge) + an `ExternalBaseModelCache` on `AppState`.
- **web**: pickers (`App.jsx`) + screen-gate (`modelEligibility.js`) exclude `usable !== false`, so a not-yet-runnable external model is never offered as a generation target. Manifest models never set `usable`, so they are unaffected (non-regressing).

## Honest matching (avoids the epic's recurring wrong-assumption trap)
Encoders are paired only where the detector labels them reliably: z-image→qwen3, wan→t5, flux2→mistral. **qwen-image uses Qwen2.5-VL** (not yet labelled) so it is left `unassemblable` rather than mis-paired with the Qwen3 encoder. VAEs are byte-identical across families (the Wan and Qwen 3D VAEs share every key), so a specific VAE is listed only when the tree is unambiguous; completeness only requires that *a* VAE is present. Precise pairing is the loader slice's job.

## Testing
- Real-tree ignored test (`real_comfyui_base_tree_smoke`) — **25 external base models assembled** across every family/quant/role class:
```
z-image    complete  bf16                  z_image_turbo_bf16
flux2      complete  fp8_inline_scale      flux2_dev_fp8mixed
wan-video  complete  scaled_fp8_companion  wan2.2_t2v_high_noise_14B_fp8_scaled
qwen-image unassemblable fp8_e4m3          qwen_image_2512_fp8_e4m3fn   (Qwen2.5-VL not yet labelled)
ideogram   unassemblable comfy_quant_packed ideogram4_fp8_scaled
ltx-video  complete  fp8_inline_scale      ltx-2.3-22b-dev-fp8   (all-in-one checkpoint)
(none)     complete  gguf                  wan2.2_t2v_high_noise_14B_Q4_K_S
```
- Unit tests over reconstructed headers (complete/incomplete/checkpoint/gguf/unrecognized/cache).
- core + rust-api `fmt`/`clippy -D warnings`/tests green (246 rust-api lib tests; the 16 model-catalog failures on this box are the pre-existing `HF_HOME` issue sc-10508, green with HF vars unset).
- **Web unit tests deferred to CI** — the worktree's monorepo `node_modules` hoisting cannot resolve vitest through a junction; the change is a non-regressing filter predicate.

## Scope / follow-ups
- Worker-side confinement widening for base paths (`normalize_app_managed_*`) and the actual remap/dequant load are the loader slices (sc-10668+).
- Richer Model Manager "detected / unsupported" card (the model-side analog of sc-10509) + Qwen2.5-VL encoder detection → filed as a follow-up.

Relates to sc-10453, sc-10662, sc-10668.

🤖 Generated with [Claude Code](https://claude.com/claude-code)