### PR TITLE
feat(worker): render external ComfyUI FLUX.2-dev fp8 base weights in place off-Mac (sc-10680, epic 10451)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-gen",
  "image",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -713,7 +713,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -738,7 +738,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -790,7 +790,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=29ed11149c06ed0e2f9f61370db4f7e2ec53125b#29ed11149c06ed0e2f9f61370db4f7e2ec53125b"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=63094acc7607f3e03ba1aabee4d39c4b5aad9cac#63094acc7607f3e03ba1aabee4d39c4b5aad9cac"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",

--- a/apps/rust-api/src/external_base_models.rs
+++ b/apps/rust-api/src/external_base_models.rs
@@ -489,16 +489,21 @@ fn assemble_wan_experts(
 /// `qwen-image`: the ComfyUI Qwen2.5-VL text encoders are themselves *scaled*-fp8
 /// (sc-10671) and the tree VAE uses native WAN-VAE keys (a 194-key 3D-VAE remap), so
 /// both are sourced from our snapshot while the plain-fp8 DiT is read in place.
+///
+/// `flux2` (sc-10680): the `flux2_dev_fp8mixed` file is a bare **inline-scale fp8** DiT
+/// with no text encoder / VAE — the Mistral-3 TE + AutoencoderKL-Flux2 + tokenizer are
+/// sourced from our snapshot while the fp8 DiT is dequanted + read in place.
 fn is_snapshot_backed(family: &str) -> bool {
     // `wan-video` is also snapshot-backed but takes the dedicated MoE-pairing path
     // ([`assemble_wan_experts`]), never the single-transformer branch this gates.
-    matches!(family, "qwen-image")
+    matches!(family, "qwen-image" | "flux2")
 }
 
 /// Whether a fully-assembled external model has a worker loader for its family+quant,
 /// i.e. is offerable as a generation target (the picker offers only `usable !== false`).
 /// Each `(family, quant)` here corresponds to a landed load-in-place slice:
-/// z-image bf16 (sc-10668) · qwen-image plain fp8_e4m3 (sc-10670). Everything else
+/// z-image bf16 (sc-10668) · qwen-image plain fp8_e4m3 (sc-10670) · wan-video
+/// scaled_fp8_companion (sc-10671) · flux2 inline-scale fp8 (sc-10680). Everything else
 /// stays fail-closed until its slice lands. Only ever true for a `complete` assembly.
 fn family_quant_runnable(family: Option<&str>, quant: Option<&str>, assembly: &str) -> bool {
     assembly == "complete"
@@ -507,6 +512,7 @@ fn family_quant_runnable(family: Option<&str>, quant: Option<&str>, assembly: &s
             (Some("z-image"), Some("bf16"))
                 | (Some("qwen-image"), Some("fp8_e4m3"))
                 | (Some("wan-video"), Some("scaled_fp8_companion"))
+                | (Some("flux2"), Some("fp8_inline_scale"))
         )
 }
 
@@ -900,6 +906,51 @@ mod tests {
         assert_eq!(row["assembly"], "complete");
         // sc-10670: plain-fp8 qwen DiT has a loader → usable, no reason. No tree VAE here, so
         // components is the DiT alone (the TE is always snapshot-sourced, sc-10671).
+        assert_eq!(row["usable"], true);
+        assert_eq!(row["unusableReason"], Value::Null);
+        assert_eq!(row["components"].as_array().unwrap().len(), 1);
+    }
+
+    /// A ComfyUI FLUX.2-dev fp8-mixed DiT (`diffusion_models/flux2_dev_fp8mixed`): BFL-native MMDiT keys
+    /// with **inline-scale fp8** MLPs (`.weight` F8_E4M3 + `.weight_scale`/`.input_scale` F32 siblings)
+    /// and BF16 attention/modulation → detector `(flux2, transformer, fp8_inline_scale)` (sc-10662).
+    fn flux2_dev_dit_inline_scale_keys() -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("double_stream_modulation_img.lin.weight", "BF16"),
+            ("single_stream_modulation.lin.weight", "BF16"),
+            ("double_blocks.0.img_attn.qkv.weight", "BF16"),
+            ("double_blocks.0.img_mlp.0.weight", "F8_E4M3"),
+            ("double_blocks.0.img_mlp.0.weight_scale", "F32"),
+            ("double_blocks.0.img_mlp.0.input_scale", "F32"),
+            ("single_blocks.0.linear1.weight", "F8_E4M3"),
+            ("single_blocks.0.linear1.weight_scale", "F32"),
+            ("single_blocks.0.linear1.input_scale", "F32"),
+        ]
+    }
+
+    #[test]
+    fn flux2_inline_scale_dit_is_snapshot_backed_complete_and_runnable() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = models_root(temp.path());
+        // Only the DiT is on disk — no tree text encoder / VAE. flux2 is snapshot-backed (sc-10680): the
+        // Mistral-3 TE / AutoencoderKL-Flux2 / tokenizer come from a resident SceneWorks snapshot, so a
+        // bare inline-scale-fp8 DiT anchor is still complete and runnable.
+        write_safetensors(
+            &root
+                .join("diffusion_models")
+                .join("flux2_dev_fp8mixed.safetensors"),
+            &flux2_dev_dit_inline_scale_keys(),
+        );
+
+        let rows = scan(&[root]);
+        assert_eq!(rows.len(), 1, "one anchored DiT model");
+        let row = &rows[0];
+        assert_eq!(row["family"], "flux2");
+        assert_eq!(row["type"], "image");
+        assert_eq!(row["quant"], "fp8_inline_scale");
+        assert_eq!(row["assembly"], "complete");
+        // sc-10680: inline-scale-fp8 flux2 DiT has a loader → usable, no reason. No tree VAE here, so
+        // components is the DiT alone (the TE / VAE are snapshot-sourced).
         assert_eq!(row["usable"], true);
         assert_eq!(row["unusableReason"], Value::Null);
         assert_eq!(row["components"].as_array().unwrap().len(), 1);

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1606,15 +1606,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4df9
 # resolves the SINGLE gen-core rev `4df97dce` (skew gate green, lock diff candle-gen-only). ALL candle-gen-*
 # move together. GPU-validated (sm_120, Qwen-Image-2512 1024²/8-step, spec-driven offload_policy=Sequential):
 # resident 82,511 -> sequential 71,655 MiB (-10.6 GB, Qwen2.5-VL reclaimed), output byte-identical.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1628,7 +1628,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1636,17 +1636,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1656,7 +1656,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1664,21 +1664,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1687,17 +1687,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1706,7 +1706,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1739,7 +1739,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1748,12 +1748,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1761,7 +1761,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed1
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1770,7 +1770,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1778,7 +1778,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1792,7 +1792,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1819,7 +1819,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1830,7 +1830,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "29ed11149c06ed0e2f9f61370db4f7e2ec53125b", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "63094acc7607f3e03ba1aabee4d39c4b5aad9cac", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -764,6 +764,22 @@ pub(crate) async fn run_image_generate_job(
                     )
                     .await?;
                 }
+                // In-place ComfyUI FLUX.2-dev fp8-mixed base (sc-10680, epic 10451): an `external_base_*`
+                // id whose forwarded row carries the DiT component path — render the user's ComfyUI
+                // weights in place via `candle_gen_flux2::load_from_comfyui_dit` (inline-scale fp8 dequant
+                // + BFL→diffusers remap; TE/VAE/tokenizer from a resident FLUX.2-dev snapshot).
+                CandleImageRoute::Flux2Comfyui => {
+                    generate_candle_flux2_comfyui_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
                 // Z-Image identity-init for Image Studio "With Character" (sc-8409, epic 4406) — the
                 // off-Mac sibling of the macOS generic lane's Z-Image identity img2img; reuses the candle
                 // ZImageEdit engine with the identity `referenceAssetId` as the source-latent init + wires
@@ -1765,6 +1781,12 @@ include!("image_jobs/zimage_comfyui_candle.rs");
 // from a resident `SceneWorks/qwen-image-mlx` snapshot tier.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 include!("image_jobs/qwen_comfyui_candle.rs");
+// FLUX.2-dev txt2img from an in-place ComfyUI fp8-mixed DiT (inline-scale fp8 dequant → f32, then
+// quantized onto the GPU) — the Windows/CUDA candle lane ONLY (sc-10680, epic 10451 Phase 2e). Sibling
+// of the Qwen-Image comfyui lane; the Mistral-3 TE / VAE / tokenizer come from a resident FLUX.2-dev
+// snapshot tier.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+include!("image_jobs/flux2_comfyui_candle.rs");
 // Z-Image identity-init for Image Studio "With Character" — the Windows/CUDA candle lane ONLY (sc-8409,
 // epic 4406). macOS keeps the MLX `z_image_turbo` generic-lane identity img2img (`generate_stream` ⇒
 // `resolve_zimage_identity_init`); off-Mac this bespoke lane reuses the candle `ZImageEdit` engine with

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -218,6 +218,10 @@ enum CandleImageRoute {
     /// An in-place ComfyUI Qwen-Image base model (`external_base_*`) → `generate_candle_qwen_comfyui_stream`
     /// (epic 10451 Phase 2b, sc-10670). Not an `is_candle_engine` id — routed off the forwarded row.
     QwenImageComfyui,
+    /// An in-place ComfyUI FLUX.2-dev fp8-mixed base model (`external_base_*`) →
+    /// `generate_candle_flux2_comfyui_stream` (epic 10451 Phase 2e, sc-10680). Not an `is_candle_engine`
+    /// id — routed off the forwarded row.
+    Flux2Comfyui,
     /// A plain candle txt2img engine id → `generate_candle_stream`.
     CandleTxt2Img,
 }
@@ -276,6 +280,10 @@ fn resolve_candle_image_route(
         // In-place ComfyUI Qwen-Image base (sc-10670): sibling of the Z-Image comfyui lane — an
         // `external_base_*` id routed off the forwarded row (family=="qwen-image", usable).
         Some(CandleImageRoute::QwenImageComfyui)
+    } else if flux2_comfyui_available(request, settings) {
+        // In-place ComfyUI FLUX.2-dev base (sc-10680): sibling of the Qwen-Image comfyui lane — an
+        // `external_base_*` id routed off the forwarded row (family=="flux2", usable).
+        Some(CandleImageRoute::Flux2Comfyui)
     } else if is_candle_engine(&request.model)
         && !matches!(
             request.model.as_str(),

--- a/crates/sceneworks-worker/src/image_jobs/flux2_comfyui_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_comfyui_candle.rs
@@ -1,0 +1,294 @@
+// Candle (Windows/CUDA) in-place ComfyUI FLUX.2-dev txt2img route (epic 10451 Phase 2e, sc-10680).
+// Renders a user's existing ComfyUI FLUX.2-dev fp8-mixed DiT — read in place, no copy, no re-download —
+// via `candle_gen_flux2::load_from_comfyui_dit`, which dequants the inline-scale fp8 MLPs
+// (`w = w_fp8·weight_scale`, dropping the `.input_scale` activation scale) and remaps the BFL-native
+// keys onto the diffusers schema in memory (candle-gen sc-10680). The 32B DiT does not fit the GPU
+// dense after the fp8→f32 dequant, so each projection is folded onto the GPU (Q8), matching the resident
+// FLUX.2-dev quant path. The single DiT file carries NO text encoder / VAE / tokenizer, so the Mistral-3
+// TE + AutoencoderKL-Flux2 + tokenizer come from a resident SceneWorks FLUX.2-dev snapshot tier.
+//
+// The model id is an `external_base_*` catalog row (assembled by the API's `external_base_models`); its
+// `modelManifestEntry` carries `family:"flux2"`, `usable:true`, `quant:"fp8_inline_scale"`, and a
+// `components[]` list whose `transformer` entry is the DiT path.
+//
+// **Candle-only**, and a **bespoke provider** (like the Qwen-Image comfyui lane): the loaded generator
+// is not registry-resolvable (its DiT is a single in-place file, not a diffusers snapshot dir), so it is
+// loaded fresh per job through `start_gen_stream`. This file is `include!`d into the `image_jobs`
+// module, sharing its imports.
+
+/// The adapter/engine id recorded on candle ComfyUI FLUX.2-dev assets + telemetry (distinct from the
+/// registry `candle` flux2 txt2img and the `flux2_dev` edit/control lanes).
+const FLUX2_COMFYUI_CANDLE_ENGINE: &str = "candle_flux2_dev_comfyui";
+
+/// Denoise-steps fallback — the `flux2_dev` manifest default (`defaults.steps`). The UI normally
+/// supplies `advanced.steps`; this only applies when it does not. FLUX.2-dev is guidance-distilled (not
+/// few-step), so this is a production count.
+const FLUX2_COMFYUI_DEFAULT_STEPS: u32 = 28;
+
+/// The shipped SceneWorks FLUX.2-dev snapshot repo — per-tier subdirs (`q4/`, `q8/`, `bf16/`), each a
+/// complete tree (`transformer/ text_encoder/ vae/ tokenizer/`). The DiT is read from the ComfyUI tree
+/// instead, so only the tier's Mistral-3 text encoder + VAE + tokenizer are used here.
+const FLUX2_COMFYUI_SNAPSHOT_REPO: &str = "SceneWorks/flux2-dev-mlx";
+
+/// Tier subdirs probed (in order) for the TE/VAE/tokenizer. bf16 first — its Mistral-3 text encoder is a
+/// **dense** diffusers tree the candle loader reads directly; the packed q8/q4 tiers are the fallback
+/// (the candle loader's packed path consumes them). The first fully-present tree wins, so a
+/// partially-downloaded tier does not block the lane.
+const FLUX2_COMFYUI_SNAPSHOT_TIERS: &[&str] = &["bf16", "q8", "q4"];
+
+/// The compute quant the dequanted DiT (and the snapshot Mistral TE) are folded onto the GPU at. The 32B
+/// dev does not fit the GPU dense after the fp8→f32 dequant, so a quant is required; Q8 preserves the
+/// ~8-bit fp8 source and fits a 96 GB card (~24 GB TE + ~32 GB DiT + VAE). An `advanced.quant` of `q4`
+/// selects the smaller/faster tier for tighter cards.
+const FLUX2_COMFYUI_DEFAULT_QUANT: Quant = Quant::Q8;
+
+/// The in-place ComfyUI DiT file + the resident snapshot tier dir supplying the other components.
+struct ComfyuiFlux2Paths {
+    /// ComfyUI FLUX.2-dev DiT (`diffusion_models/flux2_dev_fp8mixed.safetensors`), read in place.
+    transformer: PathBuf,
+    /// A resident `SceneWorks/flux2-dev-mlx` tier dir (`text_encoder/ vae/ tokenizer/tokenizer.json`).
+    snapshot_dir: PathBuf,
+}
+
+/// Resolve the ComfyUI FLUX.2-dev DiT path + the resident snapshot tier from the forwarded
+/// `external_base_*` row. Returns `Ok(None)` when this is not a runnable ComfyUI FLUX.2-dev job (wrong
+/// family, not marked usable, no transformer component, or our FLUX.2-dev snapshot is not resident), so
+/// the router falls through rather than erroring. The DiT path is confined by
+/// `normalize_app_managed_model_path` (widened to admit the operator's external roots, sc-10668) — a
+/// payload can never point it outside a declared root (epic 4484). The snapshot dir is resolved from a
+/// fixed repo constant + our own cache (never payload-derived), so it needs no confinement.
+fn resolve_flux2_comfyui_paths(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> WorkerResult<Option<ComfyuiFlux2Paths>> {
+    let entry = &request.model_manifest_entry;
+    if entry.get("family").and_then(Value::as_str) != Some("flux2") {
+        return Ok(None);
+    }
+    // Only render what the API marked runnable (flux2 inline-scale fp8, sc-10680). A non-usable row must
+    // not be silently rendered — it is either an unsupported quant (comfy_quant fp4 / gguf) or incomplete.
+    if entry.get("usable").and_then(Value::as_bool) != Some(true) {
+        return Ok(None);
+    }
+    let Some(components) = entry.get("components").and_then(Value::as_array) else {
+        return Ok(None);
+    };
+    let Some(transformer) = components
+        .iter()
+        .find(|component| component.get("role").and_then(Value::as_str) == Some("transformer"))
+        .and_then(|component| component.get("path").and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(None);
+    };
+    // The Mistral-3 TE / VAE / tokenizer come from a resident FLUX.2-dev snapshot tier; if none is
+    // installed there is nothing to encode/decode with, so this is not (yet) runnable.
+    let Some(snapshot_root) =
+        huggingface_snapshot_dir(&settings.data_dir, FLUX2_COMFYUI_SNAPSHOT_REPO)
+    else {
+        return Ok(None);
+    };
+    let Some(snapshot_dir) = FLUX2_COMFYUI_SNAPSHOT_TIERS
+        .iter()
+        .map(|tier| snapshot_root.join(tier))
+        .find(|dir| {
+            dir.join("text_encoder").is_dir()
+                && dir.join("vae").is_dir()
+                && dir.join("tokenizer").join("tokenizer.json").is_file()
+        })
+    else {
+        return Ok(None);
+    };
+    Ok(Some(ComfyuiFlux2Paths {
+        transformer: crate::paths::normalize_app_managed_model_path(
+            settings,
+            transformer,
+            "ComfyUI FLUX.2-dev transformer",
+        )?,
+        snapshot_dir,
+    }))
+}
+
+/// True when this is a candle-runnable in-place ComfyUI FLUX.2-dev txt2img job: an `external_base_*`
+/// model whose forwarded row is a usable flux2 with a transformer component + a resident snapshot, no
+/// source image / pose (txt2img only). Mirrors the Qwen-Image comfyui availability predicate.
+fn flux2_comfyui_available(request: &ImageRequest, settings: &Settings) -> bool {
+    request.model.starts_with("external_base_")
+        && request.mode != "edit_image"
+        && pose_entries(request).is_empty()
+        && matches!(resolve_flux2_comfyui_paths(request, settings), Ok(Some(_)))
+}
+
+/// The compute quant the DiT + snapshot TE fold onto the GPU at: `advanced.quant` (`q4`/`q8`), else the
+/// [`FLUX2_COMFYUI_DEFAULT_QUANT`]. The 32B dev needs a quant to fit; there is no dense option.
+fn flux2_comfyui_quant(request: &ImageRequest) -> Quant {
+    match request
+        .advanced
+        .get("quant")
+        .and_then(Value::as_str)
+        .map(|value| value.trim().to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("q4") => Quant::Q4,
+        Some("q8") => Quant::Q8,
+        _ => FLUX2_COMFYUI_DEFAULT_QUANT,
+    }
+}
+
+/// Read the requested embedded-guidance scale from `advanced.guidanceScale` (JSON number or numeric
+/// string). `None` ⇒ the candle-gen FLUX.2-dev engine default. The external-base row is in no
+/// `MODEL_TABLE`, so `resolve_guidance` (which needs a `ResolvedModel`) does not apply — this reads the
+/// same `advanced` knob directly. FLUX.2-dev is guidance-distilled (embedded scalar, no negative pass).
+fn flux2_comfyui_guidance(request: &ImageRequest) -> Option<f32> {
+    request
+        .advanced
+        .get("guidanceScale")
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
+        .map(|value| value as f32)
+}
+
+/// Flat telemetry recorded on candle ComfyUI FLUX.2-dev assets.
+fn flux2_comfyui_raw_settings(
+    request: &ImageRequest,
+    steps: u32,
+    guidance: Option<f32>,
+    quant: Quant,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw.insert("mode".to_owned(), Value::String("text_to_image".to_owned()));
+    raw.insert(
+        "engine".to_owned(),
+        Value::String(FLUX2_COMFYUI_CANDLE_ENGINE.to_owned()),
+    );
+    raw.insert(
+        "externalComfyuiBase".to_owned(),
+        Value::String(request.model.clone()),
+    );
+    raw.insert(
+        "mlxQuantize".to_owned(),
+        json!(match quant {
+            Quant::Q4 => 4,
+            Quant::Q8 => 8,
+        }),
+    );
+    if let Some(scale) = guidance {
+        raw.insert("guidanceScale".to_owned(), json!(scale));
+    }
+    raw
+}
+
+/// Real candle in-place ComfyUI FLUX.2-dev txt2img generation: resolve + confine the DiT path and
+/// resolve the snapshot tier on the async side, then `load_from_comfyui_dit` once + generate each image
+/// on the blocking thread. `request.count` images, each its own seed. FLUX.2-dev is guidance-distilled
+/// (embedded scalar, single forward — NO negative prompt / true-CFG pass). The loaded `Box<dyn
+/// Generator>` is bespoke (not registry-cached), driven like the Qwen-Image comfyui lane.
+async fn generate_candle_flux2_comfyui_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let paths = resolve_flux2_comfyui_paths(request, settings)?.ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "ComfyUI FLUX.2-dev components could not be resolved (family/usable/transformer/snapshot)"
+                .to_owned(),
+        )
+    })?;
+
+    let (width, height) = (request.width, request.height);
+    let steps =
+        resolve_advanced_or_manifest_u32(request, "steps", FLUX2_COMFYUI_DEFAULT_STEPS, 1..=50);
+    let guidance = flux2_comfyui_guidance(request);
+    let quant = flux2_comfyui_quant(request);
+    let raw_settings = flux2_comfyui_raw_settings(request, steps, guidance, quant);
+
+    // Per-image work items: (seed, prompt) — `request.count` renders.
+    let work: Vec<(i64, String)> = (0..request.count as usize)
+        .map(|index| (resolve_seed(request, index), request.prompt.clone()))
+        .collect();
+    let total = work.len();
+
+    let (cancel, rx, blocking) = start_gen_stream(
+        job.id.clone(),
+        "flux2_comfyui",
+        0,
+        move || {
+            let ComfyuiFlux2Paths {
+                transformer,
+                snapshot_dir,
+            } = paths;
+            let model =
+                candle_gen_flux2::load_from_comfyui_dit(transformer, snapshot_dir, Some(quant))
+                    .map_err(|error| {
+                        WorkerError::Engine(format!("ComfyUI FLUX.2-dev load failed: {error}"))
+                    })?;
+            Ok(model)
+        },
+        move |model, tx, cancel| {
+            drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
+                if cancel.is_cancelled() {
+                    return Ok(None);
+                }
+                let request = GenerationRequest {
+                    prompt,
+                    width,
+                    height,
+                    count: 1,
+                    seed: Some(seed as u64),
+                    steps: Some(steps),
+                    guidance,
+                    cancel: cancel.clone(),
+                    ..Default::default()
+                };
+                let output = match model.generate(&request, &mut *on_progress) {
+                    Ok(output) => output,
+                    Err(_) if cancel.is_cancelled() => return Ok(None),
+                    Err(error) => {
+                        return Err(WorkerError::Engine(format!(
+                            "ComfyUI FLUX.2-dev generation failed: {error}"
+                        )));
+                    }
+                };
+                match output {
+                    GenerationOutput::Images(mut images) => {
+                        let image = images.pop().ok_or_else(|| {
+                            WorkerError::Engine("ComfyUI FLUX.2-dev produced no image".to_owned())
+                        })?;
+                        Ok(Some((seed, image.width, image.height, image.pixels)))
+                    }
+                    _ => Err(WorkerError::Engine(
+                        "ComfyUI FLUX.2-dev returned non-image output".to_owned(),
+                    )),
+                }
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        FLUX2_COMFYUI_CANDLE_ENGINE,
+        &raw_settings,
+        total,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}


### PR DESCRIPTION
## What

The 4th Phase-2 quant slice of epic 10451 (reuse local ComfyUI model folders off-Mac) after z-image (sc-10668) / qwen (sc-10670) / wan (sc-10671): render a user's existing ComfyUI **FLUX.2-dev fp8-mixed** DiT (`diffusion_models/flux2_dev_fp8mixed.safetensors`) **in place** — no copy, no re-download.

Pairs with **candle-gen [#407](https://github.com/SceneWorks/candle-gen/pull/407)** (merged), which adds the inline-scale fp8 dequant + BFL→diffusers remap seam.

## api — `external_base_models.rs`
- `flux2` is now **snapshot-backed** (its bare inline-scale-fp8 DiT anchor assembles `complete` on its own — the Mistral-3 TE / VAE / tokenizer come from a resident SceneWorks snapshot).
- `(flux2, fp8_inline_scale)` is **family+quant-runnable**, so the picker offers it (`usable: true`).
- Unit test mirrors the qwen slice. The base-weight detector already emits `(flux2, transformer, fp8_inline_scale)` (sc-10662).

## worker
- New bespoke candle lane `flux2_comfyui_candle.rs` + `CandleImageRoute::Flux2Comfyui` (dispatch arm + `include!`, both cfg-gated `not(macos) + backend-candle`).
- Resolves the DiT from the forwarded `external_base_*` row (confined by `normalize_app_managed_model_path`) + a resident `SceneWorks/flux2-dev-mlx` tier for the TE/VAE/tokenizer, then calls `candle_gen_flux2::load_from_comfyui_dit`.
- FLUX.2-dev is guidance-distilled (embedded scalar, no negative pass); the dequanted 32B DiT + the Mistral TE fold onto the GPU at **Q8** (`advanced.quant` selects q4) — the 32B does not fit dense after the fp8→f32 dequant.

## Pin
Pins candle-gen to **`63094ac`** — my #407 content commit, based directly on the `29ed1114` rev SceneWorks main already pins. This isolates the change from sibling PR #405 (main HEAD) and keeps a **single gen-core rev** (`4df97dce`), per the pin-bump discipline.

## Gates
- worker candle clippy `-D warnings` ✅
- worker candle lib tests — **530 passed** ✅
- non-candle parity clippy ✅
- api detector unit test ✅
- `--locked` build against the git-pinned candle-gen ✅

## ⚠️ GPU-val pending
`SceneWorks/flux2-dev-mlx` is **not resident** on the build box, so a real render needs the snapshot downloaded first (q4 ~34 GB / q8 ~55 GB / bf16 ~113 GB). Open question: whether the candle loader reads the MLX-packed Mistral TE in the q4/q8 tiers or needs the dense bf16 tier. Tracked as follow-up.

Relates sc-10662, sc-10668, sc-10671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)