### PR TITLE
feat(training): ControlNet Training Studio job type — submit + orchestrate krea_control (Training Studio B1, sc-10162)

### DIFF
--- a/apps/rust-api/src/training.rs
+++ b/apps/rust-api/src/training.rs
@@ -1098,6 +1098,21 @@ pub(crate) async fn create_training_job(
         .ok_or_else(|| {
             ApiError::bad_request(format!("Unknown training target: {}", payload.target_id))
         })?;
+    // ControlNet training (epic 10159) reuses this submit path — same target registry, dataset
+    // resolution, plan build, and output/guardrail plumbing — but produces a control branch, not a
+    // LoRA. A `ControlBranch` target enqueues the orchestrated `control_training` job (render the
+    // per-image condition, then train) instead of `lora_train`. It has no dry-run mode (the worker
+    // always renders + trains), so a dry-run request is rejected rather than silently producing
+    // nothing.
+    let is_control = matches!(
+        target.output_kind,
+        sceneworks_core::training::TrainingOutputKind::ControlBranch
+    );
+    if is_control && payload.dry_run {
+        return Err(ApiError::bad_request(
+            "ControlNet training runs the full render + train pipeline and does not support a dry run; submit with dryRun=false.",
+        ));
+    }
     let preset_metadata = match payload.preset_id.as_deref() {
         Some(preset_id) => {
             let preset_registry = builtin_training_presets();
@@ -1343,7 +1358,11 @@ pub(crate) async fn create_training_job(
         store.create_job_with_id(
             job_id,
             CreateJob {
-                job_type: JobType::LoraTrain,
+                job_type: if is_control {
+                    JobType::ControlTraining
+                } else {
+                    JobType::LoraTrain
+                },
                 project_id: Some(project_id),
                 project_name: Some(project_name),
                 payload: job_payload,

--- a/apps/web/src/screens/training/ConfigureJobPanel.jsx
+++ b/apps/web/src/screens/training/ConfigureJobPanel.jsx
@@ -81,6 +81,12 @@ export function ConfigureJobPanel({
   datasetDoctor,
   readinessBlocksTraining = false,
 }) {
+  // ControlNet training (epic 10159) reuses this panel: a `control_branch` target renders the
+  // per-image control condition from the selected dataset (the data source) and trains a control
+  // branch instead of a LoRA. Surface that so the run reads as ControlNet, not a mislabeled LoRA.
+  const isControlTarget = selectedTarget?.outputKind === "control_branch";
+  const controlType =
+    selectedTarget?.defaults?.advanced?.controlType ?? selectedTarget?.limits?.controlTypes?.[0] ?? "pose";
   return (
     <WorkPanel
       className="training-config-panel"
@@ -166,7 +172,7 @@ export function ConfigureJobPanel({
             </label>
 
             <label>
-              LoRA name
+              {isControlTarget ? "Control branch name" : "LoRA name"}
               <input onChange={(event) => updateConfigDraft("outputName", event.target.value)} value={configDraft.outputName ?? ""} />
             </label>
             <label>
@@ -223,6 +229,15 @@ export function ConfigureJobPanel({
               />
             </label>
           </div>
+
+          {isControlTarget ? (
+            <p className="training-control-note inline-success">
+              <strong>ControlNet training.</strong> A {controlType} condition is rendered from each image
+              in the selected dataset — your data source — then a control branch is trained for{" "}
+              {selectedTarget.ui?.label ?? selectedTarget.name} (applied at generation time). Use a
+              captioned dataset; bring-your-own prepared/annotated datasets are coming next.
+            </p>
+          ) : null}
 
           <AdvancedSection
             hint="cleared values → preset default"

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -263,6 +263,14 @@ string_enum! {
         // entry's installState to "installed" once the HF files land.
         LoraDownload => "lora_download",
         LoraTrain => "lora_train",
+        // ControlNet Training Studio (epic 10159, B1 sc-10162): one orchestrated job that renders the
+        // per-image control condition (pose/canny/depth via the A1/A2 preprocessor, or ingests a
+        // bring-your-own dataset), builds a `krea_control` plan, then trains the control branch through
+        // the SAME native-training executor as `lora_train` (candle-gen-krea `krea_2_control`). Routed +
+        // capability-gated exactly like a real `lora_train` run keyed on the `krea_control` kernel
+        // (candle-only; no torch/MLX control trainer). GPU-required; not in NON_GPU_JOB_TYPES; reuses the
+        // `lora_train`/`lora_train_execute` capabilities (no new WorkerCapability).
+        ControlTraining => "control_training",
         TrainingCaption => "training_caption",
         // CLIP image-embedding pass over a training dataset for Dataset Doctor analysis
         // (epic 6529 P2, sc-6535): set-level near-duplicate / diversity / aesthetic findings.

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2198,6 +2198,20 @@ fn derive_job_title(job_type: &JobType, payload: &Map<String, Value>) -> Option<
                 .unwrap_or_else(|| "(unnamed LoRA)".to_owned());
             Some(format!("Training Run — {subject}"))
         }
+        JobType::ControlTraining => {
+            let subject = first_str(payload, &["loraName", "outputName", "targetName"])
+                .map(str::to_owned)
+                .or_else(|| {
+                    payload
+                        .get("plan")
+                        .and_then(|plan| plan.get("output"))
+                        .and_then(|output| output.get("loraId"))
+                        .and_then(Value::as_str)
+                        .map(str::to_owned)
+                })
+                .unwrap_or_else(|| "(unnamed control branch)".to_owned());
+            Some(format!("ControlNet Training — {subject}"))
+        }
         JobType::TrainingCaption => {
             let subject = first_str(payload, &["datasetName", "datasetId"])
                 .unwrap_or("(unnamed dataset)")
@@ -2880,7 +2894,12 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
         // (z_image / sdxl / kolors / wan / ltx) via `mlx_gen::load_trainer`. `lens_lora`
         // (sidecar, no mlx-gen crate) and LoKr-on-Wan stay on the Python torch worker.
         // Applies to both dry-run and real runs.
-        if matches!(job.job_type, JobType::LoraTrain) && !training_job_is_mlx_eligible(job) {
+        if matches!(job.job_type, JobType::LoraTrain | JobType::ControlTraining)
+            && !training_job_is_mlx_eligible(job)
+        {
+            // ControlNet studio jobs (epic 10159) are candle-only today (no MLX control trainer — that
+            // is B5/sc-10177), so `training_job_is_mlx_eligible` returns false for them and the mlx
+            // worker refuses to claim, leaving the job for a candle worker.
             return false;
         }
         // Dataset captioning (sc-3556): the mlx worker claims only JoyCaption jobs
@@ -2965,7 +2984,12 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
         // training job it can't execute (the `lora_train_execute` advertisement is coarse — it lights
         // up whenever ANY candle trainer is registered) and fail it terminally instead of leaving it
         // for torch. Applies to both dry-run and real runs; mirrors the mlx training gate above.
-        if matches!(job.job_type, JobType::LoraTrain) && !training_job_is_candle_eligible(job) {
+        if matches!(job.job_type, JobType::LoraTrain | JobType::ControlTraining)
+            && !training_job_is_candle_eligible(job)
+        {
+            // Same gate for the ControlNet studio job (epic 10159): the candle worker claims it only
+            // when its resolved plan's kernel (`krea_control`) has a candle trainer registered;
+            // otherwise it stays queued (never mis-claimed and failed terminally).
             return false;
         }
         // Dataset captioning (sc-5098): the candle worker serves only JoyCaption (the candle
@@ -3031,11 +3055,17 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
     true
 }
 
-/// True when a job is a real (non-dry-run) LoRA training run. The training
-/// payload defaults to dry-run; only an explicit `dryRun: false` is a real run.
+/// True when a job is a real (non-dry-run) training run — it needs the execute capability
+/// ([`WorkerCapability::LoraTrainExecute`]), not just the base plan-validation capability. A
+/// `lora_train` payload defaults to dry-run so only an explicit `dryRun: false` counts; a
+/// `control_training` studio job (epic 10159) has no dry-run mode — it always renders + trains — so it
+/// is always a real run.
 fn is_real_training_job(job: &JobSnapshot) -> bool {
-    matches!(job.job_type, JobType::LoraTrain)
-        && job.payload.get("dryRun").and_then(Value::as_bool) == Some(false)
+    match job.job_type {
+        JobType::ControlTraining => true,
+        JobType::LoraTrain => job.payload.get("dryRun").and_then(Value::as_bool) == Some(false),
+        _ => false,
+    }
 }
 
 /// The worker capability a job requires. Person detection/tracking default to
@@ -3051,6 +3081,10 @@ fn required_capability(job: &JobSnapshot) -> &str {
         JobType::PersonTrack if person_job_is_preview(job) => {
             WorkerCapability::PersonTrackPreview.as_str()
         }
+        // The ControlNet studio job (epic 10159) trains through the same executor as `lora_train` and
+        // is served by any worker that advertises the training capability — it has no dedicated
+        // capability of its own (the real-run gate below additionally requires `lora_train_execute`).
+        JobType::ControlTraining => WorkerCapability::LoraTrain.as_str(),
         _ => job.job_type.as_str(),
     }
 }
@@ -3232,6 +3266,7 @@ fn job_requires_gpu(job_type: &JobType) -> bool {
             | JobType::VideoUpscale
             | JobType::PersonReplace
             | JobType::LoraTrain
+            | JobType::ControlTraining
             | JobType::TrainingCaption
             | JobType::DatasetAnalysis
             | JobType::DatasetUpscale

--- a/crates/sceneworks-core/src/jobs_store/routing/candle.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/candle.rs
@@ -982,7 +982,10 @@ pub(crate) fn worker_is_candle(worker: &WorkerSnapshot) -> bool {
 /// LoKr-on-Wan exclusion here. The resolved plan is stamped into the payload at submit (apps/rust-api
 /// training.rs), so the kernel + base model are readable without touching the dataset or weights.
 pub(crate) fn training_job_is_candle_eligible(job: &JobSnapshot) -> bool {
-    if !matches!(job.job_type, JobType::LoraTrain) {
+    // The ControlNet studio job (epic 10159) trains through the SAME native executor keyed on the
+    // resolved plan's kernel (`krea_control` ∈ [`CANDLE_ROUTED_TRAINING_KERNELS`]), so it is
+    // candle-eligible on the same terms as a `lora_train` run.
+    if !matches!(job.job_type, JobType::LoraTrain | JobType::ControlTraining) {
         return false;
     }
     let Some(plan) = job.payload.get("plan").and_then(Value::as_object) else {

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -865,8 +865,17 @@ pub(crate) const MLX_ROUTED_TRAINING_KERNELS: &[&str] = &[
 /// NO torch trainer — it is in BOTH this set and [`MLX_ONLY_TRAINING_KERNELS`] (Rust-only: mlx OR
 /// candle, never torch). The dense Wan 5B + the I2V A14B have no candle trainer yet (sc-5167
 /// follow-ups) and Kolors/LTX none at all — those kernels stay on the Python torch worker off-Mac.
-pub(crate) const CANDLE_ROUTED_TRAINING_KERNELS: &[&str] =
-    &["z_image_lora", "sdxl_lora", "lens_lora", "krea_lora"];
+/// `krea_control` (epic 10159, B2 sc-10163 / B1 sc-10162) is the Krea 2 pose-ControlNet branch trainer
+/// (candle-gen-krea `ControlTrainer`, dispatched under `krea_2_control`); it too has NO torch or MLX
+/// trainer, so — like `krea_lora` — it is also in [`MLX_ONLY_TRAINING_KERNELS`] but NOT
+/// [`MLX_ROUTED_TRAINING_KERNELS`] (the MLX control lane is B5/sc-10177).
+pub(crate) const CANDLE_ROUTED_TRAINING_KERNELS: &[&str] = &[
+    "z_image_lora",
+    "sdxl_lora",
+    "lens_lora",
+    "krea_lora",
+    "krea_control",
+];
 
 /// Training kernels with NO **torch** fallback — only a Rust worker can run them, so a torch worker
 /// must refuse the job (leaving it queued for a Rust worker) rather than claim it and fail with "no
@@ -880,8 +889,13 @@ pub(crate) const CANDLE_ROUTED_TRAINING_KERNELS: &[&str] =
 /// [`CANDLE_ROUTED_TRAINING_KERNELS`]), while torch is still refused. `sd3_lora` (epic 7841 T3
 /// sc-7884) is MLX-native with no torch trainer and no candle trainer yet (the off-Mac/candle SD3.5
 /// trainer is epic 7982), so — like LTX — only an mlx worker runs it today.
-pub(crate) const MLX_ONLY_TRAINING_KERNELS: &[&str] =
-    &["ltx_mlx_lora", "krea_lora", "sd3_lora", "anima_lora"];
+pub(crate) const MLX_ONLY_TRAINING_KERNELS: &[&str] = &[
+    "ltx_mlx_lora",
+    "krea_lora",
+    "sd3_lora",
+    "anima_lora",
+    "krea_control",
+];
 
 #[cfg(test)]
 mod tests {
@@ -1093,11 +1107,21 @@ mod tests {
         "anima_lora",
     ];
 
-    const EXPECTED_CANDLE_ROUTED_TRAINING_KERNELS: &[&str] =
-        &["z_image_lora", "sdxl_lora", "lens_lora", "krea_lora"];
+    const EXPECTED_CANDLE_ROUTED_TRAINING_KERNELS: &[&str] = &[
+        "z_image_lora",
+        "sdxl_lora",
+        "lens_lora",
+        "krea_lora",
+        "krea_control",
+    ];
 
-    const EXPECTED_MLX_ONLY_TRAINING_KERNELS: &[&str] =
-        &["ltx_mlx_lora", "krea_lora", "sd3_lora", "anima_lora"];
+    const EXPECTED_MLX_ONLY_TRAINING_KERNELS: &[&str] = &[
+        "ltx_mlx_lora",
+        "krea_lora",
+        "sd3_lora",
+        "anima_lora",
+        "krea_control",
+    ];
 
     #[test]
     fn routed_model_lists_match_snapshot() {

--- a/crates/sceneworks-core/src/jobs_store/routing/gaps.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/gaps.rs
@@ -141,9 +141,9 @@ pub(crate) fn termination_failure_error(
 /// of non-generation job types (and is required anyway — `JobType` is `#[non_exhaustive]`).
 pub(crate) fn oom_remediation_hint(job_type: Option<&JobType>) -> &'static str {
     match job_type {
-        // LoRA training: the sc-4874 first-training-step OOM — gradient checkpointing is
-        // the real lever; resolution is secondary.
-        Some(JobType::LoraTrain) => {
+        // LoRA / ControlNet-branch training: the sc-4874 first-training-step OOM — gradient
+        // checkpointing is the real lever; resolution is secondary.
+        Some(JobType::LoraTrain | JobType::ControlTraining) => {
             ", likely out-of-memory during the first training step \
              — enable Gradient Checkpointing or reduce resolution"
         }
@@ -417,6 +417,16 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
 
         JobType::LoraTrain => Err(classify_training_gap(&job.payload)),
 
+        // ControlNet Training Studio (epic 10159): the control-branch trainer is candle-only — there is
+        // no MLX control trainer yet (that is B5/sc-10177) — so a `control_training` job stranded on Mac
+        // with no candle worker is a real gap, not a torch fallback.
+        JobType::ControlTraining => Err(UnsupportedReason::new(
+            None,
+            "ControlNet branch training",
+            "ControlNet training runs on the candle/CUDA control trainer (krea_control); there is no native MLX control trainer yet, so it is not available in the flow on Mac.",
+            Some("epic 10159"),
+        )),
+
         JobType::TrainingCaption => Err(UnsupportedReason::new(
             None,
             "dataset captioning",
@@ -532,6 +542,11 @@ pub fn candle_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
         | JobType::KpsExtract
         | JobType::ImageSegment
         | JobType::LoraTrain
+        // epic 10159: control_training routes by capability (only a candle worker with the
+        // krea_control trainer advertises it); candle-eligible ones already early-returned Ok via
+        // `job_is_any_candle_eligible`, so reaching here means "no candle worker yet" — leave Ok
+        // rather than enforce-fail, the same "parity landing later" treatment as lora_train.
+        | JobType::ControlTraining
         // sc-6535: a candle CLIP embedder (`candle-gen-clip`) is future work; until then
         // dataset_analysis routes by capability (no candle worker advertises it) rather than
         // enforce-failing — the same "parity landing later" treatment as the surfaces above.

--- a/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
@@ -701,10 +701,13 @@ pub(crate) fn upscale_job_requests_seedvr2(job: &JobSnapshot) -> bool {
             .is_some_and(|engine| engine.trim().eq_ignore_ascii_case("seedvr2"))
 }
 
-/// Whether this `lora_train` job targets a kernel with no non-Rust fallback (see
-/// [`MLX_ONLY_TRAINING_KERNELS`]). Such a job can only run on the mlx worker.
+/// Whether this training job targets a kernel with no torch fallback (see
+/// [`MLX_ONLY_TRAINING_KERNELS`]). Such a job can only run on a Rust worker (mlx, or candle when the
+/// candle exception in [`worker_supports_job`] admits it — e.g. `krea_control`), so a torch worker
+/// must refuse it. Covers both the `lora_train` and the ControlNet studio (`control_training`) jobs —
+/// both stamp a resolved plan whose `krea_control` kernel is no-torch-fallback (epic 10159).
 pub(crate) fn training_kernel_is_mlx_only(job: &JobSnapshot) -> bool {
-    if !matches!(job.job_type, JobType::LoraTrain) {
+    if !matches!(job.job_type, JobType::LoraTrain | JobType::ControlTraining) {
         return false;
     }
     job.payload

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -55,9 +55,13 @@ string_enum! {
 }
 
 string_enum! {
-    /// What a training run produces. Only LoRA adapters are produced today.
+    /// What a training run produces. `Lora` is a LoRA/LoKr adapter; `ControlBranch` is a
+    /// ControlNet control branch (an "overlay" the engine writes, distinct from a LoRA — it
+    /// injects a conditioning residual rather than reparameterizing weights). ControlNet
+    /// training (epic 10159, the `krea_control` kernel) produces the latter.
     pub enum TrainingOutputKind {
         Lora => "lora",
+        ControlBranch => "control_branch",
     }
 }
 
@@ -117,6 +121,13 @@ pub struct TrainingDatasetItem {
     pub asset_id: Option<String>,
     /// Path relative to the dataset root (Rust owns dataset storage layout).
     pub path: String,
+    /// Path (relative to the dataset root) to the per-item control-conditioning image — the
+    /// rendered pose/canny/depth condition for a ControlNet training run (epic 10159). `None`
+    /// for a plain LoRA item; a control-prep pass (the studio's ControlNet job) writes the
+    /// rendered condition sidecar and stamps this so [`build_training_plan`] can thread it onto
+    /// the plan item. A control-branch kernel (`krea_control`) requires it on every item.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub control_image_path: Option<String>,
     pub display_name: String,
     pub caption: Caption,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -434,6 +445,7 @@ pub fn builtin_training_targets() -> TrainingTargetRegistry {
             kolors_lora_target(),
             lens_turbo_lora_target(),
             krea_raw_lora_target(),
+            krea_control_target(),
             sd3_large_lora_target(),
             sd3_medium_lora_target(),
             anima_base_lora_target(),
@@ -1515,6 +1527,100 @@ fn krea_raw_lora_target() -> TrainingTarget {
     }
 }
 
+/// Krea 2 pose-ControlNet training target (epic 10159 ControlNet Training Studio; B2 trainer sc-10163,
+/// B1 studio wiring sc-10162). Unlike [`krea_raw_lora_target`] this produces a **control branch**
+/// ([`TrainingOutputKind::ControlBranch`]), not a LoRA: the `krea_control` kernel trains a frozen-base
+/// conditioning branch on the Krea 2 Raw DiT that applies at Krea 2 Turbo inference — the off-Mac
+/// candle `krea_2_control` trainer (`engine_trainer_id`; candle-gen-krea `ControlTrainer`). It is
+/// **candle-only** today (no torch/MLX control trainer — the MLX lane is B5/sc-10177), so it is in
+/// [`CANDLE_ROUTED_TRAINING_KERNELS`] + [`MLX_ONLY_TRAINING_KERNELS`] (no-torch-fallback) but NOT
+/// [`MLX_ROUTED_TRAINING_KERNELS`]. `defaults.advanced.controlType` selects the preprocessor/condition
+/// (pose first; canny/depth are Phase C, added by extending `controlTypes` once each trains through the
+/// studio). Gradient checkpointing is forced on (`candle_requires_gradient_checkpointing`) — the dense
+/// control-branch backward doesn't fit otherwise. Submitted through the ControlNet-training studio job
+/// (not the LoRA job): the studio renders the per-item condition via the A1/A2 preprocessor and threads
+/// it onto `control_image_path`; the LoRA submit path rejects a `ControlBranch` target.
+fn krea_control_target() -> TrainingTarget {
+    TrainingTarget {
+        id: "krea_2_control".to_owned(),
+        name: "Krea 2 ControlNet".to_owned(),
+        modality: TrainingModality::Image,
+        output_kind: TrainingOutputKind::ControlBranch,
+        family: "krea_2".to_owned(),
+        // Trains the branch on the frozen undistilled Krea 2 Raw DiT (arch-identical to Turbo), the same
+        // base the Krea LoRA target trains — so it reuses the installed-base guardrail + resolver with no
+        // new model-catalog entry. The trained branch applies at Krea 2 Turbo inference.
+        base_model: "krea_2_raw".to_owned(),
+        base_model_repo: Some("SceneWorks/krea-2-raw-mlx".to_owned()),
+        kernel: "krea_control".to_owned(),
+        defaults: TrainingConfig {
+            // rank/alpha are LoRA knobs; a control branch is a full (non-low-rank) module, so the
+            // control trainer ignores them. Kept at the family default to satisfy the shared config
+            // contract (both are validated `> 0`).
+            rank: 16,
+            alpha: 16,
+            learning_rate: ContractNumber::from_f64(0.0001).expect("0.0001 is finite"),
+            steps: 3000,
+            batch_size: 1,
+            gradient_accumulation: 1,
+            resolution: 1024,
+            save_every: 250,
+            seed: 42,
+            optimizer: "adamw8bit".to_owned(),
+            trigger_word: None,
+            advanced: object(json!({
+                // The control type selects the A1 preprocessor + the overlay `kind` metadata. Pose
+                // first (DWPose + openpose skeleton); canny/depth follow in Phase C.
+                "controlType": "pose",
+                "mixedPrecision": "bf16",
+                // The control trainer VAE-/text-encodes the raw (target, control, caption) triples
+                // itself; there is no pre-encoded latent/embedding cache to toggle here.
+                "gradientCheckpointing": true,
+                // Flow-matching noise sampling mirrors the Krea LoRA target (high-noise bias for the
+                // few-step distilled Turbo the branch applies at).
+                "timestepType": "sigmoid",
+                "timestepBias": "high_noise",
+                "lossType": "mse",
+                "weightDecay": 0.0001,
+                "lrScheduler": "constant",
+                // In-training previews need a control-conditioned render path (B3/B4 territory); keep
+                // them off for the first studio slice so a half-built preview never runs.
+                "sampleEvery": 0,
+                "qualityPreset": "balanced",
+                "outputScope": "project",
+                "requestedGpu": "auto"
+            })),
+            extra: ExtraFields::new(),
+        },
+        limits: object(json!({
+            "rank": [4, 128],
+            "alpha": [1, 128],
+            "steps": [200, 6000],
+            "resolutions": [512, 768, 1024],
+            "batchSize": [1, 4],
+            "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
+            // Control types the studio can train today. Pose is live; canny/depth are Phase C (each is
+            // just a different A1 preprocessor — no trainer change).
+            "controlTypes": ["pose"],
+            "lrSchedulers": ["constant", "linear", "cosine"],
+            "outputScopes": ["project", "global"]
+            // Candle-only (no `appleSiliconOnly`): the control trainer runs on candle/CUDA off-Mac. The
+            // MLX control lane is B5 (sc-10177); until then a Mac has no control trainer and the job
+            // stays queued for a candle worker.
+        })),
+        ui: object(json!({
+            "label": "Krea 2 ControlNet",
+            "description": "Train a pose-ControlNet branch for Krea 2. Renders a control condition (pose skeleton) per training image, trains a conditioning branch on the frozen Krea 2 Raw base, and applies it at Krea 2 Turbo inference. Windows/Linux NVIDIA (candle/CUDA) only.",
+            "recommendedFor": ["pose"],
+            "datasetModality": "image",
+            // Signals the training studio to surface this in the ControlNet MODE (data-source picker +
+            // control-type selector), not the plain LoRA target dropdown.
+            "trainingMode": "control"
+        })),
+        extra: ExtraFields::new(),
+    }
+}
+
 /// Native MLX LoRA/LoKr training for Stable Diffusion 3.5 **Large** (epic 7841, T3 sc-7884).
 ///
 /// LoRAs train on the `stabilityai/stable-diffusion-3.5-large` MMDiT (the `sd3_lora` kernel →
@@ -2372,7 +2478,14 @@ pub fn build_training_plan(
                 width: item.width,
                 height: item.height,
                 extra: ExtraFields::new(),
-                control_image_path: None,
+                // ControlNet training: resolve the per-item control-conditioning sidecar the same
+                // way as the target image (relative → absolute under the dataset root). `None` for
+                // a LoRA item; a control-branch kernel's validate rejects a plan item missing it.
+                control_image_path: item
+                    .control_image_path
+                    .as_deref()
+                    .map(|path| resolve_item_path(input.dataset_root, path))
+                    .transpose()?,
             })
         })
         .collect::<Result<Vec<_>, TrainingPlanError>>()?;

--- a/crates/sceneworks-core/src/training_store.rs
+++ b/crates/sceneworks-core/src/training_store.rs
@@ -1129,6 +1129,9 @@ fn materialize_item(
         id: item_id,
         asset_id: source.asset_id,
         path: relative_path,
+        // Fresh import → no control condition rendered yet (only a ControlNet-training prep pass
+        // writes one). epic 10159.
+        control_image_path: None,
         display_name: input.display_name.unwrap_or(source.display_name),
         caption: Caption {
             text: caption.text,
@@ -1186,6 +1189,9 @@ pub fn repoint_item(item: &TrainingDatasetItem, source: RepointSource) -> Traini
         id: item.id.clone(),
         asset_id: source.asset_id,
         path: source.path,
+        // The condition was rendered from the OLD pixels — the new bytes invalidate it exactly
+        // like tier0_scalars/quality_ack, so clear it (a re-point should re-render). epic 10159.
+        control_image_path: None,
         display_name: item.display_name.clone(),
         caption: item.caption.clone(),
         width: source.width,
@@ -1684,6 +1690,7 @@ mod tests {
             id: id.to_owned(),
             asset_id: None,
             path: format!("images/{id}.png"),
+            control_image_path: None,
             display_name: id.to_owned(),
             caption: Caption {
                 text: String::new(),

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -4524,6 +4524,62 @@ fn krea_training_has_no_torch_fallback_but_runs_on_either_rust_backend() {
     assert_eq!(claimed.id, job.id);
 }
 
+/// A ControlNet Training Studio job (epic 10159, sc-10162): the `control_training` job type carrying a
+/// resolved `krea_control` plan. Mirrors `mlx_training_job` but with no dry-run mode (the studio job
+/// always renders + trains).
+fn control_training_job(requested_gpu: &str) -> CreateJob {
+    CreateJob {
+        job_type: JobType::ControlTraining,
+        project_id: Some("project-1".to_owned()),
+        project_name: Some("Project 1".to_owned()),
+        payload: object(json!({
+            "outputName": "my pose control",
+            "plan": {
+                "planVersion": 1,
+                "target": { "kernel": "krea_control", "baseModel": "krea_2_raw" },
+                "config": { "advanced": { "controlType": "pose" } }
+            }
+        })),
+        requested_gpu: requested_gpu.to_owned(),
+        source_job_id: None,
+        duplicate_of_job_id: None,
+        attempts: 1,
+        initial_status: None,
+    }
+}
+
+#[test]
+fn control_training_routes_to_candle_only() {
+    // The Krea pose-ControlNet trainer is candle-only (epic 10159): `krea_control` has no torch and no
+    // MLX trainer (the MLX control lane is B5/sc-10177), so neither a torch nor an mlx worker may claim
+    // a `control_training` job — only the candle worker does.
+    let store = store("control-training-candle-only");
+    register_gpu_worker(&store, "worker-torch", "cuda:0", training_caps());
+    register_gpu_worker(&store, "worker-mlx", "mlx", training_caps());
+    let job = store
+        .create_job(control_training_job("auto"))
+        .expect("job creates");
+
+    // Torch refuses (no torch control trainer — krea_control is no-torch-fallback).
+    assert!(store
+        .claim_next_job("worker-torch")
+        .expect("torch claim ok")
+        .is_none());
+    // MLX refuses (no MLX control trainer yet).
+    assert!(store
+        .claim_next_job("worker-mlx")
+        .expect("mlx claim ok")
+        .is_none());
+
+    // The candle worker is the only home for it.
+    register_gpu_worker(&store, "worker-candle", "0", candle_training_caps());
+    let claimed = store
+        .claim_next_job("worker-candle")
+        .expect("candle claim ok")
+        .expect("candle claims the control training job");
+    assert_eq!(claimed.id, job.id);
+}
+
 #[test]
 fn krea_training_runs_on_the_mlx_worker() {
     let store = store("mlx-training-krea");

--- a/crates/sceneworks-core/tests/training_contracts.rs
+++ b/crates/sceneworks-core/tests/training_contracts.rs
@@ -118,6 +118,12 @@ fn builtin_targets_gate_network_types() {
         .targets
         .iter()
         .filter(|target| {
+            // Control-branch targets (krea_control, epic 10159) train a conditioning branch, not a
+            // LoRA/LoKr network, so they legitimately advertise no `networkTypes`. The lora/lokr
+            // invariant applies only to LoRA-output targets.
+            if !matches!(target.output_kind, TrainingOutputKind::Lora) {
+                return false;
+            }
             assert!(
                 advertises(target, "lora"),
                 "target {} must advertise lora in limits.networkTypes",

--- a/crates/sceneworks-worker/src/control_dataset_prep.rs
+++ b/crates/sceneworks-worker/src/control_dataset_prep.rs
@@ -97,6 +97,20 @@ pub(crate) enum SkipReason {
     PreprocessFailed(String),
 }
 
+impl SkipReason {
+    /// A short human-readable reason, for the studio job's skip tally / logs. Reads every variant's
+    /// detail (the decode/preprocess error string, the too-small dimensions) so the report a caller
+    /// surfaces carries the actual cause, not just a count.
+    pub(crate) fn describe(&self) -> String {
+        match self {
+            SkipReason::Undecodable(error) => format!("undecodable ({error})"),
+            SkipReason::TooSmall { width, height } => format!("too small ({width}x{height})"),
+            SkipReason::NoPersonDetected => "no person detected".to_owned(),
+            SkipReason::PreprocessFailed(error) => format!("preprocess failed ({error})"),
+        }
+    }
+}
+
 /// Outcome of a prep run.
 pub(crate) struct PrepReport {
     /// Successfully written `(target, control, caption)` rows.

--- a/crates/sceneworks-worker/src/control_preprocess.rs
+++ b/crates/sceneworks-worker/src/control_preprocess.rs
@@ -62,8 +62,13 @@ pub(crate) enum PoseComponents {
     /// Body-18 + head-direction only (8459 Config-1). No hands, no dense face. The studio default.
     #[default]
     Body,
+    // The richer sets exist so the same registry serves a hands/face inference lane later (epic
+    // 10159); the training studio renders `Body` (Config-1) only today, so they are not yet
+    // constructed. Kept as intentional forward API rather than deleted.
+    #[allow(dead_code)]
     /// Body-18 + 21×2 hands. No dense face.
     BodyHands,
+    #[allow(dead_code)]
     /// Full whole-body: body-18 + hands + 68-pt face (matches the `pose_detect` job's render).
     WholeBody,
 }
@@ -87,10 +92,15 @@ impl PoseComponents {
 /// (folder-ingest, byte-your-own-dataset ingest, an inference lane) builds it once from resolved
 /// resources and reuses it across a whole dataset / batch.
 pub(crate) trait ControlPreprocessor: Send + Sync {
+    // `kind`/`label` are the inference-facing accessors of the shared preprocessor contract; the
+    // training-studio caller drives only `preprocess` (it labels the dataset via `control_kind_label`
+    // directly), so they are not yet called off-Mac. Kept as intentional contract surface.
     /// The control kind this preprocessor produces.
+    #[allow(dead_code)]
     fn kind(&self) -> ControlKind;
 
     /// The stable lowercase label ([`control_kind_label`]) for this preprocessor's kind.
+    #[allow(dead_code)]
     fn label(&self) -> String {
         control_kind_label(&self.kind())
     }

--- a/crates/sceneworks-worker/src/control_training_jobs.rs
+++ b/crates/sceneworks-worker/src/control_training_jobs.rs
@@ -1,0 +1,355 @@
+//! ControlNet Training Studio orchestration job (Training Studio B1, sc-10162, epic 10159).
+//!
+//! One job that turns "an existing captioned training dataset + a control type" into a trained
+//! control branch. It chains the A1/A2 data-prep (render the per-image control condition) into the
+//! SAME native-training executor the LoRA path uses ([`crate::training_jobs::run_training_execution`]):
+//!
+//! 1. Parse the resolved [`TrainingPlan`] the API stamped into the payload (kernel `krea_control`).
+//! 2. Render the control condition for every dataset item via the A1 preprocessor registry / A2
+//!    folder-ingest core ([`crate::control_dataset_prep::prepare_control_dataset`]) — pose skeleton
+//!    (DWPose) or canny — into an app-managed control dataset (square-canonical `(target, control,
+//!    caption)` triples + `manifest.jsonl`).
+//! 3. Rewrite the plan's dataset onto that rendered control dataset, threading each item's rendered
+//!    condition onto [`TrainingPlanItem::control_image_path`].
+//! 4. Hand the rewritten plan to `run_training_execution` → `gen_core::load_trainer("krea_2_control")`
+//!    → the candle-gen-krea `ControlTrainer` writes the overlay.
+//!
+//! Backend gating mirrors [`crate::training_jobs`]: the real orchestration exists only on the
+//! neural-inference builds (macOS, or an off-Mac `backend-candle` build). Today only the candle lane
+//! has a control trainer (`krea_2_control`), and routing (`training_job_is_candle_eligible`) keeps a
+//! `control_training` job on a candle worker; on a build with no native control trainer the stub at
+//! the bottom fails loudly. Bring-your-own prepared/COCO datasets (A3,
+//! [`crate::control_dataset_byo`]) are a separate source wired by a follow-up (see the module decl in
+//! `lib.rs`); B1 ships the render-from-an-existing-dataset path.
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+mod imp {
+    use super::super::*;
+
+    use gen_core::ControlKind;
+    use sceneworks_core::training::{TrainingPlan, TrainingPlanItem};
+
+    use crate::control_dataset_prep::{
+        prepare_control_dataset, ControlPrepConfig, ControlPrepInput, PersonFilter,
+        DEFAULT_MIN_EDGE,
+    };
+    use crate::control_preprocess::{control_kind_label, PreprocessResources};
+    use crate::downloads::DownloadContext;
+    use crate::paths::resolve_dataset_item_path;
+    use crate::training_jobs::{parse_plan, run_training_execution, training_progress};
+
+    /// The only kernel the studio job trains today — the Krea 2 pose-ControlNet branch. The API stamps
+    /// it into the plan (`krea_control` target); a plan with any other kernel is rejected here rather
+    /// than mis-dispatched (the executor maps `krea_control` → the `krea_2_control` engine trainer).
+    const CONTROL_KERNEL: &str = "krea_control";
+
+    /// YOLO person-gate confidence floor when `advanced.personGate` is on — drop a target with no
+    /// detected person so a pose branch isn't trained on empty skeletons. Deliberately permissive
+    /// (Dataset Doctor runs the richer quality pass).
+    const PERSON_GATE_MIN_CONF: f32 = 0.25;
+
+    /// Run a `control_training` job: render conditions, then train the control branch.
+    pub(crate) async fn run_control_training_job(
+        api: &ApiClient,
+        settings: &Settings,
+        http_client: &reqwest::Client,
+        job: &JobSnapshot,
+    ) -> WorkerResult<()> {
+        let backend = backend_label(&settings.gpu_id);
+        let mut plan = parse_plan(&job.payload)?;
+        if plan.target.kernel != CONTROL_KERNEL {
+            return Err(WorkerError::InvalidPayload(format!(
+                "control_training expects a '{CONTROL_KERNEL}' plan, got kernel '{}'.",
+                plan.target.kernel
+            )));
+        }
+        if plan.dataset.items.is_empty() {
+            return Err(WorkerError::InvalidPayload(
+                "control_training plan has no dataset items to render conditions from.".to_owned(),
+            ));
+        }
+
+        heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+        update_job(
+            api,
+            &job.id,
+            training_progress(
+                JobStatus::Preparing,
+                ProgressStage::Preparing,
+                0.02,
+                "Preparing ControlNet training.",
+                None,
+                backend,
+            ),
+        )
+        .await?;
+        check_cancel(
+            api,
+            &job.id,
+            "ControlNet training canceled before it started.",
+        )
+        .await?;
+
+        let kind = control_kind_from_plan(&plan);
+        let label = control_kind_label(&kind);
+
+        // Resolve the preprocessor resources this control type needs (pose → DWPose weights; canny is
+        // weightless). Depth is not yet offered by the studio target (Phase C), so reject it clearly
+        // rather than silently produce nothing.
+        let mut resources = PreprocessResources::new();
+        match kind {
+            ControlKind::Pose => {
+                resources.dwpose =
+                    Some(pose_jobs::ensure_dwpose_weights(api, settings, http_client, job).await?);
+            }
+            ControlKind::Canny => {}
+            other => {
+                return Err(WorkerError::InvalidPayload(format!(
+                    "control type '{}' is not available in the training studio yet (pose and canny \
+                     only); depth/other are a Phase-C follow-up.",
+                    control_kind_label(&other)
+                )));
+            }
+        }
+
+        // Optional person-presence gate (pose/people corpora), resolved through the shared YOLO11
+        // detector the person-detect job uses.
+        let person_filter = if plan_advanced_bool(&plan, "personGate") {
+            let context = DownloadContext {
+                api,
+                client: http_client,
+                settings,
+                job_id: &job.id,
+                cancel_message: "ControlNet training canceled while fetching the person detector.",
+                fresh_download: false,
+            };
+            let weights_path = person_jobs::ensure_detector_weights(settings, &context).await?;
+            Some(PersonFilter {
+                weights_path,
+                min_conf: PERSON_GATE_MIN_CONF,
+            })
+        } else {
+            None
+        };
+
+        // Build the render inputs from the plan's dataset items — the (already trigger-composed)
+        // caption rides straight through; the target image is re-confined under the source dataset
+        // root before it is read.
+        let source_root = plan.dataset.root_path.clone();
+        let inputs = plan
+            .dataset
+            .items
+            .iter()
+            .map(|item| {
+                Ok(ControlPrepInput {
+                    target_path: resolve_dataset_item_path(
+                        settings,
+                        &source_root,
+                        &item.image_path,
+                        "ControlNet training source imagePath",
+                    )?,
+                    caption: item.caption.clone(),
+                })
+            })
+            .collect::<WorkerResult<Vec<_>>>()?;
+        let input_count = inputs.len();
+
+        // The rendered control dataset lands in an app-managed cache dir keyed by job id, so it is
+        // confined (the executor re-resolves item paths under this root) and cleaned with the cache.
+        let work_dir = settings
+            .data_dir
+            .join("cache")
+            .join("control-datasets")
+            .join(&job.id);
+        tokio::fs::create_dir_all(&work_dir).await?;
+
+        update_job(
+            api,
+            &job.id,
+            training_progress(
+                JobStatus::Preparing,
+                ProgressStage::Preparing,
+                0.05,
+                &format!("Rendering {label} conditions for {input_count} image(s)."),
+                None,
+                backend,
+            ),
+        )
+        .await?;
+
+        // A2 prep is blocking (decode + neural preprocess + PNG encode per image); run it off the
+        // async runtime. Ownership moves into the closure; the report + work dir come back out.
+        let config = ControlPrepConfig {
+            kind,
+            resources,
+            min_edge: DEFAULT_MIN_EDGE,
+            person_filter,
+        };
+        let prep_dir = work_dir.clone();
+        let report = tokio::task::spawn_blocking(move || {
+            prepare_control_dataset(&inputs, &config, &prep_dir, |_done, _total| {})
+        })
+        .await
+        .map_err(|error| WorkerError::Engine(format!("control prep task panicked: {error}")))??;
+
+        // Surface the per-image skip tally rather than silently shrinking the corpus (the report
+        // exists for exactly this). The manifest path + the individual reasons go to the log; the
+        // studio job's user-facing progress carries the counts below.
+        if !report.skipped.is_empty() {
+            let detail = report
+                .skipped
+                .iter()
+                .map(|(path, reason)| format!("{}: {}", path.display(), reason.describe()))
+                .collect::<Vec<_>>()
+                .join("; ");
+            tracing::info!(
+                event = "control_prep_skipped",
+                job_id = %job.id,
+                skipped = report.skipped.len(),
+                total = input_count,
+                %detail,
+                "some source images were skipped while rendering control conditions"
+            );
+        }
+        tracing::debug!(
+            job_id = %job.id,
+            manifest = %report.manifest_path.display(),
+            rendered = report.items.len(),
+            "wrote control training dataset"
+        );
+
+        if report.items.is_empty() {
+            return Err(WorkerError::InvalidPayload(format!(
+                "No usable training pairs after rendering conditions — all {input_count} source \
+                 image(s) were skipped (undecodable, too small, no person, or preprocess failure)."
+            )));
+        }
+
+        // Rewrite the plan's dataset onto the rendered control dataset: point the root at the work
+        // dir and thread each item's rendered condition onto `control_image_path`. The (letterboxed,
+        // square) rendered target replaces the source image so target + control share geometry.
+        plan.dataset.root_path = work_dir.display().to_string();
+        plan.dataset.items = report
+            .items
+            .iter()
+            .map(|item| TrainingPlanItem {
+                image_path: item.target_rel.clone(),
+                caption: item.caption.clone(),
+                control_image_path: Some(item.control_rel.clone()),
+                width: None,
+                height: None,
+                extra: Default::default(),
+            })
+            .collect();
+
+        let skipped = report.skipped.len();
+        update_job(
+            api,
+            &job.id,
+            training_progress(
+                JobStatus::Preparing,
+                ProgressStage::Preparing,
+                0.1,
+                &format!(
+                    "Rendered {} {label} condition(s){}. Starting control-branch training.",
+                    report.items.len(),
+                    if skipped > 0 {
+                        format!(" ({skipped} source image(s) skipped)")
+                    } else {
+                        String::new()
+                    }
+                ),
+                None,
+                backend,
+            ),
+        )
+        .await?;
+
+        // Hand off to the shared native-training executor (progress streaming, cancellation, overlay
+        // write + result post-back). It maps `krea_control` → the `krea_2_control` engine trainer.
+        run_training_execution(api, settings, job, &plan).await
+    }
+
+    /// The control type to render, from the plan config's `advanced.controlType` (default pose — the
+    /// only type the `krea_control` target advertises today).
+    fn control_kind_from_plan(plan: &TrainingPlan) -> ControlKind {
+        control_kind_from_label(
+            plan.config
+                .advanced
+                .get("controlType")
+                .and_then(|value| value.as_str())
+                .map(str::trim)
+                .unwrap_or("pose"),
+        )
+    }
+
+    /// Map a `controlType` label onto a [`ControlKind`]. Absent/blank defaults to pose (the studio
+    /// target's default); an unknown label flows through as [`ControlKind::Other`] and is rejected by
+    /// the caller with a precise "not available yet" message rather than silently mis-rendered.
+    fn control_kind_from_label(label: &str) -> ControlKind {
+        match label {
+            "" | "pose" => ControlKind::Pose,
+            "canny" => ControlKind::Canny,
+            "depth" => ControlKind::Depth,
+            other => ControlKind::Other(other.to_owned()),
+        }
+    }
+
+    /// Read a boolean flag from the plan config's `advanced` bag (absent/non-bool ⇒ false).
+    fn plan_advanced_bool(plan: &TrainingPlan, key: &str) -> bool {
+        plan.config
+            .advanced
+            .get(key)
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::{control_kind_from_label, ControlKind};
+
+        #[test]
+        fn control_kind_label_maps_studio_types_and_defaults_to_pose() {
+            // Absent/blank ⇒ pose (the krea_control target's default).
+            assert_eq!(control_kind_from_label(""), ControlKind::Pose);
+            assert_eq!(control_kind_from_label("pose"), ControlKind::Pose);
+            assert_eq!(control_kind_from_label("canny"), ControlKind::Canny);
+            assert_eq!(control_kind_from_label("depth"), ControlKind::Depth);
+            // An unknown label is preserved as Other so the caller can reject it precisely (never
+            // silently coerced to pose).
+            assert_eq!(
+                control_kind_from_label("scribble"),
+                ControlKind::Other("scribble".to_owned())
+            );
+        }
+    }
+}
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+pub(crate) use imp::run_control_training_job;
+
+/// Stub for a build with no native control trainer (off-Mac without `backend-candle`). The routing
+/// gate (`training_job_is_candle_eligible`) keeps a `control_training` job off such a worker, so this
+/// is a loud backstop rather than a reachable path.
+#[cfg(not(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+)))]
+pub(crate) async fn run_control_training_job(
+    _api: &crate::ApiClient,
+    _settings: &crate::Settings,
+    _http_client: &reqwest::Client,
+    job: &sceneworks_core::contracts::JobSnapshot,
+) -> crate::WorkerResult<()> {
+    Err(crate::WorkerError::InvalidPayload(format!(
+        "control_training job {} requires a native control trainer (macOS mlx or off-Mac \
+         backend-candle); this worker has neither.",
+        job.id
+    )))
+}

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -392,29 +392,46 @@ mod pose_jobs;
 // A1 lands this registry ahead of its first non-test consumer: the folder-ingest data-prep
 // pipeline (A2, sc-10161) is what resolves + drives a preprocessor over a dataset, and the
 // bring-your-own-dataset adapter (A3, sc-10171) reuses it for annotated-render/convention checks.
-// Until then only `control_kind_label` has a caller (the strict-control driver delegates to it), so
-// allow dead_code module-wide — remove when A2 wires `preprocessor_for` into ingest.
-#[allow(dead_code)]
+// The studio job (B1, sc-10162) is the first real consumer — it renders conditions via this registry
+// (through A2). That caller exists only on the neural-inference builds (macOS / off-Mac candle), so
+// the module is fully wired there; on a candle-disabled off-Mac ("neither") build there is still no
+// consumer of the neural path, so keep the dead_code allowance only for that build.
+#[cfg_attr(
+    all(not(target_os = "macos"), not(feature = "backend-candle")),
+    allow(dead_code)
+)]
 mod control_preprocess;
 // Folder-ingest control-dataset prep (Training Studio A2, sc-10161, epic 10159): the "create your
 // own" GENERATE core — raw target images → render each condition via the A1 `control_preprocess`
 // registry → square-canonical letterbox for alignment → write `(target, control, caption)` triples
 // + `manifest.jsonl` in the layout the Krea control trainer (B2) and the bring-your-own adapter (A3)
 // consume. Cross-platform for the canny path; pose/depth/person-filter resolve through the
-// backend-gated registry/detector. Lands ahead of its first non-test caller: the studio job type
-// (B1, sc-10162) dispatches it and feeds captions from the JoyCaption job; allow dead_code until
-// then.
-#[allow(dead_code)]
+// backend-gated registry/detector. The studio job (B1, sc-10162, `control_training_jobs`) is the
+// first real caller — it renders conditions from an existing dataset then trains. That caller exists
+// only on the neural-inference builds; on a candle-disabled off-Mac ("neither") build nothing drives
+// the pipeline, so keep the dead_code allowance only for that build.
+#[cfg_attr(
+    all(not(target_os = "macos"), not(feature = "backend-candle")),
+    allow(dead_code)
+)]
 mod control_dataset_prep;
 // Bring-your-own-dataset ingest adapter (Training Studio A3, sc-10171, epic 10159): the second
 // dataset-input path — map a PROVIDED dataset into the same on-disk layout A2 emits, skipping what
 // the source supplies. Prepared pairs (target + rendered condition) are convention-validated then
 // ingested as-is / normalized / regenerated via the A1 preprocessor; annotated COCO
 // (person_keypoints + captions) renders the OpenPose-18 skeleton from ground-truth keypoints (no
-// detection) — cross-platform. Reuses A2's square letterbox + write/manifest tail. Lands ahead of
-// its first non-test caller (the studio job type B1, sc-10162); allow dead_code until then.
+// detection) — cross-platform. Reuses A2's square letterbox + write/manifest tail. B1 (sc-10162)
+// ships only the render-from-an-existing-dataset source; wiring this bring-your-own path into the
+// studio job (source provisioning + convention-warning surfacing) is a scoped follow-up, so this
+// module keeps its dead_code allowance until that lands.
 #[allow(dead_code)]
 mod control_dataset_byo;
+// ControlNet Training Studio orchestration job (B1, sc-10162, epic 10159): renders the per-image
+// control condition from an existing captioned dataset via `control_preprocess`/`control_dataset_prep`
+// (A1/A2), then trains the control branch through the shared `training_jobs` executor
+// (`krea_control` → `krea_2_control`). Cross-platform module shell with a neural-build-gated real impl
+// + a loud stub, mirroring `training_jobs`.
+mod control_training_jobs;
 // CUDA execution-provider dependency preloading for the off-Mac candle `ort` paths
 // (sc-6209, epic 5482): `ort::ep::cuda::preload_dylibs` dlopens the CUDA-12 runtime +
 // cuDNN-9 DLLs the onnxruntime CUDA EP needs, so it engages the GPU regardless of PATH
@@ -968,7 +985,7 @@ async fn register_worker(
 /// declaring a worker gone. A non-transport error (the API answered and rejected
 /// the heartbeat, e.g. the worker is no longer registered) is a real signal and is
 /// still propagated. (sc-6320)
-async fn heartbeat(
+pub(crate) async fn heartbeat(
     api: &ApiClient,
     settings: &Settings,
     status: WorkerStatus,
@@ -1110,6 +1127,16 @@ async fn run_utility_job(
             JobType::LoraTrain => run_lora_train_job(api, settings, &job)
                 .await
                 .map_err(|error| ("LoRA training failed.", error)),
+            // ControlNet Training Studio (epic 10159, sc-10162): render the per-image control
+            // condition from the plan's dataset (A1/A2), then train the control branch through the
+            // same native executor as LoRA (`krea_control` → `krea_2_control`). Candle-only today; the
+            // routing gate keeps it on a candle worker (or the linked mlx build), the stub fails loudly
+            // elsewhere.
+            JobType::ControlTraining => {
+                control_training_jobs::run_control_training_job(api, settings, http_client, &job)
+                    .await
+                    .map_err(|error| ("ControlNet training failed.", error))
+            }
             // Native MLX JoyCaption dataset captioning (epic 3550, sc-3556). The API
             // routes only `captioner=joy_caption` jobs here; Windows/Linux and
             // explicit non-MLX GPU choices keep the Python torch captioner fallback.

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -768,6 +768,20 @@ pub(crate) fn detect_and_render_skeleton(
 // weights provisioning (download-on-first-use parity with rtmlib)
 // ---------------------------------------------------------------------------
 
+/// Resolve the two DWPose onnx weight paths `(detector, pose)`, downloading them on first use — the
+/// public seam the ControlNet Training Studio job (epic 10159, sc-10162) uses to build a
+/// [`crate::control_preprocess::PreprocessResources`] before rendering pose conditions. Thin wrapper
+/// over the module-private [`ensure_weights`] (the same resolver `run_pose_detect_job` uses), so the
+/// studio and the pose-detect job provision the identical weights.
+pub(crate) async fn ensure_dwpose_weights(
+    api: &ApiClient,
+    settings: &Settings,
+    http_client: &reqwest::Client,
+    job: &JobSnapshot,
+) -> WorkerResult<(PathBuf, PathBuf)> {
+    ensure_weights(api, settings, http_client, job).await
+}
+
 /// Resolve the two onnx weights, downloading them on first use. Order: explicit env
 /// pin (`SCENEWORKS_DWPOSE_DET`/`POSE`), then the app cache
 /// `<data_dir>/cache/dwpose/`, then rtmlib's own cache (dev machines), else download

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -106,7 +106,7 @@ pub(crate) async fn run_lora_train_job(
 /// Deserialize the Rust-resolved plan stamped into the job payload at submit time
 /// (apps/rust-api training.rs). The plan round-trips through `TrainingPlan`, so a
 /// payload missing/garbling it is a hard error (never a silent no-op).
-fn parse_plan(payload: &JsonObject) -> WorkerResult<TrainingPlan> {
+pub(crate) fn parse_plan(payload: &JsonObject) -> WorkerResult<TrainingPlan> {
     let plan = payload.get("plan").ok_or_else(|| {
         WorkerError::InvalidPayload("Training job payload is missing a resolved plan.".to_owned())
     })?;
@@ -270,7 +270,7 @@ fn dry_run_summary(settings: &Settings, plan: &TrainingPlan) -> JsonObject {
 /// A `lora_train` progress update with the worker's backend label (mirrors
 /// `image_jobs::image_progress`). LoRA training keeps `status: running` across the
 /// caching/training/checkpointing/saving stages; only the final update is `completed`.
-fn training_progress(
+pub(crate) fn training_progress(
     status: JobStatus,
     stage: ProgressStage,
     progress: f64,
@@ -671,7 +671,7 @@ fn training_text_encoder(engine_id: &str, weights_dir: &std::path::Path) -> Opti
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
-async fn run_training_execution(
+pub(crate) async fn run_training_execution(
     api: &ApiClient,
     settings: &Settings,
     job: &JobSnapshot,

--- a/tests/fixtures/rust_migration_contracts/training/target-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/target-registry.json
@@ -666,6 +666,93 @@
       }
     },
     {
+      "id": "krea_2_control",
+      "name": "Krea 2 ControlNet",
+      "modality": "image",
+      "outputKind": "control_branch",
+      "family": "krea_2",
+      "baseModel": "krea_2_raw",
+      "baseModelRepo": "SceneWorks/krea-2-raw-mlx",
+      "kernel": "krea_control",
+      "defaults": {
+        "rank": 16,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 3000,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "controlType": "pose",
+          "gradientCheckpointing": true,
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 0,
+          "timestepBias": "high_noise",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
+        }
+      },
+      "limits": {
+        "alpha": [
+          1,
+          128
+        ],
+        "batchSize": [
+          1,
+          4
+        ],
+        "controlTypes": [
+          "pose"
+        ],
+        "lrSchedulers": [
+          "constant",
+          "linear",
+          "cosine"
+        ],
+        "optimizers": [
+          "adamw8bit",
+          "adamw",
+          "adam",
+          "prodigyopt",
+          "rose"
+        ],
+        "outputScopes": [
+          "project",
+          "global"
+        ],
+        "rank": [
+          4,
+          128
+        ],
+        "resolutions": [
+          512,
+          768,
+          1024
+        ],
+        "steps": [
+          200,
+          6000
+        ]
+      },
+      "ui": {
+        "datasetModality": "image",
+        "description": "Train a pose-ControlNet branch for Krea 2. Renders a control condition (pose skeleton) per training image, trains a conditioning branch on the frozen Krea 2 Raw base, and applies it at Krea 2 Turbo inference. Windows/Linux NVIDIA (candle/CUDA) only.",
+        "label": "Krea 2 ControlNet",
+        "recommendedFor": [
+          "pose"
+        ],
+        "trainingMode": "control"
+      }
+    },
+    {
       "id": "sd3_5_large_lora",
       "name": "SD3.5 Large LoRA",
       "modality": "image",


### PR DESCRIPTION
## Training Studio B1 (sc-10162) — the "Go" surface for ControlNet training

The merged B2 trainer (`krea_2_control`, sc-10163) was **dispatchable but not submittable**. This adds the studio job type + submit + orchestration so a user can point at a captioned dataset and train a Krea pose‑ControlNet branch. Phase A (A1/A2/A3 data‑prep) is merged; this wires A1/A2 into a live job (removing their `allow(dead_code)`).

### Architecture — one orchestrated job
`ControlTraining` job → render the per‑image control condition from the dataset (A1/A2 `prepare_control_dataset`, square‑canonical) → rewrite the plan onto the rendered `(target, control, caption)` triples → hand to the **same** native executor as LoRA (`run_training_execution`), which maps `krea_control` → the `krea_2_control` engine trainer. No duplicate training path.

### core (`sceneworks-core`)
- **`krea_control` `TrainingTarget`** (`ControlBranch` output kind, family `krea_2`, `advanced.controlType=pose`, gradient‑checkpointing on) + registered.
- **`TrainingOutputKind::ControlBranch`** — control produces an overlay, not a LoRA.
- **Routing** — `krea_control` ∈ `CANDLE_ROUTED_TRAINING_KERNELS` + `MLX_ONLY_TRAINING_KERNELS` (candle‑only; no torch/MLX control trainer — MLX lane is B5/sc‑10177). New `ControlTraining` JobType routes/capability‑gates exactly like a real `krea_control` `lora_train`: **candle claims, torch + mlx refuse** (new `control_training_routes_to_candle_only` test). Parity snapshots + the committed target‑registry fixture updated.
- **`TrainingDatasetItem.control_image_path`** threaded through `build_training_plan`.

### worker (`sceneworks-worker`)
- **`control_training_jobs`** — new orchestration handler + dispatch arm. Renders pose/canny (optional YOLO person gate), writes the rendered control dataset to an app‑managed cache dir, surfaces the per‑image skip tally, then trains. Removes the blanket `allow(dead_code)` on `control_preprocess`/`control_dataset_prep` on neural builds (kept only on the `neither` build via `cfg_attr`).

### api + web
- `create_training_job` **folds** a `ControlBranch` target onto the `ControlTraining` job, reusing every guardrail + the plan builder; dry‑run is rejected (control always renders + trains).
- `ConfigureJobPanel` surfaces the ControlNet mode (control type + data‑source note) and a control‑branch output label. The target's `controlType` already flows via the config snapshot, so the run is submittable end‑to‑end.

### Scope / deferred
B1 ships the **render‑from‑an‑existing‑dataset** source (the common case; captioning stays the shipped JoyCaption/Dataset‑Doctor flow). A3 **bring‑your‑own** prepared/COCO ingest into the studio job is a scoped follow‑up (`control_dataset_byo` keeps its `allow(dead_code)` until then). Overlay auto‑registration for generation is B4 (sc‑10165); the completed job leaves the overlay in its output dir unregistered for now.

### Verification
- `cargo test -p sceneworks-core` (routing + contracts + regenerated fixture) ✅
- `cargo clippy -p sceneworks-core --all-targets -D warnings` ✅
- `cargo clippy -p sceneworks-worker --features backend-candle --all-targets -D warnings` (MSVC 14.44 + `CUDA_COMPUTE_CAP=120`) ✅ — compiles the orchestration module + its unit test
- `npm run rust:check:neither` (worker + rust‑api, Linux‑no‑candle parity) ✅
- web `vitest` (ConfigureJobPanel + trainingConfig, 20 tests) + `vite build` ✅

Not run: a fresh GPU smoke — the trainer itself is already GPU‑proven in B2; this PR is the submit/orchestration plumbing. The existing `candle_krea_control_real_weights_trains_a_branch_step` smoke drives the same executor path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
