### PR TITLE
feat(worker): measure candle Qwen-Image packed-tier sequential peaks → reject when even sequential won't fit (sc-10969)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -483,14 +483,25 @@
           "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
         }
       },
-      // candle/CUDA VRAM gate (sc-9094, epic 9083) — MEASURED on an RTX PRO 6000 (Blackwell sm_120) at
-      // 1024²/10-step via the candle-gen nvidia-smi peak monitor: q4 packed overall-peak 56.3 GB (the
-      // 20B DiT + Qwen2.5-VL TE + Qwen-Image VAE; the heaviest measured image tier). minMemoryGb 64
-      // covers it with headroom; q8/bf16 ESTIMATED (~66 / ~80 GB) pending measurement.
+      // candle/CUDA VRAM gate (epic 10765 sc-10969, superseding the sc-9094 estimate) — MEASURED on an
+      // RTX PRO 6000 (Blackwell sm_120) at 1024²/8-step via the candle-gen-qwen-image offload A/B harness
+      // (qwen_image_probed_generate_for_offload_ab, device-level nvidia-smi peak on an idle GPU 0), pointed
+      // at each staged `SceneWorks/qwen-image-mlx` tier. Two peaks per tier: `vramGbByTier` = RESIDENT
+      // (Qwen2.5-VL TE + 20B DiT + Qwen-Image VAE co-resident, the default cross-request-cached path);
+      // `sequentialPeakGb` = SEQUENTIAL residency (the ~8 GB Qwen2.5-VL text encoder + its f32 activations
+      // dropped before the DiT loads, sc-10867) — always lower, and the resident/sequential pixels are
+      // byte-identical (q4 sha 7ba5d5d2…, q8 sha 533f81b0…). The fit-gate compares the resident peak
+      // against free VRAM to choose sequential-offload vs reject, then (sc-10856) REJECTS if even the
+      // sequential peak won't fit rather than run into a reactive OOM. minMemoryGb 56 gates the DEFAULT
+      // (q4) tier with headroom (q4 resident 53.7 GB). All three hosted tiers load via the diffusers
+      // packed-detect path (a `quantization` block in transformer/config.json for q4/q8; bf16 is dense-
+      // readable by the candle Qwen loader, unlike FLUX). bf16 resident/sequential from the sc-10867 GPU
+      // A/B on the same harness.
       "candle": {
-        "minMemoryGb": 64,
-        "vramGbByTier": { "q4": 56.3, "q8": 66.0, "bf16": 80.0 },
-        "measured": false
+        "minMemoryGb": 56,
+        "vramGbByTier": { "q4": 53.7, "q8": 65.3, "bf16": 82.5 },
+        "sequentialPeakGb": { "q4": 30.3, "q8": 38.7, "bf16": 71.7 },
+        "measured": true
       },
       "ui": {
         "label": "Qwen Image",


### PR DESCRIPTION
## What

Populates the `qwen_image` **candle** block in `builtin.models.jsonc` with MEASURED resident + sequential VRAM peaks, so the epic-10765 fit-gate is **proactive** for Qwen-Image off-Mac (reject-before-OOM) instead of falling back to the reactive-OOM backstop. The qwen-image sibling of [sc-10856](https://app.shortcut.com/trefry/story/10856) (FLUX measure pattern).

Qwen already carried a `candle` block (from sc-9094), so unlike FLUX the resident gate was already active — this story adds the missing `sequentialPeakGb`, flips `measured` → true, and refreshes the resident numbers off a fresh 8-step measurement.

## Measurements

RTX PRO 6000 (Blackwell sm_120), **idle GPU 0**, 1024²/8-step, via the candle-gen-qwen-image offload A/B harness (`qwen_image_probed_generate_for_offload_ab`, `CANDLE_GEN_OFFLOAD`/`QWEN_OFFLOAD_MODE=spec-sequential`, device-level nvidia-smi peak). Two **separate processes** per tier — cudarc's caching allocator never returns pages, so a same-process second run would read the first run's peak. Tiers staged (hardlinked past HF blob symlinks) from `SceneWorks/qwen-image-mlx`.

| tier | resident | sequential | Δ | resident/seq pixel parity |
|------|----------|-----------|-----|------|
| q4   | 53.7 GB  | 30.3 GB   | −23.5 | byte-identical (`7ba5d5d2…`) |
| q8   | 65.3 GB  | 38.7 GB   | −26.6 | byte-identical (`533f81b0…`) |
| bf16 | 82.5 GB  | 71.7 GB   | −10.8 | (sc-10867 GPU A/B, same harness) |

Sequential residency drops the ~8 GB Qwen2.5-VL text encoder + its f32 activations before the DiT loads (sc-10867). Both renders validated as coherent images ("a rusty robot holding a lit candle"). Measured q4 53.7 supersedes the sc-9094 10-step 56.3 estimate; measured q8 65.3 confirms the prior 66.0 estimate.

## Gate wiring

Pure **data** change — the `vram_gate` machinery (`predicted_sequential_peak_gb` / `sequential_overflow_gb`, the `FitDecision::Offload` second-stage reject) already exists from sc-10856, and the schema already defines `candle.sequentialPeakGb`. No new gate code.

## Validation

- `node scripts/check-scaffold.mjs` green (validates the manifest against `model-manifest.schema.json`).
- No test hardcodes the prior qwen candle values.

Relates: sc-10867 (qwen sequential path), sc-10856 (FLUX measure pattern + the `sequentialPeakGb` schema/gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)