### PR TITLE
feat(worker): fit-gate selects sequential residency for qwen-image; pin-bump mlx-gen 498a12c + candle-gen lockstep (sc-11000, epic 10834)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-gen",
  "image",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -713,7 +713,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -738,7 +738,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -790,7 +790,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9#8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7587bcc85088c37a2186582792c36ea889ffcf41#7587bcc85088c37a2186582792c36ea889ffcf41"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -3674,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "image",
  "inventory",
@@ -3701,7 +3701,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "image",
  "inventory",
@@ -3715,7 +3715,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "image",
  "inventory",
@@ -3729,7 +3729,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3743,7 +3743,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3754,7 +3754,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3763,7 +3763,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3772,7 +3772,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3786,7 +3786,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3799,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3824,7 +3824,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3834,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "image",
  "inventory",
@@ -3847,7 +3847,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "image",
  "inventory",
@@ -3861,7 +3861,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "image",
  "inventory",
@@ -3875,7 +3875,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "image",
  "inventory",
@@ -3887,7 +3887,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3898,7 +3898,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3910,7 +3910,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3922,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3931,7 +3931,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3940,7 +3940,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3950,7 +3950,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "image",
  "inventory",
@@ -3977,7 +3977,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "image",
  "inventory",
@@ -3991,7 +3991,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4002,7 +4002,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4014,7 +4014,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4025,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "image",
  "inventory",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "image",
  "inventory",
@@ -5873,7 +5873,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=3612d333c91660cd4baf3e6e1432de42fb2d1257#3612d333c91660cd4baf3e6e1432de42fb2d1257"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
 dependencies = [
  "core-llm",
  "inventory",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -534,7 +534,7 @@ sceneworks-core = { path = "../sceneworks-core" }
 # reports exactly one). NOTE: this bump FIXES a live bug — on 6a10ae1, every Anima LoRA/LoKr failed at
 # model load, because the worker defaults spec.quantize to Some(Q8) for every MLX model and mlx-gen-anima
 # rejected quant+adapter together. See test `anima_default_tier_with_adapter_builds_loadable_spec`.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -891,7 +891,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -907,23 +907,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -931,7 +931,7 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d3
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
 # mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
 # mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
@@ -939,7 +939,7 @@ mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d33
 # conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
 # DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
 # generator-cache load path drives.
-mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # Anima 2B anime t2i provider (native MLX, CircleStone Labs Non-Commercial License v1.2; epic 10512,
 # sc-10523). Same git rev as mlx-gen so MLX builds once. Self-registers `anima_base` / `anima_aesthetic`
 # / `anima_turbo` (Cosmos-Predict2 DiT + Qwen3-0.6B T5-query-token adapter conditioner + Qwen-Image VAE)
@@ -948,59 +948,59 @@ mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d3
 # scheduler (sc-10519) and strong prompt-weighting on the T5 query tokens (sc-10566). Carries the
 # install-time q4/q8/bf16 converter the model_jobs.rs Anima path drives (sc-10517). Pinned to merged
 # mlx-gen main 6a10ae1 (PR #680), which carries both the Anima crate and gen-core's is_hidden_file.
-mlx-gen-anima = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-anima = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -1009,19 +1009,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d3
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -1030,7 +1030,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -1038,7 +1038,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -1049,7 +1049,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -1060,7 +1060,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -1082,7 +1082,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d3
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -1093,7 +1093,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "361
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -1125,7 +1125,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612d333c91660cd4baf3e6e1432de42fb2d1257" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "498a12c0d4386959ecff1ee5db2c4b19147b7348" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1620,15 +1620,25 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "3612
 # `4df97dce` -> `3612d333` (byte-identical, candle builds nothing new), so both the default lane AND
 # `--features backend-candle --target all` now resolve the SINGLE gen-core rev `3612d333`. mlx-rs unchanged
 # (38e1cc1 — MLX core does not rebuild). ALL mlx-gen-* + candle-gen-* pins move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+# Bumped mlx-gen `3612d333` -> `498a12c0` + candle-gen `8a910832` -> `7587bcc8` IN LOCKSTEP (sc-11000,
+# epic 10834): qwen-image sequential component residency (the sc-10840 fan-out sibling of sc-10839; PURE
+# mlx-gen-qwen-image provider Rust). `git diff 3612d333..498a12c0 -- gen-core/ gen-core-testkit/` is EMPTY
+# (gen-core BYTE-IDENTICAL) — but the skew gate keys on the git REV, not content, so candle-gen must move
+# too: candle-gen #409 (`7587bcc8`) re-pins candle-gen's own gen-core `3612d333` -> `498a12c0` (byte-
+# identical, candle builds nothing new; this also carries the candle-gen main work merged since the prior
+# `8a910832` pin — #405/#406/#407). Both the default lane AND `--features backend-candle --target all` now
+# resolve the SINGLE gen-core rev `498a12c0`. mlx-rs unchanged (38e1cc1). The worker also adds `"qwen_image"`
+# to `SEQUENTIAL_CAPABLE_ENGINES` (mlx_fit_gate.rs) so the fit-gate selects Sequential for it. ALL
+# mlx-gen-* + candle-gen-* pins move together.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1642,7 +1652,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1650,17 +1660,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1670,7 +1680,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1678,21 +1688,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1701,17 +1711,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1720,7 +1730,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1753,7 +1763,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1762,12 +1772,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1775,7 +1785,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a910
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1784,7 +1794,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1792,7 +1802,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1806,7 +1816,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1833,7 +1843,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1844,7 +1854,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8a9108324c6e8271cb8e2a5ddbb3484ebb2680d9", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7587bcc85088c37a2186582792c36ea889ffcf41", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/mlx_fit_gate.rs
+++ b/crates/sceneworks-worker/src/mlx_fit_gate.rs
@@ -40,7 +40,7 @@ use crate::{WorkerError, WorkerResult};
 /// other engine `Sequential` would be a no-op (the advisory contract treats it as `Resident`), so
 /// predicting "it fits staged" and then holding everything resident would SIGKILL — hence the
 /// allowlist. Extended per family as the fan-out (sc-10840) wires each engine.
-const SEQUENTIAL_CAPABLE_ENGINES: &[&str] = &["sdxl", "z_image_turbo"];
+const SEQUENTIAL_CAPABLE_ENGINES: &[&str] = &["sdxl", "z_image_turbo", "qwen_image"];
 
 /// Whether `engine_id`'s provider drops components in phase order under [`OffloadPolicy::Sequential`].
 pub(crate) fn engine_supports_sequential(engine_id: &str) -> bool {
@@ -509,8 +509,10 @@ mod tests {
     fn engine_supports_sequential_is_the_wired_provider_allowlist() {
         assert!(engine_supports_sequential("sdxl"));
         assert!(engine_supports_sequential("z_image_turbo"));
-        // Not-yet-wired providers must NOT be offered sequential (they'd ignore it and SIGKILL).
-        assert!(!engine_supports_sequential("qwen-image"));
+        assert!(engine_supports_sequential("qwen_image"));
+        // Not-yet-wired providers must NOT be offered sequential (they'd ignore it and SIGKILL) — this
+        // includes the qwen edit/control siblings (separate engine ids, tracked in sc-11006).
+        assert!(!engine_supports_sequential("qwen_image_edit"));
         assert!(!engine_supports_sequential("z_image_turbo_control"));
         assert!(!engine_supports_sequential("flux"));
     }


### PR DESCRIPTION
## Summary
Worker wiring for **sc-11000** (qwen-image sequential component residency — the first sc-10840 fan-out family), plus the pin bump to the merged provider work.

- **Fit-gate now selects Sequential for qwen-image:** add `"qwen_image"` to `SEQUENTIAL_CAPABLE_ENGINES` (`crates/sceneworks-worker/src/mlx_fit_gate.rs`). When the model won't fit resident but the staged `max(text-encoder, DiT+VAE)` will, the gate sets `OffloadPolicy::Sequential`; the provider then drops the ~15 GB Qwen2.5-VL encoder before the DiT loads. `sum_text_encoder_bytes` already matches qwen's `text_encoder/` subdir; the allowlist test is updated (asserts `qwen_image` wired, edit/control siblings not).
- **Pin bump:** every `mlx-gen*` crate + `sceneworks-gen-core` `3612d33` → `498a12c` (mlx-gen [#694](https://github.com/SceneWorks/mlx-gen/pull/694), merged).
- **candle-gen lockstep:** every `candle-gen*` `8a91083` → `7587bcc` (candle-gen [#409](https://github.com/SceneWorks/candle-gen/pull/409), merged — pure gen-core rev-alignment). gen-core is byte-identical, but the sc-4482 skew gate keys on the git **rev**, so both lanes now resolve a single gen-core rev.

## Verification
- Real-weight A/B (from mlx-gen #694, q8 768²/8-step): **Resident 37.752 GiB → Sequential 24.581 GiB (−34.9%), byte-identical**, repeat-bounded. Fits a 32 GB Mac.
- **Both gen-core skew lanes green** (single rev `498a12c`): default + `--features backend-candle`.
- **`npm run rust:check` green:** worker **734 passed / 0 failed**, `engine_supports_sequential_is_the_wired_provider_allowlist` updated + passing, build clean.

## Cross-repo (both merged first)
- mlx-gen [#694](https://github.com/SceneWorks/mlx-gen/pull/694) — merged (`498a12c`)
- candle-gen [#409](https://github.com/SceneWorks/candle-gen/pull/409) — merged (`7587bcc`, gen-core rev-alignment)

## Shortcut
- Epic: https://app.shortcut.com/trefry/epic/10834 · Story: https://app.shortcut.com/trefry/story/11000 (fan-out umbrella: story/10840; edit/control follow-up: story/11006)

🤖 Generated with [Claude Code](https://claude.com/claude-code)