### PR TITLE
feat(routing): candle q4/q8 packed SDXL-family inference for low-VRAM cards (sc-10767)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-gen",
  "image",
@@ -695,7 +695,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -752,7 +752,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -769,7 +769,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -789,7 +789,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -813,7 +813,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -824,7 +824,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -8342,7 +8342,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-gen",
  "image",
@@ -695,7 +695,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -752,7 +752,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -769,7 +769,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -789,7 +789,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -813,7 +813,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -824,7 +824,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=40583ff91ed4a58c85971ed2703aa3a0f90b63fe#40583ff91ed4a58c85971ed2703aa3a0f90b63fe"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e6240093ee4260233e73be1a67be7569bee6d4db#e6240093ee4260233e73be1a67be7569bee6d4db"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -8342,7 +8342,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3721,10 +3721,12 @@ mod candle_routing_tests {
 
     #[test]
     fn explicit_quantization_falls_back_to_torch_image_and_video() {
-        // sc-5099: the candle providers are dense (supported_quants: &[]); an explicit
-        // `advanced.mlxQuantize > 0` must route to Python rather than silently running dense.
+        // sc-5099: a candle provider that advertises NO quant (supported_quants: &[]) must route an
+        // explicit `advanced.mlxQuantize > 0` to Python rather than silently running dense. chroma1_hd
+        // is such a dense-only candle family (contrast the SDXL family, sc-10767, which now advertises
+        // Q4/Q8 packed tiers and stays on candle — covered by `sdxl_family_quant_and_lora_stay_on_candle`).
         assert!(!image_request_candle_eligible(
-            "sdxl",
+            "chroma1_hd",
             &object(json!({ "advanced": { "mlxQuantize": 8 } }))
         ));
         assert!(!image_request_candle_eligible(
@@ -3735,15 +3737,46 @@ mod candle_routing_tests {
             "wan_2_2",
             &object(json!({ "mode": "text_to_video", "advanced": { "mlxQuantize": 8 } }))
         ));
-        // Dense (<= 0) or absent quant leaves candle on its native dense path → still eligible.
+        // Dense (<= 0) or absent quant leaves a dense candle family on its native path → still eligible.
         assert!(image_request_candle_eligible(
-            "sdxl",
+            "chroma1_hd",
             &object(json!({ "advanced": { "mlxQuantize": 0 } }))
         ));
         assert!(image_request_candle_eligible(
-            "sdxl",
+            "chroma1_hd",
             &object(json!({ "advanced": { "steps": 30 } }))
         ));
+    }
+
+    #[test]
+    fn sdxl_family_quant_and_lora_stay_on_candle() {
+        // sc-10767 (epic 9083): the SDXL family advertises Q4/Q8 packed tiers (candle-gen sc-9416/9527)
+        // AND inference LoRA/LoKr on a packed tier (sc-9528), so a quant tier-select AND a LoRA both
+        // stay on the candle lane rather than deferring to the retired torch fallback. Mirrors the
+        // boogu/lens quant-stays coverage; the inverse of the old dense-only behavior.
+        for model in [
+            "sdxl",
+            "realvisxl",
+            "illustrious_xl_v1",
+            "illustrious_xl_v2",
+        ] {
+            for bits in [8, 4] {
+                assert!(
+                    image_request_candle_eligible(
+                        model,
+                        &object(json!({ "prompt": "x", "advanced": { "mlxQuantize": bits } }))
+                    ),
+                    "{model} Q{bits} tier-select should stay on candle (sc-10767)"
+                );
+            }
+            assert!(
+                image_request_candle_eligible(
+                    model,
+                    &object(json!({ "loras": [{ "name": "x", "path": "/x.safetensors" }] }))
+                ),
+                "{model} with a LoRA should stay on candle (sc-10767)"
+            );
+        }
     }
 
     #[test]
@@ -3889,12 +3922,14 @@ mod candle_routing_tests {
 
     #[test]
     fn sdxl_advanced_shapes_fall_back_to_torch() {
-        // Every conditioning shape the txt2img candle lane can't honor must be ineligible.
+        // Every conditioning shape the txt2img candle lane can't honor must be ineligible. A LoRA is NOT
+        // in this set anymore (sc-10767): the SDXL family advertises inference LoRA on candle, so a plain
+        // LoRA txt2img stays on the candle lane (see `sdxl_family_quant_and_lora_stay_on_candle`). Only
+        // the genuine conditioning shapes (img2img / reference / mask / strict-pose) fall back.
         let cases = [
             json!({ "mode": "edit_image", "sourceAssetId": "asset_1" }), // img2img / inpaint / outpaint
             json!({ "referenceAssetId": "asset_1" }),                    // IP-Adapter reference
             json!({ "mode": "edit_image", "sourceAssetId": "a", "maskAssetId": "m" }), // inpaint
-            json!({ "loras": [{ "name": "x" }] }),                       // LoRA
             json!({ "advanced": { "poses": [{ "id": "pose_1" }] } }),    // strict-pose ControlNet
         ];
         for case in cases {

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -564,12 +564,18 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
     // FLUX.2-dev (epic 5914 MLX / epic 6564 sc-7458 candle) — the guidance-distilled 32B flagship.
     // A SEPARATE candle engine from klein (Mistral3 TE + 48/48/15360 DiT); Q4-quantized at load off-Mac.
     ModelCaps::new("flux2_dev", true, true, false, false, false),
-    ModelCaps::new("sdxl", true, true, false, false, false),
-    ModelCaps::new("realvisxl", true, true, false, false, false),
+    // SDXL family (sc-10767, epic 9083 full-catalog parity): the candle lane serves the packed q4/q8
+    // MLX tiers end-to-end — packed UNet (sc-9416), packed dual-CLIP (sc-9527), and LoRA/LoKr fold on a
+    // packed tier (sc-9528) — and `candle-gen-sdxl` now advertises `supported_quants: [Q4, Q8]`. So
+    // BOTH a quant tier-select AND an inference LoRA stay on candle → `candle_quant_lora`. Previously
+    // `false, false, false` bounced quant requests (the sc-10726 q8 default) AND LoRA requests off the
+    // candle lane into the retired torch fallback. bf16 still resolves to Quant::None (dense), verbatim.
+    ModelCaps::new("sdxl", true, true, false, false, true),
+    ModelCaps::new("realvisxl", true, true, false, false, true),
     // Illustrious-XL v1.0 / v2.0 (epic 10609): vanilla-SDXL anime finetunes on the shared `sdxl`
-    // engine. Same routing surface as `realvisxl` — MLX + candle txt2img, dense (no candle quant).
-    ModelCaps::new("illustrious_xl_v1", true, true, false, false, false),
-    ModelCaps::new("illustrious_xl_v2", true, true, false, false, false),
+    // engine. Same routing surface as `realvisxl` — MLX + candle txt2img + packed q4/q8 (sc-10767).
+    ModelCaps::new("illustrious_xl_v1", true, true, false, false, true),
+    ModelCaps::new("illustrious_xl_v2", true, true, false, false, true),
     // RealVisXL Lightning (MLX sc-6075 / candle sc-7176): standalone few-step distilled SDXL checkpoint
     // on the shared `sdxl` engine, few-step `lightning` accel sampler. **txt2img only** on both backends —
     // edit / reference / mask / pose shapes fall back to torch (accel sampler is conditioning-incompatible).
@@ -1001,9 +1007,19 @@ mod tests {
 
     // sc-9983: Krea joins Lens as a BOTH-quant-and-LoRA candle family (sc-9607 flipped its
     // `supported_quants` to [Q4, Q8]; it already advertised inference LoRA via sc-7836). sc-9994 adds the
-    // Raw variant (candle-gen #350) with the same both-set advertisement.
-    const EXPECTED_CANDLE_QUANT_LORA_MODELS: &[&str] =
-        &["lens", "lens_turbo", "krea_2_turbo", "krea_2_raw"];
+    // Raw variant (candle-gen #350) with the same both-set advertisement. sc-10767: the SDXL family
+    // (sdxl/realvisxl/illustrious v1+v2) joins the both-set — the candle packed q4/q8 tier (sc-9416/9527)
+    // + adapter-on-packed fold (sc-9528) are wired and now advertised.
+    const EXPECTED_CANDLE_QUANT_LORA_MODELS: &[&str] = &[
+        "sdxl",
+        "realvisxl",
+        "illustrious_xl_v1",
+        "illustrious_xl_v2",
+        "lens",
+        "lens_turbo",
+        "krea_2_turbo",
+        "krea_2_raw",
+    ];
 
     // sc-9983: ideogram/boogu join SD3.5 as quant-only candle families (sc-9607 flipped their
     // `supported_quants` to [Q4, Q8]; no inference LoRA on candle).

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1549,15 +1549,23 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "5d88
 # `5c28c20` -> `09f6ef99` (byte-identical — provider-only) so `--features backend-candle` resolves the
 # SINGLE gen-core rev `09f6ef99` (skew gate green). `536c2ef` is an ancestor of `b20ef5d`, a clean
 # forward move; ALL candle-gen-* move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+# Bumped `40583ff` -> `e624009` (sc-10767, epic 9083): candle-gen #385 flips the candle SDXL descriptor
+# to `supported_quants: [Q4, Q8]` so the worker keeps a quant tier-select + LoRA on the candle lane
+# (paired with the SDXL-family `candle_quant_lora` routing flip in this PR). The packed SDXL inference
+# stack (packed UNet sc-9416, packed dual-CLIP sc-9527, adapter-on-packed fold sc-9528) was already
+# wired; this advertises it. gen-core stays `5d882290` across `40583ff..e624009` (my commits touch only
+# candle-gen-sdxl; #383 gencore-align kept 5d882290), so the `--features backend-candle` lane resolves
+# the SINGLE gen-core rev `5d882290` in LOCKSTEP with the worker's mlx-gen pin (skew gate green).
+# `40583ff` is an ancestor of `e624009`, a clean forward move; ALL candle-gen-* move together.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1571,7 +1579,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1579,17 +1587,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1599,7 +1607,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1607,21 +1615,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1630,17 +1638,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1649,7 +1657,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1682,7 +1690,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1691,12 +1699,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1704,7 +1712,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1713,7 +1721,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1721,7 +1729,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1735,7 +1743,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1762,7 +1770,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1773,7 +1781,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "40583ff91ed4a58c85971ed2703aa3a0f90b63fe", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1549,23 +1549,24 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "5d88
 # `5c28c20` -> `09f6ef99` (byte-identical — provider-only) so `--features backend-candle` resolves the
 # SINGLE gen-core rev `09f6ef99` (skew gate green). `536c2ef` is an ancestor of `b20ef5d`, a clean
 # forward move; ALL candle-gen-* move together.
-# Bumped `40583ff` -> `e624009` (sc-10767, epic 9083): candle-gen #385 flips the candle SDXL descriptor
-# to `supported_quants: [Q4, Q8]` so the worker keeps a quant tier-select + LoRA on the candle lane
-# (paired with the SDXL-family `candle_quant_lora` routing flip in this PR). The packed SDXL inference
-# stack (packed UNet sc-9416, packed dual-CLIP sc-9527, adapter-on-packed fold sc-9528) was already
-# wired; this advertises it. gen-core stays `5d882290` across `40583ff..e624009` (my commits touch only
-# candle-gen-sdxl; #383 gencore-align kept 5d882290), so the `--features backend-candle` lane resolves
-# the SINGLE gen-core rev `5d882290` in LOCKSTEP with the worker's mlx-gen pin (skew gate green).
-# `40583ff` is an ancestor of `e624009`, a clean forward move; ALL candle-gen-* move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+# Bumped `40583ff` -> `92253d2` (sc-10767, epic 9083): candle-gen #385 (merged) flips the candle SDXL
+# descriptor to `supported_quants: [Q4, Q8]` so the worker keeps a quant tier-select + LoRA on the
+# candle lane (paired with the SDXL-family `candle_quant_lora` routing flip in this PR). The packed SDXL
+# inference stack (packed UNet sc-9416, packed dual-CLIP sc-9527, adapter-on-packed fold sc-9528) was
+# already wired; this advertises it. The range also carries #384 (sc-10668 comfyui z-image loader,
+# provider-only, unrelated). gen-core stays `5d882290` across `40583ff..92253d2` (verified at main HEAD),
+# so the `--features backend-candle` lane resolves the SINGLE gen-core rev `5d882290` in LOCKSTEP with the
+# worker's mlx-gen pin (skew gate green). `40583ff` is an ancestor of `92253d2`, a clean forward move;
+# ALL candle-gen-* move together.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1579,7 +1580,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1587,17 +1588,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1607,7 +1608,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1615,21 +1616,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1638,17 +1639,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1657,7 +1658,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1690,7 +1691,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1699,12 +1700,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1712,7 +1713,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1721,7 +1722,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1729,7 +1730,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1743,7 +1744,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1770,7 +1771,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1781,7 +1782,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e6240093ee4260233e73be1a67be7569bee6d4db", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -773,8 +773,9 @@ impl ResolvedModel {
     pub fn supports_negative_prompt(&self) -> bool {
         self.descriptor.capabilities.supports_negative_prompt
     }
-    /// Whether the engine advertises any on-the-fly Q4/Q8 quantization (descriptor-derived). The
-    /// candle SDXL / sc-5096 families advertise none (dense only); Lens advertises Q4/Q8 (sc-5126).
+    /// Whether the engine advertises any Q4/Q8 quantization (descriptor-derived). The candle SDXL
+    /// family advertises Q4/Q8 as of sc-10767 (it packed-detects the pre-quantized MLX tier from disk);
+    /// the remaining sc-5096 candle families advertise none (dense only). Lens advertises Q4/Q8 (sc-5126).
     /// Used on BOTH lanes: the candle lane has always gated quant on this; the MLX lane gates on it
     /// too as of sc-8489 so SANA (the lone generic-MLX family with `supported_quants: &[]`, whose
     /// `load` rejects any quant) loads dense, while every pre-existing family (all Q4/Q8) is

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -707,9 +707,12 @@ fn standard_tier_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
 /// The DENSE (`bf16/`) tier of a SceneWorks quant-matrix turnkey, or `root` unchanged for a flat
 /// diffusers snapshot (sc-10614).
 ///
-/// The candle SDXL lanes (`sdxl_edit_candle.rs`, `sdxl_ipadapter.rs`) read dense weights —
-/// `IMAGE_MODEL_CAPS` marks the whole SDXL family `candle_quant: false` — so they always want
-/// `bf16/`, unlike [`standard_tier_subdir`], which honours `advanced.mlxQuantize`. They historically
+/// The candle SDXL edit / IP-Adapter lanes (`sdxl_edit_candle.rs`, `sdxl_ipadapter.rs`) have only a
+/// DENSE implementation — their conditioning paths read dense weights — so they always want `bf16/`,
+/// unlike [`standard_tier_subdir`], which honours `advanced.mlxQuantize`. (The plain txt2img lane DOES
+/// serve the packed q4/q8 tiers as of sc-10767 — the SDXL family is `candle_quant_lora` — but that goes
+/// through `standard_tier_subdir`; these two bespoke sub-mode lanes stay dense-only for now.) They
+/// historically
 /// handed the snapshot ROOT straight to the loader, which works only because `sdxl` and `realvisxl`
 /// fall back to flat upstream diffusers repos (`stabilityai/stable-diffusion-xl-base-1.0`,
 /// `SG161222/RealVisXL_V5.0`). An SDXL model re-hosted as a tiered turnkey has no component tree at

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
@@ -36,8 +36,9 @@ fn is_sdxl_edit_candle_model(model: &str) -> bool {
 ///
 /// `sdxl` and `realvisxl` name FLAT upstream diffusers snapshots. Illustrious has no such upstream —
 /// OnomaAI ship a single-file LDM checkpoint — so it names its tiered turnkey, and
-/// `dense_tier_subdir` descends into the dense `bf16/` tier (sc-10614). This lane is dense-only:
-/// `IMAGE_MODEL_CAPS` marks the whole SDXL family `candle_quant: false`.
+/// `dense_tier_subdir` descends into the dense `bf16/` tier (sc-10614). This edit lane is dense-only —
+/// its candle implementation reads dense weights — even though the plain txt2img lane now serves the
+/// packed q4/q8 tiers (sc-10767, the SDXL family is `candle_quant_lora`); the packed path is txt2img-only.
 fn sdxl_edit_candle_default_repo(model: &str) -> &'static str {
     match model {
         "realvisxl" => "SG161222/RealVisXL_V5.0",


### PR DESCRIPTION
## Why
Growing user base on 8–16 GB (some 8 GB) NVIDIA cards can't run SDXL-family models on the candle/Windows backend that they run quantized in ComfyUI. The candle SDXL packed-tier engine was **built but never advertised**, so the whole family ran dense-only — and with the app-wide Q8 default (sc-10726), the router was actively bouncing quant *and* LoRA requests off the candle lane into the retired torch fallback.

Epic 9083 gap #2 / full-catalog parity. Relates to epic 10609 (Illustrious is the first SDXL turnkey users hit this on).

## What
- **Routing** (`routing/catalog.rs`): SDXL family (`sdxl`, `realvisxl`, `illustrious_xl_v1`, `illustrious_xl_v2`) `candle_quant: false` → **`candle_quant_lora: true`**. Both a quant tier-select AND an inference LoRA now stay on candle. Updates the derived-list snapshot test.
- **Pin bump**: candle-gen `40583ff` → `e624009` (michaeltrefry/candle-gen#385) — flips the candle SDXL descriptor to `supported_quants: [Q4, Q8]` so `supports_quant()` is true. gen-core stays `5d882290` (single-rev, in lockstep with the worker's mlx-gen pin — skew gate green).

The packed inference stack was already wired (packed UNet sc-9416, packed dual-CLIP sc-9527, LoRA/LoKr fold on a packed tier sc-9528); this makes it reachable. `standard_tier_subdir` already descends into the q4/q8 tier via the manifest `mlx.standardTierLayout`; `candle-gen-sdxl::load` packed-detects from disk; a bf16 tier still resolves to `Quant::None` (dense), unchanged.

## GPU validation (RTX PRO 6000, sm_120, `sdxl-base-mlx` tiers)
Coherent images on `backend=candle` from the **packed q4 tier**, peak VRAM vs bf16:

| resolution | q4 peak | bf16 peak |
|---|---|---|
| 512² | **6.1 GB** | 9.0 GB |
| 768² | **6.3 GB** | 9.0 GB |
| 1024² | 10.1 GB | 9.3 GB |

At 512–768² (the low-VRAM target) q4 saves ~2.7–2.9 GB and fits an **8 GB card** where dense bf16 (~9 GB resident) does not. At 1024² the activation transient + dequant scratch flips it and q4 is ~2× slower/step — so q4 is for *fitting in VRAM*, not speed (matches the epic-9083 Blackwell spike). A real third-party kohya LoRA also applied on the q4 packed tier (sc-9528 fold) and visibly restyled the output.

## Follow-ups (out of scope)
- **kolors** (ChatGLM3 TE — different packed path) and **realvisxl_lightning** (few-step) validate separately.
- q4+LoRA peaks ~like bf16 because keep-dense dequantizes adapted layers — a VRAM-vs-chaos-safety tradeoff worth a follow-up for low-VRAM + LoRA.
- Per-variant measured `minMemoryGb` (epic 9083 sc-9094).

## Pairs with
michaeltrefry/candle-gen#385 (the descriptor flip this pin points at).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>