### PR TITLE
feat(api): resolve a selected control-overlay id to its weights path at generation (Training Studio B4, sc-10165)

### DIFF
--- a/apps/rust-api/src/control_overlays.rs
+++ b/apps/rust-api/src/control_overlays.rs
@@ -89,3 +89,84 @@ pub(crate) async fn control_overlay_catalog(
 
     Ok(overlays)
 }
+
+/// Resolve a selected control overlay id (`advanced.controlWeights.overlayId`, set by the Studio's
+/// ControlPanel picker) to its installed `.safetensors` path, written back as
+/// `advanced.controlWeights.path` — the field the worker strict-control lane
+/// (`ensure_krea_control_weights`) reads (sc-10165, epic 10159 B4). A no-op when no overlay is selected.
+/// A selected-but-unknown/uninstalled overlay is a clean 400 rather than a deep worker error. Mirrors the
+/// LoRA id→path resolution (`validate_job_lora_compatibility_with`): one catalog snapshot, in-place
+/// `advanced` mutation.
+pub(crate) async fn resolve_control_overlay_selection(
+    state: &AppState,
+    project_id: Option<&str>,
+    job_payload: &mut JsonObject,
+) -> Result<(), ApiError> {
+    let Some(overlay_id) = job_payload
+        .get("advanced")
+        .and_then(Value::as_object)
+        .and_then(|advanced| advanced.get("controlWeights"))
+        .and_then(Value::as_object)
+        .and_then(|cw| cw.get("overlayId"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+    else {
+        return Ok(());
+    };
+
+    let overlay = control_overlay_catalog(state, project_id)
+        .await?
+        .into_iter()
+        .find(|item| item.get("id").and_then(Value::as_str) == Some(overlay_id.as_str()))
+        .ok_or_else(|| ApiError::bad_request(format!("Control overlay not found: {overlay_id}")))?;
+    if overlay.get("installState").and_then(Value::as_str) != Some("installed") {
+        return Err(ApiError::bad_request(format!(
+            "Control overlay '{overlay_id}' is not installed"
+        )));
+    }
+    let installed_path = overlay
+        .get("installedPath")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            ApiError::bad_request(format!(
+                "Control overlay '{overlay_id}' has no installed weights"
+            ))
+        })?;
+    let weights_path = resolve_overlay_weights_file(installed_path, overlay.get("files"))
+        .ok_or_else(|| {
+            ApiError::bad_request(format!(
+                "Control overlay '{overlay_id}' weights (.safetensors) not found under {installed_path}"
+            ))
+        })?;
+
+    let advanced = job_payload
+        .entry("advanced".to_owned())
+        .or_insert_with(|| Value::Object(JsonObject::new()));
+    if let Some(advanced) = advanced.as_object_mut() {
+        let control_weights = advanced
+            .entry("controlWeights".to_owned())
+            .or_insert_with(|| Value::Object(JsonObject::new()));
+        if let Some(control_weights) = control_weights.as_object_mut() {
+            control_weights.insert("path".to_owned(), Value::String(weights_path));
+        }
+    }
+    Ok(())
+}
+
+/// The overlay's registered `installedPath` may be the overlay dir (the normalized `source.path`) or the
+/// `.safetensors` file itself; the worker wants the file. Resolve to the file: the path directly if it is
+/// a file, else `<dir>/<files[0]>` when that exists on disk.
+fn resolve_overlay_weights_file(installed_path: &str, files: Option<&Value>) -> Option<String> {
+    let base = PathBuf::from(installed_path);
+    if base.is_file() {
+        return Some(installed_path.to_owned());
+    }
+    let file = files
+        .and_then(Value::as_array)
+        .and_then(|entries| entries.first())
+        .and_then(Value::as_str)?;
+    let candidate = base.join(file);
+    candidate.is_file().then(|| candidate.display().to_string())
+}

--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -42,6 +42,15 @@ pub(crate) async fn create_image_job(
         Some(&catalogs),
     )
     .await?;
+    // Resolve a selected control overlay id → its installed `.safetensors` path (sc-10165, B4), so a
+    // ControlNet the user picked in the Studio's ControlPanel is loadable by the worker strict-control
+    // lane. A no-op unless `advanced.controlWeights.overlayId` is set.
+    crate::control_overlays::resolve_control_overlay_selection(
+        &state,
+        Some(&payload.project_id),
+        &mut job_payload,
+    )
+    .await?;
     if payload.seed.is_none() {
         let count = job_payload
             .get("count")


### PR DESCRIPTION
## What

The **backend half of B4 increment 2**: `create_image_job` now resolves a selected control overlay id → its installed weights path, so a registered ControlNet overlay is **runnable by id** (not just by a hand-passed env/path).

- reads `advanced.controlWeights.overlayId` (the id the Studio's ControlPanel picker will set),
- looks it up via `control_overlay_catalog` (the sc-10165 increment-1 registry),
- resolves to the overlay's `.safetensors` and writes it back as `advanced.controlWeights.path` — the exact field the merged sc-8464 worker `KreaControl` lane (`ensure_krea_control_weights`) already reads.

Mirrors the LoRA id→path resolution (`validate_job_lora_compatibility_with`): one `control_overlay_catalog` snapshot, in-place `advanced` mutation. A selected-but-unknown or uninstalled overlay is a clean **400**, not a deep worker error.

## Changes (api-only, additive)
- `control_overlays.rs`: `resolve_control_overlay_selection` + `resolve_overlay_weights_file` (dir-or-file → the `.safetensors`).
- `generation.rs`: call it in `create_image_job` right after the LoRA resolution (no-op unless `overlayId` is set).

## Scope / ordering
This is plumbing **ahead of its UI caller** — a pattern used throughout epic 10159. The next increment lands the two coupled UI pieces **together** (so the panel is never half-wired):
1. `ui.controlModes: ["pose"]` + `controlScale` on `krea_2_turbo` in `builtin.models.jsonc` (+ the `controlModesParity.test.js` backbone-list update) — makes the ControlPanel appear for Krea.
2. the web `ControlPanel` overlay picker (fetch `/api/v1/control-overlays?baseModel=krea_2_turbo`) threading the chosen id → `advanced.controlWeights.overlayId` through ImageStudio's `buildImageJobAdvanced`.

## Verification
`cargo clippy -p sceneworks-rust-api --all-targets -- -D warnings` + `cargo fmt` clean.

sc-10165 (epic 10159 B4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)