### PR TITLE
feat(krea): Krea 2 image-edit — SceneWorks integration (epic 10871 P3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,7 +473,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb)",
  "serde_json",
  "thiserror 2.0.18",
 ]
@@ -3673,12 +3673,12 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04)",
  "serde_json",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
@@ -3687,7 +3687,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "image",
  "inventory",
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "image",
  "inventory",
@@ -3714,7 +3714,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "image",
  "inventory",
@@ -3728,7 +3728,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3742,7 +3742,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3753,7 +3753,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3762,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3771,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3785,7 +3785,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3798,7 +3798,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3811,7 +3811,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3823,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "image",
  "inventory",
@@ -3846,11 +3846,12 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "image",
  "inventory",
  "mlx-gen",
+ "mlx-gen-boogu",
  "mlx-gen-pid",
  "mlx-gen-qwen-image",
  "pmetal-mlx-rs",
@@ -3860,7 +3861,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "image",
  "inventory",
@@ -3874,7 +3875,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "image",
  "inventory",
@@ -3886,7 +3887,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3897,7 +3898,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3909,7 +3910,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3921,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3930,7 +3931,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3939,7 +3940,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3949,7 +3950,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3961,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "image",
  "inventory",
@@ -3976,7 +3977,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "image",
  "inventory",
@@ -3990,7 +3991,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4001,7 +4002,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4013,7 +4014,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4024,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "image",
  "inventory",
@@ -4038,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
 dependencies = [
  "image",
  "inventory",
@@ -5872,6 +5873,19 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04#212cba567102ffbf6866b3006ece2db384698f04"
+dependencies = [
+ "core-llm",
+ "inventory",
+ "safetensors 0.4.5",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokenizers 0.21.4",
+]
+
+[[package]]
+name = "sceneworks-gen-core"
+version = "0.1.0"
 source = "git+https://github.com/michaeltrefry/mlx-gen?rev=8db1ab6235b8b8beeecd96a7e7a21a131153e1fb#8db1ab6235b8b8beeecd96a7e7a21a131153e1fb"
 dependencies = [
  "core-llm",
@@ -6024,7 +6038,7 @@ dependencies = [
  "pmetal-mlx-rs",
  "reqwest 0.12.28",
  "sceneworks-core",
- "sceneworks-gen-core",
+ "sceneworks-gen-core 0.1.0 (git+https://github.com/michaeltrefry/mlx-gen?rev=212cba567102ffbf6866b3006ece2db384698f04)",
  "sceneworks-image-quality",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-gen",
  "image",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -713,7 +713,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -738,7 +738,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -790,7 +790,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -825,7 +825,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463#4cd3e55f5f0ff46a3c2d7bc691d9ba8519adc463"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -3674,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "image",
  "inventory",
@@ -3701,7 +3701,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "image",
  "inventory",
@@ -3715,7 +3715,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "image",
  "inventory",
@@ -3729,7 +3729,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3743,7 +3743,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3754,7 +3754,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3763,7 +3763,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3772,7 +3772,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3786,7 +3786,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3799,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3824,7 +3824,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3834,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "image",
  "inventory",
@@ -3847,11 +3847,12 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "image",
  "inventory",
  "mlx-gen",
+ "mlx-gen-boogu",
  "mlx-gen-pid",
  "mlx-gen-qwen-image",
  "pmetal-mlx-rs",
@@ -3861,7 +3862,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "image",
  "inventory",
@@ -3875,7 +3876,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "image",
  "inventory",
@@ -3887,7 +3888,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3898,7 +3899,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3910,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3922,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3931,7 +3932,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3940,7 +3941,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3950,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3962,7 +3963,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "image",
  "inventory",
@@ -3977,7 +3978,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "image",
  "inventory",
@@ -3991,7 +3992,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4002,7 +4003,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4014,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4025,7 +4026,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "image",
  "inventory",
@@ -4039,7 +4040,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "image",
  "inventory",
@@ -5873,7 +5874,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=498a12c0d4386959ecff1ee5db2c4b19147b7348#498a12c0d4386959ecff1ee5db2c4b19147b7348"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
 dependencies = [
  "core-llm",
  "inventory",
@@ -8343,7 +8344,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/config/manifests/builtin.loras.jsonc
+++ b/config/manifests/builtin.loras.jsonc
@@ -101,6 +101,30 @@
         "repo": "lightx2v/Wan2.1-I2V-14B-480P-StepDistill-CfgDistill-Lightx2v",
         "file": "loras/Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors"
       }
+    },
+    {
+      // Krea 2 Identity Edit (epic 10871). The community instruction-based, identity-preserving
+      // image-edit LoRA for Krea 2 (conradlocke/krea2-identity-edit). Krea has no product-layer edit
+      // surface — its "reference image" is SDEdit img2img — so this LoRA is INERT without the
+      // Kontext-style edit path (epic 10871): the source image enters as in-context VAE tokens at a
+      // distinct RoPE frame AND grounds the Qwen3-VL vision tower. `conditioningRole: image_edit` makes
+      // selecting it auto-activate that dual-conditioning edit recipe (the base can't edit without it);
+      // on a plain t2i job the weights do nothing. Referenced directly from the author's HF repo (NO
+      // re-host / NO bundle); downloaded on demand when selected. Default variant is rank-128 (v1.1);
+      // the repo also ships an r64 (smaller) file. Krea 2 Community License (commercial < $1M/yr) — the
+      // same license we already ship Krea 2 Raw/Turbo under, so no new gating beyond the base.
+      "id": "krea2_identity_edit",
+      "name": "Krea 2 Identity Edit",
+      "family": "krea_2",
+      "triggerWords": [],
+      "compatibility": { "families": ["krea_2"] },
+      "conditioningRole": "image_edit",
+      "defaultWeight": 1.0,
+      "source": {
+        "provider": "huggingface",
+        "repo": "conradlocke/krea2-identity-edit",
+        "file": "krea2_identity_edit_v1_1_r128.safetensors"
+      }
     }
   ]
 }

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2482,12 +2482,14 @@
       "family": "krea_2",
       "type": "image",
       "adapter": "mlx_krea",
-      // Text-to-image GENERATION model (mirrors Krea 2 Turbo). This top-level `capabilities` array is what
-      // the web layer keys on: ImageStudio/`imageModelServesMode` gates the model into the picker on
-      // `capabilities.includes("text_to_image")`, and the Model Manager renders the "Text to Image" chip
-      // from it. `ui.recommendedFor` is a separate recommendation hint and does NOT confer the capability —
-      // without this line Raw is invisible in Image Studio and untagged in the Model Manager (epic 9992).
-      "capabilities": ["text_to_image"],
+      // Text-to-image GENERATION model, PLUS the Kontext-style image-edit surface (epic 10871 — Raw only;
+      // the full-CFG variant the `krea2_identity_edit` LoRA targets, Turbo stays t2i-only). This top-level
+      // `capabilities` array is what the web layer keys on: ImageStudio/`imageModelServesMode` gates the
+      // model into the picker on `capabilities.includes("text_to_image")` and surfaces the Edit tab on
+      // `edit_image` (further gated by `macSupport.features.edit`, which the router probe flips true for
+      // Raw); the Model Manager renders the capability chips from it. `ui.recommendedFor` is a separate
+      // recommendation hint and does NOT confer the capability.
+      "capabilities": ["text_to_image", "edit_image"],
       // Routing (not this flag) drives availability: `krea_2_raw` is BOTH mlx- and candle-routed
       // (sc-9994). All-platform downloads serve generation on all three platforms + the candle trainer.
       "macOnly": false,

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -6030,6 +6030,42 @@ mod mlx_routing_tests {
     }
 
     #[test]
+    fn krea_2_raw_edit_image_routes_to_mlx() {
+        // epic 10871 (sc-10882): Krea 2 Raw serves BOTH text-to-image and the Kontext-style edit
+        // surface. A t2i job routes to MLX; an `edit_image` job WITH a source routes to the edit lane;
+        // an `edit_image` job WITHOUT a source is rejected (the defensive shape). Edit is Raw-only, so
+        // the `features.edit` oracle flips true for Raw while Turbo (validated above) stays false.
+        assert!(image_request_mlx_eligible(
+            "krea_2_raw",
+            &object(json!({ "model": "krea_2_raw", "prompt": "full-CFG editorial portrait" }))
+        ));
+        assert!(image_request_mlx_eligible("krea_2_raw", &Map::new()));
+        assert!(
+            image_request_mlx_eligible(
+                "krea_2_raw",
+                &object(
+                    json!({ "model": "krea_2_raw", "mode": "edit_image", "sourceAssetId": "asset_1" })
+                )
+            ),
+            "krea_2_raw edit_image with a source must route to the edit lane"
+        );
+        assert!(
+            !image_request_mlx_eligible(
+                "krea_2_raw",
+                &object(json!({ "model": "krea_2_raw", "mode": "edit_image" }))
+            ),
+            "krea_2_raw edit_image without a source is rejected"
+        );
+
+        let support = model_mac_support("krea_2_raw", "image");
+        assert!(support.supported, "krea_2_raw must be Mac-supported");
+        assert!(
+            support.features.edit,
+            "krea_2_raw advertises the edit tab (epic 10871)"
+        );
+    }
+
+    #[test]
     fn sd3_5_text_to_image_routes_to_mlx() {
         // sc-7873 (epic 7841): the three SD3.5 variants have native `mlx-gen-sd3` text-to-image engines
         // (S2 MODEL_TABLE), so they must reach the Text → Image picker (macSupport.supported) rather than

--- a/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
@@ -431,12 +431,25 @@ pub(crate) fn boogu_mlx_eligible(payload: &Map<String, Value>) -> bool {
     true
 }
 
-/// Krea 2 Turbo (epic 7565 / sc-7572) + Krea 2 Raw (epic 9992) MLX-eligibility. The native
-/// `mlx-gen-krea` engine serves the text-to-image surface only for both variants (distilled Turbo +
-/// full-CFG Raw); `edit_image` has no source/reference path, so reject that defensive shape the same way
-/// Lens does.
+/// Krea 2 Turbo (epic 7565 / sc-7572) + Krea 2 Raw (epic 9992) MLX-eligibility. Both variants serve
+/// text-to-image on the native `mlx-gen-krea` engine. Krea 2 **Raw** additionally serves the
+/// Kontext-style image-edit surface (epic 10871): an `edit_image` job with a `sourceAssetId` routes to
+/// the dual-conditioned edit lane (source image as in-context VAE tokens + Qwen3-VL vision-tower
+/// grounding), which the community `krea2_identity_edit` LoRA needs. Edit is Raw-only — it denoises from
+/// pure noise under full CFG (the tier the LoRA targets and the one validated on Metal, sc-10881); the
+/// distilled few-step **Turbo** sampler has no validated edit recipe, so Turbo stays t2i-only and its
+/// `features.edit` (the `model_mac_support` probe) stays false. An `edit_image` shape without a source is
+/// rejected (the same defensive shape the t2i-only engines reject).
 pub(crate) fn krea_mlx_eligible(payload: &Map<String, Value>) -> bool {
-    payload.get("mode").and_then(Value::as_str) != Some("edit_image")
+    if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
+        let is_raw = payload.get("model").and_then(Value::as_str) == Some("krea_2_raw");
+        let has_source = payload
+            .get("sourceAssetId")
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty());
+        return is_raw && has_source;
+    }
+    true
 }
 
 /// Stable Diffusion 3.5 Large / Large Turbo / Medium (epic 7841, surfaced S4 sc-7873) MLX-eligibility.

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1630,24 +1630,25 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1957
 # default lane AND `--features backend-candle --target all` now resolve the SINGLE gen-core rev `498a12c0`.
 # mlx-rs unchanged (38e1cc1). The worker also adds `"qwen_image"` to `SEQUENTIAL_CAPABLE_ENGINES`
 # (mlx_fit_gate.rs) so the fit-gate selects Sequential for it. ALL mlx-gen-* + candle-gen-* pins move together.
-# Bumped mlx-gen `498a12c0` -> `19573a9a` + candle-gen `4cd3e55f` -> `b0e9a5bf` IN LOCKSTEP (epic 10871,
+# Bumped mlx-gen `498a12c0` -> `19573a9a` + candle-gen `4cd3e55f` -> `95a2ebcc` IN LOCKSTEP (epic 10871,
 # Krea 2 image-edit): mlx-gen #693 adds the native Kontext-style edit engine + the `krea_2_edit`
 # `gen_core::Generator` (`KreaEdit` worker lane consumes it). `19573a9a` is mlx-gen main HEAD (the #693
 # merge; a superset of `498a12c0`/#694). `git diff 498a12c0..19573a9a -- gen-core/ gen-core-testkit/` is
 # EMPTY (gen-core BYTE-IDENTICAL — the edit work is additive to mlx-gen-krea only), but the skew gate keys
-# on the git REV, so candle-gen re-pins its gen-core in lockstep (candle-gen #413, `b0e9a5bf` = `4cd3e55f`
-# + the one-line gen-core rev-align, candle surface UNCHANGED). Both the default lane AND
+# on the git REV, so candle-gen re-pins its gen-core in lockstep. `95a2ebcc` is candle-gen main HEAD (the
+# squash-merge of candle-gen #413, the one-line gen-core `498a12c0` -> `19573a9a` rev-align; also carries
+# #412 bernini — additive candle-only, no worker surface change). Both the default lane AND
 # `--features backend-candle --target all` resolve the SINGLE gen-core rev `19573a9a`. ALL mlx-gen-* +
 # candle-gen-* pins move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1661,7 +1662,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1669,17 +1670,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1689,7 +1690,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1697,21 +1698,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1720,17 +1721,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1739,7 +1740,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1772,7 +1773,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1781,12 +1782,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1794,7 +1795,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1803,7 +1804,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1811,7 +1812,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1825,7 +1826,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1852,7 +1853,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1863,7 +1864,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b0e9a5bf6bea296089de0ace734a9dc237b15e55", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -534,7 +534,22 @@ sceneworks-core = { path = "../sceneworks-core" }
 # reports exactly one). NOTE: this bump FIXES a live bug — on 6a10ae1, every Anima LoRA/LoKr failed at
 # model load, because the worker defaults spec.quantize to Some(Q8) for every MLX model and mlx-gen-anima
 # rejected quant+adapter together. See test `anima_default_tier_with_adapter_builds_loadable_spec`.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+# Rev 8db1ab6 -> 212cba5 (epic 10871 / sc-10881, mlx-gen PR #693): brings the native Krea 2 Kontext-style
+# IMAGE-EDIT engine into mlx-gen-krea — `KreaPipeline::generate_edit`/`generate_edit_with_progress` (dual
+# conditioning: in-context VAE tokens via the reused `img_in` at a distinct RoPE frame + image-grounded
+# Qwen3-VL via a NEW krea->mlx-gen-boogu VisionTower dep) + `RopeTables::build_edit` + transformer
+# `prepare_edit`/`forward_prepared_edit`. It also registers a `krea_2_edit` generator id (sc-10882) that
+# routes a source `Conditioning::Reference` through the edit entrypoint on the `gen_core::Generator` seam,
+# so the worker reaches the edit path the SAME way it reaches every other engine (load-by-id + generate).
+# Consumed by the SceneWorks KreaEdit routing lane (this bump is the pin that lane needs). The range ALSO
+# folds in main #692 (sequential-residency, sdxl/z-image only):
+# gen-core is NOT byte-identical this time but the delta is ADDITIVE (`gen-core/src/runtime.rs` +32
+# OffloadPolicy runtime, `lib.rs` re-export) — worker import surface unchanged, compiles clean. Bumps
+# EVERY mlx-gen crate + gen-core 8db1ab6 -> 212cba5. BRANCH-HEAD pin (PR #693 not yet merged) — flip to the
+# merged/squashed SHA once #693 lands. candle-gen is NOT re-pinned in lockstep (the candle Krea-edit engine
+# is unwritten, P1.2/P2.2): `--features backend-candle --target all` is TEMPORARILY gen-core-skewed until
+# candle catches up; the DEFAULT PR gate (check.yml, blind to candle-gen) stays single-rev/green at 212cba5.
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -891,7 +906,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -907,23 +922,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -931,7 +946,7 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
 # mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
 # mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
@@ -939,7 +954,7 @@ mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6
 # conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
 # DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
 # generator-cache load path drives.
-mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # Anima 2B anime t2i provider (native MLX, CircleStone Labs Non-Commercial License v1.2; epic 10512,
 # sc-10523). Same git rev as mlx-gen so MLX builds once. Self-registers `anima_base` / `anima_aesthetic`
 # / `anima_turbo` (Cosmos-Predict2 DiT + Qwen3-0.6B T5-query-token adapter conditioner + Qwen-Image VAE)
@@ -948,59 +963,59 @@ mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab
 # scheduler (sc-10519) and strong prompt-weighting on the T5 query tokens (sc-10566). Carries the
 # install-time q4/q8/bf16 converter the model_jobs.rs Anima path drives (sc-10517). Pinned to merged
 # mlx-gen main 6a10ae1 (PR #680), which carries both the Anima crate and gen-core's is_hidden_file.
-mlx-gen-anima = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-anima = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -1009,19 +1024,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -1030,7 +1045,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1a
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -1038,7 +1053,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -1049,7 +1064,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -1060,7 +1075,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1a
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -1082,7 +1097,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -1093,7 +1108,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -1125,7 +1140,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "8db1ab6235b8b8beeecd96a7e7a21a131153e1fb" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -545,8 +545,10 @@ sceneworks-core = { path = "../sceneworks-core" }
 # folds in main #692 (sequential-residency, sdxl/z-image only):
 # gen-core is NOT byte-identical this time but the delta is ADDITIVE (`gen-core/src/runtime.rs` +32
 # OffloadPolicy runtime, `lib.rs` re-export) — worker import surface unchanged, compiles clean. Bumps
-# EVERY mlx-gen crate + gen-core 8db1ab6 -> 212cba5. BRANCH-HEAD pin (PR #693 not yet merged) — flip to the
-# merged/squashed SHA once #693 lands. candle-gen is NOT re-pinned in lockstep (the candle Krea-edit engine
+# EVERY mlx-gen crate + gen-core 8db1ab6 -> 212cba5. PR #693 is MERGED (regular merge 19573a9 on main), so
+# 212cba5 is a durable ancestor of main HEAD — this pins the exact validated engine tree WITHOUT pulling
+# in the unrelated #694 (qwen-image residency) that also rode main HEAD. candle-gen is NOT re-pinned in
+# lockstep (the candle Krea-edit engine
 # is unwritten, P1.2/P2.2): `--features backend-candle --target all` is TEMPORARILY gen-core-skewed until
 # candle catches up; the DEFAULT PR gate (check.yml, blind to candle-gen) stays single-rev/green at 212cba5.
 sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "212cba567102ffbf6866b3006ece2db384698f04" }

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -565,6 +565,20 @@ pub(crate) async fn run_image_generate_job(
                 )
                 .await?;
             }
+            ImageRoute::KreaEdit => {
+                // Krea 2 Raw Kontext-style edit (mode edit_image + a source) → the `krea_2_edit`
+                // engine: source as in-context VAE tokens + Qwen3-VL grounding (epic 10871, sc-10882).
+                generate_krea_edit_stream(
+                    api,
+                    settings,
+                    job,
+                    &plan,
+                    &project_path,
+                    backend,
+                    &mut asset_writes,
+                )
+                .await?;
+            }
             ImageRoute::InstantId => {
                 // InstantID identity-preserving character image (sc-3345): single identity or
                 // grouped angle/pose sets, on RealVisXL + IdentityNet + the native face stack.
@@ -1671,6 +1685,9 @@ include!("image_jobs/flux1_control.rs");
 #[cfg(target_os = "macos")]
 // Qwen control/edit routing.
 include!("image_jobs/qwen.rs");
+#[cfg(target_os = "macos")]
+// Krea 2 Kontext-style image-edit routing (epic 10871).
+include!("image_jobs/krea_edit.rs");
 #[cfg(target_os = "macos")]
 // SenseNova edit routing.
 include!("image_jobs/sensenova.rs");

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -87,6 +87,7 @@ enum ImageRoute {
     Flux2DevControl,
     Flux2Edit,
     QwenEdit,
+    KreaEdit,
     InstantId,
     PulidFlux,
     SdxlAdvanced,
@@ -121,6 +122,11 @@ fn resolve_image_route(request: &ImageRequest, settings: &Settings) -> Option<Im
         Some(ImageRoute::Flux2Edit)
     } else if qwen_edit_available(request, settings) {
         Some(ImageRoute::QwenEdit)
+    } else if krea_edit_available(request, settings) {
+        // Krea 2 Raw Kontext-style edit (mode edit_image + a source) → the `krea_2_edit` engine
+        // (epic 10871). Wins over the generic MLX arm below — `krea_2_raw` is in MODEL_TABLE, so
+        // `mlx_available` would otherwise render it as plain t2i and silently drop the source.
+        Some(ImageRoute::KreaEdit)
     } else if instantid_available(request, settings) {
         Some(ImageRoute::InstantId)
     } else if pulid_flux_available(request, settings) {
@@ -161,10 +167,12 @@ impl ImageRoute {
                 EditGrouping::Poses(_) | EditGrouping::Plain => request.count,
             },
             // PuLID-FLUX is one identity image per seed (no angle/pose grouping) — like the base
-            // MLX + SDXL-advanced + Bernini paths, the effective count is the requested count.
+            // MLX + SDXL-advanced + Bernini paths, the effective count is the requested count. Krea
+            // edit (epic 10871) is likewise plain per-image: `count` edits of the one source.
             ImageRoute::PulidFlux
             | ImageRoute::SdxlAdvanced
             | ImageRoute::Bernini
+            | ImageRoute::KreaEdit
             | ImageRoute::Mlx => request.count,
         }
     }

--- a/crates/sceneworks-worker/src/image_jobs/krea_edit.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_edit.rs
@@ -1,0 +1,237 @@
+// ---------------------------------------------------------------------------
+// Krea 2 image-edit (macOS, epic 10871): the Kontext-style dual-conditioned edit
+// surface. Routed here from `ImageRoute::KreaEdit` — an `edit_image` job on
+// `krea_2_raw` carrying a source image. Loads the `krea_2_edit` registry generator
+// (the Raw pipeline routed to `generate_edit_with_progress`: the source rides as
+// in-context VAE tokens at a distinct RoPE frame AND grounds the Qwen3-VL vision
+// tower), passing the source as a single `Conditioning::Reference`. One output per
+// requested count, each an edit of the same source under the instruction prompt.
+// Krea is MLX-only, so this is the only Krea edit path (the candle mirror is a
+// separate slice, P1.2/P2.2). Mirrors `generate_flux2_edit_stream`'s blocking-
+// thread + streamed-events shape and reuses `consume_gen_events`.
+// ---------------------------------------------------------------------------
+
+/// The engine registry id the edit lane loads: the Raw pipeline routed to the Kontext edit entrypoint
+/// (mlx-gen `krea_2_edit`, epic 10871). Distinct from the `krea_2_raw` t2i/img2img generator — the
+/// distinct id is what tells the engine to treat the source `Reference` as an edit, not an img2img init.
+const KREA_EDIT_ENGINE_ID: &str = "krea_2_edit";
+
+/// True when a selected LoRA declares the image-edit conditioning role (`conditioningRole: image_edit`,
+/// e.g. the builtin `krea2_identity_edit`). The image-edit sibling of the LTX IC-LoRA detector
+/// (`lora_looks_like_ic_lora`): this LoRA is what makes the in-context source actually steer the edit —
+/// the base weights leave it inert (R5).
+fn lora_declares_image_edit_role(lora: &Value) -> bool {
+    lora.as_object()
+        .and_then(|obj| obj.get("conditioningRole"))
+        .and_then(Value::as_str)
+        .map(|role| role.trim().to_lowercase().replace('-', "_") == "image_edit")
+        .unwrap_or(false)
+}
+
+/// Whether the job carries an image-edit LoRA (any selected LoRA with `conditioningRole: image_edit`).
+fn request_has_image_edit_lora(request: &ImageRequest) -> bool {
+    request.loras.iter().any(lora_declares_image_edit_role)
+}
+
+/// True when this is a Krea edit job whose weights resolve — routed to the `krea_2_edit` engine rather
+/// than the plain `krea_2_raw` t2i/img2img path. Edit is Krea 2 **Raw** only (the full-CFG variant the
+/// `krea2_identity_edit` LoRA targets; Turbo has no validated edit recipe), keyed on `edit_image` mode +
+/// a source asset. Mirrors the core router's `krea_mlx_eligible` edit branch (sc-10882).
+fn krea_edit_available(request: &ImageRequest, settings: &Settings) -> bool {
+    request.model == "krea_2_raw"
+        && request.mode == "edit_image"
+        && !edit_reference_ids(request).is_empty()
+        && matches!(resolve_weights_dir(request, settings), Ok(Some(_)))
+}
+
+/// Flat telemetry for a Krea edit generation (parity with `flux2_edit_raw_settings`).
+fn krea_edit_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    quant_bits: Option<i64>,
+    guidance: Option<f32>,
+    reference_count: usize,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw.insert(
+        "guidanceScale".to_owned(),
+        guidance.map(|value| json!(value)).unwrap_or(Value::Null),
+    );
+    raw.insert(
+        "mlxQuantize".to_owned(),
+        quant_bits.map(|bits| json!(bits)).unwrap_or(Value::Null),
+    );
+    raw.insert(
+        "editEngine".to_owned(),
+        Value::String(KREA_EDIT_ENGINE_ID.to_owned()),
+    );
+    raw.insert("referenceCount".to_owned(), json!(reference_count));
+    raw
+}
+
+/// Generate one Krea edit image conditioned on `conditioning` (the source `Reference`). Full-CFG: passes
+/// the negative prompt + `guidance`. The `krea_2_edit` generator routes the `Reference` to the Kontext
+/// edit entrypoint. Mirrors [`flux2_edit_generate_one`].
+#[allow(clippy::too_many_arguments)]
+fn krea_edit_generate_one(
+    generator: &dyn Generator,
+    prompt: &str,
+    negative_prompt: Option<String>,
+    width: u32,
+    height: u32,
+    seed: i64,
+    steps: u32,
+    guidance: Option<f32>,
+    conditioning: Vec<Conditioning>,
+    cancel: &CancelFlag,
+    on_progress: &mut dyn FnMut(Progress),
+) -> WorkerResult<(u32, u32, Vec<u8>)> {
+    let request = GenerationRequest {
+        prompt: prompt.to_owned(),
+        negative_prompt,
+        width,
+        height,
+        count: 1,
+        seed: Some(seed as u64),
+        steps: Some(steps),
+        guidance,
+        conditioning,
+        cancel: cancel.clone(),
+        ..Default::default()
+    };
+    let output = generator
+        .generate(&request, on_progress)
+        .map_err(|error| WorkerError::Engine(format!("Krea edit generation failed: {error}")))?;
+    match output {
+        GenerationOutput::Images(mut images) => {
+            let image = images.pop().ok_or_else(|| {
+                WorkerError::Engine("Krea edit generator produced no image".to_owned())
+            })?;
+            Ok((image.width, image.height, image.pixels))
+        }
+        _ => Err(WorkerError::Engine(
+            "Krea edit generator returned non-image output".to_owned(),
+        )),
+    }
+}
+
+/// Real Krea 2 edit generation: load the `krea_2_edit` generator once, then one output per requested
+/// count, each an edit of the shared source under the instruction prompt. Mirrors
+/// [`generate_flux2_edit_stream`]'s blocking-thread + streamed-events shape and reuses
+/// [`consume_gen_events`]; differs in the required edit LoRA (R5) and the single-source conditioning.
+async fn generate_krea_edit_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let model = mlx_model(&request.model)
+        .ok_or_else(|| WorkerError::InvalidPayload("not an MLX-backed model".to_owned()))?;
+    let weights_dir = resolve_weights_dir(request, settings)?
+        .ok_or_else(|| WorkerError::InvalidPayload("Krea 2 weights not found".to_owned()))?;
+
+    // R5 (epic 10871): the base cannot edit without the edit LoRA — its in-context/grounded source
+    // conditioning is inert without the trained weights (a VAE-only render is off-distribution, not
+    // shippable). Require an `image_edit`-role LoRA (the builtin `krea2_identity_edit`), mirroring the
+    // LTX IC-LoRA hard requirement. Checked before loading weights so the error is fast + clear.
+    if !request_has_image_edit_lora(request) {
+        return Err(WorkerError::InvalidPayload(
+            "Krea 2 edit requires the Krea 2 Identity Edit LoRA (or another image-edit LoRA): without \
+             it the source-image conditioning is inert. Select it in the LoRA picker."
+                .to_owned(),
+        ));
+    }
+
+    let (quant, quant_bits) = resolve_quant(request);
+    let steps = resolve_steps(request, &model);
+    let guidance = resolve_guidance(request, &model);
+    let negative_prompt = resolve_negative_prompt(request, &model);
+    let adapters = resolve_adapters(request, settings)?;
+    let repo = model_repo(request, &model);
+    let adapter_label = model.adapter_label();
+
+    // Resolve the source image on the async side (decode → Send Image moved into the worker thread).
+    // Krea edit is single-source for now — the `krea_2_edit` generator conditions on exactly one
+    // `Reference` (a second person reference is P1.3). Take the first resolved edit reference.
+    let reference_ids = edit_reference_ids(request);
+    let source_id = reference_ids.first().ok_or_else(|| {
+        WorkerError::InvalidPayload("Krea 2 edit requires a source image (sourceAssetId).".to_owned())
+    })?;
+    let source = load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        source_id,
+        project_path,
+    )?;
+    // Pre-fit the source to the target W×H (crop / pad / outpaint→pad) so an off-aspect source isn't
+    // squished into the latent grid; `stretch` keeps the legacy resize. Shared with the other edit lanes.
+    let source = fit_edit_references(vec![source], request, request.width, request.height)?
+        .pop()
+        .expect("fit_edit_references preserves the single source");
+
+    // Plain per-image work: `request.count` edits of the same source, each its own seed + the base
+    // instruction prompt (Krea edit has no angle/pose grouping — that is the character_image path).
+    let work: Vec<(i64, String)> = (0..request.count as usize)
+        .map(|index| (resolve_seed(request, index), request.prompt.clone()))
+        .collect();
+    let total = work.len();
+    let raw_settings = krea_edit_raw_settings(request, &repo, steps, quant_bits, guidance, 1);
+
+    let (width, height) = (request.width, request.height);
+    let adapter_count = adapters.len();
+    let spec = load_spec(weights_dir, quant, adapters, None);
+    let (cancel, rx, blocking) = start_cached_gen_stream(
+        job.id.clone(),
+        KREA_EDIT_ENGINE_ID,
+        adapter_count,
+        spec,
+        format!("{KREA_EDIT_ENGINE_ID} load failed"),
+        move |generator, tx, cancel| {
+            drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
+                if cancel.is_cancelled() {
+                    return Ok(None);
+                }
+                let conditioning = build_edit_conditioning(std::slice::from_ref(&source));
+                let (out_w, out_h, pixels) = krea_edit_generate_one(
+                    generator,
+                    &prompt,
+                    negative_prompt.clone(),
+                    width,
+                    height,
+                    seed,
+                    steps,
+                    guidance,
+                    conditioning,
+                    &cancel,
+                    on_progress,
+                )?;
+                Ok(Some((seed, out_w, out_h, pixels)))
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        adapter_label,
+        &raw_settings,
+        total,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -55,7 +55,7 @@ use crate::image_jobs::{classify_adapter, load_reference_image, lora_path};
 ))]
 use gen_core::{
     AdapterSpec, CancelFlag, Conditioning, GenerationOutput, GenerationRequest, Generator,
-    LoadSpec, Precision, Progress, Quant, WeightsSource,
+    LoadSpec, OffloadPolicy, Precision, Progress, Quant, WeightsSource,
 };
 // MLX-only contract types (LoRA classification, MoE experts) — the candle video lane uses none of these.
 #[cfg(target_os = "macos")]
@@ -3789,6 +3789,11 @@ fn video_load_spec(input: &VideoGenInput) -> LoadSpec {
         // LTX's external Gemma-3 text encoder rides the spec (sc-8827); `None` ⇒ the provider's
         // `$LTX_GEMMA_DIR` / `<root>/text_encoder` fallback.
         text_encoder: input.text_encoder_dir.clone().map(WeightsSource::Dir),
+        // `offload_policy` entered `LoadSpec` in mlx-gen #689 (sc-10821); every builder-constructed
+        // spec defaults it to `Resident`. This is the one raw literal, so set it explicitly to the
+        // same value — video providers keep all components co-resident (today's behavior); sequential
+        // residency is an image-lane (sdxl/z-image) feature (epic 10834).
+        offload_policy: OffloadPolicy::Resident,
     }
 }
 

--- a/packages/schemas/lora-manifest.schema.json
+++ b/packages/schemas/lora-manifest.schema.json
@@ -23,7 +23,8 @@
           "icLora": { "type": "boolean" },
           "conditioningRole": {
             "type": "string",
-            "enum": ["ic_lora"]
+            "description": "How the worker must condition a job for this LoRA to function. 'ic_lora' = LTX in-context video conditioning (source clip). 'image_edit' = Kontext-style image edit (source image as in-context VAE tokens + vision-tower grounding); selecting such a LoRA auto-activates the model's edit recipe. A base without the matching conditioning leaves these weights inert.",
+            "enum": ["ic_lora", "image_edit"]
           }
         },
         "additionalProperties": true


### PR DESCRIPTION
## Krea 2 image-edit — SceneWorks integration (epic 10871, Phase 3)

Wires the Kontext-style Krea 2 image-edit surface into SceneWorks end-to-end on the MLX backend. Motivated by the community `conradlocke/krea2-identity-edit` LoRA, which needs an edit surface Krea didn't have (Krea's "reference image" is product-layer SDEdit img2img — off-distribution for this LoRA). The edit keeps the source as **in-context conditioning** (VAE tokens at a distinct RoPE frame + Qwen3-VL vision-tower grounding), not a noised init.

**Engine dependency (already merged):** the mlx-gen edit engine landed in [SceneWorks/mlx-gen#693](https://github.com/SceneWorks/mlx-gen/pull/693). This PR bumps the pin to it (`8db1ab6` → `212cba5`, a durable ancestor of that merge) and consumes the new `krea_2_edit` generator.

### What's here

**Pin bump** — every mlx-gen crate + `sceneworks-gen-core` `8db1ab6` → `212cba5`. (The #689 `offload_policy` `LoadSpec` integration is already on `main` from epic 10834; this branch reconciles to it in the merge.)

**P3.1 — routing + caps**
- `krea_mlx_eligible` accepts `edit_image` + a `sourceAssetId` on **`krea_2_raw` only** — the full-CFG variant the edit LoRA targets and the tier validated on Metal. Turbo stays t2i-only, so `macSupport.features.edit` flips true for Raw only. New test `krea_2_raw_edit_image_routes_to_mlx`.
- `ImageRoute::KreaEdit` + resolver / `image_count` / dispatch arms. Wins over the generic MLX arm so an edit isn't silently rendered as t2i with the source dropped.
- `image_jobs/krea_edit.rs`: loads the `krea_2_edit` engine, passes the source as a single `Conditioning::Reference`, `count` plain edits. Modeled on the flux2/qwen edit lanes; reuses `edit_reference_ids` / `fit_edit_references` / `build_edit_conditioning` / `consume_gen_events`.
- Krea 2 Raw catalog `capabilities += edit_image`.

**P3.2 — conditioningRole auto-apply / R5**
- New generic `image_edit` `conditioningRole` (schema) + a worker detector (`lora_declares_image_edit_role`, the image sibling of the LTX IC-LoRA detector).
- The lane **requires** an `image_edit`-role LoRA — the base can't edit without it (a VAE-only render is off-distribution), so its absence is a loud `InvalidPayload` error, mirroring the LTX IC-LoRA hard requirement.

**P3.3 — discoverable builtin LoRA (no re-host)**
- `krea2_identity_edit` entry in `builtin.loras.jsonc` referencing the source repo (`conradlocke/krea2-identity-edit`), downloaded on demand — the `scail2_lightning` precedent. `conditioningRole: image_edit`, family `krea_2`.

### Verification
- Core + worker compile (incl. `--all-targets`), fmt clean; krea routing, worker route-assertion, and builtin-manifest tests pass.
- **Real-weight, on Metal:** the `krea_2_edit` generator driven through `Generator::generate` with a `Conditioning::Reference` (the exact worker path) produces an identity-preserving edit — verified against the direct pipeline method (byte-identical output).
- **Provisioning confirmed:** the shipped `SceneWorks/krea-2-raw-mlx` q8 (default) and q4 turnkeys both carry the 315-tensor Qwen3-VL vision tower, so edit grounding works on the real download.

### Not in this PR (tracked)
- **Candle** KreaEdit — the candle edit engine is unwritten (P1.2/P2.2) and unverifiable on this Mac; a separate slice. This PR is MLX-only.
- **Phase 4** UI edit mode; the numeric **parity golden** (folded into P4.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
