### PR TITLE
feat(worker): candle Krea 2 pose-ControlNet inference lane (KreaControl) (sc-8464, epic 8459)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-gen",
  "image",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -713,7 +713,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -738,7 +738,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -790,7 +790,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=ee5a7b5c19b65edde34acf9e4e68cbd098448ae4#ee5a7b5c19b65edde34acf9e4e68cbd098448ae4"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",

--- a/crates/sceneworks-core/src/jobs_store/routing/candle.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/candle.rs
@@ -220,6 +220,14 @@ pub(crate) fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     if model == "flux2_dev" && flux2_dev_control_candle_eligible(&job.payload) {
         return true;
     }
+    // Krea 2 pose-ControlNet (sc-8464, epic 8459): `krea_2_turbo` + `advanced.poses` is the bespoke candle
+    // `Krea2Control` lane (`generate_candle_krea_control_stream`), NOT txt2img — `krea_2_turbo` is a
+    // registered candle txt2img id, so without diverting first a pose job would render as plain txt2img and
+    // drop the poses. Branch it out before the registry txt2img gate (mirrors the qwen/flux2-control
+    // reasoning, for the first Krea backbone). Mirrors the worker's `krea_control_candle_available`.
+    if model == "krea_2_turbo" && krea_control_candle_eligible(&job.payload) {
+        return true;
+    }
     // PuLID-FLUX face identity (sc-5492, epic 5480): `pulid_flux_dev` is a distinct model id (not a
     // candle txt2img id), so the `image_request_candle_eligible` gate below would reject it; the candle
     // `candle-gen-pulid` provider serves it via a bespoke `generate_candle_pulid_stream` lane (the
@@ -901,6 +909,24 @@ pub(crate) fn flux1_control_candle_eligible(payload: &Map<String, Value>) -> boo
 /// gate (`flux2_dev`) is applied at the call site. Mirrors the worker's `flux2_control_candle_available`.
 /// Candle-only — the macOS path is the MLX `flux2_dev_control` registry generator (sc-6055).
 pub(crate) fn flux2_dev_control_candle_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
+        return false;
+    }
+    payload
+        .get("advanced")
+        .and_then(Value::as_object)
+        .and_then(|advanced| advanced.get("poses"))
+        .and_then(Value::as_array)
+        .is_some_and(|poses| !poses.is_empty())
+}
+
+/// Krea 2 pose-ControlNet candle-routing conditions (sc-8464, epic 8459). The candle `Krea2Control`
+/// provider serves `krea_2_turbo` + a non-empty `advanced.poses` (one image per pose, each conditioned on
+/// a DWPose skeleton via a trained control-branch overlay on the frozen Turbo base), NOT an `edit_image`.
+/// Same shape as the qwen/kolors/zimage/flux control gates — the model gate (`krea_2_turbo`) is applied at
+/// the call site. Mirrors the worker's `krea_control_candle_available`. Candle-only (there is no MLX Krea
+/// control twin yet — 8459 S5 / sc-8465).
+pub(crate) fn krea_control_candle_eligible(payload: &Map<String, Value>) -> bool {
     if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
         return false;
     }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1620,15 +1620,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612
 # `4df97dce` -> `3612d333` (byte-identical, candle builds nothing new), so both the default lane AND
 # `--features backend-candle --target all` now resolve the SINGLE gen-core rev `3612d333`. mlx-rs unchanged
 # (38e1cc1 — MLX core does not rebuild). ALL mlx-gen-* + candle-gen-* pins move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1642,7 +1642,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1650,17 +1650,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1670,7 +1670,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1678,21 +1678,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1701,17 +1701,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1720,7 +1720,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1753,7 +1753,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1762,12 +1762,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1775,7 +1775,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1784,7 +1784,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1792,7 +1792,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1806,7 +1806,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1833,7 +1833,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1844,7 +1844,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ee5a7b5c19b65edde34acf9e4e68cbd098448ae4", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -903,6 +903,21 @@ pub(crate) async fn run_image_generate_job(
                     )
                     .await?;
                 }
+                // Krea 2 pose-ControlNet (sc-8464, epic 8459) — `krea_2_turbo` + `advanced.poses` is the
+                // bespoke candle Krea2Control lane (a trained control-branch overlay on the frozen Turbo
+                // base), diverted before the registry txt2img arm.
+                CandleImageRoute::KreaControl => {
+                    generate_candle_krea_control_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
                 // No-silent-T2I (sc-5968): a strict-pose job on a candle model with NO pose lane (e.g.
                 // sdxl) must be REJECTED with a clear error, not silently rendered as plain txt2img (poses
                 // dropped) and not bounced to torch. The candle worker CLAIMS these (jobs_store
@@ -913,8 +928,8 @@ pub(crate) async fn run_image_generate_job(
                     return Err(WorkerError::InvalidPayload(format!(
                         "strict pose (advanced.poses) is not supported for model '{}' on the candle backend — \
                          refusing rather than silently generating an unconditioned image (wired candle pose \
-                         families: qwen_image, kolors, z_image_turbo, z_image, flux2_dev, flux_dev; SDXL \
-                         identity-pose runs via InstantID)",
+                         families: qwen_image, kolors, z_image_turbo, z_image, flux2_dev, flux_dev, \
+                         krea_2_turbo; SDXL identity-pose runs via InstantID)",
                         request.model
                     )));
                 }
@@ -1751,6 +1766,11 @@ include!("image_jobs/flux2_control_candle.rs");
 // bf16 dev DiT).
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 include!("image_jobs/flux1_control_candle.rs");
+// Krea 2 pose-ControlNet (strict pose) — the Windows/CUDA candle lane ONLY (sc-8464, epic 8459). There is
+// no MLX Krea control twin yet (8459 S5 / sc-8465); the candle `Krea2Control` loads a trained
+// control-branch overlay on the frozen dense bf16 Turbo base.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+include!("image_jobs/krea_control_candle.rs");
 // Z-Image img2img / edit — the Windows/CUDA candle lane ONLY (sc-6595). macOS keeps the MLX
 // `z_image_turbo` registry generator's `Conditioning::Reference` img2img path; the candle `ZImageEdit`
 // is a bespoke provider.

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -210,6 +210,8 @@ enum CandleImageRoute {
     Flux2Control,
     /// FLUX.1-dev strict-control Shakker Union-Pro-2.0 (sc-8412).
     Flux1Control,
+    /// Krea 2 pose-ControlNet — a trained control-branch overlay on the frozen Turbo base (sc-8464).
+    KreaControl,
     /// A strict-pose job on a candle model with NO pose lane → reject loudly, never silent T2I (sc-5968).
     PoseReject,
     /// An in-place ComfyUI Z-Image base model (`external_base_*`) → `generate_candle_zimage_comfyui_stream`
@@ -268,6 +270,11 @@ fn resolve_candle_image_route(
         Some(CandleImageRoute::Flux2Control)
     } else if flux1_control_candle_available(request, settings) {
         Some(CandleImageRoute::Flux1Control)
+    } else if krea_control_candle_available(request, settings) {
+        // Krea 2 pose-ControlNet (sc-8464): `krea_2_turbo` + `advanced.poses` is the bespoke candle
+        // `Krea2Control` lane, diverted before the registry txt2img arm (which would render it as plain
+        // txt2img and drop the poses). Mirrors `jobs_store::krea_control_candle_eligible`.
+        Some(CandleImageRoute::KreaControl)
     } else if zimage_comfyui_available(request, settings) {
         // In-place ComfyUI Z-Image base (sc-10668): an `external_base_*` id, so it matches no
         // `is_candle_engine` arm below — route it here off the forwarded `modelManifestEntry`.
@@ -279,7 +286,13 @@ fn resolve_candle_image_route(
     } else if is_candle_engine(&request.model)
         && !matches!(
             request.model.as_str(),
-            "qwen_image" | "kolors" | "z_image_turbo" | "z_image" | "flux2_dev" | "flux_dev"
+            "qwen_image"
+                | "kolors"
+                | "z_image_turbo"
+                | "z_image"
+                | "flux2_dev"
+                | "flux_dev"
+                | "krea_2_turbo"
         )
         && request.mode != "edit_image"
         && !pose_entries(request).is_empty()

--- a/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
@@ -1,0 +1,287 @@
+// Candle (Windows/CUDA) Krea 2 pose-ControlNet route (sc-8464, epic 8459) — `krea_2_turbo` +
+// `advanced.poses` off-Mac via `candle_gen_krea::Krea2Control`. The first Krea backbone control lane and
+// the deployable form of the sc-8460 spike: a trained control-branch overlay loaded on the frozen Krea 2
+// Turbo base (dense bf16), rendering one image per library pose, each conditioned on a full DWPose
+// skeleton (rendered cross-platform by `openpose_skeleton::draw_wholebody`, the SAME renderer training
+// used). True pose lock via a residual added to the single CFG-free guidance forward, scaled by
+// `control_scale`; `control_scale = 0` is engine-proven byte-identical to base txt2img.
+//
+// **Candle-only.** There is no MLX Krea control twin yet (8459 S5 / sc-8465); this whole file is gated to
+// the Windows/CUDA candle build (the `include!` in image_jobs.rs carries the cfg). It is `include!`d into
+// the `image_jobs` module, so it shares that module's imports (`parse_poses`/`pose_entries`/`Settings`/
+// `WorkerResult`/`huggingface_snapshot_dir`/`start_gen_stream`/… all in scope unqualified).
+//
+// Krea 2 Turbo needs the DENSE diffusers snapshot (`transformer/ text_encoder/ vae/ tokenizer/`), NOT the
+// packed q8 turnkey the registered `krea_2_turbo` txt2img generator loads: the control branch is a
+// composable-forward overlay (`KreaTrainDit`), and it was trained against the bf16 base. Base + branch +
+// TE + VAE are dense on a single 96 GB card.
+
+/// The dense Krea 2 Turbo diffusers repo when the manifest omits `repo`. Distinct from the packed q8
+/// turnkey (`SceneWorks/krea-2-turbo-mlx`) the txt2img lane uses — the control provider loads the dense
+/// bf16 composable base the overlay applies on.
+const KREA_CONTROL_BASE_REPO: &str = "krea/Krea-2-Turbo";
+/// Pose ControlNet conditioning-scale default (candle-gen `Krea2Control::DEFAULT_CONTROL_SCALE`). The S0
+/// spike found the usable band ~0.5–0.85 for the distilled CFG-free base; ship a comfortable mid.
+const KREA_CONTROL_DEFAULT_SCALE: f32 = candle_gen_krea::DEFAULT_CONTROL_SCALE;
+/// Hard cap on the exposed `control_scale` — above ~0.85 the frozen CFG-free base over-drives to halftone
+/// (S0 finding: graceful soft-haze, never confetti, but not a usable range).
+const KREA_CONTROL_SCALE_CAP: f32 = 0.85;
+/// Denoise-steps default — the distilled Turbo schedule (8-step CFG-free).
+const KREA_CONTROL_DEFAULT_STEPS: u32 = 8;
+/// The adapter/engine id recorded on candle Krea control assets (distinct from the `candle_krea` txt2img
+/// lane).
+const KREA_CONTROL_ENGINE: &str = "candle_krea_control";
+/// The [`STRICT_CONTROL_ENGINES`] catalog id this lane validates `advanced.controlMode` against (the Krea
+/// pose-only row — `{Pose}`).
+const KREA_CONTROL_ENGINE_ID: &str = "krea_2_turbo_control";
+/// Env override pointing directly at a Krea 2 Turbo dense diffusers snapshot dir (validation / bring-your-
+/// own base) — bypasses the HF-cache resolve.
+const KREA_CONTROL_BASE_ENV: &str = "SCENEWORKS_KREA_CONTROL_BASE";
+/// Env override pointing directly at a trained control-branch overlay `.safetensors` (validation against
+/// the spike checkpoint; no published overlay repo exists yet — the studio-trained overlay + a hosted
+/// catalog are B4/sc-10165 + sc-8466).
+const KREA_CONTROL_WEIGHTS_ENV: &str = "SCENEWORKS_CONTROLNET_KREA";
+
+/// Model ids the candle Krea strict-pose control route accepts (the deployed base the overlay applies on).
+fn is_krea_control_model(model: &str) -> bool {
+    model == "krea_2_turbo"
+}
+
+/// Resolve the Krea 2 Turbo dense diffusers snapshot: the `SCENEWORKS_KREA_CONTROL_BASE` env → an explicit
+/// `modelPath` (advanced or manifest) → the HF cache snapshot for the manifest `repo` (default
+/// `krea/Krea-2-Turbo`). `None` ⇒ not present locally (the job is not candle-runnable). Mirrors
+/// `resolve_flux2_control_base`.
+fn resolve_krea_control_base(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> WorkerResult<Option<PathBuf>> {
+    if let Ok(env_dir) = std::env::var(KREA_CONTROL_BASE_ENV) {
+        let p = PathBuf::from(env_dir.trim());
+        if p.is_dir() {
+            return Ok(Some(p));
+        }
+    }
+    if let Some(path) = request
+        .advanced
+        .get("modelPath")
+        .or_else(|| request.model_manifest_entry.get("modelPath"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+    {
+        return resolve_app_managed_model_dir(settings, &path, "Krea control modelPath").map(Some);
+    }
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(KREA_CONTROL_BASE_REPO);
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
+}
+
+/// True when this is a candle-eligible Krea 2 strict-pose job: `krea_2_turbo` with a non-empty
+/// `advanced.poses`, not edit mode, whose dense base resolves locally. Mirrors
+/// `jobs_store::krea_control_candle_eligible` so the worker and router agree. The overlay weights are NOT
+/// part of the gate: they are resolved on first use in the stream.
+fn krea_control_candle_available(request: &ImageRequest, settings: &Settings) -> bool {
+    is_krea_control_model(&request.model)
+        && request.mode != "edit_image"
+        && !pose_entries(request).is_empty()
+        && matches!(resolve_krea_control_base(request, settings), Ok(Some(_)))
+}
+
+/// Resolve denoise steps: `advanced.steps` (clamped 1..=50) → manifest `steps` → default (8).
+fn krea_control_candle_steps(request: &ImageRequest) -> u32 {
+    resolve_advanced_or_manifest_u32(request, "steps", KREA_CONTROL_DEFAULT_STEPS, 1..=50)
+}
+
+/// Resolve the control-branch overlay checkpoint the `Krea2Control` provider loads. Order: the
+/// `SCENEWORKS_CONTROLNET_KREA` env → an `advanced.controlWeights.path` override → error. There is no
+/// published default Krea overlay repo yet (a studio-trained overlay registered via B4/sc-10165 or a
+/// hosted catalog via sc-8466 will supply it), so a job that reaches here without one fails loudly rather
+/// than silently rendering an un-conditioned base image.
+fn ensure_krea_control_weights(request: &ImageRequest) -> WorkerResult<PathBuf> {
+    if let Ok(p) = std::env::var(KREA_CONTROL_WEIGHTS_ENV) {
+        let p = PathBuf::from(p.trim());
+        if p.is_file() {
+            return Ok(p);
+        }
+    }
+    if let Some(path) = request
+        .advanced
+        .get("controlWeights")
+        .and_then(Value::as_object)
+        .and_then(|cw| cw.get("path"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let p = PathBuf::from(path);
+        if p.is_file() {
+            return Ok(p);
+        }
+    }
+    Err(WorkerError::InvalidPayload(
+        "Krea 2 pose control requires a trained control-branch overlay; set SCENEWORKS_CONTROLNET_KREA \
+         or advanced.controlWeights.path (no hosted Krea overlay is published yet)"
+            .to_owned(),
+    ))
+}
+
+/// Flat telemetry recorded on candle Krea control assets.
+fn krea_control_candle_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    control_scale: f32,
+    pose_count: usize,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw.insert("controlScale".to_owned(), json!(control_scale));
+    raw.insert("poseCount".to_owned(), json!(pose_count));
+    raw.insert(
+        "controlEngine".to_owned(),
+        Value::String(KREA_CONTROL_ENGINE.to_owned()),
+    );
+    raw
+}
+
+/// The per-lane half of the candle Krea strict-control [`CandleStrictControl`] driver: the resolved base +
+/// overlay paths + request numerics. Krea 2 Turbo is CFG-free (no guidance / negative pass) and bf16
+/// (no quant tier). Moved onto the blocking thread, loaded once, drives every pose.
+struct KreaStrictControl {
+    base: PathBuf,
+    control: PathBuf,
+    prompt: String,
+    width: u32,
+    height: u32,
+    steps: u32,
+    control_scale: f32,
+}
+
+impl CandleStrictControl for KreaStrictControl {
+    type Model = candle_gen_krea::Krea2Control;
+
+    fn engine_id(&self) -> &'static str {
+        KREA_CONTROL_ENGINE_ID
+    }
+
+    fn engine_label(&self) -> &'static str {
+        KREA_CONTROL_ENGINE
+    }
+
+    fn stream_tag(&self) -> &'static str {
+        "krea_control"
+    }
+
+    fn out_width(&self) -> u32 {
+        self.width
+    }
+
+    fn out_height(&self) -> u32 {
+        self.height
+    }
+
+    fn load(&self) -> WorkerResult<Self::Model> {
+        let paths = candle_gen_krea::Krea2ControlPaths {
+            root: self.base.clone(),
+            control: self.control.clone(),
+        };
+        candle_gen_krea::Krea2Control::load(&paths).map_err(|error| {
+            WorkerError::Engine(format!("Krea 2 strict-pose control load failed: {error}"))
+        })
+    }
+
+    fn generate_one(
+        &self,
+        model: &Self::Model,
+        control: &Image,
+        seed: u64,
+        cancel: &CancelFlag,
+        on_progress: &mut dyn FnMut(Progress),
+    ) -> WorkerResult<Image> {
+        let req = candle_gen_krea::Krea2ControlRequest {
+            prompt: self.prompt.clone(),
+            width: self.width,
+            height: self.height,
+            steps: self.steps as usize,
+            control_scale: self.control_scale,
+            seed,
+            cancel: cancel.clone(),
+        };
+        model.generate(&req, control, on_progress).map_err(|error| {
+            WorkerError::Engine(format!("Krea 2 strict-pose generation failed: {error}"))
+        })
+    }
+}
+
+/// Real candle Krea 2 strict-pose generation: one image per pose, each conditioned on a full DWPose
+/// skeleton (`controlMode` unset ⇒ pose) via a trained control-branch overlay on the frozen Turbo base
+/// (sc-8464; engine sc-8462). Resolves the dense base + the overlay, then hands a [`KreaStrictControl`] to
+/// the shared [`run_candle_strict_control`] driver (validation against `krea_2_turbo_control`'s
+/// `supported_kinds` = {Pose}, per-pose skeleton rendering, scoring). Krea is CFG-free bf16. The pose path
+/// is byte-preserved; `control_scale = 0` is byte-identical to base.
+async fn generate_candle_krea_control_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let base = resolve_krea_control_base(request, settings)?.ok_or_else(|| {
+        WorkerError::InvalidPayload("Krea 2 Turbo base (krea/Krea-2-Turbo) weights not found".to_owned())
+    })?;
+    let control = ensure_krea_control_weights(request)?;
+
+    let steps = krea_control_candle_steps(request);
+    let control_scale = advanced::f32_clamped(
+        &request.advanced,
+        "controlScale",
+        KREA_CONTROL_DEFAULT_SCALE,
+        0.0..=KREA_CONTROL_SCALE_CAP,
+    );
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(KREA_CONTROL_BASE_REPO)
+        .to_owned();
+
+    let pose_count = pose_entries(request).len();
+    let raw_settings =
+        krea_control_candle_raw_settings(request, &repo, steps, control_scale, pose_count);
+
+    let provider = KreaStrictControl {
+        base,
+        control,
+        prompt: request.prompt.clone(),
+        width: request.width,
+        height: request.height,
+        steps,
+        control_scale,
+    };
+
+    run_candle_strict_control(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        provider,
+        raw_settings,
+        asset_writes,
+    )
+    .await
+}

--- a/crates/sceneworks-worker/src/image_jobs/strict_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/strict_control.rs
@@ -96,6 +96,18 @@ const STRICT_CONTROL_ENGINES: &[StrictControlEngine] = &[
         repo: "Kwai-Kolors/Kolors-ControlNet-Pose",
         supported_kinds: &[ControlKind::Pose],
     },
+    StrictControlEngine {
+        // Pose-ONLY (sc-8464, epic 8459). The Krea 2 candle strict-control lane rides a trained
+        // control-branch overlay on the frozen Turbo base — a from-scratch pose ControlNet, not a
+        // Fun-Union VACE engine, so it has no canny/depth conditioning (those are Phase-C follow-ups).
+        // Listed here so the candle lane routes through `run_candle_strict_control` and a
+        // `controlMode = canny | depth` request is REJECTED (not silently rendered as pose). Off-Mac
+        // candle-only; the candle lane resolves its overlay from env / `advanced.controlWeights` (no
+        // hosted default repo yet — B4/sc-10165 + sc-8466), so `repo` here is informational.
+        engine_id: "krea_2_turbo_control",
+        repo: "krea/Krea-2-Turbo",
+        supported_kinds: &[ControlKind::Pose],
+    },
 ];
 
 /// The catalog row for a registry strict-control engine id, or `None` if it is not a Fun-Union


### PR DESCRIPTION
## What

Wires the candle **`Krea2Control`** provider (candle-gen [#405](https://github.com/SceneWorks/candle-gen/pull/405), merged) into generation as the `KreaControl` route — the first Krea backbone control lane and the deployable form of the sc-8460 spike. A `krea_2_turbo` pose job now loads a trained control-branch overlay on the frozen dense bf16 Turbo base and renders one pose-locked image per library pose. This is the **critical-path unlock to consume any Krea control overlay** (studio-trained B4/sc-10165, built-in sc-8466, user-imported sc-10979) — nothing rendered a trained Krea branch before this.

**Unblocked via the spike model:** the story's real gate was S3 (full training run) — not needed. The GPU-proven 5k spike overlay is sufficient to build + validate the lane.

## Changes
- **`image_jobs/krea_control_candle.rs`** (new): `KreaStrictControl` impl of the shared `CandleStrictControl` trait (only `load`/`generate_one` are Krea-specific — `run_candle_strict_control` already renders the DWPose skeleton, preprocesses, and scores) + `generate_candle_krea_control_stream` + `krea_control_candle_available`. Krea is CFG-free bf16 (no quant/guidance). `control_scale=0` = byte-identical base.
- **`image_jobs/base.rs`**: `CandleImageRoute::KreaControl` variant + `resolve_candle_image_route` branch + `krea_2_turbo` added to the PoseReject exclusion.
- **`image_jobs.rs`**: dispatch arm + `include!` + PoseReject message updated.
- **`image_jobs/strict_control.rs`**: `krea_2_turbo_control` engine (Pose-only, like `kolors_control`) so `controlMode = canny|depth` is rejected, not silently rendered as pose.
- **`jobs_store/routing/candle.rs`**: `krea_control_candle_eligible` + the `krea_2_turbo` routing branch (router/worker agree).
- **Cargo pin bump**: candle-gen `ee5a7b5 → 8a91083` (adds only #405; gen-core stays `3612d333` — matches the worker's mlx-gen after the sc-10839 lockstep). Single gen-core rev; skew green.

## Base / overlay resolution (v1)
Krea control needs the **dense `krea/Krea-2-Turbo` diffusers snapshot** (composable `KreaTrainDit` base the branch trained against), NOT the packed q8 turnkey the `krea_2_turbo` txt2img gen uses. v1 resolves the base via `SCENEWORKS_KREA_CONTROL_BASE` / `huggingface_snapshot_dir(krea/Krea-2-Turbo)` and the overlay via `SCENEWORKS_CONTROLNET_KREA` / `advanced.controlWeights.path`, and **fails loudly** if absent (never a silent un-conditioned image). Shippable provisioning — the dense repo in the catalog + a hosted overlay repo + UI Poses-tab exposure — is **sc-8466 / B4**.

## Validation
- Worker `clippy --features backend-candle --all-targets -- -D warnings`: clean (against gen-core `3612d333`).
- `npm run rust:check:neither`: clean.
- `cargo fmt`, single-gen-core skew verified.
- The provider itself is **GPU-proven** in #405 (pose-locked render vs the spike overlay). Worker-lane end-to-end GPU smoke to follow (both halves independently proven).

sc-8464 (epic 8459 S4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)