### PR TITLE
Illustrious epic: Mac-doable remainder — negative prompt, tier footprints, LoRA inference (sc-10621, sc-10619, sc-10616)

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -379,6 +379,8 @@ export const fallbackModels = [
     capabilities: ["text_to_image", "edit_image", "character_image", "style_variations"],
     ui: {
       description: "Danbooru-tag anime SDXL finetune from OnomaAI, trained for high-resolution illustration. Same SDXL UNet + dual CLIP, sdxl-family LoRA support, real CFG + negative prompt. Prompts blend Danbooru tags with natural language. Handles wide frames up to 1536x1536. SDXL license (openrail++), commercial use OK, ungated.",
+      defaultNegativePrompt:
+        "lowres, bad anatomy, bad hands, missing fingers, extra digits, worst quality, low quality, jpeg artifacts, signature, watermark, username, blurry",
       promptGuide: { title: "Illustrious Prompt Guide", path: "/prompt-guides/illustrious.md" },
     },
   },
@@ -389,6 +391,8 @@ export const fallbackModels = [
     capabilities: ["text_to_image", "edit_image", "character_image", "style_variations"],
     ui: {
       description: "The v2.0-STABLE snapshot of Illustrious-XL — subtler and more stable than v1.0, but with a narrower safe frame width (it tends to duplicate the subject in wide compositions, so the widest aspect buckets are not offered — prefer square or tall). Same Danbooru-tag prompting and sdxl-family LoRA support. CreativeML OpenRAIL-M, commercial use OK, ungated.",
+      defaultNegativePrompt:
+        "lowres, bad anatomy, bad hands, missing fingers, extra digits, worst quality, low quality, jpeg artifacts, signature, watermark, username, blurry",
       promptGuide: { title: "Illustrious Prompt Guide", path: "/prompt-guides/illustrious.md" },
     },
   },

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -4802,7 +4802,7 @@
           "default": true,
           "files": ["q4/*"],
           "estimatedSizeBytes": 3911461825,
-          "footprint": { "diskSizeBytes": 3911461825, "residentMemoryBytes": null, "peakMemoryBytes": null }
+          "footprint": { "diskSizeBytes": 3911461825, "residentMemoryBytes": 3624606692, "peakMemoryBytes": 18696383256 }
         },
         {
           "provider": "huggingface",
@@ -4810,7 +4810,7 @@
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 5385646417,
-          "footprint": { "diskSizeBytes": 5385646417, "residentMemoryBytes": null, "peakMemoryBytes": null }
+          "footprint": { "diskSizeBytes": 5385646417, "residentMemoryBytes": 5094661092, "peakMemoryBytes": 20166437656 }
         },
         {
           "provider": "huggingface",
@@ -4818,7 +4818,7 @@
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 7108498305,
-          "footprint": { "diskSizeBytes": 7108498305, "residentMemoryBytes": null, "peakMemoryBytes": null }
+          "footprint": { "diskSizeBytes": 7108498305, "residentMemoryBytes": 6954313820, "peakMemoryBytes": 22025741200 }
         }
       ],
       "paths": {
@@ -4893,7 +4893,7 @@
           "default": true,
           "files": ["q4/*"],
           "estimatedSizeBytes": 3911461501,
-          "footprint": { "diskSizeBytes": 3911461501, "residentMemoryBytes": null, "peakMemoryBytes": null }
+          "footprint": { "diskSizeBytes": 3911461501, "residentMemoryBytes": 3624606692, "peakMemoryBytes": 18696383256 }
         },
         {
           "provider": "huggingface",
@@ -4901,7 +4901,7 @@
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 5385646137,
-          "footprint": { "diskSizeBytes": 5385646137, "residentMemoryBytes": null, "peakMemoryBytes": null }
+          "footprint": { "diskSizeBytes": 5385646137, "residentMemoryBytes": 5094546404, "peakMemoryBytes": 20166322968 }
         },
         {
           "provider": "huggingface",
@@ -4909,7 +4909,7 @@
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 7108498177,
-          "footprint": { "diskSizeBytes": 7108498177, "residentMemoryBytes": null, "peakMemoryBytes": null }
+          "footprint": { "diskSizeBytes": 7108498177, "residentMemoryBytes": 6954313820, "peakMemoryBytes": 22025741200 }
         }
       ],
       "paths": {

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -4856,6 +4856,9 @@
         "label": "Illustrious-XL v1.0 (anime)",
         "description": "Danbooru-tag anime SDXL finetune from OnomaAI, trained for high-resolution illustration. Same UNet and dual-CLIP as SDXL, so sdxl-family LoRAs apply and real CFG + negative prompt work as usual. Prompts blend Danbooru tags with natural language. Handles wide frames up to 1536x1536. SDXL license (openrail++), commercial use OK, ungated.",
         "recommendedFor": ["text_to_image", "style_variations"],
+        // Anime negative-prompt convention (sc-10621), matching the baseline in the prompt guide.
+        // Image Studio seeds this into an empty negative box.
+        "defaultNegativePrompt": "lowres, bad anatomy, bad hands, missing fingers, extra digits, worst quality, low quality, jpeg artifacts, signature, watermark, username, blurry",
         "pid": { "checkpointId": "pid_sdxl" },
         "promptGuide": {
           "title": "Illustrious Prompt Guide",
@@ -4946,6 +4949,9 @@
         "label": "Illustrious-XL v2.0 (anime)",
         "description": "The v2.0-STABLE snapshot of Illustrious-XL — subtler and more stable than v1.0, but with a narrower safe frame width: it tends to duplicate the subject in wide compositions, so the widest aspect buckets are not offered. Prefer square or tall framing. Same Danbooru-tag prompting and sdxl-family LoRA support. CreativeML OpenRAIL-M, commercial use OK, ungated.",
         "recommendedFor": ["text_to_image", "style_variations"],
+        // Anime negative-prompt convention (sc-10621), matching the baseline in the prompt guide.
+        // Image Studio seeds this into an empty negative box.
+        "defaultNegativePrompt": "lowres, bad anatomy, bad hands, missing fingers, extra digits, worst quality, low quality, jpeg artifacts, signature, watermark, username, blurry",
         "pid": { "checkpointId": "pid_sdxl" },
         "promptGuide": {
           "title": "Illustrious Prompt Guide",

--- a/crates/sceneworks-worker/src/footprint_measure.rs
+++ b/crates/sceneworks-worker/src/footprint_measure.rs
@@ -262,6 +262,10 @@ fn turbo_request(steps: u32, guidance: Option<f32>) -> GenerationRequest {
 }
 
 const SDXL_SENTINEL: &str = "unet/diffusion_pytorch_model.safetensors";
+// The dense bf16 tier packs the UNet under the `.fp16.safetensors` variant filename (the turnkey
+// recipe: quantized tiers use the plain name, the dense tier uses `.fp16`). `resolve_weight_file`
+// tries both at load, but the tier-presence sentinel must name the file that actually exists.
+const SDXL_BF16_SENTINEL: &str = "unet/diffusion_pytorch_model.fp16.safetensors";
 // Lens turnkeys pack the DiT under transformer/diffusion_pytorch_model.safetensors …
 const LENS_SENTINEL: &str = "transformer/diffusion_pytorch_model.safetensors";
 // … while Z-Image turnkeys pack it under transformer/model.safetensors.
@@ -301,6 +305,84 @@ fn footprint_sdxl_bf16() {
         SDXL_SENTINEL,
     );
     measure_footprint("sdxl", "bf16", "sdxl", &dir, sdxl_request());
+}
+
+// Illustrious-XL v1.0 / v2.0 (epic 10609, sc-10619): SDXL-family turnkeys, so the same `sdxl` engine,
+// the same `unet/` sentinel, and the same per-tier resolution as sdxl-base. `FP_ILL_V{1,2}_DIR` points
+// at the turnkey ROOT (the dir holding q4/ q8/ bf16/); resolve_tier_dir joins the tier. Set an anime
+// `FP_PROMPT` for a representative render — the footprint is prompt-independent, but the non-degenerate
+// gate is more meaningful on an in-distribution image. One tier per process (the process-global MLX
+// counter invariant), so run these one `-- --ignored footprint_illustrious_<x>` at a time.
+#[test]
+#[ignore = "footprint measurement; needs SceneWorks/illustrious-xl-v1-mlx q4 cached + an Apple-Silicon Mac"]
+fn footprint_illustrious_v1_q4() {
+    let dir = resolve_tier_dir(
+        "FP_ILL_V1_DIR",
+        "SceneWorks/illustrious-xl-v1-mlx",
+        "q4",
+        SDXL_SENTINEL,
+    );
+    measure_footprint("illustrious_xl_v1", "q4", "sdxl", &dir, sdxl_request());
+}
+
+#[test]
+#[ignore = "footprint measurement; needs SceneWorks/illustrious-xl-v1-mlx q8 cached + an Apple-Silicon Mac"]
+fn footprint_illustrious_v1_q8() {
+    let dir = resolve_tier_dir(
+        "FP_ILL_V1_DIR",
+        "SceneWorks/illustrious-xl-v1-mlx",
+        "q8",
+        SDXL_SENTINEL,
+    );
+    measure_footprint("illustrious_xl_v1", "q8", "sdxl", &dir, sdxl_request());
+}
+
+#[test]
+#[ignore = "footprint measurement; needs SceneWorks/illustrious-xl-v1-mlx bf16 cached + an Apple-Silicon Mac"]
+fn footprint_illustrious_v1_bf16() {
+    let dir = resolve_tier_dir(
+        "FP_ILL_V1_DIR",
+        "SceneWorks/illustrious-xl-v1-mlx",
+        "bf16",
+        SDXL_BF16_SENTINEL,
+    );
+    measure_footprint("illustrious_xl_v1", "bf16", "sdxl", &dir, sdxl_request());
+}
+
+#[test]
+#[ignore = "footprint measurement; needs SceneWorks/illustrious-xl-v2-mlx q4 cached + an Apple-Silicon Mac"]
+fn footprint_illustrious_v2_q4() {
+    let dir = resolve_tier_dir(
+        "FP_ILL_V2_DIR",
+        "SceneWorks/illustrious-xl-v2-mlx",
+        "q4",
+        SDXL_SENTINEL,
+    );
+    measure_footprint("illustrious_xl_v2", "q4", "sdxl", &dir, sdxl_request());
+}
+
+#[test]
+#[ignore = "footprint measurement; needs SceneWorks/illustrious-xl-v2-mlx q8 cached + an Apple-Silicon Mac"]
+fn footprint_illustrious_v2_q8() {
+    let dir = resolve_tier_dir(
+        "FP_ILL_V2_DIR",
+        "SceneWorks/illustrious-xl-v2-mlx",
+        "q8",
+        SDXL_SENTINEL,
+    );
+    measure_footprint("illustrious_xl_v2", "q8", "sdxl", &dir, sdxl_request());
+}
+
+#[test]
+#[ignore = "footprint measurement; needs SceneWorks/illustrious-xl-v2-mlx bf16 cached + an Apple-Silicon Mac"]
+fn footprint_illustrious_v2_bf16() {
+    let dir = resolve_tier_dir(
+        "FP_ILL_V2_DIR",
+        "SceneWorks/illustrious-xl-v2-mlx",
+        "bf16",
+        SDXL_BF16_SENTINEL,
+    );
+    measure_footprint("illustrious_xl_v2", "bf16", "sdxl", &dir, sdxl_request());
 }
 
 #[test]

--- a/crates/sceneworks-worker/src/illustrious_train_apply_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/illustrious_train_apply_mlx_smoke.rs
@@ -451,3 +451,122 @@ fn illustrious_train_apply_mlx_smoke() {
          family=sdxl, delta={delta:.2}, train {train_secs:.1}s peak {train_peak_gb:.1}GB"
     );
 }
+
+/// sc-10616 — real THIRD-PARTY **kohya** LoRA inference validation. Distinct from the training smoke
+/// above: it loads a community Illustrious LoRA in kohya format (`lora_te1_`/`lora_te2_`/`lora_unet_`,
+/// the Civitai/HF convention — NOT the PEFT naming the trainer emits) and proves (a) `lora_family`
+/// classifies it as `sdxl` off the dual-text-encoder key split (the real detection path, not the
+/// happy path where metadata declares the family), and (b) it applies at generation and visibly
+/// changes output. Applies on the DENSE bf16 tier — a packed q4/q8 base fails `merge_dense_delta`
+/// (a pre-existing family-wide constraint, filed as the sc-10616 finding).
+///
+/// ```sh
+/// ILL_BF16_DIR=/path/ill-v1-fixed/bf16 ILL_MODEL=illustrious_xl_v1 \
+///   ILL_LORA_PATH="/path/The Artist - Style for Illustrious XL.safetensors" \
+///   RUST_TEST_THREADS=1 cargo test -p sceneworks-worker --lib \
+///   illustrious_external_kohya_lora_apply_mlx_smoke -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore = "real-weight MLX inference smoke (sc-10616); needs an Illustrious bf16 tier + a kohya LoRA. Set ILL_BF16_DIR, ILL_LORA_PATH"]
+fn illustrious_external_kohya_lora_apply_mlx_smoke() {
+    let bf16_dir = PathBuf::from(
+        std::env::var("ILL_BF16_DIR")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .expect("set ILL_BF16_DIR to the Illustrious dense bf16 tier")
+            .trim(),
+    );
+    assert!(
+        bf16_dir.join("unet").is_dir(),
+        "ILL_BF16_DIR must be a diffusers component tree with unet/; got {}",
+        bf16_dir.display()
+    );
+    let lora_path = PathBuf::from(
+        std::env::var("ILL_LORA_PATH")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .expect("set ILL_LORA_PATH to a kohya Illustrious LoRA .safetensors")
+            .trim(),
+    );
+    assert!(
+        lora_path.is_file(),
+        "ILL_LORA_PATH is not a file: {}",
+        lora_path.display()
+    );
+    let model = env_or("ILL_MODEL", "illustrious");
+    let res: u32 = env_or("ILL_RES", "1024").parse().expect("ILL_RES");
+    let seed: u64 = env_or("ILL_SEED", "7").parse().expect("ILL_SEED");
+    let scale: f32 = env_or("ILL_SCALE", "1.0").parse().expect("ILL_SCALE");
+    let out_dir = PathBuf::from(env_or("ILL_OUT_DIR", "/tmp/ill_ext_lora"));
+    std::fs::create_dir_all(&out_dir).expect("out dir");
+
+    // (1) Kohya dual-text-encoder format + the REAL family-detection path (not a declared-metadata
+    // shortcut): `detect_model_family` must classify it `sdxl` off the `lora_te1_`/`lora_te2_` split.
+    let names = safetensors_tensor_names(&lora_path);
+    let has_te1 = names.iter().any(|k| k.starts_with("lora_te1_"));
+    let has_te2 = names.iter().any(|k| k.starts_with("lora_te2_"));
+    let has_unet = names.iter().any(|k| k.starts_with("lora_unet_"));
+    println!(
+        "[ill-ext {model}] adapter {} tensors: kohya lora_te1_={has_te1} lora_te2_={has_te2} lora_unet_={has_unet}",
+        names.len()
+    );
+    assert!(
+        has_te1 && has_te2 && has_unet,
+        "expected a kohya SDXL dual-text-encoder LoRA (lora_te1_/lora_te2_/lora_unet_)"
+    );
+    let detected = sceneworks_core::lora_family::detect_model_family(&lora_path)
+        .expect("family detection reads the safetensors header");
+    assert_eq!(
+        detected.as_deref(),
+        Some("sdxl"),
+        "lora_family must classify a kohya dual-TE Illustrious LoRA as `sdxl` (got {detected:?})"
+    );
+    println!("[ill-ext {model}] lora_family detected: {detected:?}");
+
+    // (2) Apply at generation on the dense tier — same seed, without vs with the LoRA.
+    let prompt = env_or(
+        "ILL_PROMPT",
+        "1girl, solo, silver hair, anime portrait, detailed, masterpiece",
+    );
+    let baseline = render(&bf16_dir, None, None, &prompt, seed, res);
+    save_png(
+        &baseline,
+        &out_dir.join(format!("{model}_extlora_baseline.png")),
+    );
+    let with_lora = render(
+        &bf16_dir,
+        None,
+        Some(AdapterSpec::new(
+            lora_path.clone(),
+            scale,
+            AdapterKind::Lora,
+        )),
+        &prompt,
+        seed,
+        res,
+    );
+    let after_png = out_dir.join(format!("{model}_extlora_with.png"));
+    save_png(&with_lora, &after_png);
+
+    let (bstd, astd) = (image_std(&baseline), image_std(&with_lora));
+    let delta = mean_abs_delta(&baseline, &with_lora);
+    println!(
+        "[ill-ext {model}] base_std={bstd:.1} after_std={astd:.1} mean_abs_delta={delta:.2} -> {}",
+        after_png.display()
+    );
+    assert!(
+        !is_all_zero(&baseline) && !is_all_zero(&with_lora),
+        "a render is all-zero (broken decode)"
+    );
+    assert!(
+        bstd > DEGENERATE_STD_FLOOR_TIGHT && astd > DEGENERATE_STD_FLOOR_TIGHT,
+        "a render looks degenerate (base_std {bstd:.1}, after_std {astd:.1})"
+    );
+    assert!(
+        delta > 1.0,
+        "the kohya LoRA did not change output (mean_abs_delta {delta:.2}) — not applied at inference"
+    );
+    println!(
+        "[ill-ext-DONE {model}] third-party kohya LoRA: family=sdxl, applies on bf16, delta={delta:.2}"
+    );
+}


### PR DESCRIPTION
Everything the epic 10609 remainder can validate/wire **on the dev Mac** (MLX). Three stories, one commit each. The candle/CUDA halves are hardware-gated (no NVIDIA GPU here) → sc-10710.

## sc-10621 — anime negative prompt (feature)
Wire `ui.defaultNegativePrompt` on both catalog entries + the constants.js mirror, matching the baseline in the prompt guide. Image Studio now seeds the negative box on model select. Manifest audit 7/7; web vitest green.

## sc-10619 — per-tier GPU validation + measured footprints (MLX half)
Add `footprint_illustrious_v{1,2}_{q4,q8,bf16}` and backfill the manifest `residentMemoryBytes`/`peakMemoryBytes` (were `null`) with **measured** numbers. All 6 MLX cells render non-degenerate (std 82–100):

| tier | resident | peak |
|---|---|---|
| q4 | 3.38 GiB | 17.4 GiB |
| q8 | 4.74 GiB | 18.8 GiB |
| bf16 | 6.48 GiB | 20.5 GiB |

Also fixes a latent sentinel bug: the bf16 tier packs the UNet as `.fp16.safetensors` (added `SDXL_BF16_SENTINEL`). The candle 6 cells of the 12-cell matrix are hardware-gated.

## sc-10616 — LoRA/LoKr inference validation (MLX half)
Add `illustrious_external_kohya_lora_apply_mlx_smoke`. Loads a **real third-party** kohya Illustrious LoRA (`robb-0/TheArtist-Style-IllustriousXL`, 2628 tensors, `lora_te1_`/`lora_te2_`/`lora_unet_`) and proves `lora_family` classifies it `sdxl` off the dual-TE split (the real detection path) **and** it applies + visibly restyles output — v1 delta 34.90, v2 delta 16.73, both coherent single subjects.

LoKr: no clean third-party Illustrious LoKr exists on HF (format is rare); the LoKr apply seam is proven by the self-trained LoKr in sc-10618.

## ⚠️ Confirmed LIVE, family-wide bug (needs a decision)
While validating, I confirmed — by **code trace + repro** — that applying **any** LoRA on a **quantized (q4/q8) SDXL-family base fails** `merge_dense_delta: base is quantized`. The production MLX path (`image_jobs/base.rs:3368` `load_spec`) combines the quantized tier + quant + adapters with **no dense-fallback when a LoRA is present**, and SDXL-family models default to `mlxQuantize: 4`. So **SDXL / RealVisXL / Illustrious LoRA-on-default-tier is broken today** — not Illustrious-specific, not introduced here. Filed separately with fix options (force-dense-when-adapters vs. an mlx-gen additive-branch like Wan/Anima). These smokes apply on the dense tier, which works.

## Verified locally
`cargo fmt --check` + `clippy --all-targets -- -D warnings` clean (worker); manifest audit 7/7; web vitest green; the 6-tier sweep + both LoRA-inference cells above (real weights, on-device). All new tests are `#[ignore]`d real-weight smokes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)