### PR TITLE
feat(worker): read the ComfyUI Qwen-Image VAE in place (native WAN-VAE keys → diffusers remap) (sc-10830)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-gen",
  "image",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -713,7 +713,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -738,7 +738,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -790,7 +790,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=3c7d98146463498203fbde0319cf91a2c7b7149a#3c7d98146463498203fbde0319cf91a2c7b7149a"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -636,13 +636,14 @@ dependencies = [
  "inventory",
  "rand 0.9.4",
  "rand_distr 0.5.1",
+ "serde_json",
  "tokenizers 0.22.2",
 ]
 
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -672,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -685,7 +686,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-gen",
  "image",
@@ -695,7 +696,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -712,7 +713,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -726,7 +727,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -737,7 +738,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -752,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -769,7 +770,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -789,7 +790,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -800,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -813,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -824,7 +825,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -837,7 +838,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=77c06ad8ff862e5d90e704f9c4b0857914363b57#77c06ad8ff862e5d90e704f9c4b0857914363b57"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e4379677aef5ab1658072fbef0ef82c5442d5d47#e4379677aef5ab1658072fbef0ef82c5442d5d47"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",

--- a/apps/rust-api/src/external_base_models.rs
+++ b/apps/rust-api/src/external_base_models.rs
@@ -418,12 +418,17 @@ fn assemble_one(
                     components,
                 ));
             };
-            // Snapshot-backed families (sc-10670): the DiT is read in place, but the TE / VAE /
-            // tokenizer come from a resident SceneWorks snapshot, so a bare DiT anchor is complete on
-            // its own — the tree's own components (a different quant / key schema) are not folded in.
-            // Runnability is then decided by family+quant in `finish_row` (only the plain-fp8 qwen DiT
-            // has a loader today; other qwen quants stay fail-closed until their slice).
+            // Snapshot-backed families (sc-10670): the DiT is read in place; the TE + tokenizer come
+            // from a resident SceneWorks snapshot (the tree's Qwen2.5-VL TE is scaled-fp8, sc-10671),
+            // so a bare DiT anchor is complete on its own. The **VAE**, however, now has an in-place
+            // loader (sc-10830: native WAN-VAE keys → diffusers remap), so when the tree carries an
+            // unambiguous VAE it is folded into the row and read in place; ambiguous/absent falls back
+            // to the snapshot VAE (still complete). Runnability stays decided by the DiT's family+quant
+            // in `finish_row`.
             if is_snapshot_backed(&family_name) {
+                if let [only_vae] = vaes {
+                    components.push(only_vae.component_json());
+                }
                 return Some(finish_row(
                     id,
                     anchor,
@@ -716,11 +721,45 @@ mod tests {
         assert_eq!(row["type"], "image");
         assert_eq!(row["quant"], "fp8_e4m3");
         assert_eq!(row["assembly"], "complete");
-        // sc-10670: plain-fp8 qwen DiT has a loader → usable, no reason. The tree's own TE / VAE are
-        // deliberately NOT folded in (different quant / key schema), so components is the DiT alone.
+        // sc-10670: plain-fp8 qwen DiT has a loader → usable, no reason. No tree VAE here, so
+        // components is the DiT alone (the TE is always snapshot-sourced, sc-10671).
         assert_eq!(row["usable"], true);
         assert_eq!(row["unusableReason"], Value::Null);
         assert_eq!(row["components"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn qwen_image_fp8_dit_folds_in_an_unambiguous_tree_vae() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = models_root(temp.path());
+        // sc-10830: a ComfyUI Qwen-Image DiT + exactly one tree VAE → the VAE is folded into the row
+        // (read in place, native WAN-VAE keys → diffusers remap) while the DiT stays snapshot-backed
+        // for the TE + tokenizer. Runnable, and the VAE rides along as a `vae` component.
+        write_safetensors(
+            &root
+                .join("diffusion_models")
+                .join("qwen_image_2512_fp8_e4m3fn.safetensors"),
+            &qwen_image_dit_fp8_keys(),
+        );
+        write_safetensors(
+            &root.join("vae").join("qwen_image_vae.safetensors"),
+            &vae_keys(),
+        );
+
+        let rows = scan(&[root]);
+        assert_eq!(rows.len(), 1, "one anchored DiT model");
+        let row = &rows[0];
+        assert_eq!(row["family"], "qwen-image");
+        assert_eq!(row["assembly"], "complete");
+        assert_eq!(row["usable"], true);
+        let components = row["components"].as_array().unwrap();
+        assert_eq!(components.len(), 2, "DiT + the folded tree VAE");
+        assert!(
+            components
+                .iter()
+                .any(|component| component["role"] == "vae"),
+            "the tree VAE rides along as a `vae` component for the in-place loader"
+        );
     }
 
     #[test]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1576,17 +1576,17 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df9
 # only); every other candle-gen-* crate is a clean forward move. candle-gen's OWN gen-core stays mlx-gen
 # `4df97dce` (EXACTLY this worker's mlx-gen pin), so `--features backend-candle` resolves the SINGLE
 # gen-core rev `4df97dce` (skew gate green, lock diff is candle-gen-only). ALL candle-gen-* move together.
-# (Pre-merge of candle-gen #397 this points at the branch commit `e437967`; flip to the merged candle-gen
-# `main` rev once #397 lands.)
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+# (candle-gen #397 MERGED on candle-gen main as `3c7d981` — the merge of `e437967` onto `5c27bf1`, tree-
+# identical to the branch commit — the canonical SHA all candle-gen-* pins point at.)
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1600,7 +1600,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1608,17 +1608,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1628,7 +1628,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1636,21 +1636,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1659,17 +1659,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1678,7 +1678,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1711,7 +1711,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1720,12 +1720,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1733,7 +1733,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1742,7 +1742,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1750,7 +1750,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1764,7 +1764,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1791,7 +1791,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1802,7 +1802,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3c7d98146463498203fbde0319cf91a2c7b7149a", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1566,15 +1566,27 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df9
 # candle-gen-qwen-image `comfyui.rs`/`lib.rs` + the qwen example — provider-only, every other candle-gen-*
 # crate byte-identical to `7552820`), so candle-gen's gen-core stays mlx-gen `8db1ab6` (skew gate green).
 # `7552820` is an ancestor of `dc2c750`, a clean forward move; ALL candle-gen-* move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+# Bumped `77c06ad` -> `e437967` (sc-10830, epic 10451 Phase 2b): candle-gen #397 extends
+# `candle_gen_qwen_image::load_from_comfyui_dit(dit, snapshot, vae_file)` with an optional in-place VAE —
+# the tree's `vae/qwen_image_vae.safetensors` (native WAN-VAE keys) key-remapped to the diffusers schema
+# (`remap_vae_wan_to_diffusers`) so the ComfyUI Qwen VAE is read in place (falls back to the snapshot VAE
+# when absent); the qwen_comfyui worker route now passes the folded `vae` component path. The range
+# `77c06ad..e437967` carries only #396 (candle-gen-kolors packed load, sc-10819 — provider-only, adds a
+# `serde_json` dep to candle-gen-kolors) + #397 (candle-gen-qwen-image `comfyui.rs`/`lib.rs` — provider-
+# only); every other candle-gen-* crate is a clean forward move. candle-gen's OWN gen-core stays mlx-gen
+# `4df97dce` (EXACTLY this worker's mlx-gen pin), so `--features backend-candle` resolves the SINGLE
+# gen-core rev `4df97dce` (skew gate green, lock diff is candle-gen-only). ALL candle-gen-* move together.
+# (Pre-merge of candle-gen #397 this points at the branch commit `e437967`; flip to the merged candle-gen
+# `main` rev once #397 lands.)
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1588,7 +1600,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1596,17 +1608,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1616,7 +1628,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1624,21 +1636,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1647,17 +1659,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1666,7 +1678,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1699,7 +1711,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1708,12 +1720,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1721,7 +1733,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1730,7 +1742,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1738,7 +1750,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1752,7 +1764,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1779,7 +1791,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1790,7 +1802,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "77c06ad8ff862e5d90e704f9c4b0857914363b57", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e4379677aef5ab1658072fbef0ef82c5442d5d47", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/qwen_comfyui_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_comfyui_candle.rs
@@ -1,15 +1,17 @@
-// Candle (Windows/CUDA) in-place ComfyUI Qwen-Image txt2img route (epic 10451 Phase 2b, sc-10670).
-// Renders a user's existing ComfyUI Qwen-Image DiT — read in place, no copy, no re-download — via
-// `candle_gen_qwen_image::load_from_comfyui_dit`, which strips the `model.diffusion_model.` prefix and
-// upcasts the plain `fp8_e4m3fn` DiT to bf16 in memory (candle-gen sc-10670). Unlike the Z-Image lane
-// (sc-10668), which read all three components in place, only the **DiT** comes from the ComfyUI tree:
-// the tree's Qwen2.5-VL text encoders are themselves scaled-fp8 (sc-10671) and its VAE uses native
-// WAN-VAE keys (a separate 3D-VAE remap), so the text encoder / VAE / tokenizer are sourced from a
-// resident SceneWorks Qwen-Image snapshot (the same tier tree the registry `qwen_image` path loads).
+// Candle (Windows/CUDA) in-place ComfyUI Qwen-Image txt2img route (epic 10451 Phase 2b, sc-10670 +
+// sc-10830). Renders a user's existing ComfyUI Qwen-Image DiT — read in place, no copy, no
+// re-download — via `candle_gen_qwen_image::load_from_comfyui_dit`, which strips the
+// `model.diffusion_model.` prefix and upcasts the plain `fp8_e4m3fn` DiT to bf16 in memory (candle-gen
+// sc-10670). The tree's **VAE** is also read in place when the API folded it into the row (sc-10830:
+// native WAN-VAE keys → diffusers remap); when absent it falls back to the snapshot VAE. The tree's
+// Qwen2.5-VL text encoders are themselves scaled-fp8 (sc-10671), so the **text encoder** + tokenizer
+// are still sourced from a resident SceneWorks Qwen-Image snapshot (the same tier tree the registry
+// `qwen_image` path loads).
 //
 // The model id is an `external_base_*` catalog row (assembled by the API's `external_base_models`);
 // its `modelManifestEntry` carries `family:"qwen-image"`, `usable:true`, `quant:"fp8_e4m3"`, and a
-// `components[]` list whose `transformer` entry is the DiT path.
+// `components[]` list whose `transformer` entry is the DiT path (and, when present, a `vae` entry is
+// the tree VAE path read in place).
 //
 // **Candle-only**, and a **bespoke provider** (like the Z-Image comfyui lane): the loaded generator is
 // not registry-resolvable (its DiT is a single in-place file, not a diffusers snapshot dir), so it is
@@ -37,12 +39,17 @@ const QWEN_COMFYUI_SNAPSHOT_REPO: &str = "SceneWorks/qwen-image-mlx";
 /// partially-downloaded tier does not block the lane.
 const QWEN_COMFYUI_SNAPSHOT_TIERS: &[&str] = &["bf16", "q8", "q4"];
 
-/// The in-place ComfyUI DiT file + the resident snapshot tier dir supplying the other components.
+/// The in-place ComfyUI DiT file + the resident snapshot tier dir supplying the other components,
+/// plus the optional in-place tree VAE (sc-10830).
 struct ComfyuiQwenPaths {
     /// ComfyUI Qwen-Image DiT (`diffusion_models/qwen_image_*_fp8_e4m3fn.safetensors`), read in place.
     transformer: PathBuf,
     /// A resident `SceneWorks/qwen-image-mlx` tier dir (`text_encoder/ vae/ tokenizer/tokenizer.json`).
     snapshot_dir: PathBuf,
+    /// The tree's `vae/qwen_image_vae.safetensors` (native WAN-VAE keys), read in place when the API
+    /// folded it into the row (sc-10830). `None` ⇒ the snapshot tier's VAE. The TE + tokenizer always
+    /// come from the snapshot (the tree TE is scaled-fp8, sc-10671).
+    vae: Option<PathBuf>,
 }
 
 /// Resolve the ComfyUI Qwen-Image DiT path + the resident snapshot tier from the forwarded
@@ -95,6 +102,23 @@ fn resolve_qwen_comfyui_paths(
     else {
         return Ok(None);
     };
+    // sc-10830: the tree's VAE (native WAN-VAE keys), read in place when the API folded it into the
+    // row as a `vae` component. Optional — absent ⇒ the snapshot tier's VAE. Confined by the same
+    // external-root normalization as the DiT (a payload can never point it outside a declared root).
+    let vae = components
+        .iter()
+        .find(|component| component.get("role").and_then(Value::as_str) == Some("vae"))
+        .and_then(|component| component.get("path").and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| {
+            crate::paths::normalize_app_managed_model_path(
+                settings,
+                value,
+                "ComfyUI Qwen-Image VAE",
+            )
+        })
+        .transpose()?;
     Ok(Some(ComfyuiQwenPaths {
         transformer: crate::paths::normalize_app_managed_model_path(
             settings,
@@ -102,6 +126,7 @@ fn resolve_qwen_comfyui_paths(
             "ComfyUI Qwen-Image transformer",
         )?,
         snapshot_dir,
+        vae,
     }))
 }
 
@@ -198,11 +223,13 @@ async fn generate_candle_qwen_comfyui_stream(
             let ComfyuiQwenPaths {
                 transformer,
                 snapshot_dir,
+                vae,
             } = paths;
             let model =
-                candle_gen_qwen_image::load_from_comfyui_dit(transformer, snapshot_dir).map_err(
-                    |error| WorkerError::Engine(format!("ComfyUI Qwen-Image load failed: {error}")),
-                )?;
+                candle_gen_qwen_image::load_from_comfyui_dit(transformer, snapshot_dir, vae)
+                    .map_err(|error| {
+                        WorkerError::Engine(format!("ComfyUI Qwen-Image load failed: {error}"))
+                    })?;
             Ok(model)
         },
         move |model, tx, cancel| {


### PR DESCRIPTION
Follow-up to sc-10670 (which read only the DiT in place). The qwen ComfyUI lane now reads the tree's **VAE** (`vae/qwen_image_vae.safetensors`, native WAN-VAE keys) **in place** instead of always sourcing it from the resident `SceneWorks/qwen-image-mlx` snapshot. Consumes candle-gen [#397](https://github.com/SceneWorks/candle-gen/pull/397)'s `remap_vae_wan_to_diffusers` seam.

## What
- **API** (`external_base_models`): fold an unambiguous tree VAE into the qwen row's `components[]` as a `vae` component. The DiT stays snapshot-backed for the scaled-fp8 Qwen2.5-VL TE + tokenizer (sc-10671); an ambiguous/absent VAE falls back to the snapshot VAE (still `complete`).
- **Worker** (`qwen_comfyui_candle`): resolve + confine the optional `vae` component path (same external-root normalization as the DiT) and pass it to `load_from_comfyui_dit(dit, snapshot, vae)`. `None` keeps the byte-identical snapshot-VAE path.
- **deps**: bump every `candle-gen-*` pin `77c06ad → e437967` (candle-gen #397 + the intervening merged #396 kolors packed load). Lock diff is **candle-gen-only**; candle-gen's gen-core stays mlx-gen `4df97dce` (single gen-core rev, skew gate green).

Together with sc-10671 (scaled-fp8 TE) this brings a Qwen-Image generation entirely from the user's ComfyUI tree within reach (VAE-in-place done here + TE-in-place next + our tiny tokenizer).

## Validation
- `cargo build -p sceneworks-worker --features backend-candle` ✓ (new 3-arg signature wired); `cargo test -p sceneworks-rust-api external_base` green incl. the new `qwen_image_fp8_dit_folds_in_an_unambiguous_tree_vae`; fmt + clippy clean.
- candle-gen #397 GPU-val: the in-place-remapped VAE decode is **byte-identical** to the snapshot VAE (max abs decode diff `0.000e0`), and the remapped tree VAE is bit-identical to the `Qwen/Qwen-Image-2512` diffusers VAE (all 194 tensors).

## Pin note
Pre-merge of candle-gen #397, the pin points at #397's branch commit `e437967`; flip to the merged candle-gen `main` rev once #397 lands. Relates sc-10670, sc-10671, sc-10668, sc-10662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)