### PR TITLE
Default MLX generation tier to Q8, clamped to installed (sc-10726)

### DIFF
--- a/apps/web/src/quantTier.js
+++ b/apps/web/src/quantTier.js
@@ -132,8 +132,11 @@ function defaultInstalledTier(model, tiers) {
 // The tier the picker should start on for `model`. Preference order:
 //   1. `lastUsed` — the per-model last-used tier, when it is still installed (persistence).
 //   2. the model's declared default tier (`variant.default: true`), when installed.
-//   3. q4 if installed (the catalog's smallest/default convention).
-//   4. the first installed tier.
+//   3. q8 if installed — the base generation default (epic 10721: stop seeding the washed q4; Q8 is
+//      near-lossless). S4 (sc-10728) replaces this literal q8 with the global "Default generation
+//      quality" setting (whose own default is q8) and lifts it above the declared default (step 2).
+//   4. the first installed tier (smallest, per TIER_ORDER) — so with only q4 on disk it stays q4:
+//      the Q8 default is CLAMPED to what's installed, never forcing a heavier tier the machine lacks.
 // Returns null when nothing is installed (no picker will render anyway). `options` (sc-9300) forwards
 // the `convRotEligible` gate so a hidden INT8-ConvRot tier is never seeded as the selection.
 export function defaultTierSelection(model, lastUsed, options = {}) {
@@ -148,8 +151,8 @@ export function defaultTierSelection(model, lastUsed, options = {}) {
   if (declared) {
     return declared;
   }
-  if (tiers.includes("q4")) {
-    return "q4";
+  if (tiers.includes("q8")) {
+    return "q8";
   }
   return tiers[0];
 }

--- a/apps/web/src/quantTier.test.js
+++ b/apps/web/src/quantTier.test.js
@@ -143,15 +143,29 @@ describe("defaultTierSelection", () => {
     expect(defaultTierSelection(model, null)).toBe("q8");
   });
 
-  it("falls back to q4 when installed and no default/last-used applies", () => {
+  it("picks an installed declared default when there is no last-used tier", () => {
     const model = matrixModel({ installed: ["q4", "bf16"], defaultTier: "q4" });
-    // Declared default q4 is installed → picked.
+    // Declared default q4 is installed → picked (step 2, ahead of the base default).
     expect(defaultTierSelection(model, undefined)).toBe("q4");
   });
 
-  it("falls back to the first installed tier when neither default nor q4 is present", () => {
-    const model = matrixModel({ tiers: ["q8", "bf16"], installed: ["q8", "bf16"], defaultTier: "none" });
+  it("uses q8 as the base default when no last-used or declared default applies (epic 10721)", () => {
+    // No last-used, no installed declared default → the base generation default is q8, not the
+    // washed q4 (was q4 before epic 10721). Clamped to installed.
+    const model = matrixModel({ installed: ["q4", "q8", "bf16"], defaultTier: "none" });
     expect(defaultTierSelection(model, undefined)).toBe("q8");
+  });
+
+  it("clamps the q8 base default to the smallest installed tier when q8 is absent", () => {
+    // Only q4 (+bf16) on disk, no last-used / declared default → falls to the smallest installed
+    // tier (q4), never forcing a heavier tier the machine didn't install.
+    const model = matrixModel({ installed: ["q4", "bf16"], defaultTier: "none" });
+    expect(defaultTierSelection(model, undefined)).toBe("q4");
+  });
+
+  it("falls back to the first installed tier when neither default nor q8 is present", () => {
+    const model = matrixModel({ tiers: ["q4", "bf16"], installed: ["q4", "bf16"], defaultTier: "none" });
+    expect(defaultTierSelection(model, undefined)).toBe("q4");
   });
 
   it("returns null when nothing is installed", () => {

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -635,8 +635,10 @@ fn is_dense_te_tier(request: &ImageRequest) -> bool {
 
 /// Pick the engine-complete tier subdir of a standard SceneWorks quant-matrix turnkey `root`:
 /// `bf16/` when the request opts out of quantization (`advanced.mlxQuantize <= 0` / "none"), `q8/`
-/// when it opts into Q8 (`> 4`), else the default `q4/`. Falls back through q4 → q8 → bf16 → `root`
-/// so a partially-downloaded turnkey surfaces as a load error rather than a silent half-load.
+/// when it opts into Q8 (`> 4`), `q4/` on an explicit low pick (`1..=4`), else — no explicit
+/// `mlxQuantize` — the default `q8/` (epic 10721: stop hard-defaulting to the washed q4). Falls back
+/// clean-tiers-first (q8 → bf16 → q4 → `root`) so a partially-downloaded turnkey surfaces as a load
+/// error rather than a silent half-load, and Q8-default clamps to whatever tier is installed.
 ///
 /// Tier presence is filename-agnostic: a tier is "present" when its backbone component holds any
 /// `*.safetensors` (packed single-file OR a `*-00001-of-*.safetensors` shard) or a `*.index.json`
@@ -682,16 +684,21 @@ fn standard_tier_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
             || component_has_weights(&dir);
         has_backbone.then_some(dir)
     };
-    // bits<=0 (advanced.mlxQuantize: 0 / "none") → bf16; bits>4 → q8; else the q4 default.
+    // Default (no explicit `mlxQuantize`) → Q8 (epic 10721: stop hard-defaulting to the washed q4;
+    // Q8 is near-lossless ≈ bf16). `<= 0` / "none" → bf16 (opt out of quant); `> 4` → q8; an explicit
+    // low pick (1..=4) → q4 is still honored. Fallback prefers the clean tiers (q8 → bf16 → q4) so a
+    // partial install never silently lands on q4 — and Q8-default is CLAMPED to what's installed, so a
+    // heavy model with only q4 on disk still resolves q4 (no blanket OOM risk).
     let preferred = match bits {
+        None => "q8",
         Some(b) if b <= 0 => "bf16",
         Some(b) if b > 4 => "q8",
         _ => "q4",
     };
     present(preferred)
-        .or_else(|| present("q4"))
         .or_else(|| present("q8"))
         .or_else(|| present("bf16"))
+        .or_else(|| present("q4"))
         .unwrap_or_else(|| root.to_path_buf())
 }
 
@@ -800,11 +807,14 @@ fn ideogram_tier_subdir(bits: Option<i64>) -> Option<&'static str> {
     }
 }
 
-/// Pick the engine-complete packed subdir of an Ideogram 4 turnkey `root`: `q8/` when the request
-/// opts into Q8 (`advanced.mlxQuantize: 8`) AND it is downloaded, else the default `q4/`. Falls back
-/// to `root` if neither subdir is present (a partially-downloaded bundle surfaces as a load error
-/// rather than a silent half-load). The non-default `q8/` tier is an on-demand download fetched by
-/// [`ensure_ideogram_tier_present`] before this resolves (sc-9607); `q4/` is the manifest default.
+/// Pick the engine-complete packed subdir of an Ideogram 4 turnkey `root`. Default (no explicit
+/// `mlxQuantize`) prefers an installed `q8/` (epic 10721: stop hard-defaulting to q4), else `q4/`; an
+/// explicit low pick (`1..=4`) is still honored → `q4/`; an explicit Q8 (`> 4`) → `q8/`. CLAMPED to
+/// what's installed — Q8-default only wins when `q8/` is on disk (it is an on-demand download fetched
+/// by [`ensure_ideogram_tier_present`] only on an EXPLICIT Q8 pick, sc-9607; the default path never
+/// triggers a fetch), otherwise it falls back to the shipped `q4/`, then `root` (a partial bundle
+/// surfaces as a load error, not a silent half-load). bf16 is a separate catalog repo, not a subdir
+/// here, so an `<= 0` request resolves the cleanest installed tier rather than a missing `bf16/`.
 fn ideogram_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
     let bits = request
         .advanced
@@ -816,13 +826,15 @@ fn ideogram_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
             .is_file()
             .then_some(dir)
     };
-    if let Some(tier) = ideogram_tier_subdir(bits) {
-        if let Some(dir) = present(tier) {
-            return dir;
-        }
-    }
-    present("q4")
+    // Only an explicit low pick (1..=4) prefers q4; the default and every other pick prefer q8 when
+    // installed (clamped: falls back to q4 if q8 isn't on disk).
+    let preferred = match bits {
+        Some(b) if (1..=4).contains(&b) => "q4",
+        _ => "q8",
+    };
+    present(preferred)
         .or_else(|| present("q8"))
+        .or_else(|| present("q4"))
         .unwrap_or_else(|| root.to_path_buf())
 }
 
@@ -4727,7 +4739,7 @@ mod standard_tier_tests {
     }
 
     #[test]
-    fn defaults_to_q4_and_honors_quantize_selection() {
+    fn defaults_to_q8_and_honors_quantize_selection() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
         // Packed q4/q8 single-file + dense sharded bf16 (only the index.json shape).
@@ -4735,12 +4747,13 @@ mod standard_tier_tests {
         seed_tier(root, "q8", "diffusion_pytorch_model.safetensors");
         seed_tier(root, "bf16", "diffusion_pytorch_model.safetensors.index.json");
 
-        // No selection → q4 default.
+        // No selection → q8 default (epic 10721; was the washed q4).
         assert_eq!(
             standard_tier_subdir(root, &request(json!({}))),
-            root.join("q4")
+            root.join("q8")
         );
-        // mlxQuantize 8 → q8; 0/"none" → bf16; numeric-string accepted.
+        // mlxQuantize 8 → q8; 0/"none" → bf16; an explicit low pick 1..=4 → q4 is still honored;
+        // numeric-string accepted.
         assert_eq!(
             standard_tier_subdir(root, &request(json!({ "mlxQuantize": 8 }))),
             root.join("q8")
@@ -4748,6 +4761,10 @@ mod standard_tier_tests {
         assert_eq!(
             standard_tier_subdir(root, &request(json!({ "mlxQuantize": 0 }))),
             root.join("bf16")
+        );
+        assert_eq!(
+            standard_tier_subdir(root, &request(json!({ "mlxQuantize": 4 }))),
+            root.join("q4")
         );
         assert_eq!(
             standard_tier_subdir(root, &request(json!({ "mlxQuantize": "8" }))),
@@ -4759,12 +4776,27 @@ mod standard_tier_tests {
     fn falls_back_when_preferred_tier_absent() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
-        // Only q4 downloaded: a q8/bf16 request still resolves to the present q4 rather than a
-        // half-empty subdir, so a partial turnkey surfaces as a load error, not a silent half-load.
+        // Only q4 downloaded: the Q8 default (and a q8/bf16 request) CLAMPS to the present q4 rather
+        // than a half-empty subdir — a partial/heavy turnkey surfaces as a load error or a smaller
+        // installed tier, never a silent half-load. This is the "q4 when only q4 installed" case.
         seed_tier(root, "q4", "diffusion_pytorch_model.safetensors");
+        assert_eq!(
+            standard_tier_subdir(root, &request(json!({}))),
+            root.join("q4")
+        );
         assert_eq!(
             standard_tier_subdir(root, &request(json!({ "mlxQuantize": 8 }))),
             root.join("q4")
+        );
+        // Clean-tiers-first fallback: with q4 + bf16 installed but no q8, the Q8 default lands on the
+        // clean bf16 before the washed q4.
+        let mixed = tempfile::tempdir().unwrap();
+        let mroot = mixed.path();
+        seed_tier(mroot, "q4", "diffusion_pytorch_model.safetensors");
+        seed_tier(mroot, "bf16", "diffusion_pytorch_model.safetensors.index.json");
+        assert_eq!(
+            standard_tier_subdir(mroot, &request(json!({}))),
+            mroot.join("bf16")
         );
         // Nothing present → the repo root (engine surfaces the missing-weights error).
         let empty = tempfile::tempdir().unwrap();
@@ -4788,10 +4820,10 @@ mod standard_tier_tests {
         seed_unet("q4");
         seed_unet("q8");
         seed_unet("bf16");
-        // Default q4, q8 selection, bf16 opt-out all resolve to the unet-backed tier subdir.
+        // Default q8, q8 selection, bf16 opt-out all resolve to the unet-backed tier subdir.
         assert_eq!(
             standard_tier_subdir(root, &request(json!({}))),
-            root.join("q4")
+            root.join("q8")
         );
         assert_eq!(
             standard_tier_subdir(root, &request(json!({ "mlxQuantize": 8 }))),
@@ -4821,7 +4853,7 @@ mod standard_tier_tests {
         seed_flat("bf16", "model.safetensors.index.json");
         assert_eq!(
             standard_tier_subdir(root, &request(json!({}))),
-            root.join("q4")
+            root.join("q8")
         );
         assert_eq!(
             standard_tier_subdir(root, &request(json!({ "mlxQuantize": 8 }))),
@@ -5238,11 +5270,13 @@ mod standard_tier_tests {
         seed_tier(root, "q8", "diffusion_pytorch_model.safetensors");
         seed_tier(root, "bf16", "diffusion_pytorch_model.safetensors.index.json");
 
-        // A/B tier toggle: default (q4) / mlxQuantize:8 (q8) / mlxQuantize:0 (bf16) each resolve to
-        // their tier subdir — the same q4-default recipe the `lens` manifest declares (`mlx.quantize:4`).
+        // A/B tier toggle: default → q8 (epic 10721; was q4) / mlxQuantize:8 (q8) / mlxQuantize:0 (bf16)
+        // each resolve to their tier subdir. `standard_tier_subdir` reads only `advanced.mlxQuantize`,
+        // not the `lens` manifest's `mlx.quantize:4`, so the app-wide Q8 default applies here too (a real
+        // q4-only lens install still clamps to q4).
         assert_eq!(
             standard_tier_subdir(root, &lens_request(json!(null))),
-            root.join("q4")
+            root.join("q8")
         );
         assert_eq!(
             standard_tier_subdir(root, &lens_request(json!(8))),
@@ -5272,25 +5306,37 @@ mod standard_tier_tests {
             )
         };
 
-        // Ideogram turnkey (`SceneWorks/ideogram-4-mlx`): q4 default (candle off-Mac tier) + on-demand
-        // q8. `ideogram_model_subdir` probes `<tier>/transformer/model.safetensors`.
+        // Ideogram turnkey (`SceneWorks/ideogram-4-mlx`): q4 is the shipped off-Mac download tier, q8 an
+        // on-demand fetch. `ideogram_model_subdir` probes `<tier>/transformer/model.safetensors`.
         {
             let tmp = tempfile::tempdir().unwrap();
             let root = tmp.path();
             seed_tier(root, "q4", "model.safetensors");
             seed_tier(root, "q8", "model.safetensors");
             for model in ["ideogram_4", "ideogram_4_turbo"] {
-                // Default → q4 (the shipped off-Mac tier).
+                // Default → q8 when it's installed (epic 10721); an explicit low pick (1..=4) still
+                // resolves q4; an explicit q8 → q8.
                 assert_eq!(
                     ideogram_model_subdir(root, &model_request(model, json!(null))),
+                    root.join("q8")
+                );
+                assert_eq!(
+                    ideogram_model_subdir(root, &model_request(model, json!(4))),
                     root.join("q4")
                 );
-                // mlxQuantize:8 → q8 when present.
                 assert_eq!(
                     ideogram_model_subdir(root, &model_request(model, json!(8))),
                     root.join("q8")
                 );
             }
+            // Realistic install — the catalog pulls only `q4/` (q8 is on-demand, never auto-fetched by
+            // the default path): the Q8 default CLAMPS to the shipped q4, no silent OOM/half-load.
+            let q4_only = tempfile::tempdir().unwrap();
+            seed_tier(q4_only.path(), "q4", "model.safetensors");
+            assert_eq!(
+                ideogram_model_subdir(q4_only.path(), &model_request("ideogram_4", json!(null))),
+                q4_only.path().join("q4")
+            );
         }
 
         // Boogu turnkey (`SceneWorks/boogu-image-mlx`): Q8 `base/`/`turbo/`/`edit/` is the shipped


### PR DESCRIPTION
**S2 of epic 10721** — stop hard-defaulting every MLX image generation to the washed **Q4**.

A generation with no explicit `advanced.mlxQuantize` now resolves **Q8** (near-lossless ≈ bf16), **clamped to what's installed** — a heavy model with only q4 on disk still loads q4 (no blanket OOM risk). Generalizes the merged sc-10714 Anima Q8-default to the rest.

## Worker — `crates/sceneworks-worker/src/image_jobs/base.rs`
- **`standard_tier_subdir`**: default (no `mlxQuantize`) → `q8`; `<= 0` → bf16; `> 4` → q8; an explicit low pick (`1..=4`) → q4 is **still honored**. Fallback is now **clean-tiers-first** (q8 → bf16 → q4 → root) so a partial install never silently lands on q4.
- **`ideogram_model_subdir`**: default prefers an installed `q8`, else `q4`; explicit `1..=4` still → q4. The on-demand q8 **fetch** (`ideogram_tier_subdir` / `ensure_ideogram_tier_present`) is unchanged, so the default path never auto-downloads q8 — it clamps to what's on disk.
- `krea`/`boogu` already default q8; `anima` done in sc-10714 — unchanged.

## Web — `apps/web/src/quantTier.js`
- `defaultTierSelection` base fallback `q4` → `q8` (still clamps to installed via the smallest-installed fallback). **S4 (sc-10728)** replaces this literal q8 with the persisted global "Default generation quality" setting and lifts it above the declared-default step.

## Tests
- Worker (backend-candle, **21 pass**): default→q8, explicit q4/q8/bf16 honored, clamp-to-installed (only-q4 → q4), clean-tiers-first (q4+bf16 → bf16), ideogram default→q8-when-installed + clamp, lens default→q8.
- Web (vitest, **18 pass**): precedence + q8-base-default + clamp-to-smallest cases.
- fmt + default-features clippy (`-D warnings`) clean. NOTE: the tier tests are `backend-candle`-gated (don't run in parity CI); verified locally with the candle toolchain.

## Scope / deferred
- Declared-default (`variant.default`) precedence vs the global setting is **S4 (sc-10728)**; per-model quality floor is **S6 (sc-10731)**; sticky last-pick is **S3 (sc-10727)**; `Auto` capability default is deferred (**sc-10733**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)