### PR TITLE
feat(worker): render external ComfyUI Qwen-Image base weights in place off-Mac (sc-10670)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-gen",
  "image",
@@ -695,7 +695,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -752,7 +752,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -769,7 +769,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -789,7 +789,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -813,7 +813,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -824,7 +824,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=92253d233c6985774c4c040c6512a7c37778c2f8#92253d233c6985774c4c040c6512a7c37778c2f8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a38829066a96bf746da8624c655728203d47e0e5#a38829066a96bf746da8624c655728203d47e0e5"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",

--- a/apps/rust-api/src/external_base_models.rs
+++ b/apps/rust-api/src/external_base_models.rs
@@ -323,6 +323,33 @@ fn assemble_models(detected: Vec<DetectedFile>) -> Vec<Value> {
 /// present". VAE families are intentionally not pinned — the Wan and Qwen 3D VAEs
 /// are byte-identical by key, so the detector returns no VAE family, and requiring
 /// one would false-negative every assembly.
+/// Families the worker loads **DiT-in-place, snapshot-backed** (epic 10451 Phase 2b,
+/// sc-10670): the diffusion transformer is read from the ComfyUI tree, but the text
+/// encoder / VAE / tokenizer come from a resident SceneWorks diffusers snapshot —
+/// not the tree. So a bare DiT anchor is a **complete** assembly on its own; the
+/// tree's own components are a different quant/key-schema (separate slices) and are
+/// deliberately not folded in.
+///
+/// `qwen-image`: the ComfyUI Qwen2.5-VL text encoders are themselves *scaled*-fp8
+/// (sc-10671) and the tree VAE uses native WAN-VAE keys (a 194-key 3D-VAE remap), so
+/// both are sourced from our snapshot while the plain-fp8 DiT is read in place.
+fn is_snapshot_backed(family: &str) -> bool {
+    matches!(family, "qwen-image")
+}
+
+/// Whether a fully-assembled external model has a worker loader for its family+quant,
+/// i.e. is offerable as a generation target (the picker offers only `usable !== false`).
+/// Each `(family, quant)` here corresponds to a landed load-in-place slice:
+/// z-image bf16 (sc-10668) · qwen-image plain fp8_e4m3 (sc-10670). Everything else
+/// stays fail-closed until its slice lands. Only ever true for a `complete` assembly.
+fn family_quant_runnable(family: Option<&str>, quant: Option<&str>, assembly: &str) -> bool {
+    assembly == "complete"
+        && matches!(
+            (family, quant),
+            (Some("z-image"), Some("bf16")) | (Some("qwen-image"), Some("fp8_e4m3"))
+        )
+}
+
 fn required_text_encoders(family: &str) -> Option<&'static [&'static str]> {
     match family {
         // Z-Image pairs with Qwen3-4B; Wan with UMT5 (a T5 encoder); FLUX.2 with
@@ -391,6 +418,21 @@ fn assemble_one(
                     components,
                 ));
             };
+            // Snapshot-backed families (sc-10670): the DiT is read in place, but the TE / VAE /
+            // tokenizer come from a resident SceneWorks snapshot, so a bare DiT anchor is complete on
+            // its own — the tree's own components (a different quant / key schema) are not folded in.
+            // Runnability is then decided by family+quant in `finish_row` (only the plain-fp8 qwen DiT
+            // has a loader today; other qwen quants stay fail-closed until their slice).
+            if is_snapshot_backed(&family_name) {
+                return Some(finish_row(
+                    id,
+                    anchor,
+                    Some(family_name),
+                    "complete",
+                    LOADER_PENDING_REASON.to_owned(),
+                    components,
+                ));
+            }
             match required_text_encoders(&family_name) {
                 None => (
                     Some(family_name),
@@ -457,12 +499,11 @@ fn finish_row(
         BaseWeightDetection::Unrecognized { .. } => None,
     };
     // A model is **runnable** only when a worker loader exists for its family+quant and
-    // the assembly is complete (all component paths resolved). sc-10668 wires the first:
-    // z-image bf16 (the candle `load_from_comfyui_components` seam). Everything else stays
-    // fail-closed (`usable:false` + reason) until its loader slice lands — the web picker
-    // offers only `usable !== false`.
-    let runnable =
-        assembly == "complete" && family.as_deref() == Some("z-image") && quant == Some("bf16");
+    // the assembly is complete (all component paths resolved). sc-10668 wired z-image bf16;
+    // sc-10670 wires qwen-image plain fp8_e4m3. Everything else stays fail-closed
+    // (`usable:false` + reason) until its loader slice lands — the web picker offers only
+    // `usable !== false`.
+    let runnable = family_quant_runnable(family.as_deref(), quant, assembly);
     let mut row = json!({
         "id": id,
         "name": format!("{} (ComfyUI)", anchor.name),
@@ -635,6 +676,51 @@ mod tests {
         assert!(reason.contains("text encoder"), "reason: {reason}");
         // The VAE it did find is still listed as a component.
         assert_eq!(row["components"].as_array().unwrap().len(), 2);
+    }
+
+    /// A ComfyUI Qwen-Image DiT (`diffusion_models/*_fp8_e4m3fn`): dual-stream MMDiT keys under the
+    /// BFL `model.diffusion_model.` prefix, all `F8_E4M3` → detector `(qwen-image, transformer,
+    /// fp8_e4m3)`.
+    fn qwen_image_dit_fp8_keys() -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("model.diffusion_model.img_in.weight", "F8_E4M3"),
+            (
+                "model.diffusion_model.transformer_blocks.0.attn.add_q_proj.weight",
+                "F8_E4M3",
+            ),
+            (
+                "model.diffusion_model.transformer_blocks.0.img_mlp.net.0.proj.weight",
+                "F8_E4M3",
+            ),
+        ]
+    }
+
+    #[test]
+    fn qwen_image_fp8_dit_is_snapshot_backed_complete_and_runnable() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = models_root(temp.path());
+        // Only the DiT is on disk — no tree text encoder / VAE. Snapshot-backed families (sc-10670)
+        // source the TE / VAE / tokenizer from a resident SceneWorks snapshot, so a bare DiT anchor is
+        // still complete and runnable.
+        write_safetensors(
+            &root
+                .join("diffusion_models")
+                .join("qwen_image_2512_fp8_e4m3fn.safetensors"),
+            &qwen_image_dit_fp8_keys(),
+        );
+
+        let rows = scan(&[root]);
+        assert_eq!(rows.len(), 1, "one anchored DiT model");
+        let row = &rows[0];
+        assert_eq!(row["family"], "qwen-image");
+        assert_eq!(row["type"], "image");
+        assert_eq!(row["quant"], "fp8_e4m3");
+        assert_eq!(row["assembly"], "complete");
+        // sc-10670: plain-fp8 qwen DiT has a loader → usable, no reason. The tree's own TE / VAE are
+        // deliberately NOT folded in (different quant / key schema), so components is the DiT alone.
+        assert_eq!(row["usable"], true);
+        assert_eq!(row["unusableReason"], Value::Null);
+        assert_eq!(row["components"].as_array().unwrap().len(), 1);
     }
 
     #[test]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1558,7 +1558,7 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "5d88
 # so the `--features backend-candle` lane resolves the SINGLE gen-core rev `5d882290` in LOCKSTEP with the
 # worker's mlx-gen pin (skew gate green). `40583ff` is an ancestor of `92253d2`, a clean forward move;
 # ALL candle-gen-* move together.
-# Bumped `92253d2` -> `a388290` (sc-10670, epic 10451 Phase 2b): candle-gen #386 adds
+# Bumped `92253d2` -> `a388290` (sc-10670, epic 10451 Phase 2b): candle-gen #393 adds
 # `candle_gen_qwen_image::load_from_comfyui_dit` — load a ComfyUI Qwen-Image DiT in place (plain
 # `fp8_e4m3fn` → bf16, `model.diffusion_model.` prefix strip), sourcing the TE/VAE/tokenizer from a
 # resident snapshot. Provider-only, touches ONLY candle-gen-qwen-image, so every other candle-gen-* crate

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1558,15 +1558,21 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "5d88
 # so the `--features backend-candle` lane resolves the SINGLE gen-core rev `5d882290` in LOCKSTEP with the
 # worker's mlx-gen pin (skew gate green). `40583ff` is an ancestor of `92253d2`, a clean forward move;
 # ALL candle-gen-* move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+# Bumped `92253d2` -> `a388290` (sc-10670, epic 10451 Phase 2b): candle-gen #386 adds
+# `candle_gen_qwen_image::load_from_comfyui_dit` — load a ComfyUI Qwen-Image DiT in place (plain
+# `fp8_e4m3fn` → bf16, `model.diffusion_model.` prefix strip), sourcing the TE/VAE/tokenizer from a
+# resident snapshot. Provider-only, touches ONLY candle-gen-qwen-image, so every other candle-gen-* crate
+# is byte-identical at `a388290`; gen-core stays `5d882290` (skew gate green). `92253d2` is an ancestor of
+# `a388290`, a clean forward move; ALL candle-gen-* move together.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1580,7 +1586,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1588,17 +1594,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1608,7 +1614,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1616,21 +1622,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1639,17 +1645,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1658,7 +1664,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1691,7 +1697,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1700,12 +1706,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1713,7 +1719,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1722,7 +1728,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1730,7 +1736,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1744,7 +1750,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1771,7 +1777,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1782,7 +1788,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "92253d233c6985774c4c040c6512a7c37778c2f8", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a38829066a96bf746da8624c655728203d47e0e5", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -752,6 +752,18 @@ pub(crate) async fn run_image_generate_job(
                     )
                     .await?;
                 }
+                CandleImageRoute::QwenImageComfyui => {
+                    generate_candle_qwen_comfyui_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
                 // Z-Image identity-init for Image Studio "With Character" (sc-8409, epic 4406) — the
                 // off-Mac sibling of the macOS generic lane's Z-Image identity img2img; reuses the candle
                 // ZImageEdit engine with the identity `referenceAssetId` as the source-latent init + wires
@@ -1748,6 +1760,11 @@ include!("image_jobs/zimage_edit_candle.rs");
 // a user's ComfyUI Z-Image weights in place via `candle_gen_z_image::load_from_comfyui_components`.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 include!("image_jobs/zimage_comfyui_candle.rs");
+// Qwen-Image txt2img from an in-place ComfyUI DiT (plain fp8_e4m3fn → bf16) — the Windows/CUDA candle
+// lane ONLY (sc-10670, epic 10451 Phase 2b). Sibling of the Z-Image comfyui lane; TE/VAE/tokenizer come
+// from a resident `SceneWorks/qwen-image-mlx` snapshot tier.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+include!("image_jobs/qwen_comfyui_candle.rs");
 // Z-Image identity-init for Image Studio "With Character" — the Windows/CUDA candle lane ONLY (sc-8409,
 // epic 4406). macOS keeps the MLX `z_image_turbo` generic-lane identity img2img (`generate_stream` ⇒
 // `resolve_zimage_identity_init`); off-Mac this bespoke lane reuses the candle `ZImageEdit` engine with

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -215,6 +215,9 @@ enum CandleImageRoute {
     /// An in-place ComfyUI Z-Image base model (`external_base_*`) → `generate_candle_zimage_comfyui_stream`
     /// (epic 10451 Phase 2, sc-10668). Not an `is_candle_engine` id — routed off the forwarded row.
     ZimageComfyui,
+    /// An in-place ComfyUI Qwen-Image base model (`external_base_*`) → `generate_candle_qwen_comfyui_stream`
+    /// (epic 10451 Phase 2b, sc-10670). Not an `is_candle_engine` id — routed off the forwarded row.
+    QwenImageComfyui,
     /// A plain candle txt2img engine id → `generate_candle_stream`.
     CandleTxt2Img,
 }
@@ -269,6 +272,10 @@ fn resolve_candle_image_route(
         // In-place ComfyUI Z-Image base (sc-10668): an `external_base_*` id, so it matches no
         // `is_candle_engine` arm below — route it here off the forwarded `modelManifestEntry`.
         Some(CandleImageRoute::ZimageComfyui)
+    } else if qwen_comfyui_available(request, settings) {
+        // In-place ComfyUI Qwen-Image base (sc-10670): sibling of the Z-Image comfyui lane — an
+        // `external_base_*` id routed off the forwarded row (family=="qwen-image", usable).
+        Some(CandleImageRoute::QwenImageComfyui)
     } else if is_candle_engine(&request.model)
         && !matches!(
             request.model.as_str(),

--- a/crates/sceneworks-worker/src/image_jobs/qwen_comfyui_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_comfyui_candle.rs
@@ -1,0 +1,265 @@
+// Candle (Windows/CUDA) in-place ComfyUI Qwen-Image txt2img route (epic 10451 Phase 2b, sc-10670).
+// Renders a user's existing ComfyUI Qwen-Image DiT — read in place, no copy, no re-download — via
+// `candle_gen_qwen_image::load_from_comfyui_dit`, which strips the `model.diffusion_model.` prefix and
+// upcasts the plain `fp8_e4m3fn` DiT to bf16 in memory (candle-gen sc-10670). Unlike the Z-Image lane
+// (sc-10668), which read all three components in place, only the **DiT** comes from the ComfyUI tree:
+// the tree's Qwen2.5-VL text encoders are themselves scaled-fp8 (sc-10671) and its VAE uses native
+// WAN-VAE keys (a separate 3D-VAE remap), so the text encoder / VAE / tokenizer are sourced from a
+// resident SceneWorks Qwen-Image snapshot (the same tier tree the registry `qwen_image` path loads).
+//
+// The model id is an `external_base_*` catalog row (assembled by the API's `external_base_models`);
+// its `modelManifestEntry` carries `family:"qwen-image"`, `usable:true`, `quant:"fp8_e4m3"`, and a
+// `components[]` list whose `transformer` entry is the DiT path.
+//
+// **Candle-only**, and a **bespoke provider** (like the Z-Image comfyui lane): the loaded generator is
+// not registry-resolvable (its DiT is a single in-place file, not a diffusers snapshot dir), so it is
+// loaded fresh per job through `start_gen_stream`. This file is `include!`d into the `image_jobs`
+// module, sharing its imports.
+
+/// The adapter/engine id recorded on candle ComfyUI Qwen-Image assets + telemetry (distinct from the
+/// registry `candle` qwen txt2img and the `qwen_edit`/`qwen_control` lanes).
+const QWEN_COMFYUI_CANDLE_ENGINE: &str = "candle_qwen_image_comfyui";
+
+/// Denoise-steps fallback — the `qwen_image` manifest default (`defaults.steps`). The UI normally
+/// supplies `advanced.steps`; this only applies when it does not. Qwen-Image base is a non-distilled
+/// 20B flow-match model, so this is a production count (not a few-step distilled one).
+const QWEN_COMFYUI_DEFAULT_STEPS: u32 = 20;
+
+/// The shipped SceneWorks Qwen-Image snapshot repo — a per-tier turnkey (`q4/`, `q8/`, `bf16/`), each
+/// a complete diffusers tree (`transformer/ text_encoder/ vae/ tokenizer/`). The DiT is read from the
+/// ComfyUI tree instead, so only the tier's **dense** Qwen2.5-VL text encoder + VAE + tokenizer are
+/// used here — those are byte-identical across tiers (only the transformer is quantized), so any
+/// present tier serves.
+const QWEN_COMFYUI_SNAPSHOT_REPO: &str = "SceneWorks/qwen-image-mlx";
+
+/// Tier subdirs probed (in order) for the dense TE/VAE/tokenizer. bf16 first (native TE dtype), then
+/// the quantized tiers, whose TE/VAE are the same dense bf16 — the first fully-present tree wins, so a
+/// partially-downloaded tier does not block the lane.
+const QWEN_COMFYUI_SNAPSHOT_TIERS: &[&str] = &["bf16", "q8", "q4"];
+
+/// The in-place ComfyUI DiT file + the resident snapshot tier dir supplying the other components.
+struct ComfyuiQwenPaths {
+    /// ComfyUI Qwen-Image DiT (`diffusion_models/qwen_image_*_fp8_e4m3fn.safetensors`), read in place.
+    transformer: PathBuf,
+    /// A resident `SceneWorks/qwen-image-mlx` tier dir (`text_encoder/ vae/ tokenizer/tokenizer.json`).
+    snapshot_dir: PathBuf,
+}
+
+/// Resolve the ComfyUI Qwen-Image DiT path + the resident snapshot tier from the forwarded
+/// `external_base_*` row. Returns `Ok(None)` when this is not a runnable ComfyUI Qwen-Image job (wrong
+/// family, not marked usable, no transformer component, or our Qwen-Image snapshot is not resident), so
+/// the router falls through rather than erroring. The DiT path is confined by
+/// `normalize_app_managed_model_path` (widened to admit the operator's external roots, sc-10668) — a
+/// payload can never point it outside a declared root (epic 4484). The snapshot dir is resolved from a
+/// fixed repo constant + our own cache (never payload-derived), so it needs no confinement.
+fn resolve_qwen_comfyui_paths(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> WorkerResult<Option<ComfyuiQwenPaths>> {
+    let entry = &request.model_manifest_entry;
+    if entry.get("family").and_then(Value::as_str) != Some("qwen-image") {
+        return Ok(None);
+    }
+    // Only render what the API marked runnable (qwen-image plain fp8_e4m3, sc-10670). A non-usable row
+    // must not be silently rendered — it is either an unsupported quant (scaled-fp8/gguf) or incomplete.
+    if entry.get("usable").and_then(Value::as_bool) != Some(true) {
+        return Ok(None);
+    }
+    let Some(components) = entry.get("components").and_then(Value::as_array) else {
+        return Ok(None);
+    };
+    let Some(transformer) = components
+        .iter()
+        .find(|component| component.get("role").and_then(Value::as_str) == Some("transformer"))
+        .and_then(|component| component.get("path").and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(None);
+    };
+    // The dense TE/VAE/tokenizer come from a resident Qwen-Image snapshot tier; if none is installed
+    // there is nothing to encode/decode with, so this is not (yet) runnable.
+    let Some(snapshot_root) =
+        huggingface_snapshot_dir(&settings.data_dir, QWEN_COMFYUI_SNAPSHOT_REPO)
+    else {
+        return Ok(None);
+    };
+    let Some(snapshot_dir) = QWEN_COMFYUI_SNAPSHOT_TIERS
+        .iter()
+        .map(|tier| snapshot_root.join(tier))
+        .find(|dir| {
+            dir.join("text_encoder").is_dir()
+                && dir.join("vae").is_dir()
+                && dir.join("tokenizer").join("tokenizer.json").is_file()
+        })
+    else {
+        return Ok(None);
+    };
+    Ok(Some(ComfyuiQwenPaths {
+        transformer: crate::paths::normalize_app_managed_model_path(
+            settings,
+            transformer,
+            "ComfyUI Qwen-Image transformer",
+        )?,
+        snapshot_dir,
+    }))
+}
+
+/// True when this is a candle-runnable in-place ComfyUI Qwen-Image txt2img job: an `external_base_*`
+/// model whose forwarded row is a usable qwen-image with a transformer component + a resident snapshot,
+/// no source image / pose (txt2img only). Mirrors the Z-Image comfyui availability predicate.
+fn qwen_comfyui_available(request: &ImageRequest, settings: &Settings) -> bool {
+    request.model.starts_with("external_base_")
+        && request.mode != "edit_image"
+        && pose_entries(request).is_empty()
+        && matches!(resolve_qwen_comfyui_paths(request, settings), Ok(Some(_)))
+}
+
+/// Flat telemetry recorded on candle ComfyUI Qwen-Image assets. Qwen-Image base is non-distilled, so
+/// unlike the Z-Image comfyui lane it records true-CFG guidance.
+fn qwen_comfyui_raw_settings(request: &ImageRequest, steps: u32, guidance: Option<f32>) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw.insert("mode".to_owned(), Value::String("text_to_image".to_owned()));
+    raw.insert(
+        "engine".to_owned(),
+        Value::String(QWEN_COMFYUI_CANDLE_ENGINE.to_owned()),
+    );
+    raw.insert(
+        "externalComfyuiBase".to_owned(),
+        Value::String(request.model.clone()),
+    );
+    if let Some(scale) = guidance {
+        raw.insert("guidanceScale".to_owned(), json!(scale));
+    }
+    raw
+}
+
+/// Read the requested true-CFG guidance scale from `advanced.guidanceScale` (JSON number or numeric
+/// string). `None` ⇒ the candle-gen Qwen-Image engine default (`DEFAULT_GUIDANCE`). The external-base
+/// row is in no `MODEL_TABLE`, so `resolve_guidance` (which needs a `ResolvedModel`) does not apply —
+/// this reads the same `advanced` knob directly.
+fn qwen_comfyui_guidance(request: &ImageRequest) -> Option<f32> {
+    request
+        .advanced
+        .get("guidanceScale")
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+}
+
+/// Real candle in-place ComfyUI Qwen-Image txt2img generation: resolve + confine the DiT path and
+/// resolve the snapshot tier on the async side, then `load_from_comfyui_dit` once + generate each image
+/// on the blocking thread. `request.count` images, each its own seed. Qwen-Image base is non-distilled,
+/// so guidance (true CFG) + negative prompt are threaded through. The loaded `Box<dyn Generator>` is
+/// bespoke (not registry-cached), driven like the Z-Image comfyui lane.
+async fn generate_candle_qwen_comfyui_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let paths = resolve_qwen_comfyui_paths(request, settings)?.ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "ComfyUI Qwen-Image components could not be resolved (family/usable/transformer/snapshot)"
+                .to_owned(),
+        )
+    })?;
+
+    let (width, height) = (request.width, request.height);
+    let steps =
+        resolve_advanced_or_manifest_u32(request, "steps", QWEN_COMFYUI_DEFAULT_STEPS, 1..=50);
+    let guidance = qwen_comfyui_guidance(request);
+    let negative_prompt = {
+        let trimmed = request.negative_prompt.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_owned())
+    };
+    let raw_settings = qwen_comfyui_raw_settings(request, steps, guidance);
+
+    // Per-image work items: (seed, prompt) — `request.count` renders.
+    let work: Vec<(i64, String)> = (0..request.count as usize)
+        .map(|index| (resolve_seed(request, index), request.prompt.clone()))
+        .collect();
+    let total = work.len();
+
+    let (cancel, rx, blocking) = start_gen_stream(
+        job.id.clone(),
+        "qwen_comfyui",
+        0,
+        move || {
+            let ComfyuiQwenPaths {
+                transformer,
+                snapshot_dir,
+            } = paths;
+            let model =
+                candle_gen_qwen_image::load_from_comfyui_dit(transformer, snapshot_dir).map_err(
+                    |error| WorkerError::Engine(format!("ComfyUI Qwen-Image load failed: {error}")),
+                )?;
+            Ok(model)
+        },
+        move |model, tx, cancel| {
+            drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
+                if cancel.is_cancelled() {
+                    return Ok(None);
+                }
+                let request = GenerationRequest {
+                    prompt,
+                    negative_prompt: negative_prompt.clone(),
+                    width,
+                    height,
+                    count: 1,
+                    seed: Some(seed as u64),
+                    steps: Some(steps),
+                    guidance,
+                    cancel: cancel.clone(),
+                    ..Default::default()
+                };
+                let output = match model.generate(&request, &mut *on_progress) {
+                    Ok(output) => output,
+                    Err(_) if cancel.is_cancelled() => return Ok(None),
+                    Err(error) => {
+                        return Err(WorkerError::Engine(format!(
+                            "ComfyUI Qwen-Image generation failed: {error}"
+                        )));
+                    }
+                };
+                match output {
+                    GenerationOutput::Images(mut images) => {
+                        let image = images.pop().ok_or_else(|| {
+                            WorkerError::Engine("ComfyUI Qwen-Image produced no image".to_owned())
+                        })?;
+                        Ok(Some((seed, image.width, image.height, image.pixels)))
+                    }
+                    _ => Err(WorkerError::Engine(
+                        "ComfyUI Qwen-Image returned non-image output".to_owned(),
+                    )),
+                }
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        QWEN_COMFYUI_CANDLE_ENGINE,
+        &raw_settings,
+        total,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}


### PR DESCRIPTION
Epic 10451 Phase 2b (sc-10670). Point SceneWorks at an existing ComfyUI `models/` tree and its Qwen-Image base weights now render **in place** off-Mac — no copy, no re-download. The worker + API half; the candle-gen loader seam is [candle-gen #393](https://github.com/SceneWorks/candle-gen/pull/393) (paired, pin bumped here).

Sibling of sc-10668 (bf16 Z-Image), and the smallest Phase 2 quant slice: the ComfyUI qwen DiT (`diffusion_models/qwen_image_*_fp8_e4m3fn.safetensors`) is **all F8_E4M3 with zero scale companions**, so it's a pure `model.diffusion_model.` prefix strip + a straight fp8→bf16 upcast.

## What

- **candle-gen pin** `92253d2` → `a388290` (#393; provider-only, gen-core stays `5d882290`, skew gate green; ALL candle-gen-* move together).
- **worker** — `CandleImageRoute::QwenImageComfyui` + `image_jobs/qwen_comfyui_candle.rs` (bespoke, non-registry, mirrors the `ZimageComfyui` lane). Resolves the DiT path from the forwarded row's `components[transformer]`, confines it (the sc-10668-widened `external_model_roots` allow-list), probes the resident `SceneWorks/qwen-image-mlx` snapshot for a complete tier (bf16→q8→q4) to supply the **dense TE / VAE / tokenizer**, and drives the `Box<dyn Generator>`. Qwen-Image base is non-distilled → threads guidance (true CFG) + negative prompt. Routed off the forwarded row (`family=="qwen-image"`, `usable`), not the model id (`external_base_*` is in no `MODEL_TABLE`).
- **api** — qwen-image is **snapshot-backed** (`is_snapshot_backed`): a bare DiT anchor is a *complete* assembly on its own (TE/VAE come from our snapshot, not the tree — the tree's Qwen2.5-VL TE is scaled-fp8 (sc-10671) and its VAE uses native WAN-VAE keys, both separate slices), runnable at `fp8_e4m3` via `family_quant_runnable` (generalizes the sc-10668 z-image/bf16 gate). Every other qwen quant stays fail-closed (`usable:false` + reason).

## Why only the DiT is read in place

The DiT is the ~20 GB reusable bulk (and the part users fine-tune / re-quantize). The Qwen2.5-VL TE and the VAE are standard, shared components we already ship; the tree's copies are a different quant / key schema (their own slices). This mirrors how the Z-Image lane sourced its tokenizer from our snapshot, and the Krea 2 ConvRot lane swaps only the DiT over a snapshot.

## Test / validation

- `cargo clippy -p sceneworks-worker --features backend-candle -- -D warnings` clean; `cargo test -p sceneworks-worker --lib --features backend-candle` → **505 passed, 0 failed**.
- Non-candle "neither" build clean (`cargo clippy -p sceneworks-worker --all-targets -- -D warnings`).
- `cargo test -p sceneworks-rust-api --lib external_base_models` → 11 passed, incl. the new `qwen_image_fp8_dit_is_snapshot_backed_complete_and_runnable`.
- **GPU render**: recorded on the story (2× RTX PRO 6000, sm_120).

🤖 Generated with [Claude Code](https://claude.com/claude-code)