### PR TITLE
chore(docker): chain HF cache bind-mount default to HF_HOME

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,10 +57,18 @@ SCENEWORKS_CONFIG_BIND=./config
 SCENEWORKS_UID=1000
 SCENEWORKS_GID=1000
 
-# Host path bind-mounted as the Hugging Face cache. Defaults to the user's
-# standard HF cache (%USERPROFILE%\.cache\huggingface on Windows, $HOME/.cache/
-# huggingface on Linux/macOS) so models are shared with other HF tools instead
-# of re-downloaded into the repo. Override for an isolated/alternate cache.
+# Host path bind-mounted as the Hugging Face cache, shared with other HF tools
+# instead of re-downloaded into the repo. Resolution order (first set wins):
+#   1. SCENEWORKS_HF_CACHE_BIND (this var) — explicit override
+#   2. HF_HOME — the same cache root native tools use, so one OS-level var drives
+#      both. Set HF_HOME once (e.g. E:\huggingface) and Docker follows it.
+#   3. the platform default (%USERPROFILE%\.cache\huggingface on Windows,
+#      $HOME/.cache/huggingface on Linux/macOS)
+# NOTE: the value must be a path valid for YOUR Docker engine's mount syntax.
+# Docker Desktop on Windows/PowerShell accepts a Windows path (E:\huggingface);
+# under WSL2 the source must be the Linux view of that drive (/mnt/e/huggingface).
+# If HF_HOME holds a Windows path but you run compose from WSL2, set this var
+# explicitly to the /mnt/... form rather than relying on the HF_HOME fallback.
 SCENEWORKS_HF_CACHE_BIND=
 
 # Optional API metadata and storage overrides.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - "${SCENEWORKS_API_PUBLISH_HOST:-127.0.0.1}:${SCENEWORKS_API_PORT:-8010}:${SCENEWORKS_API_PORT:-8010}"
     volumes:
       - ${SCENEWORKS_DATA_BIND:-./data}:/sceneworks/data
-      - ${SCENEWORKS_HF_CACHE_BIND:-${USERPROFILE:-$HOME}/.cache/huggingface}:/sceneworks/data/cache/huggingface
+      - ${SCENEWORKS_HF_CACHE_BIND:-${HF_HOME:-${USERPROFILE:-$HOME}/.cache/huggingface}}:/sceneworks/data/cache/huggingface
       - ${SCENEWORKS_CONFIG_BIND:-./config}:/sceneworks/config
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS \"http://127.0.0.1:$${SCENEWORKS_API_PORT:-8010}/api/v1/health\" >/dev/null"]
@@ -82,7 +82,7 @@ services:
       NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
     volumes:
       - ${SCENEWORKS_DATA_BIND:-./data}:/sceneworks/data
-      - ${SCENEWORKS_HF_CACHE_BIND:-${USERPROFILE:-$HOME}/.cache/huggingface}:/sceneworks/data/cache/huggingface
+      - ${SCENEWORKS_HF_CACHE_BIND:-${HF_HOME:-${USERPROFILE:-$HOME}/.cache/huggingface}}:/sceneworks/data/cache/huggingface
       - ${SCENEWORKS_CONFIG_BIND:-./config}:/sceneworks/config
     depends_on:
       api:
@@ -128,7 +128,7 @@ services:
       NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
     volumes:
       - ${SCENEWORKS_DATA_BIND:-./data}:/sceneworks/data
-      - ${SCENEWORKS_HF_CACHE_BIND:-${USERPROFILE:-$HOME}/.cache/huggingface}:/sceneworks/data/cache/huggingface
+      - ${SCENEWORKS_HF_CACHE_BIND:-${HF_HOME:-${USERPROFILE:-$HOME}/.cache/huggingface}}:/sceneworks/data/cache/huggingface
       - ${SCENEWORKS_CONFIG_BIND:-./config}:/sceneworks/config
     depends_on:
       api:


### PR DESCRIPTION
## What

The compose HF cache bind-mount was already env-driven via `SCENEWORKS_HF_CACHE_BIND`, but its fallback pointed at `${USERPROFILE:-$HOME}/.cache/huggingface`. This chains that fallback through `HF_HOME` so a single OS-level `HF_HOME` drives both native HF tooling and the Docker stack.

New resolution order (first set wins):
1. `SCENEWORKS_HF_CACHE_BIND` — explicit override
2. `HF_HOME` — the same cache root native tools use
3. platform default (`%USERPROFILE%\.cache\huggingface` / `$HOME/.cache/huggingface`)

## Why

Relocating the HF cache (e.g. to a larger drive) previously required repointing `HF_HOME` for native tools **and** separately setting `SCENEWORKS_HF_CACHE_BIND` for Docker. Now setting `HF_HOME` once is enough; the explicit var remains for cases where the Docker bind path must differ from the native path (e.g. `/mnt/e/huggingface` when running compose from WSL2 while `HF_HOME` holds a Windows path).

## Verification

- `docker compose config` resolves the worker HF bind source to `E:\huggingface` when `HF_HOME=E:\huggingface`, and to the explicit value when `SCENEWORKS_HF_CACHE_BIND` is set (override wins).
- Container-internal `HF_HOME` and all mount targets are unchanged, so `check-compose-config.mjs` still passes.

## Notes

- `.env.example` ships `SCENEWORKS_HF_CACHE_BIND=` empty (behavior for existing users is unchanged); docs updated to describe the resolution order and the WSL2 path caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)