### PR TITLE
feat(web): persist per-(screen,model) last tier pick (sc-10727)

### DIFF
--- a/apps/web/src/lastTierStore.js
+++ b/apps/web/src/lastTierStore.js
@@ -1,0 +1,70 @@
+// Persistent, per-(screen, modelId) sticky for the last EXPLICIT quant tier a user picked in a
+// tiered studio surface (epic 10721 / sc-10727 — the "anti-friction core"). When a user picks a
+// tier for a model on a screen, that pick becomes the default the next time they open that model on
+// that screen, so they stop re-selecting a tier for every generation.
+//
+// Keyed by (screen, modelId) and DELIBERATELY project-independent: the quant tier is a
+// hardware/quality tradeoff (RAM vs. fidelity), not a per-project authoring choice, so picking q4
+// for a model on Image Studio makes q4 that model's Image-Studio default in every workspace until
+// the user explicitly picks another tier. This is why the sticky lives in its own store rather than
+// the per-workspace `useStudioSettings` blob — the workspace dimension would wrongly reset the
+// preference when switching projects.
+//
+// Reuses the app's existing per-UI-pref persistence pattern — a single JSON blob in localStorage
+// behind a try/catch guard, mirroring hooks/useStudioSettings.js — rather than inventing a new
+// mechanism. One key holds a nested { [screen]: { [modelId]: tier } } map, so screens and models
+// are independent namespaces (no key-separator collisions).
+//
+// PRECEDENCE (epic-locked): an explicit same-session pick > this per-(screen,model) sticky > the
+// hardcoded q8 base default in `defaultTierSelection` > clamp-to-installed. This module owns only
+// the sticky rung: callers read it and pass the result as the `lastUsed` argument to
+// `defaultTierSelection`, which honors it whenever the sticky tier is still installed and otherwise
+// falls through to the base default — so a stale/uninstalled sticky is safely ignored (clamped).
+
+const STORAGE_KEY = "sceneworks-last-tier";
+
+function readAll() {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : null;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    // localStorage unavailable (private mode, quota, non-DOM env) — no sticky this session.
+    return {};
+  }
+}
+
+function writeAll(map) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // localStorage unavailable — the sticky just won't persist this session.
+  }
+}
+
+// The last explicit tier the user picked for (screen, modelId), or null when none is stored. Reads
+// localStorage fresh on every call (no in-memory cache), so a value written in a previous session
+// is returned after an app restart.
+export function readLastTier(screen, modelId) {
+  if (!screen || !modelId) {
+    return null;
+  }
+  const perScreen = readAll()[screen];
+  const value = perScreen && typeof perScreen === "object" ? perScreen[modelId] : undefined;
+  return typeof value === "string" && value ? value : null;
+}
+
+// Record the user's explicit tier pick for (screen, modelId), persisting immediately. A falsy
+// screen/modelId/tier is ignored (nothing to key on / clearing is not a supported operation here).
+export function writeLastTier(screen, modelId, tier) {
+  if (!screen || !modelId || !tier) {
+    return;
+  }
+  const map = readAll();
+  const perScreen = map[screen] && typeof map[screen] === "object" ? map[screen] : {};
+  if (perScreen[modelId] === tier) {
+    return;
+  }
+  map[screen] = { ...perScreen, [modelId]: tier };
+  writeAll(map);
+}

--- a/apps/web/src/lastTierStore.test.js
+++ b/apps/web/src/lastTierStore.test.js
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readLastTier, writeLastTier } from "./lastTierStore.js";
+import { defaultTierSelection } from "./quantTier.js";
+
+// A download-matrix model whose `installed` tiers are present; unlisted declared tiers are missing.
+function matrixModel({ tiers = ["q4", "q8", "bf16"], installed = [], id = "model_x" } = {}) {
+  return {
+    id,
+    hasVariantMatrix: true,
+    variants: tiers.map((tier) => ({
+      variant: tier,
+      // No `default: true` — the real catalog never emits it, so the sticky must win on its own.
+      installState: installed.includes(tier) ? "installed" : "missing",
+    })),
+  };
+}
+
+const STORAGE_KEY = "sceneworks-last-tier";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe("lastTierStore — (screen, model) key", () => {
+  it("round-trips a written tier for the same (screen, model)", () => {
+    writeLastTier("image", "model_x", "q4");
+    expect(readLastTier("image", "model_x")).toBe("q4");
+  });
+
+  it("returns null when nothing has been stored for (screen, model)", () => {
+    expect(readLastTier("image", "model_x")).toBe(null);
+  });
+
+  it("keys are independent per MODEL — model Y is unaffected by a pick on model X", () => {
+    writeLastTier("image", "model_x", "q4");
+    expect(readLastTier("image", "model_x")).toBe("q4");
+    expect(readLastTier("image", "model_y")).toBe(null);
+  });
+
+  it("keys are independent per SCREEN — Video/Character are unaffected by an Image pick", () => {
+    writeLastTier("image", "model_x", "q4");
+    expect(readLastTier("image", "model_x")).toBe("q4");
+    expect(readLastTier("video", "model_x")).toBe(null);
+    expect(readLastTier("character", "model_x")).toBe(null);
+  });
+
+  it("the same model on two screens holds two independent picks", () => {
+    writeLastTier("image", "model_x", "q4");
+    writeLastTier("video", "model_x", "q8");
+    expect(readLastTier("image", "model_x")).toBe("q4");
+    expect(readLastTier("video", "model_x")).toBe("q8");
+  });
+
+  it("a later explicit pick overwrites the earlier sticky for that (screen, model)", () => {
+    writeLastTier("image", "model_x", "q4");
+    writeLastTier("image", "model_x", "q8");
+    expect(readLastTier("image", "model_x")).toBe("q8");
+  });
+
+  it("ignores writes with a falsy screen, model, or tier", () => {
+    writeLastTier("", "model_x", "q4");
+    writeLastTier("image", "", "q4");
+    writeLastTier("image", "model_x", "");
+    expect(readLastTier("image", "model_x")).toBe(null);
+  });
+
+  it("returns null for a read with a falsy screen or model", () => {
+    writeLastTier("image", "model_x", "q4");
+    expect(readLastTier("", "model_x")).toBe(null);
+    expect(readLastTier("image", "")).toBe(null);
+  });
+});
+
+describe("lastTierStore — persistence (survives app restart)", () => {
+  it("persists to localStorage and re-reads after a simulated restart", () => {
+    writeLastTier("image", "model_x", "q4");
+    // A restart drops all in-memory state. readLastTier reads localStorage fresh every call, so a
+    // read AFTER the write — with no module-level cache in between — is the restart-equivalent.
+    expect(readLastTier("image", "model_x")).toBe("q4");
+    // And the value genuinely lives in the persisted blob, not just in memory.
+    const persisted = JSON.parse(window.localStorage.getItem(STORAGE_KEY));
+    expect(persisted).toEqual({ image: { model_x: "q4" } });
+  });
+
+  it("survives corrupt/absent storage by falling back to null", () => {
+    window.localStorage.setItem(STORAGE_KEY, "{not json");
+    expect(readLastTier("image", "model_x")).toBe(null);
+  });
+});
+
+// The sticky rung is base-agnostic: it is passed to `defaultTierSelection` as `lastUsed`, which
+// honors it above the model's base default (currently q8 — epic 10721 / sc-10726 — for both
+// download-matrix and convert-at-install mlxTiers models) whenever the sticky tier is still
+// installed, and otherwise falls through to that base and clamps to installed.
+describe("lastTierStore — precedence with defaultTierSelection", () => {
+  it("sticky beats the base default when the sticky tier is installed (download-matrix)", () => {
+    // q4, q8 both installed; the model's base default is q8, but the user's sticky is q4.
+    const model = matrixModel({ installed: ["q4", "q8"] });
+    writeLastTier("image", model.id, "q4");
+    expect(defaultTierSelection(model, readLastTier("image", model.id))).toBe("q4");
+  });
+
+  it("clamps a sticky to installed — sticky bf16 but only q4 installed → q4 (base clamps too)", () => {
+    const model = matrixModel({ installed: ["q4"] });
+    writeLastTier("image", model.id, "bf16");
+    // The sticky bf16 is not installed, so defaultTierSelection ignores it and falls to the base
+    // default (q8); q8 is not installed either, so it clamps to the only installed tier, q4.
+    expect(defaultTierSelection(model, readLastTier("image", model.id))).toBe("q4");
+  });
+
+  it("clamps a sticky q8 to q4 when only q4 is installed (acceptance: sticky q8, q4-only → q4)", () => {
+    const model = matrixModel({ installed: ["q4"] });
+    writeLastTier("image", model.id, "q8");
+    expect(defaultTierSelection(model, readLastTier("image", model.id))).toBe("q4");
+  });
+
+  it("with no sticky, defaultTierSelection uses the q8 base default (download-matrix)", () => {
+    const model = matrixModel({ installed: ["q4", "q8"] });
+    expect(readLastTier("image", model.id)).toBe(null);
+    expect(defaultTierSelection(model, readLastTier("image", model.id))).toBe("q8");
+  });
+
+  it("applies to convert-at-install (mlxTiers) models — sticky q4 beats the q8 base default", () => {
+    // Convert-at-install models surface installed tiers via `mlxTiers` (S5) instead of a variant
+    // matrix and preselect q8 by default. The same sticky store seeds them: pick q4, and q4 wins.
+    const convertModel = { id: "anima", mlxTiers: ["q4", "q8", "bf16"] };
+    expect(defaultTierSelection(convertModel, readLastTier("image", convertModel.id))).toBe("q8");
+    writeLastTier("image", convertModel.id, "q4");
+    expect(defaultTierSelection(convertModel, readLastTier("image", convertModel.id))).toBe("q4");
+  });
+});

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -123,6 +123,7 @@ import {
   shouldShowTierPicker,
   tierLabel,
 } from "../quantTier.js";
+import { readLastTier, writeLastTier } from "../lastTierStore.js";
 import { PROMPT_REFINE_MODEL_ID, VISION_CAPTION_MODEL_ID, VISION_CAPTION_MODEL_REPO } from "../constants.js";
 import { pickClosestResolution } from "../resolutionMatch.js";
 import {
@@ -157,6 +158,10 @@ import {
 
 // Used only for models that don't declare limits.resolutions (e.g. user-imported).
 const DEFAULT_RESOLUTION_OPTIONS = ["768x768", "1024x1024", "1280x720", "720x1280"];
+// Screen identity for the per-(screen, model) sticky quant-tier store (sc-10727). Matches this
+// studio's `loadStudioSettings`/`useStudioSettingsWriter` key so the sticky namespace is stable and
+// distinct from Video/Character studios. Change this and existing users lose their Image sticky.
+const TIER_SCREEN = "image";
 // Studio sub-modes a saved preset may restore (the "type") — the tabs the mode
 // segmented control actually exposes. Edit lives in its own workflow; text and
 // character share the text_to_image workflow.
@@ -566,11 +571,11 @@ export function ImageStudio() {
   // picker so the user can A/B a bf16 vs Q8 vs Q4 build. The picked tier rides
   // `advanced.mlxQuantize` (bf16→0, q8→8, q4→4); the worker's resolve_quant + generator cache
   // route to it (reload-always — the cache evicts + reloads on a heavy-tier switch). `quantTier`
-  // holds the selected tier key ("" = no picker / not applicable). Last-used is persisted PER
-  // MODEL in `lastUsedTiers` so re-entering a model restores the tier you last generated with.
-  const [lastUsedTiers, setLastUsedTiers] = useState(
-    saved.lastUsedTiers && typeof saved.lastUsedTiers === "object" ? saved.lastUsedTiers : {},
-  );
+  // holds the selected tier key ("" = no picker / not applicable). The user's last EXPLICIT pick is
+  // persisted per (screen, model) in `lastTierStore` (epic 10721 / sc-10727) — project-independent,
+  // so re-entering a model on this screen restores the tier you last generated with, in any
+  // workspace and across app restarts. It seeds the picker as the top rung below a same-session pick
+  // and above the model's base default (see the seed effect + `defaultTierSelection`).
   const [quantTier, setQuantTier] = useState("");
   // Brief "loading <tier>" hint shown right after a switch (reload-always): switching a heavy
   // tier evicts + reloads on the worker, so we surface a transient loading note rather than
@@ -1112,8 +1117,10 @@ export function ImageStudio() {
   }, [resolutionOptions, resolution, selectedModel]);
   // Keep the selected quant tier valid for the active model (sc-8515). When the current tier is
   // still installed for this model, leave it; otherwise snap to the model's default selection
-  // (last-used-for-this-model → declared default → q4 → first installed). Also clears to "" when
+  // (sticky-for-this-(screen,model) → declared default → q8 base → q4 → first installed). Clears "" when
   // no tier is installed / the model has no matrix, so a stale tier never leaks into the payload.
+  // The sticky rung (sc-10727) is read straight from the persistent per-(screen,model) store, so it
+  // survives restarts and is honored above the base default whenever that tier is still installed.
   // Keyed on `model` (not `selectedModel`) plus the installed-tier list so a catalog refresh that
   // newly installs a second tier re-derives the default without churning on every render.
   const availableTiersKey = availableTiers.join(",");
@@ -1121,12 +1128,14 @@ export function ImageStudio() {
     if (availableTiers.includes(quantTier)) {
       return;
     }
-    setQuantTier(defaultTierSelection(selectedModel, lastUsedTiers[model], tierOptions) ?? "");
+    setQuantTier(
+      defaultTierSelection(selectedModel, readLastTier(TIER_SCREEN, model), tierOptions) ?? "",
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [model, availableTiersKey]);
-  // Switch the active quant tier (sc-8515): persist it as this model's last-used tier and surface
-  // a brief "loading <tier>" note (reload-always — the worker evicts + reloads a heavy tier on the
-  // next generation; there is no co-residence). The note is cosmetic and self-clears.
+  // Switch the active quant tier (sc-8515): persist it as this (screen, model)'s last EXPLICIT tier
+  // (sc-10727 — sticky) and surface a brief "loading <tier>" note (reload-always — the worker evicts
+  // + reloads a heavy tier on the next generation; there is no co-residence). The note self-clears.
   const tierSwitchTimer = useRef(null);
   useEffect(() => () => clearTimeout(tierSwitchTimer.current), []);
   const handleTierChange = useCallback(
@@ -1135,7 +1144,7 @@ export function ImageStudio() {
         return;
       }
       setQuantTier(nextTier);
-      setLastUsedTiers((prev) => ({ ...prev, [model]: nextTier }));
+      writeLastTier(TIER_SCREEN, model, nextTier);
       setTierSwitching(nextTier);
       clearTimeout(tierSwitchTimer.current);
       tierSwitchTimer.current = setTimeout(() => setTierSwitching(""), 1500);
@@ -1530,7 +1539,6 @@ export function ImageStudio() {
     bf16Precision,
     usePid,
     pidTarget,
-    lastUsedTiers,
   });
 
   // Each stacked run carries its already-resolved completed assets + the

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -968,6 +968,60 @@ describe("ImageStudio model picker capability gating", () => {
     await click(generateButton());
     expect(createImageJob.mock.calls[0][0].advanced.mlxQuantize).toBe(4);
   });
+
+  // Per-(screen, model) sticky last-tier (sc-10727 / epic 10721). An explicit pick is persisted and
+  // reused as the default on the next visit to that model on this screen, surviving app restarts.
+  it("persists the explicit tier pick per (screen, model) across a remount, above the declared default (sc-10727)", async () => {
+    // All three tiers installed; declared default is q4.
+    const model = matrixModel(["q4", "q8", "bf16"], "q4");
+    await render(baseContext({ imageModels: [model], macCapabilities: MAC_CAPS }));
+    await openAdvanced(container);
+    await act(async () => {});
+    // First visit: seeds on the declared default (no sticky stored yet).
+    expect(tierPicker(container).value).toBe("q4");
+    // User explicitly picks q8 → written to the persistent per-(screen, model) store.
+    setSelect(tierPicker(container), "q8");
+    await act(async () => {});
+    expect(tierPicker(container).value).toBe("q8");
+
+    // Simulate an app restart: tear the tree down and mount a FRESH one (React state is gone; only
+    // the persisted sticky survives), then re-render the SAME model. (The Advanced panel's open
+    // state persists in the studio-settings blob, so it may already be open — guard the toggle.)
+    await unmountRoot(root, container);
+    ({ container, root } = mountRoot());
+    await render(baseContext({ imageModels: [model], macCapabilities: MAC_CAPS }));
+    if (!tierPicker(container)) {
+      await openAdvanced(container);
+      await act(async () => {});
+    }
+    // The sticky q8 now seeds the picker, winning over the declared default q4 — persistence +
+    // precedence (sticky > declared/base default) proven end-to-end.
+    expect(tierPicker(container).value).toBe("q8");
+  });
+
+  it("keeps the sticky independent per model — a pick on model X does not affect model Y (sc-10727)", async () => {
+    const modelX = matrixModel(["q4", "q8", "bf16"], "q4");
+    const modelY = { ...matrixModel(["q4", "q8", "bf16"], "q4"), id: "other_model", name: "Other Model" };
+
+    await render(baseContext({ imageModels: [modelX], macCapabilities: MAC_CAPS }));
+    await openAdvanced(container);
+    await act(async () => {});
+    setSelect(tierPicker(container), "q8");
+    await act(async () => {});
+    expect(tierPicker(container).value).toBe("q8");
+
+    // Fresh mount, render a DIFFERENT model (Y). Its picker seeds on its OWN default (q4), untouched
+    // by X's q8 sticky — a global (non-model-keyed) store would wrongly surface q8 here. (Advanced
+    // may already be open from the persisted studio-settings blob — guard the toggle.)
+    await unmountRoot(root, container);
+    ({ container, root } = mountRoot());
+    await render(baseContext({ imageModels: [modelY], macCapabilities: MAC_CAPS }));
+    if (!tierPicker(container)) {
+      await openAdvanced(container);
+      await act(async () => {});
+    }
+    expect(tierPicker(container).value).toBe("q4");
+  });
 });
 
 describe("ImageStudio structured-prompt recipe round-trip (sc-6147)", () => {


### PR DESCRIPTION
## What & why

Epic 10721 (capability-aware & user-settable default generation quant tier) — the **anti-friction core** (sc-10727). The user's last EXPLICIT quant-tier pick is now remembered per **(screen, model)** and reused as the picker's default the next time they open that model on that screen, so they stop re-selecting a tier for every generation.

## The (screen, model) key design

New module `apps/web/src/lastTierStore.js` — a persistent, **project-independent** store keyed by `(screen, modelId)`:

- **Reuses the app's existing per-UI-pref persistence pattern**: one JSON blob in `localStorage` behind a `try/catch` guard, mirroring `hooks/useStudioSettings.js`. No new persistence mechanism invented.
- Stores a nested `{ [screen]: { [modelId]: tier } }` map, so screens and models are independent namespaces (no key-separator collisions).
- **Deliberately drops the workspace dimension** that `useStudioSettings` carries: the quant tier is a hardware/quality tradeoff (RAM vs. fidelity), not a per-project authoring choice, so picking q4 for a model on Image Studio makes q4 that model's Image-Studio default in every workspace. This is a small, intentional behavior change from the previous per-project `lastUsedTiers` blob.
- API: `readLastTier(screen, modelId)` → tier | null; `writeLastTier(screen, modelId, tier)`.

## Where seed/save are hooked

`apps/web/src/screens/ImageStudio.jsx` — the only tiered surface with a quant picker today (the S5 `mlxTiers` picker on main):

- **Seed**: the tier-validity effect now seeds via `defaultTierSelection(selectedModel, readLastTier("image", model), tierOptions)`. The sticky is passed as `defaultTierSelection`'s `lastUsed` argument, so the epic-locked precedence holds: **explicit same-session pick > per-(screen,model) sticky > q8 base default > clamp-to-installed > smallest installed**. Because the sticky occupies the `lastUsed` rung (checked before the dead `variant.default` path), it is never shadowed.
- **Save**: `handleTierChange` now calls `writeLastTier("image", model, nextTier)` on every explicit pick, replacing the old in-blob `setLastUsedTiers` map (and its entry in the `useStudioSettingsWriter` payload).
- A module-level `const TIER_SCREEN = "image"` names this screen's sticky namespace.

**Convert-at-install (mlxTiers) models** are covered identically — they flow through the same `defaultTierSelection`/`installedTiers`, so the sticky seeds/saves for them exactly as for download-matrix models.

## Tests

- `apps/web/src/lastTierStore.test.js` (new): `(screen,model)` key isolation (model Y and other screens unaffected; same model on two screens holds two independent picks), persistence round-trip + corrupt-storage fallback, and precedence vs. `defaultTierSelection` (sticky beats the q8 base; sticky clamped to installed → sticky q8 with only q4 installed yields q4; no-sticky → q8 base; convert-at-install mlxTiers coverage).
- `apps/web/src/screens/ImageStudio.test.jsx` (new tests): sticky **persists across a fresh remount** (app-restart-equivalent) and seeds above the declared default; sticky stays **independent per model** (a q8 pick on model X does not surface on model Y).

## How I verified

`npx vitest run src/lastTierStore.test.js src/quantTier.test.js src/screens/ImageStudio.test.jsx --environment jsdom` → **96 passed**. `eslint` on all touched files → 0 errors (only pre-existing `react-hooks/exhaustive-deps` warnings in ImageStudio.jsx). The component tests mount the real `ImageStudio`, drive the actual picker, remount a fresh tree, and assert the seeded value — end-to-end proof of the seed/save wiring and persistence.

## Follow-ups / notes

- **Video Studio and Character Studio have no quant picker today** (they use `loadStudioSettings("video"|"character", …)` but render no tier control). The store is already screen-parameterized, so those surfaces adopt the sticky for free by calling `readLastTier`/`writeLastTier` with their screen key once they gain a picker. No seed/save site exists to wire there yet.
- **Not in scope** (separate stories): S4 global "Default generation quality" setting, S6 quality floor. The base default remains the hardcoded q8 in `defaultTierSelection`.
- One-time behavior change: existing per-project `lastUsedTiers` blobs are no longer read; a user's first pick after this lands re-establishes their sticky in the new project-independent store.

Story: https://app.shortcut.com/trefry/story/10727 (sc-10727)

🤖 Generated with [Claude Code](https://claude.com/claude-code)