### PR TITLE
feat(worker): measure packed FLUX candle sequential peaks + reject when even sequential won't fit (sc-10856)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1507,6 +1507,20 @@
         "minMemoryGb": 42,
         "quantize": 4
       },
+      // candle/CUDA VRAM gate (epic 10765 sc-10856). schnell shares FLUX.1's EXACT packed architecture
+      // with dev — same 12B MMDiT, T5-XXL, CLIP-L, VAE (schnell only omits the tiny guidance embedding),
+      // and peak VRAM is set by tensor/activation shapes at 1024², not weight values — so the packed q4/q8
+      // peaks are the dev measurement (flux1-dev-mlx, RTX PRO 6000 sm_120: q4 resident 21.3 / sequential
+      // 18.4 GB, q8 31.8 / 26.4 GB). `measured: false` records that these were carried from the identical-
+      // architecture dev sibling rather than run against flux1-schnell-mlx directly (the offload harness
+      // hardcodes load_dev and can't load schnell weights). Same reject-when-even-sequential-won't-fit gate
+      // (sc-10856). bf16 omitted for the same diffusers-dense candle load gap as dev (sc-10888).
+      "candle": {
+        "minMemoryGb": 24,
+        "vramGbByTier": { "q4": 21.3, "q8": 31.8 },
+        "sequentialPeakGb": { "q4": 18.4, "q8": 26.4 },
+        "measured": false
+      },
       "ui": {
         "label": "FLUX.1 [schnell]",
         "description": "Black Forest Labs FLUX.1 [schnell] — fast ~4-step distilled text-to-image, Apache-2.0 (commercial-safe). 12B transformer + T5-XXL text encoder; ~34GB bf16 VRAM, needs a large-VRAM GPU.",
@@ -1594,6 +1608,25 @@
       "mlx": {
         "minMemoryGb": 42,
         "quantize": 4
+      },
+      // candle/CUDA VRAM gate (epic 10765 sc-10856) — MEASURED on an RTX PRO 6000 (Blackwell sm_120) at
+      // 1024²/8-step via the candle-gen-flux offload A/B harness (flux_dev_probed_generate_for_offload_ab,
+      // device-level nvidia-smi peak on an idle GPU 0), pointed at each packed `SceneWorks/flux1-dev-mlx`
+      // tier. Two peaks per tier: `vramGbByTier` = RESIDENT (T5+CLIP+DiT+VAE co-resident, the default
+      // cross-request-cached path); `sequentialPeakGb` = SEQUENTIAL residency (the ~3–5 GB text encoders
+      // dropped before the DiT loads, sc-10769) — always lower, and the resident/sequential pixels are
+      // byte-identical. The fit-gate compares the resident peak against free VRAM to choose sequential-
+      // offload vs reject, then (sc-10856) REJECTS if even the sequential peak won't fit rather than OOM.
+      // minMemoryGb 24 gates the DEFAULT (q4) tier with headroom (q4 resident 21.3 GB). Only q4/q8 are
+      // recorded: the packed tiers load via the diffusers packed-detect path (a `quantization` block in
+      // config.json). The `bf16/` tier is diffusers-layout DENSE (sharded `transformer/`, no quantization
+      // block) which the candle FLUX loader does NOT read — it wants the black-forest-labs single-file
+      // `flux1-dev.safetensors` — so bf16 off-Mac candle is a separate load gap (sc-10888), not gated here.
+      "candle": {
+        "minMemoryGb": 24,
+        "vramGbByTier": { "q4": 21.3, "q8": 31.8 },
+        "sequentialPeakGb": { "q4": 18.4, "q8": 26.4 },
+        "measured": true
       },
       // sc-8669: re-hosted ungated on SceneWorks (FLUX.1 [dev] Non-Commercial License redistributed
       // with LICENSE + NOTICE, the flux2_dev re-host precedent) — no HF token / license-accept gate.

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -4039,12 +4039,14 @@ async fn generate_candle_stream(
     // PiD output tier (sc-10054): 2K caps the effective base so PiD's fixed 4× lands on ~2048 (default
     // 4K/native leaves the requested dims untouched). Rebind before `generate_one`.
     let (width, height) = pid_effective_dims(width, height, use_pid, pid_output_tier(request));
-    // VRAM fit-gate (epic 10765, sc-10766 Phase 0 + sc-10821 Phase 1b): when the selected tier's
-    // predicted resident peak won't fit the card, either RUN SEQUENTIALLY (a provider that supports
-    // sequential component residency — the candle FLUX lane, sc-10769 — drops the text encoders before
-    // the DiT so peak = DiT+VAE, not TE+DiT+VAE) or, for a family that has not wired it, reject-before-
-    // OOM with an actionable message. Honors `SCENEWORKS_CUDA_VRAM_CAP_GB` to emulate a small card.
-    // Unmeasured models (no `candle` block) and non-NVIDIA hosts yield `Unknown` → never block.
+    // VRAM fit-gate (epic 10765, sc-10766 Phase 0 + sc-10821 Phase 1b + sc-10856): when the selected
+    // tier's predicted resident peak won't fit the card, either RUN SEQUENTIALLY (a provider that
+    // supports sequential component residency — the candle FLUX lane, sc-10769 — drops the text encoders
+    // before the DiT so peak = DiT+VAE, not TE+DiT+VAE) or, for a family that has not wired it, reject-
+    // before-OOM with an actionable message. sc-10856 adds a second stage on the sequential path: when
+    // the tier's MEASURED sequential peak (`candle.sequentialPeakGb`) is known and STILL won't fit, reject
+    // instead of running into a reactive OOM. Honors `SCENEWORKS_CUDA_VRAM_CAP_GB` to emulate a small
+    // card. Unmeasured models (no `candle` block) and non-NVIDIA hosts yield `Unknown` → never block.
     let use_sequential = {
         let budget = crate::vram_gate::apply_vram_cap(
             crate::gpu::nvidia_vram_budget_gb(&settings.gpu_id).await,
@@ -4063,6 +4065,28 @@ async fn generate_candle_stream(
                 needed_gb,
                 available_gb,
             } => {
+                // Second-stage gate (sc-10856): sequential residency was selected because the resident
+                // peak won't fit. If this tier's MEASURED sequential peak is known and STILL exceeds the
+                // budget, reject before load instead of running into a reactive OOM. Absent the number
+                // (unmeasured tier) keep the best-effort run — the reactive OOM containment backstops it.
+                let sequential_needed = crate::vram_gate::predicted_sequential_peak_gb(
+                    &request.model_manifest_entry,
+                    tier,
+                );
+                if let Some(seq_gb) =
+                    crate::vram_gate::sequential_overflow_gb(sequential_needed, budget)
+                {
+                    return Err(WorkerError::InvalidPayload(format!(
+                        "{model} at the {tier} tier needs ~{seq} GB of VRAM even with sequential \
+                         component residency (loading one component at a time), but GPU {gpu} has \
+                         ~{available} GB available. Pick a lower tier (Q4/Q8), lower the output \
+                         resolution, or run on a card with more VRAM.",
+                        model = request.model,
+                        seq = seq_gb.round() as i64,
+                        available = available_gb.round() as i64,
+                        gpu = settings.gpu_id,
+                    )));
+                }
                 tracing::info!(
                     model = %request.model,
                     needed_gb = needed_gb.round() as i64,

--- a/crates/sceneworks-worker/src/vram_gate.rs
+++ b/crates/sceneworks-worker/src/vram_gate.rs
@@ -47,9 +47,10 @@ pub(crate) enum FitDecision {
     Fits,
     /// The predicted resident peak won't fit, but the model's provider supports sequential component
     /// residency (the candle FLUX lane, sc-10769) — run with `OffloadPolicy::Sequential` instead of
-    /// rejecting. Sequential peak is always ≤ resident, so this is the best option before a reject;
-    /// it's best-effort (the reactive Metal/CUDA-OOM containment is the backstop if even sequential
-    /// overflows), which is why it needs no separately-measured sequential-peak number to be correct.
+    /// rejecting. Sequential peak is always ≤ resident, so this is the best option before a reject.
+    /// When the tier's sequential peak is MEASURED (`candle.sequentialPeakGb`, sc-10856) the caller runs
+    /// a second [`sequential_overflow_gb`] check and rejects if even sequential won't fit; absent that
+    /// number it's best-effort (the reactive Metal/CUDA-OOM containment is the backstop).
     Offload {
         needed_gb: f64,
         available_gb: f64,
@@ -127,6 +128,23 @@ pub(crate) fn predicted_peak_gb(manifest_entry: &JsonObject, tier_key: &str) -> 
     candle.get("minMemoryGb").and_then(json_f64)
 }
 
+/// Predicted SEQUENTIAL peak VRAM (GB) for `tier_key`: `candle.sequentialPeakGb[tier_key]` (the measured
+/// largest single working set of the sequential-residency path, sc-10856) + [`HEADROOM_GB`], mirroring
+/// [`predicted_peak_gb`]'s headroom. `None` when unmeasured (no `sequentialPeakGb`, or no entry for this
+/// tier) — then the [`FitDecision::Offload`] path keeps today's best-effort behavior: run sequentially
+/// and lean on the reactive Metal/CUDA-OOM containment backstop rather than reject.
+pub(crate) fn predicted_sequential_peak_gb(
+    manifest_entry: &JsonObject,
+    tier_key: &str,
+) -> Option<f64> {
+    manifest_entry
+        .get("candle")?
+        .get("sequentialPeakGb")
+        .and_then(|tiers| tiers.get(tier_key))
+        .and_then(json_f64)
+        .map(|gb| gb + HEADROOM_GB)
+}
+
 /// Decide whether the predicted peak fits the (possibly capped) live budget. Missing either input ⇒
 /// `Unknown` (never block). Compares against `free_gb` — what is actually allocatable now — mirroring
 /// the flux2 edit guard's use of `available_gb`.
@@ -160,6 +178,20 @@ pub(crate) fn resolve_offload(decision: FitDecision, sequential_capable: bool) -
         },
         other => other,
     }
+}
+
+/// Second-stage gate for an [`FitDecision::Offload`] (epic 10765, sc-10856): sequential residency was
+/// selected because the RESIDENT peak won't fit, on the promise that the sequential working set will.
+/// If the tier's MEASURED sequential peak is known (`sequential_needed_gb` = [`predicted_sequential_peak_gb`])
+/// and STILL exceeds the budget, this returns `Some(needed_gb)` so the caller can reject before load with
+/// an actionable message instead of running into a reactive Metal/CUDA OOM. `None` — the sequential peak
+/// fits, is unmeasured for this tier, or there is no live budget — keeps today's best-effort run.
+pub(crate) fn sequential_overflow_gb(
+    sequential_needed_gb: Option<f64>,
+    budget: Option<VramBudget>,
+) -> Option<f64> {
+    let (needed_gb, budget) = (sequential_needed_gb?, budget?);
+    (budget.free_gb + f64::EPSILON < needed_gb).then_some(needed_gb)
 }
 
 /// Parse a JSON uint/int from either a number or a numeric string (mirrors base.rs `quant_int`).
@@ -333,6 +365,49 @@ mod tests {
             resolve_offload(FitDecision::Unknown, true),
             FitDecision::Unknown
         );
+    }
+
+    #[test]
+    fn predicted_sequential_peak_reads_the_measured_tier_plus_headroom() {
+        let manifest = obj(json!({
+            "candle": {
+                "vramGbByTier": { "q4": 47.2, "q8": 58.0, "bf16": 72.0 },
+                "sequentialPeakGb": { "q4": 30.0, "q8": 40.0, "bf16": 55.0 }
+            }
+        }));
+        assert_eq!(
+            predicted_sequential_peak_gb(&manifest, "q4"),
+            Some(30.0 + HEADROOM_GB)
+        );
+        assert_eq!(
+            predicted_sequential_peak_gb(&manifest, "bf16"),
+            Some(55.0 + HEADROOM_GB)
+        );
+        // Tier absent from sequentialPeakGb ⇒ None (best-effort run, no reject).
+        let sparse = obj(json!({ "candle": { "sequentialPeakGb": { "q4": 30.0 } } }));
+        assert_eq!(predicted_sequential_peak_gb(&sparse, "q8"), None);
+        // No sequentialPeakGb block ⇒ None (today's behavior: resident-only gate).
+        let resident_only = obj(json!({ "candle": { "vramGbByTier": { "q4": 47.2 } } }));
+        assert_eq!(predicted_sequential_peak_gb(&resident_only, "q4"), None);
+        // No candle block ⇒ None.
+        assert_eq!(predicted_sequential_peak_gb(&obj(json!({})), "q4"), None);
+    }
+
+    #[test]
+    fn sequential_overflow_rejects_only_a_measured_genuine_overflow() {
+        let budget = VramBudget {
+            free_gb: 10.0,
+            total_gb: 10.0,
+        };
+        // Measured sequential peak still exceeds the budget ⇒ reject, carrying the number.
+        assert_eq!(sequential_overflow_gb(Some(32.0), Some(budget)), Some(32.0));
+        // Sequential peak fits ⇒ proceed (None). Exactly-fits is not an overflow.
+        assert_eq!(sequential_overflow_gb(Some(8.0), Some(budget)), None);
+        assert_eq!(sequential_overflow_gb(Some(10.0), Some(budget)), None);
+        // Unmeasured tier ⇒ best-effort run (None), even when the card is tiny.
+        assert_eq!(sequential_overflow_gb(None, Some(budget)), None);
+        // No live budget ⇒ never block (None).
+        assert_eq!(sequential_overflow_gb(Some(32.0), None), None);
     }
 
     /// Live real-hardware validation (sc-10766): exercises the REAL `nvidia-smi` VRAM reading on GPU 0

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -222,7 +222,12 @@
               },
               "vramGbByTier": {
                 "type": "object",
-                "description": "Measured (or explicitly-estimated) candle/CUDA overall-peak VRAM (GB) at 1024², keyed by quant tier (q4 / q8 / bf16). The peak is the max across the whole generate (load + denoise + VAE decode); candle loads weights lazily on first forward, so load-peak is negligible and the denoise peak dominates (sc-9094).",
+                "description": "Measured (or explicitly-estimated) candle/CUDA overall-peak VRAM (GB) at 1024², keyed by quant tier (q4 / q8 / bf16). The peak is the max across the whole generate (load + denoise + VAE decode); candle loads weights lazily on first forward, so load-peak is negligible and the denoise peak dominates (sc-9094). This is the RESIDENT peak (all components co-resident) that the fit-gate compares against free VRAM to pick sequential offload vs reject.",
+                "additionalProperties": { "type": "number" }
+              },
+              "sequentialPeakGb": {
+                "type": "object",
+                "description": "Measured candle/CUDA SEQUENTIAL-residency peak VRAM (GB) at 1024², keyed by quant tier — the largest single working set when the provider loads→uses→drops each component in phase order (text encoders dropped before the DiT). Always ≤ the resident vramGbByTier. Present only for sequential-capable providers (the candle FLUX lane, epic 10765 sc-10769). The fit-gate consults it as the SECOND-stage check (sc-10856): when the resident peak forces sequential offload but this measured sequential peak still exceeds free VRAM, reject before load instead of running into a reactive OOM. Absent this number the gate keeps its best-effort behavior (run sequentially, reactive-OOM backstop).",
                 "additionalProperties": { "type": "number" }
               },
               "measured": {


### PR DESCRIPTION
Epic 10765 follow-up to sc-10821. Story: [sc-10856](https://app.shortcut.com/trefry/story/10856).

## Problem
Phase-1b's fit-gate runs FLUX sequentially when the resident peak won't fit, backstopped only by a reactive OOM. Worse, **FLUX had no `candle` block in the manifest at all** — so `predicted_peak_gb` returned `None` → `Unknown` → the gate never engaged for FLUX in the app. The sc-10769/10821 sequential machinery was only ever exercised on the candle-gen spec-path, never through the worker manifest gate.

## What this does
1. **Measures** the packed `SceneWorks/flux1-dev-mlx` candle tiers on an RTX PRO 6000 (Blackwell sm_120), 1024²/8-step, via the existing `flux_dev_probed_generate_for_offload_ab` A/B harness (device-level nvidia-smi peak, idle GPU 0). Resident vs sequential pixels **byte-identical**:

   | tier | resident | sequential | Δ (T5 drop) |
   |------|----------|------------|-------------|
   | q4   | 21.3 GB  | 18.4 GB    | −2.9 GB |
   | q8   | 31.8 GB  | 26.4 GB    | −5.4 GB |

2. **Adds the FLUX candle block** (`flux_dev` measured; `flux_schnell` carried from the identical packed FLUX.1 architecture, `measured:false`): `minMemoryGb` + `vramGbByTier` (resident) + `sequentialPeakGb`. This is what makes the gate actually engage for FLUX.

3. **`vram_gate`**: `predicted_sequential_peak_gb` + `sequential_overflow_gb`. On an `Offload` decision (resident won't fit → run sequential), a second-stage check now **rejects before load** with an actionable message when the *measured sequential* peak still won't fit — instead of a reactive OOM. Absent the number, today's best-effort behavior is unchanged.

4. **schema**: `candle.sequentialPeakGb`.

## bf16 gap (out of scope → new story)
The `flux1-dev-mlx` **bf16** tier is diffusers-layout DENSE (sharded `transformer/`, no `quantization` block); the candle FLUX loader only reads the BFL single-file `flux1-dev.safetensors`, so bf16 can't load off-Mac today. q4/q8 (packed, `quantization` block) load fine. Filed as **[sc-10888](https://app.shortcut.com/trefry/story/10888)**; bf16 is omitted from the gate here.

## Validation
- 6 GPU measurement runs (q4/q8 × resident/sequential); resident==sequential byte-identical for both.
- `cargo clippy -p sceneworks-worker --features backend-candle -- -D warnings` clean.
- 516 lib tests pass (backend-candle), incl 2 new `vram_gate` tests.
- Non-candle `rust:check:neither` passes; scaffold check + schema JSON valid; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)