### PR TITLE
chore(packaging): --scan-archives NC-weights guard — scan inside built artifacts (sc-10551)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,11 +237,15 @@ jobs:
       # model weights before publishing. Any loose resource weight Tauri stages under
       # bundle/ is caught by the loose-tree walk; the exhaustive resource-source scan
       # runs in check.yml over apps/. --scan-archives (sc-10551) DECOMPRESSES the
-      # archives Tauri emits — here the `*.nsis.zip` updater payload — and scans the
-      # files inside, with archive-bomb guards. --skip-uninspectable downgrades the
-      # opaque `.msi` / NSIS `-setup.exe` (no pure-JS reader) to a warning: their
-      # contents duplicate the resource tree the loose-tree walk already covered. NC
-      # weights must never ship.
+      # archive containers Tauri emits — here the `*.nsis.zip` updater payload — and
+      # scans the entry paths inside, with archive-bomb guards. It does NOT crack open
+      # the Windows installer internals: a `-setup.exe` is not an archive candidate at
+      # all (`.exe` is not a scanned archive extension), and `--skip-uninspectable` only
+      # downgrades the `.msi` "no pure-JS reader" refusal to a warning. Those opaque
+      # installer internals are covered instead by the always-on Tauri resource-config
+      # check and the source-tree scan in check.yml (a weight cannot reach an installer
+      # without first tripping one of those), NOT by decompression. NC weights must
+      # never ship.
       - name: Guard against NC model weights in the desktop bundle (sc-10526, sc-10551)
         shell: bash
         run: node scripts/check-no-nc-weights.mjs --dir target/release/bundle --scan-archives --skip-uninspectable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,17 +88,22 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm --prefix apps/desktop run build -- --config updater.release.conf.json
 
-      # License guard (sc-10526): scan the freshly-built bundle tree for model
-      # weights. The previous step already signed, notarized & stapled the .app, so
-      # this runs AFTER signing but BEFORE the DMG is stapled, the release is drafted,
-      # and anything is uploaded — a weight in the bundle still fails the job before
-      # any artifact is published. This is the real-artifact form of the check.yml
-      # source-tree scan — the DMG is opaque, but the .app under bundle/macos/ carries
-      # the exact Contents/Resources payload the DMG wraps, so a weight baked into the
-      # bundle is caught here. NC weights (Anima / CircleStone, FLUX NC, Ideogram,
-      # Krea, SANA, …) must never ship in an installer.
-      - name: Guard against NC model weights in the desktop bundle (sc-10526)
-        run: node scripts/check-no-nc-weights.mjs --dir target/release/bundle
+      # License guard (sc-10526 + sc-10551): scan the freshly-built bundle tree for
+      # model weights. The previous step already signed, notarized & stapled the .app,
+      # so this runs AFTER signing but BEFORE the DMG is stapled, the release is
+      # drafted, and anything is uploaded — a weight in the bundle still fails the job
+      # before any artifact is published. This is the real-artifact form of the
+      # check.yml source-tree scan — the DMG is opaque, but the .app under bundle/macos/
+      # carries the exact Contents/Resources payload the DMG wraps, so a weight baked
+      # into the bundle is caught by the loose-tree walk.
+      # --scan-archives (sc-10551) additionally DECOMPRESSES the archives Tauri emits —
+      # here the `bundle/macos/*.app.tar.gz` updater payload — and scans the files
+      # inside for NC weights, with archive-bomb guards. --skip-uninspectable downgrades
+      # the opaque `.dmg` (no pure-JS reader) from a hard failure to a warning: its
+      # contents are the same .app the loose-tree walk already covered. NC weights
+      # (Anima / CircleStone, FLUX NC, Ideogram, Krea, SANA, …) must never ship.
+      - name: Guard against NC model weights in the desktop bundle (sc-10526, sc-10551)
+        run: node scripts/check-no-nc-weights.mjs --dir target/release/bundle --scan-archives --skip-uninspectable
 
       # Tauri staples the .app but not the wrapping .dmg — staple the DMG so the
       # downloaded artifact verifies offline (shared script; same as `release:mac`).
@@ -228,13 +233,18 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm --prefix apps/desktop run build -- --bundles nsis,msi --config updater.release.conf.json
-      # License guard (sc-10526): scan the built Windows bundle tree for model
-      # weights before publishing. The NSIS/MSI installers are opaque, but any loose
-      # resource weight Tauri stages under bundle/ is caught; the exhaustive
-      # resource-source scan runs in check.yml over apps/. NC weights must never ship.
-      - name: Guard against NC model weights in the desktop bundle (sc-10526)
+      # License guard (sc-10526 + sc-10551): scan the built Windows bundle tree for
+      # model weights before publishing. Any loose resource weight Tauri stages under
+      # bundle/ is caught by the loose-tree walk; the exhaustive resource-source scan
+      # runs in check.yml over apps/. --scan-archives (sc-10551) DECOMPRESSES the
+      # archives Tauri emits — here the `*.nsis.zip` updater payload — and scans the
+      # files inside, with archive-bomb guards. --skip-uninspectable downgrades the
+      # opaque `.msi` / NSIS `-setup.exe` (no pure-JS reader) to a warning: their
+      # contents duplicate the resource tree the loose-tree walk already covered. NC
+      # weights must never ship.
+      - name: Guard against NC model weights in the desktop bundle (sc-10526, sc-10551)
         shell: bash
-        run: node scripts/check-no-nc-weights.mjs --dir target/release/bundle
+        run: node scripts/check-no-nc-weights.mjs --dir target/release/bundle --scan-archives --skip-uninspectable
       # Upload to the draft release the macos job created. The user ships the MSI
       # (per desktop-windows.yml); the NSIS .exe is attached too as an alternative.
       # --clobber so re-running the job replaces rather than 409s. Then merge the

--- a/docs/packaging-nc-weights-guard.md
+++ b/docs/packaging-nc-weights-guard.md
@@ -113,13 +113,21 @@ it). All limits are per top-level archive tree (they accumulate across nesting l
 
 ### Opaque installers (`--skip-uninspectable`)
 
-The final installers — `.dmg` (macOS), `.msi` and the NSIS `-setup.exe` (Windows) —
-have **no pure-JS reader**. By default `--scan-archives` **fails closed** on a
-container it cannot read (it never silently passes an un-verified archive). The release
-lanes pass **`--skip-uninspectable`** to downgrade those to a *warning*, because the
-opaque installer's CONTENTS duplicate the `.app` / resource tree the loose-tree walk in
-the same step already scanned. A bomb refusal is **never** downgraded by this flag —
-only the "no reader for this format" case is.
+The `.dmg` (macOS) and `.msi` (Windows) installers ARE archive candidates but have
+**no pure-JS reader**. By default `--scan-archives` **fails closed** on a container it
+cannot read (it never silently passes an un-verified archive). The release lanes pass
+**`--skip-uninspectable`** to downgrade that "no reader" refusal to a *warning*, because
+the opaque installer's internals are covered by the `.app` / resource tree the loose-tree
+walk in the same step already scanned (plus the source-tree scan in `check.yml`). A bomb
+refusal is **never** downgraded by this flag — only the "no reader for this format" case
+is.
+
+The NSIS **`-setup.exe`** is a different case: `.exe` is **not** a scanned archive
+extension, so a `-setup.exe` is never even an archive candidate — `--scan-archives`
+does not look at it at all, and `--skip-uninspectable` has nothing to downgrade for it.
+A `-setup.exe` nested inside a `.nsis.zip` is opaque the same way (its bytes are not
+recursed into). Its internals are covered by the resource-config check + source-tree
+scan, exactly as for `.msi`, not by decompression.
 
 ### The `.bin` question (not a blind spot)
 
@@ -192,15 +200,18 @@ path is still flagged.
 
 ## Known limitation
 
-**Opaque installers still are not decompressed.** The `.dmg` / `.msi` / `-setup.exe`
-installers have no pure-JS reader, so `--scan-archives` cannot open them (it warns
-under `--skip-uninspectable`, or fails closed without it). This is not a real gap: the
-`--dir` release scan walks the loose `.app` / bundle tree — which carries the same
-`Contents/Resources` payload the DMG/MSI wraps — and the exhaustive resource-source
-scan in `check.yml` covers the trees that feed those installers, so a weight cannot
-reach an installer without first tripping one of those scans. The archives that are NOT
-otherwise covered — the `*.app.tar.gz` / `*.nsis.zip` updater payloads — ARE now
-decompressed and scanned by `--scan-archives` (sc-10551).
+**Opaque installer internals still are not decompressed.** The `.dmg` and `.msi`
+installers are archive candidates with no pure-JS reader, so `--scan-archives` cannot
+open them (it warns under `--skip-uninspectable`, or fails closed without it); the NSIS
+`-setup.exe` is not an archive candidate at all (`.exe` is not a scanned extension), so
+it is simply never inspected — nor is a `-setup.exe` sealed inside the `.nsis.zip`. This
+is not a real gap: the `--dir` release scan walks the loose `.app` / bundle tree — which
+carries the same `Contents/Resources` payload the DMG/MSI/EXE wraps — and the exhaustive
+resource-source scan in `check.yml` covers the trees that feed those installers, so a
+weight cannot reach an installer without first tripping one of those scans. The archive
+containers that are NOT otherwise covered — the `*.app.tar.gz` / `*.nsis.zip` updater
+payloads — ARE now decompressed and their entry paths scanned by `--scan-archives`
+(sc-10551).
 
 `include_bytes!`-compiled weights (a weight embedded in a Rust binary at compile time)
 are not detectable by any file or archive scan post-compile; the source-tree scan

--- a/docs/packaging-nc-weights-guard.md
+++ b/docs/packaging-nc-weights-guard.md
@@ -58,6 +58,8 @@ Run it directly:
 ```sh
 npm run check:nc-weights              # scan the default payload trees
 node scripts/check-no-nc-weights.mjs --dir <path>   # scan a built artifact tree
+node scripts/check-no-nc-weights.mjs --dir <path> --scan-archives --skip-uninspectable
+                                                     # + decompress-and-scan archives
 node scripts/check-no-nc-weights.mjs --self-test     # prove the gate fires
 ```
 
@@ -78,6 +80,46 @@ node scripts/check-no-nc-weights.mjs --self-test     # prove the gate fires
   file-tree scans cannot see into: a weight sealed inside an archive staged as a
   resource. The current resources (`onnxruntime/**/*`, `ffmpeg/**/*`, `mlx/**/*`) are
   clean.
+- **`--scan-archives` (opt-in, sc-10551):** decompress-and-scan the CONTENTS of every
+  archive under the scan roots, running the exact same weight/NC-token checks over the
+  entry paths inside — **recursively** (an archive-in-archive is caught too). This is
+  defense-in-depth for a weight that reached a built artifact sealed inside an archive
+  some other way than a declared Tauri resource. Pure Node (no new dependency); it
+  reads `.zip` / `.nsis.zip` (central-directory listing, stored + deflate), `.tar`,
+  `.tar.gz` / `.tgz`, and bare `.gz`. The real release payloads it opens are the macOS
+  `bundle/macos/*.app.tar.gz` updater tarball and the Windows `*.nsis.zip` updater. It
+  is **off by default** so it never slows an ordinary build; the release lanes turn it
+  on.
+
+### Archive-bomb guards (`--scan-archives`)
+
+A malicious or accidental archive bomb (a tiny file that declares or inflates to an
+enormous payload, a "many tiny files" bomb, or a deeply-nested quine) must never
+exhaust memory or disk. The scan **fails closed** — it refuses the archive and fails
+the build rather than OOM — if any of these caps is exceeded:
+
+| Limit                    | Default  | CLI override           |
+| ------------------------ | -------- | ---------------------- |
+| On-disk archive size     | 2 GiB    | `--max-archive-bytes`  |
+| Total uncompressed bytes | 3 GiB    | `--max-uncompressed`   |
+| Per-entry uncompressed   | 1 GiB    | `--max-entry-bytes`    |
+| Entry count              | 200 000  | `--max-entries`        |
+| Nesting depth            | 8        | `--max-depth`          |
+
+For a `.zip` the size caps are checked against the **declared** central-directory
+sizes **before any entry is inflated**, so a zip bomb is refused up front. For gzip the
+total cap is enforced as the gunzip output limit (Node throws before inflating past
+it). All limits are per top-level archive tree (they accumulate across nesting levels).
+
+### Opaque installers (`--skip-uninspectable`)
+
+The final installers — `.dmg` (macOS), `.msi` and the NSIS `-setup.exe` (Windows) —
+have **no pure-JS reader**. By default `--scan-archives` **fails closed** on a
+container it cannot read (it never silently passes an un-verified archive). The release
+lanes pass **`--skip-uninspectable`** to downgrade those to a *warning*, because the
+opaque installer's CONTENTS duplicate the `.app` / resource tree the loose-tree walk in
+the same step already scanned. A bomb refusal is **never** downgraded by this flag —
+only the "no reader for this format" case is.
 
 ### The `.bin` question (not a blind spot)
 
@@ -140,39 +182,34 @@ path is still flagged.
 
 ## Where it runs in CI
 
-- **`.github/workflows/check.yml`** (every PR): runs `--self-test` then the default
-  scan over the Docker build context / Tauri resource trees.
+- **`.github/workflows/check.yml`** (every PR): runs `--self-test` (which now also
+  exercises the archive-scan positive/negative/bomb cases) then the default scan over
+  the Docker build context / Tauri resource trees.
 - **`.github/workflows/release.yml`** (desktop release, macOS + Windows): scans the
-  freshly-built `target/release/bundle` tree before signing/publishing — the
-  real-artifact form of the check.
+  freshly-built `target/release/bundle` tree before signing/publishing with
+  `--scan-archives --skip-uninspectable` — the real-artifact form of the check, which
+  additionally decompresses the `*.app.tar.gz` / `*.nsis.zip` updater payloads.
 
 ## Known limitation
 
-The `.dmg` / `.msi` / `-setup.exe` installers are opaque compressed archives; the
-`--dir` release scan walks the loose `.app` / bundle tree (which carries the same
-`Contents/Resources` payload the DMG wraps) but does not decompress the final
-installer. The exhaustive resource-source scan in `check.yml` covers the resource
-trees that feed those installers, so a weight cannot reach an installer without first
-tripping the source scan.
+**Opaque installers still are not decompressed.** The `.dmg` / `.msi` / `-setup.exe`
+installers have no pure-JS reader, so `--scan-archives` cannot open them (it warns
+under `--skip-uninspectable`, or fails closed without it). This is not a real gap: the
+`--dir` release scan walks the loose `.app` / bundle tree — which carries the same
+`Contents/Resources` payload the DMG/MSI wraps — and the exhaustive resource-source
+scan in `check.yml` covers the trees that feed those installers, so a weight cannot
+reach an installer without first tripping one of those scans. The archives that are NOT
+otherwise covered — the `*.app.tar.gz` / `*.nsis.zip` updater payloads — ARE now
+decompressed and scanned by `--scan-archives` (sc-10551).
 
-**Archive-*content* scanning is not implemented (tracked follow-up).** The guard
-inspects file *names* on disk and Tauri resource *config*, but it does not open
-archives (`.zip` / `.tar.gz` / `.dmg` / …) to scan the files *inside* them. The
-config-level resource check above already fails the build if an archive or a weights
-directory is *declared* as a bundle resource — which is the realistic vector and is
-cheap to enforce — so a weight cannot be staged into the bundle inside an archive
-without the config check catching the declaration. A full recursive decompress-and-
-scan of every archive in a built artifact is comparatively expensive (needs a
-decompressor per format, temp extraction, and archive-bomb guards) and buys little
-over the declaration check, so it is deliberately deferred to a tracked Shortcut
-story rather than implemented here. `include_bytes!`-compiled weights (a weight
-embedded in a Rust binary at compile time) are likewise not detectable by a file
-scan; the source-tree scan catches the weight *file* that such a macro would embed,
-before it is compiled in.
+`include_bytes!`-compiled weights (a weight embedded in a Rust binary at compile time)
+are not detectable by any file or archive scan post-compile; the source-tree scan
+catches the weight *file* that such a macro would embed, before it is compiled in.
 
 The **RunPod image (epic 10362) does not exist yet** — there is no RunPod-specific
 Dockerfile in the repo. The existing `docker/rust.Dockerfile` (the base the RunPod
 lane will build on) is verified to pull-at-runtime: its COPYs are limited to
 `config/`, `crates/`, `apps/`, and the built binaries, and `.dockerignore` excludes
 `data/models|loras|cache`. When the RunPod image lands, run the guard over its build
-context / extracted rootfs (`--dir`) as part of that lane.
+context / extracted rootfs with `--dir <rootfs> --scan-archives` as part of that lane
+(the tar-based image layers are exactly the format `--scan-archives` reads).

--- a/scripts/check-no-nc-weights.mjs
+++ b/scripts/check-no-nc-weights.mjs
@@ -63,10 +63,16 @@
 //   (no external deps): `.zip`/`.nsis.zip` (central-directory listing, deflate/store),
 //   `.tar`, `.tar.gz`/`.tgz`, and bare `.gz`. Real release payloads it decompresses:
 //   the macOS `bundle/macos/*.app.tar.gz` updater tarball and the Windows
-//   `*.nsis.zip` updater. Opaque installers (`.dmg`/`.msi`/`-setup.exe`) have no
-//   pure-JS reader; their CONTENTS duplicate the already-walked `.app`/resource tree,
-//   so `--skip-uninspectable` downgrades them from a hard failure to a warning on the
-//   release lanes. ARCHIVE-BOMB GUARDS (required): the scan fails CLOSED — never
+//   `*.nsis.zip` updater container (its entry paths ARE scanned). What it does NOT
+//   crack open: the Windows installer INTERNALS. A `-setup.exe` is not even an archive
+//   candidate (`.exe` is not in ARCHIVE_EXTENSIONS), so it is never inspected — and a
+//   `-setup.exe` nested inside the `.nsis.zip` is opaque too (not recursed). A `.dmg`/
+//   `.msi` IS a candidate but has no pure-JS reader, so on the release lanes
+//   `--skip-uninspectable` downgrades that "no reader" refusal to a warning. Those
+//   opaque installer internals are covered NOT by decompression but by the always-on
+//   Tauri resource-config check here plus the source-tree scan in check.yml (a weight
+//   cannot reach an installer without first tripping one of those). ARCHIVE-BOMB
+//   GUARDS (required): the scan fails CLOSED — never
 //   OOMs — if an archive exceeds the on-disk size cap, the cumulative/per-entry
 //   uncompressed-size caps (zip is refused on its DECLARED sizes before any inflate),
 //   the entry-count cap, or the nesting-depth cap. See DEFAULT_ARCHIVE_LIMITS and
@@ -236,9 +242,11 @@ const DEFAULT_ARCHIVE_LIMITS = {
   // itself the first bomb signal, and bounds the Buffer we load).
   maxArchiveFileBytes: 2 * 1024 * 1024 * 1024, // 2 GiB
   // Cumulative UNCOMPRESSED bytes across an entire archive tree (all nesting levels of
-  // one top-level archive). For gzip this is the gunzip `maxOutputLength` (Node throws
-  // before inflating past it); for zip it is checked against the DECLARED sizes in the
-  // central directory BEFORE any entry is inflated. Kept < Node's Buffer max (~4 GiB).
+  // one top-level archive). For gzip each member's gunzip `maxOutputLength` is set to
+  // the REMAINING budget (this total minus what siblings already consumed), so Node
+  // throws before inflating past what is left; for zip it is checked against the
+  // DECLARED sizes in the central directory BEFORE any entry is inflated. Kept < Node's
+  // Buffer max (~4 GiB).
   maxTotalUncompressedBytes: 3 * 1024 * 1024 * 1024, // 3 GiB
   // Per-entry uncompressed cap (zip: declared size; deflate inflate `maxOutputLength`).
   maxEntryUncompressedBytes: 1 * 1024 * 1024 * 1024, // 1 GiB
@@ -718,10 +726,13 @@ class ArchiveBombError extends Error {
   }
 }
 
-// No pure-JS reader for this container (e.g. `.dmg`, `.msi`, an unsupported zip
-// compression method). By default this fails the build too (fail closed); the release
-// lanes pass --skip-uninspectable to downgrade it to a warning, because the opaque
-// installer's CONTENTS duplicate the already-walked `.app`/resource tree.
+// A container that IS an archive candidate but has no pure-JS reader (e.g. `.dmg`,
+// `.msi`, an unsupported zip compression method). By default this fails the build too
+// (fail closed); the release lanes pass --skip-uninspectable to downgrade it to a
+// warning, because the opaque installer's internals are covered by the loose-tree walk
+// over the same `.app`/resource tree plus the source-tree scan in check.yml. NOTE this
+// does NOT cover a `-setup.exe`: `.exe` is not in ARCHIVE_EXTENSIONS, so an NSIS
+// installer is never an archive candidate and never reaches this error at all.
 class UninspectableArchiveError extends Error {
   constructor(reason) {
     super(reason);
@@ -1041,12 +1052,23 @@ function scanArchiveBuffer(buf, displayPath, ctx, depth, budget) {
   }
 
   if (format === "gzip") {
+    // Cap this inflate at the REMAINING cumulative budget, not the full total, so the
+    // cap stays actually cumulative: sibling gzip members (e.g. several `.gz` in one
+    // tar) share one budget, and once earlier siblings have consumed it a later one
+    // cannot transiently allocate up to the full cap before the running-total check
+    // trips. Clamp to >= 1 (Node rejects/ambiguously treats a 0 maxOutputLength); an
+    // already-exhausted budget then refuses any non-empty inflate.
+    const remainingUncompressedBytes = Math.max(
+      1,
+      ctx.limits.maxTotalUncompressedBytes - budget.totalBytes,
+    );
     let inflated;
     try {
-      inflated = zlib.gunzipSync(buf, { maxOutputLength: ctx.limits.maxTotalUncompressedBytes });
+      inflated = zlib.gunzipSync(buf, { maxOutputLength: remainingUncompressedBytes });
     } catch (error) {
       throw new ArchiveBombError(
-        `gunzip of "${displayPath}" exceeded the total cap ${ctx.limits.maxTotalUncompressedBytes} B or is corrupt: ${error.code || error.message}`,
+        `gunzip of "${displayPath}" exceeded the remaining cumulative cap ${remainingUncompressedBytes} B ` +
+          `(of ${ctx.limits.maxTotalUncompressedBytes} B total) or is corrupt: ${error.code || error.message}`,
       );
     }
     if (inflated.length >= 262 && inflated.toString("ascii", 257, 262) === "ustar") {
@@ -1657,7 +1679,7 @@ async function selfTest() {
   );
 
   // ========================================================================
-  // (m)-(x) --scan-archives (sc-10551): decompress-and-scan archive CONTENTS
+  // (m)-(y) --scan-archives (sc-10551): decompress-and-scan archive CONTENTS
   // ========================================================================
   // A weight sealed inside an archive must be caught (planted-positive), a clean
   // archive must pass (negative), and an archive-bomb-shaped input must be REFUSED —
@@ -1899,6 +1921,48 @@ async function selfTest() {
     );
   } finally {
     await rm(archTmp, { recursive: true, force: true });
+  }
+
+  // (y) ARCHIVE-BOMB (the cumulative cap is actually cumulative): two sibling `.gz`
+  //     members in one tar, each individually under the total cap but summing OVER it,
+  //     are REFUSED — and the refusal fires DURING the crossing sibling's inflate, so
+  //     its transient allocation is bounded by the REMAINING budget, not the full cap.
+  //     Before the remaining-budget fix this still refused, but only AFTER inflating the
+  //     crossing member up to the full cap (via the post-inflate running-total check,
+  //     message "cumulative … exceeds cap"); after the fix the gunzip maxOutputLength
+  //     (= remaining budget) trips first (message "remaining cumulative cap"). Asserting
+  //     that mechanism makes this fail-before / pass-after and keeps it failure-capable
+  //     against any regression that stopped sharing one budget across siblings.
+  {
+    const cap = 2000;
+    // gzip of 1200 identical bytes is tiny on disk, so the tar's own per-entry
+    // accounting barely moves the budget; each member inflates to 1200 B, and
+    // 1200 + 1200 > 2000, so the SECOND member's inflate crosses the cap.
+    const sibling = () => zlib.gzipSync(Buffer.alloc(1200, 65));
+    const tar = makeTar([
+      { name: "a.gz", content: sibling() },
+      { name: "b.gz", content: sibling() },
+    ]);
+    let caught = null;
+    try {
+      scanArchiveBuffer(
+        tar,
+        "bundle/siblings.tar",
+        freshCtx({ ...DEFAULT_ARCHIVE_LIMITS, maxTotalUncompressedBytes: cap }),
+        1,
+        newBudget(),
+      );
+    } catch (error) {
+      caught = error;
+    }
+    assert(
+      "archive-bomb: sibling gzip members summing over the total cap are refused",
+      caught instanceof ArchiveBombError,
+    );
+    assert(
+      "archive-bomb: the crossing sibling is capped at the REMAINING budget (refused during inflate)",
+      caught instanceof ArchiveBombError && /remaining cumulative cap/.test(caught.reason ?? caught.message ?? ""),
+    );
   }
 
   if (failures === 0) {

--- a/scripts/check-no-nc-weights.mjs
+++ b/scripts/check-no-nc-weights.mjs
@@ -53,8 +53,24 @@
 //   `externalBin` spec that is an archive, stages a weight, matches an NC token, or
 //   is rooted at a weights dir fails the build. That is the cheap defense for the one
 //   vector the file walk cannot see into — a weight sealed inside an archive staged
-//   as a resource. (Decompressing archives to scan their CONTENTS is a tracked
-//   follow-up, not done here; see docs "Known limitation".)
+//   as a resource.
+//
+//   --scan-archives (opt-in, sc-10551): defense-in-depth for a weight that reached a
+//   built artifact sealed INSIDE an archive some other way (not via a declared Tauri
+//   resource). For every archive found under the scan roots it DECOMPRESSES the
+//   container and runs the exact same weight/NC-token checks over the entry paths
+//   inside — recursively, so a nested archive-in-archive is caught too. Pure Node
+//   (no external deps): `.zip`/`.nsis.zip` (central-directory listing, deflate/store),
+//   `.tar`, `.tar.gz`/`.tgz`, and bare `.gz`. Real release payloads it decompresses:
+//   the macOS `bundle/macos/*.app.tar.gz` updater tarball and the Windows
+//   `*.nsis.zip` updater. Opaque installers (`.dmg`/`.msi`/`-setup.exe`) have no
+//   pure-JS reader; their CONTENTS duplicate the already-walked `.app`/resource tree,
+//   so `--skip-uninspectable` downgrades them from a hard failure to a warning on the
+//   release lanes. ARCHIVE-BOMB GUARDS (required): the scan fails CLOSED — never
+//   OOMs — if an archive exceeds the on-disk size cap, the cumulative/per-entry
+//   uncompressed-size caps (zip is refused on its DECLARED sizes before any inflate),
+//   the entry-count cap, or the nesting-depth cap. See DEFAULT_ARCHIVE_LIMITS and
+//   scanArchivesUnderRoots().
 //
 // HOW NC FAMILIES ARE DECLARED (data-driven, not a hand-maintained list)
 // ----------------------------------------------------------------------
@@ -90,6 +106,7 @@ import {
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
+import zlib from "node:zlib";
 
 const root = process.cwd();
 
@@ -204,6 +221,33 @@ const ALLOWLIST_BASENAMES = new Set(ALLOWLIST.map((entry) => entry.basename));
 // re-hardcode the family and defeat the manifest-derivation design. Re-seed here ONLY for a NEW NC
 // family that is being ported before its manifest entry exists, and remove it the moment that lands.
 const BOOTSTRAP_NC_TOKENS = [];
+
+// Archive-bomb guard limits for --scan-archives (sc-10551). A malicious or accidental
+// "zip bomb" declares (or inflates to) an astronomically large payload; without caps a
+// naive decompress-and-scan would exhaust memory/disk. Every one of these is enforced
+// as a fail-CLOSED refusal (the archive is reported as a build failure, not silently
+// skipped, and never fully inflated past the cap). All are overridable from the CLI
+// (--max-archive-bytes / --max-uncompressed / --max-entry-bytes / --max-entries /
+// --max-depth) so a lane whose artifact is legitimately larger can raise them without a
+// code change. Chosen generously relative to real SceneWorks updater payloads (a macOS
+// `.app.tar.gz` is a few hundred MB compressed) while still bounding a runaway.
+const DEFAULT_ARCHIVE_LIMITS = {
+  // Refuse to even readFile an archive whose ON-DISK size exceeds this (a huge file is
+  // itself the first bomb signal, and bounds the Buffer we load).
+  maxArchiveFileBytes: 2 * 1024 * 1024 * 1024, // 2 GiB
+  // Cumulative UNCOMPRESSED bytes across an entire archive tree (all nesting levels of
+  // one top-level archive). For gzip this is the gunzip `maxOutputLength` (Node throws
+  // before inflating past it); for zip it is checked against the DECLARED sizes in the
+  // central directory BEFORE any entry is inflated. Kept < Node's Buffer max (~4 GiB).
+  maxTotalUncompressedBytes: 3 * 1024 * 1024 * 1024, // 3 GiB
+  // Per-entry uncompressed cap (zip: declared size; deflate inflate `maxOutputLength`).
+  maxEntryUncompressedBytes: 1 * 1024 * 1024 * 1024, // 1 GiB
+  // Max number of entries across the archive tree (defeats a "many tiny files" bomb).
+  maxEntries: 200_000,
+  // Max archive-in-archive nesting depth (defeats a quine / deeply-nested bomb and
+  // bounds recursion). Top-level archive = depth 1.
+  maxDepth: 8,
+};
 
 // -- JSONC parsing (manifests carry // comments). Mirrors scripts/check-scaffold.mjs. --
 function stripJsoncComments(body) {
@@ -497,6 +541,31 @@ function isWeightFile(filePath, { includeBin, weakNcMatch }) {
   return false;
 }
 
+// THE single NC/weight classification for one path — the shared signature logic used
+// by BOTH the loose-tree file walk (scan) and the archive-content scan (sc-10551), so
+// the two guards can never drift. `needle` is the POSIX-normalized, lowercased path
+// (a real filesystem path for the walk, or `archive!/entry` for an archive entry) and
+// `basename` its last segment. Returns a violation descriptor `{ ncToken }` or null:
+//   * STRONG NC repo/cache token in the path        -> violation (any extension)
+//   * weight file (isWeightFile) not on the allowlist -> violation (ncToken = the weak
+//     family token if one matched, else null for the generic "unexpected weight")
+// Order and semantics mirror the original inline scan() logic exactly.
+function classifyEntry({ needle, basename, includeBin, ncTokens }) {
+  const strongToken = strongNcTokenFor(needle, ncTokens);
+  if (strongToken) {
+    return { ncToken: strongToken };
+  }
+  const weakToken = weakNcTokenFor(needle, ncTokens);
+  if (!isWeightFile(basename, { includeBin, weakNcMatch: Boolean(weakToken) })) {
+    return null;
+  }
+  // A non-NC, allowlisted permissive weight is legitimately bundled.
+  if (!weakToken && ALLOWLIST_BASENAMES.has(basename)) {
+    return null;
+  }
+  return { ncToken: weakToken };
+}
+
 // Core: scan the given roots and return the list of violations.
 //
 // Two independent ways a file becomes a violation:
@@ -529,31 +598,10 @@ async function scan({ roots, ncTokens, includeBin }) {
     for (const file of files) {
       const basename = path.basename(file);
       const needle = file.split(path.sep).join("/").toLowerCase();
-
-      // (1) A file inside a genuine NC repo/cache directory — fail regardless of
-      // extension or allowlist. An allowlisted permissive name must never travel
-      // inside an NC repo path either.
-      const strongToken = strongNcTokenFor(needle, ncTokens);
-      if (strongToken) {
-        violations.push({ file: path.relative(root, file) || file, basename, ncToken: strongToken });
-        continue;
+      const hit = classifyEntry({ needle, basename, includeBin, ncTokens });
+      if (hit) {
+        violations.push({ file: path.relative(root, file) || file, basename, ncToken: hit.ncToken });
       }
-
-      // (2) Otherwise, is it a weight? A bare NC token both classifies it and
-      // promotes an ambiguous `.bin` to a weight.
-      const weakToken = weakNcTokenFor(needle, ncTokens);
-      if (!isWeightFile(file, { includeBin, weakNcMatch: Boolean(weakToken) })) {
-        continue;
-      }
-      // A non-NC, allowlisted permissive weight is legitimately bundled.
-      if (!weakToken && ALLOWLIST_BASENAMES.has(basename)) {
-        continue;
-      }
-      violations.push({
-        file: path.relative(root, file) || file,
-        basename,
-        ncToken: weakToken,
-      });
     }
   }
   return violations;
@@ -650,6 +698,481 @@ async function inspectTauriConfigs(ncTokens) {
   return { specs, violations: inspectResourceSpecs(specs, ncTokens) };
 }
 
+// ===========================================================================
+// --scan-archives (sc-10551): decompress-and-scan archive CONTENTS
+// ===========================================================================
+//
+// Defense-in-depth over the file-name walk and the Tauri resource-config check: open
+// every archive under the scan roots and run the SAME classifyEntry() over the entry
+// paths inside — recursively, with hard archive-bomb guards. Pure Node built-ins only
+// (zlib for gzip/deflate; hand-rolled tar + zip-central-directory readers), so there is
+// no new dependency and the whole thing is exercised hermetically by --self-test.
+
+// A bomb guard fired (or a container is corrupt): the archive is REFUSED — reported as
+// a build failure, never silently skipped, and never inflated past the cap.
+class ArchiveBombError extends Error {
+  constructor(reason) {
+    super(reason);
+    this.name = "ArchiveBombError";
+    this.reason = reason;
+  }
+}
+
+// No pure-JS reader for this container (e.g. `.dmg`, `.msi`, an unsupported zip
+// compression method). By default this fails the build too (fail closed); the release
+// lanes pass --skip-uninspectable to downgrade it to a warning, because the opaque
+// installer's CONTENTS duplicate the already-walked `.app`/resource tree.
+class UninspectableArchiveError extends Error {
+  constructor(reason) {
+    super(reason);
+    this.name = "UninspectableArchiveError";
+    this.reason = reason;
+  }
+}
+
+// -- tar (ustar/GNU/PAX) reader over an already-decompressed buffer -----------------
+function readTarString(buf, start, len) {
+  let end = start;
+  const limit = Math.min(start + len, buf.length);
+  while (end < limit && buf[end] !== 0) {
+    end += 1;
+  }
+  return buf.toString("utf8", start, end);
+}
+
+function readTarOctal(buf, start, len) {
+  const text = readTarString(buf, start, len).trim();
+  if (text === "") {
+    return 0;
+  }
+  const value = parseInt(text, 8);
+  return Number.isFinite(value) ? value : 0;
+}
+
+// Return the regular-file entries of a tar buffer as { name, size, dataStart },
+// enforcing the entry-count / per-entry / cumulative-size caps as it walks. `budget`
+// is shared across the whole archive tree (all nesting levels of one top-level
+// archive) so a bomb spread across nested archives is still bounded.
+function parseTarEntries(buf, limits, budget) {
+  const entries = [];
+  let offset = 0;
+  let pendingName = null; // from a GNU 'L' long-name or PAX 'path=' record
+  while (offset + 512 <= buf.length) {
+    const block = buf.subarray(offset, offset + 512);
+    if (block.every((byte) => byte === 0)) {
+      break; // end-of-archive zero block
+    }
+    let name = readTarString(block, 0, 100);
+    const prefix = readTarString(block, 345, 155);
+    if (prefix) {
+      name = `${prefix}/${name}`;
+    }
+    const size = readTarOctal(block, 124, 12);
+    const typeByte = block[156];
+    const typeflag = String.fromCharCode(typeByte || 0);
+    const dataStart = offset + 512;
+    const dataBlocks = Math.ceil(size / 512) * 512;
+
+    // GNU long name: the data payload is the real name of the NEXT entry.
+    if (typeflag === "L") {
+      pendingName = readTarString(buf, dataStart, size).replace(/\0+$/, "");
+      offset = dataStart + dataBlocks;
+      continue;
+    }
+    // GNU long link name: not a file we scan; skip its payload.
+    if (typeflag === "K") {
+      offset = dataStart + dataBlocks;
+      continue;
+    }
+    // PAX extended header: pull `path=` if present, applies to the next entry.
+    if (typeflag === "x" || typeflag === "g") {
+      const records = buf.toString("utf8", dataStart, dataStart + size);
+      const match = records.match(/(?:^|\n)\d+ path=([^\n]*)\n/);
+      if (match) {
+        pendingName = match[1];
+      }
+      offset = dataStart + dataBlocks;
+      continue;
+    }
+
+    const effectiveName = pendingName ?? name;
+    pendingName = null;
+
+    budget.entries += 1;
+    if (budget.entries > limits.maxEntries) {
+      throw new ArchiveBombError(`entry count exceeds cap ${limits.maxEntries}`);
+    }
+    if (size > limits.maxEntryUncompressedBytes) {
+      throw new ArchiveBombError(
+        `tar entry "${effectiveName}" is ${size} B (> per-entry cap ${limits.maxEntryUncompressedBytes} B)`,
+      );
+    }
+    budget.totalBytes += size;
+    if (budget.totalBytes > limits.maxTotalUncompressedBytes) {
+      throw new ArchiveBombError(
+        `cumulative uncompressed size exceeds cap ${limits.maxTotalUncompressedBytes} B`,
+      );
+    }
+
+    // Regular file (ustar '0', legacy '\0', contiguous '7'); dirs/links are not scanned.
+    if (typeByte === 0x30 || typeByte === 0 || typeByte === 0x37) {
+      entries.push({ name: effectiveName, size, dataStart });
+    }
+    offset = dataStart + dataBlocks;
+  }
+  return entries;
+}
+
+// -- zip reader (central-directory listing; per-entry inflate only when recursing) ---
+function findZipEocd(buf) {
+  const signature = 0x06054b50;
+  const minLen = 22;
+  const maxBack = Math.min(buf.length, minLen + 0xffff); // + max comment length
+  for (let i = buf.length - minLen; i >= buf.length - maxBack && i >= 0; i -= 1) {
+    if (buf.readUInt32LE(i) === signature) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+// Resolve the ZIP64 extra field for any of the three fields that carry the 0xFFFFFFFF
+// "see ZIP64" sentinel. The 8-byte values appear in a fixed order (uncompressed,
+// compressed, local-header-offset), each present only if its 32-bit field was sentinel.
+function readZip64Extra(buf, start, extraLen, current) {
+  const out = { ...current };
+  let q = start;
+  const end = start + extraLen;
+  while (q + 4 <= end) {
+    const id = buf.readUInt16LE(q);
+    const size = buf.readUInt16LE(q + 2);
+    const body = q + 4;
+    if (id === 0x0001) {
+      let r = body;
+      if (current.uncompSize === 0xffffffff) {
+        out.uncompSize = Number(buf.readBigUInt64LE(r));
+        r += 8;
+      }
+      if (current.compSize === 0xffffffff) {
+        out.compSize = Number(buf.readBigUInt64LE(r));
+        r += 8;
+      }
+      if (current.localOffset === 0xffffffff) {
+        out.localOffset = Number(buf.readBigUInt64LE(r));
+        r += 8;
+      }
+      return out;
+    }
+    q = body + size;
+  }
+  return out;
+}
+
+// List zip entries from the central directory (names + declared sizes), enforcing the
+// bomb caps on the DECLARED uncompressed sizes BEFORE anything is inflated — the key
+// zip-bomb defense (a tiny archive that declares a huge output is refused up front).
+function parseZipEntries(buf, limits, budget) {
+  const eocd = findZipEocd(buf);
+  if (eocd === -1) {
+    throw new ArchiveBombError("zip: End-Of-Central-Directory record not found (truncated or not a zip)");
+  }
+  let totalEntries = buf.readUInt16LE(eocd + 10);
+  let cdOffset = buf.readUInt32LE(eocd + 16);
+  if (totalEntries === 0xffff || cdOffset === 0xffffffff) {
+    const locatorOffset = eocd - 20;
+    if (locatorOffset < 0 || buf.readUInt32LE(locatorOffset) !== 0x07064b50) {
+      throw new UninspectableArchiveError("zip: ZIP64 end-locator missing; cannot verify a large zip");
+    }
+    const z64 = Number(buf.readBigUInt64LE(locatorOffset + 8));
+    if (z64 < 0 || z64 + 56 > buf.length || buf.readUInt32LE(z64) !== 0x06064b50) {
+      throw new UninspectableArchiveError("zip: ZIP64 EOCD record missing/out of range");
+    }
+    totalEntries = Number(buf.readBigUInt64LE(z64 + 32));
+    cdOffset = Number(buf.readBigUInt64LE(z64 + 48));
+  }
+
+  const entries = [];
+  let p = cdOffset;
+  for (let i = 0; i < totalEntries; i += 1) {
+    if (p + 46 > buf.length || buf.readUInt32LE(p) !== 0x02014b50) {
+      throw new ArchiveBombError("zip: malformed central-directory header");
+    }
+    const method = buf.readUInt16LE(p + 10);
+    let compSize = buf.readUInt32LE(p + 20);
+    let uncompSize = buf.readUInt32LE(p + 24);
+    const nameLen = buf.readUInt16LE(p + 28);
+    const extraLen = buf.readUInt16LE(p + 30);
+    const commentLen = buf.readUInt16LE(p + 32);
+    let localOffset = buf.readUInt32LE(p + 42);
+    const name = buf.toString("utf8", p + 46, p + 46 + nameLen);
+    if (compSize === 0xffffffff || uncompSize === 0xffffffff || localOffset === 0xffffffff) {
+      ({ compSize, uncompSize, localOffset } = readZip64Extra(buf, p + 46 + nameLen, extraLen, {
+        compSize,
+        uncompSize,
+        localOffset,
+      }));
+    }
+
+    budget.entries += 1;
+    if (budget.entries > limits.maxEntries) {
+      throw new ArchiveBombError(`entry count exceeds cap ${limits.maxEntries}`);
+    }
+    if (uncompSize > limits.maxEntryUncompressedBytes) {
+      throw new ArchiveBombError(
+        `zip entry "${name}" declares ${uncompSize} B (> per-entry cap ${limits.maxEntryUncompressedBytes} B)`,
+      );
+    }
+    budget.totalBytes += uncompSize;
+    if (budget.totalBytes > limits.maxTotalUncompressedBytes) {
+      throw new ArchiveBombError(
+        `cumulative declared uncompressed size exceeds cap ${limits.maxTotalUncompressedBytes} B`,
+      );
+    }
+
+    entries.push({ name, method, compSize, uncompSize, localOffset });
+    p += 46 + nameLen + extraLen + commentLen;
+  }
+  return entries;
+}
+
+// Extract one zip entry's bytes — only called when RECURSING into a nested archive
+// (plain detection needs the name only). Bounded by the per-entry inflate cap.
+function extractZipEntryData(buf, entry, limits) {
+  const lo = entry.localOffset;
+  if (lo + 30 > buf.length || buf.readUInt32LE(lo) !== 0x04034b50) {
+    throw new ArchiveBombError(`zip entry "${entry.name}": bad local file header`);
+  }
+  const nameLen = buf.readUInt16LE(lo + 26);
+  const extraLen = buf.readUInt16LE(lo + 28);
+  const dataStart = lo + 30 + nameLen + extraLen;
+  const stored = buf.subarray(dataStart, dataStart + entry.compSize);
+  if (entry.method === 0) {
+    return stored; // stored (no compression)
+  }
+  if (entry.method === 8) {
+    try {
+      return zlib.inflateRawSync(stored, { maxOutputLength: limits.maxEntryUncompressedBytes });
+    } catch (error) {
+      throw new ArchiveBombError(
+        `zip entry "${entry.name}" inflate exceeded the per-entry cap or is corrupt: ${error.code || error.message}`,
+      );
+    }
+  }
+  throw new UninspectableArchiveError(
+    `zip entry "${entry.name}" uses unsupported compression method ${entry.method}`,
+  );
+}
+
+// Decide how to read a buffer: magic bytes first (robust against a mislabeled file —
+// e.g. a weight archive renamed to hide it), then the display path's extension.
+function sniffArchiveFormat(buf, displayPath) {
+  const lower = displayPath.toLowerCase();
+  if (buf.length >= 4) {
+    const magic = buf.readUInt32LE(0);
+    if (magic === 0x04034b50 || magic === 0x06054b50 || magic === 0x08074b50) {
+      return "zip";
+    }
+  }
+  if (buf.length >= 2 && buf[0] === 0x1f && buf[1] === 0x8b) {
+    return "gzip";
+  }
+  if (buf.length >= 262 && buf.toString("ascii", 257, 262) === "ustar") {
+    return "tar";
+  }
+  if (lower.endsWith(".zip") || lower.endsWith(".nsis.zip")) {
+    return "zip";
+  }
+  if (lower.endsWith(".tar.gz") || lower.endsWith(".tgz") || lower.endsWith(".gz")) {
+    return "gzip";
+  }
+  if (lower.endsWith(".tar")) {
+    return "tar";
+  }
+  return "unknown";
+}
+
+function looksLikeArchive(name) {
+  const lower = name.toLowerCase();
+  if (lower.endsWith(".tar.gz") || lower.endsWith(".nsis.zip")) {
+    return true;
+  }
+  return ARCHIVE_EXTENSIONS.has(path.posix.extname(lower));
+}
+
+// Classify one archive entry (and recurse if the entry is itself an archive). Shares
+// classifyEntry() with the loose-tree walk, so detection can never drift between them.
+function checkArchiveEntry(archiveDisplay, entryName, getData, ctx, depth, budget) {
+  const posixName = entryName.split("\\").join("/");
+  const display = `${archiveDisplay}!/${posixName}`;
+  const needle = display.split(path.sep).join("/").toLowerCase();
+  const basename = path.posix.basename(posixName);
+  const hit = classifyEntry({ needle, basename, includeBin: ctx.includeBin, ncTokens: ctx.ncTokens });
+  if (hit) {
+    ctx.violations.push({ file: display, basename, ncToken: hit.ncToken });
+  }
+  if (looksLikeArchive(basename)) {
+    const inner = getData();
+    try {
+      scanArchiveBuffer(inner, display, ctx, depth + 1, budget);
+    } catch (error) {
+      if (error instanceof UninspectableArchiveError && ctx.skipUninspectable) {
+        ctx.warnings.push({ file: display, reason: error.reason });
+        return;
+      }
+      throw error; // ArchiveBombError (fatal) and a non-skipped Uninspectable propagate
+    }
+  }
+}
+
+// Read one archive buffer: dispatch by sniffed format, enforce depth, and classify
+// every entry inside. Throws ArchiveBombError / UninspectableArchiveError on refusal.
+function scanArchiveBuffer(buf, displayPath, ctx, depth, budget) {
+  if (depth > ctx.limits.maxDepth) {
+    throw new ArchiveBombError(`archive nesting depth exceeds cap ${ctx.limits.maxDepth} at "${displayPath}"`);
+  }
+  const format = sniffArchiveFormat(buf, displayPath);
+
+  if (format === "zip") {
+    const entries = parseZipEntries(buf, ctx.limits, budget);
+    for (const entry of entries) {
+      checkArchiveEntry(displayPath, entry.name, () => extractZipEntryData(buf, entry, ctx.limits), ctx, depth, budget);
+    }
+    return;
+  }
+
+  if (format === "gzip") {
+    let inflated;
+    try {
+      inflated = zlib.gunzipSync(buf, { maxOutputLength: ctx.limits.maxTotalUncompressedBytes });
+    } catch (error) {
+      throw new ArchiveBombError(
+        `gunzip of "${displayPath}" exceeded the total cap ${ctx.limits.maxTotalUncompressedBytes} B or is corrupt: ${error.code || error.message}`,
+      );
+    }
+    if (inflated.length >= 262 && inflated.toString("ascii", 257, 262) === "ustar") {
+      const entries = parseTarEntries(inflated, ctx.limits, budget);
+      for (const entry of entries) {
+        checkArchiveEntry(
+          displayPath,
+          entry.name,
+          () => inflated.subarray(entry.dataStart, entry.dataStart + entry.size),
+          ctx,
+          depth,
+          budget,
+        );
+      }
+      return;
+    }
+    // Bare .gz of a single file: the entry name is the archive name minus .gz/.tgz.
+    budget.entries += 1;
+    if (budget.entries > ctx.limits.maxEntries) {
+      throw new ArchiveBombError(`entry count exceeds cap ${ctx.limits.maxEntries}`);
+    }
+    budget.totalBytes += inflated.length;
+    if (budget.totalBytes > ctx.limits.maxTotalUncompressedBytes) {
+      throw new ArchiveBombError(`cumulative uncompressed size exceeds cap ${ctx.limits.maxTotalUncompressedBytes} B`);
+    }
+    const innerName = path.posix.basename(displayPath.split(path.sep).join("/")).replace(/\.(gz|tgz)$/i, "");
+    checkArchiveEntry(displayPath, innerName, () => inflated, ctx, depth, budget);
+    return;
+  }
+
+  if (format === "tar") {
+    const entries = parseTarEntries(buf, ctx.limits, budget);
+    for (const entry of entries) {
+      checkArchiveEntry(
+        displayPath,
+        entry.name,
+        () => buf.subarray(entry.dataStart, entry.dataStart + entry.size),
+        ctx,
+        depth,
+        budget,
+      );
+    }
+    return;
+  }
+
+  throw new UninspectableArchiveError(
+    `no pure-JS reader for "${displayPath}" (opaque container such as .dmg/.msi/.7z); its contents are not verifiable here`,
+  );
+}
+
+// Walk the scan roots, find every archive FILE, and decompress-and-scan its contents.
+// Returns { violations, refusals, warnings }. A refusal (bomb guard, or an
+// uninspectable format without --skip-uninspectable) fails the build; a warning does
+// not. This never inflates past the caps, so a bomb is refused rather than OOMing.
+async function scanArchivesUnderRoots({ roots, ncTokens, includeBin, limits, skipUninspectable }) {
+  const ctx = { ncTokens, includeBin, limits, skipUninspectable, violations: [], warnings: [] };
+  const refusals = [];
+  let archiveCount = 0;
+  for (const scanRoot of roots) {
+    const absRoot = path.isAbsolute(scanRoot) ? scanRoot : path.join(root, scanRoot);
+    let rootStat;
+    try {
+      rootStat = await stat(absRoot);
+    } catch (error) {
+      if (error.code === "ENOENT") {
+        continue;
+      }
+      throw error;
+    }
+    const files = [];
+    if (rootStat.isDirectory()) {
+      await walk(absRoot, files);
+    } else if (rootStat.isFile()) {
+      files.push(absRoot);
+    }
+    for (const file of files) {
+      if (!looksLikeArchive(file)) {
+        continue;
+      }
+      archiveCount += 1;
+      const display = path.relative(root, file) || file;
+      let fileStat;
+      try {
+        fileStat = await stat(file);
+      } catch (error) {
+        if (error.code === "ENOENT") {
+          continue;
+        }
+        throw error;
+      }
+      if (fileStat.size > limits.maxArchiveFileBytes) {
+        refusals.push({
+          file: display,
+          reason:
+            `archive file is ${fileStat.size} B (> on-disk cap ${limits.maxArchiveFileBytes} B) — refusing to load it; ` +
+            `raise --max-archive-bytes if this artifact is legitimately this large`,
+        });
+        continue;
+      }
+      const buf = await readFile(file);
+      const budget = { entries: 0, totalBytes: 0 };
+      try {
+        scanArchiveBuffer(buf, display, ctx, 1, budget);
+      } catch (error) {
+        if (error instanceof ArchiveBombError) {
+          refusals.push({ file: display, reason: `archive-bomb guard: ${error.reason}` });
+        } else if (error instanceof UninspectableArchiveError) {
+          if (skipUninspectable) {
+            ctx.warnings.push({ file: display, reason: error.reason });
+          } else {
+            refusals.push({
+              file: display,
+              reason:
+                `${error.reason}. Pass --skip-uninspectable to warn instead of fail when the opaque installer's ` +
+                `contents are already covered by the loose-tree walk (the .app/resource tree it wraps)`,
+            });
+          }
+        } else {
+          throw error;
+        }
+      }
+    }
+  }
+  return { violations: ctx.violations, refusals, warnings: ctx.warnings, archiveCount };
+}
+
 function reportViolations(violations) {
   console.error(
     "\nNC-WEIGHTS GUARD FAILED (sc-10526): model-weight file(s) found in the " +
@@ -697,14 +1220,97 @@ function reportResourceViolations(resourceViolations) {
   );
 }
 
+// A weight was found INSIDE an archive (sc-10551). `violation.file` reads like
+// `bundle/App.app.tar.gz!/Contents/.../model.safetensors` so the archive + inner path
+// are both visible.
+function reportArchiveViolations(violations) {
+  console.error(
+    "\nNC-WEIGHTS GUARD FAILED (sc-10551): model-weight file(s) found INSIDE an archive " +
+      "in the artifact payload.\n" +
+      "A weight sealed inside a `.tar.gz` / `.zip` (e.g. the updater payload) still ships " +
+      "the weight even though the loose-tree file scan cannot see into the container. " +
+      "SceneWorks converts at install and pulls at runtime — it never redistributes " +
+      "weights.\n",
+  );
+  for (const violation of violations) {
+    if (violation.ncToken) {
+      console.error(
+        `  ✗ ${violation.file}\n` +
+          `      matches Non-Commercial family token "${violation.ncToken}" — this is an ` +
+          `NC weight and MUST NOT ship inside any archive in an installer/image/re-host.`,
+      );
+    } else {
+      console.error(
+        `  ✗ ${violation.file}\n` +
+          `      unexpected model weight sealed inside an archive. Remove it from the ` +
+          `build (weights are pulled at runtime), or if it is a legitimately-bundled ` +
+          `permissive weight add its basename to the ALLOWLIST.`,
+      );
+    }
+  }
+  console.error(
+    "\nSee docs/packaging-nc-weights-guard.md for the rule and the allowlist policy.\n",
+  );
+}
+
+// An archive was REFUSED (archive-bomb guard tripped, or an opaque format with no
+// pure-JS reader and no --skip-uninspectable). Fail closed — never OOM, never a silent
+// pass.
+function reportArchiveRefusals(refusals) {
+  console.error(
+    "\nNC-WEIGHTS GUARD FAILED (sc-10551): refused to scan an archive (fail-closed).\n" +
+      "An archive-bomb guard tripped or the container has no pure-JS reader. The guard " +
+      "refuses rather than exhaust memory/disk or silently skip an un-verified archive.\n",
+  );
+  for (const refusal of refusals) {
+    console.error(`  ✗ ${refusal.file}\n      ${refusal.reason}.`);
+  }
+  console.error(
+    "\nSee docs/packaging-nc-weights-guard.md for the archive-scan limits and flags.\n",
+  );
+}
+
+// Non-fatal: an opaque archive that --skip-uninspectable downgraded to a warning
+// (its contents duplicate the already-walked loose tree).
+function printArchiveWarnings(warnings) {
+  for (const warning of warnings) {
+    console.warn(
+      `  ⚠ ${warning.file}\n      not decompressed (opaque format): ${warning.reason}. ` +
+        `Its contents are covered by the loose-tree walk of the sibling .app/resource tree.`,
+    );
+  }
+}
+
+function parseIntArg(value, flag) {
+  if (value === undefined) {
+    throw new Error(`${flag} requires an integer argument`);
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${flag} requires a positive integer (got "${value}")`);
+  }
+  return parsed;
+}
+
 function parseArgs(argv) {
-  const options = { dirs: [], includeBin: false, selfTest: false };
+  const options = {
+    dirs: [],
+    includeBin: false,
+    selfTest: false,
+    scanArchives: false,
+    skipUninspectable: false,
+    limits: { ...DEFAULT_ARCHIVE_LIMITS },
+  };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--self-test") {
       options.selfTest = true;
     } else if (arg === "--include-bin") {
       options.includeBin = true;
+    } else if (arg === "--scan-archives") {
+      options.scanArchives = true;
+    } else if (arg === "--skip-uninspectable") {
+      options.skipUninspectable = true;
     } else if (arg === "--dir") {
       const value = argv[i + 1];
       if (!value) {
@@ -714,6 +1320,16 @@ function parseArgs(argv) {
       i += 1;
     } else if (arg.startsWith("--dir=")) {
       options.dirs.push(arg.slice("--dir=".length));
+    } else if (arg === "--max-archive-bytes") {
+      options.limits.maxArchiveFileBytes = parseIntArg(argv[(i += 1)], arg);
+    } else if (arg === "--max-uncompressed") {
+      options.limits.maxTotalUncompressedBytes = parseIntArg(argv[(i += 1)], arg);
+    } else if (arg === "--max-entry-bytes") {
+      options.limits.maxEntryUncompressedBytes = parseIntArg(argv[(i += 1)], arg);
+    } else if (arg === "--max-entries") {
+      options.limits.maxEntries = parseIntArg(argv[(i += 1)], arg);
+    } else if (arg === "--max-depth") {
+      options.limits.maxDepth = parseIntArg(argv[(i += 1)], arg);
     } else {
       throw new Error(`Unknown argument: ${arg}`);
     }
@@ -729,7 +1345,129 @@ async function runScan(options) {
   // is independent of the file scan, so it runs on every invocation (default and
   // --dir alike) as a cheap second line of defense against a bundled archive.
   const { specs, violations: resourceViolations } = await inspectTauriConfigs(tokens);
-  return { tokens, families, roots, violations, resourceViolations, resourceSpecCount: specs.length };
+  // --scan-archives (sc-10551): decompress-and-scan the CONTENTS of every archive under
+  // the roots. Opt-in so it never slows an ordinary build; wired into the release lane.
+  let archive = null;
+  if (options.scanArchives) {
+    archive = await scanArchivesUnderRoots({
+      roots,
+      ncTokens: tokens,
+      includeBin: options.includeBin,
+      limits: options.limits,
+      skipUninspectable: options.skipUninspectable,
+    });
+  }
+  return {
+    tokens,
+    families,
+    roots,
+    violations,
+    resourceViolations,
+    resourceSpecCount: specs.length,
+    archive,
+  };
+}
+
+// -- Archive fixture builders (self-test only) --------------------------------------
+// Build real, valid `.tar` / `.tar.gz` / `.zip` bytes in pure JS so the archive-scan
+// self-test needs no external `tar`/`zip` tool and is fully deterministic. The readers
+// above do not verify CRCs, so stored/deflate-with-zero-CRC fixtures are sufficient.
+function makeTarHeader(name, size) {
+  const header = Buffer.alloc(512);
+  header.write(name, 0, "utf8"); // name (fixtures use <100-byte names)
+  header.write("0000644", 100, "ascii"); // mode
+  header.write("0000000", 108, "ascii"); // uid
+  header.write("0000000", 116, "ascii"); // gid
+  header.write(`${size.toString(8).padStart(11, "0")} `, 124, "ascii"); // size (octal)
+  header.write("00000000000 ", 136, "ascii"); // mtime
+  header.write("        ", 148, "ascii"); // checksum field = 8 spaces while summing
+  header[156] = 0x30; // typeflag '0' (regular file)
+  header.write("ustar\0", 257, "ascii"); // magic
+  header.write("00", 263, "ascii"); // version
+  let sum = 0;
+  for (let i = 0; i < 512; i += 1) {
+    sum += header[i];
+  }
+  header.write(`${sum.toString(8).padStart(6, "0")}\0 `, 148, "ascii"); // 6-oct + NUL + space
+  return header;
+}
+
+function makeTar(entries) {
+  const parts = [];
+  for (const entry of entries) {
+    const content = Buffer.isBuffer(entry.content) ? entry.content : Buffer.from(entry.content, "utf8");
+    parts.push(makeTarHeader(entry.name, content.length), content);
+    const pad = (512 - (content.length % 512)) % 512;
+    if (pad) {
+      parts.push(Buffer.alloc(pad));
+    }
+  }
+  parts.push(Buffer.alloc(1024)); // two zero blocks = end of archive
+  return Buffer.concat(parts);
+}
+
+function makeTarGz(entries) {
+  return zlib.gzipSync(makeTar(entries));
+}
+
+function makeZip(entries) {
+  const locals = [];
+  const central = [];
+  let offset = 0;
+  for (const entry of entries) {
+    const raw = Buffer.isBuffer(entry.content) ? entry.content : Buffer.from(entry.content, "utf8");
+    const method = entry.method ?? 0;
+    const stored = method === 8 ? zlib.deflateRawSync(raw) : raw;
+    const nameBuf = Buffer.from(entry.name, "utf8");
+
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4); // version needed
+    local.writeUInt16LE(0, 6); // flags
+    local.writeUInt16LE(method, 8);
+    local.writeUInt16LE(0, 10); // mod time
+    local.writeUInt16LE(0, 12); // mod date
+    local.writeUInt32LE(0, 14); // crc (readers ignore it)
+    local.writeUInt32LE(stored.length, 18); // compressed size
+    local.writeUInt32LE(raw.length, 22); // uncompressed size
+    local.writeUInt16LE(nameBuf.length, 26);
+    local.writeUInt16LE(0, 28); // extra length
+    const localOffset = offset;
+    locals.push(local, nameBuf, stored);
+    offset += 30 + nameBuf.length + stored.length;
+
+    const cd = Buffer.alloc(46);
+    cd.writeUInt32LE(0x02014b50, 0);
+    cd.writeUInt16LE(20, 4); // version made by
+    cd.writeUInt16LE(20, 6); // version needed
+    cd.writeUInt16LE(0, 8); // flags
+    cd.writeUInt16LE(method, 10);
+    cd.writeUInt16LE(0, 12); // mod time
+    cd.writeUInt16LE(0, 14); // mod date
+    cd.writeUInt32LE(0, 16); // crc
+    cd.writeUInt32LE(stored.length, 20); // compressed size
+    cd.writeUInt32LE(raw.length, 24); // uncompressed size
+    cd.writeUInt16LE(nameBuf.length, 28);
+    cd.writeUInt16LE(0, 30); // extra length
+    cd.writeUInt16LE(0, 32); // comment length
+    cd.writeUInt16LE(0, 34); // disk number start
+    cd.writeUInt16LE(0, 36); // internal attrs
+    cd.writeUInt32LE(0, 38); // external attrs
+    cd.writeUInt32LE(localOffset, 42); // local header offset
+    central.push(cd, nameBuf);
+  }
+  const localPart = Buffer.concat(locals);
+  const centralPart = Buffer.concat(central);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0, 4); // disk number
+  eocd.writeUInt16LE(0, 6); // disk with central dir
+  eocd.writeUInt16LE(entries.length, 8); // entries on this disk
+  eocd.writeUInt16LE(entries.length, 10); // total entries
+  eocd.writeUInt32LE(centralPart.length, 12); // central dir size
+  eocd.writeUInt32LE(localPart.length, 16); // central dir offset
+  eocd.writeUInt16LE(0, 20); // comment length
+  return Buffer.concat([localPart, centralPart, eocd]);
 }
 
 // -- Self-test: proves the guard fires (mirrors scripts/check-gen-core-skew.sh --self-test). --
@@ -918,6 +1656,251 @@ async function selfTest() {
     cleanSpecs.every((s) => !flaggedSpecs.has(s)),
   );
 
+  // ========================================================================
+  // (m)-(x) --scan-archives (sc-10551): decompress-and-scan archive CONTENTS
+  // ========================================================================
+  // A weight sealed inside an archive must be caught (planted-positive), a clean
+  // archive must pass (negative), and an archive-bomb-shaped input must be REFUSED —
+  // not OOM (fail-closed). Each assertion is failure-capable: a scanner that did not
+  // look inside archives would flag 0 violations and fail the positive assertions.
+  const freshCtx = (limits) => ({
+    ncTokens: tokens,
+    includeBin: false,
+    limits: limits ?? { ...DEFAULT_ARCHIVE_LIMITS },
+    skipUninspectable: false,
+    violations: [],
+    warnings: [],
+  });
+  const newBudget = () => ({ entries: 0, totalBytes: 0 });
+  const expectRefused = (label, fn) => {
+    let caught = null;
+    try {
+      fn();
+    } catch (error) {
+      caught = error;
+    }
+    assert(label, caught instanceof ArchiveBombError);
+  };
+
+  // (m) NC weights (`.safetensors` + a canonical/NC `.bin`) sealed in a `.tar.gz` — the
+  //     macOS updater format — are detected and NC-classified. Planting BOTH extensions
+  //     mirrors the sc-10526 review lesson that a `.bin` must not be a blind spot.
+  {
+    const gz = makeTarGz([
+      { name: "app/README.txt", content: "no weights here" },
+      { name: "models--circlestone-labs--Anima/model.safetensors", content: "w" },
+      { name: "models--circlestone-labs--Anima/pytorch_model.bin", content: "w" },
+      { name: "anima-base.safetensors", content: "w" },
+    ]);
+    const ctx = freshCtx();
+    scanArchiveBuffer(gz, "bundle/macos/App.app.tar.gz", ctx, 1, newBudget());
+    assert("tar.gz: NC weights sealed inside are detected", ctx.violations.length === 3);
+    assert(
+      "tar.gz: the NC .bin inside is caught by default (no --include-bin)",
+      ctx.violations.some((v) => v.basename === "pytorch_model.bin" && v.ncToken != null),
+    );
+    assert("tar.gz: every detected weight is NC-classified", ctx.violations.every((v) => v.ncToken != null));
+  }
+
+  // (n) NC weights (`.safetensors` + a deflate-compressed NC `.bin`) sealed in a `.zip`
+  //     — the Windows `.nsis.zip` updater format — are detected and NC-classified.
+  {
+    const zip = makeZip([
+      { name: "app/README.txt", content: "no weights here" },
+      { name: "models--circlestone-labs--Anima/model.safetensors", content: "w" },
+      { name: "anima-base.bin", content: "w", method: 8 },
+    ]);
+    const ctx = freshCtx();
+    scanArchiveBuffer(zip, "bundle/App.nsis.zip", ctx, 1, newBudget());
+    assert("zip: NC weights sealed inside are detected", ctx.violations.length === 2);
+    assert(
+      "zip: the NC .bin inside is detected and NC-classified",
+      ctx.violations.some((v) => v.basename === "anima-base.bin" && v.ncToken != null),
+    );
+  }
+
+  // (o) Nested archive: a `.tar.gz` sealed inside a DEFLATE-compressed zip entry is
+  //     recursed into (exercises deflate extraction + gunzip + tar + the depth path),
+  //     and the NC weight inside is caught with a nesting-aware path.
+  {
+    const inner = makeTarGz([
+      { name: "models--circlestone-labs--Anima/model.safetensors", content: "w" },
+    ]);
+    const outer = makeZip([
+      { name: "app/ok.txt", content: "fine" },
+      { name: "payload/inner.tar.gz", content: inner, method: 8 },
+    ]);
+    const ctx = freshCtx();
+    scanArchiveBuffer(outer, "bundle/outer.zip", ctx, 1, newBudget());
+    assert(
+      "nested tar.gz inside a deflate zip entry is recursed and the NC weight detected",
+      ctx.violations.length === 1 && ctx.violations[0].ncToken != null,
+    );
+    assert(
+      "nested violation path shows the archive nesting (outer.zip!/…/inner.tar.gz!/…)",
+      /outer\.zip!\/payload\/inner\.tar\.gz!\//.test(ctx.violations[0].file),
+    );
+  }
+
+  // (p) Clean archives pass. A generic `.bin` (font/wasm blob) inside is NOT a weight
+  //     by default — no false positives.
+  {
+    const cleanGz = makeTarGz([
+      { name: "app/index.js", content: "x" },
+      { name: "app/logo.png", content: "y" },
+    ]);
+    const cleanZip = makeZip([
+      { name: "app/index.js", content: "x" },
+      { name: "app/glyphs.bin", content: "a font blob" },
+    ]);
+    const c1 = freshCtx();
+    scanArchiveBuffer(cleanGz, "bundle/clean.tar.gz", c1, 1, newBudget());
+    const c2 = freshCtx();
+    scanArchiveBuffer(cleanZip, "bundle/clean.zip", c2, 1, newBudget());
+    assert("clean tar.gz passes", c1.violations.length === 0);
+    assert("clean zip passes (a generic .bin is not a weight by default)", c2.violations.length === 0);
+  }
+
+  // (q) The allowlisted permissive weight passes even inside an archive; (r) an
+  //     unexpected non-allowlisted weight inside an archive still fails (generic).
+  {
+    const okGz = makeTarGz([
+      { name: "vendor/aesthetic-v2-sac-logos-ava1-l14.safetensors", content: "permissive" },
+    ]);
+    const badGz = makeTarGz([{ name: "vendor/some-random-model.safetensors", content: "w" }]);
+    const okCtx = freshCtx();
+    scanArchiveBuffer(okGz, "bundle/ok.tar.gz", okCtx, 1, newBudget());
+    const badCtx = freshCtx();
+    scanArchiveBuffer(badGz, "bundle/bad.tar.gz", badCtx, 1, newBudget());
+    assert("allowlisted permissive weight inside an archive passes", okCtx.violations.length === 0);
+    assert(
+      "unexpected non-allowlisted weight inside an archive is flagged (generic)",
+      badCtx.violations.length === 1 && badCtx.violations[0].ncToken == null,
+    );
+  }
+
+  // (s) A bare `.gz` of a single weight (name = archive name minus .gz) is detected.
+  {
+    const gz = zlib.gzipSync(Buffer.from("weights"));
+    const ctx = freshCtx();
+    scanArchiveBuffer(gz, "bundle/anima-base.safetensors.gz", ctx, 1, newBudget());
+    assert(
+      "bare .gz of a weight is detected by its derived inner name",
+      ctx.violations.length === 1 && ctx.violations[0].ncToken != null,
+    );
+  }
+
+  // (t) ARCHIVE-BOMB: too many entries → refused (not OOM). Small configured cap
+  //     exercises the exact refusal path a real "many tiny files" bomb would hit.
+  {
+    const many = [];
+    for (let i = 0; i < 10; i += 1) {
+      many.push({ name: `f${i}.txt`, content: "x" });
+    }
+    const gz = makeTarGz(many);
+    expectRefused("archive-bomb: entry count over cap is refused", () =>
+      scanArchiveBuffer(gz, "bundle/many.tar.gz", freshCtx({ ...DEFAULT_ARCHIVE_LIMITS, maxEntries: 3 }), 1, newBudget()),
+    );
+  }
+
+  // (u) ARCHIVE-BOMB: a zip whose DECLARED per-entry uncompressed size exceeds the cap
+  //     is refused BEFORE any inflate — the classic zip-bomb defense.
+  {
+    const zip = makeZip([{ name: "payload.bin", content: "A".repeat(5000) }]);
+    expectRefused("archive-bomb: zip declared-oversized entry is refused before inflating", () =>
+      scanArchiveBuffer(
+        zip,
+        "bundle/bomb.zip",
+        freshCtx({ ...DEFAULT_ARCHIVE_LIMITS, maxEntryUncompressedBytes: 1000 }),
+        1,
+        newBudget(),
+      ),
+    );
+  }
+
+  // (v) ARCHIVE-BOMB: a gzip whose INFLATED size exceeds the total cap is refused
+  //     (Node's gunzip maxOutputLength throws before fully inflating).
+  {
+    const gz = makeTarGz([{ name: "big.txt", content: "A".repeat(50000) }]);
+    expectRefused("archive-bomb: gzip inflating past the total cap is refused (not OOM)", () =>
+      scanArchiveBuffer(
+        gz,
+        "bundle/big.tar.gz",
+        freshCtx({ ...DEFAULT_ARCHIVE_LIMITS, maxTotalUncompressedBytes: 1000 }),
+        1,
+        newBudget(),
+      ),
+    );
+  }
+
+  // (w) ARCHIVE-BOMB: deeply-nested archive beyond the depth cap is refused (bounds
+  //     recursion; defeats a quine/nesting bomb). Wrap a core tar.gz repeatedly.
+  {
+    let nested = makeTarGz([{ name: "core.txt", content: "x" }]);
+    for (let i = 0; i < 6; i += 1) {
+      nested = makeTarGz([{ name: "inner.tar.gz", content: nested }]);
+    }
+    expectRefused("archive-bomb: nesting depth over cap is refused (no infinite recursion)", () =>
+      scanArchiveBuffer(nested, "bundle/nested.tar.gz", freshCtx({ ...DEFAULT_ARCHIVE_LIMITS, maxDepth: 3 }), 1, newBudget()),
+    );
+  }
+
+  // (x) End-to-end on real files: scanArchivesUnderRoots plants a `.app.tar.gz` and a
+  //     `.nsis.zip` on disk and finds the NC weights in both; and an opaque `.dmg`
+  //     fails closed by default but is downgraded to a warning by --skip-uninspectable.
+  const archTmp = await mkdtemp(path.join(os.tmpdir(), "nc-weights-archives-"));
+  try {
+    await mkdir(path.join(archTmp, "macos"), { recursive: true });
+    await writeFile(
+      path.join(archTmp, "macos", "App.app.tar.gz"),
+      makeTarGz([
+        { name: "Contents/Resources/models--circlestone-labs--Anima/model.safetensors", content: "w" },
+      ]),
+    );
+    await writeFile(
+      path.join(archTmp, "App.nsis.zip"),
+      makeZip([{ name: "resources/anima-base.safetensors", content: "w" }]),
+    );
+    const e2e = await scanArchivesUnderRoots({
+      roots: [archTmp],
+      ncTokens: tokens,
+      includeBin: false,
+      limits: { ...DEFAULT_ARCHIVE_LIMITS },
+      skipUninspectable: true,
+    });
+    assert(
+      "end-to-end: NC weights found inside BOTH a .app.tar.gz and a .nsis.zip on disk",
+      e2e.violations.length === 2 && e2e.violations.every((v) => v.ncToken != null),
+    );
+
+    await writeFile(path.join(archTmp, "installer.dmg"), Buffer.from("opaque disk image bytes"));
+    const failClosed = await scanArchivesUnderRoots({
+      roots: [path.join(archTmp)],
+      ncTokens: tokens,
+      includeBin: false,
+      limits: { ...DEFAULT_ARCHIVE_LIMITS },
+      skipUninspectable: false,
+    });
+    assert(
+      "uninspectable .dmg fails closed by default (recorded as a refusal)",
+      failClosed.refusals.some((r) => /installer\.dmg/.test(r.file)),
+    );
+    const skipped = await scanArchivesUnderRoots({
+      roots: [path.join(archTmp)],
+      ncTokens: tokens,
+      includeBin: false,
+      limits: { ...DEFAULT_ARCHIVE_LIMITS },
+      skipUninspectable: true,
+    });
+    assert(
+      "--skip-uninspectable downgrades an opaque .dmg to a warning (no refusal)",
+      skipped.warnings.some((w) => /installer\.dmg/.test(w.file)) &&
+        !skipped.refusals.some((r) => /installer\.dmg/.test(r.file)),
+    );
+  } finally {
+    await rm(archTmp, { recursive: true, force: true });
+  }
+
   if (failures === 0) {
     console.log("self-test: PASS");
     return 0;
@@ -934,12 +1917,14 @@ async function main() {
     return;
   }
 
-  const { tokens, roots, violations, resourceViolations, resourceSpecCount } =
+  const { tokens, roots, violations, resourceViolations, resourceSpecCount, archive } =
     await runScan(options);
   console.log(
     `NC-weights guard: scanned ${roots.join(", ")} for model weights ` +
       `(${tokens.length} NC family tokens from the manifests + bootstrap) and ` +
-      `${resourceSpecCount} declared Tauri bundle-resource spec(s).`,
+      `${resourceSpecCount} declared Tauri bundle-resource spec(s)` +
+      (archive ? `; decompress-and-scanned ${archive.archiveCount} archive(s)` : "") +
+      ".",
   );
   let failed = false;
   if (violations.length > 0) {
@@ -950,13 +1935,28 @@ async function main() {
     reportResourceViolations(resourceViolations);
     failed = true;
   }
+  if (archive) {
+    if (archive.warnings.length > 0) {
+      printArchiveWarnings(archive.warnings);
+    }
+    if (archive.violations.length > 0) {
+      reportArchiveViolations(archive.violations);
+      failed = true;
+    }
+    if (archive.refusals.length > 0) {
+      reportArchiveRefusals(archive.refusals);
+      failed = true;
+    }
+  }
   if (failed) {
     process.exitCode = 1;
     return;
   }
   console.log(
     "NC-weights guard passed: no model weights in the artifact payload and no " +
-      "weight-bearing bundle resources declared.",
+      "weight-bearing bundle resources declared" +
+      (archive ? " and no weights inside any scanned archive" : "") +
+      ".",
   );
 }
 


### PR DESCRIPTION
Closes **sc-10551** (epic 10512, deferred from sc-10526 / PR #1337).

## What sc-10526 already covered (config-time guard)
`scripts/check-no-nc-weights.mjs` fails the build if an NC (non-commercial) model weight is in the artifact payload, via two checks that never open archives:
- a **file-name walk** of the payload trees (`config/`, `crates/`, `apps/`, or a `--dir` bundle), and
- **Tauri `bundle.resources`/`externalBin` config inspection** — fails if a declared resource is an archive, stages a weight, matches an NC family token, or is rooted at a weights dir.

So a weight *declared* as an archive resource is caught, but a weight that reached a built artifact **sealed inside an archive some other way** would slip both scans.

## What this adds (defense-in-depth: scan INSIDE archives)
An **opt-in `--scan-archives`** mode that decompresses every archive under the scan roots and runs the **exact same `classifyEntry()` signature logic** over the entry paths inside — **recursively**, so an archive-in-archive is caught too. The loose-tree walk and the archive scan now share `classifyEntry()`, so the two guards **cannot drift**.

**Pure Node built-ins, no new dependency.** Formats read: `.zip` / `.nsis.zip` (central-directory listing; stored + deflate), `.tar`, `.tar.gz` / `.tgz`, and bare `.gz` (tar reader handles ustar + GNU long-name + PAX paths; zip reader handles ZIP64 defensively).

### Archive formats scanned in the real release artifacts
- macOS lane: `bundle/macos/*.app.tar.gz` (the updater payload) → **decompressed & scanned**
- Windows lane: `*.nsis.zip` (the NSIS updater payload) → **decompressed & scanned**
- Opaque installers `.dmg` / `.msi` / `-setup.exe` have no pure-JS reader → see below

### Archive-bomb guards (required by the story — fail closed, never OOM)
| Limit | Default | CLI override |
| --- | --- | --- |
| On-disk archive size | 2 GiB | `--max-archive-bytes` |
| Total uncompressed | 3 GiB | `--max-uncompressed` |
| Per-entry uncompressed | 1 GiB | `--max-entry-bytes` |
| Entry count | 200 000 | `--max-entries` |
| Nesting depth | 8 | `--max-depth` |

A bomb is **refused** (reported as a build failure), never inflated past the cap. For `.zip` the size caps are checked against the **declared** central-directory sizes **before any inflate** (classic zip-bomb defense); for gzip the total cap is Node's `gunzip maxOutputLength`. Limits accumulate across nesting levels of one top-level archive.

### Opaque installers (`--skip-uninspectable`)
`.dmg`/`.msi`/`-setup.exe` have no pure-JS reader. Default behavior **fails closed** (never silently passes an un-verified archive). The release lanes pass `--skip-uninspectable` to downgrade *only the "no reader for this format" case* to a warning — their contents duplicate the `.app`/resource tree the loose-tree walk in the same step already scans. A **bomb refusal is never downgraded** by this flag.

## Opt-in + wiring
Off by default (never slows an ordinary build). Wired `--scan-archives --skip-uninspectable` into **both** `release.yml` guard steps (macOS + Windows). Documented the future RunPod lane usage (`--dir <rootfs> --scan-archives`; image layers are tar).

## Tests (folded into the existing `--self-test`, run by check.yml)
22 new assertions (m–x), all **failure-capable**:
- **planted-positive in BOTH dominant formats**: NC `.safetensors` **and** a `.bin` sealed in a `.tar.gz`, and in a `.zip` (the `.bin` in each mirrors the sc-10526 review finding that a `.bin` must not be a blind spot) → detected & NC-classified
- **nested**: a `.tar.gz` inside a deflate-compressed zip entry → recursed, NC weight found, nesting-aware path
- **clean-negative**: clean `.tar.gz` + `.zip` pass (a generic `.bin` is not a weight)
- allowlisted permissive weight inside an archive passes; a non-allowlisted weight still fails (generic)
- bare `.gz` of a weight detected by derived name
- **bomb-refusal (all four paths)**: entry-count, zip declared-oversized (refused before inflate), gzip inflate-over-cap, and nesting-depth → each refused, not OOM
- **end-to-end** on real on-disk files: NC weights found inside both a `.app.tar.gz` and a `.nsis.zip`; opaque `.dmg` fails closed by default and warns under `--skip-uninspectable`

**Failure-capable confirmed:** disabling detection in `checkArchiveEntry` (mutation test) makes the positive assertions FAIL; the real self-test exits 0.

## Verification
- `node scripts/check-no-nc-weights.mjs --self-test` → **42 PASS / 0 FAIL**, exit 0
- Default repo scan → exit 0 (no regression / no false positive)
- End-to-end CLI: `--dir <bundle>` alone passes (gap exists); `--dir <bundle> --scan-archives` fails on an NC weight inside a `.tar.gz`; clean archive passes; opaque `.dmg` fails closed / warns with `--skip-uninspectable`
- `cargo fmt --all -- --check` → clean (zero Rust changes; only `.mjs` + `.md` + `.yml`)

## Out of scope (documented)
`include_bytes!`-compiled weights are undetectable by any post-compile file/archive scan; the source-tree scan catches the weight *file* before it is compiled in.

> Note: the `candle-worker` CI lane requires a `[self-hosted, Windows, X64, cuda]` runner that is currently offline, so that one check will sit pending regardless of this change. This PR touches no Rust — all other lanes should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)