### PR TITLE
feat(api): register + list trained ControlNet overlays (Training Studio B4, sc-10165)

### DIFF
--- a/apps/rust-api/src/control_overlays.rs
+++ b/apps/rust-api/src/control_overlays.rs
@@ -1,0 +1,91 @@
+use super::*;
+
+/// Query params for `GET /api/v1/control-overlays` (sc-10165, epic 10159 B4). Optional project scope +
+/// `baseModel` filter so the Studio lists only overlays applicable to the selected model (the frozen
+/// inference base the overlay applies on, e.g. `krea_2_turbo`).
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ControlOverlaysQuery {
+    pub project_id: Option<String>,
+    pub base_model: Option<String>,
+}
+
+/// List installed + registered control overlays. Studio-trained overlays register here on completion
+/// (`register_trained_control_overlay`); a hosted catalog + user import arrive with sc-8466 / sc-10979,
+/// which extend this same registry. Mirrors [`list_loras`]: assemble user-global + project manifests,
+/// normalize install state, optionally filter by `baseModel`.
+pub(crate) async fn list_control_overlays(
+    State(state): State<AppState>,
+    Query(query): Query<ControlOverlaysQuery>,
+) -> Result<Json<Vec<Value>>, ApiError> {
+    let mut items = control_overlay_catalog(&state, query.project_id.as_deref()).await?;
+    if let Some(base_model) = query.base_model {
+        let base_model = base_model.trim().to_owned();
+        items.retain(|item| {
+            item.get("baseModel").and_then(Value::as_str) == Some(base_model.as_str())
+        });
+    }
+    Ok(Json(items))
+}
+
+/// Assemble the control-overlay catalog: user-global (`user.control_overlays.jsonc`) + the project
+/// manifest (`<project>/control-overlays/manifest.jsonc`) when a project id is given. Each entry is
+/// normalized (installedPath / installState / manifestPath) via the shared [`normalize_lora_entry`] — the
+/// resolution is identical (a relative `source.path` under the scope root; the training provider carries
+/// no HF repo, so the local-path branch resolves it). No builtin control overlays yet — a hosted catalog
+/// (`builtin.control_overlays.jsonc`) lands with sc-8466.
+pub(crate) async fn control_overlay_catalog(
+    state: &AppState,
+    project_id: Option<&str>,
+) -> Result<Vec<Value>, ApiError> {
+    let manifest_dir = state.settings.config_dir.join("manifests");
+    let user_manifest = manifest_dir.join("user.control_overlays.jsonc");
+    let user = load_manifest_entries(state, &user_manifest, "controlOverlays").await?;
+    let data_dir = state.settings.data_dir.clone();
+
+    let mut overlays = {
+        let data_dir = data_dir.clone();
+        let user_manifest = user_manifest.clone();
+        tokio::task::spawn_blocking(move || -> Result<Vec<Value>, ApiError> {
+            let mut out = Vec::new();
+            for entry in user {
+                out.push(crate::loras::normalize_lora_entry(
+                    entry,
+                    "global",
+                    &user_manifest,
+                    &data_dir,
+                    &data_dir,
+                )?);
+            }
+            Ok(out)
+        })
+        .await
+        .map_err(|error| ApiError::internal(error.to_string()))??
+    };
+
+    if let Some(project_id) = project_id {
+        let project_path = project_path_for_id(state.clone(), project_id).await?;
+        let project_manifest = project_path.join("control-overlays").join("manifest.jsonc");
+        let entries = load_manifest_entries(state, &project_manifest, "controlOverlays").await?;
+        let data_dir = data_dir.clone();
+        let project_overlays =
+            tokio::task::spawn_blocking(move || -> Result<Vec<Value>, ApiError> {
+                let mut out = Vec::new();
+                for entry in entries {
+                    out.push(crate::loras::normalize_lora_entry(
+                        entry,
+                        "project",
+                        &project_manifest,
+                        &project_path,
+                        &data_dir,
+                    )?);
+                }
+                Ok(out)
+            })
+            .await
+            .map_err(|error| ApiError::internal(error.to_string()))??;
+        overlays.extend(project_overlays);
+    }
+
+    Ok(overlays)
+}

--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -386,6 +386,12 @@ pub(crate) async fn update_job_progress(
         if let Some(status) = register_completed_training_lora(&state, &job_id).await {
             result.get_or_insert_with(JsonObject::new).extend(status);
         }
+        // A completing ControlTraining run registers its trained overlay into the control-overlay
+        // manifest so it is selectable + runnable in generation (sc-10165, B4). Gates on
+        // `JobType::ControlTraining`, so exactly one of these two fires per job.
+        if let Some(status) = register_completed_control_overlay(&state, &job_id).await {
+            result.get_or_insert_with(JsonObject::new).extend(status);
+        }
     }
     // Persist any generated assets the worker reported as `assetWrites` facts and
     // re-inject the built sidecars into the result so the UI keeps streaming them
@@ -647,4 +653,150 @@ pub(crate) async fn register_trained_lora(
     })
     .await?;
     Ok(Some((lora_id, manifest_path)))
+}
+
+/// The control-overlay analog of [`register_completed_training_lora`] (sc-10165, epic 10159 B4). A
+/// completing `ControlTraining` run leaves a trained overlay in its output dir that nothing yet
+/// registers (`register_completed_training_lora` is `LoraTrain`-only), so a Krea ControlNet was produced
+/// but not usable in generation. This registers it into the control-overlay manifest. Never errors the
+/// progress update: a failure is logged and surfaced via `controlOverlayRegistered: false` +
+/// `controlOverlayRegistrationError` so the trained output is not silently lost.
+pub(crate) async fn register_completed_control_overlay(
+    state: &AppState,
+    job_id: &str,
+) -> Option<JsonObject> {
+    let job = store_call(state.clone(), {
+        let job_id = job_id.to_owned();
+        move |store, _timeout| store.get_job(&job_id)
+    })
+    .await
+    .ok()?;
+    if !matches!(job.job_type, JobType::ControlTraining) {
+        return None;
+    }
+    match register_trained_control_overlay(state, &job).await {
+        Ok(None) => None,
+        Ok(Some((overlay_id, manifest_path))) => {
+            let mut status = JsonObject::new();
+            status.insert("controlOverlayRegistered".to_owned(), Value::Bool(true));
+            status.insert("controlOverlayId".to_owned(), Value::String(overlay_id));
+            status.insert(
+                "controlOverlayManifestPath".to_owned(),
+                Value::String(manifest_path.display().to_string()),
+            );
+            Some(status)
+        }
+        Err(error) => {
+            tracing::error!(
+                event = "control_overlay_registration_failed",
+                jobId = %job.id,
+                detail = %error.detail,
+                "failed to register trained control overlay"
+            );
+            let mut status = JsonObject::new();
+            status.insert("controlOverlayRegistered".to_owned(), Value::Bool(false));
+            status.insert(
+                "controlOverlayRegistrationError".to_owned(),
+                Value::String(error.detail),
+            );
+            Some(status)
+        }
+    }
+}
+
+/// Registers a completed control-training run's overlay as a SceneWorks control overlay, returning the
+/// registered `(overlay_id, manifest_path)` or `None` when there is nothing to register (a dry run, or a
+/// job without a staged entry).
+///
+/// Security: mirrors [`register_trained_lora`] exactly — the manifest path and output dir are recomputed
+/// from the run's scope, owning project, and a validated overlay id (never the mutable job payload), so a
+/// crafted or duplicated job cannot redirect the write outside the two canonical control-overlay
+/// manifests (`config_dir/manifests/user.control_overlays.jsonc` or
+/// `<project>/control-overlays/manifest.jsonc`). A run whose overlay is missing under the recomputed dir
+/// registers nothing. The entry lands in the `controlOverlays` field and is selectable as a ControlNet
+/// for its backbone in the Studio.
+pub(crate) async fn register_trained_control_overlay(
+    state: &AppState,
+    job: &JobSnapshot,
+) -> Result<Option<(String, PathBuf)>, ApiError> {
+    if job
+        .payload
+        .get("dryRun")
+        .and_then(Value::as_bool)
+        .unwrap_or(true)
+    {
+        return Ok(None);
+    }
+    let Some(manifest_entry) = job
+        .payload
+        .get("manifestEntry")
+        .and_then(Value::as_object)
+        .cloned()
+    else {
+        return Ok(None);
+    };
+    let scope = manifest_entry
+        .get("scope")
+        .and_then(Value::as_str)
+        .unwrap_or("project")
+        .to_owned();
+    let overlay_id = manifest_entry
+        .get("id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ApiError::internal("Control training manifest entry requires an id"))?
+        .to_owned();
+    validate_lora_id_component(&overlay_id)?;
+
+    // Recompute the output dir + manifest path from trusted inputs; the payload's own paths are ignored.
+    let (output_dir, manifest_path) = resolve_control_overlay_output_location(
+        state,
+        &scope,
+        job.project_id.as_deref(),
+        &overlay_id,
+    )
+    .await?;
+    let Some(files) = trusted_adapter_files(manifest_entry.get("files"), &output_dir) else {
+        return Err(ApiError::internal(format!(
+            "No declared trained overlay found under {}; skipping control-overlay registration",
+            output_dir.display()
+        )));
+    };
+
+    // Overwrite the security-sensitive fields with trusted values, keeping the descriptive control
+    // metadata (name, controlType, controlEngine, backbone, baseModel, kind, provenance) the submit step
+    // captured. `source.path` stays relative so the catalog resolves it under the scope root.
+    let mut entry = manifest_entry;
+    entry.insert("id".to_owned(), Value::String(overlay_id.clone()));
+    entry.insert("scope".to_owned(), Value::String(scope));
+    entry.insert(
+        "source".to_owned(),
+        json!({ "provider": "training", "path": format!("control-overlays/{overlay_id}") }),
+    );
+    entry.insert(
+        "files".to_owned(),
+        Value::Array(files.into_iter().map(Value::String).collect()),
+    );
+    entry.insert("updatedAt".to_owned(), Value::String(now_rfc3339()));
+
+    let upsert_id = overlay_id.clone();
+    mutate_manifest_entries(state, &manifest_path, "controlOverlays", move |entries| {
+        // Replace any prior entry with this id (re-run) so provenance refreshes without duplicating,
+        // preserving the original createdAt.
+        let created_at = entries
+            .iter()
+            .find(|item| item.get("id").and_then(Value::as_str) == Some(upsert_id.as_str()))
+            .and_then(|item| item.get("createdAt").cloned());
+        let mut entries = entries
+            .into_iter()
+            .filter(|item| item.get("id").and_then(Value::as_str) != Some(upsert_id.as_str()))
+            .collect::<Vec<_>>();
+        let mut entry = entry;
+        if let Some(created_at) = created_at {
+            entry.insert("createdAt".to_owned(), created_at);
+        }
+        entries.push(Value::Object(entry));
+        Ok((entries, ()))
+    })
+    .await?;
+    Ok(Some((overlay_id, manifest_path)))
 }

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -107,10 +107,10 @@ use training::{
     create_training_dataset_face_analysis_job, create_training_dataset_upscale_job,
     create_training_job, delete_training_dataset, get_training_dataset,
     get_training_dataset_readiness, list_training_datasets, list_training_presets,
-    list_training_targets, repoint_training_dataset_items, resolve_training_output_location,
-    set_training_dataset_item_quality_ack, smart_crop_training_dataset_items,
-    strip_exif_training_dataset_items, trusted_adapter_files, update_training_dataset,
-    upload_training_dataset_item, validate_lora_id_component,
+    list_training_targets, repoint_training_dataset_items, resolve_control_overlay_output_location,
+    resolve_training_output_location, set_training_dataset_item_quality_ack,
+    smart_crop_training_dataset_items, strip_exif_training_dataset_items, trusted_adapter_files,
+    update_training_dataset, upload_training_dataset_item, validate_lora_id_component,
     write_training_dataset_analysis_embeddings, write_training_dataset_caption_sidecars,
     write_training_dataset_face_embeddings,
 };
@@ -173,8 +173,10 @@ use models::{
     merge_model_manifest_entry, mlx_catalog_status, model_co_requisite_downloads, model_download,
     retain_downloads_for_os,
 };
+mod control_overlays;
 mod external_base_models;
 mod external_loras;
+use control_overlays::list_control_overlays;
 mod loras;
 use loras::{
     create_lora_download_job, create_lora_import_job, delete_lora, list_loras, lora_catalog,
@@ -1214,6 +1216,7 @@ pub(crate) fn create_app_with_state(
             post(create_model_import_job)
                 .layer(DefaultBodyLimit::max(MAX_MODEL_MULTIPART_BODY_BYTES)),
         )
+        .route("/api/v1/control-overlays", get(list_control_overlays))
         .route("/api/v1/loras", get(list_loras))
         .route(
             "/api/v1/loras/:lora_id",

--- a/apps/rust-api/src/training.rs
+++ b/apps/rust-api/src/training.rs
@@ -1231,10 +1231,31 @@ pub(crate) async fn create_training_job(
     // recomputed from the same trusted inputs at registration time
     // (`register_trained_lora`), never read back from the job payload.
     let output_scope = training_output_scope(&payload.config.advanced)?;
-    let (output_dir, _manifest_path) =
-        resolve_training_output_location(&state, &output_scope, Some(&project_id), &lora_id)
-            .await?;
-    let source_relpath = format!("loras/{lora_id}");
+    // A control overlay is a distinct artifact class (registered into its own store + manifest, applied at
+    // inference on a frozen base via a strict-control lane, not a mergeable adapter), so its output +
+    // source path go to `control-overlays/`, never the LoRA tree (sc-10165, epic 10159 B4).
+    let (output_dir, _manifest_path) = if is_control {
+        resolve_control_overlay_output_location(&state, &output_scope, Some(&project_id), &lora_id)
+            .await?
+    } else {
+        resolve_training_output_location(&state, &output_scope, Some(&project_id), &lora_id).await?
+    };
+    let source_relpath = if is_control {
+        format!("control-overlays/{lora_id}")
+    } else {
+        format!("loras/{lora_id}")
+    };
+    // Capture the control kind before `payload.config` is moved into `build_training_plan` below; used
+    // only when shaping the control-overlay manifest entry (sc-10165, B4).
+    let control_type = payload
+        .config
+        .advanced
+        .get("controlType")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("pose")
+        .to_ascii_lowercase();
 
     // Operational guardrails (story 1419): fail fast with actionable errors for
     // the common setup problems, before a job is queued.
@@ -1332,6 +1353,45 @@ pub(crate) async fn create_training_job(
         .and_then(Value::as_object_mut)
     {
         provenance.retain(|_, value| !value.is_null());
+    }
+
+    // A control overlay registers as a ControlNet, not a LoRA (sc-10165, B4): swap the LoRA-shaped
+    // descriptive fields (networkType/triggerWords/family) for its inference-side control identity — the
+    // control kind, the STRICT_CONTROL_ENGINES engine id, and the frozen base the overlay applies on at
+    // generation (krea_2 trains against krea_2_raw but applies on krea_2_turbo). `register_completed_\
+    // control_overlay` writes this into the control-overlay manifest; the security-sensitive id/scope/
+    // source are recomputed from trusted inputs there, so this stays purely descriptive.
+    if is_control {
+        let (control_engine, inference_base) = control_overlay_inference_identity(&target.family)
+            .ok_or_else(|| {
+                ApiError::bad_request(format!(
+                    "Control training target '{}' (family '{}') has no control-inference lane to apply the overlay on",
+                    target.id, target.family
+                ))
+            })?;
+        if let Some(entry) = manifest_entry.as_object_mut() {
+            entry.remove("networkType");
+            entry.remove("triggerWords");
+            entry.remove("family");
+            entry.insert("backbone".to_owned(), Value::String(target.family.clone()));
+            entry.insert(
+                "controlType".to_owned(),
+                Value::String(control_type.clone()),
+            );
+            entry.insert(
+                "controlEngine".to_owned(),
+                Value::String(control_engine.to_owned()),
+            );
+            entry.insert(
+                "kind".to_owned(),
+                Value::String(format!("{control_type}_control_branch")),
+            );
+            // Override the training base (krea_2_raw) with the inference base the overlay is used on.
+            entry.insert(
+                "baseModel".to_owned(),
+                Value::String(inference_base.to_owned()),
+            );
+        }
     }
 
     let plan_value =
@@ -1569,6 +1629,63 @@ pub(crate) async fn resolve_training_output_location(
         other => Err(ApiError::bad_request(format!(
             "Unsupported training outputScope: {other}. Use project or global."
         ))),
+    }
+}
+
+/// The control-overlay analog of [`resolve_training_output_location`] (sc-10165, epic 10159 B4). A
+/// registered ControlNet overlay is a distinct artifact class from a LoRA — it applies at inference on a
+/// frozen base via a strict-control lane, not as a mergeable adapter — so it gets its own store + manifest
+/// (`control-overlays/` + `control_overlays.jsonc`), never the LoRA tree. Same trusted-input recomputation
+/// discipline: the id is validated to a safe path component before it can name a dir/manifest. Returns
+/// `(output_dir, manifest_path)`.
+pub(crate) async fn resolve_control_overlay_output_location(
+    state: &AppState,
+    scope: &str,
+    project_id: Option<&str>,
+    overlay_id: &str,
+) -> Result<(PathBuf, PathBuf), ApiError> {
+    match scope {
+        "project" => {
+            let project_id = project_id.ok_or_else(|| {
+                ApiError::bad_request("Project-scoped training requires a project id")
+            })?;
+            let overlays_dir = project_path_for_id(state.clone(), project_id)
+                .await?
+                .join("control-overlays");
+            Ok((
+                overlays_dir.join(overlay_id),
+                overlays_dir.join("manifest.jsonc"),
+            ))
+        }
+        "global" => {
+            let overlays_dir = state.settings.data_dir.join("control-overlays");
+            Ok((
+                overlays_dir.join(overlay_id),
+                state
+                    .settings
+                    .config_dir
+                    .join("manifests")
+                    .join("user.control_overlays.jsonc"),
+            ))
+        }
+        other => Err(ApiError::bad_request(format!(
+            "Unsupported training outputScope: {other}. Use project or global."
+        ))),
+    }
+}
+
+/// Maps a control training target's family to its inference-side control identity (sc-10165, B4): the
+/// [`STRICT_CONTROL_ENGINES`](../../../crates/sceneworks-worker) engine id + the frozen base model the
+/// trained overlay applies on at generation time. The inference base is DISTINCT from the training base —
+/// e.g. `krea_2` trains against `krea_2_raw` but the overlay applies on `krea_2_turbo` (the deployed base
+/// the control branch was frozen against; the trainer records the same in its overlay meta). Returns
+/// `None` for a family with no candle control-inference lane (a control overlay nothing can run).
+pub(crate) fn control_overlay_inference_identity(
+    family: &str,
+) -> Option<(&'static str, &'static str)> {
+    match family {
+        "krea_2" => Some(("krea_2_turbo_control", "krea_2_turbo")),
+        _ => None,
     }
 }
 


### PR DESCRIPTION
## What

The registration half of B4 — **close the loop so a studio-trained ControlNet overlay is no longer orphaned.** Before this, a completed `ControlTraining` run left its overlay unregistered (`register_completed_training_lora` gates on `JobType::LoraTrain`), so a trained Krea ControlNet was produced but nothing tracked it. Now:
- a completing `ControlTraining` run **registers its overlay** into a new control-overlay registry, and
- `GET /api/v1/control-overlays` **enumerates** them.

This defines the **shared control-overlay manifest/store shape** that sc-8466 (built-in per-backbone) and sc-10979 (user-imported) both extend — first-lands-wins. Built on the merged sc-8464 inference lane, so a registered overlay is actually runnable.

## Registry shape
```jsonc
{ "id", "name", "scope",
  "controlType": "pose", "controlEngine": "krea_2_turbo_control",
  "backbone": "krea_2", "baseModel": "krea_2_turbo",  // INFERENCE base, not the training base
  "kind": "pose_control_branch",
  "source": { "provider": "training", "path": "control-overlays/<id>" },
  "files": ["<slug>.safetensors"], "provenance": {…}, "createdAt", "updatedAt" }
```

## Changes (api-only, additive)
- **`training.rs`**: control jobs write to `control-overlays/<id>` (their own store, not the LoRA tree) and get a **control-shaped submit entry** — `baseModel` overridden to the inference base `krea_2_turbo` (the overlay applies on Turbo, not the training base `krea_2_raw`), via `control_overlay_inference_identity`; new `resolve_control_overlay_output_location`.
- **`jobs.rs`**: `register_completed_control_overlay` / `register_trained_control_overlay` — mirror the LoRA registration path (dry-run bail, trusted-input recompute of output/manifest paths, validated id, overlay-file existence check), writing the `controlOverlays` manifest field. Dispatched alongside the LoRA registration on completion (exactly one fires per job).
- **`control_overlays.rs`**: `control_overlay_catalog` + `GET /api/v1/control-overlays` (user-global + project manifests, normalized `installState`/`installedPath`, optional `?baseModel=` filter).

## Scope
This is **increment 1 (registration + enumeration)**. The overlay is runnable today via the sc-8464 `KreaControl` lane's `advanced.controlWeights.path`. **Increment 2** (a follow-up) makes it *seamlessly selectable*: the API resolves a chosen overlay id → installed path in image-job creation, plus the web `ControlPanel` picker + `ui.controlModes:["pose"]` on `krea_2_turbo`. MLX convert stays deferred (sc-8465/B5).

## Verification
`cargo clippy -p sceneworks-rust-api --all-targets -- -D warnings` + `cargo fmt` clean.

sc-10165 (epic 10159 B4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)