### PR TITLE
test(models): lock default-tier precedence + q8-not-q4 revert guard (sc-10732)

### DIFF
--- a/apps/web/src/quantTier.test.js
+++ b/apps/web/src/quantTier.test.js
@@ -367,3 +367,60 @@ describe("defaultTierSelection — per-model quality floor (sc-10731)", () => {
     expect(defaultTierSelection(model, null, { defaultQuality: "bf16" })).toBe("bf16");
   });
 });
+
+// sc-10732 — acceptance #1 (WEB ANALOG of the worker `default_tier_is_q8_not_q4_regression` guard).
+// Epic 10721 moved the app-wide gen-time default OFF the old blind q4 to q8 (sc-10726), matching the
+// worker's `preferred_tier(None, None) == "q8"`. If a future change reverts `DEFAULT_GENERATION_QUALITY`
+// (or the no-options fallback base) back to q4, these fail loudly on the CI-runnable web side too.
+describe("defaultTierSelection — q8-not-q4 base-default revert guard (sc-10732)", () => {
+  it("keeps the app-wide base default constant at q8, never q4", () => {
+    expect(DEFAULT_GENERATION_QUALITY).toBe("q8");
+    expect(DEFAULT_GENERATION_QUALITY).not.toBe("q4");
+  });
+
+  it("resolves the no-sticky/no-setting default to q8 (not q4) for matrix AND convert models", () => {
+    // Download-matrix model: no sticky, no declared default, no global setting → the q8 base default.
+    const matrix = matrixModel({ installed: ["q4", "q8", "bf16"], defaultTier: "none" });
+    expect(defaultTierSelection(matrix, null)).toBe("q8");
+    expect(defaultTierSelection(matrix, null)).not.toBe("q4");
+    // Convert-at-install (mlxTiers) model — the same base default, so the picker never silently
+    // re-sends the washed q4 (the sc-10714 Anima quality bug epic 10721 fixed).
+    const convert = convertModel({ mlxTiers: ["q4", "q8", "bf16"] });
+    expect(defaultTierSelection(convert, null)).toBe("q8");
+    expect(defaultTierSelection(convert, null)).not.toBe("q4");
+  });
+});
+
+// sc-10732 — the FULL precedence LADDER in one place, so the rung ORDER (not just each rung in
+// isolation, as the sc-10727/28/31 suites above cover) is locked coherently: peel rungs from the top on
+// one floored convert model —
+//   sticky (rung 1, un-floored) > global setting (rung 3) > floor clamp > installed clamp > first installed.
+describe("defaultTierSelection — full precedence ladder (sc-10732)", () => {
+  const floored = () => flooredConvertModel({ mlxTiers: ["q4", "q8", "bf16"], floor: "q8" });
+
+  it("rung 1: a below-floor sticky beats BOTH the global setting and the floor", () => {
+    // Sticky q4 (a prior EXPLICIT pick) wins over a bf16 global setting and is NOT re-floored up to q8.
+    // Combines two rungs the isolated suites test separately — sticky-beats-global and sticky-below-floor.
+    expect(defaultTierSelection(floored(), "q4", { defaultQuality: "bf16" })).toBe("q4");
+  });
+
+  it("rung 3: with no sticky, the global setting (above the floor) drives the default", () => {
+    expect(defaultTierSelection(floored(), null, { defaultQuality: "bf16" })).toBe("bf16");
+  });
+
+  it("floor clamp: a global setting BELOW the floor is raised to the floor, never landing on q4", () => {
+    expect(defaultTierSelection(floored(), null, { defaultQuality: "q4" })).toBe("q8");
+  });
+
+  it("installed clamp: the floor is capped by what's on disk (floor q8, only q4 installed → q4)", () => {
+    const model = flooredConvertModel({ mlxTiers: ["q4"], floor: "q8" });
+    expect(defaultTierSelection(model, null, { defaultQuality: "q4" })).toBe("q4");
+  });
+
+  it("first-installed fallback: a lone tier outside the clean-fallback chain is the last resort", () => {
+    // bf16 alone: no sticky/global/declared/floor; base q8 + fallback [q8,q4] are all absent → the sole
+    // installed tier (rung 4 / `tiers[0]`), proving the bottom of the ladder.
+    const model = matrixModel({ tiers: ["bf16"], installed: ["bf16"], defaultTier: "none" });
+    expect(defaultTierSelection(model, null)).toBe("bf16");
+  });
+});

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -4845,6 +4845,69 @@ mod standard_tier_tests {
         );
     }
 
+    /// **sc-10732 — acceptance #1: the app-wide default-tier revert guard.**
+    ///
+    /// Epic 10721 moved the gen-time default tier off the old blind `q4` to `q8` (sc-10726): the shared
+    /// [`preferred_tier`] returns `"q8"` with no explicit `mlxQuantize` pick and no per-model floor, and
+    /// BOTH tier resolvers ([`standard_tier_subdir`] and [`anima_tier_subdir`]) inherit it. If a future
+    /// change reverts that default back to `q4` — in `preferred_tier`'s `None => …` arm, or a resolver
+    /// special-case — this test FAILS LOUDLY. That is the whole point of the sc-10732 lock: the finer
+    /// resolver/floor tests each imply it, but this one names it at the revert site so the intent is
+    /// unmissable. Deliberately redundant.
+    #[test]
+    fn default_tier_is_q8_not_q4_regression() {
+        // The shared default-tier primitive: no explicit `mlxQuantize`, no per-model floor → q8, never q4.
+        assert_eq!(
+            preferred_tier(None, None),
+            "q8",
+            "app-wide gen default MUST be q8 (epic 10721 / sc-10726) — a revert to q4 is the regression \
+             this guards"
+        );
+        assert_ne!(
+            preferred_tier(None, None),
+            "q4",
+            "the pre-epic-10721 blind-q4 default has been reverted — do NOT reinstate it (sc-10726/sc-10732)"
+        );
+
+        // Disk-backed through the standard resolver: a default job (no mlxQuantize) with ALL tiers
+        // installed resolves the q8 subdir, not the washed q4 — the revert is caught end-to-end too.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        for tier in ["bf16", "q8", "q4"] {
+            seed_tier(root, tier, "diffusion_pytorch_model.safetensors");
+        }
+        let default_job = request(json!({}));
+        assert_eq!(
+            standard_tier_subdir(root, &default_job),
+            root.join("q8"),
+            "standard_tier_subdir default MUST land on q8 (not q4) when all tiers are installed"
+        );
+        assert_ne!(standard_tier_subdir(root, &default_job), root.join("q4"));
+
+        // The Anima resolver shares the same default (sc-10714 → sc-10731): its no-pick default is q8 too,
+        // so a revert to q4 also washes Anima — the exact quality bug epic 10721 fixed.
+        #[cfg(any(target_os = "macos", feature = "backend-candle"))]
+        {
+            let anima_root = tempfile::tempdir().unwrap();
+            for tier in ["bf16", "q8", "q4"] {
+                let dir = anima_root.path().join(tier).join("diffusion_models");
+                std::fs::create_dir_all(&dir).unwrap();
+                std::fs::write(dir.join("anima-base-v1.0.safetensors"), b"x").unwrap();
+            }
+            let anima_default =
+                ImageRequest::from_payload(json!({ "model": "anima_base" }).as_object().unwrap());
+            assert_eq!(
+                anima_tier_subdir(anima_root.path(), &anima_default),
+                anima_root.path().join("q8"),
+                "anima_tier_subdir default MUST be q8 (sc-10714), never the washed q4"
+            );
+            assert_ne!(
+                anima_tier_subdir(anima_root.path(), &anima_default),
+                anima_root.path().join("q4")
+            );
+        }
+    }
+
     #[test]
     fn falls_back_when_preferred_tier_absent() {
         let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

Epic 10721's **last story (sc-10732)** — lock the new app-wide gen-time default-tier behaviour so it can't silently regress. This is the guard the sc-10714 washed-q4 Anima bug got past (its real-weights acceptance only asserted `assert_coherent`, which a washed image passes). **Regression tests only; no behaviour change.**

The full precedence chain (S2 q8 default, S3 sticky, S4 global setting, S5 mlxTiers, S6 quality floor) was already merged; this story audits the existing S2–S6 tests and **fills the gaps** — a named revert guard + a coherent precedence-ladder lock — rather than duplicating them.

## Worker — `crates/sceneworks-worker/src/image_jobs/base.rs`

New `default_tier_is_q8_not_q4_regression` test (**acceptance #1**):
- `preferred_tier(None, None) == "q8"` (and `!= "q4"`) — the shared default-tier primitive both resolvers inherit.
- Disk-backed: `standard_tier_subdir` and `anima_tier_subdir` no-pick defaults (all tiers installed) both resolve `q8/`, never the washed `q4/`.
- **Reverting the app-wide default from q8 back to q4** (in `preferred_tier`'s `None =>` arm) **fails this test loudly** — verified by mutation (`left: "q4", right: "q8"`, with the guard's explanatory message).

The existing sc-10726/sc-10731 resolver + floor tests already cover default→q8, explicit-pick-honored, floor clamp-up, floor-capped-by-installed, and clean-tier fallback (`defaults_to_q8_and_honors_quantize_selection`, `falls_back_when_preferred_tier_absent`, `preferred_tier_clamps_default_up_to_the_floor_only`, `min_quality_floor_reads_valid_manifest_values_only`, `standard_tier_subdir_clamps_default_to_the_floor`, and the floor-driven `anima_tier_subdir_selects_and_falls_back`). This PR adds the **named** guard at the revert site so intent is unmissable.

## Web — `apps/web/src/quantTier.test.js`

- **`q8-not-q4 base-default revert guard`** — the web analog of the worker guard: locks `DEFAULT_GENERATION_QUALITY` at q8 and the no-sticky/no-setting default to q8 for both matrix and convert (mlxTiers) models. Verified by mutation (flipping the constant to q4 fails both the constant assertion and the behavioural `defaultTierSelection` assertion).
- **`full precedence ladder`** — locks the rung ORDER coherently in one place (the isolated sc-10727/28/31 suites each test one rung): **sticky (un-floored) > global setting > floor clamp > installed clamp > first-installed**. Includes the combined *sticky-beats-BOTH-global-and-floor* case (`defaultTierSelection(flooredModel, "q4", { defaultQuality: "bf16" }) === "q4"`) the isolated suites didn't exercise.

## Precedence cases now locked

| Rung | Case | Test surface |
|---|---|---|
| explicit pick | q4/q8/bf16 honored even below floor | worker + web (existing + guard) |
| sticky (rung 1) | beats global + floor; not re-floored | web ladder |
| global setting (rung 3) | drives default, clamped to installed | web |
| floor clamp | raised UP to `minQualityTier`, never down | worker + web |
| installed clamp | floor capped by what's on disk | worker + web |
| fallback | first-installed tier | worker + web |
| **base default** | **q8, never q4 (revert guard)** | **worker + web (acceptance #1)** |

## Tests / checks
- `cargo test -p sceneworks-worker --lib standard_tier_tests` — 19 passed, 1 ignored (real-weights smoke).
- `npx vitest run src/quantTier.test.js --environment jsdom` — 50 passed.
- **Mutation checks (acceptance #1):** reverting q8→q4 fails the worker guard AND the web guard; both restored.
- `cargo fmt --all -- --check` clean · `cargo clippy -p sceneworks-worker --all-targets -- -D warnings` clean · `eslint` clean.

## PART 2 — Anima sharpness floor in `mlx-gen-anima` (investigation, NOT done here)

The sharpness floor (the gap that let sc-10714 ship) lives in the **separate `mlx-gen-anima` repo**, which the worker pins by SHA — a cross-repo change + pin-bump. Findings:

- **Location / pin:** `mlx-gen-anima` is a subdir of `github.com/michaeltrefry/mlx-gen`, checked out locally at `/Users/michael/Repos/mlx-gen` (HEAD `8a9be0bc`, ahead of pin). The SceneWorks worker pins **both `mlx-gen` and `mlx-gen-anima` at the same rev `5d882290cd74eb4676793ef4bdf2978a8484fd91`** (`crates/sceneworks-worker/Cargo.toml`); the CUDA sibling `candle-gen` is a separate pin.
- **`assert_coherent` lives in** `mlx-gen-anima/tests/real_weights.rs` (helper at ~L105). It computes only LOW-frequency metrics via `coherence()`: full-image grayscale `std > 8.0` and 32×32 block-averaged `coarse32_std > 12.0`. A **washed** q4 image (smudgy but still colourful, with intact coarse layout) passes BOTH — the exact miss. Real-weights acceptance tests that call it: the per-variant bf16 tests and `generate_quant_tiers_all_variants_q8_q4` (~L334).
- **The change:** add a `laplacian_variance(img) -> f32` helper (variance of the 3×3 Laplacian over the grayscale image — the classic focus/sharpness metric: crisp detail ⇒ high variance; a washed/blurry tier ⇒ collapsed variance) next to `coherence()`, and assert `lap_var > SHARPNESS_FLOOR` inside `assert_coherent` (so the bf16 per-variant + q8 matrix acceptances gain it). The deliberately-q4 corner of the q8/q4 matrix test would use a weaker/lower bound since q4 is legitimately softer. **Acceptance #2** ("forcing q4 washes the output and trips the floor") is then satisfied on the q8/bf16 outputs.
- **Feasibility → FOLLOW-UP, not this session.** The code is small and mechanical, but (a) `SHARPNESS_FLOOR` must be **calibrated on-device** (Mac + the gated `circlestone-labs/Anima` snapshot + Metal) by measuring `laplacian_variance` for a clean q8/bf16 image vs a forced-q4 image to bracket a threshold that separates them — an uncalibrated constant is either useless (too low) or flaky/false-failing (too high); and (b) the SceneWorks **pin-bump is cross-repo fragile** — `mlx-gen`/`mlx-gen-anima` share a rev and must move in lockstep with `candle-gen`/gen-core (known squash-merge + gen-core-skew hazards). The real-weights test is `#[ignore]` (needs Mac + weights), so it is **not CI-runnable** regardless — it adds no CI protection this PR can verify. Recommend a tracked cross-repo story: land the Laplacian floor + calibrated threshold in `mlx-gen-anima`, then bump the SceneWorks pins deliberately.

Story: https://app.shortcut.com/trefry/story/10732 (sc-10732)

🤖 Generated with [Claude Code](https://claude.com/claude-code)