### PR TITLE
feat(models): per-model quality floor mlx.minQualityTier; Anima base/aesthetic = q8 (sc-10731)

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1308,6 +1308,24 @@ fn tier_subdir_has_weights(tier_dir: &FsPath) -> bool {
 }
 
 fn apply_mac_and_mlx_fields(object: &mut JsonObject, data_dir: &FsPath) {
+    // Per-model quality FLOOR (sc-10731, epic 10721): surface the manifest `mlx.minQualityTier` as a
+    // top-level `minQualityTier` so the web `defaultTierSelection` can clamp the DEFAULT generation tier
+    // UP to it (a floored model — Anima base/aesthetic = q8 — never lets a low global "default quality"
+    // setting land the default on the washed q4). An EXPLICIT picker pick below the floor is still
+    // honored, with a non-blocking advisory. Decoupled top-level field, mirroring `mlxTiers` — the web
+    // reads one stable key rather than reaching into the passed-through `mlx` sub-object. Emitted on every
+    // platform where the manifest declares it (the picker only renders where >1 tier installs, but the
+    // field is cheap and lets any surface read the floor). Only bf16/q8/q4 are valid; others are dropped.
+    if let Some(floor) = object
+        .get("mlx")
+        .and_then(|mlx| mlx.get("minQualityTier"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|tier| matches!(*tier, "bf16" | "q8" | "q4"))
+        .map(str::to_owned)
+    {
+        object.insert("minQualityTier".to_owned(), Value::String(floor));
+    }
     let mac_support = {
         let id = object.get("id").and_then(Value::as_str).unwrap_or_default();
         let model_type = object
@@ -2783,5 +2801,35 @@ mod mlx_tier_probe_tests {
         assert_eq!(tiers, vec!["bf16", "q8", "q4"]);
         // Decoupled from the download matrix — the picker must NOT flip `hasVariantMatrix`.
         assert!(object.get("hasVariantMatrix").is_none());
+    }
+
+    // Per-model quality floor (sc-10731): `apply_mac_and_mlx_fields` surfaces the manifest
+    // `mlx.minQualityTier` as a top-level `minQualityTier` so the web can clamp the DEFAULT tier up to
+    // it. Platform-independent (not gated on the macOS mlx-status probe), and only a valid bf16/q8/q4
+    // value is emitted — a bogus floor is dropped, an absent floor emits nothing.
+    #[test]
+    fn catalog_emits_min_quality_floor_from_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path();
+        let apply = |mlx: Value| {
+            let mut object = json!({ "id": "anima_base", "type": "image", "mlx": mlx })
+                .as_object()
+                .unwrap()
+                .clone();
+            apply_mac_and_mlx_fields(&mut object, data_dir);
+            object
+                .get("minQualityTier")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        };
+        // A declared q8 floor is surfaced verbatim as a top-level field.
+        assert_eq!(
+            apply(json!({ "minQualityTier": "q8" })),
+            Some("q8".to_owned())
+        );
+        // A model with no floor emits nothing (default absent = q4-tolerant, no clamp).
+        assert_eq!(apply(json!({ "requiresConversion": true })), None);
+        // An invalid floor value is dropped rather than surfaced.
+        assert_eq!(apply(json!({ "minQualityTier": "q2" })), None);
     }
 }

--- a/apps/web/src/quantTier.js
+++ b/apps/web/src/quantTier.js
@@ -133,6 +133,39 @@ export function installedTiers(model, options = {}) {
   return [];
 }
 
+// Quality rank of a generation quant tier: higher = more faithful (bf16 > q8 > q4). Derived from
+// GENERATION_QUALITY_TIERS (highest-fidelity first), so it stays in lockstep with that vocabulary.
+// Unknown / non-quality tiers (e.g. int8-convrot, "training") rank 0 so they never take part in a floor
+// comparison — a below-floor advisory or default clamp only ever fires between two known quality tiers.
+function tierQualityRank(tier) {
+  const i = GENERATION_QUALITY_TIERS.indexOf(tier);
+  return i === -1 ? 0 : GENERATION_QUALITY_TIERS.length - i;
+}
+
+// Whether tier `a` is LOWER fidelity than tier `b`. Both must be known quality tiers (else false).
+function isTierBelow(a, b) {
+  const ra = tierQualityRank(a);
+  const rb = tierQualityRank(b);
+  return ra > 0 && rb > 0 && ra < rb;
+}
+
+// The model's per-model quality FLOOR (sc-10731, epic 10721): the backend surfaces the manifest
+// `mlx.minQualityTier` as a top-level `minQualityTier`. Returns the floor tier (bf16|q8|q4) when declared
+// and valid, else null (default absent = no floor, q4-tolerant). A floored model's DEFAULT tier is
+// clamped UP to this (see `defaultTierSelection`); an EXPLICIT picker pick below it is honored + flagged.
+export function modelQualityFloor(model) {
+  return GENERATION_QUALITY_TIERS.includes(model?.minQualityTier) ? model.minQualityTier : null;
+}
+
+// Whether `tier` is BELOW the model's quality floor (sc-10731): true only when the model declares a floor
+// AND `tier` is a lower-fidelity quality tier than it. Drives the Studio's non-blocking advisory when a
+// user EXPLICITLY picks a below-floor tier — the pick is honored (a quant tier is a deliberate creative
+// choice) but flagged as a quality caution, never silently switched.
+export function isBelowFloor(tier, model) {
+  const floor = modelQualityFloor(model);
+  return !!floor && isTierBelow(tier, floor);
+}
+
 // Whether the studio should render the tier picker: only when MORE THAN ONE quant tier is
 // installed (a single installed tier — the common case — shows no toggle, per acceptance).
 // `options` (sc-9300) forwards the `convRotEligible` gate so an ineligible host doesn't count the
@@ -163,6 +196,11 @@ function defaultInstalledTier(model, tiers) {
 //      uninstalled base resolves to the nearest installed clean tier rather than null. Convert-at-install
 //      models (mlxTiers, sc-10730) fall through bf16 before q4; download-matrix models fall q8 → q4.
 //   4. the first installed tier.
+// Rungs 2–4 (the derived DEFAULT) are then CLAMPED UP to the model's per-model quality floor
+// (`minQualityTier`, sc-10731): a floored model (Anima base/aesthetic = q8) never lets a low global
+// setting / fallback land the default below the floor. The sticky (rung 1) is NOT floored — it was a
+// prior explicit pick, honored as-is. The clamp is capped by clamp-to-installed (a floor tier not on
+// disk resolves to the nearest installed clean tier).
 // Returns null when nothing is installed (no picker will render anyway). `options` also forwards the
 // `convRotEligible` gate (sc-9300) so a hidden INT8-ConvRot tier is never seeded as the selection —
 // and because `defaultQuality` can only ever be bf16|q8|q4, it never re-introduces a filtered tier.
@@ -174,18 +212,32 @@ export function defaultTierSelection(model, lastUsed, options = {}) {
   if (lastUsed && tiers.includes(lastUsed)) {
     return lastUsed;
   }
+  // The per-model quality FLOOR (sc-10731): the DEFAULT derivation below (rungs 2–4) is clamped UP to
+  // this tier. A floored model (Anima base/aesthetic = q8) never lets a declared default, a low global
+  // "default quality" setting, or the fallback land the default below the floor. NOT applied to the
+  // sticky (rung 1) above — that was a prior EXPLICIT pick, honored as-is (the picker re-surfaces the
+  // advisory). Capped by clamp-to-installed (the clean-tier fallback), so a floor tier not on disk
+  // resolves to the nearest installed clean tier, never null.
+  const floor = modelQualityFloor(model);
+  // Rung 2: the model's declared default tier (`variant.default`), when installed. Dead against the real
+  // catalog (no `default` emitted), kept so a manifest that does declare one still wins — subject to the
+  // floor below (a declared q4 on a q8-floored model still starts at q8).
   const declared = defaultInstalledTier(model, tiers);
-  if (declared) {
-    return declared;
-  }
   // Rung 3: the global default-generation-quality setting is the app-wide base default. The caller
   // passes it as `options.defaultQuality`; an absent/invalid value falls back to Q8 (the historical
   // base + worker default) so legacy call sites are unchanged. The base leads a clean-tier fallback so
   // it is always clamped to what's installed — a base tier that isn't on disk resolves to the nearest
   // installed clean tier (never the washed q4 unless that's all that's left), never null.
-  const base = GENERATION_QUALITY_TIERS.includes(options.defaultQuality)
-    ? options.defaultQuality
-    : DEFAULT_GENERATION_QUALITY;
+  let base =
+    declared ??
+    (GENERATION_QUALITY_TIERS.includes(options.defaultQuality)
+      ? options.defaultQuality
+      : DEFAULT_GENERATION_QUALITY);
+  // Clamp the default UP to the model's quality floor (raises only — a base at/above the floor is
+  // untouched; the below fallback still caps it at what's installed).
+  if (floor && isTierBelow(base, floor)) {
+    base = floor;
+  }
   const cleanFallback =
     !model?.hasVariantMatrix && Array.isArray(model?.mlxTiers)
       ? ["q8", "bf16", "q4"]

--- a/apps/web/src/quantTier.test.js
+++ b/apps/web/src/quantTier.test.js
@@ -4,8 +4,10 @@ import {
   GENERATION_QUALITY_TIERS,
   defaultTierSelection,
   installedTiers,
+  isBelowFloor,
   isConvRotTier,
   isSelectableTier,
+  modelQualityFloor,
   shouldShowTierPicker,
   tierLabel,
   tierQuantize,
@@ -288,5 +290,80 @@ describe("quantTier — convert-at-install mlxTiers (sc-10730)", () => {
         null,
       ),
     ).toBe("q8");
+  });
+});
+
+// Per-model quality floor (sc-10731, epic 10721): the backend surfaces the manifest `mlx.minQualityTier`
+// as a top-level `minQualityTier`. `defaultTierSelection` clamps the DEFAULT (rungs 2–4) UP to it — a
+// floored model (Anima base/aesthetic = q8) never lets a low global setting / fallback land the default
+// on the washed q4 — while an EXPLICIT below-floor picker pick is honored + flagged (`isBelowFloor`).
+function flooredConvertModel({ mlxTiers = ["q4", "q8", "bf16"], floor = "q8" } = {}) {
+  return { id: "anima_base", hasVariantMatrix: false, mlxTiers, minQualityTier: floor };
+}
+
+describe("modelQualityFloor / isBelowFloor (sc-10731)", () => {
+  it("reads a valid declared floor and ignores absent/invalid ones", () => {
+    expect(modelQualityFloor({ minQualityTier: "q8" })).toBe("q8");
+    expect(modelQualityFloor({ minQualityTier: "bf16" })).toBe("bf16");
+    expect(modelQualityFloor({ minQualityTier: "q2" })).toBe(null);
+    expect(modelQualityFloor({})).toBe(null);
+    expect(modelQualityFloor(undefined)).toBe(null);
+  });
+
+  it("flags a tier below the floor, not one at/above it", () => {
+    const model = { minQualityTier: "q8" };
+    expect(isBelowFloor("q4", model)).toBe(true);
+    expect(isBelowFloor("q8", model)).toBe(false);
+    expect(isBelowFloor("bf16", model)).toBe(false);
+    // No floor → nothing is ever below it.
+    expect(isBelowFloor("q4", { minQualityTier: undefined })).toBe(false);
+    // A non-quality tier (int8-convrot) never participates in a floor compare.
+    expect(isBelowFloor(INT8_CONVROT_TIER, model)).toBe(false);
+  });
+});
+
+describe("defaultTierSelection — per-model quality floor (sc-10731)", () => {
+  it("clamps a low global setting UP to the floor (acceptance #1: global q4 + Anima base → q8)", () => {
+    const model = flooredConvertModel({ mlxTiers: ["q4", "q8", "bf16"], floor: "q8" });
+    // Global "default quality" is q4, but the model floors at q8 → the DEFAULT resolves q8, never q4.
+    expect(defaultTierSelection(model, null, { defaultQuality: "q4" })).toBe("q8");
+    // The plain q8 base default is already at the floor → still q8.
+    expect(defaultTierSelection(model, null)).toBe("q8");
+  });
+
+  it("raises a declared default below the floor up to the floor", () => {
+    // A download-matrix model that (hypothetically) declares a q4 default but floors at q8 → q8.
+    const model = {
+      ...matrixModel({ installed: ["q4", "q8", "bf16"], defaultTier: "q4" }),
+      minQualityTier: "q8",
+    };
+    expect(defaultTierSelection(model, null)).toBe("q8");
+  });
+
+  it("caps the floor at what's installed (floor q8, only q4 on disk → q4)", () => {
+    const model = flooredConvertModel({ mlxTiers: ["q4"], floor: "q8" });
+    expect(defaultTierSelection(model, null, { defaultQuality: "q4" })).toBe("q4");
+  });
+
+  it("prefers the clean bf16 over the washed q4 when the floor tier is absent", () => {
+    // Floor q8 not installed; bf16 (above the floor) + q4 present → the clean-tier fallback picks bf16.
+    const model = flooredConvertModel({ mlxTiers: ["q4", "bf16"], floor: "q8" });
+    expect(defaultTierSelection(model, null, { defaultQuality: "q4" })).toBe("bf16");
+  });
+
+  it("still honors a below-floor STICKY (rung 1) — a prior explicit pick is not re-floored", () => {
+    const model = flooredConvertModel({ mlxTiers: ["q4", "q8", "bf16"], floor: "q8" });
+    // The user explicitly stickied q4 for this model before → honored as-is (the picker re-flags it).
+    expect(defaultTierSelection(model, "q4")).toBe("q4");
+  });
+
+  it("leaves non-floored models unaffected (acceptance #3)", () => {
+    // No floor (no `minQualityTier`) → the app-wide q8 base default and a q4 global setting both
+    // resolve exactly as before.
+    const model = { id: "anima_base", hasVariantMatrix: false, mlxTiers: ["q4", "q8", "bf16"] };
+    expect(defaultTierSelection(model, null)).toBe("q8");
+    expect(defaultTierSelection(model, null, { defaultQuality: "q4" })).toBe("q4");
+    // And a bf16 global setting is not lowered by any floor.
+    expect(defaultTierSelection(model, null, { defaultQuality: "bf16" })).toBe("bf16");
   });
 });

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -126,6 +126,8 @@ import { pidToggleVisible } from "../pidEligibility.js";
 import {
   defaultTierSelection,
   installedTiers,
+  isBelowFloor,
+  modelQualityFloor,
   shouldShowTierPicker,
   tierLabel,
 } from "../quantTier.js";
@@ -872,6 +874,15 @@ export function ImageStudio() {
   const showTierPicker = useMemo(
     () => shouldShowTierPicker(selectedModel, tierOptions),
     [selectedModel, tierOptions],
+  );
+  // Per-model quality floor (sc-10731): the model's minimum-fidelity tier (`minQualityTier`) and whether
+  // the CURRENT pick sits below it. The DEFAULT is already clamped up to the floor (defaultTierSelection),
+  // so this only fires when the user EXPLICITLY picks a below-floor tier — a deliberate quality/creative
+  // choice we HONOR, but flag with a non-blocking advisory (never silently switch their tier).
+  const qualityFloor = useMemo(() => modelQualityFloor(selectedModel), [selectedModel]);
+  const tierBelowFloor = useMemo(
+    () => showTierPicker && isBelowFloor(quantTier, selectedModel),
+    [showTierPicker, quantTier, selectedModel],
   );
   // PiD decoder toggle visibility (epic 7840, sc-7851): the model's latent space has a PiD
   // backbone (ui.pid) AND that backbone's PiD checkpoint is installed. Hidden otherwise — for
@@ -2836,6 +2847,13 @@ export function ImageStudio() {
                   {tierSwitching ? (
                     <span className="field-hint" role="status">
                       Loading {tierLabel(tierSwitching)}…
+                    </span>
+                  ) : null}
+                  {tierBelowFloor ? (
+                    <span className="field-hint quant-tier-floor-note">
+                      {tierLabel(quantTier)} is below the {tierLabel(qualityFloor)} recommended for{" "}
+                      {selectedModel?.name ?? "this model"} — it can look washed or lose fine detail
+                      here (quantization error is amplified under CFG). Your pick is honored.
                     </span>
                   ) : null}
                 </label>

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -945,6 +945,64 @@ describe("ImageStudio model picker capability gating", () => {
     expect(createImageJob.mock.calls[0][0].advanced.mlxQuantize).toBe(8);
   });
 
+  // Per-model quality floor (sc-10731). A floored convert-at-install model (Anima base = q8 floor) is a
+  // decoupled `mlxTiers` model: the DEFAULT clamps UP to the floor, and an EXPLICIT below-floor pick is
+  // honored (never silently switched) but flagged with a non-blocking advisory.
+  // `floor` is passed explicitly (no default) so `undefined` yields a genuinely non-floored model.
+  const flooredModel = (mlxTiers, floor) => ({
+    ...Z_IMAGE,
+    id: "anima_base",
+    name: "Anima 2B",
+    hasVariantMatrix: false,
+    variants: undefined,
+    mlxTiers,
+    minQualityTier: floor,
+  });
+  const floorNote = () => container.querySelector(".quant-tier-floor-note");
+
+  it("floors the default tier to q8 and flags an explicit below-floor pick (sc-10731)", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    // Even with the global default set to q4, the q8-floored model clamps the DEFAULT up to q8.
+    window.localStorage.setItem("sceneworks-default-generation-quality", "q4");
+    await render(
+      baseContext({
+        createImageJob,
+        imageModels: [flooredModel(["q4", "q8"], "q8")],
+        macCapabilities: MAC_CAPS,
+      }),
+    );
+    await openAdvanced(container);
+    await act(async () => {});
+    const picker = tierPicker(container);
+    expect(picker).toBeTruthy();
+    // Acceptance #1: global q4 + floored model → q8 (floored), and no advisory at the floor.
+    expect(picker.value).toBe("q8");
+    expect(floorNote()).toBeFalsy();
+    // Acceptance #2: explicitly pick the below-floor q4 → honored (value stays q4) + advisory appears.
+    setSelect(picker, "q4");
+    await act(async () => {});
+    expect(tierPicker(container).value).toBe("q4");
+    expect(floorNote()).toBeTruthy();
+    // The explicit q4 is honored on Generate (not switched back to the floor).
+    await click(generateButton());
+    expect(createImageJob.mock.calls[0][0].advanced.mlxQuantize).toBe(4);
+  });
+
+  it("does not flag or clamp a NON-floored model's q4 default (sc-10731, acceptance #3)", async () => {
+    // Same convert-at-install shape but no floor → the global q4 default is honored, no advisory.
+    window.localStorage.setItem("sceneworks-default-generation-quality", "q4");
+    await render(
+      baseContext({
+        imageModels: [flooredModel(["q4", "q8"], undefined)],
+        macCapabilities: MAC_CAPS,
+      }),
+    );
+    await openAdvanced(container);
+    await act(async () => {});
+    expect(tierPicker(container).value).toBe("q4");
+    expect(floorNote()).toBeFalsy();
+  });
+
   // Disjointness guard (sc-8515): the tier picker and Boogu's ui.precisionToggle both write
   // advanced.mlxQuantize and MUST never co-render/co-emit. In the catalog they are disjoint —
   // Boogu downloads via `base/`-style subfolder globs (no downloads[].variant keys), so it is

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -4247,6 +4247,15 @@
         // covers both the convert peak and a 1536² generate.
         "minMemoryGb": 16,
         "quantize": 4,
+        // Per-model quality FLOOR (sc-10731, epic 10721): the minimum-fidelity tier the DEFAULT resolution
+        // may land on. Anima base renders WASHED/smudged at q4 under CFG 4.5 × 30 steps (sc-10714 — q4
+        // weight-quant error is amplified), so the app-wide default (and a low global "default quality"
+        // setting) clamps UP to q8 here rather than silently landing on q4. This REPLACES the sc-10714
+        // `anima_tier_subdir` q8 hardcode: the q8 default is now floor-driven, not a resolver special-case.
+        // An EXPLICIT q4 pick in the Studio picker is still honored (a quant tier is a creative choice) —
+        // the web surfaces a non-blocking advisory instead. Turbo omits this floor (it is CFG-free, so q4
+        // is acceptable there).
+        "minQualityTier": "q8",
         "requiresConversion": true,
         "converter": "anima_quant",
         "convertSourceRepo": "circlestone-labs/Anima",
@@ -4339,6 +4348,10 @@
       "mlx": {
         "minMemoryGb": 16,
         "quantize": 4,
+        // Per-model quality FLOOR (sc-10731, epic 10721): same q8 floor as `anima_base` — the aesthetic
+        // fine-tune shares the base's washed-at-q4-under-CFG behavior (sc-10714), so the DEFAULT clamps UP
+        // to q8. Floor-driven, not the old resolver hardcode; an explicit q4 pick is honored + flagged.
+        "minQualityTier": "q8",
         "requiresConversion": true,
         "converter": "anima_quant",
         "convertSourceRepo": "circlestone-labs/Anima",

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -633,6 +633,70 @@ fn is_dense_te_tier(request: &ImageRequest) -> bool {
             .unwrap_or(false)
 }
 
+/// Quality rank of a generation quant tier: higher = more faithful (`bf16` = 3, `q8` = 2, `q4` = 1,
+/// anything else = 0). Used to CLAMP a resolver's DEFAULT tier UP to a model's per-model quality floor
+/// (`mlx.minQualityTier`, sc-10731) — the clamp only ever RAISES, never lowers.
+fn tier_quality_rank(tier: &str) -> u8 {
+    match tier {
+        "bf16" => 3,
+        "q8" => 2,
+        "q4" => 1,
+        _ => 0,
+    }
+}
+
+/// Normalize a floor tier string to its canonical `&'static str` name (`bf16`/`q8`/`q4`), so a floor
+/// borrowed from the request manifest can be returned as a static tier subdir name. An unknown value
+/// falls to `q4` (harmless — it never outranks the `q8` default, so it is never actually selected).
+fn tier_static_name(tier: &str) -> &'static str {
+    match tier {
+        "bf16" => "bf16",
+        "q8" => "q8",
+        _ => "q4",
+    }
+}
+
+/// The tier subdir name a request prefers, given its explicit `advanced.mlxQuantize` `bits` and the
+/// model's per-model quality `floor` (`mlx.minQualityTier`, sc-10731 — `None` = no floor).
+///
+/// An EXPLICIT pick maps directly (`<= 0` → bf16, `> 4` → q8, `1..=4` → q4) and is HONORED even below
+/// the floor — a quant tier is a deliberate quality/creative choice, so the worker never silently
+/// overrides it (the web surfaces a non-blocking advisory on a below-floor pick instead). With NO
+/// explicit pick, the app-wide default (Q8, epic 10721 / sc-10726) is CLAMPED UP to the floor: a floored
+/// model (Anima base/aesthetic = q8) never lets the plain default land below the floor. The floor only
+/// ever RAISES the default — a floor at or below Q8 leaves the Q8 default unchanged — and the caller's
+/// clean-tier fallback chain still caps the result at what's installed (a floor tier not on disk falls
+/// to the best installed tier). This is the SHARED default-tier logic behind both [`standard_tier_subdir`]
+/// and [`anima_tier_subdir`]; it REPLACES the sc-10714 anima-specific `None => "q8"` hardcode so Anima's
+/// q8 default is now floor-driven from the manifest, not a resolver special-case.
+fn preferred_tier(bits: Option<i64>, floor: Option<&str>) -> &'static str {
+    match bits {
+        Some(b) if b <= 0 => "bf16",
+        Some(b) if b > 4 => "q8",
+        Some(_) => "q4",
+        None => match floor {
+            Some(f) if tier_quality_rank(f) > tier_quality_rank("q8") => tier_static_name(f),
+            _ => "q8",
+        },
+    }
+}
+
+/// The model's per-model quality FLOOR (`mlx.minQualityTier`, sc-10731): the MINIMUM-fidelity tier a
+/// DEFAULT resolution may land on, read from the request's forwarded manifest entry. `None` (field
+/// absent) means no floor — the app-wide default stands (e.g. Anima turbo is q4-tolerant and declares
+/// none). Only `bf16`/`q8`/`q4` are honored; any other value is ignored. Ungated (like
+/// [`standard_tier_subdir`], its ungated caller) so every build config that compiles the resolver also
+/// compiles this.
+fn min_quality_floor(request: &ImageRequest) -> Option<&str> {
+    request
+        .model_manifest_entry
+        .get("mlx")
+        .and_then(|mlx| mlx.get("minQualityTier"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|tier| tier_quality_rank(tier) > 0)
+}
+
 /// Pick the engine-complete tier subdir of a standard SceneWorks quant-matrix turnkey `root`:
 /// `bf16/` when the request opts out of quantization (`advanced.mlxQuantize <= 0` / "none"), `q8/`
 /// when it opts into Q8 (`> 4`), `q4/` for an explicit Q4 pick (`1..=4`), else — with NO explicit
@@ -687,16 +751,13 @@ fn standard_tier_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
             || component_has_weights(&dir);
         has_backbone.then_some(dir)
     };
-    // No explicit selection → q8 (the app-wide default, epic 10721 / sc-10726); bits<=0
+    // No explicit selection → the app-wide q8 default (epic 10721 / sc-10726), CLAMPED UP to the model's
+    // per-model quality floor (`mlx.minQualityTier`, sc-10731 — raises only, never lowers); bits<=0
     // (advanced.mlxQuantize: 0 / "none") → bf16; bits>4 → q8; else (an explicit 1..=4) the q4 the user
-    // asked for. Fallback prefers the clean tiers (q8 → bf16 → q4) so a partial install never silently
-    // lands on the washed q4, and the q8 default is clamped to what's on disk.
-    let preferred = match bits {
-        None => "q8",
-        Some(b) if b <= 0 => "bf16",
-        Some(b) if b > 4 => "q8",
-        _ => "q4",
-    };
+    // asked for (an explicit below-floor pick is honored — the web flags it, the worker never overrides).
+    // Fallback prefers the clean tiers (q8 → bf16 → q4) so a partial install never silently lands on the
+    // washed q4, and the (possibly floored) default is clamped to what's on disk.
+    let preferred = preferred_tier(bits, min_quality_floor(request));
     present(preferred)
         .or_else(|| present("q8"))
         .or_else(|| present("bf16"))
@@ -761,18 +822,17 @@ fn anima_tier_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
             .unwrap_or(false);
         has_dit.then_some(dir)
     };
-    // Default (no explicit `mlxQuantize`) → Q8 (sc-10714 fix; aligns with epic 10721's "Q8 everywhere"
-    // default). q4 was the old blind default and it renders base/aesthetic WASHED — q4 weight-quant error
-    // is amplified by CFG 4.5 over 30 steps (turbo is CFG-free, so q4 is acceptable there). Q8 is
-    // near-lossless (≈bf16) and fixes the smudge at ~2.2 GB; bf16 (explicit `<= 0`) is there for max
-    // fidelity/speed on this small 2B DiT, and an explicit q4 pick is still honored. Fallback prefers the
-    // clean tiers (q8 → bf16 → q4) so a partial install never silently lands on the washed q4.
-    let preferred = match bits {
-        None => "q8",
-        Some(b) if b <= 0 => "bf16",
-        Some(b) if b > 4 => "q8",
-        _ => "q4",
-    };
+    // Default (no explicit `mlxQuantize`) → the app-wide Q8 default (epic 10721 / sc-10726), CLAMPED UP
+    // to the model's per-model quality floor (`mlx.minQualityTier`, sc-10731). This REPLACES the sc-10714
+    // anima-specific `None => "q8"` hardcode with the SHARED, floor-driven [`preferred_tier`]: Anima
+    // base/aesthetic declare `minQualityTier: q8` in the manifest, so their default is now floor-derived
+    // — the fix for base/aesthetic rendering WASHED at q4 (q4 weight-quant error amplified by CFG 4.5 over
+    // 30 steps) is a general mechanism, not a resolver special-case. Turbo declares NO floor (it is
+    // CFG-free, so q4 is acceptable there) and rides the plain q8 default. bf16 (explicit `<= 0`) is there
+    // for max fidelity/speed on this small 2B DiT, and an explicit q4 pick is still honored (the web
+    // flags a below-floor pick with an advisory). Fallback prefers the clean tiers (q8 → bf16 → q4) so a
+    // partial install never silently lands on the washed q4.
+    let preferred = preferred_tier(bits, min_quality_floor(request));
     present(preferred)
         .or_else(|| present("q8"))
         .or_else(|| present("bf16"))
@@ -4866,13 +4926,18 @@ mod standard_tier_tests {
         );
     }
 
-    /// sc-10517 / sc-10714: Anima is convert-at-install with a q4/q8/bf16 MATRIX under the injected
-    /// `modelPath` root (`bf16/ q8/ q4/`, each a `diffusion_models/<variant>.safetensors` tree — NOT a
-    /// `transformer/` component). [`anima_tier_subdir`] picks the tier by `mlxQuantize`
+    /// sc-10517 / sc-10714 / sc-10731: Anima is convert-at-install with a q4/q8/bf16 MATRIX under the
+    /// injected `modelPath` root (`bf16/ q8/ q4/`, each a `diffusion_models/<variant>.safetensors` tree —
+    /// NOT a `transformer/` component). [`anima_tier_subdir`] picks the tier by `mlxQuantize`
     /// (**default Q8**; `<= 0` → bf16; `1..=4` → q4; `> 4` → q8) and falls back clean-tiers-first through
     /// q8 → bf16 → q4 → root, so a partial install surfaces as a load error, never a silent half-load onto
     /// the washed q4. The Q8 default (sc-10714) is the fix for base/aesthetic rendering smudgy at q4 —
     /// q4 × CFG amplifies quant error; Q8 is near-lossless. [`is_anima_model`] gates only the three ids.
+    ///
+    /// sc-10731 reconciled the old anima-specific `None => "q8"` hardcode into the shared, floor-driven
+    /// [`preferred_tier`]: with no manifest floor the app-wide q8 default still stands (the assertions
+    /// above), and the added assertions below prove the floor now DRIVES the default — a manifest
+    /// `mlx.minQualityTier` clamps the default UP (capped by installed), while an explicit pick is honored.
     #[test]
     fn anima_tier_subdir_selects_and_falls_back() {
         let anima_request = |bits: serde_json::Value| {
@@ -4938,6 +5003,150 @@ mod standard_tier_tests {
         assert_eq!(
             anima_tier_subdir(tmp3.path(), &anima_request(json!(null))),
             tmp3.path().to_path_buf()
+        );
+
+        // sc-10731 — the per-model quality FLOOR now DRIVES the anima default (was a hardcode).
+        // A floored request carries `advanced.mlxQuantize` AND the forwarded manifest floor.
+        let floored_request = |bits: serde_json::Value, floor: &str| {
+            ImageRequest::from_payload(
+                json!({
+                    "model": "anima_base",
+                    "advanced": { "mlxQuantize": bits },
+                    "modelManifestEntry": { "mlx": { "minQualityTier": floor } }
+                })
+                .as_object()
+                .unwrap(),
+            )
+        };
+        // Anima base's PRODUCTION shape: floor q8, all tiers present, no explicit pick → the default is
+        // q8 — now floor-DERIVED (the hardcode is gone), not a resolver special-case.
+        assert_eq!(
+            anima_tier_subdir(root, &floored_request(json!(null), "q8")),
+            root.join("q8"),
+            "floor q8 drives the default to q8 (reconciled from the sc-10714 hardcode)"
+        );
+        // Floor CAPPED by installed: floor q8 but only q4 on disk → q4 (the floor never selects an
+        // uninstalled tier — a heavy model never resolves a tier the user didn't download).
+        assert_eq!(
+            anima_tier_subdir(tmp2.path(), &floored_request(json!(null), "q8")),
+            tmp2.path().join("q4"),
+            "floor q8 but only q4 installed → q4 (floor capped by installed)"
+        );
+        // Floor RAISES above the q8 default: a synthetic bf16 floor + no explicit pick → bf16 (proves the
+        // clamp genuinely lifts the default, not just coincides with the app-wide q8).
+        assert_eq!(
+            anima_tier_subdir(root, &floored_request(json!(null), "bf16")),
+            root.join("bf16"),
+            "floored default → the floor tier (bf16 floor raises above the q8 default)"
+        );
+        // An EXPLICIT below-floor pick is HONORED even against a q8 floor — the worker never overrides a
+        // deliberate quant choice (the web surfaces the advisory instead).
+        assert_eq!(
+            anima_tier_subdir(root, &floored_request(json!(4), "q8")),
+            root.join("q4"),
+            "explicit q4 honored despite the q8 floor (below-floor pick is the user's choice)"
+        );
+    }
+
+    /// sc-10731: the shared, floor-aware default-tier logic behind both [`standard_tier_subdir`] and
+    /// [`anima_tier_subdir`]. An explicit `mlxQuantize` pick maps directly and is honored regardless of
+    /// the floor; with NO pick, the app-wide q8 default is clamped UP to the floor (never DOWN).
+    #[test]
+    fn preferred_tier_clamps_default_up_to_the_floor_only() {
+        // No explicit pick, no floor → the app-wide q8 default (unchanged, non-floored models).
+        assert_eq!(preferred_tier(None, None), "q8");
+        // Floor at/below q8 leaves the q8 default untouched (the floor only ever RAISES).
+        assert_eq!(preferred_tier(None, Some("q8")), "q8");
+        assert_eq!(preferred_tier(None, Some("q4")), "q8");
+        // A floor ABOVE q8 raises the default to the floor tier.
+        assert_eq!(preferred_tier(None, Some("bf16")), "bf16");
+        // Explicit picks map directly and are HONORED even below the floor (no clamp on an explicit pick).
+        assert_eq!(preferred_tier(Some(4), Some("q8")), "q4");
+        assert_eq!(preferred_tier(Some(0), Some("q8")), "bf16");
+        assert_eq!(preferred_tier(Some(8), None), "q8");
+        assert_eq!(preferred_tier(Some(2), None), "q4");
+        // Rank order + normalization helpers.
+        assert!(tier_quality_rank("bf16") > tier_quality_rank("q8"));
+        assert!(tier_quality_rank("q8") > tier_quality_rank("q4"));
+        assert_eq!(tier_quality_rank("mystery"), 0);
+    }
+
+    /// sc-10731: [`min_quality_floor`] reads the forwarded manifest `mlx.minQualityTier`, honoring only a
+    /// valid bf16/q8/q4 value and treating an absent/bogus one as no floor.
+    #[test]
+    fn min_quality_floor_reads_valid_manifest_values_only() {
+        let with_floor = |mlx: serde_json::Value| {
+            ImageRequest::from_payload(
+                json!({ "model": "anima_base", "modelManifestEntry": { "mlx": mlx } })
+                    .as_object()
+                    .unwrap(),
+            )
+        };
+        assert_eq!(
+            min_quality_floor(&with_floor(json!({ "minQualityTier": "q8" }))),
+            Some("q8")
+        );
+        assert_eq!(min_quality_floor(&with_floor(json!({ "quantize": 4 }))), None);
+        assert_eq!(
+            min_quality_floor(&with_floor(json!({ "minQualityTier": "q2" }))),
+            None
+        );
+        // No manifest entry at all → no floor.
+        assert_eq!(min_quality_floor(&request(json!({}))), None);
+    }
+
+    /// sc-10731: [`standard_tier_subdir`] applies the same floor clamp — a floored standard-tier model's
+    /// DEFAULT lands at the floor (capped by installed), while a non-floored one is unchanged and an
+    /// explicit below-floor pick is honored.
+    #[test]
+    fn standard_tier_subdir_clamps_default_to_the_floor() {
+        let floored = |bits: Option<i64>, floor: &str| {
+            let advanced = match bits {
+                Some(b) => json!({ "mlxQuantize": b }),
+                None => json!({}),
+            };
+            ImageRequest::from_payload(
+                json!({
+                    "model": "some_matrix_model",
+                    "advanced": advanced,
+                    "modelManifestEntry": { "mlx": { "minQualityTier": floor } }
+                })
+                .as_object()
+                .unwrap(),
+            )
+        };
+        // All three tiers present.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        for tier in ["bf16", "q8", "q4"] {
+            seed_tier(root, tier, "diffusion_pytorch_model.safetensors");
+        }
+        // Floor bf16, no explicit pick → bf16 (floored default → floor tier).
+        assert_eq!(
+            standard_tier_subdir(root, &floored(None, "bf16")),
+            root.join("bf16")
+        );
+        // Floor q8, no explicit pick → q8; a non-floored default is q8 too, but here it is floor-driven.
+        assert_eq!(
+            standard_tier_subdir(root, &floored(None, "q8")),
+            root.join("q8")
+        );
+        // Explicit q4 honored despite a bf16 floor (below-floor pick is the user's choice).
+        assert_eq!(
+            standard_tier_subdir(root, &floored(Some(4), "bf16")),
+            root.join("q4")
+        );
+        // Floor capped by installed: floor bf16 but only q4 on disk → q4.
+        let only_q4 = tempfile::tempdir().unwrap();
+        seed_tier(only_q4.path(), "q4", "diffusion_pytorch_model.safetensors");
+        assert_eq!(
+            standard_tier_subdir(only_q4.path(), &floored(None, "bf16")),
+            only_q4.path().join("q4")
+        );
+        // Non-floored model unaffected — the plain q8 default still stands (acceptance #3).
+        assert_eq!(
+            standard_tier_subdir(root, &request(json!({}))),
+            root.join("q8")
         );
     }
 


### PR DESCRIPTION
## What & why

**S6 of epic 10721 — the guardrail.** Some models are quality-BROKEN at a low tier regardless of RAM (Anima base/aesthetic at q4 — sc-10714). A per-model quality FLOOR keeps the DEFAULT (and a low global "default generation quality" setting) from silently landing there.

Quality order is **bf16 > q8 > q4**. The floor = the minimum-fidelity tier a **default** resolution may land on. "Clamp UP to floor" raises a below-floor default to the floor — always capped by clamp-to-installed (the floor never selects an uninstalled tier). An **explicit** user pick below the floor is still **honored** (a quant tier is a deliberate creative choice) but flagged with a non-blocking advisory.

## Changes

**Manifest (`config/manifests/builtin.models.jsonc`)**
- New `mlx.minQualityTier` field. Default absent = q4 (unchanged — no floor).
- `anima_base` + `anima_aesthetic` → `"q8"` (they render washed at q4 under CFG 4.5 × 30 steps). `anima_turbo` omits it (CFG-free, q4-tolerant).

**Backend (`apps/rust-api/src/models.rs`)**
- `apply_mac_and_mlx_fields` surfaces the manifest `mlx.minQualityTier` as a top-level `minQualityTier` (mirrors how `mlxTiers` is emitted), so the web reads one stable key. Only valid bf16/q8/q4 is emitted; platform-independent.

**Worker (`crates/sceneworks-worker/src/image_jobs/base.rs`)**
- New shared `preferred_tier(bits, floor)` (+ `tier_quality_rank`, `min_quality_floor`) behind **both** `standard_tier_subdir` and `anima_tier_subdir`. With no explicit `mlxQuantize`, the app-wide q8 default (sc-10726) is **clamped UP to the floor** (raises only), then capped by the existing clean-tier fallback. An **explicit** pick maps directly and is honored even below the floor.
- **Reconciles the sc-10714 anima `None => "q8"` hardcode** into this general mechanism: Anima's q8 default is now floor-driven from the manifest, not a resolver special-case. The floor value reaches the resolver via the already-forwarded `model_manifest_entry` — no new plumbing.

**Web (`apps/web/src/quantTier.js`, `screens/ImageStudio.jsx`)**
- `defaultTierSelection` clamps the DEFAULT (rungs 2–4) UP to the floor, capped by clamp-to-installed. The sticky (rung 1, a prior explicit pick) is **not** re-floored.
- New `modelQualityFloor` / `isBelowFloor` exports drive a non-blocking `field-hint` advisory in the Studio tier picker when the user **explicitly** picks a below-floor tier — honored, never silently switched.

## Tests

- **Worker:** `preferred_tier` clamp (floored default → floor tier; floor at/below q8 leaves q8; explicit below-floor honored), `min_quality_floor` manifest parse, `standard_tier_subdir` floor clamp (capped by installed, non-floored unaffected), and the existing anima resolver test extended to prove the floor now drives the default.
- **rust-api:** `catalog_emits_min_quality_floor_from_manifest` (valid/absent/invalid).
- **Web:** `quantTier.test.js` — global q4 + floored model → q8, declared-default raise, floor capped by installed, below-floor sticky honored, non-floored unaffected; `ImageStudio.test.jsx` — floored default → q8 under a global q4 setting (no advisory), explicit q4 → advisory shown + q4 honored in the payload, non-floored model unaffected.
- `npm run rust:fmt` + clippy `-D warnings` clean; worker/rust-api cargo tests pass; `npx vitest run` (101 tests) + eslint clean; embedded manifest parses.

## Acceptance
1. Global setting q4 + Anima base → resolves **q8** (floored). ✓
2. Explicit q4 pick on Anima base → **q4** (honored) + UI advisory. ✓
3. Non-floored models unaffected (still q4-tolerant defaults). ✓
4. Worker + web unit tests; the sc-10714 Anima default is now floor-driven. ✓

Out of scope (not implemented): S7 real-weights sharpness/regression test, S8 Auto.

Story: https://app.shortcut.com/trefry/story/10731 (sc-10731)

🤖 Generated with [Claude Code](https://claude.com/claude-code)