### PR TITLE
chore(worker): pin candle-gen 5770c0b — ship the flux diffusers-tier AdaLN output-head fix (sc-10973)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-gen",
  "image",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -713,7 +713,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -738,7 +738,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -790,7 +790,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=2eb03893d154fb35ac42fc1eb304052057fb404e#2eb03893d154fb35ac42fc1eb304052057fb404e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5770c0bdb64d0e21e338cd3c6a59804712f2ff7d#5770c0bdb64d0e21e338cd3c6a59804712f2ff7d"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1606,15 +1606,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df9
 # resolves the SINGLE gen-core rev `4df97dce` (skew gate green, lock diff candle-gen-only). ALL candle-gen-*
 # move together. GPU-validated (sm_120, Qwen-Image-2512 1024²/8-step, spec-driven offload_policy=Sequential):
 # resident 82,511 -> sequential 71,655 MiB (-10.6 GB, Qwen2.5-VL reclaimed), output byte-identical.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1628,7 +1628,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1636,17 +1636,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1656,7 +1656,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1664,21 +1664,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1687,17 +1687,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1706,7 +1706,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1739,7 +1739,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1748,12 +1748,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1761,7 +1761,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1770,7 +1770,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1778,7 +1778,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1792,7 +1792,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1819,7 +1819,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1830,7 +1830,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2eb03893d154fb35ac42fc1eb304052057fb404e", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5770c0bdb64d0e21e338cd3c6a59804712f2ff7d", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with


### PR DESCRIPTION
Deploy step for [sc-10914](https://app.shortcut.com/trefry/story/10914) / [sc-10973](https://app.shortcut.com/trefry/story/10973).

Bumps all 27 `candle-gen*` pins **2eb0389 → 5770c0b** — the [candle-gen #403](https://github.com/SceneWorks/candle-gen/pull/403) merge that fixes the diffusers packed-DiT `OutputHead` scale/shift swap. The worker's live candle flux1 diffusers tiers (**q4/q8**, `SceneWorks/flux1-*-mlx`, routed via `standard_tier_subdir`) rendered a per-2×2-patch magenta grid at all resolutions; the pinned rev reads the `AdaLayerNormContinuous` output head scale-first.

## Scope
`5770c0b` is candle-gen main **before** #402 (wan sc-10909), so this is a **flux-only** bump — no wan changes, no overlap with sc-10909's own pin bump (#1406). Diff to current pin is exactly `candle-gen-flux/src/packed_dit.rs`.

## Skew checks
- `git diff` touches only `crates/sceneworks-worker/Cargo.toml` + `Cargo.lock`.
- `Cargo.lock` diff changes only candle-gen source lines.
- Exactly one `mlx-gen?rev=` (`4df97dc`, **unchanged** — no gen-core skew) and one candle-gen rev (`5770c0b`).
- `cargo metadata --locked` green.

## Validation
The pinned `candle-gen-flux` is byte-identical to the fix already GPU-validated on RTX PRO 6000 (q8 tier, 512², seed 42): pre-VAE latent checkerboard-projection 0.46 → 0.007 (stock 0.006), q8↔BFL latent correlation 0.44 → 0.97, render clean. Parity CI (`rust:check`) will confirm the pin compiles/links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)