### PR TITLE
fix(desktop): stop sidecars before auto-update install so NSIS can overwrite sceneworks-api.exe (sc-11015)

### DIFF
--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -1480,6 +1480,102 @@ pub fn begin_shutdown(app: &AppHandle) -> bool {
     true
 }
 
+/// True while any `sceneworks-api` sidecar image is still running. The auto-update
+/// install gate polls this so the NSIS installer only overwrites `sceneworks-api.exe`
+/// once every sidecar has released its lock on the binary — the API, the candle `auto`
+/// worker supervisor, and its per-GPU + CPU children are all this same image.
+#[cfg(windows)]
+fn api_sidecar_running() -> bool {
+    use std::os::windows::process::CommandExt;
+    // CREATE_NO_WINDOW: this is polled in a tight loop during the update, so keep a
+    // console window from flashing on every probe.
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    let Ok(output) = std::process::Command::new("tasklist")
+        .args([
+            "/FI",
+            "IMAGENAME eq sceneworks-api.exe",
+            "/FO",
+            "CSV",
+            "/NH",
+        ])
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()
+    else {
+        // If the probe itself fails, don't spin — treat the binary as clear and let the
+        // installer's own retry/abort dialog handle any lingering lock.
+        return false;
+    };
+    String::from_utf8_lossy(&output.stdout).contains("sceneworks-api")
+}
+
+/// Non-Windows replaces a running executable in place (the swap unlinks the old inode,
+/// which the live process keeps using), so an update never waits on the binary being
+/// unlocked — the wait loop that calls this exits immediately.
+#[cfg(not(windows))]
+fn api_sidecar_running() -> bool {
+    false
+}
+
+/// Stop the API + GPU-worker sidecars for an in-place auto-update and BLOCK until the
+/// `sceneworks-api` binary is no longer running, so the installer can overwrite it
+/// (sc-11015).
+///
+/// The Windows update path is why this exists: `tauri-plugin-updater`'s NSIS `/UPDATE`
+/// terminates only the main app binary (`SceneWorks.exe`), not the `sceneworks-api.exe`
+/// sidecars this shell spawned — the API, the candle `auto` worker supervisor, and its
+/// per-GPU + CPU children. Any of them still holding the binary open makes NSIS abort
+/// with "Error opening file for writing: …\sceneworks-api.exe". We tear them down and
+/// wait for the lock to release before handing off to the installer.
+///
+/// Unlike [`begin_shutdown`] this does NOT exit the app — the shell must stay alive to
+/// launch the installer (which relaunches into the new build on Windows, or which the
+/// caller follows with `restart()` off Windows). Latches `shutting_down` so the worker
+/// supervisors stop respawning and a sidecar exit doesn't surface the "API stopped
+/// unexpectedly" error dialog mid-update.
+pub fn stop_sidecars_for_update(app: &AppHandle) {
+    let managed = app.state::<Managed>();
+    managed.shutting_down.store(true, Ordering::SeqCst);
+
+    let mlx_worker = managed.mlx_worker.lock().expect("mlx worker lock").take();
+    let candle_worker = managed
+        .candle_worker
+        .lock()
+        .expect("candle worker lock")
+        .take();
+    let api_child = managed.api.lock().expect("api lock").take();
+
+    // Tree-kill the candle `auto` supervisor so its per-GPU + CPU grandchildren die
+    // with it (each is a `sceneworks-api.exe` holding the binary open);
+    // CommandChild::kill() reaps only the supervisor and orphans them — the same reason
+    // `begin_shutdown` tree-kills it.
+    if let Some(child) = candle_worker {
+        #[cfg(windows)]
+        kill_pid(child.pid());
+        #[cfg(not(windows))]
+        let _ = child.kill();
+    }
+    if let Some(child) = mlx_worker {
+        let _ = child.kill();
+    }
+    if let Some(child) = api_child {
+        let _ = child.kill();
+    }
+
+    // These PIDs are being terminated on purpose; drop the pidfile so the next launch
+    // doesn't try to reap them (or a since-recycled PID).
+    let _ = std::fs::remove_file(sidecar_pidfile());
+
+    // Wait for the OS to report no `sceneworks-api.exe` still running, so its file
+    // handle is released before the installer overwrites it. Bounded, so a wedged
+    // process can't hang the update forever — past the deadline the installer's own
+    // retry/abort dialog takes over. Returns immediately off Windows (no lock to wait
+    // on).
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while api_sidecar_running() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(200));
+    }
+}
+
 /// Minimum NVIDIA display driver for the bundled CUDA 12.9 runtime (sc-3676 /
 /// sc-5560): the floor that supports it and forward-JITs the compute_80 PTX.
 #[cfg(target_os = "windows")]

--- a/apps/desktop/src/update.rs
+++ b/apps/desktop/src/update.rs
@@ -67,11 +67,14 @@ async fn check_and_prompt(app: &AppHandle) -> tauri_plugin_updater::Result<()> {
             // runtime. `update` is moved in (it carries the verified manifest).
             tauri::async_runtime::spawn(async move {
                 if let Err(err) = install_update(&app_for_install, update).await {
-                    tracing::error!(error = %err, "auto-update: install failed");
+                    // Reached only for a download/verify failure — `install_update` stops
+                    // the sidecars only after the bytes are in hand and handles any
+                    // install-time failure itself, so here the app is still fully running.
+                    tracing::error!(error = %err, "auto-update: download failed");
                     app_for_install
                         .dialog()
                         .message(
-                            "The update could not be installed. You can download the \
+                            "The update could not be downloaded. You can download the \
                              latest release manually from the SceneWorks releases page.",
                         )
                         .title("Update failed")
@@ -86,14 +89,49 @@ async fn check_and_prompt(app: &AppHandle) -> tauri_plugin_updater::Result<()> {
 
 /// Download + install the verified update, then restart into it. `restart()`
 /// diverges (`-> !`), so it is the function's tail and nothing runs after it.
+///
+/// Download and install are split deliberately (sc-11015): the signed bundle is
+/// fetched + verified FIRST, while the app and its sidecars keep running, so a
+/// download/verify failure leaves the session fully intact (the caller shows a
+/// recoverable error and the app stays usable). Only with the bytes in hand do we stop
+/// the `sceneworks-api` sidecars — the Windows NSIS installer overwrites
+/// `sceneworks-api.exe` in place, and a still-live sidecar holds a lock on it, which is
+/// what produced the "Error opening file for writing: …\sceneworks-api.exe" abort.
+/// `tauri-plugin-updater`'s NSIS `/UPDATE` only kills the main app binary
+/// (`SceneWorks.exe`), never the sidecars this shell spawned.
 async fn install_update(app: &AppHandle, update: Update) -> tauri_plugin_updater::Result<()> {
     tracing::info!(version = %update.version, "auto-update: downloading");
-    update
-        .download_and_install(
+    let bytes = update
+        .download(
             |_chunk_len: usize, _content_len: Option<u64>| {},
-            || tracing::info!("auto-update: download complete, installing"),
+            || tracing::info!("auto-update: download complete"),
         )
         .await?;
+
+    // Stop the API + GPU-worker sidecars and BLOCK until `sceneworks-api.exe` is no
+    // longer running, so the installer can overwrite it (no-op wait off Windows).
+    tracing::info!("auto-update: stopping sidecars before install");
+    crate::setup::stop_sidecars_for_update(app);
+
+    // Hand off to the installer. On Windows `install` launches the NSIS updater and
+    // terminates this process (the installer relaunches into the new build), so the
+    // `restart()` tail below is reached only on macOS/Linux, where `install` returns.
+    tracing::info!("auto-update: installing");
+    if let Err(err) = update.install(bytes) {
+        // The sidecars are already down, so the running session can't recover in place.
+        // Tell the user, then relaunch to come back cleanly on the current (un-updated)
+        // build rather than sit with a dead API window; they can retry the update.
+        tracing::error!(error = %err, "auto-update: install failed after sidecar teardown; restarting to recover");
+        app.dialog()
+            .message(
+                "The update could not be installed. SceneWorks will restart on the \
+                 current version — you can try updating again from the releases page.",
+            )
+            .title("Update failed")
+            .kind(MessageDialogKind::Error)
+            .blocking_show();
+        app.restart();
+    }
     tracing::info!("auto-update: installed, restarting");
     app.restart()
 }


### PR DESCRIPTION
## Problem

Accepting the in-app auto-update on the **Windows** desktop build aborts partway through the NSIS installer:

> Error opening file for writing: `…\SceneWorks\sceneworks-api.exe`
> Abort / Retry / Ignore

## Root cause

`tauri-plugin-updater`'s Windows `install` runs the NSIS installer with `/UPDATE`, and the Tauri NSIS template kills only the **main app binary** (`SceneWorks.exe`) — never the `sceneworks-api.exe` **sidecars** this shell spawns: the API process, the candle `auto` GPU-worker supervisor, and its per-GPU + CPU children (all the same `sceneworks-api.exe` image). Those processes keep a lock on the binary, so NSIS can't overwrite it.

Because `install()` internally calls `std::process::exit(0)`, the pre-existing `app.restart()` was also never reached on Windows.

## Fix

Split `download_and_install` into `download` → **stop sidecars** → `install` in [update.rs](apps/desktop/src/update.rs):

1. **Download + verify first**, while the app + sidecars keep running — a download/verify failure now leaves the running session fully intact (recoverable; the app stays usable).
2. New `setup::stop_sidecars_for_update()` ([setup.rs](apps/desktop/src/setup.rs)): latches `shutting_down` (supervisors stop respawning; a sidecar exit no longer surfaces the "API stopped unexpectedly" dialog mid-update), tree-kills the candle supervisor (`taskkill /T`) + API + MLX children, drops the pidfile, then **blocks until no `sceneworks-api.exe` image is running** (bounded 15s; polled via `tasklist` with `CREATE_NO_WINDOW` so no console flash). No-op wait off Windows, where a running executable is replaced in place.
3. `install` then hands off to NSIS (exits on Windows) or returns and we `restart()` (macOS/Linux). An install failure *after* teardown recovers by relaunching the current build.

## Testing

- `cargo check / clippy / fmt / test -p sceneworks-desktop` all green (35 tests pass) on the Windows/CUDA box.
- ⚠️ Full E2E (real signed release → accept update → clean overwrite + relaunch) still needs a run on a packaged build.

Relates to sc-1355 (auto-updater) and epic 5558 (Windows candle packaging — the sidecar processes that lock the binary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)