### PR TITLE
fix(core): route candle Q4/Q8 tier-select for qwen_image (sc-11020, epic 9083)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3766,10 +3766,9 @@ mod candle_routing_tests {
             "chroma1_hd",
             &object(json!({ "advanced": { "mlxQuantize": 8 } }))
         ));
-        assert!(!image_request_candle_eligible(
-            "qwen_image",
-            &object(json!({ "advanced": { "mlxQuantize": 4 } }))
-        ));
+        // NOTE: qwen_image USED to be a dense-only counter-example here; sc-11020 moved it to
+        // CANDLE_QUANT_MODELS (its turnkey q4/q8 packed tiers load off-Mac), so its quant tier-select now
+        // STAYS on candle — covered by `qwen_image_quant_tier_select_stays_on_candle`.
         assert!(!video_request_candle_eligible(
             "wan_2_2",
             &object(json!({ "mode": "text_to_video", "advanced": { "mlxQuantize": 8 } }))
@@ -3782,6 +3781,34 @@ mod candle_routing_tests {
         assert!(image_request_candle_eligible(
             "chroma1_hd",
             &object(json!({ "advanced": { "steps": 30 } }))
+        ));
+    }
+
+    #[test]
+    fn qwen_image_quant_tier_select_stays_on_candle() {
+        // sc-11020 (epic 9083): base `qwen_image` is a turnkey packed-quant candle family — its q4/q8/bf16
+        // subdirs load off-Mac via `standard_tier_subdir` (sc-8669) and the tiers are GPU-measured
+        // (sc-10969), so a `mlxQuantize` tier-select now STAYS on candle instead of enforce-failing
+        // `candle_unsupported` at routing (the routing half sc-9983 flipped for krea/ideogram/boogu but
+        // missed qwen). A LoRA still defers — base qwen advertises no candle inference LoRA.
+        for bits in [4, 8] {
+            assert!(
+                image_request_candle_eligible(
+                    "qwen_image",
+                    &object(json!({ "prompt": "x", "advanced": { "mlxQuantize": bits } }))
+                ),
+                "qwen_image Q{bits} tier-select should stay on candle"
+            );
+        }
+        // A plain (no tier-select) job is of course still eligible.
+        assert!(image_request_candle_eligible(
+            "qwen_image",
+            &object(json!({ "prompt": "x" }))
+        ));
+        // A LoRA request still defers to torch — no candle inference LoRA on base qwen.
+        assert!(!image_request_candle_eligible(
+            "qwen_image",
+            &object(json!({ "loras": [{ "name": "x", "path": "/x.safetensors" }] }))
         ));
     }
 

--- a/crates/sceneworks-core/src/jobs_store/routing/candle.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/candle.rs
@@ -274,8 +274,9 @@ pub(crate) fn image_request_candle_eligible(model: &str, payload: &Map<String, V
     }
     // Lens / Lens-Turbo and Krea 2 Turbo advertise Q4/Q8 + LoRA/LoKr, so a quant request OR a LoRA stays
     // on the candle lane for them (Krea gained Q4/Q8 in sc-9607, joining Lens in the both-set — sc-9983).
-    // SD3.5 (sc-7880) and the Ideogram/Boogu packed families (sc-9607) advertise Q4/Q8 but NOT inference
-    // LoRA (quant stays, LoRA defers). Every other candle family advertises neither and defers both. The
+    // SD3.5 (sc-7880), the Ideogram/Boogu packed families (sc-9607), and Qwen-Image (sc-11020, its
+    // turnkey q4/q8/bf16 tiers) advertise Q4/Q8 but NOT inference LoRA (quant stays, LoRA defers). Every
+    // other candle family advertises neither and defers both. The
     // two capabilities are decoupled: `supports_lora` and `supports_quant` each consult the both-set plus
     // their own list.
     let supports_lora =
@@ -304,8 +305,9 @@ pub(crate) fn image_request_candle_eligible(model: &str, payload: &Map<String, V
     // On-the-fly quantization (`advanced.mlxQuantize` > 0) → torch UNLESS the family advertises quant.
     // The sc-3675/sc-5096 candle providers advertise `supported_quants: &[]` (dense bf16/fp16 only), so
     // an explicit quant request can't be honored — route to Python rather than silently running dense
-    // (sc-5099). Lens (sc-5126), SD3.5 (sc-7880), Krea (sc-9607/sc-9983), and the Ideogram/Boogu packed
-    // families (sc-9607) advertise Q4/Q8, so their quant requests stay on candle. For the packed families
+    // (sc-5099). Lens (sc-5126), SD3.5 (sc-7880), Krea (sc-9607/sc-9983), the Ideogram/Boogu packed
+    // families (sc-9607), and Qwen-Image (sc-11020) advertise Q4/Q8, so their quant requests stay on
+    // candle. For the packed families
     // the `mlxQuantize` value is a turnkey tier-SELECT (which pre-quantized q4/q8 subdir to load), a no-op
     // on the loader rather than a runtime quantize — but the gate is the same: quant-capable → stay.
     if !supports_quant && candle_request_wants_quant(payload) {

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -542,7 +542,12 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
     ModelCaps::new("z_image_edit", true, false, false, false, false),
     ModelCaps::new("flux_schnell", true, true, false, false, false),
     ModelCaps::new("flux_dev", true, true, false, false, false),
-    ModelCaps::new("qwen_image", true, true, false, false, false),
+    // Base `qwen_image` candle txt2img is a turnkey packed-quant family (sc-8669 wired the q4/q8/bf16
+    // subdirs into `STANDARD_TIER_MODELS`; sc-10969 measured the tiers), so a tier-select `mlxQuantize`
+    // stays on candle — `candle_quant` is set (sc-11020, the routing half previously missed by sc-9983,
+    // which flipped krea/ideogram/boogu but not qwen). No inference LoRA on base qwen off-Mac, so NOT
+    // quant/lora-exempt.
+    ModelCaps::new("qwen_image", true, true, true, false, false),
     // Qwen-Image-Edit ids (sc-3397/3398): MLX edit siblings; candle serves them via the bespoke
     // `qwen_edit_candle_eligible` lane (NOT the txt2img gate), so they are NOT candle-routed txt2img ids.
     ModelCaps::new("qwen_image_edit", true, false, false, false, false),
@@ -1062,6 +1067,10 @@ mod tests {
         "boogu_image_turbo",
         "boogu_image_edit",
         "kolors",
+        // sc-11020: qwen_image's turnkey q4/q8/bf16 packed tiers (sc-8669, measured sc-10969) load on
+        // the candle txt2img lane, so a tier-select stays on candle; no candle inference LoRA on base
+        // qwen. (sc-9983 flipped this for krea/ideogram/boogu but missed qwen.)
+        "qwen_image",
     ];
 
     // sc-9983: Krea moved to CANDLE_QUANT_LORA_MODELS (BOTH). sc-10676: Anima is the LoRA-only candle


### PR DESCRIPTION
## Symptom
Generating **Qwen-Image T2I off-Mac** fails with:
> `candle_unsupported: conditioned shape on a txt2img candle family (qwen_image) is not in the candle/CUDA flow off-Mac … [epic 5480]`

Intermittent by design: a plain job runs, but selecting a **Q4/Q8 tier** (or the app-wide default tier from sc-10726) hard-rejects at routing. The user hit it right after a bf16 VRAM-fit reject whose own message said *"Pick a lower tier (Q4/Q8)"* — advice the router made un-routable.

## Root cause — router↔worker quant-capability skew
`qwen_image` is a fully-wired candle **packed-quant** family:
- Turnkey `q4/`(default)`q8/``bf16/` subdirs in the manifest; `candle` block GPU-measured on RTX PRO 6000 (sc-10969, #1408).
- Registered in the worker `STANDARD_TIER_MODELS` → the candle txt2img lane packed-loads the selected tier via `standard_tier_subdir` (sc-8669, #1019); q4/q8 GPU-validated in sc-10969.

But the router's `IMAGE_MODEL_CAPS` row was `candle_quant=false`, so `image_request_candle_eligible` refused any `advanced.mlxQuantize > 0` and `classify_candle_image_gap` fell to the "conditioned shape (… quant …)" catch-all → enforce-fail.

sc-9983 (#1203) flipped `candle_quant=true` for krea/ideogram/boogu but **missed qwen_image** — the "engine wired but router half missed" class (chroma sc-5576, krea sc-7836).

## Fix (router-only — no candle-gen change / pin bump)
The worker already serves qwen q4/q8 (packed-detect load, a no-op runtime-quantize on already-packed weights), so this is purely the routing half:
- `catalog.rs`: qwen_image row → `candle_quant=true`; add to `EXPECTED_CANDLE_QUANT_MODELS` membership-parity snapshot.
- `candle.rs`: update the quant-capable-family doc comments.
- `jobs_store.rs` tests: drop the now-stale qwen "defers to torch" assertion; add `qwen_image_quant_tier_select_stays_on_candle` (q4/q8 stay on candle, LoRA still defers).

## Verification
- `cargo test -p sceneworks-core --lib` → 436 passed (incl. routing + membership-parity + superset-invariant).
- `cargo test -p sceneworks-core --test jobs_store` → 143 passed.
- `cargo fmt -p sceneworks-core` clean; `cargo clippy -p sceneworks-core` clean.

Story: sc-11020 (epic 9083). Relates: sc-9983, sc-10969, sc-8669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)