### PR TITLE
feat(worker): drive candle Qwen-Image-Edit sequential residency from the edit fit-gate; pin-bump candle-gen (sc-10968)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-gen",
  "image",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -713,7 +713,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -738,7 +738,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -790,7 +790,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=49d81cda325cc88224bee71dd66aab01acbe4ddc#49d81cda325cc88224bee71dd66aab01acbe4ddc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=25f08a12a99e48ba2803420b5580c4ee0e4b78ec#25f08a12a99e48ba2803420b5580c4ee0e4b78ec"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1620,15 +1620,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612
 # `4df97dce` -> `3612d333` (byte-identical, candle builds nothing new), so both the default lane AND
 # `--features backend-candle --target all` now resolve the SINGLE gen-core rev `3612d333`. mlx-rs unchanged
 # (38e1cc1 — MLX core does not rebuild). ALL mlx-gen-* + candle-gen-* pins move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1642,7 +1642,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1650,17 +1650,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1670,7 +1670,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1678,21 +1678,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1701,17 +1701,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1720,7 +1720,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1753,7 +1753,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1762,12 +1762,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1775,7 +1775,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1784,7 +1784,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1792,7 +1792,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1806,7 +1806,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1833,7 +1833,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1844,7 +1844,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "49d81cda325cc88224bee71dd66aab01acbe4ddc", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "25f08a12a99e48ba2803420b5580c4ee0e4b78ec", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
@@ -347,6 +347,79 @@ async fn generate_candle_qwen_edit_stream(
     let total = work.len();
     let negative = request.negative_prompt.clone();
 
+    // VRAM fit-gate for the Qwen-Image-Edit lane (epic 10765 Phase 1c follow-up, sc-10968) — the edit
+    // sibling of the txt2img gate (base.rs `generate_candle_stream`). The edit lane routes through THIS
+    // function, not `generate_candle_stream`, so it needs its own gate: when the selected tier's predicted
+    // resident peak won't fit the card, load with sequential component residency (`QwenEdit` loads the
+    // VL encoder + VAE encoder → encodes + VAE-encodes the references → DROPS them before the DiT loads)
+    // instead of OOMing; and if even the MEASURED sequential peak won't fit, reject-before-OOM. The edit
+    // lane IS sequential-capable (sc-10968 wired `QwenEdit::generate_sequential`). Inert (Unknown →
+    // resident) until the edit manifest tiers carry a `candle` block with measured peaks (the sc-10969 /
+    // sc-10920 measure sibling for edit) — mirroring flux2 / qwen txt2img before their measure stories.
+    let use_sequential = {
+        let budget = crate::vram_gate::apply_vram_cap(
+            crate::gpu::nvidia_vram_budget_gb(&settings.gpu_id).await,
+            crate::vram_gate::cuda_vram_cap_gb(),
+        );
+        let tier =
+            crate::vram_gate::requested_tier_key(&request.advanced, &request.model_manifest_entry);
+        let needed = crate::vram_gate::predicted_peak_gb(&request.model_manifest_entry, tier);
+        match crate::vram_gate::resolve_offload(
+            crate::vram_gate::fit_decision(needed, budget),
+            /* sequential_capable */ true,
+        ) {
+            crate::vram_gate::FitDecision::Offload {
+                needed_gb,
+                available_gb,
+            } => {
+                // Second-stage gate (sc-10856): if this tier's MEASURED sequential peak is known and STILL
+                // exceeds the budget, reject before load instead of a reactive OOM. Absent the number
+                // (unmeasured edit tier) keep the best-effort sequential run.
+                let sequential_needed = crate::vram_gate::predicted_sequential_peak_gb(
+                    &request.model_manifest_entry,
+                    tier,
+                );
+                if let Some(seq_gb) =
+                    crate::vram_gate::sequential_overflow_gb(sequential_needed, budget)
+                {
+                    return Err(WorkerError::InvalidPayload(format!(
+                        "{model} at the {tier} tier needs ~{seq} GB of VRAM even with sequential \
+                         component residency (loading one component at a time), but GPU {gpu} has \
+                         ~{available} GB available. Pick a lower tier (Q4/Q8), lower the output \
+                         resolution, or run on a card with more VRAM.",
+                        model = request.model,
+                        seq = seq_gb.round() as i64,
+                        available = available_gb.round() as i64,
+                        gpu = settings.gpu_id,
+                    )));
+                }
+                tracing::info!(
+                    model = %request.model,
+                    needed_gb = needed_gb.round() as i64,
+                    available_gb = available_gb.round() as i64,
+                    "candle Qwen-Edit VRAM fit-gate: resident peak exceeds free VRAM — loading with \
+                     sequential component residency (VL encoder dropped before the DiT)"
+                );
+                true
+            }
+            crate::vram_gate::FitDecision::TooBig {
+                needed_gb,
+                available_gb,
+            } => {
+                return Err(WorkerError::InvalidPayload(format!(
+                    "{model} at the {tier} tier needs ~{needed} GB of VRAM (with headroom) but GPU \
+                     {gpu} has ~{available} GB available. Pick a lower tier (Q4/Q8), lower the output \
+                     resolution, or run on a card with more VRAM.",
+                    model = request.model,
+                    needed = needed_gb.round() as i64,
+                    available = available_gb.round() as i64,
+                    gpu = settings.gpu_id,
+                )));
+            }
+            _ => false,
+        }
+    };
+
     let (cancel, rx, blocking) = start_gen_stream(
         job.id.clone(),
         "qwen_edit",
@@ -355,6 +428,13 @@ async fn generate_candle_qwen_edit_stream(
             let model = QwenEdit::load(&QwenEditPaths {
                 root: qwen_base,
                 adapters,
+                // sc-10968: the fit-gate above picks sequential residency when the resident peak won't
+                // fit; the provider then loads→encodes→drops the VL encoder before the DiT.
+                offload_policy: if use_sequential {
+                    gen_core::OffloadPolicy::Sequential
+                } else {
+                    gen_core::OffloadPolicy::Resident
+                },
             })
             .map_err(|error| WorkerError::Engine(format!("Qwen edit load failed: {error}")))?;
             Ok((model, reference))


### PR DESCRIPTION
## What

The paired SceneWorks half of candle-gen [#411](https://github.com/SceneWorks/candle-gen/pull/411) (QwenEdit sequential residency, epic 10765). The Qwen-Image-Edit lane routes through `generate_candle_qwen_edit_stream`, **not** `generate_candle_stream`, so base.rs's `sequential_capable` set doesn't cover it — this ports the VRAM fit-gate into the edit lane.

## Changes

- **`qwen_edit_candle.rs`**: a VRAM fit-gate (mirroring base.rs) before load — predicts the tier's resident peak, and on overflow sets `QwenEditPaths::offload_policy = Sequential` (the provider loads→encodes→**drops** the Qwen2.5-VL encoder + VAE encoder before the DiT) instead of OOMing. Second stage reject-before-OOM fires when even the measured sequential peak won't fit.
- **Pin-bump**: 27 candle-gen crates `8a910832` → `25f08a12` (the sc-10968 edit-sequential rev, which supersedes main's `49d81cd`). **gen-core stays `3612d333` at both revs — no skew**; lock regenerated via `cargo metadata`. The gap additionally pulls candle-gen #407 (flux2 comfyui fp8) + #408 (bernini, a new crate not referenced here).

## Validation

Worker `cargo build` + `clippy --features backend-candle --locked -D warnings` clean. GPU A/B on the candle-gen side (qwen-image-edit-2511 q4, spec-sequential): **resident 56.7 GB → sequential 36.9 GB, byte-identical (−19.8 GB)**.

## Gating note + follow-up

The edit fit-gate is **inert in-app** until the qwen edit manifest tiers carry a `candle` block (resident + `sequentialPeakGb`) — the measure sibling **sc-11019** (seeded with the q4 A/B numbers), same relationship sc-10969 had to sc-10867. This PR wires the code path; the offload runs today via the harness / `offload_policy` contract.

> ⚠️ Pin tracks candle-gen #411's branch rev; re-pin to the #411 **merge** rev if that PR squash-merges before this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)