### PR TITLE
fix(api): run a small in-process CPU utility worker pool so desktop downloads don't serialize (sc-10744)

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -438,25 +438,73 @@ pub fn gpu_check() -> Result<(), String> {
     sceneworks_worker::metal_preflight()
 }
 
-/// Spawns the utility worker loop ([`sceneworks_worker::run_worker_loop`]) as a
-/// tokio task in this process, pointed at the local API over loopback. The loop
-/// observes the same Ctrl+C/SIGTERM as the HTTP server (via the worker's own
-/// shutdown handling), so `shutdown()` only bounds the wait by the worker's
-/// configured grace period.
+/// Spawns the in-process CPU utility worker pool ([`sceneworks_worker::run_worker_loop`])
+/// as tokio tasks in this process, pointed at the local API over loopback. Each loop
+/// observes the same Ctrl+C/SIGTERM as the HTTP server (via the worker's own shutdown
+/// handling), so `shutdown()` only bounds the wait by the worker's configured grace
+/// period.
+///
+/// The count comes from [`inprocess_utility_worker_count`] (default 2). A single worker
+/// claims one job at a time, so a lone in-process worker serialized *all* CPU utility
+/// work — most visibly, model/LoRA downloads queued one-at-a-time on the desktop
+/// (sc-10723). Running ≥2 loops lets independent downloads proceed in parallel; the
+/// per-file `DownloadLock` (sc-8900) still serializes two jobs resolving the *same*
+/// cache target, so concurrency never corrupts a shared file.
 fn spawn_inprocess_utility_worker(port: u16) -> InProcessUtilityWorker {
     let mut worker_settings = sceneworks_worker::Settings::from_env();
     worker_settings.api_url = format!("http://127.0.0.1:{port}");
     worker_settings.gpu_id =
         inprocess_worker_gpu_id(std::env::var("SCENEWORKS_RUST_WORKER_GPU_ID").ok());
     let grace = Duration::from_secs(worker_settings.shutdown_timeout_seconds.max(1));
-    tracing::info!(
-        event = "utility_worker_inprocess",
-        apiUrl = %worker_settings.api_url,
-        "SceneWorks utility worker running in-process (loopback)"
-    );
-    let handle =
-        tokio::spawn(async move { sceneworks_worker::run_worker_loop(worker_settings).await });
-    InProcessUtilityWorker { handle, grace }
+    let count = inprocess_utility_worker_count();
+    let base_worker_id = worker_settings.worker_id.clone();
+    let handles = (0..count)
+        .map(|index| {
+            let mut settings = worker_settings.clone();
+            settings.worker_id = inprocess_utility_worker_id(&base_worker_id, index);
+            tracing::info!(
+                event = "utility_worker_inprocess",
+                apiUrl = %settings.api_url,
+                workerId = %settings.worker_id,
+                index,
+                count,
+                "SceneWorks utility worker running in-process (loopback)"
+            );
+            tokio::spawn(async move { sceneworks_worker::run_worker_loop(settings).await })
+        })
+        .collect();
+    InProcessUtilityWorker { handles, grace }
+}
+
+/// Number of in-process CPU utility worker loops to run. Defaults to **2** so desktop
+/// model/LoRA downloads (and other CPU utility jobs) run two-at-a-time instead of
+/// serializing behind a single worker; `SCENEWORKS_UTILITY_WORKERS` overrides it
+/// (clamped to >= 1). This default is intentionally more conservative than the
+/// standalone/Docker worker pool's `Settings::utility_workers` default of 4, because the
+/// same knob also governs CPU/RAM-heavy conversions/imports that share this pool.
+fn inprocess_utility_worker_count() -> usize {
+    parse_inprocess_utility_worker_count(std::env::var("SCENEWORKS_UTILITY_WORKERS").ok())
+}
+
+/// Pure parser behind [`inprocess_utility_worker_count`] (env split out so it is unit
+/// testable): a present, parseable value wins (clamped to >= 1 so `0`/negative-ish input
+/// never yields a zero-worker pool); a missing/blank/unparseable value falls back to 2.
+fn parse_inprocess_utility_worker_count(raw: Option<String>) -> usize {
+    raw.and_then(|value| value.trim().parse::<usize>().ok())
+        .unwrap_or(2)
+        .max(1)
+}
+
+/// Distinct worker id for the `index`-th in-process utility worker. Index 0 keeps the
+/// configured `worker_id` unchanged (so a single-worker setup registers exactly as
+/// before); each additional worker is suffixed `-1`, `-2`, ... to avoid a registration
+/// collision. Mirrors the standalone pool's `utility_worker_id` scheme.
+fn inprocess_utility_worker_id(base_worker_id: &str, index: usize) -> String {
+    if index == 0 {
+        base_worker_id.to_owned()
+    } else {
+        format!("{base_worker_id}-{index}")
+    }
 }
 
 /// GPU id for the in-process utility worker. Defaults to `cpu` so the embedded
@@ -473,29 +521,35 @@ fn inprocess_worker_gpu_id(override_var: Option<String>) -> String {
 }
 
 struct InProcessUtilityWorker {
-    handle: tokio::task::JoinHandle<sceneworks_worker::WorkerResult<()>>,
+    handles: Vec<tokio::task::JoinHandle<sceneworks_worker::WorkerResult<()>>>,
     grace: Duration,
 }
 
 impl InProcessUtilityWorker {
     async fn shutdown(self) {
-        match tokio::time::timeout(self.grace, self.handle).await {
-            Ok(Ok(Ok(()))) => {}
-            Ok(Ok(Err(error))) => tracing::error!(
-                event = "in_process_worker_exited_error",
-                error = %error,
-                "in-process utility worker exited with error"
-            ),
-            Ok(Err(join_error)) => tracing::error!(
-                event = "in_process_worker_task_failed",
-                error = %join_error,
-                "in-process utility worker task failed"
-            ),
-            Err(_) => tracing::warn!(
-                event = "in_process_worker_shutdown_timeout",
-                graceSeconds = self.grace.as_secs(),
-                "in-process utility worker did not stop within the grace period"
-            ),
+        let InProcessUtilityWorker { handles, grace } = self;
+        // The loops observe the shared shutdown signal concurrently, so awaiting them
+        // in sequence just collects results — each is already stopping (or stopped) by
+        // the time we reach it. The per-handle timeout bounds a stuck loop.
+        for handle in handles {
+            match tokio::time::timeout(grace, handle).await {
+                Ok(Ok(Ok(()))) => {}
+                Ok(Ok(Err(error))) => tracing::error!(
+                    event = "in_process_worker_exited_error",
+                    error = %error,
+                    "in-process utility worker exited with error"
+                ),
+                Ok(Err(join_error)) => tracing::error!(
+                    event = "in_process_worker_task_failed",
+                    error = %join_error,
+                    "in-process utility worker task failed"
+                ),
+                Err(_) => tracing::warn!(
+                    event = "in_process_worker_shutdown_timeout",
+                    graceSeconds = grace.as_secs(),
+                    "in-process utility worker did not stop within the grace period"
+                ),
+            }
         }
     }
 }

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -6,12 +6,14 @@ use super::training::{
 use super::workers::person_readiness_from_workers;
 use super::{
     create_app, create_app_with_state, huggingface_repo_cache_path, inject_converted_model_path,
-    inprocess_worker_gpu_id, lora_artifact_paths, merge_model_manifest_entry, mlx_catalog_status,
-    open_bind_override_enabled, safe_download_dir, seed_mode_for_config_dir, serialize_job_lora,
-    should_warn_open_bind, strip_jsonc_comments, sweep_stale_asset_uploads_before,
-    sweep_stale_lora_uploads_before, sweep_stale_uploads, Settings, WorkerCapability,
-    WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER, DEFAULT_API_HOST, EVENT_BUFFER_SIZE,
-    HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
+    inprocess_utility_worker_id, inprocess_worker_gpu_id, lora_artifact_paths,
+    merge_model_manifest_entry, mlx_catalog_status, open_bind_override_enabled,
+    parse_inprocess_utility_worker_count, safe_download_dir, seed_mode_for_config_dir,
+    serialize_job_lora, should_warn_open_bind, strip_jsonc_comments,
+    sweep_stale_asset_uploads_before, sweep_stale_lora_uploads_before, sweep_stale_uploads,
+    Settings, WorkerCapability, WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER,
+    DEFAULT_API_HOST, EVENT_BUFFER_SIZE, HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE,
+    TEST_MAX_LORA_UPLOAD_BYTES,
 };
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
@@ -10699,6 +10701,64 @@ fn inprocess_worker_defaults_to_cpu_utility() {
     // Explicit override is honored.
     assert_eq!(inprocess_worker_gpu_id(Some("auto".to_owned())), "auto");
     assert_eq!(inprocess_worker_gpu_id(Some("0".to_owned())), "0");
+}
+
+#[test]
+fn inprocess_utility_worker_count_defaults_to_two() {
+    // Unset / blank / unparseable → 2 so desktop downloads run two-at-a-time
+    // (sc-10744) instead of serializing behind a single worker.
+    assert_eq!(parse_inprocess_utility_worker_count(None), 2);
+    assert_eq!(parse_inprocess_utility_worker_count(Some(String::new())), 2);
+    assert_eq!(
+        parse_inprocess_utility_worker_count(Some("   ".to_owned())),
+        2
+    );
+    assert_eq!(
+        parse_inprocess_utility_worker_count(Some("two".to_owned())),
+        2
+    );
+    // A set, parseable value wins; surrounding whitespace is tolerated.
+    assert_eq!(
+        parse_inprocess_utility_worker_count(Some("1".to_owned())),
+        1
+    );
+    assert_eq!(
+        parse_inprocess_utility_worker_count(Some("4".to_owned())),
+        4
+    );
+    assert_eq!(
+        parse_inprocess_utility_worker_count(Some(" 3 ".to_owned())),
+        3
+    );
+    // Never a zero-worker pool: 0 clamps up to 1.
+    assert_eq!(
+        parse_inprocess_utility_worker_count(Some("0".to_owned())),
+        1
+    );
+}
+
+#[test]
+fn inprocess_utility_worker_ids_are_distinct_and_stable() {
+    // Index 0 keeps the configured id unchanged (a single-worker setup registers
+    // exactly as before); each extra worker gets a unique `-N` suffix so two loops
+    // never collide on registration.
+    assert_eq!(
+        inprocess_utility_worker_id("rust-utility-worker", 0),
+        "rust-utility-worker"
+    );
+    assert_eq!(
+        inprocess_utility_worker_id("rust-utility-worker", 1),
+        "rust-utility-worker-1"
+    );
+    assert_eq!(
+        inprocess_utility_worker_id("rust-utility-worker", 2),
+        "rust-utility-worker-2"
+    );
+    // Distinctness across a small pool.
+    let ids: std::collections::HashSet<_> = (0..4)
+        .map(|index| inprocess_utility_worker_id("host-a", index))
+        .collect();
+    assert_eq!(ids.len(), 4);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What & why

On the **desktop app**, every CPU utility job — model/LoRA **downloads**, imports, converts, ffmpeg — was served by a *single* in-process worker. `spawn_inprocess_utility_worker` called `run_worker_loop` exactly once and ignored `SCENEWORKS_UTILITY_WORKERS`. Because a worker claims one job at a time, and the macOS MLX worker deliberately carries no download capability, **downloads queued one-at-a-time** (the concrete desktop instance of WKA-007 / sc-5768: "a single-utility-worker deployment fully stalls quick jobs behind long downloads").

The standalone/Docker worker already runs a configurable pool (`utility_worker_specs`, default 4); the desktop in-process path just bypassed it.

## Change

`apps/rust-api/src/lib.rs`:
- `spawn_inprocess_utility_worker` now spawns a **pool** of `run_worker_loop` tasks. Count = `SCENEWORKS_UTILITY_WORKERS` if set, else **2** (new `inprocess_utility_worker_count`, with a pure `parse_inprocess_utility_worker_count` split out for testing; clamped ≥ 1).
- Each loop gets a distinct id via `inprocess_utility_worker_id`: index 0 keeps the existing id (single-worker registration unchanged), extras suffixed `-1`, `-2`, … — mirrors the standalone pool's scheme, so two loops never collide on registration.
- `InProcessUtilityWorker` now holds a `Vec<JoinHandle>`; `shutdown()` joins all loops.

Default is intentionally **2**, not the standalone pool's 4, because the same knob also governs CPU/RAM-heavy conversions/imports.

## Reviewer notes

- **No corruption risk from concurrency:** same-target downloads stay serialized by the per-file `DownloadLock` (sc-8900); only *distinct* downloads run in parallel.
- **Known trade-off:** the single count also permits 2 concurrent heavy conversions. Accepted for now; a follow-up could split concurrency by job class (I/O-bound downloads vs CPU/RAM-bound converts) if that becomes a problem.
- **Effect requires a rebuilt app** — this lives in the API sidecar, so it ships with a desktop/worker build carrying this commit.

## Verification

- `cargo fmt --check` + `cargo clippy -p sceneworks-rust-api --all-targets -- -D warnings` clean.
- `cargo test -p sceneworks-rust-api` → **250 passed, 0 failed** (incl. 2 new unit tests: default→2 / `0`→1 clamp / blank→2, and distinct-ids).
- **Runtime smoke:** booted the API binary with `SCENEWORKS_RUN_UTILITY_INPROCESS=true` in a sandbox HOME; `GET /api/v1/workers` returned **two** CPU workers within 1s (`rust-utility-worker` + `rust-utility-worker-1`, both `event=utility_worker_inprocess count=2` at index 0/1), no panics.

Story: [sc-10744](https://app.shortcut.com/trefry/story/10744) (relates to WKA-007 / [sc-5768](https://app.shortcut.com/trefry/story/5768)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)