### PR TITLE
feat(worker): measure candle FLUX.2 packed-tier sequential peaks → flux2 candle block + reject gate (sc-10920)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2750,6 +2750,22 @@
         "minMemoryGb": 42,
         "quantize": 4
       },
+      // candle/CUDA VRAM gate (epic 10765 sc-10920) — CARRIED (measured:false), arch-scaled, NOT directly
+      // measured: the candle-gen-flux2 offload A/B harness is dev-only (Mistral TE), and klein's Qwen3-TE
+      // txt2img path has no probe harness. Basis: klein keeps the 8B Qwen3 TE DENSE bf16 (~16 GB) in EVERY
+      // tier (only the 9B transformer is packed: q4 ~5 / q8 ~9.5 / bf16 ~18 GB), so the dense TE is the
+      // sequential FLOOR — dropping it before the DiT can't take the peak below its own ~18–20 GB working
+      // set. Estimated resident = TE + DiT + VAE + activations; sequential = max(TE-phase, DiT-phase). These
+      // corroborate the MLX ~36 GB bf16 peak. Behavior they drive: on the epic's 8–16 GB target cards klein
+      // rejects either way (the 16 GB dense TE alone overflows them); on a ~24 GB card the resident overflows
+      // so the gate offloads to the sequential path, which fits. Replace with real numbers if a klein
+      // (Qwen3-TE) offload harness is added to candle-gen-flux2.
+      "candle": {
+        "minMemoryGb": 26,
+        "vramGbByTier": { "q4": 26.0, "q8": 31.0, "bf16": 39.0 },
+        "sequentialPeakGb": { "q4": 20.0, "q8": 20.0, "bf16": 23.0 },
+        "measured": false
+      },
       // SceneWorks public/ungated re-host (LICENSE.md travels with the weights). FLUX
       // Non-Commercial License — generations are non-commercial use only, matching SceneWorks's
       // overall non-commercial posture, so no new app-level guardrail beyond the existing one. No
@@ -3122,16 +3138,30 @@
         "minMemoryGb": 96,
         "quantize": 4
       },
-      // candle/CUDA VRAM gate (sc-9094, epic 9083) — the epic HEADLINE, MEASURED on an RTX PRO 6000
-      // (Blackwell sm_120) at 1024²/8-step via the candle-gen VramProbe. The packed Q4 tier loads its
-      // quantized footprint on-device directly (no dense CPU-staging), so the old ~105 GB dense-staging
-      // load peak is GONE — measured q4 overall-peak 47.2 GB with a negligible load-peak. minMemoryGb 56
-      // covers the measured q4 tier with headroom; q8/bf16 are ESTIMATED (~58 / ~72 GB, scaled from the
-      // 32B DiT weight sizes) pending a q8/bf16 measurement (their TE dirs are not yet cached locally).
+      // candle/CUDA VRAM gate — MEASURED on an RTX PRO 6000 (Blackwell sm_120) at 1024²/8-step via the
+      // candle-gen-flux2 offload A/B harness (flux2_dev_probed_generate_for_offload_ab, device-level
+      // nvidia-smi PeakSampler on an idle GPU 0), the FLUX.1 (sc-10856) / Qwen-Image (sc-10969) methodology.
+      // Two peaks per tier: `vramGbByTier` = RESIDENT (packed TE + DiT + VAE co-resident, the default
+      // cross-request-cached path); `sequentialPeakGb` = SEQUENTIAL residency (sc-10868: the Mistral text
+      // encoder dropped before the DiT loads) — always lower, byte-identical pixels (md5-verified). The
+      // fit-gate compares the resident peak against free VRAM to pick sequential-offload vs reject, then
+      // (sc-10856) REJECTS if even the sequential peak won't fit rather than OOM.
+      // MEASURED (sc-10920): q4 res 44.0 / seq 35.6, q8 res 70.7 / seq 64.9. The reclaim is MODEST because
+      // the packed q4/q8 tiers ALSO pack the Mistral TE (q4 15 GB / q8 25 GB on disk), so dropping it frees
+      // far less than a dense TE would. This CORRECTS the earlier sc-10868 "95 GB resident / ~60 GB reclaim"
+      // figure, which was taken against a DENSE-bf16-TE staging that does NOT match the shipping packed tier
+      // (sc-10868's SEQUENTIAL 35.4 reproduces exactly here at 35.6; only its resident diverged) — and it
+      // agrees with the older sc-9094 VramProbe (q4 47.2). bf16 is CARRIED (measured:false): its 113 GB
+      // dense weights exceed a 96 GB card even sequentially (Mistral TE bf16 ~48 GB + f32 activation), so it
+      // is un-measurable on the dev box — the ~128 GB resident / ~97 GB sequential estimates both exceed
+      // 96 GB, so the gate rejects bf16 off-Mac before OOM (the intended outcome). minMemoryGb 56 stays the
+      // conservative STATIC admit floor (sc-9094 memory-eligibility); the dynamic fit-gate now drives the
+      // true resident/sequential/reject decision per card.
       "candle": {
         "minMemoryGb": 56,
-        "vramGbByTier": { "q4": 47.2, "q8": 58.0, "bf16": 72.0 },
-        "measured": false
+        "vramGbByTier": { "q4": 44.0, "q8": 70.7, "bf16": 128.0 },
+        "sequentialPeakGb": { "q4": 35.6, "q8": 64.9, "bf16": 97.0 },
+        "measured": true
       },
       "gated": false,
       "licenseUrl": "https://huggingface.co/SceneWorks/flux2-dev-mlx/blob/main/LICENSE.md",

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -459,6 +459,88 @@ fn builtin_model_entry(id: &str) -> Value {
         .unwrap_or_else(|| panic!("{id} present in builtin.models.jsonc"))
 }
 
+/// epic 10765 sc-10920: the FLUX.2 `candle` blocks drive the dynamic fit-gate end-to-end against the
+/// SHIPPED manifest bytes — resident-fits → sequential-offload → reject-before-OOM. The pure
+/// `vram_gate` unit tests cover the decision logic on synthetic fixtures; THIS guards the data half:
+/// a manifest edit that drops the flux2 `vramGbByTier` / `sequentialPeakGb` makes `predicted_*` return
+/// `None` → the whole gate goes INERT for flux2 (the exact "candle block missing" failure the story
+/// targets). Exercises the same `SCENEWORKS_CUDA_VRAM_CAP_GB` small-card emulation the worker honors via
+/// `apply_vram_cap`. Gated to the candle lane where `vram_gate` compiles (sc-10920 measured q4/q8;
+/// bf16 + klein are carried, and are asserted to reject on real cards, which is the intended outcome).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn flux2_candle_blocks_drive_the_fit_gate_and_reject() {
+    use crate::vram_gate::{
+        apply_vram_cap, fit_decision, predicted_peak_gb, predicted_sequential_peak_gb,
+        resolve_offload, sequential_overflow_gb, FitDecision,
+    };
+
+    let dev = builtin_model_entry("flux2_dev");
+    // `predicted_*` take the MODEL ENTRY (they read `.candle` internally), not the candle sub-object.
+    let dev_entry = dev.as_object().expect("flux2_dev entry object");
+    assert!(
+        dev_entry.get("candle").and_then(Value::as_object).is_some(),
+        "flux2_dev candle block present (absent ⇒ fit-gate inert for flux2)"
+    );
+
+    // Measured q4 (sc-10920): resident 44.0 / sequential 35.6, each + the gate's 2 GB headroom.
+    let q4_res = predicted_peak_gb(dev_entry, "q4").expect("q4 resident predicted");
+    let q4_seq = predicted_sequential_peak_gb(dev_entry, "q4").expect("q4 sequential predicted");
+    assert!((q4_res - 46.0).abs() < 1e-6, "q4 resident 44.0 + 2 headroom, got {q4_res}");
+    assert!((q4_seq - 37.6).abs() < 1e-6, "q4 sequential 35.6 + 2 headroom, got {q4_seq}");
+    assert!(q4_seq < q4_res, "sequential is the lower peak");
+
+    // A 96 GB card fits q4 resident outright — no offload.
+    let card96 = apply_vram_cap(None, Some(96.0));
+    assert_eq!(fit_decision(Some(q4_res), card96), FitDecision::Fits);
+
+    // Emulate a 40 GB card: resident 46 won't fit, but sequential 37.6 does → OFFLOAD, run sequentially.
+    let card40 = apply_vram_cap(None, Some(40.0));
+    let at40 = resolve_offload(fit_decision(Some(q4_res), card40), /* sequential_capable */ true);
+    assert!(matches!(at40, FitDecision::Offload { .. }), "40 GB → offload, got {at40:?}");
+    assert_eq!(sequential_overflow_gb(Some(q4_seq), card40), None, "sequential fits 40 GB → run");
+
+    // Emulate a 30 GB card: even the sequential 37.6 peak won't fit → REJECT-before-OOM (sc-10856 gate).
+    let card30 = apply_vram_cap(None, Some(30.0));
+    let at30 = resolve_offload(fit_decision(Some(q4_res), card30), true);
+    assert!(matches!(at30, FitDecision::Offload { .. }), "30 GB → offload attempt, got {at30:?}");
+    assert_eq!(
+        sequential_overflow_gb(Some(q4_seq), card30),
+        Some(q4_seq),
+        "sequential 37.6 > 30 GB → reject carrying the number"
+    );
+
+    // Measured q8 is present too (resident 70.7 / sequential 64.9 + headroom).
+    assert!((predicted_peak_gb(dev_entry, "q8").unwrap() - 72.7).abs() < 1e-6);
+    assert!((predicted_sequential_peak_gb(dev_entry, "q8").unwrap() - 66.9).abs() < 1e-6);
+
+    // The carried bf16 tier (128 / 97) rejects on a 96 GB card even sequentially — the intended outcome
+    // (113 GB dense weights can't run off-Mac), reject-before-OOM instead of a silent load-time OOM.
+    let bf16_seq = predicted_sequential_peak_gb(dev_entry, "bf16").expect("bf16 sequential carried");
+    assert_eq!(
+        sequential_overflow_gb(Some(bf16_seq), card96),
+        Some(bf16_seq),
+        "bf16 sequential 99 > 96 GB → reject"
+    );
+
+    // klein carries a candle block so ITS fit-gate is live: on a 16 GB epic-target card klein rejects
+    // even sequentially (the ~16 GB dense Qwen3 TE is the sequential floor).
+    let klein = builtin_model_entry("flux2_klein_9b");
+    let klein_entry = klein.as_object().expect("flux2_klein_9b entry object");
+    assert!(
+        klein_entry.get("candle").and_then(Value::as_object).is_some(),
+        "flux2_klein_9b candle block present"
+    );
+    let klein_seq =
+        predicted_sequential_peak_gb(klein_entry, "q4").expect("klein q4 sequential carried");
+    let card16 = apply_vram_cap(None, Some(16.0));
+    assert_eq!(
+        sequential_overflow_gb(Some(klein_seq), card16),
+        Some(klein_seq),
+        "klein sequential 22 > 16 GB → reject on the epic's small-card target"
+    );
+}
+
 /// sc-7875 (SD3.5 S6, MLX-path validation boundary): the three SD3.5 builtin-manifest entries gate
 /// correctly at the catalog layer — `macOnly: false` (cross-platform now that the candle off-Mac lane
 /// is wired, sc-7880/epic 7982; availability is driven by the routing tables, not this flag),


### PR DESCRIPTION
## What

Populates the `candle` VRAM-gate block for the FLUX.2 models in `builtin.models.jsonc` so the worker fit-gate (wired in sc-10868) actually fires in-app, plus a manifest-driven worker test that drives the resident → sequential-offload → reject-before-OOM chain under `SCENEWORKS_CUDA_VRAM_CAP_GB`.

Sibling of sc-10856 (FLUX.1) / sc-10969 (Qwen-Image). The gate machinery already existed; this is the data + measurement half — absent the `candle` block, `predicted_peak_gb`/`predicted_sequential_peak_gb` return `Unknown` and the gate is inert for flux2.

## Measured (device-level A/B on idle GPU0, candle-gen-flux2 `flux2_dev_probed_generate_for_offload_ab`, RTX PRO 6000 sm_120, 1024²/8-step, byte-identical resident vs sequential pixels)

| tier | resident | sequential | reclaim |
|---|---|---|---|
| flux2_dev q4 | 44.0 GB | 35.6 GB | 8.4 GB |
| flux2_dev q8 | 70.7 GB | 64.9 GB (spec-sequential) | 5.8 GB |

## ⚠️ Correction to the sc-10868 figure

sc-10868's story text cited **q4 resident ~95 GB / ~60 GB reclaim**. That was measured against a **dense-bf16-TE** staging that does **not** match the shipping packed tier: the packed q4/q8 tiers also **pack the Mistral TE** (q4 15 GB / q8 25 GB on disk), so dropping it before the DiT reclaims far less. sc-10868's **sequential** number (35.4) reproduces here (35.6) — only its resident diverged, exactly as expected (sequential doesn't hold the TE resident). The measured resident also agrees with sc-9094's `VramProbe` (q4 47.2). So the offload win for flux2_dev is real but **modest** (the TE is already quantized), and the manifest now records the true shipping-tier peaks.

## Carried (`measured:false`)

- **flux2_dev bf16** — 113 GB dense weights exceed a 96 GB card even sequentially (Mistral TE bf16 ~48 GB + f32 activation), so it's un-measurable on the dev box. Estimates (resident 128 / sequential 97) both exceed 96 GB → the gate **rejects bf16 off-Mac before OOM** (the intended outcome for a tier that can't run off-Mac).
- **flux2_klein_9b** — no Qwen3-TE offload harness exists (the dev harness is Mistral-only). klein keeps the 8 GB Qwen3 TE **dense bf16 (~16 GB)** in every tier, which is the sequential floor. Arch-scaled resident q4 26 / q8 31 / bf16 39, sequential ~20/20/23; corroborates the MLX ~36 GB bf16 peak. Adequate to drive the right decision (reject on ≤16 GB target cards, offload on ~24 GB).

## Tests

`cargo test -p sceneworks-worker --lib --features backend-candle` — new `flux2_candle_blocks_drive_the_fit_gate_and_reject` (manifest-driven: Fits @96 GB, Offload @40 GB, reject-before-OOM @30 GB, bf16/klein carried tiers reject) + the existing `vram_gate` unit tests all pass. Scaffold check green.

## Follow-up

A klein (Qwen3-TE) offload A/B harness in candle-gen-flux2 would let klein be directly measured rather than carried — worth a story if precise klein small-card numbers become important.

🤖 Generated with [Claude Code](https://claude.com/claude-code)