### PR TITLE
fix(web): give batchSize/gradientAccumulation an input so validation names a reachable field (sc-10689)

### DIFF
--- a/apps/web/src/screens/training/ConfigureJobPanel.jsx
+++ b/apps/web/src/screens/training/ConfigureJobPanel.jsx
@@ -264,6 +264,30 @@ export function ConfigureJobPanel({
                   {...invalidProps(configValidity, "alpha")}
                 />
               </label>
+              {/* Real hyperparameters the config validates (sc-10689). They live here
+                  beside the other numeric knobs so every `> 0` error the rule set can
+                  raise names an input the user can reach. The draft always seeds a
+                  working value (configDraftFromTarget), so these are never empty. */}
+              <label title="Images per optimizer step. Higher batches smooth gradients but cost more VRAM.">
+                Batch size
+                <input
+                  min="1"
+                  onChange={(event) => updateConfigDraft("batchSize", event.target.value)}
+                  type="number"
+                  value={configDraft.batchSize ?? ""}
+                  {...invalidProps(configValidity, "batchSize")}
+                />
+              </label>
+              <label title="Optimizer steps accumulated before an update — multiplies the effective batch size without extra VRAM.">
+                Gradient accumulation
+                <input
+                  min="1"
+                  onChange={(event) => updateConfigDraft("gradientAccumulation", event.target.value)}
+                  type="number"
+                  value={configDraft.gradientAccumulation ?? ""}
+                  {...invalidProps(configValidity, "gradientAccumulation")}
+                />
+              </label>
               {showNetworkType ? (
                 <label title="Adapter parameterization. LoRA is the standard low-rank adapter; LoKr (LyCORIS Kronecker) trains a much smaller, often more expressive adapter (torch backends only).">
                   Network type

--- a/apps/web/src/screens/training/ConfigureJobPanel.test.jsx
+++ b/apps/web/src/screens/training/ConfigureJobPanel.test.jsx
@@ -220,3 +220,42 @@ describe("ConfigureJobPanel surfaces broken values and stays quiet about unfille
     expect(pill.className).toContain("is-ready");
   });
 });
+
+// sc-10689: configValidation raises a `> 0` error for eight numeric fields; every one must
+// name an input the user can reach, or the chip points at a control that isn't on the screen
+// and Start dies unfixably (the epic's own defect class, one step worse). This drove the bug:
+// batchSize and gradientAccumulation were validated with no input, so clearing either chipped
+// with nothing to outline. The map is the field label configValidation uses, which is also the
+// panel's label text — so it double-checks the two agree.
+describe("every validated numeric field maps to a reachable, outline-able input", () => {
+  const FIELD_LABELS = {
+    rank: "Rank",
+    alpha: "Alpha",
+    learningRate: "Learning rate",
+    steps: "Steps",
+    resolution: "Resolution",
+    batchSize: "Batch size",
+    gradientAccumulation: "Gradient accumulation",
+    saveEvery: "Checkpoint cadence",
+  };
+
+  for (const [field, label] of Object.entries(FIELD_LABELS)) {
+    it(`chips ${field} and outlines the ${label} control the chip names`, () => {
+      const draft = { ...VALID_DRAFT, [field]: "" };
+      const configValidity = validityFor(draft);
+      mount(
+        <ConfigureJobPanel
+          {...baseProps({ configValidity, configDraft: draft, showAdvancedConfig: true, visibleResolutionOptions: [512, 768, 1024] })}
+        />,
+      );
+
+      expect(chips()).toContain(`${label} must be greater than zero`);
+
+      const control = [...container.querySelectorAll("label")]
+        .find((node) => node.textContent.trim().startsWith(label))
+        ?.querySelector("input, select");
+      expect(control).toBeTruthy();
+      expect(control.getAttribute("aria-invalid")).toBe("true");
+    });
+  }
+});

--- a/apps/web/src/training/trainingConfig.js
+++ b/apps/web/src/training/trainingConfig.js
@@ -174,8 +174,12 @@ export function configDraftFromTarget(target, dataset, gpuOptions, triggerPhrase
         ? advanced.samplePrompts
         : samplePromptsFromTrigger(triggerPhrase || asText(defaults.triggerWord)),
     ),
-    batchSize: numericDraft(defaults.batchSize),
-    gradientAccumulation: numericDraft(defaults.gradientAccumulation),
+    // Batch size and gradient accumulation have inputs in the Advanced grid
+    // (sc-10689), so a bad value there is now fixable. The `?? default` floor
+    // guarantees the box is never empty: a target/preset whose defaults omit either
+    // field would otherwise seed "" and fail the `> 0` rule with no way to clear it.
+    batchSize: numericDraft(defaults.batchSize ?? defaultBatchSize),
+    gradientAccumulation: numericDraft(defaults.gradientAccumulation ?? defaultGradientAccumulation),
     seed: numericDraft(defaults.seed),
   };
 }
@@ -206,9 +210,10 @@ export function configValidation(configDraft, { activeDataset, selectedTarget, d
     issues.push(issue.requirement("triggerWord", "Add a trigger phrase"));
   }
   // The field name is the draft key, so `invalidProps` can outline the very input the
-  // chip is talking about. `batchSize` and `gradientAccumulation` have no input in the
-  // panel — they arrive from the preset — so a bad value there chips without outlining
-  // anything, and the user cannot clear it. Tracked in sc-10689.
+  // chip is talking about. Every field below has an input in ConfigureJobPanel — the
+  // basic grid (steps, saveEvery) or the Advanced disclosure (the rest, including
+  // batchSize and gradientAccumulation as of sc-10689) — so every error names a field
+  // the user can reach and clear, which is the epic's premise (10644 R5).
   for (const [field, label] of [
     ["rank", "Rank"],
     ["alpha", "Alpha"],
@@ -251,6 +256,16 @@ export function samplePromptsFromTrigger(triggerWord) {
 // unchanged when neither knob is touched. The backends cap the prompt pool at
 // this count (one preview per prompt, truncated — never padded).
 export const defaultSampleCount = 4;
+
+// Safety-net defaults for the two hyperparameters the panel now exposes (sc-10689).
+// Every built-in target/preset already ships explicit values (the Rust `TrainingConfig`
+// contract types both as required, so the API can't omit them), and that per-model
+// value is what `configDraftFromTarget` uses when present. These only fill the box for
+// a source that omits the field — a loosened contract or a user-authored preset — where
+// `1` (batch of one, no accumulation) is the universally safe floor: minimum VRAM,
+// always fits, and never larger than any advertised `limits.batchSize` range.
+export const defaultBatchSize = 1;
+export const defaultGradientAccumulation = 1;
 
 // The sample-prompts textarea holds one prompt per line; the worker payload wants
 // a string array. These two convert between the draft string and the array.

--- a/apps/web/src/training/trainingConfig.test.js
+++ b/apps/web/src/training/trainingConfig.test.js
@@ -60,6 +60,27 @@ describe("configDraftFromTarget", () => {
     expect(draft.outputName).toBe("Custom name");
   });
 
+  // sc-10689: batchSize and gradientAccumulation are validated with a `> 0` rule and now
+  // have inputs. A target/preset whose defaults omit either would seed "" and fail that
+  // rule with no fixable box. The draft floors both so the box is never empty.
+  it("floors batch size and gradient accumulation so an omitting target can't seed a dead CTA", () => {
+    const { batchSize: _b, gradientAccumulation: _g, ...leanDefaults } = target.defaults;
+    const leanTarget = { ...target, defaults: leanDefaults };
+    const draft = configDraftFromTarget(leanTarget, dataset, ["auto"]);
+    expect(draft.batchSize).toBe("1");
+    expect(draft.gradientAccumulation).toBe("1");
+    const summary = summarize(configValidation(draft, { activeDataset: dataset, selectedTarget: leanTarget }));
+    expect(summary.invalidFields.has("batchSize")).toBe(false);
+    expect(summary.invalidFields.has("gradientAccumulation")).toBe(false);
+  });
+
+  it("carries an explicit batch size / gradient accumulation from the target defaults", () => {
+    const richTarget = { ...target, defaults: { ...target.defaults, batchSize: 4, gradientAccumulation: 2 } };
+    const draft = configDraftFromTarget(richTarget, dataset, ["auto"]);
+    expect(draft.batchSize).toBe("4");
+    expect(draft.gradientAccumulation).toBe("2");
+  });
+
   it("defaults the LoKr factor to an auto -1 string and normalizes the adapter version", () => {
     const draft = configDraftFromTarget(target, dataset, ["auto"]);
     expect(draft.decomposeFactor).toBe("-1");


### PR DESCRIPTION
## Problem

`configValidation` (`apps/web/src/training/trainingConfig.js`) blocks **Start training** with a `> 0` error for eight numeric fields, but **`batchSize` and `gradientAccumulation` had no input anywhere in `ConfigureJobPanel`**. A training target or preset whose `defaults` omit either seeds `""` in the draft and fails the rule with a chip ("Batch size must be greater than zero") the user is powerless to clear — the epic's own defect class (10644), one step worse: a blocking condition with a stated reason the user cannot act on.

**Latent, not live.** The Rust `TrainingConfig` contract (`crates/sceneworks-core/src/training.rs`) types both as required non-optional `u32`, so no built-in target/preset can omit them (all ship `1`). Closed off regardless — a loosened contract, an external registry, or a user-authored preset would resurrect it.

## Fix (Option 1 from the story + a guaranteed pre-fill)

- **Render both** as `type="number"` inputs in the Advanced grid beside rank/alpha/LR, each wired to `updateConfigDraft` + `invalidProps` so a bad value chips **and** outlines the box it names (10644 R5). Every `error` the rule set can raise now names a field the user can reach.
- **Floor the draft** in `configDraftFromTarget` with new `defaultBatchSize`/`defaultGradientAccumulation` (`1`/`1`, the universally safe minimum: batch of one, no accumulation — minimum VRAM, always fits). Each model's own per-model default is used when present; the floor only catches a source that omits the field, so the box is never empty and never carries a value that won't run.
- Corrected the now-stale comment in `configValidation` that said these fields have no input.

**Why not the alternatives:** dropping them from the rule set leaves a range-advertised (`limits.batchSize: [1,4]`) knob unreachable and pushes bad values to the worker's submit-time rejection (a scoped-out surface); a draft-only fallback leaves validation guarding an input-less field and doesn't cover an explicit `0` from a preset.

## Tests (both DoD items)

- `trainingConfig.test.js` — a target whose `defaults` omit both fields seeds `"1"`/`"1"` and produces no invalid fields (no dead CTA); an explicit `4`/`2` is carried through.
- `ConfigureJobPanel.test.jsx` — a parametrized cross-check over all eight validated fields: clearing each raises a chip **and** outlines the control the chip names. Mutation-checked — with the two inputs removed, exactly `batchSize`/`gradientAccumulation` fail and the other six pass, so it genuinely catches the defect rather than passing on a happy path.

Full web suite green (1622), eslint clean on all four changed files. Merged `origin/main` (ControlNet training work) before opening; clean auto-merge.

Shortcut: [sc-10689](https://app.shortcut.com/trefry/story/10689) (epic 10644).

🤖 Generated with [Claude Code](https://claude.com/claude-code)