### PR TITLE
feat(routing): candle SDXL edit / inpaint / IP-Adapter on packed q4/q8 tiers (sc-10813)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-gen",
  "image",
@@ -695,7 +695,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -752,7 +752,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -769,7 +769,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -789,7 +789,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -813,7 +813,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -824,7 +824,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8480cfb15e9cde977439b5a8b04065288f916bba#8480cfb15e9cde977439b5a8b04065288f916bba"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1558,15 +1558,26 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "5d88
 # so the `--features backend-candle` lane resolves the SINGLE gen-core rev `5d882290` in LOCKSTEP with the
 # worker's mlx-gen pin (skew gate green). `40583ff` is an ancestor of `92253d2`, a clean forward move;
 # ALL candle-gen-* move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+# Bumped `92253d2` -> `8480cfb` (sc-10813, epic 9083): candle-gen #392 teaches the vendored
+# InstantID/edit/IP-Adapter UNet loader (`load_instantid_unet`) to packed-detect the tier (the shared
+# `pipeline::detect_packed_unet`), so the candle SDXL edit / inpaint / IP-Adapter lanes serve the packed
+# q4/q8 tier instead of forcing dense bf16 (paired with the `standard_tier_subdir` descent in the two
+# lanes' base resolvers in this PR). Provider-only + a single-file fork — no `Cargo.toml` change in that
+# commit, so gen-core stays `5d882290` (the branch is based on `92253d2`, gen-core untouched), keeping the
+# `--features backend-candle` lane on the SINGLE gen-core rev in LOCKSTEP with the worker's mlx-gen pin
+# (skew gate green). `92253d2` is the parent of `8480cfb`, a clean forward move; ALL candle-gen-* move
+# together. NB: `8480cfb` is the PR branch tip on michaeltrefry/candle-gen (gen-core `5d882290`); candle-gen
+# `main` has since advanced gen-core to `8db1ab6`, so pin the branch tip — NOT the eventual squash on main —
+# until a coordinated mlx-gen + candle-gen gen-core bump moves both lanes together.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1580,7 +1591,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1588,17 +1599,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1608,7 +1619,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1616,21 +1627,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1639,17 +1650,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1658,7 +1669,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1691,7 +1702,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1700,12 +1711,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1713,7 +1724,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1722,7 +1733,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1730,7 +1741,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1744,7 +1755,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1771,7 +1782,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1782,7 +1793,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1566,9 +1566,11 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "5d88
 # commit, so gen-core stays `5d882290` (the branch is based on `92253d2`, gen-core untouched), keeping the
 # `--features backend-candle` lane on the SINGLE gen-core rev in LOCKSTEP with the worker's mlx-gen pin
 # (skew gate green). `92253d2` is the parent of `8480cfb`, a clean forward move; ALL candle-gen-* move
-# together. NB: `8480cfb` is the PR branch tip on michaeltrefry/candle-gen (gen-core `5d882290`); candle-gen
-# `main` has since advanced gen-core to `8db1ab6`, so pin the branch tip — NOT the eventual squash on main —
-# until a coordinated mlx-gen + candle-gen gen-core bump moves both lanes together.
+# together. NB: candle-gen #392 merged as a MERGE commit (`7552820`), so `8480cfb` is a permanent ancestor
+# of candle-gen `main` (fetchable forever) that still carries gen-core `5d882290`. candle-gen `main` HEAD
+# has since advanced gen-core to `8db1ab6`, so we deliberately pin this ANCESTOR — not `main` HEAD — to keep
+# the candle lane on the single gen-core rev in lockstep with the worker's mlx-gen pin, until a coordinated
+# mlx-gen + candle-gen gen-core bump moves both lanes together.
 candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8480cfb15e9cde977439b5a8b04065288f916bba", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -768,16 +768,14 @@ fn standard_tier_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
 /// The DENSE (`bf16/`) tier of a SceneWorks quant-matrix turnkey, or `root` unchanged for a flat
 /// diffusers snapshot (sc-10614).
 ///
-/// The candle SDXL edit / IP-Adapter lanes (`sdxl_edit_candle.rs`, `sdxl_ipadapter.rs`) have only a
-/// DENSE implementation — their conditioning paths read dense weights — so they always want `bf16/`,
-/// unlike [`standard_tier_subdir`], which honours `advanced.mlxQuantize`. (The plain txt2img lane DOES
-/// serve the packed q4/q8 tiers as of sc-10767 — the SDXL family is `candle_quant_lora` — but that goes
-/// through `standard_tier_subdir`; these two bespoke sub-mode lanes stay dense-only for now.) They
-/// historically
-/// handed the snapshot ROOT straight to the loader, which works only because `sdxl` and `realvisxl`
-/// fall back to flat upstream diffusers repos (`stabilityai/stable-diffusion-xl-base-1.0`,
-/// `SG161222/RealVisXL_V5.0`). An SDXL model re-hosted as a tiered turnkey has no component tree at
-/// its root, so the loader would find no `unet/` at all.
+/// The FALLBACK tier resolver for the candle SDXL edit / IP-Adapter lanes (`sdxl_edit_candle.rs`,
+/// `sdxl_ipadapter.rs`) on a NON-standard-layout repo. As of sc-10813 those lanes packed-detect and,
+/// for a standard-tier turnkey (`mlx.standardTierLayout`), descend through [`standard_tier_subdir`]
+/// (honouring `advanced.mlxQuantize`, exactly like the txt2img lane, sc-10767) — so the packed q4/q8
+/// tiers now serve edit / inpaint / IP-Adapter, not just txt2img. This helper stays the else-branch:
+/// a flat upstream diffusers repo (`stabilityai/stable-diffusion-xl-base-1.0`, `SG161222/RealVisXL_V5.0`)
+/// roots its `unet/` and is returned untouched, and a non-standard tiered turnkey resolves its dense
+/// `bf16/` (an SDXL turnkey has no component tree at its root, so the loader would find no `unet/`).
 ///
 /// A flat snapshot roots its backbone dir — `unet/` for the SDXL family, `transformer/` for the DiTs
 /// — and is returned untouched, so the existing two models keep resolving exactly as before. Same

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
@@ -34,11 +34,12 @@ fn is_sdxl_edit_candle_model(model: &str) -> bool {
 
 /// Default SDXL base repo for a model id when the manifest omits `repo`.
 ///
-/// `sdxl` and `realvisxl` name FLAT upstream diffusers snapshots. Illustrious has no such upstream —
-/// OnomaAI ship a single-file LDM checkpoint — so it names its tiered turnkey, and
-/// `dense_tier_subdir` descends into the dense `bf16/` tier (sc-10614). This edit lane is dense-only —
-/// its candle implementation reads dense weights — even though the plain txt2img lane now serves the
-/// packed q4/q8 tiers (sc-10767, the SDXL family is `candle_quant_lora`); the packed path is txt2img-only.
+/// `sdxl` and `realvisxl` name FLAT upstream diffusers snapshots (the conditioning fallback when the
+/// manifest omits `repo`, per sc-10614). Illustrious has no such upstream — OnomaAI ship a single-file
+/// LDM checkpoint — so it names its tiered turnkey. In practice the built-in SDXL family points `repo`
+/// at the SceneWorks quant-matrix turnkey (`mlx.standardTierLayout`), and — as of sc-10813 — this edit
+/// lane packed-detects + serves the request's q4/q8 tier through `standard_tier_subdir`, exactly like
+/// the txt2img lane (sc-10767); this default is only the flat-repo fallback.
 fn sdxl_edit_candle_default_repo(model: &str) -> &'static str {
     match model {
         "realvisxl" => "SG161222/RealVisXL_V5.0",
@@ -102,9 +103,19 @@ fn resolve_sdxl_edit_candle_base(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| sdxl_edit_candle_default_repo(&request.model));
-    // A tiered turnkey re-host has no component tree at its root — descend to the dense `bf16/`
-    // tier. Flat upstream diffusers snapshots pass through untouched (sc-10614).
-    Ok(huggingface_snapshot_dir(&settings.data_dir, repo).map(dense_tier_subdir))
+    // sc-10813: a standard-tier turnkey (`mlx.standardTierLayout`, e.g. `SceneWorks/sdxl-base-mlx`)
+    // descends into the request's packed q4/q8 tier (or bf16) via `standard_tier_subdir` — the SAME
+    // resolver the txt2img lane uses (base.rs `resolve_base_model_dir`) — now that `load_instantid_unet`
+    // packed-detects the tier. A flat upstream diffusers snapshot (no q4/q8/bf16 subdirs) has no present
+    // tier, so `standard_tier_subdir` returns its root untouched; a NON-standard tiered turnkey keeps the
+    // dense `bf16/` descent (sc-10614). Both fall through `dense_tier_subdir` on the non-standard branch.
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo).map(|root| {
+        if uses_standard_tier_layout(request) {
+            standard_tier_subdir(&root, request)
+        } else {
+            dense_tier_subdir(root)
+        }
+    }))
 }
 
 /// True when this is a candle-eligible SDXL edit job: an sdxl-family `edit_image` job with a source (an

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
@@ -46,9 +46,12 @@ fn is_sdxl_ipadapter_model(model: &str) -> bool {
 
 /// Default SDXL base repo for a model id when the manifest omits `repo`.
 ///
-/// `sdxl` and `realvisxl` name FLAT upstream diffusers snapshots. Illustrious has no such upstream —
-/// OnomaAI ship a single-file LDM checkpoint — so it names its tiered turnkey, and
-/// `dense_tier_subdir` descends into the dense `bf16/` tier (sc-10614).
+/// `sdxl` and `realvisxl` name FLAT upstream diffusers snapshots (the conditioning fallback when the
+/// manifest omits `repo`, per sc-10614). Illustrious has no such upstream — OnomaAI ship a single-file
+/// LDM checkpoint — so it names its tiered turnkey. In practice the built-in SDXL family points `repo`
+/// at the SceneWorks quant-matrix turnkey (`mlx.standardTierLayout`), and — as of sc-10813 — this
+/// IP-Adapter lane packed-detects + serves the request's q4/q8 tier through `standard_tier_subdir`,
+/// exactly like the txt2img lane (sc-10767); this default is only the flat-repo fallback.
 fn sdxl_ipadapter_default_repo(model: &str) -> &'static str {
     match model {
         "realvisxl" => "SG161222/RealVisXL_V5.0",
@@ -83,9 +86,19 @@ fn resolve_sdxl_ipadapter_base(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| sdxl_ipadapter_default_repo(&request.model));
-    // A tiered turnkey re-host has no component tree at its root — descend to the dense `bf16/`
-    // tier. Flat upstream diffusers snapshots pass through untouched (sc-10614).
-    Ok(huggingface_snapshot_dir(&settings.data_dir, repo).map(dense_tier_subdir))
+    // sc-10813: a standard-tier turnkey (`mlx.standardTierLayout`, e.g. `SceneWorks/sdxl-base-mlx`)
+    // descends into the request's packed q4/q8 tier (or bf16) via `standard_tier_subdir` — the SAME
+    // resolver the txt2img lane uses (base.rs `resolve_base_model_dir`) — now that `load_instantid_unet`
+    // packed-detects the tier. A flat upstream diffusers snapshot (no q4/q8/bf16 subdirs) has no present
+    // tier, so `standard_tier_subdir` returns its root untouched; a NON-standard tiered turnkey keeps the
+    // dense `bf16/` descent (sc-10614). Both fall through `dense_tier_subdir` on the non-standard branch.
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo).map(|root| {
+        if uses_standard_tier_layout(request) {
+            standard_tier_subdir(&root, request)
+        } else {
+            dense_tier_subdir(root)
+        }
+    }))
 }
 
 /// True when this is a candle-eligible SDXL IP-Adapter job: an sdxl-family model with a reference image


### PR DESCRIPTION
## What
Route the candle SDXL **edit / inpaint / IP-Adapter** lane base resolvers through the packed-tier descent (`standard_tier_subdir`) instead of forcing dense bf16 (`dense_tier_subdir`), and bump candle-gen `92253d2` → `8480cfb` (candle-gen #392) which teaches the vendored edit/IP UNet loader to packed-detect. Low-VRAM users can now edit / inpaint / reference SDXL on the same packed q4/q8 tier they already generate on.

## Why
sc-10767 gave the candle SDXL **txt2img** lane packed q4/q8 (the 8 GB unlock). But `sdxl_edit_candle.rs` + `sdxl_ipadapter.rs` still handed the snapshot through `dense_tier_subdir` (descends a turnkey into `bf16/`) because `load_instantid_unet` only read the dense `.fp16` UNet. So a user who could *generate* SDXL in ~6 GB still OOM'd *editing / referencing* it.

## Changes
- **worker**: `resolve_sdxl_edit_candle_base` / `resolve_sdxl_ipadapter_base` now use `standard_tier_subdir(root, request)` when `uses_standard_tier_layout(request)` (the whole SDXL family flags `mlx.standardTierLayout`), exactly like the txt2img `resolve_base_model_dir`; `dense_tier_subdir` stays the flat-repo / non-standard fallback. Refreshed the now-stale `dense_tier_subdir` + lane docstrings.
- **pin**: all candle-gen-* `92253d2` → `8480cfb`. The branch is based on `92253d2`, gen-core untouched (`5d882290`), so the `--features backend-candle` lane stays in gen-core lockstep with the worker's mlx-gen pin (skew gate green). See the Cargo.toml pin note.
- Routing predicates (`sdxl_edit_candle_eligible` / `sdxl_ipadapter_candle_eligible`) gate on payload shape only (mode/source/reference), not the tier — unchanged, still agree with the worker gates.

## GPU validation (RTX PRO 6000 Blackwell, sm_120, q4 vs bf16, 1024²)
Ran the candle-gen `edit_validate` + `ip_validate` real-weight harnesses against the `SceneWorks/sdxl-base-mlx` q4 and bf16 tiers:

| Lane | q4 peak | bf16 peak | drop | gates |
|------|---------|-----------|------|-------|
| Edit + inpaint | **10.95 GB** | 18.73 GB | **7.78 GB (42%)** | strength ablation (19.0 vs 3.4), inpaint kept 0.5 vs repaint 19.6, cancel pre+mid ✓ |
| IP-Adapter | **13.9 GB** | 17.6 GB | **3.75 GB (21%)** | clip-cosine ip 0.945 ≫ no-ip 0.662, cancel pre+mid ✓ |

Both tiers pass identical quality gates — packed q4 does not degrade the edit strength control or the IP reference pull, at a materially lower peak.

## Checks
- `cargo clippy -p sceneworks-worker --features backend-candle -- -D warnings` — green
- `cargo test -p sceneworks-worker --lib --features backend-candle` — **504 passed, 0 failed** (29 tier)
- `cargo test -p sceneworks-core routing` — 7 passed
- candle-gen #392: `cargo test -p candle-gen-sdxl --lib` — 90 passed (incl. new packed-vs-dense fork test)
- worker fmt clean

## Merge order
Depends on candle-gen #392 (pinned as branch tip `8480cfb`). Relates to sc-10767, sc-10614.