### PR TITLE
feat(worker): default gen tier to Q8 app-wide, clamped to installed (sc-10726)

### DIFF
--- a/apps/web/src/quantTier.js
+++ b/apps/web/src/quantTier.js
@@ -145,8 +145,11 @@ function defaultInstalledTier(model, tiers) {
 // The tier the picker should start on for `model`. Preference order:
 //   1. `lastUsed` — the per-model last-used tier, when it is still installed (persistence).
 //   2. the model's declared default tier (`variant.default: true`), when installed.
-//   3. q4 if installed (the catalog's smallest/default convention).
-//   4. the first installed tier.
+//   3. q8 if installed (epic 10721 / sc-10726 — Q8 is the app-wide default generation tier, replacing
+//      the old q4 base convention; clamped to installed so it only wins when q8 is actually present).
+//      A later story (S4) sources this from a global user setting; here it is the hardcoded base default.
+//   4. q4 if installed (clean-tiers fallback so a q4-only install still seeds a real tier, not null).
+//   5. the first installed tier.
 // Returns null when nothing is installed (no picker will render anyway). `options` (sc-9300) forwards
 // the `convRotEligible` gate so a hidden INT8-ConvRot tier is never seeded as the selection.
 export function defaultTierSelection(model, lastUsed, options = {}) {
@@ -161,11 +164,14 @@ export function defaultTierSelection(model, lastUsed, options = {}) {
   if (declared) {
     return declared;
   }
-  // Convert-at-install models (mlxTiers) preselect q8 — matching the worker's Q8 generation default
-  // (sc-10714 / epic 10721), so the picker's initial value never silently sends the washed q4.
-  // Download-matrix models keep the historical q4 (smallest) preselection.
+  // Q8 is the app-wide base default (epic 10721 / sc-10726), matching the worker's Q8 generation
+  // default and replacing the old q4-hard-default so the picker never silently sends the washed q4.
+  // Clamped to installed. Convert-at-install models (mlxTiers, sc-10730) additionally prefer bf16
+  // over q4 as the clean-tier fallback when q8 isn't on disk; download-matrix models fall q8 → q4.
   const preferred =
-    !model?.hasVariantMatrix && Array.isArray(model?.mlxTiers) ? ["q8", "bf16", "q4"] : ["q4"];
+    !model?.hasVariantMatrix && Array.isArray(model?.mlxTiers)
+      ? ["q8", "bf16", "q4"]
+      : ["q8", "q4"];
   for (const tier of preferred) {
     if (tiers.includes(tier)) {
       return tier;

--- a/apps/web/src/quantTier.test.js
+++ b/apps/web/src/quantTier.test.js
@@ -143,15 +143,27 @@ describe("defaultTierSelection", () => {
     expect(defaultTierSelection(model, null)).toBe("q8");
   });
 
-  it("falls back to q4 when installed and no default/last-used applies", () => {
+  it("honors an installed declared default tier over the q8 base default", () => {
     const model = matrixModel({ installed: ["q4", "bf16"], defaultTier: "q4" });
-    // Declared default q4 is installed → picked.
+    // Declared default q4 is installed → picked (the manifest's per-model default still wins).
     expect(defaultTierSelection(model, undefined)).toBe("q4");
   });
 
-  it("falls back to the first installed tier when neither default nor q4 is present", () => {
-    const model = matrixModel({ tiers: ["q8", "bf16"], installed: ["q8", "bf16"], defaultTier: "none" });
+  it("prefers q8 by default when installed and no declared default/last-used applies (sc-10726)", () => {
+    // No declared default, no last-used → the app-wide q8 base default is seeded when q8 is installed.
+    const model = matrixModel({ installed: ["q4", "q8", "bf16"], defaultTier: "none" });
     expect(defaultTierSelection(model, undefined)).toBe("q8");
+  });
+
+  it("clamps the q8 base default to q4 when only q4 is installed (sc-10726)", () => {
+    // Q8 base default falls back to q4 when q8 isn't on disk — never seeds a tier that isn't installed.
+    const model = matrixModel({ tiers: ["q4", "q8", "bf16"], installed: ["q4"], defaultTier: "none" });
+    expect(defaultTierSelection(model, undefined)).toBe("q4");
+  });
+
+  it("falls back to the first installed tier when neither a declared default, q8, nor q4 is present", () => {
+    const model = matrixModel({ tiers: ["bf16"], installed: ["bf16"], defaultTier: "none" });
+    expect(defaultTierSelection(model, undefined)).toBe("bf16");
   });
 
   it("returns null when nothing is installed", () => {
@@ -191,13 +203,16 @@ describe("quantTier — convert-at-install mlxTiers (sc-10730)", () => {
     expect(defaultTierSelection(convertModel(), "q4")).toBe("q4");
   });
 
-  it("does not touch download-matrix behavior (still preselects q4)", () => {
+  it("mlxTiers logic does not disturb download-matrix models (which now also default q8, sc-10726)", () => {
+    // A bare non-matrix model with no mlxTiers still surfaces no tiers.
     expect(installedTiers({ id: "x", hasVariantMatrix: false })).toEqual([]);
+    // Download-matrix models honor the same app-wide q8 base default (epic 10721 / sc-10726),
+    // consistent with the worker resolvers — not the old q4-hard-default.
     expect(
       defaultTierSelection(
         matrixModel({ installed: ["q4", "q8", "bf16"], defaultTier: "none" }),
         null,
       ),
-    ).toBe("q4");
+    ).toBe("q8");
   });
 });

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -635,8 +635,13 @@ fn is_dense_te_tier(request: &ImageRequest) -> bool {
 
 /// Pick the engine-complete tier subdir of a standard SceneWorks quant-matrix turnkey `root`:
 /// `bf16/` when the request opts out of quantization (`advanced.mlxQuantize <= 0` / "none"), `q8/`
-/// when it opts into Q8 (`> 4`), else the default `q4/`. Falls back through q4 → q8 → bf16 → `root`
-/// so a partially-downloaded turnkey surfaces as a load error rather than a silent half-load.
+/// when it opts into Q8 (`> 4`), `q4/` for an explicit Q4 pick (`1..=4`), else — with NO explicit
+/// `mlxQuantize` — the **`q8/`** default (epic 10721 / sc-10726: the app-wide gen-time default tier,
+/// matching [`resolve_quant`]'s Q8 default and [`anima_tier_subdir`], replacing the old blind q4).
+/// Falls back through the clean tiers first (q8 → bf16 → q4 → `root`) so a partial install never
+/// silently lands on the low-fidelity q4 (and a fully-absent turnkey surfaces as a load error). The
+/// Q8 default is CLAMPED to what's installed: with only `q4/` on disk it resolves q4, so a heavy model
+/// never OOMs on a tier the user didn't download.
 ///
 /// Tier presence is filename-agnostic: a tier is "present" when its backbone component holds any
 /// `*.safetensors` (packed single-file OR a `*-00001-of-*.safetensors` shard) or a `*.index.json`
@@ -682,16 +687,20 @@ fn standard_tier_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
             || component_has_weights(&dir);
         has_backbone.then_some(dir)
     };
-    // bits<=0 (advanced.mlxQuantize: 0 / "none") → bf16; bits>4 → q8; else the q4 default.
+    // No explicit selection → q8 (the app-wide default, epic 10721 / sc-10726); bits<=0
+    // (advanced.mlxQuantize: 0 / "none") → bf16; bits>4 → q8; else (an explicit 1..=4) the q4 the user
+    // asked for. Fallback prefers the clean tiers (q8 → bf16 → q4) so a partial install never silently
+    // lands on the washed q4, and the q8 default is clamped to what's on disk.
     let preferred = match bits {
+        None => "q8",
         Some(b) if b <= 0 => "bf16",
         Some(b) if b > 4 => "q8",
         _ => "q4",
     };
     present(preferred)
-        .or_else(|| present("q4"))
         .or_else(|| present("q8"))
         .or_else(|| present("bf16"))
+        .or_else(|| present("q4"))
         .unwrap_or_else(|| root.to_path_buf())
 }
 
@@ -801,10 +810,14 @@ fn ideogram_tier_subdir(bits: Option<i64>) -> Option<&'static str> {
 }
 
 /// Pick the engine-complete packed subdir of an Ideogram 4 turnkey `root`: `q8/` when the request
-/// opts into Q8 (`advanced.mlxQuantize: 8`) AND it is downloaded, else the default `q4/`. Falls back
-/// to `root` if neither subdir is present (a partially-downloaded bundle surfaces as a load error
-/// rather than a silent half-load). The non-default `q8/` tier is an on-demand download fetched by
-/// [`ensure_ideogram_tier_present`] before this resolves (sc-9607); `q4/` is the manifest default.
+/// opts into Q8 (`advanced.mlxQuantize: 8`) AND it is downloaded, `q4/` for an explicit Q4 pick
+/// (`1..=4`), else — with NO explicit `mlxQuantize` — the **`q8/`** default (epic 10721 / sc-10726),
+/// CLAMPED to what's installed (only `q4/` on disk ⇒ q4). Falls back to `root` if neither subdir is
+/// present (a partially-downloaded bundle surfaces as a load error rather than a silent half-load).
+/// The `q8/` tier is an on-demand download fetched by [`ensure_ideogram_tier_present`] on an explicit
+/// opt-in (sc-9607); this resolver never triggers that fetch for the plain default — it simply prefers
+/// q8 when it happens to be on disk. Ideogram's turnkey carries only `q4/`/`q8/` (bf16 is a separate
+/// catalog repo), so the clean-tiers fallback here is q8 ⇆ q4.
 fn ideogram_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
     let bits = request
         .advanced
@@ -821,9 +834,15 @@ fn ideogram_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
             return dir;
         }
     }
-    present("q4")
-        .or_else(|| present("q8"))
-        .unwrap_or_else(|| root.to_path_buf())
+    // An explicit Q4 pick (`1..=4`) stays q4-first; the default (no `mlxQuantize`) and any other
+    // non-q8-opt-in prefer the clean q8 tier when installed, clamping to q4 otherwise.
+    let prefer_q4 = matches!(bits, Some(b) if (1..=4).contains(&b));
+    if prefer_q4 {
+        present("q4").or_else(|| present("q8"))
+    } else {
+        present("q8").or_else(|| present("q4"))
+    }
+    .unwrap_or_else(|| root.to_path_buf())
 }
 
 /// The Boogu subfolder for a `mlxQuantize` request — `None` keeps the Q8 default. Shared by
@@ -1262,8 +1281,10 @@ fn resolve_quant(request: &ImageRequest) -> (Option<Quant>, Option<i64>) {
 
 /// The transformer-tier bit count a dense-TE turnkey (FLUX.2-klein, the [`DENSE_TE_TIER_MODELS`]
 /// class) actually asked for, derived from `advanced.mlxQuantize` the SAME way [`standard_tier_subdir`]
-/// picks its `bf16`/`q8`/`q4` tier (`<=0 → bf16`, `>4 → q8`, else the q4 default). Returns the recipe
-/// bit count of the REQUESTED tier: `None` (bf16) / `Some(8)` / `Some(4)`.
+/// picks its `bf16`/`q8`/`q4` tier (no explicit pick → `q8`; `<=0 → bf16`; `>4 → q8`; else `q4`).
+/// Returns the recipe bit count of the REQUESTED tier: `None` (bf16) / `Some(8)` / `Some(4)`. Kept in
+/// lockstep with the q8 default (sc-10726) so a straight default dense-TE job that resolves the q8 tier
+/// isn't mis-reported as a bf16/q4→q8 tier change by [`reconcile_resolved_tier_quant`].
 ///
 /// sc-9362 (F-018 follow-up): [`resolve_quant`] returns `(None, None)` for every dense-TE job (the
 /// load quant must stay `None` so the deliberately-dense bf16 text encoder is never re-quantized), so
@@ -1284,6 +1305,7 @@ fn dense_te_requested_tier_bits(request: &ImageRequest) -> Option<i64> {
         .get("mlxQuantize")
         .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()));
     match bits {
+        None => Some(8),
         Some(b) if b <= 0 => None,
         Some(b) if b > 4 => Some(8),
         _ => Some(4),
@@ -4727,7 +4749,7 @@ mod standard_tier_tests {
     }
 
     #[test]
-    fn defaults_to_q4_and_honors_quantize_selection() {
+    fn defaults_to_q8_and_honors_quantize_selection() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
         // Packed q4/q8 single-file + dense sharded bf16 (only the index.json shape).
@@ -4735,9 +4757,14 @@ mod standard_tier_tests {
         seed_tier(root, "q8", "diffusion_pytorch_model.safetensors");
         seed_tier(root, "bf16", "diffusion_pytorch_model.safetensors.index.json");
 
-        // No selection → q4 default.
+        // No selection → q8 default (epic 10721 / sc-10726), clamped to installed.
         assert_eq!(
             standard_tier_subdir(root, &request(json!({}))),
+            root.join("q8")
+        );
+        // An explicit Q4 pick is still honored (never overridden by the q8 default).
+        assert_eq!(
+            standard_tier_subdir(root, &request(json!({ "mlxQuantize": 4 }))),
             root.join("q4")
         );
         // mlxQuantize 8 → q8; 0/"none" → bf16; numeric-string accepted.
@@ -4766,6 +4793,12 @@ mod standard_tier_tests {
             standard_tier_subdir(root, &request(json!({ "mlxQuantize": 8 }))),
             root.join("q4")
         );
+        // sc-10726: the q8 default is CLAMPED to installed — with only q4 on disk a default job
+        // (no mlxQuantize) resolves q4, never a tier the user didn't download (no OOM risk).
+        assert_eq!(
+            standard_tier_subdir(root, &request(json!({}))),
+            root.join("q4")
+        );
         // Nothing present → the repo root (engine surfaces the missing-weights error).
         let empty = tempfile::tempdir().unwrap();
         assert_eq!(
@@ -4788,10 +4821,10 @@ mod standard_tier_tests {
         seed_unet("q4");
         seed_unet("q8");
         seed_unet("bf16");
-        // Default q4, q8 selection, bf16 opt-out all resolve to the unet-backed tier subdir.
+        // Default q8, q8 selection, bf16 opt-out all resolve to the unet-backed tier subdir.
         assert_eq!(
             standard_tier_subdir(root, &request(json!({}))),
-            root.join("q4")
+            root.join("q8")
         );
         assert_eq!(
             standard_tier_subdir(root, &request(json!({ "mlxQuantize": 8 }))),
@@ -4821,7 +4854,7 @@ mod standard_tier_tests {
         seed_flat("bf16", "model.safetensors.index.json");
         assert_eq!(
             standard_tier_subdir(root, &request(json!({}))),
-            root.join("q4")
+            root.join("q8")
         );
         assert_eq!(
             standard_tier_subdir(root, &request(json!({ "mlxQuantize": 8 }))),
@@ -5033,7 +5066,9 @@ mod standard_tier_tests {
                 .expect("set SDXL_TIER_ROOT to the downloaded realvisxl-mlx tier root")
                 .trim(),
         );
-        // The worker resolution: a `realvisxl` request (q4 default, no mlxQuantize) must land on q4/.
+        // The worker resolution: a default `realvisxl` request (no mlxQuantize) prefers the q8 default
+        // (sc-10726) but CLAMPS to installed — only the q4 tier was downloaded here (`--include "q4/*"`),
+        // so it lands on q4/.
         let req = ImageRequest::from_payload(
             json!({ "model": "realvisxl", "advanced": {} })
                 .as_object()
@@ -5238,11 +5273,12 @@ mod standard_tier_tests {
         seed_tier(root, "q8", "diffusion_pytorch_model.safetensors");
         seed_tier(root, "bf16", "diffusion_pytorch_model.safetensors.index.json");
 
-        // A/B tier toggle: default (q4) / mlxQuantize:8 (q8) / mlxQuantize:0 (bf16) each resolve to
-        // their tier subdir — the same q4-default recipe the `lens` manifest declares (`mlx.quantize:4`).
+        // A/B tier toggle: default (q8, sc-10726) / mlxQuantize:8 (q8) / mlxQuantize:0 (bf16) each
+        // resolve to their tier subdir — the default now prefers the clean q8 tier (clamped to
+        // installed), matching `resolve_quant`'s Q8 default.
         assert_eq!(
             standard_tier_subdir(root, &lens_request(json!(null))),
-            root.join("q4")
+            root.join("q8")
         );
         assert_eq!(
             standard_tier_subdir(root, &lens_request(json!(8))),
@@ -5272,23 +5308,28 @@ mod standard_tier_tests {
             )
         };
 
-        // Ideogram turnkey (`SceneWorks/ideogram-4-mlx`): q4 default (candle off-Mac tier) + on-demand
-        // q8. `ideogram_model_subdir` probes `<tier>/transformer/model.safetensors`.
+        // Ideogram turnkey (`SceneWorks/ideogram-4-mlx`): q4 + q8 tiers. `ideogram_model_subdir` probes
+        // `<tier>/transformer/model.safetensors`.
         {
             let tmp = tempfile::tempdir().unwrap();
             let root = tmp.path();
             seed_tier(root, "q4", "model.safetensors");
             seed_tier(root, "q8", "model.safetensors");
             for model in ["ideogram_4", "ideogram_4_turbo"] {
-                // Default → q4 (the shipped off-Mac tier).
+                // Default (no mlxQuantize) → q8 when installed (epic 10721 / sc-10726).
                 assert_eq!(
                     ideogram_model_subdir(root, &model_request(model, json!(null))),
-                    root.join("q4")
+                    root.join("q8")
                 );
                 // mlxQuantize:8 → q8 when present.
                 assert_eq!(
                     ideogram_model_subdir(root, &model_request(model, json!(8))),
                     root.join("q8")
+                );
+                // An explicit Q4 pick is still honored.
+                assert_eq!(
+                    ideogram_model_subdir(root, &model_request(model, json!(4))),
+                    root.join("q4")
                 );
             }
         }
@@ -5448,10 +5489,10 @@ mod quant_tier_reconcile_tests {
     }
 
     /// sc-9362 (F-018 follow-up): the dense-TE transformer tier the request asks for is derived from
-    /// `advanced.mlxQuantize` exactly like [`standard_tier_subdir`] — `<=0 → bf16 (None)`, `>4 → q8`,
-    /// else the q4 default — regardless of the always-`None` load quant `resolve_quant` returns for
-    /// dense-TE. This is what reconcile compares the resolved tier against so a straight job isn't a
-    /// spurious downgrade.
+    /// `advanced.mlxQuantize` exactly like [`standard_tier_subdir`] — no explicit pick → `q8` (sc-10726),
+    /// `<=0 → bf16 (None)`, `>4 → q8`, else `q4` — regardless of the always-`None` load quant
+    /// `resolve_quant` returns for dense-TE. This is what reconcile compares the resolved tier against so
+    /// a straight default job (resolving the q8 tier) isn't flagged as a spurious downgrade.
     #[test]
     fn dense_te_requested_tier_bits_mirrors_standard_tier_mapping() {
         let req = |mlx_quantize: serde_json::Value| {
@@ -5464,45 +5505,47 @@ mod quant_tier_reconcile_tests {
         let default = ImageRequest::from_payload(
             json!({ "model": "flux2_klein_9b" }).as_object().unwrap(),
         );
-        // No selection → the q4 default (matches standard_tier_subdir's preferred).
-        assert_eq!(dense_te_requested_tier_bits(&default), Some(4));
+        // No selection → the q8 default (matches standard_tier_subdir's preferred, sc-10726).
+        assert_eq!(dense_te_requested_tier_bits(&default), Some(8));
         assert_eq!(dense_te_requested_tier_bits(&req(json!(0))), None); // bf16 opt-out
-        assert_eq!(dense_te_requested_tier_bits(&req(json!(4))), Some(4));
+        assert_eq!(dense_te_requested_tier_bits(&req(json!(4))), Some(4)); // explicit q4 honored
         assert_eq!(dense_te_requested_tier_bits(&req(json!(8))), Some(8));
         assert_eq!(dense_te_requested_tier_bits(&req(json!("8"))), Some(8)); // numeric-string
         assert_eq!(dense_te_requested_tier_bits(&req(json!(-1))), None);
     }
 
-    /// sc-9362 (F-018 follow-up): a straight (no-fallback) dense-TE job — its q4 transformer tier is
-    /// downloaded and resolves as requested — records the ACTUAL transformer tier (Q4) while keeping
-    /// the load quant `None` (the dense bf16 TE is never re-quantized). Before the fix the request
-    /// derived `(None, None)` and — since dense-TE always requests bf16 in `resolve_quant` — the
-    /// resolved q4 tier read as a bf16→q4 downgrade; now the requested tier is the q4 the request
-    /// actually asked for, so the resolved tier MATCHES and reconcile pass-throughs it with no event.
+    /// sc-9362 (F-018 follow-up) + sc-10726: a straight (no-fallback) dense-TE default job — its q8
+    /// transformer tier is downloaded and resolves as the new q8 default — records the ACTUAL
+    /// transformer tier (Q8) while keeping the load quant `None` (the dense bf16 TE is never
+    /// re-quantized). The requested tier ([`dense_te_requested_tier_bits`], now q8 by default) MATCHES
+    /// the resolved q8 tier, so reconcile pass-throughs it with no spurious `quant_tier_downgraded`.
     #[test]
     fn dense_te_no_fallback_records_transformer_tier() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
-        // The klein q4 transformer tier is present (dense bf16 TE lives alongside in the same tier).
-        let dir = root.join("q4").join("transformer");
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(dir.join("diffusion_pytorch_model.safetensors"), b"x").unwrap();
+        // The klein q4 + q8 transformer tiers are present (dense bf16 TE lives alongside in each tier);
+        // a default job takes the q8 default.
+        for tier in ["q4", "q8"] {
+            let dir = root.join(tier).join("transformer");
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("diffusion_pytorch_model.safetensors"), b"x").unwrap();
+        }
 
         let req = ImageRequest::from_payload(
             json!({ "model": "flux2_klein_9b", "advanced": {} })
                 .as_object()
                 .unwrap(),
         );
-        // The tier resolver lands on the requested q4 tier (no fallback).
+        // The tier resolver lands on the q8 default tier (no fallback).
         let resolved = standard_tier_subdir(root, &req);
-        assert_eq!(resolved, root.join("q4"));
+        assert_eq!(resolved, root.join("q8"));
         // resolve_quant keeps dense-TE at `(None, None)` (never re-quantize the dense bf16 TE)…
         assert_eq!(resolve_quant(&req), (None, None));
-        // …but reconcile against the REQUESTED transformer tier (q4) records the real transformer
-        // precision (Q4) with the load quant still `None`, and — since resolved == requested — with no
+        // …but reconcile against the REQUESTED transformer tier (q8) records the real transformer
+        // precision (Q8) with the load quant still `None`, and — since resolved == requested — with no
         // downgrade (the requested/resolved tiers match, so it's a clean pass-through).
         let requested_for_reconcile = (None, dense_te_requested_tier_bits(&req));
-        assert_eq!(requested_for_reconcile, (None, Some(4)));
+        assert_eq!(requested_for_reconcile, (None, Some(8)));
         let (quant, bits) = reconcile_resolved_tier_quant(
             requested_for_reconcile,
             &resolved,
@@ -5513,8 +5556,8 @@ mod quant_tier_reconcile_tests {
         );
         assert_eq!(
             (quant, bits),
-            (None, Some(4)),
-            "records the actual q4 transformer tier, load quant stays None"
+            (None, Some(8)),
+            "records the actual q8 transformer tier, load quant stays None"
         );
     }
 

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -15,17 +15,47 @@ const QWEN_CONTROL_FILE: &str = "model.safetensors";
 /// `standard_tier_subdir` uses for the base transformer tier, so the control overlay tier tracks the
 /// base tier for a coherent A/B (a q8-default base pairs with the q8 control overlay). The whole control
 /// matrix (q4/q8/bf16) installs as co-requisites alongside the base, so the q8 overlay is on disk
-/// whenever the base is. Mirrors the candle `qwen_control_tier_subdir` (`qwen_control.rs`).
-fn qwen_control_tier_subdir(request: &ImageRequest) -> &'static str {
+/// whenever the base is.
+///
+/// The Q8 default is CLAMPED to what's installed (sc-10726): `snapshot` is the control repo's HF cache
+/// snapshot, and — with NO explicit pick — the resolver picks the highest CLEAN overlay tier whose
+/// `<tier>/model.safetensors` is actually on disk (q8 → bf16 → q4), so a legacy/partial install that
+/// carries only the q4 overlay resolves q4 rather than forcing a NEW ~1.87 GB q8 fetch on the plain
+/// default path. An EXPLICIT pick is returned as-is (it may legitimately fetch its tier on demand), and
+/// an absent `snapshot` (nothing cached yet) falls back to `q8`, the fresh-install co-requisite the base
+/// download brings. Mirrors the candle `qwen_control_tier_subdir` (`qwen_control.rs`).
+fn qwen_control_tier_subdir(request: &ImageRequest, snapshot: Option<&Path>) -> &'static str {
     let bits = request
         .advanced
         .get("mlxQuantize")
         .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()));
     match bits {
-        None => "q8",
         Some(b) if b <= 0 => "bf16",
         Some(b) if b > 4 => "q8",
-        _ => "q4",
+        Some(_) => "q4",
+        // Default: the app-wide Q8 default CLAMPED to the installed overlay — never a new fetch.
+        None => qwen_control_installed_default_tier(snapshot),
+    }
+}
+
+/// The highest CLEAN control overlay tier (q8 → bf16 → q4) whose `<tier>/model.safetensors` is present
+/// in the control repo `snapshot`, else `"q8"` (the fresh-install co-requisite default). Keeps a plain
+/// default job from forcing a NEW on-demand fetch on a legacy/partial install that carries only q4
+/// (sc-10726) — the default tier only wins when it is actually on disk.
+fn qwen_control_installed_default_tier(snapshot: Option<&Path>) -> &'static str {
+    let present = |tier: &str| {
+        snapshot
+            .map(|root| root.join(tier).join(QWEN_CONTROL_FILE).is_file())
+            .unwrap_or(false)
+    };
+    if present("q8") {
+        "q8"
+    } else if present("bf16") {
+        "bf16"
+    } else if present("q4") {
+        "q4"
+    } else {
+        "q8"
     }
 }
 
@@ -65,13 +95,19 @@ fn resolve_qwen_control_weights(
     };
     let repo =
         override_field("repo").unwrap_or_else(|| strict_control_default_repo(QWEN_CONTROL_ENGINE_ID).to_owned());
+    let snapshot = huggingface_snapshot_dir(&settings.data_dir, &repo);
     // Repo-relative path: an explicit override filename (plain component, no tier subdir) else the packed
-    // tier subdir `<tier>/model.safetensors` selected by `advanced.mlxQuantize`.
+    // tier subdir `<tier>/model.safetensors` selected by `advanced.mlxQuantize` — whose DEFAULT tier is
+    // clamped to the installed overlay (`snapshot`) so a plain default job never forces a new fetch
+    // (sc-10726).
     let rel = match override_field("filename") {
         Some(name) => safe_weight_filename(&name, "advanced.controlWeights.filename")?,
-        None => format!("{}/{QWEN_CONTROL_FILE}", qwen_control_tier_subdir(request)),
+        None => format!(
+            "{}/{QWEN_CONTROL_FILE}",
+            qwen_control_tier_subdir(request, snapshot.as_deref())
+        ),
     };
-    let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, &repo) else {
+    let Some(snapshot) = snapshot else {
         return Ok(None);
     };
     let path = snapshot.join(rel);
@@ -898,3 +934,94 @@ async fn generate_qwen_edit_stream(
 // ControlNet, so strict pose is excluded by `sensenova_mlx_eligible`. Mirrors
 // `generate_qwen_edit_stream`'s blocking-thread + streamed-events shape.
 // ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod qwen_control_tier_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn request(advanced: serde_json::Value) -> ImageRequest {
+        ImageRequest::from_payload(
+            json!({ "model": "qwen_image", "advanced": advanced })
+                .as_object()
+                .unwrap(),
+        )
+    }
+
+    /// Write a present `<tier>/model.safetensors` overlay so [`qwen_control_tier_subdir`]'s clamp sees
+    /// the tier as installed.
+    fn seed_tier(root: &Path, tier: &str) {
+        let dir = root.join(tier);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(QWEN_CONTROL_FILE), b"x").unwrap();
+    }
+
+    /// sc-10726: the plain default (no `advanced.mlxQuantize`) resolves the app-wide Q8 default when the
+    /// q8 overlay is on disk, and every explicit pick is honored as-is (an explicit request may fetch its
+    /// tier on demand, so it is NOT clamped to what's installed).
+    #[test]
+    fn default_prefers_installed_q8_and_honors_explicit_picks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        seed_tier(root, "q4");
+        seed_tier(root, "q8");
+        seed_tier(root, "bf16");
+
+        // No selection → q8 default (epic 10721 / sc-10726), clamped to installed (q8 present).
+        assert_eq!(qwen_control_tier_subdir(&request(json!({})), Some(root)), "q8");
+        // Explicit picks are returned verbatim.
+        assert_eq!(
+            qwen_control_tier_subdir(&request(json!({ "mlxQuantize": 4 })), Some(root)),
+            "q4"
+        );
+        assert_eq!(
+            qwen_control_tier_subdir(&request(json!({ "mlxQuantize": 8 })), Some(root)),
+            "q8"
+        );
+        assert_eq!(
+            qwen_control_tier_subdir(&request(json!({ "mlxQuantize": 0 })), Some(root)),
+            "bf16"
+        );
+        // Numeric-string opt-out is accepted the same way.
+        assert_eq!(
+            qwen_control_tier_subdir(&request(json!({ "mlxQuantize": "0" })), Some(root)),
+            "bf16"
+        );
+    }
+
+    /// sc-10726 acceptance #3: on a legacy/partial install carrying ONLY the q4 overlay, the plain
+    /// default must resolve q4 — NOT the app-wide q8 default — so it never forces a NEW ~1.87 GB q8
+    /// on-demand fetch. An EXPLICIT q8 pick is still returned verbatim (it may legitimately fetch).
+    #[test]
+    fn default_clamps_to_only_installed_q4() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        seed_tier(root, "q4");
+
+        // Default clamps down to the only installed tier — no q8 fetch forced.
+        assert_eq!(qwen_control_tier_subdir(&request(json!({})), Some(root)), "q4");
+        // Clean-tier ranking prefers bf16 over q4 when both are present but q8 is not.
+        seed_tier(root, "bf16");
+        assert_eq!(
+            qwen_control_tier_subdir(&request(json!({})), Some(root)),
+            "bf16"
+        );
+        // An explicit q8 opt-in is honored even though only q4/bf16 are on disk.
+        assert_eq!(
+            qwen_control_tier_subdir(&request(json!({ "mlxQuantize": 8 })), Some(root)),
+            "q8"
+        );
+    }
+
+    /// With NO snapshot cached yet (or an empty snapshot), the default falls back to `q8` — the
+    /// fresh-install co-requisite the base download brings alongside the base tier.
+    #[test]
+    fn default_falls_back_to_q8_when_nothing_installed() {
+        assert_eq!(qwen_control_tier_subdir(&request(json!({})), None), "q8");
+        let empty = tempfile::tempdir().unwrap();
+        assert_eq!(
+            qwen_control_tier_subdir(&request(json!({})), Some(empty.path())),
+            "q8"
+        );
+    }
+}

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -10,15 +10,19 @@ const QWEN_CONTROL_ENGINE_ID: &str = "qwen_image_control";
 const QWEN_CONTROL_FILE: &str = "model.safetensors";
 
 /// The packed control tier subdir the request's `advanced.mlxQuantize` selects (sc-9870): `bf16` (opt
-/// out of quantization, `<= 0` / "none"), `q8` (`> 4`), else the `q4` default — the SAME mapping
+/// out of quantization, `<= 0` / "none"), `q8` (`> 4`), `q4` for an explicit Q4 pick (`1..=4`), else —
+/// with NO explicit `mlxQuantize` — the **`q8`** default (sc-10726) — the SAME mapping
 /// `standard_tier_subdir` uses for the base transformer tier, so the control overlay tier tracks the
-/// base tier for a coherent A/B. Mirrors the candle `qwen_control_tier_subdir` (`qwen_control.rs`).
+/// base tier for a coherent A/B (a q8-default base pairs with the q8 control overlay). The whole control
+/// matrix (q4/q8/bf16) installs as co-requisites alongside the base, so the q8 overlay is on disk
+/// whenever the base is. Mirrors the candle `qwen_control_tier_subdir` (`qwen_control.rs`).
 fn qwen_control_tier_subdir(request: &ImageRequest) -> &'static str {
     let bits = request
         .advanced
         .get("mlxQuantize")
         .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()));
     match bits {
+        None => "q8",
         Some(b) if b <= 0 => "bf16",
         Some(b) if b > 4 => "q8",
         _ => "q4",

--- a/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
@@ -123,17 +123,48 @@ fn qwen_control_guidance(request: &ImageRequest) -> f32 {
 /// [`standard_tier_subdir`] uses for the base transformer tier, so the control overlay tier tracks the
 /// base tier for a coherent A/B (a q8-default base pairs with the q8 control overlay). The whole control
 /// matrix (q4/q8/bf16) installs as co-requisites alongside the base, so the q8 overlay is on disk
-/// whenever the base is. Mirrors the MLX `qwen_control_tier_subdir`.
-fn qwen_control_tier_subdir(request: &ImageRequest) -> &'static str {
+/// whenever the base is.
+///
+/// The Q8 default is CLAMPED to what's installed (sc-10726): `snapshot` is the control repo's HF cache
+/// snapshot, and — with NO explicit pick — the resolver picks the highest CLEAN overlay tier whose
+/// `<tier>/model.safetensors` is actually on disk (q8 → bf16 → q4), so a legacy/partial install that
+/// carries only the q4 overlay resolves q4 rather than forcing a NEW q8 fetch (via
+/// [`ensure_qwen_control_weights`]) on the plain default path. An EXPLICIT pick is returned as-is (it
+/// may legitimately fetch its tier on demand), and an absent `snapshot` falls back to `q8`, the
+/// fresh-install co-requisite the base download brings. Mirrors the MLX `qwen_control_tier_subdir`.
+fn qwen_control_tier_subdir(request: &ImageRequest, snapshot: Option<&Path>) -> &'static str {
     let bits = request
         .advanced
         .get("mlxQuantize")
         .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()));
     match bits {
-        None => "q8",
         Some(b) if b <= 0 => "bf16",
         Some(b) if b > 4 => "q8",
-        _ => "q4",
+        Some(_) => "q4",
+        // Default: the app-wide Q8 default CLAMPED to the installed overlay — never a new fetch.
+        None => qwen_control_installed_default_tier(snapshot),
+    }
+}
+
+/// The highest CLEAN control overlay tier (q8 → bf16 → q4) whose `<tier>/model.safetensors` is present
+/// in the control repo `snapshot`, else `"q8"` (the fresh-install co-requisite default). Keeps a plain
+/// default job from forcing a NEW on-demand fetch on a legacy/partial install that carries only q4
+/// (sc-10726) — the default tier only wins when it is actually on disk. Mirrors the MLX
+/// `qwen_control_installed_default_tier`.
+fn qwen_control_installed_default_tier(snapshot: Option<&Path>) -> &'static str {
+    let present = |tier: &str| {
+        snapshot
+            .map(|root| root.join(tier).join(QWEN_CONTROL_FILE).is_file())
+            .unwrap_or(false)
+    };
+    if present("q8") {
+        "q8"
+    } else if present("bf16") {
+        "bf16"
+    } else if present("q4") {
+        "q4"
+    } else {
+        "q8"
     }
 }
 
@@ -146,7 +177,10 @@ fn qwen_control_tier_subdir(request: &ImageRequest) -> &'static str {
 /// Override: `advanced.controlWeights.{repo,filename}` still points at a flat repo with a plain-component
 /// weight file (sc-8821 / F-019 — the filename must have no path separators). When a `filename` override
 /// is present the tier subdir is NOT applied (the override addresses a specific file directly).
-fn qwen_control_repo_file(request: &ImageRequest) -> WorkerResult<(String, String)> {
+fn qwen_control_repo_file(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> WorkerResult<(String, String)> {
     let cw = request.advanced.get("controlWeights").and_then(Value::as_object);
     let pick = |key: &str| {
         cw.and_then(|m| m.get(key))
@@ -159,8 +193,16 @@ fn qwen_control_repo_file(request: &ImageRequest) -> WorkerResult<(String, Strin
     let file = match pick("filename") {
         // Explicit override — a plain-component file in the override repo (no tier subdir).
         Some(name) => safe_weight_filename(&name, "advanced.controlWeights.filename")?,
-        // Default packed tier — `<tier>/model.safetensors` selected by `advanced.mlxQuantize`.
-        None => format!("{}/{QWEN_CONTROL_FILE}", qwen_control_tier_subdir(request)),
+        // Default packed tier — `<tier>/model.safetensors` selected by `advanced.mlxQuantize`, whose
+        // DEFAULT tier is clamped to the installed overlay so a plain default job never forces a new
+        // fetch (sc-10726).
+        None => {
+            let snapshot = huggingface_snapshot_dir(&settings.data_dir, &repo);
+            format!(
+                "{}/{QWEN_CONTROL_FILE}",
+                qwen_control_tier_subdir(request, snapshot.as_deref())
+            )
+        }
     };
     Ok((repo, file))
 }
@@ -174,7 +216,7 @@ async fn ensure_qwen_control_weights(
     job: &JobSnapshot,
     request: &ImageRequest,
 ) -> WorkerResult<PathBuf> {
-    let (repo, file) = qwen_control_repo_file(request)?;
+    let (repo, file) = qwen_control_repo_file(request, settings)?;
     if let Ok(p) = std::env::var("SCENEWORKS_CONTROLNET_QWEN") {
         let p = PathBuf::from(p);
         if p.is_file() {
@@ -378,4 +420,89 @@ async fn generate_candle_qwen_control_stream(
         asset_writes,
     )
     .await
+}
+
+#[cfg(test)]
+mod qwen_control_tier_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn request(advanced: serde_json::Value) -> ImageRequest {
+        ImageRequest::from_payload(
+            json!({ "model": "qwen_image", "advanced": advanced })
+                .as_object()
+                .unwrap(),
+        )
+    }
+
+    /// Write a present `<tier>/model.safetensors` overlay so [`qwen_control_tier_subdir`]'s clamp sees
+    /// the tier as installed.
+    fn seed_tier(root: &Path, tier: &str) {
+        let dir = root.join(tier);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(QWEN_CONTROL_FILE), b"x").unwrap();
+    }
+
+    /// sc-10726: the plain default (no `advanced.mlxQuantize`) resolves the app-wide Q8 default when the
+    /// q8 overlay is on disk, and every explicit pick is honored as-is (an explicit request may fetch its
+    /// tier on demand, so it is NOT clamped to what's installed). Mirrors the MLX lane's test.
+    #[test]
+    fn default_prefers_installed_q8_and_honors_explicit_picks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        seed_tier(root, "q4");
+        seed_tier(root, "q8");
+        seed_tier(root, "bf16");
+
+        assert_eq!(qwen_control_tier_subdir(&request(json!({})), Some(root)), "q8");
+        assert_eq!(
+            qwen_control_tier_subdir(&request(json!({ "mlxQuantize": 4 })), Some(root)),
+            "q4"
+        );
+        assert_eq!(
+            qwen_control_tier_subdir(&request(json!({ "mlxQuantize": 8 })), Some(root)),
+            "q8"
+        );
+        assert_eq!(
+            qwen_control_tier_subdir(&request(json!({ "mlxQuantize": 0 })), Some(root)),
+            "bf16"
+        );
+        assert_eq!(
+            qwen_control_tier_subdir(&request(json!({ "mlxQuantize": "0" })), Some(root)),
+            "bf16"
+        );
+    }
+
+    /// sc-10726 acceptance #3: on a legacy/partial install carrying ONLY the q4 overlay, the plain
+    /// default must resolve q4 — NOT the app-wide q8 default — so it never forces a NEW q8 on-demand
+    /// fetch (via [`ensure_qwen_control_weights`]). An EXPLICIT q8 pick is still returned verbatim.
+    #[test]
+    fn default_clamps_to_only_installed_q4() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        seed_tier(root, "q4");
+
+        assert_eq!(qwen_control_tier_subdir(&request(json!({})), Some(root)), "q4");
+        seed_tier(root, "bf16");
+        assert_eq!(
+            qwen_control_tier_subdir(&request(json!({})), Some(root)),
+            "bf16"
+        );
+        assert_eq!(
+            qwen_control_tier_subdir(&request(json!({ "mlxQuantize": 8 })), Some(root)),
+            "q8"
+        );
+    }
+
+    /// With NO snapshot cached yet (or an empty snapshot), the default falls back to `q8` — the
+    /// fresh-install co-requisite the base download brings alongside the base tier.
+    #[test]
+    fn default_falls_back_to_q8_when_nothing_installed() {
+        assert_eq!(qwen_control_tier_subdir(&request(json!({})), None), "q8");
+        let empty = tempfile::tempdir().unwrap();
+        assert_eq!(
+            qwen_control_tier_subdir(&request(json!({})), Some(empty.path())),
+            "q8"
+        );
+    }
 }

--- a/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
@@ -118,15 +118,19 @@ fn qwen_control_guidance(request: &ImageRequest) -> f32 {
 }
 
 /// The packed control tier subdir the request's `advanced.mlxQuantize` selects (sc-9870): `bf16` (opt
-/// out of quantization, `<= 0` / "none"), `q8` (`> 4`), else the `q4` default — the SAME mapping
+/// out of quantization, `<= 0` / "none"), `q8` (`> 4`), `q4` for an explicit Q4 pick (`1..=4`), else —
+/// with NO explicit `mlxQuantize` — the **`q8`** default (sc-10726) — the SAME mapping
 /// [`standard_tier_subdir`] uses for the base transformer tier, so the control overlay tier tracks the
-/// base tier for a coherent A/B. Mirrors the MLX `qwen_control_tier_subdir`.
+/// base tier for a coherent A/B (a q8-default base pairs with the q8 control overlay). The whole control
+/// matrix (q4/q8/bf16) installs as co-requisites alongside the base, so the q8 overlay is on disk
+/// whenever the base is. Mirrors the MLX `qwen_control_tier_subdir`.
 fn qwen_control_tier_subdir(request: &ImageRequest) -> &'static str {
     let bits = request
         .advanced
         .get("mlxQuantize")
         .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()));
     match bits {
+        None => "q8",
         Some(b) if b <= 0 => "bf16",
         Some(b) if b > 4 => "q8",
         _ => "q4",

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -8057,28 +8057,36 @@ fn candle_control_providers_resolve_models_and_repos() {
     // sc-8350 — qwen InstantX → 2512-Fun. sc-9870 — repointed to the SceneWorks PACKED tier: the default
     // control repo is the per-quant `SceneWorks/qwen-image-2512-fun-controlnet-union` matrix (NOT the dense
     // alibaba-pai overlay, and NOT the retired InstantX repo). sc-10726 — with no `mlxQuantize` the default
-    // control tier is now the q8 subdir's single `model.safetensors` (tracking the q8-default base tier;
-    // the whole matrix installs as co-requisites). The base repo is unchanged (2512 base).
+    // control tier is the q8 subdir's single `model.safetensors` (tracking the q8-default base tier; the
+    // whole matrix installs as co-requisites), CLAMPED to what's installed. This empty `data_dir` has no
+    // control snapshot cached, so `qwen_control_repo_file` sees no on-disk overlay and takes the
+    // fresh-install fallback (q8) — the exact tier the base download's co-requisite brings. The base repo
+    // is unchanged (2512 base). (The clamp-to-only-q4 behavior is proved directly in
+    // `qwen_control_tier_tests`.)
+    let empty_data = tempfile::tempdir().unwrap();
+    let mut settings = Settings::from_env();
+    settings.data_dir = empty_data.path().to_path_buf();
     let qwen = request(json!({ "projectId": "p", "model": "qwen_image" }));
-    let (q_repo, q_file) = qwen_control_repo_file(&qwen).expect("defaults resolve");
+    let (q_repo, q_file) = qwen_control_repo_file(&qwen, &settings).expect("defaults resolve");
     assert_eq!(q_repo, "SceneWorks/qwen-image-2512-fun-controlnet-union");
     assert_eq!(q_file, "q8/model.safetensors");
     assert_eq!(QWEN_CONTROL_DEFAULT_REPO, "Qwen/Qwen-Image-2512");
     assert_ne!(q_repo, "alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union");
     assert_ne!(q_repo, "InstantX/Qwen-Image-ControlNet-Union");
     // Tier tracks `advanced.mlxQuantize`: q8 selects the q8 subdir, bf16 opt-out selects the bf16 subdir.
+    // Explicit picks are honored verbatim (never clamped), so they resolve regardless of the empty cache.
     let qwen_q8 = request(
         json!({ "projectId": "p", "model": "qwen_image", "advanced": { "mlxQuantize": 8 } }),
     );
     assert_eq!(
-        qwen_control_repo_file(&qwen_q8).unwrap().1,
+        qwen_control_repo_file(&qwen_q8, &settings).unwrap().1,
         "q8/model.safetensors"
     );
     let qwen_bf16 = request(
         json!({ "projectId": "p", "model": "qwen_image", "advanced": { "mlxQuantize": 0 } }),
     );
     assert_eq!(
-        qwen_control_repo_file(&qwen_bf16).unwrap().1,
+        qwen_control_repo_file(&qwen_bf16, &settings).unwrap().1,
         "bf16/model.safetensors"
     );
 
@@ -8131,6 +8139,12 @@ fn candle_control_providers_resolve_models_and_repos() {
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 #[test]
 fn candle_control_weight_filenames_reject_traversal() {
+    // The qwen resolver takes `settings` for its default-tier clamp (sc-10726), but a `filename`
+    // override rejects at `safe_weight_filename` BEFORE any snapshot probe, so an empty data_dir is
+    // never read here.
+    let empty_data = tempfile::tempdir().unwrap();
+    let mut settings = Settings::from_env();
+    settings.data_dir = empty_data.path().to_path_buf();
     for filename in ["../../etc/hosts", "/etc/hosts", "sub/x.safetensors", ".."] {
         let req = request(json!({
             "projectId": "p",
@@ -8139,7 +8153,7 @@ fn candle_control_weight_filenames_reject_traversal() {
         for (label, error) in [
             (
                 "qwen",
-                qwen_control_repo_file(&req).expect_err("qwen rejects"),
+                qwen_control_repo_file(&req, &settings).expect_err("qwen rejects"),
             ),
             (
                 "kolors",

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -5613,13 +5613,14 @@ fn ideogram_engine_defaults_and_quant_resolution() {
     ));
 }
 
-/// `ideogram_model_subdir` picks the packed `q4/` subdir by default and `q8/` only when the request
-/// opts in (`mlxQuantize > 4`) AND q8 is downloaded, falling back to q4 (then the root, so a
-/// half-downloaded bundle surfaces as a load error rather than a silent half-load). This is the
-/// *effective* quant selection — the q4 default is why resolve_quant's generic Q8 is inert.
+/// `ideogram_model_subdir` prefers the packed `q8/` subdir by default (sc-10726, epic 10721) — CLAMPED
+/// to installed, so with only `q4/` on disk it resolves q4 — while an explicit Q4 pick (`1..=4`) stays
+/// q4 and an explicit Q8 opt-in (`mlxQuantize > 4`) takes q8 when downloaded (else falls back to q4,
+/// then the root, so a half-downloaded bundle surfaces as a load error). This is the *effective* quant
+/// selection — the q8 default now agrees with `resolve_quant`'s generic Q8.
 #[cfg(target_os = "macos")]
 #[test]
-fn ideogram_subdir_prefers_q4_and_opts_into_q8() {
+fn ideogram_subdir_prefers_q8_and_clamps_to_installed() {
     let root = tempfile::tempdir().unwrap();
     let touch = |sub: &str| {
         let dir = root.path().join(sub).join("transformer");
@@ -5636,26 +5637,32 @@ fn ideogram_subdir_prefers_q4_and_opts_into_q8() {
         ideogram_model_subdir(root.path(), &req(json!({}))),
         root.path()
     );
-    // q4 only → q4, even when q8 is requested but absent.
+    // q4 only → the default CLAMPS to q4 (q8 preferred but absent); a q8 opt-in also falls back to q4.
     touch("q4");
     assert_eq!(
         ideogram_model_subdir(root.path(), &req(json!({}))),
-        root.path().join("q4")
+        root.path().join("q4"),
+        "q8 default clamps to the only installed tier (q4)",
     );
     assert_eq!(
         ideogram_model_subdir(root.path(), &req(json!({ "mlxQuantize": 8 }))),
         root.path().join("q4"),
         "q8 opt-in falls back to q4 when q8 absent",
     );
-    // Both present → q4 by default, q8 only on opt-in.
+    // Both present → q8 by default (sc-10726); q8 on opt-in; an explicit q4 pick stays q4.
     touch("q8");
     assert_eq!(
         ideogram_model_subdir(root.path(), &req(json!({}))),
-        root.path().join("q4")
+        root.path().join("q8")
     );
     assert_eq!(
         ideogram_model_subdir(root.path(), &req(json!({ "mlxQuantize": 8 }))),
         root.path().join("q8"),
+    );
+    assert_eq!(
+        ideogram_model_subdir(root.path(), &req(json!({ "mlxQuantize": 4 }))),
+        root.path().join("q4"),
+        "explicit Q4 pick is honored over the q8 default",
     );
 }
 
@@ -8049,12 +8056,13 @@ fn candle_control_providers_resolve_models_and_repos() {
 
     // sc-8350 — qwen InstantX → 2512-Fun. sc-9870 — repointed to the SceneWorks PACKED tier: the default
     // control repo is the per-quant `SceneWorks/qwen-image-2512-fun-controlnet-union` matrix (NOT the dense
-    // alibaba-pai overlay, and NOT the retired InstantX repo), and the default file is the q4 tier subdir's
-    // single `model.safetensors` when no `mlxQuantize` is requested. The base repo is unchanged (2512 base).
+    // alibaba-pai overlay, and NOT the retired InstantX repo). sc-10726 — with no `mlxQuantize` the default
+    // control tier is now the q8 subdir's single `model.safetensors` (tracking the q8-default base tier;
+    // the whole matrix installs as co-requisites). The base repo is unchanged (2512 base).
     let qwen = request(json!({ "projectId": "p", "model": "qwen_image" }));
     let (q_repo, q_file) = qwen_control_repo_file(&qwen).expect("defaults resolve");
     assert_eq!(q_repo, "SceneWorks/qwen-image-2512-fun-controlnet-union");
-    assert_eq!(q_file, "q4/model.safetensors");
+    assert_eq!(q_file, "q8/model.safetensors");
     assert_eq!(QWEN_CONTROL_DEFAULT_REPO, "Qwen/Qwen-Image-2512");
     assert_ne!(q_repo, "alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union");
     assert_ne!(q_repo, "InstantX/Qwen-Image-ControlNet-Union");

--- a/crates/sceneworks-worker/src/sensenova_jobs.rs
+++ b/crates/sceneworks-worker/src/sensenova_jobs.rs
@@ -1660,7 +1660,8 @@ mod tests {
     #[ignore = "real-weight MLX smoke; needs the SceneWorks/sensenova-u1-8b-mlx q4 tier cached + a Metal device"]
     fn sensenova_q4_tier_real_weights_produces_image() {
         // Resolve the packed `q4/` tier subdir from the turnkey root — the same selection the worker's
-        // `standard_tier_subdir` makes for the manifest default (`mlx.standardTierLayout` + q4 default).
+        // `standard_tier_subdir` makes for a default job when only the q4 tier is installed (the q8
+        // default, sc-10726, clamps down to the sole installed tier here).
         let root = hf_snapshot("models--SceneWorks--sensenova-u1-8b-mlx");
         let q4_dir = root.join("q4");
         assert!(

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -2912,12 +2912,16 @@ fn wan_quant_bits(request: &VideoRequest) -> Option<i64> {
 
 /// The Wan2.2 quant-matrix tier search order for a request — preferred tier first, then the
 /// always-smaller fallback tiers so a repo missing the preferred subdir still loads (mirrors
-/// [`ltx_bundle_tier_order`]): `mlxQuantize <= 0` ⇒ `bf16`, `>= 8` ⇒ `q8`, else the `q4` default.
-/// `bf16` is only ever tried when explicitly requested, so a default job never pulls the huge dense
-/// tier by accident.
+/// [`ltx_bundle_tier_order`]): no explicit pick ⇒ **`q8`** (the app-wide default, epic 10721 /
+/// sc-10726), `mlxQuantize <= 0` ⇒ `bf16`, `>= 8` ⇒ `q8`, else an explicit `q4`. The Q8 default is
+/// CLAMPED to installed — the macOS base download ships only the lean `q4/` tier, so a default job
+/// resolves q4 unless the user opted into (and fetched) q8. `bf16` stays OUT of the default order
+/// entirely, so a default job never pulls the huge dense tier by accident (preserved from the old q4
+/// default; a heavy Wan model never OOMs on a tier the user didn't request).
 #[cfg(target_os = "macos")]
 fn wan_tier_order(request: &VideoRequest) -> &'static [&'static str] {
     match wan_quant_bits(request) {
+        None => &["q8", "q4"],
         Some(b) if b <= 0 => &["bf16", "q8", "q4"],
         Some(b) if b >= 8 => &["q8", "q4"],
         _ => &["q4", "q8"],
@@ -4488,7 +4492,8 @@ fn candle_video_repo(request: &VideoRequest, engine_id: &str) -> String {
 /// quant-matrix (sc-10027) hosts each candle tier as a per-`variant` download entry — `q4`/`q8` in the
 /// packed `SceneWorks/wan2.2-*-candle` repo, `bf16` in the dense `Wan-AI/*-Diffusers` repo — rather than
 /// a single top-level `repo`, so `candle_video_repo` must consult them. Picks the repo for the highest-
-/// preference tier present for this OS (default q4-first, mirroring [`candle_wan_tier_subdir`] so the
+/// preference tier present for this OS (default **q8-first** when the manifest lists it for the platform,
+/// clamping to q4 otherwise — epic 10721 / sc-10726 — mirroring [`candle_wan_tier_subdir`] so the
 /// resolved repo is the one whose tier subdir the loader then selects). `None` for non-Wan engines or a
 /// manifest without matching platform downloads.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
@@ -4503,6 +4508,7 @@ fn candle_wan_tier_repo_from_downloads(request: &VideoRequest, engine_id: &str) 
         "linux"
     };
     let order: &[&str] = match candle_wan_quant_bits(request) {
+        None => &["q8", "q4"],
         Some(bits) if bits <= 0 => &["bf16", "q8", "q4"],
         Some(bits) if bits >= 8 => &["q8", "q4"],
         _ => &["q4", "q8"],
@@ -4566,8 +4572,9 @@ fn candle_wan_tier_complete(dir: &Path, a14b: bool) -> bool {
 }
 
 /// (sc-10027) Resolve the candle wan quant tier subdir (`q4`/`q8`/`bf16`) + its quant marker under a
-/// `SceneWorks/wan2.2-*-candle` snapshot `root`, per `advanced.mlxQuantize` (default q4, falling back
-/// through the tier order), or `None` for a non-wan engine or a flat repo with no tier subdirs (e.g. the
+/// `SceneWorks/wan2.2-*-candle` snapshot `root`, per `advanced.mlxQuantize` (default **q8** when
+/// installed, clamping to q4 — epic 10721 / sc-10726 — falling back through the tier order), or `None`
+/// for a non-wan engine or a flat repo with no tier subdirs (e.g. the
 /// dense `Wan-AI/*-Diffusers` fallback, which loads as-is). A resolved subdir **is** the diffusers-layout
 /// snapshot the sc-10025 packed-detect seam loads — the quant is baked into the tier, so the `Quant`
 /// returned is a tier-select marker (`spec.quantize` is a no-op on the candle wan load). Candle analog of
@@ -4581,8 +4588,11 @@ fn candle_wan_tier_subdir(
     if !engine_id.starts_with("wan2_2") {
         return None;
     }
-    // Tier preference by requested bits (mirrors the macOS `wan_tier_order`): default / ≤4 → q4.
+    // Tier preference by requested bits (mirrors the macOS `wan_tier_order`): no explicit pick → q8
+    // (the app-wide default, clamped to the installed tier, so q4-only installs still resolve q4);
+    // explicit ≤4 → q4. `bf16` stays out of the default order (never auto-loaded on a default job).
     let order: &[&str] = match candle_wan_quant_bits(request) {
+        None => &["q8", "q4"],
         Some(b) if b <= 0 => &["bf16", "q8", "q4"],
         Some(b) if b >= 8 => &["q8", "q4"],
         _ => &["q4", "q8"],
@@ -5916,11 +5926,14 @@ const BERNINI_TIER_FILES: &[&str] = &[
 
 /// The Bernini quant-matrix tier search order for a request — preferred tier first, then the
 /// always-smaller fallback tiers so a repo missing the preferred subdir still loads (mirrors
-/// [`wan_tier_order`]): `mlxQuantize <= 0` ⇒ `bf16`, `>= 8` ⇒ `q8`, else the `q4` default. `bf16` is
-/// only ever tried when explicitly requested, so a default job never pulls the huge dense tier.
+/// [`wan_tier_order`]): no explicit pick ⇒ **`q8`** (the app-wide default, epic 10721 / sc-10726,
+/// clamped to installed — the lean `q4/` base download still resolves q4 until q8 is fetched);
+/// `mlxQuantize <= 0` ⇒ `bf16`; `>= 8` ⇒ `q8`; else an explicit `q4`. `bf16` stays OUT of the default
+/// order, so a default job never pulls the huge dense tier by accident.
 #[cfg(target_os = "macos")]
 fn bernini_tier_order(bits: Option<i64>) -> &'static [&'static str] {
     match bits {
+        None => &["q8", "q4"],
         Some(b) if b <= 0 => &["bf16", "q8", "q4"],
         Some(b) if b >= 8 => &["q8", "q4"],
         _ => &["q4", "q8"],
@@ -6315,11 +6328,23 @@ fn scail2_tier_repo(model: &str) -> Option<(&'static str, &'static str)> {
 
 /// The SCAIL-2 quant-matrix tier search order for a request — preferred tier first, then the
 /// always-smaller fallback tiers so a repo missing the preferred subdir still loads (mirrors
-/// [`wan_tier_order`]): `mlxQuantize <= 0` ⇒ `bf16`, `>= 8` ⇒ `q8`, else the `q4` default. `bf16` is
-/// only ever tried when explicitly requested, so a default job never pulls the huge dense tier by
-/// accident. Reuses [`resolve_scail2_quant`] (the shared `mlxQuantize` parse) as the selector.
+/// [`wan_tier_order`]): no explicit `mlxQuantize` ⇒ **`q8`** (the app-wide default, epic 10721 /
+/// sc-10726, clamped to installed — the lean `q4/` base download still resolves q4 until q8 is
+/// fetched); `<= 0` ⇒ `bf16`; `>= 8` ⇒ `q8`; else an explicit `q4`. `bf16` stays OUT of the default
+/// order, so a default job never pulls the huge dense tier by accident. A raw `mlxQuantize`-presence
+/// check distinguishes the default from an explicit Q4 pick — [`resolve_scail2_quant`] maps BOTH to
+/// `Some(Quant::Q4)`, so it can't tell them apart on its own.
 #[cfg(target_os = "macos")]
 fn scail2_tier_order(request: &VideoRequest) -> &'static [&'static str] {
+    // No explicit pick → prefer the clean q8 tier when installed (clamped to q4 otherwise).
+    let has_explicit_quant = request
+        .advanced
+        .get("mlxQuantize")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()))
+        .is_some();
+    if !has_explicit_quant {
+        return &["q8", "q4"];
+    }
     match resolve_scail2_quant(request) {
         None => &["bf16", "q8", "q4"],
         Some(Quant::Q8) => &["q8", "q4"],
@@ -6921,15 +6946,21 @@ fn ltx_wants_bf16(request: &VideoRequest) -> bool {
 
 /// The SceneWorks LTX bundle tier search order for a request — preferred tier first, then the
 /// always-smaller fallback tiers so a bundle missing the preferred subdir still loads (sc-8513):
-/// `mlxQuantize <= 0` ⇒ `bf16`, `>= 8` ⇒ `q8`, else the `q4` default. bf16 is only ever tried when
-/// explicitly requested, so a default job never loads the huge dense tier by accident.
+/// `mlxQuantize <= 0` ⇒ `bf16`, `>= 8` ⇒ `q8`, an explicit `1..=4` ⇒ `q4`, else — with NO explicit
+/// `mlxQuantize` — the **`q8`** default (epic 10721 / sc-10726), CLAMPED to installed (the lean `q4/`
+/// bundle download still resolves q4 until q8 is fetched). bf16 stays OUT of the default order, so a
+/// default job never loads the huge dense tier by accident.
 #[cfg(target_os = "macos")]
 fn ltx_bundle_tier_order(request: &VideoRequest) -> &'static [&'static str] {
     if ltx_wants_bf16(request) {
         &["bf16", "q8", "q4"]
     } else if ltx_wants_q8(request) {
         &["q8", "q4"]
+    } else if ltx_quant_bits(request).is_none() {
+        // No explicit pick → the q8 default, clamped to installed (q4-only bundles still resolve q4).
+        &["q8", "q4"]
     } else {
+        // An explicit Q4 pick (`1..=4`) stays q4-first.
         &["q4", "q8"]
     }
 }
@@ -10945,11 +10976,13 @@ mod tests {
         assert_eq!(wan_tier_order(&bf16), &["bf16", "q8", "q4"]);
         let q8 = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 8 } }));
         assert_eq!(wan_tier_order(&q8), &["q8", "q4"]);
+        // An explicit Q4 pick stays q4-first (never overridden by the q8 default).
         let q4 = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 4 } }));
         assert_eq!(wan_tier_order(&q4), &["q4", "q8"]);
-        // Absent knob defaults to the lean q4 tier; bf16 is never in a default job's search path.
+        // sc-10726: an absent knob now prefers the clean q8 tier (clamped to installed — q4-only
+        // installs still resolve q4); bf16 is never in a default job's search path (no OOM by accident).
         let absent = request(json!({ "projectId": "p" }));
-        assert_eq!(wan_tier_order(&absent), &["q4", "q8"]);
+        assert_eq!(wan_tier_order(&absent), &["q8", "q4"]);
     }
 
     /// [`wan_tier_subdir`] resolves the requested tier, falls back to a smaller COMPLETE
@@ -10972,11 +11005,14 @@ mod tests {
         std::fs::write(root.join("q8").join("config.json"), b"x").unwrap();
         assert_eq!(wan_tier_subdir(&root, &q8_req), Some(root.join("q4")));
 
-        // Completed q8 now wins for a q8 request; a default job still prefers q4.
+        // Completed q8 now wins for a q8 request; a default job also prefers the clean q8 default
+        // (sc-10726) now that q8 is installed, while an explicit q4 pick still resolves q4.
         write_complete_wan_tier(&root, "q8");
         assert_eq!(wan_tier_subdir(&root, &q8_req), Some(root.join("q8")));
         let default_req = request(json!({ "projectId": "p" }));
-        assert_eq!(wan_tier_subdir(&root, &default_req), Some(root.join("q4")));
+        assert_eq!(wan_tier_subdir(&root, &default_req), Some(root.join("q8")));
+        let q4_req = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 4 } }));
+        assert_eq!(wan_tier_subdir(&root, &q4_req), Some(root.join("q4")));
 
         // bf16 request with no bf16 tier falls back to q8 (never silently to a default).
         let bf16_req = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 0 } }));
@@ -11072,8 +11108,10 @@ mod tests {
         make_tier("q4");
         make_tier("q8");
 
-        // Default (no bits) → q4.
-        assert_eq!(bernini_tier_subdir(&root, None), Some(root.join("q4")));
+        // Default (no bits) → q8 when installed (sc-10726), clamped to what's on disk.
+        assert_eq!(bernini_tier_subdir(&root, None), Some(root.join("q8")));
+        // An explicit Q4 pick stays q4 (never overridden by the q8 default).
+        assert_eq!(bernini_tier_subdir(&root, Some(4)), Some(root.join("q4")));
         // Q8 (bits >= 8) → q8.
         assert_eq!(bernini_tier_subdir(&root, Some(8)), Some(root.join("q8")));
         // bf16 (bits <= 0) with no bf16 tier falls back to q8 (never silently to a default).
@@ -11128,11 +11166,14 @@ mod tests {
         assert_eq!(scail2_tier_order(&bf16), &["bf16", "q8", "q4"]);
         let q8 = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 8 } }));
         assert_eq!(scail2_tier_order(&q8), &["q8", "q4"]);
+        // An explicit Q4 pick stays q4-first (resolve_scail2_quant maps both this and the default to
+        // Some(Q4), so the tier order tells them apart via raw mlxQuantize presence).
         let q4 = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 4 } }));
         assert_eq!(scail2_tier_order(&q4), &["q4", "q8"]);
-        // Absent knob defaults to the lean q4 tier; bf16 is never in a default job's search path.
+        // sc-10726: an absent knob now prefers the clean q8 tier (clamped to installed); bf16 is never
+        // in a default job's search path (no OOM by accident).
         let absent = request(json!({ "projectId": "p" }));
-        assert_eq!(scail2_tier_order(&absent), &["q4", "q8"]);
+        assert_eq!(scail2_tier_order(&absent), &["q8", "q4"]);
     }
 
     /// [`scail2_tier_subdir`] resolves the requested tier, falls back to a smaller COMPLETE tier,
@@ -11155,14 +11196,17 @@ mod tests {
         std::fs::write(root.join("q8").join("config.json"), b"x").unwrap();
         assert_eq!(scail2_tier_subdir(&root, &q8_req), Some(root.join("q4")));
 
-        // Completed q8 now wins for a q8 request; a default job still prefers q4.
+        // Completed q8 now wins for a q8 request; a default job also prefers the clean q8 default
+        // (sc-10726) now that q8 is installed, while an explicit q4 pick still resolves q4.
         write_complete_scail2_tier(&root, "q8");
         assert_eq!(scail2_tier_subdir(&root, &q8_req), Some(root.join("q8")));
         let default_req = request(json!({ "projectId": "p" }));
         assert_eq!(
             scail2_tier_subdir(&root, &default_req),
-            Some(root.join("q4"))
+            Some(root.join("q8"))
         );
+        let q4_req = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 4 } }));
+        assert_eq!(scail2_tier_subdir(&root, &q4_req), Some(root.join("q4")));
 
         // bf16 request with no bf16 tier falls back to q8 (never silently to a default).
         let bf16_req = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 0 } }));
@@ -12847,7 +12891,14 @@ mod tests {
             ltx_bundle_tier_order(&with(json!({ "mlxQuantize": 8 }))),
             &["q8", "q4"]
         );
-        assert_eq!(ltx_bundle_tier_order(&plain), &["q4", "q8"]);
+        // sc-10726: a plain request (no mlxQuantize) prefers the clean q8 tier, clamped to installed
+        // (q4-only bundles still resolve q4); bf16 stays out of the default search path.
+        assert_eq!(ltx_bundle_tier_order(&plain), &["q8", "q4"]);
+        // An explicit Q4 pick stays q4-first.
+        assert_eq!(
+            ltx_bundle_tier_order(&with(json!({ "mlxQuantize": 4 }))),
+            &["q4", "q8"]
+        );
     }
 
     #[cfg(target_os = "macos")]
@@ -14136,9 +14187,9 @@ mod candle_video_label_tests {
         );
     }
 
-    /// (sc-10027) `candle_wan_tier_subdir` picks the q4/q8 subdir per `advanced.mlxQuantize` (default q4),
-    /// falls back through the tier order, requires a complete tier, and returns `None` for a non-wan
-    /// engine or a flat/dense repo with no tier subdirs.
+    /// (sc-10027 / sc-10726) `candle_wan_tier_subdir` picks the q4/q8 subdir per `advanced.mlxQuantize`
+    /// (default q8 when installed, clamped to q4), falls back through the tier order, requires a complete
+    /// tier, and returns `None` for a non-wan engine or a flat/dense repo with no tier subdirs.
     #[test]
     fn candle_wan_tier_subdir_resolves_by_mlx_quantize() {
         let root = std::env::temp_dir().join(format!("sc10027_wan_tier_{}", std::process::id()));
@@ -14159,8 +14210,14 @@ mod candle_video_label_tests {
             VideoRequest::from_payload(json!({ "advanced": adv }).as_object().unwrap())
         };
 
-        // Default (no mlxQuantize) → q4.
+        // Default (no mlxQuantize) → q8 when installed (sc-10726), clamped to what's on disk.
         let (d, q) = candle_wan_tier_subdir(&root, "wan2_2_t2v_14b", &req(json!({}))).unwrap();
+        assert!(d.ends_with("q8"));
+        assert_eq!(q, Some(Quant::Q8));
+        // An explicit Q4 pick stays q4 (never overridden by the q8 default).
+        let (d, q) =
+            candle_wan_tier_subdir(&root, "wan2_2_t2v_14b", &req(json!({ "mlxQuantize": 4 })))
+                .unwrap();
         assert!(d.ends_with("q4"));
         assert_eq!(q, Some(Quant::Q4));
         // mlxQuantize = 8 → q8.


### PR DESCRIPTION
## Summary

Replaces the hardcoded **Q4** generation-time default tier with **Q8** across every tiered MLX model, **clamped to what's installed** so a heavy model never OOMs on a tier the user didn't download. This is epic 10721 story S2 (sc-10726).

This also fixes a latent inconsistency: `resolve_quant` already defaulted the *load quant* to Q8 (`None => (Some(Quant::Q8), Some(8))`), while `standard_tier_subdir` resolved the *q4 subdir* by default. On a model with q8 on disk, a default job therefore loaded q4 but fired a spurious `quant_tier_downgraded` event on every generation. The two now agree.

## What changed

**Worker — image (`crates/sceneworks-worker/src/image_jobs/`)**
- `base.rs::standard_tier_subdir` — no explicit `mlxQuantize` → **q8**; fallback reordered to clean-tiers-first (**q8 → bf16 → q4**). Explicit bf16/q8/q4 picks unchanged. (This is the story's primary target; mirrors the already-merged `anima_tier_subdir` pattern from sc-10714.)
- `base.rs::ideogram_model_subdir` — default → **q8 when installed**, clamped to q4; explicit Q4 (`1..=4`) still honored. `ideogram_tier_subdir` (the fetch-side map) is left untouched so the default never triggers a q8 download.
- `base.rs::dense_te_requested_tier_bits` — default → `Some(8)`, kept in lockstep with `standard_tier_subdir` so a default dense-TE (FLUX.2-klein) job resolving q8 isn't mis-reported as a downgrade.
- `qwen.rs` + `qwen_control.rs::qwen_control_tier_subdir` (both MLX + candle lanes) — default → **q8** so the ControlNet overlay tracks the q8-default base tier for a coherent A/B (the full q4/q8/bf16 control matrix installs as co-requisites, so the q8 overlay is always present when the base is).

**Worker — video (`crates/sceneworks-worker/src/video_jobs.rs`)**
- `wan_tier_order`, `candle_wan_tier_subdir`, `candle_wan_tier_repo_from_downloads`, `bernini_tier_order`, `scail2_tier_order`, `ltx_bundle_tier_order` — default → **prefer q8 when installed**, clamped to q4. `bf16` deliberately stays **OUT** of the default order (preserving the existing "a default job never auto-loads the huge dense tier" invariant). `scail2_tier_order` gains a raw-`mlxQuantize`-presence check because `resolve_scail2_quant` maps both the default and an explicit Q4 to `Some(Quant::Q4)`.
- The `ensure_*_tier_present` fetchers are **untouched** — a default job never triggers a new q8 download. For these lean-download video models the q8 default only "wins" when the user already fetched q8; otherwise it clamps to the shipped q4.

**Web (`apps/web/src/quantTier.js`)**
- `defaultTierSelection` base fallback **q4 → q8** (then q4, then first installed). A model's declared `variant.default` still wins (unchanged); sourcing this from a global user setting is deferred to S4 per the story.

**Left as-is (intentionally):** `anima_tier_subdir` (already q8, sc-10714 — reference pattern); `instantid_tier_subdir` (already defaults to the higher-fidelity dense bf16 identity tier, not q4).

## Scope vs acceptance criteria
- [x] No `mlxQuantize` → resolves q8 when q8 installed; q4 when only q4 installed (clamp-to-installed preserved on every resolver).
- [x] Explicit q4/q8/bf16 pick still honored (only the `None`/default arm changed; all `Some(...)` arms are byte-identical).
- [x] Q8-default clamped — no blanket OOM risk; `ensure_*` download logic unchanged; bf16 kept out of the video default fallback.
- [x] Unit tests for both worker resolvers + web `defaultTierSelection`.

## Tests & verification
- Worker lib suite: **698 passed, 0 failed** (150 ignored real-weight smokes). Updated the standard/ideogram/dense-TE/qwen-control/wan/bernini/scail2/ltx resolver tests to the q8 default and added explicit-Q4-honored + clamp-to-q4 cases.
- Web: `quantTier.test.js` (20), `ImageStudio.test.jsx` + `tierSuggestion.test.js` + `imageJobAdvanced.test.js` (96) all pass. New `defaultTierSelection` tests cover q8-prefers, q4-clamp, declared-default-still-wins.
- `cargo fmt --all --check` clean; `cargo clippy -p sceneworks-worker --all-targets -D warnings` clean.
- Candle-only tests (`candle_wan_*`, `qwen_control_repo_file`) are `not(target_os = "macos")`-gated and validated by the Linux/candle parity lane; my edits mirror existing match-arm patterns.

## Follow-ups (out of scope — not absorbed)
- **S4** — source the web/worker default from a global user setting + per-model `variant.default` manifest declarations (still q4 for most models, so the manifest-declared default currently wins over the new q8 base fallback in the picker for those models).
- **S3** — sticky per-model tier selection.
- **S6** — quality floor.
- For lean-download video/LTX models, the q8 default only takes effect for users who already fetched q8; making q8 the *download* default is a separate download-policy decision, not this gen-time-default story.

Story: https://app.shortcut.com/trefry/story/10726

🤖 Generated with [Claude Code](https://claude.com/claude-code)