### PR TITLE
feat(web): seed booru quality prefix + negative and prompt hint in text-to-image (sc-10760)

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -379,8 +379,13 @@ export const fallbackModels = [
     capabilities: ["text_to_image", "edit_image", "character_image", "style_variations"],
     ui: {
       description: "Danbooru-tag anime SDXL finetune from OnomaAI, trained for high-resolution illustration. Same SDXL UNet + dual CLIP, sdxl-family LoRA support, real CFG + negative prompt. Prompts blend Danbooru tags with natural language. Handles wide frames up to 1536x1536. SDXL license (openrail++), commercial use OK, ungated.",
+      // Danbooru-tag anime SDXL: same quality-prefix + booru-hint seam as Anima (sc-10760). Studio seeds
+      // defaultPrompt into an unedited prompt box and defaultNegativePrompt into an empty negative box.
+      defaultPrompt: "masterpiece, best quality, ",
       defaultNegativePrompt:
         "lowres, bad anatomy, bad hands, missing fingers, extra digits, worst quality, low quality, jpeg artifacts, signature, watermark, username, blurry",
+      promptHint:
+        "Danbooru-tag model: lead with the quality prefix and describe your subject as comma-separated tags (e.g. 1girl, solo, silver hair, ornate dress, dynamic pose). Plain sentences underperform tags.",
       promptGuide: { title: "Illustrious Prompt Guide", path: "/prompt-guides/illustrious.md" },
     },
   },
@@ -391,8 +396,12 @@ export const fallbackModels = [
     capabilities: ["text_to_image", "edit_image", "character_image", "style_variations"],
     ui: {
       description: "The v2.0-STABLE snapshot of Illustrious-XL — subtler and more stable than v1.0, but with a narrower safe frame width (it tends to duplicate the subject in wide compositions, so the widest aspect buckets are not offered — prefer square or tall). Same Danbooru-tag prompting and sdxl-family LoRA support. CreativeML OpenRAIL-M, commercial use OK, ungated.",
+      // Danbooru-tag anime SDXL: same quality-prefix + booru-hint seam as Anima (sc-10760).
+      defaultPrompt: "masterpiece, best quality, ",
       defaultNegativePrompt:
         "lowres, bad anatomy, bad hands, missing fingers, extra digits, worst quality, low quality, jpeg artifacts, signature, watermark, username, blurry",
+      promptHint:
+        "Danbooru-tag model: lead with the quality prefix and describe your subject as comma-separated tags (e.g. 1girl, solo, silver hair, ornate dress, dynamic pose). Plain sentences underperform tags.",
       promptGuide: { title: "Illustrious Prompt Guide", path: "/prompt-guides/illustrious.md" },
     },
   },

--- a/apps/web/src/promptSeed.js
+++ b/apps/web/src/promptSeed.js
@@ -1,0 +1,30 @@
+// Booru quality-prefix + negative seeding for the Image Studio prompt box (sc-10760). Anima and
+// Illustrious are danbooru-tag models: they render low-effort art from a bare natural-language sentence
+// and reward a quality prefix (`masterpiece, best quality, …`) plus tag-style prompting — exactly what
+// their model cards prescribe. The studio seeds the model-declared `ui.defaultPrompt` into an UNEDITED
+// prompt box and `ui.defaultNegativePrompt` into an EMPTY negative box, and shows `ui.promptHint` under
+// the box. These pure helpers hold the decisions so they can be unit-tested without rendering the studio.
+
+// The generic scene default the prompt box starts on. A model WITHOUT a `defaultPrompt` restores this in
+// an unedited box, so a booru quality prefix never lingers after the user switches to a non-booru model.
+export const DEFAULT_SCENE_PROMPT = "A cinematic frame of a neon street at midnight";
+
+// The prompt to seed into an UNEDITED text-to-image prompt box for a model's `ui`. Returns the model's
+// booru quality prefix when it declares a non-empty string `defaultPrompt`; otherwise the scene default.
+export function promptSeedFor(modelUi) {
+  const prefix = modelUi?.defaultPrompt;
+  return typeof prefix === "string" && prefix ? prefix : DEFAULT_SCENE_PROMPT;
+}
+
+// Whether the studio seeds a curated default negative into an EMPTY box in `mode`. Character mode has
+// always done this (sc-3857); text-to-image now does too (sc-10760) so booru models get their booru
+// negative there. Edit mode keeps whatever the user has.
+export function seedsNegativeInMode(mode) {
+  return mode === "character_image" || mode === "text_to_image";
+}
+
+// The booru prompt hint to render under the box for a model's `ui`, or null when none is declared.
+export function promptHintFor(modelUi) {
+  const hint = modelUi?.promptHint;
+  return typeof hint === "string" && hint ? hint : null;
+}

--- a/apps/web/src/promptSeed.test.js
+++ b/apps/web/src/promptSeed.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SCENE_PROMPT,
+  promptHintFor,
+  promptSeedFor,
+  seedsNegativeInMode,
+} from "./promptSeed.js";
+
+describe("promptSeedFor (sc-10760)", () => {
+  it("returns a booru model's defaultPrompt quality prefix", () => {
+    expect(promptSeedFor({ defaultPrompt: "masterpiece, best quality, " })).toBe(
+      "masterpiece, best quality, ",
+    );
+  });
+
+  it("falls back to the generic scene default when no defaultPrompt is declared", () => {
+    expect(promptSeedFor({ defaultNegativePrompt: "worst quality" })).toBe(DEFAULT_SCENE_PROMPT);
+    expect(promptSeedFor({})).toBe(DEFAULT_SCENE_PROMPT);
+    expect(promptSeedFor(undefined)).toBe(DEFAULT_SCENE_PROMPT);
+    expect(promptSeedFor(null)).toBe(DEFAULT_SCENE_PROMPT);
+  });
+
+  it("treats an empty-string defaultPrompt as absent (no stale prefix)", () => {
+    expect(promptSeedFor({ defaultPrompt: "" })).toBe(DEFAULT_SCENE_PROMPT);
+  });
+
+  it("ignores a non-string defaultPrompt", () => {
+    expect(promptSeedFor({ defaultPrompt: 42 })).toBe(DEFAULT_SCENE_PROMPT);
+  });
+});
+
+describe("seedsNegativeInMode (sc-3857, sc-10760)", () => {
+  it("seeds the booru negative in character AND text-to-image", () => {
+    expect(seedsNegativeInMode("character_image")).toBe(true);
+    expect(seedsNegativeInMode("text_to_image")).toBe(true);
+  });
+
+  it("does not seed in edit mode or unknown modes", () => {
+    expect(seedsNegativeInMode("edit_image")).toBe(false);
+    expect(seedsNegativeInMode("batch")).toBe(false);
+    expect(seedsNegativeInMode(undefined)).toBe(false);
+  });
+});
+
+describe("promptHintFor (sc-10760)", () => {
+  it("returns the declared booru hint", () => {
+    expect(promptHintFor({ promptHint: "Booru-tag model: keep the quality prefix" })).toBe(
+      "Booru-tag model: keep the quality prefix",
+    );
+  });
+
+  it("returns null when no hint is declared", () => {
+    expect(promptHintFor({})).toBe(null);
+    expect(promptHintFor(undefined)).toBe(null);
+    expect(promptHintFor({ promptHint: "" })).toBe(null);
+  });
+});

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -28,6 +28,12 @@ import {
 } from "../resolutionOverride.js";
 import { batchItemStatus, summarizeBatchRun } from "../batchOps.js";
 import {
+  DEFAULT_SCENE_PROMPT,
+  promptHintFor,
+  promptSeedFor,
+  seedsNegativeInMode,
+} from "../promptSeed.js";
+import {
   emptyCaption,
   orderCaption,
   parseMagicPromptCaption,
@@ -352,7 +358,7 @@ export function ImageStudio() {
   const [sceneSuggestions] = useState(() => pickSuggestions(4));
   const [characterSuggestions] = useState(() => pickSuggestions(4, CHARACTER_SUGGESTION_POOL));
   const [mode, setMode] = useState(() => normalizeImageMode(saved.mode));
-  const [prompt, setPrompt] = useState(saved.prompt ?? "A cinematic frame of a neon street at midnight");
+  const [prompt, setPrompt] = useState(saved.prompt ?? DEFAULT_SCENE_PROMPT);
   // True once the user types or picks a suggestion, so the character-mode default
   // prompt never clobbers their own wording. A restored prompt counts as edited so
   // re-entering character mode doesn't overwrite it.
@@ -766,6 +772,9 @@ export function ImageStudio() {
     }
   }, [pickerModels, model]);
   const selectedModel = imageModels.find((item) => item.id === model);
+  // Booru-convention prompt hint (sc-10760): non-null for danbooru-tag models (Anima, Illustrious)
+  // that declare `ui.promptHint`; rendered under the prompt box with a link into the prompt guide.
+  const promptHint = promptHintFor(selectedModel?.ui);
   // Prompt guide for the selected model; fall back to the generic image guide
   // when a model declares none, so the button is always useful (sc-1817).
   const promptGuide = selectedModel?.ui?.promptGuide ?? {
@@ -970,19 +979,33 @@ export function ImageStudio() {
       setPrompt(defaultCharacterPrompt(character));
     }
   }, [mode, characterId, characters]);
-  // Seed the model's curated default negative prompt when entering character mode
-  // with an empty box (sc-3857). InstantID/RealVisXL declares one to fight its
-  // shiny/over-saturated look; running character mode with an empty negative was
-  // the main reason Image Studio output trailed Character Studio. Only fills an
-  // empty box, so it never clobbers a typed, restored, or preset negative.
+  // Seed the model's curated default negative prompt into an EMPTY negative box (sc-3857, sc-10760).
+  // Originally character-mode only (InstantID/RealVisXL declares one to fight its shiny/over-saturated
+  // look); now also text-to-image, so booru models (Anima, Illustrious) get their booru negative there
+  // too — a bare negative was a big reason their anime renders looked worse. Only fills an empty box, so
+  // it never clobbers a typed, restored, or preset negative.
   useEffect(() => {
-    if (mode !== "character_image" || negativePrompt !== "") {
+    if (!seedsNegativeInMode(mode) || negativePrompt !== "") {
       return;
     }
     const ui = imageModels.find((item) => item.id === model)?.ui ?? {};
     if (typeof ui.defaultNegativePrompt === "string" && ui.defaultNegativePrompt) {
       setNegativePrompt(ui.defaultNegativePrompt);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, model]);
+  // Seed the model's booru quality prefix (`ui.defaultPrompt`) into an UNEDITED prompt box in
+  // text-to-image (sc-10760). Anima/Illustrious are danbooru-tag models that render low-effort art from a
+  // bare sentence; opening with `masterpiece, best quality,` and building on it is what their model cards
+  // recommend. Mirrors the character-mode prompt seed: only when `!promptEdited`, so it replaces the
+  // throwaway scene default, never the user's own wording. A model WITHOUT a defaultPrompt restores the
+  // generic scene default, so a stale prefix never lingers after switching to a non-booru model.
+  useEffect(() => {
+    if (mode !== "text_to_image" || promptEdited.current) {
+      return;
+    }
+    const ui = imageModels.find((item) => item.id === model)?.ui ?? {};
+    setPrompt(promptSeedFor(ui));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode, model]);
   const resolutionOptions = useMemo(
@@ -2136,6 +2159,19 @@ export function ImageStudio() {
           {submitError ? (
             <p className="structured-error" role="alert">
               {submitError}
+            </p>
+          ) : null}
+
+          {/* Booru-convention prompt hint (sc-10760): danbooru-tag models (Anima, Illustrious) declare
+              `ui.promptHint`, so the studio nudges toward the quality prefix + tag-style prompting the model
+              was trained on (a bare sentence renders low-effort art). Opens the existing prompt-guide modal.
+              Free-text models only. */}
+          {!structuredPromptModel && promptHint ? (
+            <p className="prompt-hint">
+              {promptHint}{" "}
+              <button className="prompt-hint-link" onClick={() => setGuideOpen(true)} type="button">
+                Prompt guide →
+              </button>
             </p>
           ) : null}
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2424,6 +2424,30 @@ label {
   color: var(--danger);
 }
 
+/* Booru-convention prompt hint (sc-10760): a muted nudge under the prompt box for danbooru-tag
+   models (Anima, Illustrious), with an inline link into the prompt-guide modal. */
+.prompt-hint {
+  margin: 6px 0 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-muted);
+}
+
+.prompt-hint-link {
+  background: none;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  color: var(--text);
+  text-decoration: underline;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.prompt-hint-link:hover {
+  opacity: 0.8;
+}
+
 /* Palette editor (sc-5996): swatch chips + native color picker. */
 .palette-editor {
   display: flex;

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -4257,10 +4257,16 @@
       "licenseUrl": "https://huggingface.co/circlestone-labs/Anima",
       "ui": {
         "label": "Anima 2B",
-        "description": "CircleStone Labs Anima 2B — an anime text-to-image model ported natively to MLX (Apple Silicon only). A Cosmos-Predict2 diffusion transformer conditioned by a compact query-token text adapter over a Qwen3-0.6B encoder, decoded through the Qwen-Image VAE. Runs ~30 steps at guidance 4.5 (flow-match, ER-SDE-3 sampler, shift 3.0). Uses the danbooru/booru tag convention — comma-separated lowercase tags, spaces not underscores, artists prefixed with `@`; strong prompt weighting works (e.g. `(chibi:2)`), applied to the text query tokens. Convert-at-install: the ~5.6 GB source is packed on-device into bf16 / q8 (default) / q4 tiers — q8 is the default (near-lossless, ≈bf16); pick bf16 for max fidelity (and, on this small 2B model, often the fastest on Apple Silicon), or q4 to save RAM. Distributed under the CircleStone Labs Non-Commercial License v1.2: generations are for non-commercial use only. Runs comfortably on a 16 GB-class Mac.",
+        "description": "CircleStone Labs Anima 2B — an anime text-to-image model ported natively to MLX (Apple Silicon only). A Cosmos-Predict2 diffusion transformer conditioned by a compact query-token text adapter over a Qwen3-0.6B encoder, decoded through the Qwen-Image VAE. Runs ~30 steps at guidance 4.5 (flow-match, ER-SDE-3 sampler, shift 3.0). Uses the danbooru/booru tag convention — comma-separated lowercase tags, spaces not underscores, artists prefixed with `@`; strong prompt weighting works (e.g. `(chibi:2)`), applied to the text query tokens. Convert-at-install: the ~5.6 GB source is packed on-device into bf16 / q8 (default) / q4 tiers — q8 is the default (near-lossless, ≈bf16); pick bf16 for max fidelity (and, on this small 2B model, often the fastest on Apple Silicon), or q4 for a softer, more painterly look (and to save RAM). Distributed under the CircleStone Labs Non-Commercial License v1.2: generations are for non-commercial use only. Runs comfortably on a 16 GB-class Mac.",
         "recommendedFor": ["text_to_image"],
-        // Booru negative-prompt prefix (sc-10523). Image Studio seeds this into an empty negative box.
+        // Booru quality prefix + negative (sc-10523, sc-10760). Image Studio seeds `defaultPrompt` into an
+        // UNEDITED prompt box and `defaultNegativePrompt` into an EMPTY negative box (text-to-image AND
+        // character mode). Anima is a danbooru-tag model that renders low-effort art from a bare sentence, so
+        // opening the prompt with the quality prefix and building on it is what the model card recommends.
+        // `promptHint` shows the inline booru tip under the prompt box (and opens the prompt guide).
+        "defaultPrompt": "masterpiece, best quality, ",
         "defaultNegativePrompt": "worst quality, low quality, score_1, score_2, score_3, artist name, blurry, jpeg artifacts, chromatic aberration",
+        "promptHint": "Booru-tag model: keep the quality prefix and describe your subject as comma-separated tags (e.g. 1girl, solo, pink hair, superhero costume, cape, dynamic pose). A plain sentence renders low-effort art.",
         "promptGuide": {
           "title": "Anima Prompt Guide",
           "path": "/prompt-guides/anima.md",
@@ -4341,9 +4347,12 @@
       "licenseUrl": "https://huggingface.co/circlestone-labs/Anima",
       "ui": {
         "label": "Anima 2B Aesthetic",
-        "description": "CircleStone Labs Anima 2B Aesthetic — the aesthetic fine-tune of Anima 2B, ported natively to MLX (Apple Silicon only). Same Cosmos-Predict2 transformer + query-token text adapter (Qwen3-0.6B) + Qwen-Image VAE as the base, tuned for a stronger aesthetic. Runs ~30 steps at guidance 4.5 (flow-match, ER-SDE-3 sampler, shift 3.0). Uses the danbooru/booru tag convention — comma-separated lowercase tags, spaces not underscores, artists prefixed with `@`; strong prompt weighting (e.g. `(chibi:2)`) works. Convert-at-install into bf16 / q8 (default) / q4 tiers. Distributed under the CircleStone Labs Non-Commercial License v1.2: non-commercial use only. Runs comfortably on a 16 GB-class Mac.",
+        "description": "CircleStone Labs Anima 2B Aesthetic — the aesthetic fine-tune of Anima 2B, ported natively to MLX (Apple Silicon only). Same Cosmos-Predict2 transformer + query-token text adapter (Qwen3-0.6B) + Qwen-Image VAE as the base, tuned for a stronger aesthetic. Runs ~30 steps at guidance 4.5 (flow-match, ER-SDE-3 sampler, shift 3.0). Uses the danbooru/booru tag convention — comma-separated lowercase tags, spaces not underscores, artists prefixed with `@`; strong prompt weighting (e.g. `(chibi:2)`) works. Convert-at-install into bf16 / q8 (default) / q4 (softer, painterly) tiers. Distributed under the CircleStone Labs Non-Commercial License v1.2: non-commercial use only. Runs comfortably on a 16 GB-class Mac.",
         "recommendedFor": ["text_to_image"],
+        // Booru quality prefix + negative (sc-10523, sc-10760) — same seams as anima_base.
+        "defaultPrompt": "masterpiece, best quality, ",
         "defaultNegativePrompt": "worst quality, low quality, score_1, score_2, score_3, artist name, blurry, jpeg artifacts, chromatic aberration",
+        "promptHint": "Booru-tag model: keep the quality prefix and describe your subject as comma-separated tags (e.g. 1girl, solo, pink hair, superhero costume, cape, dynamic pose). A plain sentence renders low-effort art.",
         "promptGuide": {
           "title": "Anima Prompt Guide",
           "path": "/prompt-guides/anima.md",
@@ -4428,7 +4437,11 @@
         "label": "Anima 2B Turbo",
         "description": "CircleStone Labs Anima 2B Turbo — the merged few-step student of Anima 2B, ported natively to MLX (Apple Silicon only). Same Cosmos-Predict2 transformer + query-token text adapter (Qwen3-0.6B) + Qwen-Image VAE, guidance-distilled to run CFG-free in ~10 steps (much faster than the 30-step base). Uses the danbooru/booru tag convention — comma-separated lowercase tags, spaces not underscores, artists prefixed with `@`; strong prompt weighting (e.g. `(chibi:2)`) works. Convert-at-install into bf16 / q8 (default) / q4 tiers. Distributed under the CircleStone Labs Non-Commercial License v1.2: non-commercial use only. Runs comfortably on a 16 GB-class Mac.",
         "recommendedFor": ["text_to_image"],
+        // Booru quality prefix + negative (sc-10523, sc-10760) — same seams as anima_base. (Turbo is CFG-free,
+        // so its q4 tier stays crisp — no painterly note in the description.)
+        "defaultPrompt": "masterpiece, best quality, ",
         "defaultNegativePrompt": "worst quality, low quality, score_1, score_2, score_3, artist name, blurry, jpeg artifacts, chromatic aberration",
+        "promptHint": "Booru-tag model: keep the quality prefix and describe your subject as comma-separated tags (e.g. 1girl, solo, pink hair, superhero costume, cape, dynamic pose). A plain sentence renders low-effort art.",
         "promptGuide": {
           "title": "Anima Prompt Guide",
           "path": "/prompt-guides/anima.md",


### PR DESCRIPTION
## Why

Owner reported Anima **base/aesthetic** produce "drawn by a 5-year-old" quality — even at **bf16**, the cleanest tier — for a plain prompt (`A cute female anime super hero with pink hair`), while turbo is fine. This is distinct from the q4×CFG smudge ([sc-10714](https://app.shortcut.com/trefry/story/10714), fixed via the Q8 default).

## Diagnosis (verified with real weights, parity-confirmed against the app)

It's **prompting, not a pipeline bug.** Anima is a danbooru-tag model; its model card prescribes a quality prefix (`masterpiece, best quality, …`) and, for natural language, "at least 2 sentences." A bare 8-word sentence renders a low-effort **chibi**. Holding model, seed, and settings constant and changing **only** the prompt to proper booru tags turns the chibi into a professional superhero illustration. Turbo (CFG-free, aesthetic/RL-tuned) masks the gap.

A full **bf16/q8/q4 × plain/booru** matrix (worker generator path) was **byte-identical to the app** (owner confirmed "your images are all identical to mine"). Two independent axes:
- **Prompt = dominant** (chibi ↔ polished at every tier) — this PR.
- **Quant = secondary** (bf16 ≈ q8 crisp; q4 softer/painterly) — already fixed via the Q8 default.

The real UX gap: in **text-to-image** the Studio seeded **neither** the quality prefix (no mechanism existed) **nor** the booru negative (that seed was gated to character mode). The worker adds nothing — the prompt reaches the DiT verbatim.

## What this does

- **`ui.defaultPrompt`** (new generic seam): seed the model's quality prefix into an **unedited** prompt box in text-to-image, mirroring the existing character-mode prompt seed (`!promptEdited` only, never clobbers typed/restored/preset text). A model without one restores the generic scene default, so a stale prefix never lingers after switching to a non-booru model.
- **Ungate `ui.defaultNegativePrompt`** seeding so it fires in text-to-image too (was character-mode only). Only fills an empty box.
- **`ui.promptHint`** (new): a muted booru tip under the prompt box that opens the existing prompt-guide modal.
- **Honest q4 relabel** for base/aesthetic descriptions (softer/painterly, per the owner's "painted not drawn" observation); **turbo q4 stays crisp** (CFG-free, so no wash).
- Wired for **Anima** (3 variants, `builtin.models.jsonc`) and **Illustrious-XL v1/v2** (`constants.js`, same `masterpiece, best quality` opener). Logic lives in pure `promptSeed.js` helpers.

## Testing

- New `promptSeed.test.js` (8 tests) covering the prefix/negative/hint decisions incl. empty/absent/non-string fallbacks.
- Full web vitest suite green: **1419 tests**. eslint clean (0 errors). Manifest JSONC re-validated.
- Not browser-verified here: this is a data-driven catalog seed and the dev API serves a stale seeded catalog (`SeedMode::IfMissing`) that wouldn't reflect the manifest edits — a live check belongs on a real build. Logic is pure and fully unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)