### PR TITLE
chore(ci): cut parity-job Rust rebuild waste (sc-10823)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -91,8 +91,17 @@ jobs:
           bash scripts/check-gen-core-skew.sh
       - name: Run Rust workspace checks
         run: npm run rust:check
-      - name: Build Rust API before contract tests
-        run: cargo build -q -p sceneworks-rust-api
+      - name: Export prebuilt Rust binaries for the e2e/parity harnesses
+        # `npm run rust:check` ends in `cargo build`, which builds both default-member
+        # binaries into target/debug. Point the pytest harnesses at them so the ~30
+        # API + worker spawns across the e2e/parity steps launch the binary directly
+        # and skip `cargo run`'s per-launch freshness check over the whole workspace
+        # graph. This also replaces the old redundant `cargo build -p sceneworks-rust-api`
+        # step (the binary is already built above). See tests/test_rust_api_worker_smoke.py
+        # `_launch_command` and tests/test_rust_api_contract_snapshots.py (sc-10823).
+        run: |
+          echo "SCENEWORKS_RUST_API_BINARY=${{ github.workspace }}/target/debug/sceneworks-rust-api" >> "$GITHUB_ENV"
+          echo "SCENEWORKS_RUST_WORKER_BINARY=${{ github.workspace }}/target/debug/sceneworks-rust-worker" >> "$GITHUB_ENV"
       - name: Run end-to-end job pipeline test
         # tests/conftest.py fails this gate (via `require_tool` + an all-skipped
         # session guard) if `CI` is set and every collected test skips -- e.g. a
@@ -104,5 +113,33 @@ jobs:
         # Same all-skipped guard as the e2e step: a parity run that exercised
         # nothing fails instead of reporting success (sc-8935 / F-133).
         run: python -m pytest -q -m parity --strict-markers
+      - name: Decide whether to run the Docker runtime smoke
+        id: docker_smoke_gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        # The Docker smoke recompiles the whole ~275-crate workspace from scratch in
+        # the release profile inside BuildKit — its `--mount=type=cache` target dir is
+        # empty on ephemeral runners and isn't exportable to the gha cache, so it shares
+        # nothing with the host's rust-cache-warmed target/ and costs ~5 min every run.
+        # The host contract + e2e steps already exercise the API binary's startup and
+        # /health, so the container smoke only adds packaging coverage. Re-run it only
+        # when an input that can actually regress the image changed; always run off a
+        # pull request (push to main / codex/**) for full coverage (sc-10823).
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "Not a pull request; running the Docker runtime smoke."
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed="$(gh pr view "${{ github.event.pull_request.number }}" --json files --jq '.files[].path')"
+          if printf '%s\n' "$changed" | grep -qE '^(docker/|config/|docker-compose\.yml|Cargo\.lock|\.github/workflows/check\.yml|scripts/check-(docker-api-runtime|compose-config)\.mjs)'; then
+            echo "Docker-relevant files changed; running the Docker runtime smoke."
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No Docker-relevant changes; skipping the Docker runtime smoke (sc-10823)."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Smoke default Rust API Docker runtime
+        if: steps.docker_smoke_gate.outputs.run == 'true'
         run: npm run check:docker:rust-api

--- a/tests/test_rust_api_worker_smoke.py
+++ b/tests/test_rust_api_worker_smoke.py
@@ -193,6 +193,25 @@ def complete_image_job(
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def _launch_command(binary_env: str, package: str, purpose: str) -> list[str]:
+    """Command to spawn a workspace binary for the e2e smoke.
+
+    Prefer a prebuilt binary exported by CI (SCENEWORKS_RUST_API_BINARY /
+    SCENEWORKS_RUST_WORKER_BINARY) so the ~30 API+worker spawns across the e2e
+    and parity steps skip `cargo run`'s per-launch freshness check over the whole
+    workspace graph (sc-10823). Local ad-hoc runs with no export fall back to
+    `cargo run`. A binary path that is set but missing means the earlier build
+    step regressed, so fail loudly rather than silently reverting to cargo —
+    mirroring the require_tool honesty guard (sc-8935 / F-133)."""
+    binary = os.getenv(binary_env)
+    if binary:
+        if not Path(binary).is_file():
+            raise AssertionError(f"{binary_env}={binary} does not exist")
+        return [binary]
+    require_tool("cargo", purpose)
+    return ["cargo", "run", "-q", "-p", package]
+
+
 def wait_for_job_status(base_url: str, job_id: str, status: str, process: subprocess.Popen) -> dict:
     deadline = time.monotonic() + 30
     last_job: dict | None = None
@@ -213,7 +232,9 @@ def wait_for_job_status(base_url: str, job_id: str, status: str, process: subpro
 
 @pytest.fixture()
 def rust_api(tmp_path):
-    require_tool("cargo", "the Rust API smoke test")
+    command = _launch_command(
+        "SCENEWORKS_RUST_API_BINARY", "sceneworks-rust-api", "the Rust API smoke test"
+    )
 
     port = free_port()
     base_url = f"http://127.0.0.1:{port}"
@@ -229,7 +250,7 @@ def rust_api(tmp_path):
         }
     )
     process = subprocess.Popen(
-        ["cargo", "run", "-q", "-p", "sceneworks-rust-api"],
+        command,
         cwd=ROOT,
         env=env,
         stdout=subprocess.PIPE,
@@ -476,7 +497,9 @@ def test_character_image_angle_and_pose_sets_carry_loras_through_worker(rust_api
 
 
 def test_rust_worker_claims_and_completes_lora_import_against_rust_api_binary(rust_api, tmp_path):
-    require_tool("cargo", "the Rust worker smoke test")
+    worker_command = _launch_command(
+        "SCENEWORKS_RUST_WORKER_BINARY", "sceneworks-rust-worker", "the Rust worker smoke test"
+    )
 
     # The Rust API only imports a sourcePath from app-managed roots (data/loras,
     # project loras, or staged uploads) for path safety; stage the source inside
@@ -497,7 +520,7 @@ def test_rust_worker_claims_and_completes_lora_import_against_rust_api_binary(ru
         }
     )
     worker = subprocess.Popen(
-        ["cargo", "run", "-q", "-p", "sceneworks-rust-worker"],
+        worker_command,
         cwd=ROOT,
         env=env,
         stdout=subprocess.PIPE,
@@ -533,13 +556,16 @@ def test_rust_worker_claims_and_completes_lora_import_against_rust_api_binary(ru
 
 
 def test_rust_worker_completes_ffmpeg_frame_and_timeline_jobs_against_rust_api_binary(rust_api, tmp_path):
-    require_tool("cargo", "the Rust worker smoke test")
     # ffmpeg is intentionally NOT provisioned in the `check.yml` CI (only in the
     # desktop/release packaging workflows), so this stays a plain skip: it must not
     # red the e2e gate. The all-skipped guard in conftest still fires if cargo (and
     # thus every other e2e test) also went missing (sc-8935 / F-133).
     if shutil.which("ffmpeg") is None:
         pytest.skip("ffmpeg is required for the FFmpeg worker smoke test")
+
+    worker_command = _launch_command(
+        "SCENEWORKS_RUST_WORKER_BINARY", "sceneworks-rust-worker", "the Rust worker smoke test"
+    )
 
     env = os.environ.copy()
     env.update(
@@ -554,7 +580,7 @@ def test_rust_worker_completes_ffmpeg_frame_and_timeline_jobs_against_rust_api_b
         }
     )
     worker = subprocess.Popen(
-        ["cargo", "run", "-q", "-p", "sceneworks-rust-worker"],
+        worker_command,
         cwd=ROOT,
         env=env,
         stdout=subprocess.PIPE,


### PR DESCRIPTION
## Problem

The `parity` job in `.github/workflows/check.yml` runs **~19–20 min**, mostly recompiling the Rust workspace several times over. Profiling run [29147786742](https://github.com/SceneWorks/SceneWorks/actions/runs/29147786742/job/86532176916) (PR #1375):

| Step | Time |
|---|---|
| Run Rust workspace checks (`npm run rust:check`) | 221s |
| e2e pytest | 121s |
| parity contract-snapshot pytest | 448s |
| Smoke default Rust API Docker runtime | 310s |

Root causes of redundant compilation:

1. **Docker smoke recompiles the entire ~275-crate dep tree from scratch, in release**, every run — the Dockerfile builds inside BuildKit against a `--mount=type=cache` that is empty on ephemeral runners and isn't exportable to the gha cache, so it shares nothing with the host's `Swatinem/rust-cache`-warmed `target/`. ~290s of the 310s.
2. **pytest spawns the API/worker via `cargo run` ~30×** — the contract fixture is function-scoped and starts **two** APIs per test (24 spawns), plus the worker smoke. `ServerApiHarness` already honored `SCENEWORKS_RUST_API_BINARY`, but the workflow never set it, so every spawn paid cargo's freshness check.
3. Redundant standalone `cargo build -p sceneworks-rust-api` step (rust:check already ran `cargo build`).

## Fixes

1. **Gate the Docker smoke** behind a `docker_smoke_gate` step: always runs on push (main / `codex/**`); on PRs it runs only when an input that can regress the image changed (`docker/`, `config/`, `docker-compose.yml`, `Cargo.lock`, the workflow, or the docker/compose check scripts). Host contract + e2e tests already exercise API startup + `/health`. Uses preinstalled `gh` — no new action dependency. Saves ~310s on the common PR path.
2. **Reuse prebuilt binaries in pytest**: export `SCENEWORKS_RUST_API_BINARY` / `SCENEWORKS_RUST_WORKER_BINARY` (the `target/debug` binaries built by `rust:check`) via `$GITHUB_ENV`, and teach `tests/test_rust_api_worker_smoke.py` those overrides via a new `_launch_command()` helper (fails loudly if a set path is missing, else falls back to `cargo run`). All ~30 spawns now launch directly.
3. **Drop** the redundant `cargo build -p sceneworks-rust-api` step.

## Verification

- `_launch_command` unit-checked across all three branches (binary set+exists, set+missing→AssertionError, unset→`cargo run` fallback).
- Built both debug binaries locally, then with the env overrides set ran the worker LoRA-import e2e test (spawns API + worker directly, **1 passed 2.75s**) and a parity contract test (spawns two APIs directly, **1 passed 1.29s**).
- `check.yml` parses as YAML; test file `py_compile`s.

Story: sc-10823 · relates to sc-10420 (parity timeout), sc-5972 (Docker smoke exit-13 hardening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)