### PR TITLE
feat(worker): read the ComfyUI Wan UMT5 TE + VAE in place (sc-10909, epic 10451)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-gen",
  "image",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -713,7 +713,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -738,7 +738,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -790,7 +790,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-gen",
  "image",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -713,7 +713,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -738,7 +738,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -790,7 +790,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0dd5b787a1adfba49e9cc6303b7806773852065e#0dd5b787a1adfba49e9cc6303b7806773852065e"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",

--- a/apps/rust-api/src/external_base_models.rs
+++ b/apps/rust-api/src/external_base_models.rs
@@ -425,9 +425,9 @@ fn assemble_wan_experts(
                 // sc-10909: fold the tree's UMT5 TE (a `t5` encoder — `required_text_encoders`) and an
                 // unambiguous VAE in as in-place components. Additive only; whichever is absent falls
                 // back to the snapshot tier at load, so completeness/runnability is unaffected.
-                if let Some(encoder) = text_encoders.iter().find(|encoder| {
-                    matches!(encoder.verdict(), Some((Some(fam), _, _)) if fam == "t5")
-                }) {
+                if let Some(encoder) = text_encoders.iter().find(
+                    |encoder| matches!(encoder.verdict(), Some((Some(fam), _, _)) if fam == "t5"),
+                ) {
                     components.push(encoder.component_json());
                 }
                 if let [only_vae] = vaes {
@@ -981,7 +981,10 @@ mod tests {
                 .join("umt5_xxl_fp8_e4m3fn_scaled.safetensors"),
             &umt5_scaled_te_keys(),
         );
-        write_safetensors(&root.join("vae").join("wan_2.1_vae.safetensors"), &vae_keys());
+        write_safetensors(
+            &root.join("vae").join("wan_2.1_vae.safetensors"),
+            &vae_keys(),
+        );
 
         let rows = scan(&[root]);
         assert_eq!(rows.len(), 1, "experts + TE + VAE → one MoE model");

--- a/apps/rust-api/src/external_base_models.rs
+++ b/apps/rust-api/src/external_base_models.rs
@@ -303,7 +303,9 @@ fn assemble_models(detected: Vec<DetectedFile>) -> Vec<Value> {
 
     // Wan2.2 is a dual-expert MoE (sc-10671): pair the high/low-noise transformer files into ONE model
     // (a single expert can't run), handled entirely here — the paired indices are then skipped below.
-    let (wan_rows, wan_consumed) = assemble_wan_experts(&detected, &mut used_ids);
+    // The tree's UMT5 TE + VAE are folded in when present (sc-10909), read in place like the experts.
+    let (wan_rows, wan_consumed) =
+        assemble_wan_experts(&detected, &text_encoders, &vaes, &mut used_ids);
     rows.extend(wan_rows);
 
     for (index, anchor) in detected.iter().enumerate() {
@@ -368,13 +370,20 @@ fn wan_component_json(file: &DetectedFile, role: &str) -> Value {
 }
 
 /// Pair Wan2.2 MoE transformer experts (sc-10671). Returns one row per pairing group — a **complete**
-/// model with both `transformer_high` + `transformer_low` components when both noise levels are present
-/// (snapshot-backed: UMT5 TE / VAE / tokenizer come from a resident tier, not the tree), or an
-/// **incomplete** unusable row per lone expert when its sibling is missing. Also returns the set of
-/// `detected` indices consumed, so `assemble_models` skips them (a single Wan expert must never fall to
-/// the snapshot-backed single-transformer path, which would wrongly mark it runnable).
+/// model with both `transformer_high` + `transformer_low` components when both noise levels are present,
+/// or an **incomplete** unusable row per lone expert when its sibling is missing. Also returns the set
+/// of `detected` indices consumed, so `assemble_models` skips them (a single Wan expert must never fall
+/// to the snapshot-backed single-transformer path, which would wrongly mark it runnable).
+///
+/// The tree's **UMT5 text encoder** (a `t5` encoder, itself scaled-fp8) and **VAE** are folded into the
+/// complete row as `text_encoder` / `vae` components when present (sc-10909) — the worker then reads
+/// them in place (scaled-fp8 dequant / native-key remap) instead of the snapshot tier. This is purely
+/// additive: the tiny tokenizer (and either component when absent) still comes from the resident
+/// snapshot, so the row is `complete` and runnable regardless of whether the TE/VAE were folded.
 fn assemble_wan_experts(
     detected: &[DetectedFile],
+    text_encoders: &[&DetectedFile],
+    vaes: &[&DetectedFile],
     used_ids: &mut HashSet<String>,
 ) -> (Vec<Value>, HashSet<usize>) {
     // Group the wan-video transformers by their pairing base (the name with the high/low token
@@ -409,10 +418,21 @@ fn assemble_wan_experts(
             // Both experts present → one complete MoE model (runnable at scaled_fp8_companion).
             (Some(high), Some(low)) => {
                 let anchor = &detected[high];
-                let components = vec![
+                let mut components = vec![
                     wan_component_json(anchor, "transformer_high"),
                     wan_component_json(&detected[low], "transformer_low"),
                 ];
+                // sc-10909: fold the tree's UMT5 TE (a `t5` encoder — `required_text_encoders`) and an
+                // unambiguous VAE in as in-place components. Additive only; whichever is absent falls
+                // back to the snapshot tier at load, so completeness/runnability is unaffected.
+                if let Some(encoder) = text_encoders.iter().find(|encoder| {
+                    matches!(encoder.verdict(), Some((Some(fam), _, _)) if fam == "t5")
+                }) {
+                    components.push(encoder.component_json());
+                }
+                if let [only_vae] = vaes {
+                    components.push(only_vae.component_json());
+                }
                 let id = unique_id(&anchor.name, used_ids);
                 rows.push(finish_row(
                     id,
@@ -745,6 +765,23 @@ mod tests {
             ("decoder.up.0.block.0.conv1.weight", "F32"),
         ]
     }
+    /// A ComfyUI UMT5-XXL text encoder (`text_encoders/umt5_xxl_fp8_e4m3fn_scaled`): T5 encoder keys +
+    /// a `.scale_weight` companion → detector `(t5, text_encoder, scaled_fp8_companion)`.
+    fn umt5_scaled_te_keys() -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("shared.weight", "F32"),
+            ("encoder.block.0.layer.0.SelfAttention.q.weight", "F8_E4M3"),
+            (
+                "encoder.block.0.layer.0.SelfAttention.q.scale_weight",
+                "F32",
+            ),
+            (
+                "encoder.block.0.layer.1.DenseReluDense.wi_0.weight",
+                "F8_E4M3",
+            ),
+            ("encoder.final_layer_norm.weight", "F32"),
+        ]
+    }
 
     fn models_root(temp: &Path) -> PathBuf {
         temp.join("ComfyUI").join("models")
@@ -917,6 +954,51 @@ mod tests {
             .collect();
         assert!(roles.contains(&"transformer_high"));
         assert!(roles.contains(&"transformer_low"));
+    }
+
+    #[test]
+    fn wan_moe_folds_in_tree_umt5_te_and_vae() {
+        // sc-10909: a complete MoE pair + the tree's UMT5 TE (t5, scaled-fp8) + one VAE → both are
+        // folded in as in-place `text_encoder` / `vae` components (worker reads them in place). Still
+        // complete + runnable (the tokenizer stays snapshot-sourced).
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = models_root(temp.path());
+        write_safetensors(
+            &root
+                .join("unet")
+                .join("wan2.2_t2v_high_noise_14B_fp8_scaled.safetensors"),
+            &wan_expert_scaled_fp8_keys(),
+        );
+        write_safetensors(
+            &root
+                .join("unet")
+                .join("wan2.2_t2v_low_noise_14B_fp8_scaled.safetensors"),
+            &wan_expert_scaled_fp8_keys(),
+        );
+        write_safetensors(
+            &root
+                .join("text_encoders")
+                .join("umt5_xxl_fp8_e4m3fn_scaled.safetensors"),
+            &umt5_scaled_te_keys(),
+        );
+        write_safetensors(&root.join("vae").join("wan_2.1_vae.safetensors"), &vae_keys());
+
+        let rows = scan(&[root]);
+        assert_eq!(rows.len(), 1, "experts + TE + VAE → one MoE model");
+        let row = &rows[0];
+        assert_eq!(row["family"], "wan-video");
+        assert_eq!(row["assembly"], "complete");
+        assert_eq!(row["usable"], true);
+        let components = row["components"].as_array().unwrap();
+        let roles: Vec<&str> = components
+            .iter()
+            .map(|c| c["role"].as_str().unwrap())
+            .collect();
+        assert!(roles.contains(&"transformer_high"));
+        assert!(roles.contains(&"transformer_low"));
+        // The TE + VAE ride along as in-place components (worker reads them in place, sc-10909).
+        assert!(roles.contains(&"text_encoder"), "roles: {roles:?}");
+        assert!(roles.contains(&"vae"), "roles: {roles:?}");
     }
 
     #[test]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1606,15 +1606,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df9
 # resolves the SINGLE gen-core rev `4df97dce` (skew gate green, lock diff candle-gen-only). ALL candle-gen-*
 # move together. GPU-validated (sm_120, Qwen-Image-2512 1024²/8-step, spec-driven offload_policy=Sequential):
 # resident 82,511 -> sequential 71,655 MiB (-10.6 GB, Qwen2.5-VL reclaimed), output byte-identical.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1628,7 +1628,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1636,17 +1636,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1656,7 +1656,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1664,21 +1664,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1687,17 +1687,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1706,7 +1706,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1739,7 +1739,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1748,12 +1748,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1761,7 +1761,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1770,7 +1770,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1778,7 +1778,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1792,7 +1792,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1819,7 +1819,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1830,7 +1830,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1606,15 +1606,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df9
 # resolves the SINGLE gen-core rev `4df97dce` (skew gate green, lock diff candle-gen-only). ALL candle-gen-*
 # move together. GPU-validated (sm_120, Qwen-Image-2512 1024²/8-step, spec-driven offload_policy=Sequential):
 # resident 82,511 -> sequential 71,655 MiB (-10.6 GB, Qwen2.5-VL reclaimed), output byte-identical.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1628,7 +1628,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1636,17 +1636,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1656,7 +1656,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1664,21 +1664,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1687,17 +1687,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1706,7 +1706,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1739,7 +1739,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1748,12 +1748,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1761,7 +1761,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1770,7 +1770,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1778,7 +1778,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1792,7 +1792,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1819,7 +1819,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1830,7 +1830,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0dd5b787a1adfba49e9cc6303b7806773852065e", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -3697,8 +3697,9 @@ fn scail2_adapters_have_lightning(adapters: &[AdapterSpec]) -> bool {
 /// In-place ComfyUI Wan2.2 A14B experts for the sc-10671 base lane (epic 10451 Phase 2c). When set on a
 /// [`VideoGenInput`], [`generate_video`] builds the two experts from these files (key remap +
 /// scaled-fp8 dequant, `candle_gen_wan::load_from_comfyui_experts`) via the uncached bespoke load path
-/// instead of the registry snapshot; the UMT5 TE / VAE / tokenizer still come from `model_dir` (a
-/// resident Wan snapshot tier). Read in place, never copied.
+/// instead of the registry snapshot. The UMT5 TE + VAE are read in place too when `te_file` / `vae_file`
+/// are set (sc-10909), else they come from `model_dir` (a resident Wan snapshot tier); the tiny
+/// tokenizer always comes from `model_dir`. Read in place, never copied.
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
@@ -3713,6 +3714,12 @@ struct ComfyuiWanExperts {
     high_file: PathBuf,
     /// The low-noise expert file (ComfyUI `*_low_noise_*`), read in place → candle `transformer_2/`.
     low_file: PathBuf,
+    /// The UMT5-XXL text encoder (`umt5_xxl_fp8_e4m3fn_scaled`, companion scaled-fp8), read in place
+    /// when present (sc-10909); `None` ⇒ the snapshot `text_encoder/`.
+    te_file: Option<PathBuf>,
+    /// The Wan VAE (`wan_2.1_vae.safetensors`, native WAN-VAE keys), read in place when present
+    /// (sc-10909); `None` ⇒ the snapshot `vae/`.
+    vae_file: Option<PathBuf>,
     /// I2V (channel-concat) vs T2V — selects the Wan config (`patch_embedding` in-channels differ).
     i2v: bool,
 }
@@ -4213,6 +4220,8 @@ async fn generate_video(
             (
                 e.high_file.clone(),
                 e.low_file.clone(),
+                e.te_file.clone(),
+                e.vae_file.clone(),
                 input.model_dir.clone(),
                 e.i2v,
             )
@@ -4231,11 +4240,11 @@ async fn generate_video(
             };
             #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
             let result = match comfyui_load {
-                Some((high, low, snapshot, i2v)) => {
+                Some((high, low, te, vae, snapshot, i2v)) => {
                     crate::generator_cache::with_uncached_generator(
                         move || {
                             candle_gen_wan::wan14b::load_from_comfyui_experts(
-                                high, low, snapshot, i2v,
+                                high, low, te, vae, snapshot, i2v,
                             )
                             .map_err(|error| {
                                 crate::classify_engine_error("video load failed", error)
@@ -5204,9 +5213,11 @@ async fn generate_candle_video(
 // Candle (Windows/CUDA) in-place ComfyUI Wan2.2 base generation (epic 10451 Phase 2c, sc-10671): the
 // video sibling of the z-image/qwen ComfyUI base image lanes. Reads a user's two ComfyUI Wan A14B
 // expert files in place (native-Wan keys + companion scaled-fp8), remapped + dequant'd off-Mac via
-// `candle_gen_wan::load_from_comfyui_experts`, and sources the UMT5 TE / VAE / tokenizer from a resident
-// `SceneWorks/wan2.2-*-candle` snapshot tier. T2V only for now (I2V's channel-concat reference
-// conditioning is a follow-up); the model id is an `external_base_*` catalog row.
+// `candle_gen_wan::load_from_comfyui_experts`. The UMT5 TE + VAE are read in place too when the tree
+// carries them (sc-10909, folded into `components[]` by the API); the tokenizer (and either component
+// when absent) comes from a resident `SceneWorks/wan2.2-*-candle` snapshot tier. T2V only for now
+// (I2V's channel-concat reference conditioning is a follow-up); the model id is an `external_base_*`
+// catalog row.
 // ---------------------------------------------------------------------------
 
 /// The candle Wan2.2 T2V-A14B engine id the ComfyUI base experts load into.
@@ -5232,11 +5243,17 @@ const WAN_COMFYUI_SNAPSHOT_TIERS: &[&str] = &["q8", "q4", "bf16"];
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const WAN_T2V_IN_CHANNELS: u64 = 16;
 
-/// The two in-place ComfyUI expert files + the resident snapshot tier supplying TE/VAE/tokenizer.
+/// The two in-place ComfyUI expert files + the resident snapshot tier, plus the optional in-place UMT5
+/// TE / VAE files (sc-10909). The snapshot tier always supplies the tokenizer (and the TE/VAE when their
+/// files are absent).
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 struct ComfyuiWanPaths {
     high: PathBuf,
     low: PathBuf,
+    /// In-place UMT5 TE (`text_encoder` component), confined; `None` ⇒ snapshot `text_encoder/`.
+    te: Option<PathBuf>,
+    /// In-place Wan VAE (`vae` component), confined; `None` ⇒ snapshot `vae/`.
+    vae: Option<PathBuf>,
     snapshot_dir: PathBuf,
 }
 
@@ -5328,9 +5345,24 @@ fn resolve_wan_comfyui_paths(
     if wan_expert_in_channels(&high) != Some(WAN_T2V_IN_CHANNELS) {
         return Ok(None);
     }
+    // Optional in-place UMT5 TE + Wan VAE (sc-10909): the API folds them into `components[]` as
+    // `text_encoder` / `vae` when the tree carries them; each is confined like the experts. Absent ⇒
+    // `None` ⇒ the resident snapshot tier supplies that component (the row is complete either way).
+    let te = path_for("text_encoder")
+        .map(|te| {
+            crate::paths::normalize_app_managed_model_path(settings, te, "ComfyUI Wan UMT5 encoder")
+        })
+        .transpose()?;
+    let vae = path_for("vae")
+        .map(|vae| {
+            crate::paths::normalize_app_managed_model_path(settings, vae, "ComfyUI Wan VAE")
+        })
+        .transpose()?;
     Ok(Some(ComfyuiWanPaths {
         high,
         low,
+        te,
+        vae,
         snapshot_dir,
     }))
 }
@@ -5367,8 +5399,9 @@ async fn generate_candle_wan_comfyui(
     })?;
     let input = VideoGenInput {
         engine_id: WAN_COMFYUI_T2V_ENGINE,
-        // The snapshot tier supplies the UMT5 TE / VAE / tokenizer (and the metrics `model_dir`); the
-        // experts are read in place via `comfyui` below.
+        // The snapshot tier supplies the tokenizer (and the metrics `model_dir`, and the UMT5 TE / VAE
+        // when their tree files are absent); the experts — and the TE/VAE when present — are read in
+        // place via `comfyui` below (sc-10909).
         model_dir: paths.snapshot_dir.clone(),
         prompt: request.prompt.clone(),
         negative_prompt: non_empty_negative_prompt(request),
@@ -5385,6 +5418,8 @@ async fn generate_candle_wan_comfyui(
         comfyui: Some(ComfyuiWanExperts {
             high_file: paths.high,
             low_file: paths.low,
+            te_file: paths.te,
+            vae_file: paths.vae,
             i2v: false,
         }),
         ..VideoGenInput::default()

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -5354,9 +5354,7 @@ fn resolve_wan_comfyui_paths(
         })
         .transpose()?;
     let vae = path_for("vae")
-        .map(|vae| {
-            crate::paths::normalize_app_managed_model_path(settings, vae, "ComfyUI Wan VAE")
-        })
+        .map(|vae| crate::paths::normalize_app_managed_model_path(settings, vae, "ComfyUI Wan VAE"))
         .transpose()?;
     Ok(Some(ComfyuiWanPaths {
         high,


### PR DESCRIPTION
Follow-up to sc-10671 (the in-place ComfyUI Wan2.2 A14B lane read only the two DiT experts in place; the UMT5 TE / VAE / tokenizer came from a resident `SceneWorks/wan2.2-*-candle` snapshot tier). This wires the candle-gen sc-10909 change so the tree's **UMT5 text encoder** and **Wan VAE** are read in place too — a Wan T2V generation is then sourced entirely from the user's ComfyUI tree plus our tiny tokenizer.

Pairs with candle-gen [#402](https://github.com/SceneWorks/candle-gen/pull/402) (re-pinned here: `2eb0389` → `0dd5b78`; candle-gen-only, gen-core unchanged).

## API (`external_base_models.rs`)
- `assemble_wan_experts` now folds the tree's UMT5 TE (a `t5` encoder, per `required_text_encoders("wan-video")`) and an unambiguous VAE into the complete MoE row as `text_encoder` / `vae` components — the same additive posture sc-10830 gave the qwen VAE. Purely additive: the tokenizer (and either component when absent) stays snapshot-sourced, so the row is `complete`/runnable regardless.

## Worker (`video_jobs.rs`)
- `resolve_wan_comfyui_paths` resolves the optional `text_encoder` / `vae` components, each confined by `normalize_app_managed_model_path` like the experts, into `ComfyuiWanPaths { te, vae }`.
- Threaded through `ComfyuiWanExperts { te_file, vae_file }` into the 6-arg `candle_gen_wan::wan14b::load_from_comfyui_experts(high, low, te, vae, snapshot, i2v)`; each component falls back to the snapshot tier when its file is absent.

## Tests
- `wan_moe_folds_in_tree_umt5_te_and_vae` — a complete expert pair + a tree UMT5 TE + VAE → both fold in as `text_encoder`/`vae` components, row stays complete + usable.
- Existing `external_base_models` tests green; worker `--features backend-candle` clippy `-D warnings` clean + test build green.

Real-weight GPU validation to follow (needs a real ComfyUI Wan tree on the box). Relates sc-10671, sc-10830, sc-10908.

🤖 Generated with [Claude Code](https://claude.com/claude-code)