### PR TITLE
feat(worker): MLX fit-gate selects sequential residency; pin-bump mlx-gen 3612d33 + candle-gen lockstep (sc-10839, epic 10834)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-gen",
  "image",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -713,7 +713,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -738,7 +738,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -790,7 +790,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -3674,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "image",
  "inventory",
@@ -3701,7 +3701,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "image",
  "inventory",
@@ -3715,7 +3715,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "image",
  "inventory",
@@ -3729,7 +3729,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3743,7 +3743,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3754,7 +3754,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3763,7 +3763,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3772,7 +3772,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3786,7 +3786,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3799,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3824,7 +3824,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3834,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "image",
  "inventory",
@@ -3847,7 +3847,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "image",
  "inventory",
@@ -3861,7 +3861,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "image",
  "inventory",
@@ -3875,7 +3875,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "image",
  "inventory",
@@ -3887,7 +3887,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3898,7 +3898,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3910,7 +3910,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3922,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3931,7 +3931,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3940,7 +3940,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3950,7 +3950,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "image",
  "inventory",
@@ -3977,7 +3977,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "image",
  "inventory",
@@ -3991,7 +3991,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4002,7 +4002,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4014,7 +4014,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4025,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "image",
  "inventory",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "image",
  "inventory",
@@ -5873,7 +5873,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4df97dcebc283f556e983289075119b21ccba459#4df97dcebc283f556e983289075119b21ccba459"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
 dependencies = [
  "core-llm",
  "inventory",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -534,7 +534,7 @@ sceneworks-core = { path = "../sceneworks-core" }
 # reports exactly one). NOTE: this bump FIXES a live bug — on 6a10ae1, every Anima LoRA/LoKr failed at
 # model load, because the worker defaults spec.quantize to Some(Q8) for every MLX model and mlx-gen-anima
 # rejected quant+adapter together. See test `anima_default_tier_with_adapter_builds_loadable_spec`.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -891,7 +891,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -907,23 +907,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc2
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -931,7 +931,7 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97d
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
 # mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
 # mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
@@ -939,7 +939,7 @@ mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dc
 # conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
 # DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
 # generator-cache load path drives.
-mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # Anima 2B anime t2i provider (native MLX, CircleStone Labs Non-Commercial License v1.2; epic 10512,
 # sc-10523). Same git rev as mlx-gen so MLX builds once. Self-registers `anima_base` / `anima_aesthetic`
 # / `anima_turbo` (Cosmos-Predict2 DiT + Qwen3-0.6B T5-query-token adapter conditioner + Qwen-Image VAE)
@@ -948,59 +948,59 @@ mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97d
 # scheduler (sc-10519) and strong prompt-weighting on the T5 query tokens (sc-10566). Carries the
 # install-time q4/q8/bf16 converter the model_jobs.rs Anima path drives (sc-10517). Pinned to merged
 # mlx-gen main 6a10ae1 (PR #680), which carries both the Anima crate and gen-core's is_hidden_file.
-mlx-gen-anima = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-anima = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -1009,19 +1009,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97d
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -1030,7 +1030,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -1038,7 +1038,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -1049,7 +1049,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df9
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -1060,7 +1060,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -1082,7 +1082,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97d
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -1093,7 +1093,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -1125,7 +1125,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df97dcebc283f556e983289075119b21ccba459" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1606,15 +1606,29 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df9
 # resolves the SINGLE gen-core rev `4df97dce` (skew gate green, lock diff candle-gen-only). ALL candle-gen-*
 # move together. GPU-validated (sm_120, Qwen-Image-2512 1024²/8-step, spec-driven offload_policy=Sequential):
 # resident 82,511 -> sequential 71,655 MiB (-10.6 GB, Qwen2.5-VL reclaimed), output byte-identical.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+# Bumped mlx-gen `4df97dce` -> `3612d333` + candle-gen `29ed1114` -> `ee5a7b5c` IN LOCKSTEP (sc-10839,
+# epic 10834): mlx-gen PR #692 adds SDXL + Z-Image sequential component residency (Residency enum; under
+# Sequential the text encoder is dropped after encode with a single clear_cache() at the phase boundary,
+# so peak = largest single component). PURE mlx-gen provider Rust (mlx-gen-sdxl + mlx-gen-z-image;
+# 3612d333 = mlx-gen main HEAD, also carrying unrelated mlx-gen-anima main work). `git diff
+# 4df97dce..3612d333 -- gen-core/ gen-core-testkit/` is EMPTY (gen-core BYTE-IDENTICAL), so candle-gen
+# compiles UNCHANGED. BUT unlike the sc-10867 entry above, byte-identical gen-core does NOT let candle-gen
+# stay put: the sc-4482 skew gate keys on the git REV, not content, so leaving candle-gen at `29ed1114`
+# (gen-core `4df97dce`) resolves TWO gen-core revs under `--features backend-candle` and turns the
+# desktop-windows + windows-candle PR lanes RED (verified by running check-gen-core-skew.sh — the earlier
+# "no candle re-pin" plan was wrong). candle-gen #404 (`ee5a7b5c`) re-pins candle-gen's own gen-core
+# `4df97dce` -> `3612d333` (byte-identical, candle builds nothing new), so both the default lane AND
+# `--features backend-candle --target all` now resolve the SINGLE gen-core rev `3612d333`. mlx-rs unchanged
+# (38e1cc1 — MLX core does not rebuild). ALL mlx-gen-* + candle-gen-* pins move together.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1628,7 +1642,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1636,17 +1650,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1656,7 +1670,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1664,21 +1678,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1687,17 +1701,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1706,7 +1720,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1739,7 +1753,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1748,12 +1762,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1761,7 +1775,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed1
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1770,7 +1784,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1778,7 +1792,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1792,7 +1806,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1819,7 +1833,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1830,7 +1844,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/generator_cache.rs
+++ b/crates/sceneworks-worker/src/generator_cache.rs
@@ -175,16 +175,14 @@ impl GeneratorCache {
     ) -> WorkerResult<R> {
         if self.entry.as_ref().map_or(true, |entry| entry.key != key) {
             self.entry = None;
-            // Pre-load unified-memory fit-gate (epic 10834 Phase 0, sc-10835): reject a model that
-            // can't fit this machine's unified memory BEFORE gen_core::load allocates — a wired
-            // overcommit SIGKILLs the worker mid-load rather than returning a catchable error. This
-            // is the cold-load path only (a warm cache hit takes the branch above and skips it), so
-            // an already-resident model is never re-gated.
-            let weight_bytes = match &spec.weights {
-                WeightsSource::Dir(dir) => crate::mlx_fit_gate::sum_safetensors_bytes(dir),
-                WeightsSource::File(file) => std::fs::metadata(file).map_or(0, |meta| meta.len()),
-            };
-            crate::mlx_fit_gate::ensure_fits(weight_bytes, &key.engine_id)?;
+            // Pre-load unified-memory fit-gate + residency selection (epic 10834; sc-10835 Phase 0,
+            // sc-10839 Phase 1): BEFORE gen_core::load allocates, either reject a model that can't fit
+            // this machine's unified memory (a wired overcommit SIGKILLs the worker mid-load rather
+            // than returning a catchable error) OR, for a provider that supports sequential component
+            // residency, select `OffloadPolicy::Sequential` when the resident sum won't fit but the
+            // staged max-single-component will. Cold-load path only (a warm cache hit takes the branch
+            // above and skips it), so an already-resident model is never re-gated.
+            let spec = crate::mlx_fit_gate::apply_residency_policy(spec, &key.engine_id)?;
             let generator = gen_core::load(&key.engine_id, &spec)
                 .map_err(|error| crate::classify_engine_error(&load_error_context, error))?;
             self.entry = Some(GeneratorCacheEntry {

--- a/crates/sceneworks-worker/src/mlx_fit_gate.rs
+++ b/crates/sceneworks-worker/src/mlx_fit_gate.rs
@@ -1,12 +1,18 @@
-//! MLX unified-memory pre-load fit-gate (epic 10834 Phase 0, sc-10835).
+//! MLX unified-memory pre-load fit-gate (epic 10834 Phase 0 sc-10835; Phase 1 residency selection
+//! sc-10839).
 //!
-//! The unified-memory sibling of the candle `vram_gate.rs` (epic 10765, sc-10766). Before an MLX
-//! generation loads, predict the model's whole-model peak footprint and compare it against the
-//! machine's unified-memory budget, so a Mac that cannot fit the model is rejected with an
-//! actionable message instead of being SIGKILL'd / Metal-OOM'd mid-render. Also honors
-//! [`MLX_MEMORY_CAP_ENV`], which emulates a smaller Mac on big hardware so the Phase 1 sequential
-//! residency work (sc-10839) can be validated on the dev box's 128 GB machine without 16/32 GB
-//! hardware.
+//! The unified-memory sibling of the candle `vram_gate.rs` (epic 10765, sc-10766/sc-10821). Before an
+//! MLX generation loads, predict the model's whole-model peak footprint and compare it against the
+//! machine's unified-memory budget. Three outcomes, mirroring the candle gate:
+//!  - **Fits** (or no signal) → load resident (the warm, cross-job path).
+//!  - **Won't fit resident, but the provider supports sequential component residency (sc-10839) and
+//!    the staged max-single-component peak WILL fit** → select [`OffloadPolicy::Sequential`] so the
+//!    engine drops the text encoder(s) before the DiT loads, bounding peak to the largest component.
+//!  - **Won't fit even staged** → reject with an actionable message instead of a SIGKILL / Metal-OOM
+//!    mid-render.
+//!
+//! Also honors [`MLX_MEMORY_CAP_ENV`], which emulates a smaller Mac on big hardware so the sequential
+//! residency selection can be validated on the dev box's 128 GB machine without 16/32 GB hardware.
 //!
 //! ## Why this budgets on PREDICTED (on-disk) bytes, not live allocator deltas
 //! MLX materializes weights lazily on first forward, so `get_active_memory()` reads ~0 right after
@@ -25,7 +31,21 @@
 use std::path::Path;
 use std::sync::OnceLock;
 
+use gen_core::{LoadSpec, OffloadPolicy, WeightsSource};
+
 use crate::{WorkerError, WorkerResult};
+
+/// The MLX engine ids whose provider honors [`OffloadPolicy::Sequential`] — the sc-10839 Phase 1
+/// providers (SDXL + Z-Image-turbo). The gate only SELECTS sequential residency for these; for any
+/// other engine `Sequential` would be a no-op (the advisory contract treats it as `Resident`), so
+/// predicting "it fits staged" and then holding everything resident would SIGKILL — hence the
+/// allowlist. Extended per family as the fan-out (sc-10840) wires each engine.
+const SEQUENTIAL_CAPABLE_ENGINES: &[&str] = &["sdxl", "z_image_turbo"];
+
+/// Whether `engine_id`'s provider drops components in phase order under [`OffloadPolicy::Sequential`].
+pub(crate) fn engine_supports_sequential(engine_id: &str) -> bool {
+    SEQUENTIAL_CAPABLE_ENGINES.contains(&engine_id)
+}
 
 /// Emulate a smaller Mac: force the total-unified-memory budget (GB). Set e.g.
 /// `SCENEWORKS_MLX_MEMORY_CAP_GB=16` to make the gate treat this machine as a 16 GB Mac, so a model
@@ -63,7 +83,18 @@ pub(crate) struct MemoryBudget {
 pub(crate) enum FitDecision {
     Unknown,
     Fits,
-    TooBig { needed_gb: f64, available_gb: f64 },
+    /// The predicted RESIDENT peak won't fit, but the provider supports sequential component residency
+    /// (sc-10839) — run with [`OffloadPolicy::Sequential`] instead of rejecting. Sequential peak is
+    /// always ≤ resident. The caller then runs the second-stage [`sequential_overflow_gb`] check and
+    /// rejects only if even the staged max-single-component peak won't fit.
+    Offload {
+        needed_gb: f64,
+        available_gb: f64,
+    },
+    TooBig {
+        needed_gb: f64,
+        available_gb: f64,
+    },
 }
 
 /// Read the small-Mac cap from the environment. `Some(gb)` only for a positive number.
@@ -106,6 +137,55 @@ pub(crate) fn fit_decision(needed_gb: Option<f64>, budget: Option<MemoryBudget>)
     }
 }
 
+/// Predicted SEQUENTIAL peak (GiB) = the largest single working set + [`HEADROOM_GB`] (sc-10839). The
+/// `Sequential` schedule drops the text encoder(s) before the DiT loads and keeps the tiny VAE
+/// co-resident with the DiT, so the peak is `max(text-encoders, everything-else) + headroom` rather
+/// than the resident sum. `everything-else = total − text_encoders` (the DiT + VAE + any control/IP).
+/// `None` when nothing was measured (`total == 0`). When the text encoders are unmeasured
+/// (`te_bytes == 0`) this equals the resident peak — no claimed saving, so the second-stage overflow
+/// check then rejects exactly as the resident gate would (the safe fallback).
+pub(crate) fn predicted_sequential_peak_gb(total_bytes: u64, te_bytes: u64) -> Option<f64> {
+    if total_bytes == 0 {
+        return None;
+    }
+    let rest_bytes = total_bytes.saturating_sub(te_bytes);
+    let staged_max = te_bytes.max(rest_bytes);
+    Some(staged_max as f64 / BYTES_PER_GIB + HEADROOM_GB)
+}
+
+/// Fold sequential-residency capability into a fit decision (sc-10839, mirroring the candle
+/// `vram_gate::resolve_offload`): a [`FitDecision::TooBig`] on a provider that drops components in
+/// phase order becomes [`FitDecision::Offload`] — load→use→drop so peak is the largest single
+/// component (≤ resident) rather than a reject. Every other outcome (Fits / Unknown / TooBig on a
+/// non-capable provider) is unchanged.
+pub(crate) fn resolve_offload(decision: FitDecision, sequential_capable: bool) -> FitDecision {
+    match decision {
+        FitDecision::TooBig {
+            needed_gb,
+            available_gb,
+        } if sequential_capable => FitDecision::Offload {
+            needed_gb,
+            available_gb,
+        },
+        other => other,
+    }
+}
+
+/// Second-stage gate for a [`FitDecision::Offload`] (sc-10839): sequential residency was selected
+/// because the RESIDENT peak won't fit, on the promise that the staged working set will. If the
+/// predicted staged peak ([`predicted_sequential_peak_gb`]) STILL exceeds the budget, return
+/// `Some(needed_gb)` so the caller rejects before load with an actionable message instead of a
+/// reactive Metal-OOM / SIGKILL. `None` (staged fits, or no budget) keeps the sequential run. Unlike
+/// the candle gate — where the sequential peak is only sometimes measured — the MLX staged peak is
+/// always derivable from the on-disk component split, so this check always applies.
+pub(crate) fn sequential_overflow_gb(
+    sequential_needed_gb: Option<f64>,
+    budget: Option<MemoryBudget>,
+) -> Option<f64> {
+    let (needed_gb, budget) = (sequential_needed_gb?, budget?);
+    (budget.total_gb + f64::EPSILON < needed_gb).then_some(needed_gb)
+}
+
 /// Sum the on-disk bytes of every `.safetensors` weight file under `dir` (recursively), following
 /// symlinks (the HF cache stores each shard as a symlink into `blobs/`). AppleDouble `._*` sidecars
 /// are skipped — they masquerade as `.safetensors` and would double-count (and corrupt globs, per
@@ -136,6 +216,32 @@ pub(crate) fn sum_safetensors_bytes(dir: &Path) -> u64 {
     }
     let mut total = 0;
     walk(dir, &mut total);
+    total
+}
+
+/// Sum the on-disk `.safetensors` bytes of the model's TEXT-ENCODER component(s) — the phase-A
+/// component the `Sequential` residency drops before the DiT loads (sc-10839). Matches the diffusers
+/// snapshot's top-level `text_encoder` / `text_encoder_2` / `text_encoder_*` subdirs (SDXL has both
+/// CLIP encoders; Z-Image the single Qwen encoder), reusing [`sum_safetensors_bytes`] per subdir so
+/// the HF-cache symlink + AppleDouble handling is shared. `0` if the dir is missing or has no
+/// recognizable text-encoder subdir — which makes the staged estimate fall back to the resident sum
+/// (no claimed saving), the safe direction.
+pub(crate) fn sum_text_encoder_bytes(dir: &Path) -> u64 {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    let mut total = 0;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !std::fs::metadata(&path).is_ok_and(|meta| meta.is_dir()) {
+            continue;
+        }
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name == "text_encoder" || name.starts_with("text_encoder_") {
+            total += sum_safetensors_bytes(&path);
+        }
+    }
     total
 }
 
@@ -170,39 +276,136 @@ fn sysctl_total_unified_memory_gib() -> Option<f64> {
     None
 }
 
-/// Pre-load admission gate: reject if the model's predicted peak won't fit the machine's
-/// unified-memory budget (or the [`MLX_MEMORY_CAP_ENV`] emulated budget). Called on the generator
-/// cache's cold-load path, before `gen_core::load` allocates — never on a warm cache hit, so an
-/// already-resident model is never re-gated. Any missing signal (probe failed, no cap, unmeasurable
-/// weights) ⇒ `Ok`, so the gate never blocks a machine that can actually fit the model.
-///
-/// `model_label` is a human-facing model name for the rejection message (the engine id).
-pub(crate) fn ensure_fits(weight_bytes: u64, model_label: &str) -> WorkerResult<()> {
-    let budget = resolve_budget(probe_total_unified_memory_gib(), mlx_memory_cap_gb());
-    fit_result(weight_bytes, budget, model_label)
+/// The residency-selection outcome (sc-10839) — the pure decision, split from the [`LoadSpec`]/IO so
+/// the whole three-way selection is deterministically unit-testable without the live probe or the
+/// `MLX_MEMORY_CAP_ENV` global. See [`decide_residency`].
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum ResidencyOutcome {
+    /// Fits resident (or no signal) — load with everything co-resident (the warm cross-job path).
+    Resident,
+    /// Won't fit resident but the provider stages components and the staged peak fits — load with
+    /// [`OffloadPolicy::Sequential`].
+    Sequential,
+    /// Won't fit even staged (or the provider can't stage) — reject. `staged_gb` is `Some` when the
+    /// staged path was attempted and still overflows (so the message can name it).
+    Reject {
+        needed_gb: f64,
+        available_gb: f64,
+        staged_gb: Option<f64>,
+    },
 }
 
-/// Map a fit decision to a worker result: `TooBig` → an actionable [`WorkerError::InvalidPayload`],
-/// else `Ok`. Split from [`ensure_fits`] so the rejection message is testable without the live probe
-/// or the `MLX_MEMORY_CAP_ENV` global.
-fn fit_result(
-    weight_bytes: u64,
+/// The pure residency decision: given the model's whole-model + text-encoder on-disk bytes, the
+/// (possibly emulated) budget, and whether the provider stages components, choose Resident /
+/// Sequential / Reject (sc-10839). No IO, no globals — the live [`apply_residency_policy`] resolves
+/// those and delegates here.
+pub(crate) fn decide_residency(
+    total_bytes: u64,
+    te_bytes: u64,
     budget: Option<MemoryBudget>,
-    model_label: &str,
-) -> WorkerResult<()> {
-    match fit_decision(predicted_peak_gb(weight_bytes), budget) {
+    sequential_capable: bool,
+) -> ResidencyOutcome {
+    let resident = fit_decision(predicted_peak_gb(total_bytes), budget);
+    match resolve_offload(resident, sequential_capable) {
+        FitDecision::Fits | FitDecision::Unknown => ResidencyOutcome::Resident,
+        FitDecision::Offload {
+            needed_gb,
+            available_gb,
+        } => {
+            // Second stage: reject if even the staged max-single-component peak won't fit.
+            let staged = predicted_sequential_peak_gb(total_bytes, te_bytes);
+            match sequential_overflow_gb(staged, budget) {
+                Some(_) => ResidencyOutcome::Reject {
+                    needed_gb,
+                    available_gb,
+                    staged_gb: staged,
+                },
+                None => ResidencyOutcome::Sequential,
+            }
+        }
         FitDecision::TooBig {
             needed_gb,
             available_gb,
-        } => Err(WorkerError::InvalidPayload(format!(
-            "{model_label} needs ~{needed} GB of unified memory (model weights plus headroom for \
-             activations and the OS) but this machine has ~{available} GB. Choose a smaller quant \
-             tier, lower the output resolution, or run on a Mac with more memory.",
-            needed = needed_gb.round() as i64,
-            available = available_gb.round() as i64,
-        ))),
-        FitDecision::Fits | FitDecision::Unknown => Ok(()),
+        } => ResidencyOutcome::Reject {
+            needed_gb,
+            available_gb,
+            staged_gb: None,
+        },
     }
+}
+
+/// Pre-load admission + residency-selection gate (sc-10835 Phase 0, sc-10839 Phase 1). Called on the
+/// generator cache's cold-load path, before `gen_core::load` allocates — never on a warm cache hit,
+/// so an already-resident model is never re-gated. Resolves the budget + on-disk component bytes,
+/// delegates the choice to [`decide_residency`], and returns the [`LoadSpec`] to load with:
+///  - fits resident (or no signal / unmeasurable weights) ⇒ the spec unchanged (warm resident path);
+///  - won't fit resident but the provider stages components and the staged peak fits ⇒ the spec with
+///    [`OffloadPolicy::Sequential`] set (drop the text encoder(s) before the DiT loads);
+///  - won't fit even staged ⇒ [`WorkerError::InvalidPayload`] with an actionable message.
+///
+/// `engine_id` is both the [`engine_supports_sequential`] key and the human-facing model name in the
+/// rejection message.
+pub(crate) fn apply_residency_policy(spec: LoadSpec, engine_id: &str) -> WorkerResult<LoadSpec> {
+    // Respect an offload policy already chosen upstream (defensive: the MLX cache seam normally sees
+    // the default `Resident`, but never downgrade a `Sequential` set by another gate).
+    if spec.offload_policy == OffloadPolicy::Sequential {
+        return Ok(spec);
+    }
+    let budget = resolve_budget(probe_total_unified_memory_gib(), mlx_memory_cap_gb());
+    let (total_bytes, te_bytes) = match &spec.weights {
+        WeightsSource::Dir(dir) => (sum_safetensors_bytes(dir), sum_text_encoder_bytes(dir)),
+        // A single-file source has no component split to stage — resident-or-reject only.
+        WeightsSource::File(file) => (std::fs::metadata(file).map_or(0, |meta| meta.len()), 0),
+    };
+    match decide_residency(
+        total_bytes,
+        te_bytes,
+        budget,
+        engine_supports_sequential(engine_id),
+    ) {
+        ResidencyOutcome::Resident => Ok(spec),
+        ResidencyOutcome::Sequential => {
+            tracing::info!(
+                event = "mlx_sequential_residency_selected",
+                engine = %engine_id,
+                total_gb = (total_bytes as f64 / BYTES_PER_GIB).round() as i64,
+                text_encoder_gb = (te_bytes as f64 / BYTES_PER_GIB).round() as i64,
+                budget_gb = budget.map(|b| b.total_gb.round() as i64),
+            );
+            Ok(spec.with_offload_policy(OffloadPolicy::Sequential))
+        }
+        ResidencyOutcome::Reject {
+            needed_gb,
+            available_gb,
+            staged_gb,
+        } => Err(too_big_error(engine_id, needed_gb, available_gb, staged_gb)),
+    }
+}
+
+/// Build the actionable over-budget rejection. `staged_gb` is `Some` when sequential residency was
+/// tried and its staged peak still overflows (so the message names both the resident and the staged
+/// requirement — telling the user even one-component-at-a-time won't fit); `None` for a plain resident
+/// reject on a non-staging provider. Split out so the message is testable without the live probe.
+fn too_big_error(
+    model_label: &str,
+    needed_gb: f64,
+    available_gb: f64,
+    staged_gb: Option<f64>,
+) -> WorkerError {
+    let staged_note = match staged_gb {
+        Some(staged) => format!(
+            " (~{} GB even loading one component at a time)",
+            staged.round() as i64
+        ),
+        None => String::new(),
+    };
+    WorkerError::InvalidPayload(format!(
+        "{model_label} needs ~{needed} GB of unified memory{staged_note} (model weights plus \
+         headroom for activations and the OS) but this machine has ~{available} GB. Choose a \
+         smaller quant tier, lower the output resolution, or run on a Mac with more memory.",
+        needed = needed_gb.round() as i64,
+        available = available_gb.round() as i64,
+    ))
 }
 
 #[cfg(test)]
@@ -303,30 +506,186 @@ mod tests {
     }
 
     #[test]
-    fn fit_result_rejects_over_budget_with_an_actionable_message() {
-        // qwen-image q8 ≈ 36 GiB of weights ⇒ predicted ~46 GB; a 16 GB Mac can't fit it.
-        let bytes = 36 * 1024 * 1024 * 1024_u64;
-        let error = fit_result(bytes, Some(MemoryBudget { total_gb: 16.0 }), "qwen-image")
-            .expect_err("an over-budget model must be rejected");
-        let WorkerError::InvalidPayload(message) = error else {
-            panic!("expected InvalidPayload, got {error:?}");
-        };
-        assert!(message.contains("qwen-image"), "names the model: {message}");
-        assert!(
-            message.contains("unified memory"),
-            "explains the limit: {message}"
-        );
-        assert!(message.contains("46"), "states what it needs: {message}");
-        assert!(message.contains("16"), "states the budget: {message}");
+    fn engine_supports_sequential_is_the_wired_provider_allowlist() {
+        assert!(engine_supports_sequential("sdxl"));
+        assert!(engine_supports_sequential("z_image_turbo"));
+        // Not-yet-wired providers must NOT be offered sequential (they'd ignore it and SIGKILL).
+        assert!(!engine_supports_sequential("qwen-image"));
+        assert!(!engine_supports_sequential("z_image_turbo_control"));
+        assert!(!engine_supports_sequential("flux"));
     }
 
     #[test]
-    fn fit_result_allows_a_fit_and_never_blocks_without_signal() {
-        let bytes = 36 * 1024 * 1024 * 1024_u64;
-        // Fits a 128 GB Mac.
-        assert!(fit_result(bytes, Some(MemoryBudget { total_gb: 128.0 }), "qwen-image").is_ok());
-        // No budget signal ⇒ never block, even a huge model.
-        assert!(fit_result(999 * 1024 * 1024 * 1024_u64, None, "qwen-image").is_ok());
+    fn predicted_sequential_peak_is_largest_component_plus_headroom() {
+        let gib = 1024 * 1024 * 1024_u64;
+        // illustrious q8-class: total ~5 GiB, text encoders ~1 GiB ⇒ staged = max(1, 4) + headroom.
+        let total = 5 * gib;
+        let te = gib;
+        assert_eq!(
+            predicted_sequential_peak_gb(total, te),
+            Some(4.0 + HEADROOM_GB)
+        );
+        // TE-dominant (lens-class): total 17, TE 13 ⇒ staged = max(13, 4) + headroom = 13 + headroom.
+        assert_eq!(
+            predicted_sequential_peak_gb(17 * gib, 13 * gib),
+            Some(13.0 + HEADROOM_GB)
+        );
+        // Unmeasured text encoders ⇒ staged == resident sum (no claimed saving), the safe fallback.
+        assert_eq!(
+            predicted_sequential_peak_gb(20 * gib, 0),
+            Some(20.0 + HEADROOM_GB)
+        );
+        // Nothing measured ⇒ no signal.
+        assert_eq!(predicted_sequential_peak_gb(0, 0), None);
+    }
+
+    #[test]
+    fn resolve_offload_rewrites_toobig_only_when_capable() {
+        let too_big = FitDecision::TooBig {
+            needed_gb: 46.0,
+            available_gb: 16.0,
+        };
+        // Sequential-capable provider ⇒ Offload (carrying the resident numbers).
+        assert_eq!(
+            resolve_offload(too_big.clone(), true),
+            FitDecision::Offload {
+                needed_gb: 46.0,
+                available_gb: 16.0,
+            }
+        );
+        // Non-capable ⇒ still a reject.
+        assert!(matches!(
+            resolve_offload(too_big, false),
+            FitDecision::TooBig { .. }
+        ));
+        // Fits / Unknown are never rewritten.
+        assert_eq!(resolve_offload(FitDecision::Fits, true), FitDecision::Fits);
+        assert_eq!(
+            resolve_offload(FitDecision::Unknown, true),
+            FitDecision::Unknown
+        );
+    }
+
+    #[test]
+    fn sequential_overflow_rejects_only_a_genuine_staged_overflow() {
+        let budget = Some(MemoryBudget { total_gb: 16.0 });
+        // Staged still needs 20 > 16 ⇒ reject even sequentially.
+        assert_eq!(sequential_overflow_gb(Some(20.0), budget), Some(20.0));
+        // Staged fits (14 <= 16) ⇒ run sequentially, no reject.
+        assert_eq!(sequential_overflow_gb(Some(14.0), budget), None);
+        // Exactly-fits is not an overflow.
+        assert_eq!(sequential_overflow_gb(Some(16.0), budget), None);
+        // No staged estimate or no budget ⇒ best-effort run (no reject).
+        assert_eq!(sequential_overflow_gb(None, budget), None);
+        assert_eq!(sequential_overflow_gb(Some(20.0), None), None);
+    }
+
+    #[test]
+    fn too_big_error_names_model_budget_and_optional_staged() {
+        // Plain resident reject (non-staging provider): no staged note.
+        let WorkerError::InvalidPayload(resident) = too_big_error("qwen-image", 46.0, 16.0, None)
+        else {
+            panic!("expected InvalidPayload");
+        };
+        assert!(
+            resident.contains("qwen-image"),
+            "names the model: {resident}"
+        );
+        assert!(resident.contains("unified memory"), "explains: {resident}");
+        assert!(resident.contains("46"), "states what it needs: {resident}");
+        assert!(resident.contains("16"), "states the budget: {resident}");
+        assert!(
+            !resident.contains("one component at a time"),
+            "no staged note when not attempted: {resident}"
+        );
+        // Staged reject: the message also names the one-at-a-time requirement.
+        let WorkerError::InvalidPayload(staged) = too_big_error("sdxl", 46.0, 16.0, Some(24.0))
+        else {
+            panic!("expected InvalidPayload");
+        };
+        assert!(
+            staged.contains("one component at a time"),
+            "names the staged path: {staged}"
+        );
+        assert!(
+            staged.contains("24"),
+            "states the staged requirement: {staged}"
+        );
+    }
+
+    #[test]
+    fn decide_residency_picks_resident_sequential_or_reject_by_budget() {
+        let gib = 1024 * 1024 * 1024_u64;
+        // illustrious q8-class: total ~5 GiB (TE ~1, DiT+VAE ~4). Resident peak = 5+10 = 15;
+        // staged peak = max(1, 4)+10 = 14.
+        let total = 5 * gib;
+        let te = gib;
+
+        // Roomy budget (128 GB Mac) ⇒ Resident (keep the warm path).
+        assert_eq!(
+            decide_residency(total, te, Some(MemoryBudget { total_gb: 128.0 }), true),
+            ResidencyOutcome::Resident
+        );
+        // Budget between staged (14) and resident (15): resident won't fit, staged will, provider
+        // stages ⇒ Sequential. This is the fit-gate SELECTING sequential residency.
+        assert_eq!(
+            decide_residency(total, te, Some(MemoryBudget { total_gb: 14.5 }), true),
+            ResidencyOutcome::Sequential
+        );
+        // Same budget but a provider that can't stage ⇒ reject (never a silent Resident that OOMs).
+        assert!(matches!(
+            decide_residency(total, te, Some(MemoryBudget { total_gb: 14.5 }), false),
+            ResidencyOutcome::Reject {
+                staged_gb: None,
+                ..
+            }
+        ));
+        // Budget below even the staged peak ⇒ reject, naming the staged requirement.
+        assert!(matches!(
+            decide_residency(total, te, Some(MemoryBudget { total_gb: 12.0 }), true),
+            ResidencyOutcome::Reject {
+                staged_gb: Some(_),
+                ..
+            }
+        ));
+        // No budget signal ⇒ Resident (never block).
+        assert_eq!(
+            decide_residency(total, te, None, true),
+            ResidencyOutcome::Resident
+        );
+        // Unmeasured weights ⇒ Resident (no signal).
+        assert_eq!(
+            decide_residency(0, 0, Some(MemoryBudget { total_gb: 8.0 }), true),
+            ResidencyOutcome::Resident
+        );
+    }
+
+    #[test]
+    fn sum_text_encoder_bytes_sums_only_text_encoder_subdirs() {
+        let root = std::env::temp_dir().join(format!(
+            "mlx_fit_gate_te_{}_{}",
+            std::process::id(),
+            line!()
+        ));
+        // SDXL-shaped tree: two CLIP encoders + the U-Net + VAE.
+        for (sub, bytes) in [
+            ("text_encoder", 1000usize),
+            ("text_encoder_2", 3000),
+            ("unet", 9000),
+            ("vae", 400),
+        ] {
+            let dir = root.join(sub);
+            std::fs::create_dir_all(&dir).expect("mk subdir");
+            std::fs::write(dir.join("model.safetensors"), vec![0u8; bytes]).expect("weights");
+        }
+        // Only the two text-encoder subdirs count (1000 + 3000); unet/vae are excluded.
+        assert_eq!(sum_text_encoder_bytes(&root), 4000);
+        // The whole-model sum includes everything.
+        assert_eq!(sum_safetensors_bytes(&root), 13400);
+        // Missing dir ⇒ 0.
+        assert_eq!(sum_text_encoder_bytes(&root.join("nope")), 0);
+
+        std::fs::remove_dir_all(&root).ok();
     }
 
     // HF cache stores each shard as a symlink into `blobs/`; the gate must follow those to the real


### PR DESCRIPTION
## Summary
Worker half of **sc-10839** (MLX Phase 1 — sequential component residency, SDXL + Z-Image), plus the pin bump to the merged provider work.

- **Fit-gate now SELECTS Sequential** (`crates/sceneworks-worker/src/mlx_fit_gate.rs`): evolves the sc-10835 reject-only gate to mirror the candle `vram_gate` — `FitDecision::Offload`, `predicted_sequential_peak_gb` (= `max(text-encoders, rest) + headroom` from the on-disk component split), `resolve_offload`, `sequential_overflow_gb`, and a pure `decide_residency` → `apply_residency_policy` at the `generator_cache::with_generator` cold-load seam. Won't-fit-resident **but** staged-fits + provider staging-capable ⇒ `spec.with_offload_policy(Sequential)`; won't-fit-even-staged ⇒ reject. Provider allowlist `SEQUENTIAL_CAPABLE_ENGINES = {"sdxl","z_image_turbo"}` (selecting Sequential for a non-wired provider would SIGKILL — extended per family in the fan-out sc-10840).
- **Pin bump:** every `mlx-gen*` crate + `sceneworks-gen-core` `4df97dc` → `3612d33` (mlx-gen [#692](https://github.com/SceneWorks/mlx-gen/pull/692), merged — SDXL + Z-Image `Residency` enum; Sequential drops the TE after encode with a single `clear_cache()`; Resident byte-untouched).
- **candle-gen lockstep:** every `candle-gen*` `29ed111` → `ee5a7b5` (candle-gen [#404](https://github.com/SceneWorks/candle-gen/pull/404), merged). gen-core is byte-identical `4df97dc..3612d33`, but the sc-4482 skew gate keys on the git **rev**, not content — without this, `--features backend-candle --target all` resolves two gen-core revs and the `desktop-windows` + `windows-candle` PR lanes go red.

## Verification
- **A/B on real weights (128 GB Mac, from the mechanism work):** SDXL/illustrious-q8 768² **12.64 → 11.55 GiB**; Z-Image-turbo/bf16 768² **26.76 → 19.45 GiB** (−7.3, the 8 GB Qwen encoder dropped); both **byte-identical** Resident vs Sequential, repeat-job-bounded.
- **Both gen-core skew lanes green** (single rev `3612d33`): `check-gen-core-skew.sh` and `check-gen-core-skew.sh --features backend-candle`.
- **`npm run rust:check` green** on the merged tree: worker suite **734 passed / 0 failed**, all 13 `mlx_fit_gate` tests, build clean.

## Cross-repo (both merged first)
- mlx-gen [#692](https://github.com/SceneWorks/mlx-gen/pull/692) — merged (`3612d33`)
- candle-gen [#404](https://github.com/SceneWorks/candle-gen/pull/404) — merged (`ee5a7b5`, gen-core rev-alignment)

## Trade-off
Sequential loses the cross-job warm cache for the dropped TE — repeat gens reload it from disk (mmap/page-cache-cheap). `Resident` stays the default so large Macs keep the fast path; the fit-gate only selects Sequential when Resident wouldn't fit.

## Shortcut
- Epic: https://app.shortcut.com/trefry/epic/10834
- Story: https://app.shortcut.com/trefry/story/10839

🤖 Generated with [Claude Code](https://claude.com/claude-code)