### PR TITLE
feat(web): global default generation quality setting (sc-10728)

### DIFF
--- a/apps/rust-api/src/preferences.rs
+++ b/apps/rust-api/src/preferences.rs
@@ -22,12 +22,29 @@ pub(crate) struct UiPreferences {
     /// Last-used accent palette id (see `ACCENT_IDS`); absent until first set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     accent: Option<String>,
+    /// App-wide default generation quality (`bf16`|`q8`|`q4`); the baseline quant tier
+    /// new generations use when no per-(screen,model) sticky pick exists (sc-10728).
+    /// Absent in the stored file until first set — but the GET response always resolves
+    /// an absent/invalid value to the q8 default, so the web always has a value to seed.
+    /// Made durable through this API (not just origin-keyed `localStorage`) for the same
+    /// reason as theme/accent: the desktop shell's `127.0.0.1:<port>` origin changes every
+    /// launch, wiping `localStorage`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    default_generation_quality: Option<String>,
 }
 
 /// User-selectable accent palettes. Keep in sync with web/src/accents.js.
 const ACCENT_IDS: [&str; 7] = [
     "teal", "indigo", "cobalt", "violet", "coral", "amber", "emerald",
 ];
+
+/// User-facing generation-quality tiers. Keep in sync with
+/// web/src/quantTier.js `GENERATION_QUALITY_TIERS`.
+const GENERATION_QUALITY_IDS: [&str; 3] = ["bf16", "q8", "q4"];
+
+/// The app-wide default generation quality when unset or invalid. Matches the worker's
+/// generation default (sc-10726) and the web `DEFAULT_GENERATION_QUALITY`.
+const DEFAULT_GENERATION_QUALITY: &str = "q8";
 
 fn preferences_path(state: &AppState) -> PathBuf {
     state.settings.config_dir.join(PREFERENCES_FILENAME)
@@ -66,15 +83,36 @@ fn normalize_accent(input: Option<&str>) -> Option<String> {
         .map(|id| (*id).to_owned())
 }
 
+/// The valid stored generation quality for `input`, falling back to the q8 default when
+/// it's absent or not one of `bf16`|`q8`|`q4`. Unlike theme/accent (which return `None`
+/// for an unknown value so a partial PUT leaves the stored value untouched), the quality
+/// setting has a defined app-wide default, so this resolves to it. The PUT merge only
+/// invokes this when the payload actually carries the field, so a theme-only PUT never
+/// clobbers a previously-set value.
+fn normalize_generation_quality(input: Option<&str>) -> String {
+    match input.map(str::trim) {
+        Some(value) if GENERATION_QUALITY_IDS.contains(&value) => value.to_owned(),
+        _ => DEFAULT_GENERATION_QUALITY.to_owned(),
+    }
+}
+
 /// Current UI preferences (empty object on first run).
 pub(crate) async fn get_ui_preferences(
     State(state): State<AppState>,
 ) -> Result<Json<UiPreferences>, ApiError> {
     // sc-4202 (F-API-3): keep the preferences-file read off the async executor.
     let path = preferences_path(&state);
-    let prefs = tokio::task::spawn_blocking(move || load_preferences(&path))
-        .await
-        .map_err(|err| ApiError::internal(format!("UI preferences load task failed: {err}")))?;
+    let prefs = tokio::task::spawn_blocking(move || {
+        let mut prefs = load_preferences(&path);
+        // Always hand the web a concrete quality tier to seed (q8 when unset/invalid), so the
+        // durable value survives a desktop relaunch even before the user changes it.
+        prefs.default_generation_quality = Some(normalize_generation_quality(
+            prefs.default_generation_quality.as_deref(),
+        ));
+        prefs
+    })
+    .await
+    .map_err(|err| ApiError::internal(format!("UI preferences load task failed: {err}")))?;
     Ok(Json(prefs))
 }
 
@@ -95,6 +133,13 @@ pub(crate) async fn set_ui_preferences(
         if let Some(accent) = normalize_accent(payload.accent.as_deref()) {
             prefs.accent = Some(accent);
         }
+        // Only touch the quality when the payload actually carries it, so a theme- or
+        // accent-only PUT can't reset it. A present-but-invalid value coerces to q8.
+        if payload.default_generation_quality.is_some() {
+            prefs.default_generation_quality = Some(normalize_generation_quality(
+                payload.default_generation_quality.as_deref(),
+            ));
+        }
         save_preferences(&path, &prefs)?;
         Ok(prefs)
     })
@@ -106,7 +151,7 @@ pub(crate) async fn set_ui_preferences(
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_accent, normalize_theme};
+    use super::{normalize_accent, normalize_generation_quality, normalize_theme};
 
     #[test]
     fn normalize_theme_accepts_only_known_themes() {
@@ -126,5 +171,16 @@ mod tests {
         assert_eq!(normalize_accent(Some("amber")), Some("amber".to_owned()));
         assert_eq!(normalize_accent(Some("fuchsia")), None);
         assert_eq!(normalize_accent(None), None);
+    }
+
+    #[test]
+    fn normalize_generation_quality_accepts_only_known_tiers_and_defaults_to_q8() {
+        assert_eq!(normalize_generation_quality(Some(" bf16 ")), "bf16");
+        assert_eq!(normalize_generation_quality(Some("q8")), "q8");
+        assert_eq!(normalize_generation_quality(Some("q4")), "q4");
+        // Unknown/candle-only tiers and absent values fall back to the q8 default.
+        assert_eq!(normalize_generation_quality(Some("int8-convrot")), "q8");
+        assert_eq!(normalize_generation_quality(Some("")), "q8");
+        assert_eq!(normalize_generation_quality(None), "q8");
     }
 }

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -10620,6 +10620,65 @@ async fn ui_preferences_put_open_when_no_token_configured() {
     assert_eq!(saved["theme"], "dark");
 }
 
+#[tokio::test]
+async fn ui_preferences_default_generation_quality_round_trips_and_merges() {
+    // sc-10728: the app-wide default generation quality persists like theme/accent so it
+    // survives a desktop relaunch — the shell's per-launch 127.0.0.1:<port> origin wipes
+    // origin-keyed localStorage, so the durable copy must live server-side. GET resolves an
+    // unset value to the q8 default; PUT accepts bf16|q8|q4 and MERGES, so a theme-only
+    // write can't reset a previously-chosen quality, and an invalid value coerces to q8.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir); // no token configured ⇒ PUT is open
+    assert!(settings.access_token.is_empty());
+    let app = create_app(settings).expect("app creates");
+
+    // Fresh install: GET resolves the absent value to the q8 default so the web can seed it.
+    let (status, prefs) = request(app.clone(), "GET", "/api/v1/ui-preferences", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(prefs["defaultGenerationQuality"], "q8");
+
+    // PUT a valid tier: persisted and echoed back.
+    let (status, saved) = request(
+        app.clone(),
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "defaultGenerationQuality": "q4" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(saved["defaultGenerationQuality"], "q4");
+
+    // Survives a "relaunch": a fresh GET reads it back from disk.
+    let (status, prefs) = request(app.clone(), "GET", "/api/v1/ui-preferences", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(prefs["defaultGenerationQuality"], "q4");
+
+    // A partial PUT (theme only) MERGES — it must not clobber the stored quality.
+    let (status, _) = request(
+        app.clone(),
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "theme": "dark" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (status, prefs) = request(app.clone(), "GET", "/api/v1/ui-preferences", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(prefs["defaultGenerationQuality"], "q4");
+    assert_eq!(prefs["theme"], "dark");
+
+    // A present-but-invalid tier coerces to the q8 default (defensive; the UI never sends one).
+    let (status, saved) = request(
+        app,
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "defaultGenerationQuality": "int8-convrot" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(saved["defaultGenerationQuality"], "q8");
+}
+
 #[test]
 fn requires_token_only_gates_api_paths() {
     use axum::http::Method;

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -39,6 +39,7 @@ import { useJobEvents } from "./hooks/useJobEvents.js";
 import { AppStaticContext, AppLiveContext } from "./context/AppContext.js";
 import { DEFAULT_MAC_CAPABILITIES } from "./macGating.js";
 import { isAccentId } from "./accents.js";
+import { writeDefaultGenerationQuality } from "./generationQuality.js";
 import {
   dropUpscaledVariants,
   findFoldedAssetById,
@@ -898,6 +899,14 @@ export function App() {
         }
         if (isAccentId(prefs?.accent)) {
           setAccent(prefs.accent);
+        }
+        // Re-prime the default-generation-quality cache from the durable server copy (sc-10728).
+        // It isn't React state here — the studio reads it fresh from localStorage via
+        // readDefaultGenerationQuality() — so seeding the cache is all that's needed for it to
+        // survive a desktop relaunch (the GET always resolves a concrete tier). writeDefault…
+        // normalizes, so an absent/legacy value lands on q8. No PUT: this is a read-only seed.
+        if (prefs?.defaultGenerationQuality) {
+          writeDefaultGenerationQuality(prefs.defaultGenerationQuality);
         }
       })
       .catch(() => {});

--- a/apps/web/src/App.shell.test.jsx
+++ b/apps/web/src/App.shell.test.jsx
@@ -250,6 +250,42 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Queue");
   });
 
+  // sc-10728: the global default generation quality is durable across desktop relaunches only
+  // because App re-seeds the localStorage instant-paint cache from the server copy on mount — the
+  // shell's per-launch 127.0.0.1:<port> origin wipes origin-keyed localStorage every launch. This
+  // asserts the launch-time GET /ui-preferences primes readDefaultGenerationQuality()'s cache.
+  it("re-seeds the default generation quality cache from the server on mount (sc-10728)", async () => {
+    window.localStorage.clear(); // simulate the wiped cache after a relaunch under a new origin
+    global.fetch = vi.fn((url) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/jobs/events/ticket")) {
+        return Promise.resolve(response({ ticket: "stream-ticket" }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-default", name: "Default Project" }]));
+      }
+      if (path.endsWith("/ui-preferences")) {
+        // The durable server copy the desktop shell persisted in a previous session.
+        return Promise.resolve(response({ defaultGenerationQuality: "q4" }));
+      }
+      return Promise.resolve(response([]));
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    expect(window.localStorage.getItem("sceneworks-default-generation-quality")).toBe("q4");
+  });
+
   // sc-4193 regression (F-WEB-3): the queueCounts memo reads queueSummary, so a
   // queue.updated SSE event (which changes queueSummary but NOT jobs) must refresh
   // the topbar "Queue N" chip. Before the fix the memo's deps were [jobs] only, so

--- a/apps/web/src/generationQuality.js
+++ b/apps/web/src/generationQuality.js
@@ -1,0 +1,62 @@
+// Global "default generation quality" setting (epic 10721 / sc-10728): the app-wide baseline quant
+// tier new generations use when the user hasn't stickied a tier for a specific model. Set once in
+// Settings, applied everywhere as precedence rung 3 — below the per-(screen,model) sticky
+// (lastTierStore) and above clamp-to-installed. It replaces the old hardcoded q8 base fallback in
+// `defaultTierSelection`, which now reads it via `options.defaultQuality`.
+//
+// Persistence reuses the app's per-UI-pref pattern — a single value in localStorage behind a
+// try/catch guard, mirroring the theme/accent helpers in appHelpers.js — rather than the
+// (screen,model)-keyed lastTierStore (that store answers "which tier did you last pick FOR THIS
+// MODEL"; this answers the app-wide baseline, one dimension, no keying).
+//
+// Vocabulary is bf16|q8|q4 (the three user-facing quality tiers); default q8, matching the worker's
+// generation default (sc-10726). int8-convrot is deliberately NOT a global-default option — it is a
+// candle-only niche tier, not a sensible app-wide baseline, and would be filtered out downstream.
+
+import { DEFAULT_GENERATION_QUALITY, GENERATION_QUALITY_TIERS } from "./quantTier.js";
+
+// Re-exported so consumers of the setting (Settings UI, studios) get the vocabulary + default from one
+// import without also reaching into quantTier.js.
+export { DEFAULT_GENERATION_QUALITY, GENERATION_QUALITY_TIERS } from "./quantTier.js";
+
+const STORAGE_KEY = "sceneworks-default-generation-quality";
+
+// Legible Settings labels, keyed by tier. Unknown keys fall back to the raw key.
+const LABELS = {
+  bf16: "High fidelity (bf16)",
+  q8: "Balanced (Q8)",
+  q4: "Fast (Q4)",
+};
+
+export function generationQualityLabel(value) {
+  return LABELS[value] ?? value;
+}
+
+// The valid quality tier for `value`, or the q8 default when it isn't one of bf16|q8|q4.
+export function normalizeGenerationQuality(value) {
+  return GENERATION_QUALITY_TIERS.includes(value) ? value : DEFAULT_GENERATION_QUALITY;
+}
+
+// The persisted global default generation quality, or q8 when unset / invalid / localStorage is
+// unavailable (private mode, quota, non-DOM env). Reads fresh on every call (no in-memory cache) so a
+// value written in a previous session survives a restart and a change made in Settings is picked up the
+// next time a studio derives a default tier.
+export function readDefaultGenerationQuality() {
+  try {
+    return normalizeGenerationQuality(window.localStorage.getItem(STORAGE_KEY));
+  } catch {
+    return DEFAULT_GENERATION_QUALITY;
+  }
+}
+
+// Persist `value` (normalized to a valid tier) as the global default and return what was stored, so the
+// caller can reflect the canonical value in its UI state.
+export function writeDefaultGenerationQuality(value) {
+  const next = normalizeGenerationQuality(value);
+  try {
+    window.localStorage.setItem(STORAGE_KEY, next);
+  } catch {
+    // localStorage unavailable — the setting just won't persist this session.
+  }
+  return next;
+}

--- a/apps/web/src/generationQuality.js
+++ b/apps/web/src/generationQuality.js
@@ -4,10 +4,14 @@
 // (lastTierStore) and above clamp-to-installed. It replaces the old hardcoded q8 base fallback in
 // `defaultTierSelection`, which now reads it via `options.defaultQuality`.
 //
-// Persistence reuses the app's per-UI-pref pattern — a single value in localStorage behind a
-// try/catch guard, mirroring the theme/accent helpers in appHelpers.js — rather than the
-// (screen,model)-keyed lastTierStore (that store answers "which tier did you last pick FOR THIS
-// MODEL"; this answers the app-wide baseline, one dimension, no keying).
+// Persistence mirrors theme/accent (sc-10728): the durable copy lives server-side in
+// `ui-preferences.json`, written through `PUT /api/v1/ui-preferences` by the Settings change handler
+// and re-seeded from `GET /api/v1/ui-preferences` on launch (App.jsx). localStorage is only an
+// instant-paint cache — the read/write helpers below touch it — because on the desktop shell the UI
+// runs at the API's per-launch `http://127.0.0.1:<port>` origin, where origin-keyed localStorage does
+// NOT survive a relaunch (the port, and so the origin, changes every launch). This is one app-wide
+// dimension, not the (screen,model)-keyed lastTierStore ("which tier did you last pick FOR THIS
+// MODEL").
 //
 // Vocabulary is bf16|q8|q4 (the three user-facing quality tiers); default q8, matching the worker's
 // generation default (sc-10726). int8-convrot is deliberately NOT a global-default option — it is a
@@ -37,10 +41,11 @@ export function normalizeGenerationQuality(value) {
   return GENERATION_QUALITY_TIERS.includes(value) ? value : DEFAULT_GENERATION_QUALITY;
 }
 
-// The persisted global default generation quality, or q8 when unset / invalid / localStorage is
-// unavailable (private mode, quota, non-DOM env). Reads fresh on every call (no in-memory cache) so a
-// value written in a previous session survives a restart and a change made in Settings is picked up the
-// next time a studio derives a default tier.
+// The global default generation quality from the instant-paint cache, or q8 when unset / invalid /
+// localStorage is unavailable (private mode, quota, non-DOM env). Reads fresh on every call (no
+// in-memory cache) so a value seeded from the server on launch — or changed in Settings — is picked up
+// the next time a studio derives a default tier. On desktop the cache is re-seeded from the durable
+// server copy at launch (App.jsx), so it reflects the previous session even after the origin changed.
 export function readDefaultGenerationQuality() {
   try {
     return normalizeGenerationQuality(window.localStorage.getItem(STORAGE_KEY));
@@ -49,14 +54,16 @@ export function readDefaultGenerationQuality() {
   }
 }
 
-// Persist `value` (normalized to a valid tier) as the global default and return what was stored, so the
-// caller can reflect the canonical value in its UI state.
+// Write `value` (normalized to a valid tier) into the instant-paint localStorage cache and return what
+// was stored. This is ONLY the cache write; the durable copy is persisted separately through
+// `PUT /api/v1/ui-preferences` (see SettingsScreen.changeDefaultQuality). The launch-time seed also
+// calls this to prime the cache from the server without echoing a redundant PUT back.
 export function writeDefaultGenerationQuality(value) {
   const next = normalizeGenerationQuality(value);
   try {
     window.localStorage.setItem(STORAGE_KEY, next);
   } catch {
-    // localStorage unavailable — the setting just won't persist this session.
+    // localStorage unavailable — the cache just won't persist this session (the server copy still does).
   }
   return next;
 }

--- a/apps/web/src/generationQuality.test.js
+++ b/apps/web/src/generationQuality.test.js
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_GENERATION_QUALITY,
+  generationQualityLabel,
+  normalizeGenerationQuality,
+  readDefaultGenerationQuality,
+  writeDefaultGenerationQuality,
+} from "./generationQuality.js";
+
+const STORAGE_KEY = "sceneworks-default-generation-quality";
+
+describe("generationQuality store (sc-10728)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("defaults to q8 when nothing is stored", () => {
+    expect(DEFAULT_GENERATION_QUALITY).toBe("q8");
+    expect(readDefaultGenerationQuality()).toBe("q8");
+  });
+
+  it("reads back a valid stored value", () => {
+    window.localStorage.setItem(STORAGE_KEY, "bf16");
+    expect(readDefaultGenerationQuality()).toBe("bf16");
+    window.localStorage.setItem(STORAGE_KEY, "q4");
+    expect(readDefaultGenerationQuality()).toBe("q4");
+  });
+
+  it("normalizes an unknown/garbage stored value back to q8", () => {
+    window.localStorage.setItem(STORAGE_KEY, "int8-convrot");
+    expect(readDefaultGenerationQuality()).toBe("q8");
+    window.localStorage.setItem(STORAGE_KEY, "totally-bogus");
+    expect(readDefaultGenerationQuality()).toBe("q8");
+  });
+
+  it("persists a write and survives a simulated restart (round-trip)", () => {
+    // writeDefaultGenerationQuality returns the normalized value it stored…
+    expect(writeDefaultGenerationQuality("bf16")).toBe("bf16");
+    // …and a fresh read (no in-memory cache) returns it, mimicking a new session.
+    expect(readDefaultGenerationQuality()).toBe("bf16");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("bf16");
+  });
+
+  it("write normalizes an invalid value to q8 before persisting", () => {
+    expect(writeDefaultGenerationQuality("nonsense")).toBe("q8");
+    expect(readDefaultGenerationQuality()).toBe("q8");
+  });
+
+  it("normalizeGenerationQuality validates against bf16|q8|q4", () => {
+    expect(normalizeGenerationQuality("bf16")).toBe("bf16");
+    expect(normalizeGenerationQuality("q8")).toBe("q8");
+    expect(normalizeGenerationQuality("q4")).toBe("q4");
+    expect(normalizeGenerationQuality("int8-convrot")).toBe("q8");
+    expect(normalizeGenerationQuality(null)).toBe("q8");
+    expect(normalizeGenerationQuality(undefined)).toBe("q8");
+  });
+
+  it("labels each tier legibly and falls back to the raw key", () => {
+    expect(generationQualityLabel("bf16")).toBe("High fidelity (bf16)");
+    expect(generationQualityLabel("q8")).toBe("Balanced (Q8)");
+    expect(generationQualityLabel("q4")).toBe("Fast (Q4)");
+    expect(generationQualityLabel("mystery")).toBe("mystery");
+  });
+});

--- a/apps/web/src/quantTier.js
+++ b/apps/web/src/quantTier.js
@@ -20,6 +20,17 @@ const TIER_QUANTIZE = {
   q4: 4,
 };
 
+// The three user-facing generation-quality tiers, in fidelity order — the vocabulary the global
+// "default generation quality" setting (epic 10721 / sc-10728) ranges over. int8-convrot is
+// intentionally excluded: it's a candle-only niche tier, not a sensible app-wide default.
+export const GENERATION_QUALITY_TIERS = ["bf16", "q8", "q4"];
+
+// The app-wide base default generation tier used when no global setting, sticky, or manifest default
+// applies (epic 10721 / sc-10726). Q8 matches the worker's generation default. `defaultTierSelection`
+// uses it as the fallback base whenever `options.defaultQuality` is absent or invalid, so every legacy
+// call site (and the worker) stays consistent on Q8.
+export const DEFAULT_GENERATION_QUALITY = "q8";
+
 // The candle-only Krea 2 INT8-ConvRot tier key (sc-9300, epic 9083). NOT a bits-based quant — the
 // online-rotation int8 DiT can't be expressed as an `mlxQuantize` value — so it is DELIBERATELY absent
 // from TIER_QUANTIZE and instead sends a distinct `advanced.convRot: true` signal (see
@@ -142,16 +153,19 @@ function defaultInstalledTier(model, tiers) {
   return declared ? declared.variant : null;
 }
 
-// The tier the picker should start on for `model`. Preference order:
-//   1. `lastUsed` — the per-model last-used tier, when it is still installed (persistence).
-//   2. the model's declared default tier (`variant.default: true`), when installed.
-//   3. q8 if installed (epic 10721 / sc-10726 — Q8 is the app-wide default generation tier, replacing
-//      the old q4 base convention; clamped to installed so it only wins when q8 is actually present).
-//      A later story (S4) sources this from a global user setting; here it is the hardcoded base default.
-//   4. q4 if installed (clean-tiers fallback so a q4-only install still seeds a real tier, not null).
-//   5. the first installed tier.
-// Returns null when nothing is installed (no picker will render anyway). `options` (sc-9300) forwards
-// the `convRotEligible` gate so a hidden INT8-ConvRot tier is never seeded as the selection.
+// The tier the picker should start on for `model`. Preference order (epic-locked, epic 10721):
+//   1. `lastUsed` — the per-(screen,model) sticky tier, when it is still installed (rung 2, sc-10727).
+//   2. the model's declared default tier (`variant.default: true`), when installed. (Dead against the
+//      real catalog — the backend never emits `default` — but kept so a manifest that does still wins.)
+//   3. the global "default generation quality" setting (rung 3, sc-10728) — `options.defaultQuality`,
+//      one of bf16|q8|q4. Absent/invalid falls back to `DEFAULT_GENERATION_QUALITY` (q8), matching the
+//      worker's generation default. Clamped to installed: the base leads a clean-tier fallback so an
+//      uninstalled base resolves to the nearest installed clean tier rather than null. Convert-at-install
+//      models (mlxTiers, sc-10730) fall through bf16 before q4; download-matrix models fall q8 → q4.
+//   4. the first installed tier.
+// Returns null when nothing is installed (no picker will render anyway). `options` also forwards the
+// `convRotEligible` gate (sc-9300) so a hidden INT8-ConvRot tier is never seeded as the selection —
+// and because `defaultQuality` can only ever be bf16|q8|q4, it never re-introduces a filtered tier.
 export function defaultTierSelection(model, lastUsed, options = {}) {
   const tiers = installedTiers(model, options);
   if (tiers.length === 0) {
@@ -164,14 +178,19 @@ export function defaultTierSelection(model, lastUsed, options = {}) {
   if (declared) {
     return declared;
   }
-  // Q8 is the app-wide base default (epic 10721 / sc-10726), matching the worker's Q8 generation
-  // default and replacing the old q4-hard-default so the picker never silently sends the washed q4.
-  // Clamped to installed. Convert-at-install models (mlxTiers, sc-10730) additionally prefer bf16
-  // over q4 as the clean-tier fallback when q8 isn't on disk; download-matrix models fall q8 → q4.
-  const preferred =
+  // Rung 3: the global default-generation-quality setting is the app-wide base default. The caller
+  // passes it as `options.defaultQuality`; an absent/invalid value falls back to Q8 (the historical
+  // base + worker default) so legacy call sites are unchanged. The base leads a clean-tier fallback so
+  // it is always clamped to what's installed — a base tier that isn't on disk resolves to the nearest
+  // installed clean tier (never the washed q4 unless that's all that's left), never null.
+  const base = GENERATION_QUALITY_TIERS.includes(options.defaultQuality)
+    ? options.defaultQuality
+    : DEFAULT_GENERATION_QUALITY;
+  const cleanFallback =
     !model?.hasVariantMatrix && Array.isArray(model?.mlxTiers)
       ? ["q8", "bf16", "q4"]
       : ["q8", "q4"];
+  const preferred = [base, ...cleanFallback.filter((tier) => tier !== base)];
   for (const tier of preferred) {
     if (tiers.includes(tier)) {
       return tier;

--- a/apps/web/src/quantTier.test.js
+++ b/apps/web/src/quantTier.test.js
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_GENERATION_QUALITY,
+  GENERATION_QUALITY_TIERS,
   defaultTierSelection,
   installedTiers,
   isConvRotTier,
@@ -169,6 +171,78 @@ describe("defaultTierSelection", () => {
   it("returns null when nothing is installed", () => {
     expect(defaultTierSelection(matrixModel({ installed: [] }), null)).toBe(null);
     expect(defaultTierSelection({ id: "x", hasVariantMatrix: false }, null)).toBe(null);
+  });
+});
+
+// Global "default generation quality" setting (epic 10721 / sc-10728): the app-wide base default is
+// no longer hardcoded q8 — the caller passes the user's persisted preference as options.defaultQuality
+// (precedence rung 3: below the per-(screen,model) sticky, above clamp-to-installed). Absent/invalid
+// falls back to q8 (the historical base + worker default), so every existing call site is unchanged.
+describe("defaultTierSelection — global defaultQuality setting (sc-10728)", () => {
+  it("exposes q8 as the app-wide default and bf16|q8|q4 as the setting's vocabulary", () => {
+    expect(DEFAULT_GENERATION_QUALITY).toBe("q8");
+    expect(GENERATION_QUALITY_TIERS).toEqual(["bf16", "q8", "q4"]);
+  });
+
+  it("defaults the base to q8 when no defaultQuality is supplied", () => {
+    const model = matrixModel({ installed: ["q4", "q8", "bf16"], defaultTier: "none" });
+    // No options / empty options → the q8 base default (unchanged legacy behavior).
+    expect(defaultTierSelection(model, null)).toBe("q8");
+    expect(defaultTierSelection(model, null, {})).toBe("q8");
+  });
+
+  it("uses the supplied global setting as the base default for a no-sticky model", () => {
+    const model = matrixModel({ installed: ["q4", "q8", "bf16"], defaultTier: "none" });
+    expect(defaultTierSelection(model, null, { defaultQuality: "bf16" })).toBe("bf16");
+    expect(defaultTierSelection(model, null, { defaultQuality: "q4" })).toBe("q4");
+    expect(defaultTierSelection(model, null, { defaultQuality: "q8" })).toBe("q8");
+  });
+
+  it("applies the global setting to convert-at-install (mlxTiers) models too", () => {
+    const model = convertModel({ mlxTiers: ["q4", "q8", "bf16"] });
+    expect(defaultTierSelection(model, null, { defaultQuality: "bf16" })).toBe("bf16");
+    expect(defaultTierSelection(model, null, { defaultQuality: "q4" })).toBe("q4");
+  });
+
+  it("lets a per-(screen,model) sticky (lastUsed) still beat the global setting", () => {
+    const model = matrixModel({ installed: ["q4", "q8", "bf16"], defaultTier: "none" });
+    // Global setting says bf16, but the user has a sticky q4 for this model → sticky wins (rung 2).
+    expect(defaultTierSelection(model, "q4", { defaultQuality: "bf16" })).toBe("q4");
+  });
+
+  it("clamps the global setting to installed (bf16 set, only q4 installed → q4)", () => {
+    const model = matrixModel({ tiers: ["q4", "q8", "bf16"], installed: ["q4"], defaultTier: "none" });
+    expect(defaultTierSelection(model, null, { defaultQuality: "bf16" })).toBe("q4");
+  });
+
+  it("falls up from an uninstalled global setting to the nearest clean installed tier", () => {
+    // Global setting q4, but only q8 + bf16 are installed → clamp up to the clean q8, never null.
+    const model = matrixModel({ tiers: ["q4", "q8", "bf16"], installed: ["q8", "bf16"], defaultTier: "none" });
+    expect(defaultTierSelection(model, null, { defaultQuality: "q4" })).toBe("q8");
+  });
+
+  it("ignores an invalid global setting and uses the q8 base default", () => {
+    const model = matrixModel({ installed: ["q4", "q8", "bf16"], defaultTier: "none" });
+    expect(defaultTierSelection(model, null, { defaultQuality: "int8-convrot" })).toBe("q8");
+    expect(defaultTierSelection(model, null, { defaultQuality: "bogus" })).toBe("q8");
+  });
+
+  it("still honors a manifest-declared default over the global setting", () => {
+    // The declared per-model default (rung above the base) is honored even when the global setting differs.
+    const model = matrixModel({ installed: ["q4", "q8", "bf16"], defaultTier: "q4" });
+    expect(defaultTierSelection(model, null, { defaultQuality: "bf16" })).toBe("q4");
+  });
+
+  it("does not let the global setting override an ineligible convrot host filter", () => {
+    // defaultQuality can only ever be bf16|q8|q4, so it never re-introduces a hidden convrot tier.
+    const model = matrixModel({
+      tiers: [INT8_CONVROT_TIER, "bf16"],
+      installed: [INT8_CONVROT_TIER, "bf16"],
+      defaultTier: "none",
+    });
+    expect(
+      defaultTierSelection(model, null, { defaultQuality: "q4", convRotEligible: false }),
+    ).toBe("bf16");
   });
 });
 

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -130,6 +130,7 @@ import {
   tierLabel,
 } from "../quantTier.js";
 import { readLastTier, writeLastTier } from "../lastTierStore.js";
+import { readDefaultGenerationQuality } from "../generationQuality.js";
 import { PROMPT_REFINE_MODEL_ID, VISION_CAPTION_MODEL_ID, VISION_CAPTION_MODEL_REPO } from "../constants.js";
 import { pickClosestResolution } from "../resolutionMatch.js";
 import {
@@ -1152,7 +1153,13 @@ export function ImageStudio() {
       return;
     }
     setQuantTier(
-      defaultTierSelection(selectedModel, readLastTier(TIER_SCREEN, model), tierOptions) ?? "",
+      defaultTierSelection(selectedModel, readLastTier(TIER_SCREEN, model), {
+        ...tierOptions,
+        // Rung 3 (sc-10728): the app-wide default-generation-quality setting is the base default below
+        // the per-(screen,model) sticky. Read fresh here (like readLastTier) so a change made in Settings
+        // is picked up the next time this effect derives a default — no stale in-memory copy.
+        defaultQuality: readDefaultGenerationQuality(),
+      }) ?? "",
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [model, availableTiersKey]);

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -57,9 +57,12 @@ export function SettingsScreen() {
   // GPU card is visible; null until the first sample arrives (or on platforms without it).
   const [gpuTelemetry, setGpuTelemetry] = useState(null);
   // Global "default generation quality" (epic 10721 / sc-10728): the app-wide baseline quant tier new
-  // generations use when a model has no per-(screen,model) sticky pick. Persisted in localStorage (a
-  // client-side preference, so it needs no Tauri/REST round-trip) and read at generation time by
-  // `defaultTierSelection` (precedence rung 3). Seeded from the store; q8 by default.
+  // generations use when a model has no per-(screen,model) sticky pick, read at generation time by
+  // `defaultTierSelection` (precedence rung 3). Persisted like theme/accent — a durable server copy in
+  // `ui-preferences.json` (write-through PUT in `changeDefaultQuality`) plus a localStorage instant-paint
+  // cache — because on the desktop shell the UI's `127.0.0.1:<port>` origin changes each launch and wipes
+  // origin-keyed localStorage. Seeded here from the cache (App.jsx re-primes it from the server on launch);
+  // q8 by default.
   const [defaultQuality, setDefaultQuality] = useState(readDefaultGenerationQuality);
 
   const refresh = useCallback(async () => {
@@ -171,11 +174,18 @@ export function SettingsScreen() {
     }
   }
 
-  // Persist the global default generation quality (sc-10728). Purely client-side (localStorage), so no
-  // Tauri/REST call — the studio reads it fresh at generation time.
+  // Persist the global default generation quality (sc-10728). Write-through: the localStorage cache gives
+  // an instant read for the studio, and the PUT makes it durable across desktop relaunches (the shell's
+  // 127.0.0.1:<port> origin changes each launch, wiping origin-keyed localStorage). Same contract as
+  // theme/accent in App.jsx — the endpoint MERGES, so sending only this field can't disturb theme/accent.
+  // Token is "" because ui-preferences is a public route (like /health); mirrors App.jsx's PUT.
   function changeDefaultQuality(value) {
     const next = writeDefaultGenerationQuality(value);
     setDefaultQuality(next);
+    apiFetch("/api/v1/ui-preferences", "", {
+      method: "PUT",
+      body: JSON.stringify({ defaultGenerationQuality: next }),
+    }).catch(() => {});
     setStatus(`Default generation quality set to ${generationQualityLabel(next)}.`);
   }
 

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -8,6 +8,11 @@ import {
 } from "../credentials.js";
 import { apiFetch } from "../api.js";
 import { isDesktop, tauriInvoke as invoke } from "../runtime.js";
+import {
+  generationQualityLabel,
+  readDefaultGenerationQuality,
+  writeDefaultGenerationQuality,
+} from "../generationQuality.js";
 
 // The data-dir / GPU / worker / wizard / remote-access controls are desktop-only
 // (backed by Tauri commands in the shell) and are gated behind `isDesktop` so a
@@ -51,6 +56,11 @@ export function SettingsScreen() {
   // Live MLX memory telemetry (epic 7819, sc-7825). The worker's latest snapshot, polled while the
   // GPU card is visible; null until the first sample arrives (or on platforms without it).
   const [gpuTelemetry, setGpuTelemetry] = useState(null);
+  // Global "default generation quality" (epic 10721 / sc-10728): the app-wide baseline quant tier new
+  // generations use when a model has no per-(screen,model) sticky pick. Persisted in localStorage (a
+  // client-side preference, so it needs no Tauri/REST round-trip) and read at generation time by
+  // `defaultTierSelection` (precedence rung 3). Seeded from the store; q8 by default.
+  const [defaultQuality, setDefaultQuality] = useState(readDefaultGenerationQuality);
 
   const refresh = useCallback(async () => {
     try {
@@ -161,6 +171,14 @@ export function SettingsScreen() {
     }
   }
 
+  // Persist the global default generation quality (sc-10728). Purely client-side (localStorage), so no
+  // Tauri/REST call — the studio reads it fresh at generation time.
+  function changeDefaultQuality(value) {
+    const next = writeDefaultGenerationQuality(value);
+    setDefaultQuality(next);
+    setStatus(`Default generation quality set to ${generationQualityLabel(next)}.`);
+  }
+
   async function restartWorker() {
     try {
       // Desktop kills the worker child directly via Tauri; a remote admin restarts it
@@ -262,6 +280,29 @@ export function SettingsScreen() {
   return (
     <div className="settings-screen">
       {status ? <p className="settings-status">{status}</p> : null}
+
+      <section className="settings-card">
+        <h3>Generation quality</h3>
+        <p className="settings-muted">
+          The default quality tier new generations use for a model you haven’t picked a
+          tier for yet. Higher fidelity looks best but uses more memory and is slower;
+          smaller tiers are faster and lighter. You can still override this per model in
+          the studio, and your per-model picks are remembered.
+        </p>
+        <div className="settings-actions">
+          <label htmlFor="default-generation-quality">Default quality</label>
+          <select
+            id="default-generation-quality"
+            value={defaultQuality}
+            onChange={(event) => changeDefaultQuality(event.target.value)}
+            aria-label="Default generation quality"
+          >
+            <option value="bf16">High fidelity (bf16)</option>
+            <option value="q8">Balanced (Q8)</option>
+            <option value="q4">Fast (Q4)</option>
+          </select>
+        </div>
+      </section>
 
       {isDesktop ? (
         <section className="settings-card">

--- a/apps/web/src/screens/SettingsScreen.test.jsx
+++ b/apps/web/src/screens/SettingsScreen.test.jsx
@@ -376,3 +376,73 @@ describe("SettingsScreen GPU memory (desktop macOS)", () => {
     expect(container.textContent).toContain("applies within a couple of seconds");
   });
 });
+
+// Global "default generation quality" setting (epic 10721 / sc-10728). Purely client-side
+// (localStorage), so it renders in both desktop and web modes and needs no Tauri/REST round-trip.
+// These run in web (REST) mode with api.js mocked so refresh() resolves cleanly.
+describe("SettingsScreen default generation quality (sc-10728)", () => {
+  const STORAGE_KEY = "sceneworks-default-generation-quality";
+  let container;
+  let root;
+  let SettingsScreen;
+
+  beforeEach(async () => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    delete window.__TAURI__;
+    window.localStorage.clear();
+    vi.resetModules();
+    vi.doMock("../api.js", () => ({
+      apiFetch: vi.fn(async () => []),
+      isAbortError: () => false,
+      API_BASE_URL: "",
+      eventUrl: () => "",
+    }));
+    ({ SettingsScreen } = await import("./SettingsScreen.jsx"));
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    window.localStorage.clear();
+    vi.doUnmock("../api.js");
+    vi.restoreAllMocks();
+  });
+
+  async function render() {
+    await act(async () => {
+      root.render(<SettingsScreen />);
+    });
+    await act(async () => {});
+  }
+
+  const qualitySelect = () =>
+    container.querySelector('[aria-label="Default generation quality"]');
+
+  it("renders the control defaulting to Balanced (Q8) when nothing is stored", async () => {
+    await render();
+    expect(container.textContent).toContain("Generation quality");
+    const select = qualitySelect();
+    expect(select).toBeTruthy();
+    expect(select.value).toBe("q8");
+  });
+
+  it("persists a change to localStorage and confirms it in the status line", async () => {
+    await render();
+    await changeField(qualitySelect(), "bf16");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("bf16");
+    expect(qualitySelect().value).toBe("bf16");
+    expect(container.textContent).toContain("High fidelity (bf16)");
+  });
+
+  it("seeds the control from a previously persisted value (persistence round-trip)", async () => {
+    // Simulate a prior session having written q4, then a fresh mount.
+    window.localStorage.setItem(STORAGE_KEY, "q4");
+    await render();
+    expect(qualitySelect().value).toBe("q4");
+  });
+});

--- a/apps/web/src/screens/SettingsScreen.test.jsx
+++ b/apps/web/src/screens/SettingsScreen.test.jsx
@@ -377,22 +377,26 @@ describe("SettingsScreen GPU memory (desktop macOS)", () => {
   });
 });
 
-// Global "default generation quality" setting (epic 10721 / sc-10728). Purely client-side
-// (localStorage), so it renders in both desktop and web modes and needs no Tauri/REST round-trip.
-// These run in web (REST) mode with api.js mocked so refresh() resolves cleanly.
+// Global "default generation quality" setting (epic 10721 / sc-10728). Persisted like theme/accent:
+// a durable server copy (PUT /api/v1/ui-preferences) plus a localStorage instant-paint cache, so it
+// survives a desktop relaunch (the shell's 127.0.0.1:<port> origin changes each launch and wipes
+// origin-keyed localStorage). Renders in both desktop and web modes. These run in web (REST) mode with
+// api.js mocked so refresh() resolves cleanly and the write-through PUT is observable.
 describe("SettingsScreen default generation quality (sc-10728)", () => {
   const STORAGE_KEY = "sceneworks-default-generation-quality";
   let container;
   let root;
   let SettingsScreen;
+  let apiFetch;
 
   beforeEach(async () => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     delete window.__TAURI__;
     window.localStorage.clear();
     vi.resetModules();
+    apiFetch = vi.fn(async () => []);
     vi.doMock("../api.js", () => ({
-      apiFetch: vi.fn(async () => []),
+      apiFetch,
       isAbortError: () => false,
       API_BASE_URL: "",
       eventUrl: () => "",
@@ -431,7 +435,7 @@ describe("SettingsScreen default generation quality (sc-10728)", () => {
     expect(select.value).toBe("q8");
   });
 
-  it("persists a change to localStorage and confirms it in the status line", async () => {
+  it("writes a change to the localStorage instant-paint cache and confirms it in the status line (cache path)", async () => {
     await render();
     await changeField(qualitySelect(), "bf16");
     expect(window.localStorage.getItem(STORAGE_KEY)).toBe("bf16");
@@ -439,8 +443,26 @@ describe("SettingsScreen default generation quality (sc-10728)", () => {
     expect(container.textContent).toContain("High fidelity (bf16)");
   });
 
-  it("seeds the control from a previously persisted value (persistence round-trip)", async () => {
-    // Simulate a prior session having written q4, then a fresh mount.
+  it("writes the change through to the durable server copy via PUT /api/v1/ui-preferences (durable path)", async () => {
+    // The acceptance criterion is "persists across sessions". On the desktop shell the localStorage
+    // cache alone does NOT survive a relaunch (the origin changes), so the change must also PUT to the
+    // durable ui-preferences store — same contract as theme/accent in App.jsx. Sending only this field
+    // relies on the endpoint MERGING, so theme/accent can't be clobbered.
+    await render();
+    await changeField(qualitySelect(), "q4");
+    expect(apiFetch).toHaveBeenCalledWith(
+      "/api/v1/ui-preferences",
+      "",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ defaultGenerationQuality: "q4" }),
+      }),
+    );
+  });
+
+  it("seeds the control from the instant-paint cache on mount (cache round-trip)", async () => {
+    // App.jsx re-primes this cache from the durable server copy on launch (covered in App.shell.test.jsx);
+    // here we assert the control reflects whatever the cache holds on mount.
     window.localStorage.setItem(STORAGE_KEY, "q4");
     await render();
     expect(qualitySelect().value).toBe("q4");


### PR DESCRIPTION
## Summary

Adds a persisted, app-wide **Default generation quality** setting so a user sets their baseline quant tier once instead of re-picking it for every generation. This is the S4 rung of the epic-locked tier precedence.

**Setting**
- Name/key: `defaultGenerationQuality`. **Durably persisted server-side** in the Rust `ui-preferences.json` (camelCase JSON contract, exactly like theme/accent), with a `localStorage` (`sceneworks-default-generation-quality`) **instant-paint cache** in front of it.
- Values: `bf16 | q8 | q4`. **Default `q8`** (matches the worker's generation default, sc-10726). `Auto` is intentionally deferred to S8/sc-10733.
- Store: `apps/web/src/generationQuality.js` — the cache read/write helpers; reads fresh on every call so the studio picks up a Settings change (and a launch-time re-seed) next time it derives a default.

**Settings UI**
- New "Generation quality" card in `SettingsScreen.jsx` (a labeled `<select>`: *High fidelity (bf16)* / *Balanced (Q8)* / *Fast (Q4)*), rendered in both desktop and web modes. On change it **writes through**: the localStorage cache PLUS `PUT /api/v1/ui-preferences`, with a status confirmation.

**Precedence wiring**
- `quantTier.js` exports `GENERATION_QUALITY_TIERS` + `DEFAULT_GENERATION_QUALITY`, and `defaultTierSelection`'s base default reads `options.defaultQuality`:

  `explicit pick > per-(screen,model) sticky (S3) > global defaultGenerationQuality (this story) > clamp to installed > smallest installed`

  Absent/invalid `defaultQuality` falls back to `q8`, so every legacy call site is unchanged. The base leads a clean-tier fallback, so it's always **clamped to installed** (e.g. setting `bf16` but only `q4` installed → `q4`). `ImageStudio.jsx` passes the setting in via the options object.

## Desktop cross-launch durability (review fix)

The original S4 wrote the setting **only** to origin-keyed `localStorage`, which does **not** survive a desktop (Tauri) relaunch: the shell serves the UI at `http://127.0.0.1:<port>` and the port — and therefore the origin — changes every launch, wiping `localStorage`. Acceptance #2 ("persists across sessions") was therefore UNMET on the primary platform. This now mirrors the established theme/accent contract:

- **`apps/rust-api/src/preferences.rs`**: `UiPreferences` gains a `defaultGenerationQuality` field; `normalize_generation_quality` accepts only `bf16|q8|q4` (else `q8`). GET always resolves an absent/invalid value to `q8` so the web has a concrete tier to seed; PUT accepts and **MERGES** the field, so a theme-only PUT can't clobber it. Backward-compatible — an old `ui-preferences.json` lacking the field reads back `q8`.
- **`App.jsx`**: the launch-time `ui-preferences` seed effect re-primes the generation-quality localStorage cache from the durable server copy alongside theme/accent, so it reflects the previous session even after the origin changed.
- Desktop PUTs succeed over loopback trust (no token needed); **web/browser mode is unchanged** — it behaves exactly like the theme/accent PUT (`""` token to the public route).

## Rebase

Rebased onto current `main`, which had advanced by **#1370 (sc-10760)** — the booru quality-prefix / negative / prompt-hint seeding in `ImageStudio.jsx`. Git auto-merged the two ImageStudio.jsx regions (S4's `defaultQuality: readDefaultGenerationQuality()` in the tier-seed effect vs. #1370's prompt-seed effects/imports); verified both changes are present and coherent, and the ImageStudio suite (56 tests) is green.

## Acceptance
1. ✅ Changing it in Settings changes the resolved default tier for a no-sticky model.
2. ✅ **Persists across sessions on desktop AND web** — durable server copy (`ui-preferences.json`) re-seeded on launch, localStorage as an instant-paint cache.
3. ✅ Clamped to installed (a `bf16`/`q4` setting never seeds an uninstalled tier). The S6 quality *floor* is NOT built here.
4. ✅ Web unit tests + Settings UI test + Rust preferences tests.

## Tests
- `preferences.rs` unit test: `normalize_generation_quality` accepts only `bf16|q8|q4`, else `q8`.
- `tests.rs` integration test: GET resolves absent→`q8`; PUT round-trips a valid tier; a partial (theme-only) PUT merges without clobbering; a present-but-invalid tier coerces to `q8`.
- `SettingsScreen.test.jsx`: the change writes through — asserts the `PUT /api/v1/ui-preferences` payload `{ defaultGenerationQuality }` (durable path); the localStorage-only test is kept, relabeled as the cache path.
- `App.shell.test.jsx` (new): mounting App re-seeds the generation-quality cache from the server copy on launch (proves cross-launch durability, not just a jsdom localStorage round-trip).
- `generationQuality.test.js` / `quantTier.test.js`: default q8, round-trip/normalize/labels; precedence (sticky beats setting, clamp-to-installed, invalid→q8, declared default honored).
- `npm run rust:check` clean (fmt + clippy `-D warnings` + test + build); touched + adjacent web suites green; `eslint src` 0 errors (no new warnings).

## Out of scope / follow-ups
- **Worker not re-plumbed** (per story): the worker already defaults to q8 (S2). Surfaces that submit *without* an explicit `mlxQuantize` (single-tier / picker-less) still rely on the worker default and would not yet reflect a non-q8 global setting — flagged for a future story, not absorbed here.
- S6 (quality floor, sc-10731) and S8 (`Auto`, sc-10733) remain separate stories.

Story: https://app.shortcut.com/trefry/story/10728 (sc-10728)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
