### PR TITLE
feat(routing): keep realvisxl_lightning quant+LoRA on the candle lane (sc-10812)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3756,11 +3756,15 @@ mod candle_routing_tests {
         // AND inference LoRA/LoKr on a packed tier (sc-9528), so a quant tier-select AND a LoRA both
         // stay on the candle lane rather than deferring to the retired torch fallback. Mirrors the
         // boogu/lens quant-stays coverage; the inverse of the old dense-only behavior.
+        //
+        // sc-10812: realvisxl_lightning (the few-step distilled sibling on the SAME `sdxl` engine /
+        // descriptor) joins the family — same quant + LoRA stay-on-candle for its plain txt2img shape.
         for model in [
             "sdxl",
             "realvisxl",
             "illustrious_xl_v1",
             "illustrious_xl_v2",
+            "realvisxl_lightning",
         ] {
             for bits in [8, 4] {
                 assert!(

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -579,7 +579,12 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
     // RealVisXL Lightning (MLX sc-6075 / candle sc-7176): standalone few-step distilled SDXL checkpoint
     // on the shared `sdxl` engine, few-step `lightning` accel sampler. **txt2img only** on both backends —
     // edit / reference / mask / pose shapes fall back to torch (accel sampler is conditioning-incompatible).
-    ModelCaps::new("realvisxl_lightning", true, true, false, false, false),
+    // sc-10812 (epic 9083): shares `candle-gen-sdxl`, which advertises `supported_quants: [Q4, Q8]` +
+    // inference LoRA-on-packed after sc-10767 (packed UNet sc-9416 / dual-CLIP sc-9527 / adapter fold
+    // sc-9528). Its `SceneWorks/realvisxl-lightning-mlx` turnkey ships the standard q4/q8/bf16 tiers
+    // (standard_tier_subdir), so a quant tier-select AND a LoRA both stay on the candle lane for the
+    // plain few-step txt2img shape → `candle_quant_lora`. bf16 still resolves to Quant::None (dense).
+    ModelCaps::new("realvisxl_lightning", true, true, false, false, true),
     // InstantID on RealVisXL (sc-3345): MLX-only id — single-identity + the 11-view angle set route to
     // the native `mlx-gen-instantid` provider (candle serves it via the bespoke `instantid_candle_eligible`
     // lane, not the txt2img gate, so it is NOT a candle-routed txt2img id).
@@ -1009,12 +1014,15 @@ mod tests {
     // `supported_quants` to [Q4, Q8]; it already advertised inference LoRA via sc-7836). sc-9994 adds the
     // Raw variant (candle-gen #350) with the same both-set advertisement. sc-10767: the SDXL family
     // (sdxl/realvisxl/illustrious v1+v2) joins the both-set — the candle packed q4/q8 tier (sc-9416/9527)
-    // + adapter-on-packed fold (sc-9528) are wired and now advertised.
+    // + adapter-on-packed fold (sc-9528) are wired and now advertised. sc-10812: realvisxl_lightning (the
+    // few-step distilled sibling on the SAME `sdxl` engine / descriptor) joins the both-set too — quant +
+    // LoRA stay on candle for its plain txt2img shape.
     const EXPECTED_CANDLE_QUANT_LORA_MODELS: &[&str] = &[
         "sdxl",
         "realvisxl",
         "illustrious_xl_v1",
         "illustrious_xl_v2",
+        "realvisxl_lightning",
         "lens",
         "lens_turbo",
         "krea_2_turbo",

--- a/crates/sceneworks-worker/src/realvisxl_lightning_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/realvisxl_lightning_gpu_smoke.rs
@@ -5,11 +5,23 @@
 //! the worker pins for `realvisxl_lightning`, against the distilled RealVisXL_V5.0_Lightning weights.
 //! This is the end-to-end worker-lane validation that backs the macOnly drop.
 //!
-//! Setup (PowerShell; the diffusers fp16 components must be in the HF cache — download via the Model
-//! Manager / the manifest `realvisxl_lightning` entry):
+//! `REALVISXL_LIGHTNING_DIR` may point at EITHER a dense diffusers snapshot (the fp16 components under a
+//! `model_index.json` root) OR a packed **q4/q8 standard tier** dir (the `q4/`/`q8/` subdir of the
+//! `SceneWorks/realvisxl-lightning-mlx` turnkey, which carries engine-complete `unet/`+`text_encoder/`+
+//! `vae/`). `candle-gen-sdxl::load` packed-detects the tier from disk (sc-9416/9527), so the SAME seam
+//! serves both — this is the sc-10812 packed-tier eyeball: the routing flip to `candle_quant_lora` keeps
+//! a quant tier-select on candle, and a packed lightning render must stay coherent at 5-step. Point it
+//! at the cached `SceneWorks/sdxl-base-mlx` `q8/` tier (with `RVXL_SAMPLER=` unset → engine default,
+//! since the non-distilled base isn't a lightning checkpoint) to exercise the shared candle-gen-sdxl
+//! packed loader on this box when the lightning turnkey isn't pulled.
+//!
+//! Setup (PowerShell; the components must be in the HF cache — download via the Model Manager / the
+//! manifest `realvisxl_lightning` entry):
 //! ```text
-//! # the snapshot dir holding model_index.json + unet/ text_encoder/ ... *.fp16.safetensors
+//! # dense: the snapshot dir holding model_index.json + unet/ text_encoder/ ... *.fp16.safetensors
 //! $env:REALVISXL_LIGHTNING_DIR="C:\Users\Michael\.cache\huggingface\hub\models--SG161222--RealVisXL_V5.0_Lightning\snapshots\<hash>"
+//! # OR packed (sc-10812): a q4/q8 tier dir carrying unet/ text_encoder/ vae/
+//! # $env:REALVISXL_LIGHTNING_DIR="D:\.cache\huggingface\hub\models--SceneWorks--realvisxl-lightning-mlx\snapshots\<hash>\q8"
 //! $env:RVXL_OUT_DIR="D:\sceneworks-sampler-validate\rvxl-lightning"
 //! # optional: RVXL_STEPS=5 RVXL_W=1024 RVXL_H=1024 RVXL_PROMPT="..." RVXL_CONTRAST=1 (also render ddim@steps)
 //! cargo test -p sceneworks-worker --features backend-candle --release realvisxl_lightning_candle_gpu_smoke -- --ignored --nocapture
@@ -73,9 +85,17 @@ fn render(
 #[ignore = "real-weight GPU smoke; needs the candle RealVisXL_V5.0_Lightning diffusers snapshot"]
 fn realvisxl_lightning_candle_gpu_smoke() {
     let weights_dir = env_path("REALVISXL_LIGHTNING_DIR");
+    // Accept EITHER a dense diffusers snapshot (model_index.json root) OR a packed q4/q8 standard-tier
+    // dir (sc-10812: engine-complete unet/+text_encoder/+vae/, no model_index.json). candle-gen-sdxl
+    // packed-detects the tier from disk, so both load through the same `gen_core::load("sdxl")` seam.
+    let is_diffusers_snapshot = weights_dir.join("model_index.json").is_file();
+    let is_packed_tier = weights_dir.join("unet").is_dir()
+        && weights_dir.join("text_encoder").is_dir()
+        && weights_dir.join("vae").is_dir();
     assert!(
-        weights_dir.join("model_index.json").is_file(),
-        "REALVISXL_LIGHTNING_DIR must point at the diffusers snapshot (model_index.json missing): {}",
+        is_diffusers_snapshot || is_packed_tier,
+        "REALVISXL_LIGHTNING_DIR must be a diffusers snapshot (model_index.json) or a packed q4/q8 tier \
+         (unet/+text_encoder/+vae/): {}",
         weights_dir.display()
     );
     let out_dir = PathBuf::from(env_or("RVXL_OUT_DIR", "/tmp/rvxl_lightning_smoke"));
@@ -97,9 +117,17 @@ fn realvisxl_lightning_candle_gpu_smoke() {
     let generator = gen_core::load("sdxl", &spec).expect("load candle sdxl provider");
 
     // The shipped behavior: realvisxl_lightning forces the few-step `lightning` sampler, CFG-off
-    // (guidance 1.0 — the distilled checkpoint is trained CFG-free).
-    println!("[smoke] rendering lightning @ {steps} steps ({w}x{h}) ...");
-    let lightning = render(&*generator, &prompt, w, h, steps, 1.0, Some("lightning"));
+    // (guidance 1.0 — the distilled checkpoint is trained CFG-free). Overridable so this harness can also
+    // exercise the shared candle-gen-sdxl packed loader against the cached non-distilled `sdxl-base-mlx`
+    // q8 tier (sc-10812): `RVXL_SAMPLER=` (empty) → engine default, `RVXL_GUIDANCE=7.5` for real CFG.
+    let sampler_name = env_or("RVXL_SAMPLER", "lightning");
+    let sampler = (!sampler_name.trim().is_empty()).then_some(sampler_name.trim());
+    let guidance: f32 = env_or("RVXL_GUIDANCE", "1.0").parse().expect("RVXL_GUIDANCE");
+    println!(
+        "[smoke] rendering {} @ {steps} steps ({w}x{h}, guidance {guidance}) ...",
+        sampler.unwrap_or("engine-default")
+    );
+    let lightning = render(&*generator, &prompt, w, h, steps, guidance, sampler);
     let lightning_std = image_std(&lightning);
     save_png(
         &lightning,

--- a/crates/sceneworks-worker/src/realvisxl_lightning_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/realvisxl_lightning_gpu_smoke.rs
@@ -122,7 +122,9 @@ fn realvisxl_lightning_candle_gpu_smoke() {
     // q8 tier (sc-10812): `RVXL_SAMPLER=` (empty) → engine default, `RVXL_GUIDANCE=7.5` for real CFG.
     let sampler_name = env_or("RVXL_SAMPLER", "lightning");
     let sampler = (!sampler_name.trim().is_empty()).then_some(sampler_name.trim());
-    let guidance: f32 = env_or("RVXL_GUIDANCE", "1.0").parse().expect("RVXL_GUIDANCE");
+    let guidance: f32 = env_or("RVXL_GUIDANCE", "1.0")
+        .parse()
+        .expect("RVXL_GUIDANCE");
     println!(
         "[smoke] rendering {} @ {steps} steps ({w}x{h}, guidance {guidance}) ...",
         sampler.unwrap_or("engine-default")


### PR DESCRIPTION
Follow-up to sc-10767. Keeps **realvisxl_lightning** on the candle lane for a quant tier-select AND an inference LoRA, instead of bouncing both into the retired torch fallback.

## Why it's a safe flip
realvisxl_lightning is the few-step distilled sibling on the **shared `sdxl` engine**, so it loads through `candle-gen-sdxl` — which advertises `supported_quants: [Q4, Q8]` + inference LoRA-on-packed after sc-10767 (packed UNet sc-9416 / dual-CLIP sc-9527 / adapter fold sc-9528). Its `SceneWorks/realvisxl-lightning-mlx` turnkey ships the standard q4/q8/bf16 tiers (`standard_tier_subdir`), and `candle-gen-sdxl::load` packed-detects the tier from disk. **No candle-gen change / pin bump** — the shared descriptor is already `[Q4, Q8]`.

## Changes
- `routing/catalog.rs`: `realvisxl_lightning` → `candle_quant_lora: true`; add to the derived `EXPECTED_CANDLE_QUANT_LORA_MODELS` snapshot. bf16 still resolves to `Quant::None` (dense); edit/reference/mask/pose still fall back (accel sampler is conditioning-incompatible).
- `jobs_store.rs`: extend `sdxl_family_quant_and_lora_stay_on_candle` to assert realvisxl_lightning keeps Q8/Q4 tier-selects AND a LoRA on candle.
- `realvisxl_lightning_gpu_smoke.rs`: accept a packed q4/q8 tier dir (not just a dense diffusers snapshot) + env-overridable sampler/guidance, so the harness covers the sc-10812 packed-tier eyeball.

## Tests
`cargo test -p sceneworks-core --lib jobs_store` → **88 passed**; `routed_model_lists_match_snapshot` + `sdxl_family_quant_and_lora_stay_on_candle` green. clippy + fmt clean on core.

## Scope note — kolors split to sc-10819
sc-10812 originally paired kolors here, but a code read of the pinned candle-gen rev (`92253d2`) shows **`candle-gen-kolors` has no packed load path** — it loads dense f32 only (`f32_vb` / bare `candle_nn::linear`), rejects `spec.quantize`, and advertises `supported_quants: &[]`. Flipping it blind would break the q4/q8 tier load. Building the packed ChatGLM3 + UNet load path (mirroring `candle-gen-sdxl`'s packed-detect stack) is tracked as **sc-10819**.

## GPU validation
The candle-gen-sdxl packed q4/q8 render was GPU-validated under sc-10767; realvisxl_lightning reuses that identical loader/descriptor (weights swap + forced `lightning` sampler). The extended smoke can exercise the packed lane against the cached `SceneWorks/sdxl-base-mlx` q8 tier on the RTX PRO 6000.

Relates to sc-10767. Closes sc-10812.

🤖 Generated with [Claude Code](https://claude.com/claude-code)