### PR TITLE
feat(models): generation-time tier picker for convert-at-install models (sc-10730)

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1266,6 +1266,47 @@ fn apply_variant_fields(object: &mut JsonObject, data_dir: &FsPath) {
     object.insert("variants".to_owned(), Value::Array(variants));
 }
 
+/// The convert-output quant tiers present under a converted MLX dir (sc-10730), highest-fidelity first.
+/// Convert-at-install models (e.g. Anima) write `<converted>/<tier>/<backbone>/…` for each of
+/// bf16/q8/q4 in ONE convert job — the tiers are convert OUTPUTS, not per-tier downloads. This lets the
+/// Studio offer a generation-time tier picker via the decoupled `mlxTiers` catalog field WITHOUT the
+/// download variant-matrix (`hasVariantMatrix`), whose `QuantDownloadPanel` would render bogus per-tier
+/// download buttons for a model that has no per-tier download. Empty for a flat converted dir (no tier
+/// subdirs) → the web renders no picker. Mirrors the worker tier resolvers' "tier present" probe so the
+/// catalog and `anima_tier_subdir` agree on which tiers are loadable.
+fn mlx_convert_output_tiers(converted_dir: &FsPath) -> Vec<&'static str> {
+    ["bf16", "q8", "q4"]
+        .into_iter()
+        .filter(|tier| tier_subdir_has_weights(&converted_dir.join(tier)))
+        .collect()
+}
+
+/// Whether a converted tier subdir holds loadable weights: a non-hidden `.safetensors` / `.index.json`
+/// under a known backbone dir (`diffusion_models/` for Anima's Cosmos DiT, `transformer/` for other
+/// DiTs, `unet/` for SDXL) or flat in the tier dir. A hidden `._*` AppleDouble sidecar is not a weight
+/// (SceneWorks#1333), mirroring the worker resolvers.
+fn tier_subdir_has_weights(tier_dir: &FsPath) -> bool {
+    if !tier_dir.is_dir() {
+        return false;
+    }
+    let dir_has_weight = |dir: &FsPath| -> bool {
+        std::fs::read_dir(dir).is_ok_and(|entries| {
+            entries.flatten().any(|entry| {
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                !name.starts_with("._")
+                    && (name.ends_with(".safetensors") || name.ends_with(".index.json"))
+            })
+        })
+    };
+    // A known backbone subdir (`diffusion_models/` Anima, `transformer/` DiTs, `unet/` SDXL), or flat
+    // in the tier dir itself.
+    dir_has_weight(tier_dir)
+        || ["diffusion_models", "transformer", "unet"]
+            .into_iter()
+            .any(|sub| dir_has_weight(&tier_dir.join(sub)))
+}
+
 fn apply_mac_and_mlx_fields(object: &mut JsonObject, data_dir: &FsPath) {
     let mac_support = {
         let id = object.get("id").and_then(Value::as_str).unwrap_or_default();
@@ -1284,6 +1325,15 @@ fn apply_mac_and_mlx_fields(object: &mut JsonObject, data_dir: &FsPath) {
         None
     };
     if let Some(status) = mlx_status {
+        // Generation-time tier picker for convert-at-install models (sc-10730): surface the on-disk
+        // convert-output tiers as `mlxTiers`, DECOUPLED from `hasVariantMatrix` so the Models download
+        // panel is untouched. Only when the model is actually converted (its tier subdirs exist).
+        if let Some(converted) = status.converted_path.as_deref() {
+            let tiers = mlx_convert_output_tiers(converted);
+            if !tiers.is_empty() {
+                object.insert("mlxTiers".to_owned(), json!(tiers));
+            }
+        }
         object.insert(
             "mlxInstallState".to_owned(),
             Value::String(status.install_state.to_owned()),
@@ -2636,5 +2686,102 @@ mod variant_install_tests {
                 .and_then(|d| d.get("variant").and_then(Value::as_str).map(str::to_owned)),
             Some("q4".to_owned())
         );
+    }
+}
+
+#[cfg(test)]
+mod mlx_tier_probe_tests {
+    use super::*;
+
+    fn write_weight(dir: &std::path::Path, backbone: &str, file: &str) {
+        let d = dir.join(backbone);
+        std::fs::create_dir_all(&d).unwrap();
+        std::fs::write(d.join(file), b"x").unwrap();
+    }
+
+    #[test]
+    fn convert_output_tiers_probes_diffusion_models_highest_first_ignoring_appledouble() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // Anima layout: <tier>/diffusion_models/<dit>.safetensors present for bf16 + q8; q4 has only a
+        // hidden `._` AppleDouble sidecar, which must NOT count as a loadable tier (SceneWorks#1333).
+        write_weight(
+            &root.join("bf16"),
+            "diffusion_models",
+            "anima-base-v1.0.safetensors",
+        );
+        write_weight(
+            &root.join("q8"),
+            "diffusion_models",
+            "anima-base-v1.0.safetensors",
+        );
+        write_weight(
+            &root.join("q4"),
+            "diffusion_models",
+            "._anima-base-v1.0.safetensors",
+        );
+        // Highest-fidelity first, q4 excluded.
+        assert_eq!(mlx_convert_output_tiers(root), vec!["bf16", "q8"]);
+    }
+
+    #[test]
+    fn convert_output_tiers_handles_transformer_flat_and_empty_layouts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        write_weight(&root.join("q8"), "transformer", "model.safetensors");
+        // Flat layout: a sharded index sits directly in the tier dir (no backbone subdir).
+        std::fs::create_dir_all(root.join("bf16")).unwrap();
+        std::fs::write(
+            root.join("bf16")
+                .join("diffusion_pytorch_model.safetensors.index.json"),
+            b"x",
+        )
+        .unwrap();
+        assert_eq!(mlx_convert_output_tiers(root), vec!["bf16", "q8"]);
+        // A flat converted dir (no tier subdirs) yields no tiers → the web renders no picker.
+        let flat = tempfile::tempdir().unwrap();
+        std::fs::write(flat.path().join("model_index.json"), b"{}").unwrap();
+        assert!(mlx_convert_output_tiers(flat.path()).is_empty());
+    }
+
+    // Full catalog path: a converted convert-at-install model (Anima) emits `mlxTiers` from
+    // `apply_mac_and_mlx_fields`, so /models carries the Studio picker data. macOS-only (the mlx status
+    // probe is `cfg!(target_os = "macos")`).
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn catalog_emits_mlxtiers_for_converted_anima() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path();
+        let converted = data_dir.join("models").join("mlx").join("anima_base");
+        std::fs::create_dir_all(&converted).unwrap();
+        std::fs::write(converted.join("model_index.json"), b"{}").unwrap();
+        for tier in ["bf16", "q8", "q4"] {
+            let dm = converted.join(tier).join("diffusion_models");
+            std::fs::create_dir_all(&dm).unwrap();
+            std::fs::write(dm.join("anima-base-v1.0.safetensors"), b"x").unwrap();
+        }
+        let mut object = json!({
+            "id": "anima_base",
+            "type": "image",
+            "mlx": { "requiresConversion": true }
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        apply_mac_and_mlx_fields(&mut object, data_dir);
+        assert_eq!(
+            object.get("mlxConversionState").and_then(Value::as_str),
+            Some("converted")
+        );
+        let tiers: Vec<&str> = object
+            .get("mlxTiers")
+            .and_then(Value::as_array)
+            .expect("mlxTiers emitted")
+            .iter()
+            .filter_map(Value::as_str)
+            .collect();
+        assert_eq!(tiers, vec!["bf16", "q8", "q4"]);
+        // Decoupled from the download matrix — the picker must NOT flip `hasVariantMatrix`.
+        assert!(object.get("hasVariantMatrix").is_none());
     }
 }

--- a/apps/web/src/quantTier.js
+++ b/apps/web/src/quantTier.js
@@ -79,34 +79,47 @@ export function isSelectableTier(tier) {
 // pre-Ada NVIDIA GPU that fails the sm_89 compute-cap probe), so the tier is HIDDEN on an ineligible
 // host even when its files happen to be present in the cache. Every other tier is unaffected. Default
 // true keeps existing single-lane call sites (and tests) unchanged.
+// Sort tier keys by display order (smallest → largest); unknown keys sort after, alphabetically.
+function sortByTierOrder(a, b) {
+  const ai = TIER_ORDER.indexOf(a);
+  const bi = TIER_ORDER.indexOf(b);
+  if (ai === -1 && bi === -1) {
+    return a.localeCompare(b);
+  }
+  if (ai === -1) {
+    return 1;
+  }
+  if (bi === -1) {
+    return -1;
+  }
+  return ai - bi;
+}
+
 export function installedTiers(model, options = {}) {
   const { convRotEligible = true } = options;
-  if (!model?.hasVariantMatrix || !Array.isArray(model.variants)) {
-    return [];
+  // Download-matrix models (sc-8508): per-tier DOWNLOAD entries, install-tracked individually.
+  if (model?.hasVariantMatrix && Array.isArray(model.variants)) {
+    return model.variants
+      .filter(
+        (variant) =>
+          variant &&
+          isSelectableTier(variant.variant) &&
+          (convRotEligible || !isConvRotTier(variant.variant)) &&
+          variant.installState === "installed",
+      )
+      .map((variant) => variant.variant)
+      .sort(sortByTierOrder);
   }
-  return model.variants
-    .filter(
-      (variant) =>
-        variant &&
-        isSelectableTier(variant.variant) &&
-        (convRotEligible || !isConvRotTier(variant.variant)) &&
-        variant.installState === "installed",
-    )
-    .map((variant) => variant.variant)
-    .sort((a, b) => {
-      const ai = TIER_ORDER.indexOf(a);
-      const bi = TIER_ORDER.indexOf(b);
-      if (ai === -1 && bi === -1) {
-        return a.localeCompare(b);
-      }
-      if (ai === -1) {
-        return 1;
-      }
-      if (bi === -1) {
-        return -1;
-      }
-      return ai - bi;
-    });
+  // Convert-at-install models (sc-10730): tiers are convert OUTPUTS on disk, surfaced by the catalog as
+  // `mlxTiers` — a plain array of installed tier keys, DECOUPLED from the download variant-matrix so the
+  // Models download panel (`hasVariantMatrix`) is untouched. Anima (and other convert-at-install models)
+  // get a Studio generation-time tier picker this way.
+  if (Array.isArray(model?.mlxTiers) && model.mlxTiers.length > 0) {
+    return model.mlxTiers
+      .filter((tier) => isSelectableTier(tier) && (convRotEligible || !isConvRotTier(tier)))
+      .sort(sortByTierOrder);
+  }
+  return [];
 }
 
 // Whether the studio should render the tier picker: only when MORE THAN ONE quant tier is
@@ -148,8 +161,15 @@ export function defaultTierSelection(model, lastUsed, options = {}) {
   if (declared) {
     return declared;
   }
-  if (tiers.includes("q4")) {
-    return "q4";
+  // Convert-at-install models (mlxTiers) preselect q8 — matching the worker's Q8 generation default
+  // (sc-10714 / epic 10721), so the picker's initial value never silently sends the washed q4.
+  // Download-matrix models keep the historical q4 (smallest) preselection.
+  const preferred =
+    !model?.hasVariantMatrix && Array.isArray(model?.mlxTiers) ? ["q8", "bf16", "q4"] : ["q4"];
+  for (const tier of preferred) {
+    if (tiers.includes(tier)) {
+      return tier;
+    }
   }
   return tiers[0];
 }

--- a/apps/web/src/quantTier.test.js
+++ b/apps/web/src/quantTier.test.js
@@ -159,3 +159,45 @@ describe("defaultTierSelection", () => {
     expect(defaultTierSelection({ id: "x", hasVariantMatrix: false }, null)).toBe(null);
   });
 });
+
+// Convert-at-install models (sc-10730): tiers are convert OUTPUTS surfaced as `mlxTiers` (a plain array
+// of installed tier keys), NOT the download variant-matrix. The Studio picker reads them so Anima et al.
+// get a generation-time tier selector without touching the Models download panel (`hasVariantMatrix`).
+function convertModel({ mlxTiers = ["bf16", "q8", "q4"] } = {}) {
+  return { id: "anima_base", hasVariantMatrix: false, mlxTiers };
+}
+
+describe("quantTier — convert-at-install mlxTiers (sc-10730)", () => {
+  it("installedTiers reads mlxTiers, smallest→largest", () => {
+    expect(installedTiers(convertModel({ mlxTiers: ["q4", "bf16", "q8"] }))).toEqual([
+      "q4",
+      "q8",
+      "bf16",
+    ]);
+  });
+
+  it("shows the picker when >1 convert-output tier is present", () => {
+    expect(shouldShowTierPicker(convertModel({ mlxTiers: ["bf16", "q8", "q4"] }))).toBe(true);
+    expect(shouldShowTierPicker(convertModel({ mlxTiers: ["q8"] }))).toBe(false);
+  });
+
+  it("preselects q8 (not q4) so the picker never silently re-sends the washed q4", () => {
+    expect(defaultTierSelection(convertModel(), null)).toBe("q8");
+    // bf16 when q8 absent (clean-tier fallback), never q4 by default
+    expect(defaultTierSelection(convertModel({ mlxTiers: ["bf16", "q4"] }), null)).toBe("bf16");
+  });
+
+  it("a last-used convert tier still wins over the q8 default", () => {
+    expect(defaultTierSelection(convertModel(), "q4")).toBe("q4");
+  });
+
+  it("does not touch download-matrix behavior (still preselects q4)", () => {
+    expect(installedTiers({ id: "x", hasVariantMatrix: false })).toEqual([]);
+    expect(
+      defaultTierSelection(
+        matrixModel({ installed: ["q4", "q8", "bf16"], defaultTier: "none" }),
+        null,
+      ),
+    ).toBe("q4");
+  });
+});


### PR DESCRIPTION
## What

Anima had **no quant selector** in the Studio (owner report). The tier picker keys off the download variant-matrix (`hasVariantMatrix` + `downloads[].variant`), but Anima is **convert-at-install** — its tiers are convert *outputs* on disk (`data/models/mlx/<id>/{bf16,q8,q4}/`), not per-tier downloads. So all three tiers were written by the converter and left **unreachable** from the UI. (PR #1362 fixed the washed *default* — Q8 — but not the ability to *pick* a tier.)

## Approach — decoupled `mlxTiers`, no download-panel breakage

Flipping `hasVariantMatrix` on for Anima would render `ModelManagerScreen`'s `QuantDownloadPanel` with per-tier **download** buttons (`onDownloadVariant`) — bogus for a model with no per-tier download. So this adds a **separate** signal:

- **Backend** (`apps/rust-api/src/models.rs`): for a converted `requiresConversion` model, `apply_mac_and_mlx_fields` probes `<converted>/<tier>/` and emits `mlxTiers: ["bf16","q8","q4"]` (the tiers actually on disk). `hasVariantMatrix` stays false → Models download screen untouched.
- **Web** (`quantTier.js`): `installedTiers` reads `mlxTiers` when there's no variant matrix; `defaultTierSelection` preselects **q8** for these models (matching the worker's Q8 default, sc-10714) so the picker never silently re-sends the washed q4. `shouldShowTierPicker` (>1 tier) and the ImageStudio JSX are unchanged — the screen is data-driven, so the picker now appears for Anima automatically.

## Result

Anima shows a Studio tier picker (Full precision / Q8 / Q4), defaulting to Q8; switching sends `advanced.mlxQuantize`, which the worker resolver already honors. SANA/other convert-at-install models with the same on-disk tier layout get it too.

## Testing

- Backend: `mlx_convert_output_tiers` probe (backbone subdirs, flat, AppleDouble-ignored, empty) + full `/models` emission via `apply_mac_and_mlx_fields` for a converted Anima (asserts `mlxTiers` present + `hasVariantMatrix` absent). ✅
- Web: `installedTiers`/`shouldShowTierPicker`/`defaultTierSelection` for the `mlxTiers` path incl. q8-preselect and download-matrix untouched (23 tests). ✅
- fmt / clippy (`-D warnings`) / eslint clean. Verified the real install's on-disk layout matches the tested layout; ImageStudio renders the picker purely on `shouldShowTierPicker`.

Part of epic [sc-10721](https://app.shortcut.com/trefry/epic/10721); implements [sc-10730](https://app.shortcut.com/trefry/story/10730).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
