### PR TITLE
feat(web): ControlPanel trained-overlay picker for Krea pose control (Training Studio B4, sc-10165)

### DIFF
--- a/apps/web/src/components/ControlOverlayPicker.jsx
+++ b/apps/web/src/components/ControlOverlayPicker.jsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from "react";
+import { apiFetch, isAbortError } from "../api.js";
+import { useAppContext } from "../context/AppContext.js";
+
+// Trained ControlNet overlay picker (sc-10165 B4). Self-contained: fetches the registered overlays for
+// the given backbone (`GET /api/v1/control-overlays?baseModel=…`, project-scoped) and lets the user pick
+// one. The chosen id flows out via `onOverlayChange` → `advanced.controlWeights.overlayId`, which the API
+// (`resolve_control_overlay_selection`) resolves to the overlay's `.safetensors` for the worker
+// strict-control lane. Rendered only for backbones whose pose control rides a registered overlay
+// (e.g. Krea 2 Turbo — the Fun-Union backbones carry built-in control weights and never show this).
+export function ControlOverlayPicker({ baseModel, selectedOverlayId, onOverlayChange }) {
+  const { token, activeProject } = useAppContext();
+  const [overlays, setOverlays] = useState([]);
+  const [status, setStatus] = useState("loading"); // loading | ready | error
+
+  useEffect(() => {
+    if (!baseModel) {
+      return undefined;
+    }
+    const controller = new AbortController();
+    setStatus("loading");
+    const params = new URLSearchParams({ baseModel });
+    if (activeProject?.id) {
+      params.set("projectId", activeProject.id);
+    }
+    apiFetch(`/api/v1/control-overlays?${params.toString()}`, token, {
+      signal: controller.signal,
+    })
+      .then((items) => {
+        setOverlays(
+          Array.isArray(items)
+            ? items.filter((overlay) => overlay.installState === "installed")
+            : [],
+        );
+        setStatus("ready");
+      })
+      .catch((err) => {
+        if (isAbortError(err)) {
+          return;
+        }
+        setStatus("error");
+      });
+    return () => controller.abort();
+  }, [baseModel, activeProject?.id, token]);
+
+  return (
+    <div className="control-overlay-field">
+      <label htmlFor="control-overlay-select">ControlNet overlay</label>
+      {status === "loading" ? (
+        <p className="muted">Loading overlays…</p>
+      ) : status === "error" ? (
+        <p className="muted">Couldn&apos;t load control overlays.</p>
+      ) : overlays.length ? (
+        <select
+          id="control-overlay-select"
+          onChange={(event) => onOverlayChange?.(event.target.value || null)}
+          value={selectedOverlayId ?? ""}
+        >
+          <option value="">Select a trained overlay…</option>
+          {overlays.map((overlay) => (
+            <option key={overlay.id} value={overlay.id}>
+              {overlay.name ?? overlay.id}
+            </option>
+          ))}
+        </select>
+      ) : (
+        <p className="muted">
+          No pose ControlNet installed for this model yet — train one in the Training Studio to
+          enable pose control.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/ControlPanel.jsx
+++ b/apps/web/src/components/ControlPanel.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { PoseLibraryPicker } from "./PoseLibraryPicker.jsx";
 import { ImageEditSourcePickerField } from "./AssetPicker.jsx";
+import { ControlOverlayPicker } from "./ControlOverlayPicker.jsx";
 
 // Strict-control panel for the text-to-image studios (epic 8236, sc-8245). One picker gated by the
 // selected backbone's supported control modes (`ui.controlModes`, mirrored from the manifest /
@@ -34,6 +35,12 @@ export function ControlPanel({
   onClearPoses,
   loadUserPoses,
   poseBlockText,
+  // Trained ControlNet overlay selection (sc-10165 B4). `controlOverlayBaseModel` is the backbone id
+  // whose pose control rides a REGISTERED overlay (e.g. `krea_2_turbo`); `null` for the Fun-Union
+  // backbones that carry built-in control weights (no overlay picker). The picker self-fetches its list.
+  controlOverlayBaseModel,
+  selectedOverlayId,
+  onOverlayChange,
   // Canny / depth control image
   controlImageAssetId,
   onControlImageChange,
@@ -107,6 +114,13 @@ export function ControlPanel({
               <p className="mac-gating-note">{poseBlockText}</p>
             ) : (
               <div className="control-pose-section">
+                {controlOverlayBaseModel ? (
+                  <ControlOverlayPicker
+                    baseModel={controlOverlayBaseModel}
+                    onOverlayChange={onOverlayChange}
+                    selectedOverlayId={selectedOverlayId}
+                  />
+                ) : null}
                 <PoseLibraryPicker
                   loadUserPoses={loadUserPoses}
                   onClear={onClearPoses}

--- a/apps/web/src/controlModesParity.test.js
+++ b/apps/web/src/controlModesParity.test.js
@@ -35,9 +35,19 @@ describe("controlModes ↔ manifest parity (sc-8245)", () => {
     (model) => Array.isArray(model?.ui?.controlModes) && model.ui.controlModes.length > 0,
   );
 
-  it("the manifest advertises strict control on the five Fun-Union backbones", () => {
+  it("the manifest advertises strict control on the expected backbones", () => {
     const ids = manifestControlModels.map((model) => model.id).sort();
-    expect(ids).toEqual(["flux2_dev", "flux_dev", "qwen_image", "z_image", "z_image_turbo"]);
+    // The Fun-Union strict-control backbones (flux2_dev/flux_dev/qwen_image/z_image/z_image_turbo) plus
+    // krea_2_turbo — Krea's from-scratch pose-ControlNet (pose-only), driven by a registered trained
+    // overlay (sc-8464 inference lane / sc-10165 B4).
+    expect(ids).toEqual([
+      "flux2_dev",
+      "flux_dev",
+      "krea_2_turbo",
+      "qwen_image",
+      "z_image",
+      "z_image_turbo",
+    ]);
   });
 
   it.each(

--- a/apps/web/src/imageJobAdvanced.js
+++ b/apps/web/src/imageJobAdvanced.js
@@ -66,6 +66,7 @@ export function buildImageJobAdvanced(state) {
     activeControlMode,
     controlPassthroughId,
     effectiveControlScale,
+    controlOverlayId,
   } = state;
 
   return {
@@ -197,5 +198,11 @@ export function buildImageJobAdvanced(state) {
     // (strict_control.rs `resolve_user_control_map`). Derive mode uses request.sourceAssetId.
     ...(controlPassthroughId ? { controlImage: controlPassthroughId } : {}),
     ...(controlActive ? { controlScale: effectiveControlScale } : {}),
+    // Trained ControlNet overlay selection (sc-10165 B4): the picked overlay id (pose backbones that
+    // apply a registered overlay, e.g. Krea 2 Turbo). The API resolves it to the overlay's weights path
+    // (`resolve_control_overlay_selection`); the worker strict-control lane loads that.
+    ...(controlActive && controlOverlayId
+      ? { controlWeights: { overlayId: controlOverlayId } }
+      : {}),
   };
 }

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -546,6 +546,9 @@ export function ImageStudio() {
   // true = use-as-is (the user-supplied map passes through verbatim → advanced.controlImage).
   const [controlImagePassthrough, setControlImagePassthrough] = useState(false);
   const [controlScale, setControlScale] = useState(saved.controlScale ?? null);
+  // Selected trained ControlNet overlay id (sc-10165 B4) — for backbones whose pose control rides a
+  // registered overlay (Krea 2 Turbo). Flows to advanced.controlWeights.overlayId; the API resolves it.
+  const [controlOverlayId, setControlOverlayId] = useState(null);
   // Configurable sampler / scheduler (epic 1753). Restored from per-workspace
   // settings; reset to the selected model's manifest defaults whenever the
   // model changes.
@@ -821,6 +824,9 @@ export function ImageStudio() {
   // is its own input image / pose, distinct from the edit / character source).
   const controlModes = useMemo(() => supportedControlModes(selectedModel), [selectedModel]);
   const controlScaleConfig = selectedModel?.ui?.controlScale ?? null;
+  // Backbones whose pose control rides a registered trained overlay (sc-10165 B4) advertise
+  // `ui.controlOverlay` (Krea 2 Turbo); the ControlPanel then shows a self-fetching overlay picker.
+  const controlOverlayBaseModel = selectedModel?.ui?.controlOverlay ? selectedModel.id : null;
   // The control type actually in effect: the user's pick when the backbone still supports it, else the
   // first supported mode. Decouples the gating (derived) from the raw state so a backbone switch that
   // strands an unsupported pick degrades gracefully even before the reset effect runs.
@@ -964,6 +970,9 @@ export function ImageStudio() {
     setControlScale(typeof ui.controlScale?.default === "number" ? ui.controlScale.default : null);
     setControlImageAssetId("");
     setControlImagePassthrough(false);
+    // Clear a stale overlay pick so an id trained for a different backbone can't leak into a submit
+    // (sc-10165 B4); the picker re-fetches for the new backbone.
+    setControlOverlayId(null);
   }, [model]);
   // Approved reference images for the selected character (the IP-Adapter identity
   // source). Resolve the full asset from the catalog so thumbnails render even when
@@ -1771,6 +1780,7 @@ export function ImageStudio() {
           activeControlMode,
           controlPassthroughId,
           effectiveControlScale,
+          controlOverlayId,
         }),
       });
       onLocalJobCreated?.(job);
@@ -1852,6 +1862,7 @@ export function ImageStudio() {
       activeControlMode,
       controlPassthroughId,
       effectiveControlScale,
+      controlOverlayId,
     }),
   });
 
@@ -2647,6 +2658,9 @@ export function ImageStudio() {
               controlScaleConfig={controlScaleConfig}
               controlScale={effectiveControlScale}
               onControlScaleChange={setControlScale}
+              controlOverlayBaseModel={controlOverlayBaseModel}
+              selectedOverlayId={controlOverlayId}
+              onOverlayChange={setControlOverlayId}
             />
           </div>
         ) : null}

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2483,6 +2483,19 @@
         "label": "Krea 2 Turbo",
         "description": "Krea 2 Turbo — Krea AI's from-scratch foundation image model, distilled to a fast few-step (~8), CFG-free variant: a 28-block single-stream rectified-flow DiT with a Qwen3-VL-4B text encoder, native MLX (Apple Silicon). Strong photorealism up to 2048². Pre-quantized Q8 (~20.5 GB download, default). Krea 2 Community License (non-commercial). Needs a 48 GB-class Mac. Candle (Windows/Linux) adds an INT8-ConvRot tier (online-rotation int8 DiT), an sm_89-exclusive visibility feature: A/B @1024²/8-step — bf16 ~8.8 s (reference, coherent) · Q4-packed ~9.8 s (PSNR 22.7 dB vs bf16, coherent) · INT8-ConvRot (coherent, PSNR 34.4 dB vs bf16 — visibly closer to full precision than Q4). Requires an RTX 40xx / RTX PRO Blackwell (sm_89+) GPU; hidden on Mac and pre-Ada cards.",
         "recommendedFor": ["text_to_image"],
+        // Krea pose-ControlNet (sc-8464 candle inference lane + sc-10165 B4 registered overlays). Krea's
+        // from-scratch control branch is POSE-only (no canny/depth), so expose only "pose" — mirrors the
+        // worker STRICT_CONTROL_ENGINES `krea_2_turbo_control` supported_kinds = {Pose}. The ControlPanel
+        // then offers a trained-overlay picker (GET /api/v1/control-overlays?baseModel=krea_2_turbo); the
+        // chosen overlay resolves to its weights at submit. Usable scale ~0.5–0.85 (S0), capped at 0.85.
+        "poseLibrary": true,
+        "poseControlScale": true,
+        "controlModes": ["pose"],
+        "controlScale": { "label": "Control strength", "default": 0.6, "min": 0.0, "max": 0.85, "step": 0.05 },
+        // Pose control on Krea rides a REGISTERED trained overlay (no built-in control weights like the
+        // Fun-Union backbones), so the ControlPanel shows a trained-overlay picker; the chosen overlay id
+        // is resolved to its weights at submit (sc-10165 B4). This flag gates that picker.
+        "controlOverlay": true,
         // PiD decoder (epic 7840, qwenimage latent space — Krea 2 Turbo reuses the Qwen
         // VAE) — optional per-generation VAE replacement, decode + 2K/4K SR; NC output.
         // See `qwen_image` for detail.


### PR DESCRIPTION
## What

The **UI half of B4** — this makes a trained Krea ControlNet **seamlessly selectable in generation**, completing sc-10165. `krea_2_turbo` now surfaces pose control in the image Studio with a picker for its registered overlays; choosing one flows `advanced.controlWeights.overlayId` → the merged API resolver (#1416) → the merged sc-8464 `KreaControl` worker lane → a pose-locked render.

Builds on: #1415 (registration + list), #1416 (API id→path resolution), sc-8464 (inference lane, merged).

## Changes
- **`config/manifests/builtin.models.jsonc`**: `krea_2_turbo` `ui` gains `controlModes:["pose"]` + `controlScale` (default 0.6, cap 0.85 per S0) + a new **`controlOverlay:true`** flag (Krea's pose control rides a *registered overlay*, unlike the Fun-Union backbones' built-in weights). Pose-only — mirrors `STRICT_CONTROL_ENGINES` `krea_2_turbo_control` `supported_kinds={Pose}`.
- **`controlModesParity.test.js`**: add `krea_2_turbo` to the asserted control-backbone list.
- **`ControlOverlayPicker.jsx`** (new): a self-contained picker that fetches `GET /api/v1/control-overlays?baseModel=…` (token + project from context) and renders a `<select>` (or a "train one first" hint when none are installed). Localizing the fetch here means **no App.jsx / hook / context surgery**.
- **`ControlPanel.jsx`**: render the picker in the pose section when `controlOverlayBaseModel` is set.
- **`ImageStudio.jsx`**: `controlOverlayId` state (reset on model change) + `controlOverlayBaseModel` (from `ui.controlOverlay`) → `ControlPanel`; threaded into both `buildImageJobAdvanced` call sites.
- **`imageJobAdvanced.js`**: spread `advanced.controlWeights.overlayId` when set.

## Design note
The picker is a self-fetching component rather than App-level context plumbing on purpose: it keeps the change small and testable, and avoids touching the large App.jsx refresh-orchestration (its stale-response guards / memoization) for a per-panel, on-demand list.

## Verification
`vitest` — `controlModesParity` 6/6 + full suite pass; `vite build` clean; `eslint` clean (no new warnings).

Completes sc-10165 (epic 10159 B4): a studio-trained Krea ControlNet is now register → list → resolve → **select-in-Studio → generate**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)