### PR TITLE
fix(core): derive convert-gap allow-list from converter registry (sc-10573)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -36,7 +36,9 @@ pub(crate) use routing::mlx::*;
 pub use routing::catalog::{
     mac_capabilities, model_mac_support, MacCapabilities, MAC_NOT_AVAILABLE_LABEL,
 };
-pub use routing::gaps::{candle_supported, mac_rust_supported, UnsupportedReason};
+pub use routing::gaps::{
+    candle_supported, mac_rust_supported, UnsupportedReason, NATIVE_CONVERTERS,
+};
 
 pub const ACTIVE_STATUSES: &[&str] = &[
     "preparing",

--- a/crates/sceneworks-core/src/jobs_store/routing/gaps.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/gaps.rs
@@ -780,14 +780,47 @@ pub(crate) fn classify_training_gap(payload: &Map<String, Value>) -> Unsupported
     }
 }
 
-/// `model_convert` is supported for the in-process Rust converters (FLUX.2-klein `flux2_klein_diffusers`
-/// sc-3136; FLUX.2-dev `flux2_dev_quant`; Anima `anima_quant`, sc-10517 — the on-device q4/q8/bf16
-/// matrix). The default/absent converter is the retired Python mlx-video path (sc-3491 / sc-3224).
+/// The `mlx.converter` discriminators the native, in-process mlx-gen converters handle — the single
+/// source of truth the convert-gap gate derives its allow-list from, mirroring the
+/// `resolve_convert_plan` match arms in `sceneworks-worker` (each id here is a real arm there).
+///
+/// A `model_convert` job copies its `converter` payload verbatim from a model's `mlx.converter`
+/// manifest field (`create_model_convert_job` in `apps/rust-api`), so every reachable converter — a
+/// builtin model's OR a user model's — is either named here or is genuinely unsupported. Deriving the
+/// gate from this const (rather than a second, hand-maintained copy of the list inside the gate) is
+/// what fixes sc-10573: `ltx_video` was a live, shipped converter (the LTX-2.3 "10 Eros"
+/// install-convert) yet the gate's old hardcoded list omitted it, so `mac_rust_supported`
+/// mis-classified a valid LTX conversion as an mlx gap — a spurious `mlx_unsupported` warn event
+/// today, and a wrongful terminal failure once enforce mode ships (sc-3492).
+///
+/// Two drift guards (see their tests) keep this list honest so it can't go stale again:
+/// - `sceneworks-core` (`every_builtin_manifest_converter_is_in_the_convert_gap_allowlist`): every
+///   `mlx.converter` in the embedded `builtin.models.jsonc` is listed here.
+/// - `sceneworks-worker` (`native_converters_match_resolve_convert_plan_arms`): every id here is a
+///   real `resolve_convert_plan` arm (not its "Unknown MLX converter." fallback), and a bogus id is
+///   rejected — so the list can neither omit a live arm nor over-claim a nonexistent one.
+pub const NATIVE_CONVERTERS: &[&str] = &[
+    "flux2_klein_diffusers",
+    "ltx_video",
+    "flux2_dev_quant",
+    "sd3_5_large_quant",
+    "sd3_5_large_turbo_quant",
+    "sd3_5_medium_quant",
+    "anima_quant",
+];
+
+/// `model_convert` is supported for the in-process Rust converters enumerated in
+/// [`NATIVE_CONVERTERS`] (FLUX.2-klein `flux2_klein_diffusers` sc-3136; LTX-2.3 `ltx_video` sc-3240;
+/// FLUX.2-dev `flux2_dev_quant` sc-5921; the SD3.5 `sd3_5_*_quant` variants sc-7871; Anima
+/// `anima_quant` sc-10517). The allow-list is derived from that const so it can never drift from the
+/// worker's real converter set again (sc-10573). The default/absent converter is the retired Python
+/// mlx-video path (sc-3491 / sc-3224) — still a gap.
 pub(crate) fn classify_convert_gap(payload: &Map<String, Value>) -> Result<(), UnsupportedReason> {
-    if matches!(
-        payload.get("converter").and_then(Value::as_str),
-        Some("flux2_klein_diffusers") | Some("flux2_dev_quant") | Some("anima_quant")
-    ) {
+    let converter = payload
+        .get("converter")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if NATIVE_CONVERTERS.contains(&converter) {
         return Ok(());
     }
     Err(UnsupportedReason::new(

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -3191,6 +3191,42 @@ fn every_builtin_manifest_converter_is_in_the_convert_gap_allowlist() {
     }
 }
 
+/// sc-10573 arm→const drift guard for the LATENT (manifest-absent) converters. The sibling
+/// `every_builtin_manifest_converter_is_in_the_convert_gap_allowlist` only covers converters a
+/// shipped builtin declares in `mlx.converter`; `flux2_dev_quant` and the `sd3_5_*_quant` set ship
+/// turnkey (no `mlx.converter` in the builtin manifest), so that guard can't see them. Silently
+/// dropping one of those from the const would disable it — the gate and the worker would both reject
+/// the convert consistently (a latent regression, not a runtime lie) — and NO other test would fail.
+/// Pinning the exact set here forces every edit (add OR remove, including the latent ones) to be a
+/// deliberate, reviewed change: additions MUST also gain a `resolve_convert_plan` arm (enforced by
+/// the worker's `native_converters_match_resolve_convert_plan_arms` guard), and removals MUST be
+/// intentional (the converter is truly retired, not merely absent from the manifest).
+#[test]
+fn native_converters_registry_contents_are_pinned() {
+    use std::collections::BTreeSet;
+    let expected: BTreeSet<&str> = [
+        "flux2_klein_diffusers",
+        "ltx_video",
+        "flux2_dev_quant",
+        "sd3_5_large_quant",
+        "sd3_5_large_turbo_quant",
+        "sd3_5_medium_quant",
+        "anima_quant",
+    ]
+    .into_iter()
+    .collect();
+    let actual: BTreeSet<&str> = sceneworks_core::jobs_store::NATIVE_CONVERTERS
+        .iter()
+        .copied()
+        .collect();
+    assert_eq!(
+        actual, expected,
+        "NATIVE_CONVERTERS drifted from its pinned set — every add/remove (including the latent, \
+         manifest-absent converters flux2_dev_quant + sd3_5_*_quant) must be a deliberate, reviewed \
+         update: additions need a resolve_convert_plan arm, removals must be intentional (sc-10573)"
+    );
+}
+
 #[test]
 fn mac_rust_supported_feature_gaps_point_at_their_spikes() {
     let store = store("oracle-feature-spikes");

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -3106,6 +3106,25 @@ fn mac_rust_supported_convert_flux2_ok_else_python_gap() {
         json!({ "model": "anima_base", "converter": "anima_quant" }),
     );
     assert!(mac_rust_supported(&anima).is_ok());
+    // LTX-2.3 (mlx-gen-ltx, sc-3240) is a live in-process convert — the sc-10573 regression: it
+    // ships in the builtin manifest yet the gate's old hardcoded list omitted it, so a valid LTX
+    // install-convert was mis-classified as an mlx gap.
+    let ltx = job_of(
+        &store,
+        JobType::ModelConvert,
+        json!({ "model": "ltx_2_3_eros", "converter": "ltx_video" }),
+    );
+    assert!(
+        mac_rust_supported(&ltx).is_ok(),
+        "ltx_video is a native in-process convert (sc-10573)"
+    );
+    // SD3.5 transformer pre-quantization (sc-7871) is likewise a native convert.
+    let sd3 = job_of(
+        &store,
+        JobType::ModelConvert,
+        json!({ "model": "sd3_5_medium", "converter": "sd3_5_medium_quant" }),
+    );
+    assert!(mac_rust_supported(&sd3).is_ok());
     // The default/absent converter is the Python mlx-video Wan/LTX path → gap.
     let wan = job_of(&store, JobType::ModelConvert, json!({ "model": "wan_2_2" }));
     assert_eq!(
@@ -3115,6 +3134,61 @@ fn mac_rust_supported_convert_flux2_ok_else_python_gap() {
             .as_deref(),
         Some("sc-3491 / sc-3224")
     );
+    // A genuinely unknown converter (not in NATIVE_CONVERTERS) is still a gap.
+    let bogus = job_of(
+        &store,
+        JobType::ModelConvert,
+        json!({ "model": "whatever", "converter": "not_a_real_converter" }),
+    );
+    assert!(mac_rust_supported(&bogus).is_err());
+}
+
+/// sc-10573 drift guard (the core half): every converter a shipped builtin model declares in
+/// `mlx.converter` MUST be covered by the convert-gap allow-list ([`NATIVE_CONVERTERS`]) — otherwise
+/// its install-convert job is misclassified as an mlx gap by [`mac_rust_supported`]. That is exactly
+/// the bug that shipped: `ltx_video` was a live builtin converter absent from the gate's old
+/// hardcoded list. This test goes RED if a manifest converter is missing from the const (verified by
+/// temporarily dropping `ltx_video` from `NATIVE_CONVERTERS`).
+#[test]
+fn every_builtin_manifest_converter_is_in_the_convert_gap_allowlist() {
+    let manifest = sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS
+        .iter()
+        .find(|(name, _)| *name == "builtin.models.jsonc")
+        .map(|(_, contents)| *contents)
+        .expect("builtin.models.jsonc is embedded in BUILTIN_MANIFESTS");
+    let parsed: Value =
+        serde_json::from_str(&sceneworks_core::jsonc::strip_jsonc_comments(manifest))
+            .expect("builtin.models.jsonc parses after comment stripping");
+    let models = parsed
+        .get("models")
+        .and_then(Value::as_array)
+        .expect("manifest has a models array");
+    let declared: std::collections::BTreeSet<String> = models
+        .iter()
+        .filter_map(|model| {
+            model
+                .get("mlx")
+                .and_then(Value::as_object)
+                .and_then(|mlx| mlx.get("converter"))
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|converter| !converter.is_empty())
+                .map(str::to_owned)
+        })
+        .collect();
+    // Guard against the test silently rotting into a no-op if the manifest ever stops declaring any
+    // `mlx.converter` (or the parse shape drifts): the guard is only meaningful with something to check.
+    assert!(
+        !declared.is_empty(),
+        "expected builtin.models.jsonc to declare at least one mlx.converter"
+    );
+    for converter in &declared {
+        assert!(
+            sceneworks_core::jobs_store::NATIVE_CONVERTERS.contains(&converter.as_str()),
+            "builtin converter '{converter}' is not covered by NATIVE_CONVERTERS (the convert-gap \
+             allow-list) — its install-convert job would be misclassified as an mlx gap (sc-10573)"
+        );
+    }
 }
 
 #[test]

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -13,6 +13,10 @@ use sceneworks_core::contracts::{
     WorkerRegisterRequest, WorkerSnapshot, WorkerStatus, WorkerUtilizationSnapshot,
 };
 use sceneworks_core::hf_home::{huggingface_hub_cache_dir, huggingface_repo_cache_path};
+// The single source of truth for which `mlx.converter` discriminators the native converters handle.
+// `resolve_convert_plan` rejects anything not on it up front so this worker's converter set can never
+// drift from the convert-gap gate that derives its allow-list from the same const (sc-10573).
+use sceneworks_core::jobs_store::NATIVE_CONVERTERS;
 use sceneworks_core::jsonc::strip_jsonc_comments;
 use sceneworks_core::lora_family::{
     apply_model_manifest_defaults, detect_lora_family, detect_model_family, first_safetensors_path,

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -951,6 +951,17 @@ async fn resolve_convert_plan(
     let model_id = required_payload_string(&job.payload, "modelId")?;
     let source_repo = required_payload_string(&job.payload, "sourceRepo")?;
     let converter = optional_payload_string(&job.payload, "converter").unwrap_or_default();
+    // Reject any non-empty converter that is not in the shared registry up front, so this resolver's
+    // recognized set is derived from `NATIVE_CONVERTERS` — the same const the convert-gap gate derives
+    // its allow-list from. This guarantees the gate can never be stricter than the set of arms below,
+    // the exact drift that shipped as sc-10573 (`ltx_video` handled here but missing from the gate).
+    // The empty ("" = no converter configured) case still falls through to its own arm below.
+    if !converter.is_empty() && !NATIVE_CONVERTERS.contains(&converter) {
+        return Ok(Err(ConvertPlanError {
+            message: "Unknown MLX converter.",
+            detail: format!("Unrecognized mlx.converter '{converter}' for {model_id}."),
+        }));
+    }
     let plan = match converter {
         "flux2_klein_diffusers" => {
             let source_file_name = required_payload_string(&job.payload, "sourceFile")?.to_owned();
@@ -2871,6 +2882,125 @@ mod anima_convert_tests {
                 *expected,
                 "partition drift for `{key}` — must match mlx_gen_anima::convert::is_dit_quant_target"
             );
+        }
+    }
+}
+
+/// sc-10573 drift guard (the worker half of the convert-gap allow-list check). Pins the shared
+/// `NATIVE_CONVERTERS` registry to the actual `resolve_convert_plan` arms so the two can never drift:
+/// the convert-gap gate in `sceneworks-core` derives its allow-list from that same const, so keeping
+/// it in lockstep with the arms here keeps the gate no stricter (and no looser) than what the worker
+/// can really convert.
+#[cfg(test)]
+mod convert_registry_tests {
+    use super::*;
+
+    /// A `Settings` with just enough to construct an `ApiClient`; every download/limit field is inert
+    /// for `resolve_convert_plan`'s converter-recognition path (no network is reached — each arm
+    /// returns its own missing-source error before any fetch).
+    fn minimal_settings(data_dir: PathBuf) -> Settings {
+        Settings {
+            api_url: "http://127.0.0.1:0".to_owned(),
+            access_token: None,
+            data_dir,
+            config_dir: PathBuf::from("config"),
+            worker_id: "test-worker".to_owned(),
+            gpu_id: "cpu".to_owned(),
+            is_child_worker: true,
+            poll_seconds: 1,
+            heartbeat_seconds: 5,
+            shutdown_timeout_seconds: 1,
+            huggingface_base_url: "http://127.0.0.1:0".to_owned(),
+            huggingface_token: None,
+            credentials: Vec::new(),
+            // Values irrelevant to this test (no URL work happens); the byte-limit defaults.
+            max_lora_url_bytes: 8u64 * 1024 * 1024 * 1024,
+            max_model_url_bytes: 256u64 * 1024 * 1024 * 1024,
+            allow_private_lora_urls: true,
+            utility_workers: 1,
+            backend_mlx_enabled: true,
+            backend_candle_enabled: false,
+            gpu_memory_limit_bytes: 0,
+            external_model_roots: Vec::new(),
+        }
+    }
+
+    /// A `model_convert` `JobSnapshot` carrying `converter`. It also carries `sourceFile`/`baseRepo`
+    /// so the arms that `required_payload_string(..)` those before their existence checks reach their
+    /// own (converter-specific) failure — never an infra `?` error out of `resolve_convert_plan`.
+    fn convert_job(converter: &str) -> JobSnapshot {
+        serde_json::from_value(json!({
+            "id": "job-convert-registry-test",
+            "type": "model_convert",
+            "status": "running",
+            "projectId": null,
+            "projectName": null,
+            "payload": {
+                "modelId": "test_model",
+                "sourceRepo": "org/test-repo",
+                "converter": converter,
+                "sourceFile": "model.safetensors",
+                "baseRepo": "org/base-repo"
+            },
+            "result": {},
+            "requestedGpu": "auto",
+            "assignedGpu": null,
+            "workerId": null,
+            "progress": 0.0,
+            "stage": "queued",
+            "message": "",
+            "error": null,
+            "etaSeconds": null,
+            "elapsedSeconds": null,
+            "attempts": 0,
+            "sourceJobId": null,
+            "duplicateOfJobId": null,
+            "cancelRequested": false,
+            "createdAt": "2026-07-10T00:00:00Z",
+            "updatedAt": "2026-07-10T00:00:00Z",
+            "startedAt": null,
+            "completedAt": null,
+            "canceledAt": null,
+            "lastHeartbeatAt": null
+        }))
+        .expect("valid model_convert JobSnapshot")
+    }
+
+    /// Every id in `NATIVE_CONVERTERS` is a REAL `resolve_convert_plan` arm — it resolves to a plan or
+    /// an arm-specific error, never the "Unknown MLX converter." fallback — and a bogus id IS rejected
+    /// as unknown. Failure-capable: adding a nonexistent id to the const (no arm) makes it fall to the
+    /// "Unknown MLX converter." path and this test goes RED; the bogus-id case proves the check isn't
+    /// vacuously accepting every string.
+    #[tokio::test]
+    async fn native_converters_match_resolve_convert_plan_arms() {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let settings = minimal_settings(tmp.path().to_path_buf());
+        let api = ApiClient::new(&settings);
+        let checkpoint_dir = tmp.path();
+
+        for &converter in NATIVE_CONVERTERS {
+            let job = convert_job(converter);
+            let resolved = resolve_convert_plan(&api, &settings, &job, checkpoint_dir, None)
+                .await
+                .expect("resolver runs without an infra error");
+            if let Err(err) = &resolved {
+                assert_ne!(
+                    err.message, "Unknown MLX converter.",
+                    "'{converter}' is in NATIVE_CONVERTERS but resolve_convert_plan has no arm for it \
+                     — the gate would allow a convert the worker rejects (sc-10573)"
+                );
+            }
+        }
+
+        // A converter NOT in the registry is rejected as unknown — proving the check above is
+        // meaningful and that the fallback still fires.
+        let bogus = convert_job("definitely_not_a_real_converter");
+        let resolved = resolve_convert_plan(&api, &settings, &bogus, checkpoint_dir, None)
+            .await
+            .expect("resolver runs without an infra error");
+        match resolved {
+            Err(err) => assert_eq!(err.message, "Unknown MLX converter."),
+            Ok(_) => panic!("a bogus converter must not resolve to a plan"),
         }
     }
 }


### PR DESCRIPTION
## Summary

`classify_convert_gap` (the hard convert-gap gate in `crates/sceneworks-core/src/jobs_store/routing/gaps.rs`) used a hand-maintained, hardcoded converter allow-list that had gone stale. `ltx_video` was missing despite being a live, shipped converter, and the `sd3_5_*_quant` arms were absent too. This replaces the hardcoded list with a single shared registry the gate **derives** from, so it can't drift again, and adds two failure-capable drift guards. Closes **sc-10573**.

## Investigation

**How the allow-list is used.** `classify_convert_gap` is the `ModelConvert` arm of `mac_rust_supported` — the macOS "can the Rust/MLX flow run this?" oracle. A convert job whose `converter` is **not** on the allow-list is classified as an mlx gap (`Err(UnsupportedReason)`):
- On a Mac desktop the app sets `SCENEWORKS_MLX_REQUIRED=1` (`apps/desktop/src/setup.rs`). In the default **warn** mode (`mlx_enforce_unsupported=false`) the job still runs, but a spurious `mlx_unsupported … warn` gap event is emitted at claim time (`apps/rust-api/src/jobs.rs`), polluting the port-or-drop gap inventory with a false positive for a conversion that is actually supported.
- In **enforce** mode (`SCENEWORKS_MLX_UNSUPPORTED_MODE=enforce`, the intended final cutover sc-3492) `fail_unsupported_mlx_jobs` **fails the job terminal** with `mlx_unsupported` — so installing the LTX-2.3 "10 Eros" model would break even though the converter works.

**Was there a real user-facing bug?** Yes — a live-path correctness defect, not purely theoretical. `ltx_video` is a shipped builtin (`requiresConversion: true`, `"converter": "ltx_video"` in `config/manifests/builtin.models.jsonc`), so installing that model enqueues a real `model_convert` job the worker fully handles via `resolve_convert_plan`, yet the gate rejected it. Today it manifests as false "unsupported" gap telemetry; under enforce mode it wrongly fails the install. The `sd3_5_*_quant` arms are latent (those models currently ship turnkey, no `mlx.converter`), but they are live worker capability a user model could name and the stale gate would wrongly reject.

**Authoritative source.** A `model_convert` job copies its `converter` payload **verbatim** from a model's `mlx.converter` (`create_model_convert_job` in `apps/rust-api/src/models.rs`), and user models can declare a converter too. So the gate must allow the full set the worker can actually convert — the `resolve_convert_plan` match arms in `crates/sceneworks-worker/src/model_jobs.rs`: `flux2_klein_diffusers`, `ltx_video`, `flux2_dev_quant`, `sd3_5_large_quant`, `sd3_5_large_turbo_quant`, `sd3_5_medium_quant`, `anima_quant`. Deriving purely from the shipped builtin manifest would be *wrong* (too strict) — it omits the still-live `flux2_dev_quant`/`sd3_5_*` arms.

## Derivation approach

- New single source of truth `pub const NATIVE_CONVERTERS` in `sceneworks-core` (re-exported from `jobs_store`). The gate now derives its allow-list from it (`NATIVE_CONVERTERS.contains(&converter)`), so the gate can't drift from the const.
- `resolve_convert_plan` (worker) now rejects any non-empty converter not in `NATIVE_CONVERTERS` **up front**, so its recognized set is derived from the same const. This guarantees the gate is structurally **no stricter** than the arms the worker actually has — the exact drift class that shipped as sc-10573.

## Drift tests (the durable guard)

- **core** `every_builtin_manifest_converter_is_in_the_convert_gap_allowlist`: parses the embedded `builtin.models.jsonc`, collects every `mlx.converter`, and asserts each is in `NATIVE_CONVERTERS` (plus a non-empty guard so it can't rot into a no-op). **Verified failure-capable:** temporarily dropping `ltx_video` from the const turns it (and the updated oracle test) RED with `builtin converter 'ltx_video' is not covered by NATIVE_CONVERTERS …`.
- **worker** `native_converters_match_resolve_convert_plan_arms`: drives `resolve_convert_plan` for every `NATIVE_CONVERTERS` id and asserts none hit the `"Unknown MLX converter."` fallback, and that a bogus id **is** rejected. **Verified failure-capable:** adding a no-arm id (`fake_converter_with_no_arm`) to the const turns it RED. This covers the "over-claim" direction the core test can't.

Together: the gate can neither omit a live converter (core guard) nor over-claim a nonexistent one (worker guard), and the worker can't recognize anything the gate rejects (up-front check).

## Validation

- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p sceneworks-core -p sceneworks-worker --all-targets -- -D warnings` — clean.
- `cargo test -p sceneworks-core --test jobs_store convert` — 3 passed.
- `cargo test -p sceneworks-worker --lib` — 702 passed, 0 failed, 157 ignored (real-weight/Metal).
- Both drift tests confirmed red on injected drift, then restored to green.

The full-workspace `cargo build` (apps/desktop etc.) was left to CI to avoid a from-scratch build competing with the self-hosted runner on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
