### PR TITLE
feat(web): PiD high-res decode heads-up for multi-minute super-res decodes (sc-10144)

### DIFF
--- a/apps/web/src/components/CharacterAdvancedOptions.jsx
+++ b/apps/web/src/components/CharacterAdvancedOptions.jsx
@@ -13,6 +13,7 @@ import {
   stepsDefaultFromModel,
 } from "../samplerOptions.js";
 import { pidToggleVisible } from "../pidEligibility.js";
+import { pidDecodeHeadsUp } from "../pidDecodeNotice.js";
 
 // Shared advanced-generation controls for Character Studio's Angle Set and Pose
 // Library panels (sc-3857). Mirrors the Image Studio advanced panel
@@ -174,7 +175,7 @@ export function useCharacterAdvancedOptions(
   };
 }
 
-export function CharacterAdvancedOptions({ state }) {
+export function CharacterAdvancedOptions({ state, baseWidth, baseHeight }) {
   const {
     open,
     setOpen,
@@ -209,6 +210,12 @@ export function CharacterAdvancedOptions({ state }) {
     showSamplerPicker,
     showSchedulerPicker,
   } = state;
+
+  // PiD high-res decode heads-up (sc-10144): Character angle/pose generations render at a fixed base
+  // (baseWidth/baseHeight, passed by the panel — 1024² today), which the default 4K PiD tier
+  // super-resolves 4× to 4096² — a multi-minute decode. Surface the same "it's working, not stuck"
+  // heads-up as Image Studio so a long Character decode never reads as hung. null on the fast 2K tier.
+  const pidDecodeNotice = pidDecodeHeadsUp({ usePid, pidTarget, width: baseWidth, height: baseHeight });
 
   const guidancePlaceholder = (() => {
     const value = guidanceDefaultFromModel(model);
@@ -349,6 +356,11 @@ export function CharacterAdvancedOptions({ state }) {
                     <option value="4k">4K · max detail</option>
                     <option value="2k">2K · faster</option>
                   </select>
+                  {pidDecodeNotice ? (
+                    <span className="field-hint pid-decode-hint" role="status">
+                      {pidDecodeNotice.message}
+                    </span>
+                  ) : null}
                 </label>
               ) : null}
             </>

--- a/apps/web/src/components/CharacterAdvancedOptions.test.jsx
+++ b/apps/web/src/components/CharacterAdvancedOptions.test.jsx
@@ -19,12 +19,12 @@ const missing = [{ id: "pid_sdxl", installState: "missing" }];
 
 // Hosts the hook + presentational panel, opens the advanced section, and renders the current
 // `buildAdvanced()` output so the test can assert what the job payload would carry.
-function Harness({ model, catalog }) {
+function Harness({ model, catalog, baseWidth, baseHeight }) {
   const state = useCharacterAdvancedOptions(model, { catalog });
   React.useEffect(() => state.setOpen(true), []); // eslint-disable-line react-hooks/exhaustive-deps
   return (
     <>
-      <CharacterAdvancedOptions state={state} />
+      <CharacterAdvancedOptions state={state} baseWidth={baseWidth} baseHeight={baseHeight} />
       <output data-testid="adv">{JSON.stringify(state.buildAdvanced())}</output>
     </>
   );
@@ -47,6 +47,8 @@ describe("CharacterAdvancedOptions PiD toggle (sc-8372)", () => {
   });
 
   const pidCheckbox = () => container.querySelector(".pid-decoder-toggle input[type=checkbox]");
+  const pidHint = () => container.querySelector(".pid-decode-hint");
+  const pidTargetSelect = () => container.querySelector(".pid-target-select select");
   const advanced = () => JSON.parse(container.querySelector('[data-testid="adv"]').textContent);
 
   it("hides the toggle when the model has no PiD backbone", async () => {
@@ -70,5 +72,36 @@ describe("CharacterAdvancedOptions PiD toggle (sc-8372)", () => {
     // Checking it folds usePid:true in.
     await act(async () => box.click());
     expect(advanced().usePid).toBe(true);
+  });
+
+  // sc-10144: the high-res decode heads-up. Character panels render at a fixed 1024² base, which the
+  // default 4K PiD tier super-resolves 4× to 4096² — a multi-minute decode we warn about so it never
+  // reads as hung. The fast 2K tier (~2048² output) never warns.
+  it("shows the multi-minute heads-up at the default 4K tier for the 1024² panel base", async () => {
+    await act(async () =>
+      root.render(<Harness model={instantId} catalog={installed} baseWidth={1024} baseHeight={1024} />),
+    );
+    // No hint until PiD is on.
+    expect(pidHint()).toBe(null);
+    await act(async () => pidCheckbox().click());
+    const hint = pidHint();
+    expect(hint).not.toBe(null);
+    expect(hint.textContent).toContain("4096×4096");
+    expect(hint.textContent).toContain("not stuck");
+  });
+
+  it("drops the heads-up on the fast 2K tier", async () => {
+    await act(async () =>
+      root.render(<Harness model={instantId} catalog={installed} baseWidth={1024} baseHeight={1024} />),
+    );
+    await act(async () => pidCheckbox().click());
+    expect(pidHint()).not.toBe(null);
+    // Switch the output tier to 2K → the decode caps to ~2048², fast → no heads-up.
+    await act(async () => {
+      const select = pidTargetSelect();
+      select.value = "2k";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    expect(pidHint()).toBe(null);
   });
 });

--- a/apps/web/src/pidDecodeNotice.js
+++ b/apps/web/src/pidDecodeNotice.js
@@ -1,0 +1,62 @@
+// PiD high-res decode heads-up (sc-10144, epic 7840). PiD super-resolves the base render by a FIXED
+// 4× (worker `PID_SR_SCALE`, crates/sceneworks-worker/src/image_jobs/pid.rs), so the output image is
+// always `base × 4`. At the default 4K tier the base is UNTOUCHED, so a large base means a
+// multi-minute — and, above a 4096² output, auto-tiled (sc-10087) — super-res decode that can look
+// hung when it is really just working. The 2K tier caps the base long side to 512 → ~2048² output,
+// always fast, so it never warns. This pure helper decides when the Studio surfaces a proactive
+// heads-up so the user knows a long decode is progressing, not stuck.
+
+// PiD's fixed spatial super-resolution factor (mirrors the worker `PID_SR_SCALE`). Output = base × this.
+export const PID_SR_SCALE = 4;
+
+// Output long side (px) at/above which the decode runs multiple minutes and warrants the heads-up.
+// Grounded in the sc-10087 timing evidence: a 4096² whole-image decode ≈ 3.7 min on Metal, a 6144²
+// (tiled) decode ≈ 4.8 min, and smaller GPUs are slower. Below this (a ≤768 base → ≤3072² output) the
+// decode is short enough that a heads-up would just be noise. 4096² == a 1024 base at the 4K tier.
+export const PID_HEADS_UP_MIN_OUTPUT_LONG_SIDE = 4096;
+
+// Output long side above which the pixel-space decode auto-tiles (sc-10087) instead of running a single
+// whole-image forward. A 4096² output is the largest whole-image decode; anything larger tiles.
+export const PID_TILING_OUTPUT_LONG_SIDE = 4096;
+
+// Decide whether a PiD generation warrants a "this will take a while" heads-up, and describe it.
+// Returns null when no heads-up is needed (PiD off, the fast 2K tier, invalid dims, or a small output),
+// otherwise an object with the resolved output size, megapixels, whether it tiles, and a ready-to-render
+// `message`. Pure + unit-tested so both Studio surfaces (Image Studio + Character) stay in lock-step.
+export function pidDecodeHeadsUp({ usePid, pidTarget, width, height }) {
+  if (!usePid) {
+    return null;
+  }
+  // The 2K tier caps the base long side to 512 → ~2048² output, which is always fast: no heads-up.
+  if (String(pidTarget ?? "").trim().toLowerCase() === "2k") {
+    return null;
+  }
+  const baseWidth = Number(width);
+  const baseHeight = Number(height);
+  if (!Number.isFinite(baseWidth) || !Number.isFinite(baseHeight) || baseWidth <= 0 || baseHeight <= 0) {
+    return null;
+  }
+  const outputWidth = baseWidth * PID_SR_SCALE;
+  const outputHeight = baseHeight * PID_SR_SCALE;
+  const longSide = Math.max(outputWidth, outputHeight);
+  if (longSide < PID_HEADS_UP_MIN_OUTPUT_LONG_SIDE) {
+    return null;
+  }
+  const megapixels = (outputWidth * outputHeight) / 1_000_000;
+  const tiled = longSide > PID_TILING_OUTPUT_LONG_SIDE;
+  return {
+    outputWidth,
+    outputHeight,
+    megapixels,
+    tiled,
+    message: formatHeadsUp(outputWidth, outputHeight, megapixels, tiled),
+  };
+}
+
+function formatHeadsUp(outputWidth, outputHeight, megapixels, tiled) {
+  const size = `${outputWidth}×${outputHeight}`;
+  const mp = `~${megapixels.toFixed(1)} MP`;
+  return tiled
+    ? `PiD super-resolves to ${size} (${mp}), decoded in tiles — this can take several minutes. It's working, not stuck.`
+    : `PiD super-resolves to ${size} (${mp}) — this decode can take a few minutes. It's working, not stuck.`;
+}

--- a/apps/web/src/pidDecodeNotice.test.js
+++ b/apps/web/src/pidDecodeNotice.test.js
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PID_HEADS_UP_MIN_OUTPUT_LONG_SIDE,
+  PID_SR_SCALE,
+  pidDecodeHeadsUp,
+} from "./pidDecodeNotice.js";
+
+// sc-10144: PiD super-resolves the base render 4×, so a large base at the default 4K tier is a
+// multi-minute (or auto-tiled, sc-10087) decode. These tests pin exactly when the Studio surfaces the
+// "it's working, not stuck" heads-up so the threshold + copy can't silently drift.
+
+describe("pidDecodeHeadsUp", () => {
+  it("returns null when PiD is off (whatever the size)", () => {
+    expect(pidDecodeHeadsUp({ usePid: false, pidTarget: "4k", width: 2048, height: 2048 })).toBeNull();
+  });
+
+  it("returns null for the 2K tier — the base is capped to ~2048² output, always fast", () => {
+    expect(pidDecodeHeadsUp({ usePid: true, pidTarget: "2k", width: 1536, height: 1536 })).toBeNull();
+    // Case-insensitive / padded values still resolve to the fast tier.
+    expect(pidDecodeHeadsUp({ usePid: true, pidTarget: " 2K ", width: 4096, height: 4096 })).toBeNull();
+  });
+
+  it("returns null below the multi-minute threshold (e.g. a 768 base → 3072² output)", () => {
+    expect(pidDecodeHeadsUp({ usePid: true, pidTarget: "4k", width: 768, height: 768 })).toBeNull();
+  });
+
+  it("warns (non-tiled) exactly at the 4096² boundary — a 1024 base at 4K", () => {
+    const notice = pidDecodeHeadsUp({ usePid: true, pidTarget: "4k", width: 1024, height: 1024 });
+    expect(notice).not.toBeNull();
+    expect(notice.outputWidth).toBe(4096);
+    expect(notice.outputHeight).toBe(4096);
+    expect(notice.tiled).toBe(false);
+    expect(notice.megapixels).toBeCloseTo(16.78, 1);
+    expect(notice.message).toContain("4096×4096");
+    expect(notice.message).toContain("not stuck");
+    expect(notice.message).not.toContain("tiles");
+  });
+
+  it("warns (tiled) above 4096² — the sc-10087 1536 base → 6144² repro", () => {
+    const notice = pidDecodeHeadsUp({ usePid: true, pidTarget: "4k", width: 1536, height: 1536 });
+    expect(notice.outputWidth).toBe(6144);
+    expect(notice.tiled).toBe(true);
+    expect(notice.megapixels).toBeCloseTo(37.75, 1);
+    expect(notice.message).toContain("6144×6144");
+    expect(notice.message).toContain("tiles");
+  });
+
+  it("defaults an unrecognized / missing tier to the 4K (warn) path, matching the worker", () => {
+    // The worker treats any non-\"2k\" pidTarget as 4K; the helper mirrors that so a stray value warns.
+    expect(pidDecodeHeadsUp({ usePid: true, pidTarget: undefined, width: 1024, height: 1024 })).not.toBeNull();
+    expect(pidDecodeHeadsUp({ usePid: true, pidTarget: "4k", width: 1024, height: 1024 }).tiled).toBe(false);
+  });
+
+  it("keys off the long side for non-square requests", () => {
+    // 1280×720 base → 5120×2880 output: long side 5120 > 4096 → tiled warn.
+    const notice = pidDecodeHeadsUp({ usePid: true, pidTarget: "4k", width: 1280, height: 720 });
+    expect(notice.outputWidth).toBe(5120);
+    expect(notice.outputHeight).toBe(2880);
+    expect(notice.tiled).toBe(true);
+  });
+
+  it("returns null for invalid / non-finite dimensions", () => {
+    expect(pidDecodeHeadsUp({ usePid: true, pidTarget: "4k", width: 0, height: 1024 })).toBeNull();
+    expect(pidDecodeHeadsUp({ usePid: true, pidTarget: "4k", width: NaN, height: 1024 })).toBeNull();
+    expect(pidDecodeHeadsUp({ usePid: true, pidTarget: "4k", width: "", height: "" })).toBeNull();
+  });
+
+  it("exposes the super-res factor + threshold as the single source of truth", () => {
+    expect(PID_SR_SCALE).toBe(4);
+    expect(PID_HEADS_UP_MIN_OUTPUT_LONG_SIDE).toBe(4096);
+  });
+});

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -26,6 +26,7 @@ import {
   MIN_IMAGE_DIMENSION,
   resolveEffectiveDimensions,
 } from "../resolutionOverride.js";
+import { pidDecodeHeadsUp } from "../pidDecodeNotice.js";
 import { batchItemStatus, summarizeBatchRun } from "../batchOps.js";
 import {
   DEFAULT_SCENE_PROMPT,
@@ -1359,6 +1360,12 @@ export function ImageStudio() {
     widthOverride,
     heightOverride,
   });
+
+  // PiD high-res decode heads-up (sc-10144): PiD super-resolves the base render 4×, so a large base at
+  // the default 4K tier is a multi-minute (auto-tiled above 4096², sc-10087) decode that can look hung.
+  // Surfaced inline under the PiD output tier so the user knows the long decode is progressing, not
+  // stuck. null when PiD is off, on the fast 2K tier, or below the multi-minute threshold.
+  const pidDecodeNotice = pidDecodeHeadsUp({ usePid, pidTarget, width, height });
 
   // Magic-prompt expansion (sc-5997): expand the plain-text idea into an editable caption via the
   // native utility model (same backend as Refine), recording which model drafted it. Returns the
@@ -2922,6 +2929,11 @@ export function ImageStudio() {
                         <option value="4k">4K · max detail</option>
                         <option value="2k">2K · faster</option>
                       </select>
+                      {pidDecodeNotice ? (
+                        <span className="field-hint pid-decode-hint" role="status">
+                          {pidDecodeNotice.message}
+                        </span>
+                      ) : null}
                     </label>
                   ) : null}
                 </>

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -27,6 +27,12 @@ const POSE_LIBRARY_NEGATIVE_PROMPT =
   "cropped, out of frame, multiple people, extra limbs, deformed hands, extra fingers, " +
   "plastic skin, airbrushed, cgi, 3d render, cartoon, anime, waxy, blurry";
 
+// The fixed base render size for a Character angle/pose generation (the worker emits one image per
+// angle/pose from this square base). Single source of truth so the PiD high-res heads-up (sc-10144)
+// warns off the SAME base the job actually renders — at the default 4K PiD tier this super-resolves
+// 4× to 4096², a multi-minute decode.
+const CHARACTER_PANEL_BASE_DIMENSION = 1024;
+
 // Resolve a character generation job's produced images from the full asset
 // catalog. Using the catalog (not just latestAssets, which is the single most
 // recent generation set) is what lets pose / angle previews stream in as each
@@ -618,8 +624,8 @@ export function CharacterGenerationPanel({
         // count; count must satisfy the API's 1-8 guard, so send 1 (worker overrides).
         count: 1,
         seed: advanced.seedValue,
-        width: 1024,
-        height: 1024,
+        width: CHARACTER_PANEL_BASE_DIMENSION,
+        height: CHARACTER_PANEL_BASE_DIMENSION,
         loras: loraSelection.serializedLoras,
         advanced: advanced.buildAdvanced(controller.advancedExtras),
       });
@@ -688,7 +694,11 @@ export function CharacterGenerationPanel({
         Prompt
         <textarea onChange={(event) => setPrompt(event.target.value)} rows={2} value={prompt} />
       </label>
-      <CharacterAdvancedOptions state={advanced} />
+      <CharacterAdvancedOptions
+        state={advanced}
+        baseWidth={CHARACTER_PANEL_BASE_DIMENSION}
+        baseHeight={CHARACTER_PANEL_BASE_DIMENSION}
+      />
       {activeJobs.length ? (
         <div className="worker-progress-card-stack local-job-stack">
           {activeJobs.map((job) => (


### PR DESCRIPTION
Closes the UX tail of **sc-10087** (PiD large-output auto-tiling), filed as **sc-10144** under epic 7840.

## Why
PiD super-resolves the base render a **fixed 4×** (`PID_SR_SCALE`, `crates/sceneworks-worker/src/image_jobs/pid.rs`). At the default **4K** tier the base is untouched, so a 1024² base → 4096² output ≈ 3.7 min on Metal, and a 1536² base → 6144² output tiles (sc-10087) at ≈ 4.8 min. Without a heads-up, a valid-but-slow decode reads as **hung**.

## What
A proactive inline heads-up under the PiD **Output** tier: *"PiD super-resolves to {W}×{H} (~N MP) — this decode can take a few minutes. It's working, not stuck."* (with a "decoded in tiles" clause above 4096²).

- **`apps/web/src/pidDecodeNotice.js`** — pure, unit-tested helper (`pidDecodeHeadsUp`) computing the threshold + message. Single source of truth for `PID_SR_SCALE`, shared by both Studio surfaces.
- **Image Studio** — warns off the effective request dims (resolution + width/height override), which reach 4096 base → 16384² output.
- **Character Studio** — warns off the fixed 1024² angle/pose base (now a named constant, single source with the job payload).
- The **2K** tier caps the base to ~2048² and stays fast → never warns.

## Trigger
Output long side **≥ 4096** (base ≥ 1024 at 4K), grounded in the sc-10087 timing evidence. Below that (≤768 base → ≤3072²) stays quiet.

## Not changed
The typed `budget::guard` refusal already emits a clean *"reduce the resolution or disable PiD for this request"* message from the gen-pid engine (`candle-gen-pid`/`mlx-gen-pid` `budget.rs`), which surfaces via the normal job-error path — so the story's optional "clean refusal message" item needs no separate UI mapping.

## Tests
- 9 pure-helper unit tests (threshold boundaries, 2K skip, tiled/non-tiled, non-square, invalid dims).
- 2 new DOM tests drive the real Character PiD toggle and assert the hint appears at 4K/1024² and disappears at 2K.
- Full `apps/web` suite green (1612 tests); eslint 0 errors; production build clean.
- Layout verified against the real stylesheet (reuses the existing `.field-hint`-in-`<label>` pattern; no CSS change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)