### PR TITLE
fix(worker): candle VRAM fit-gate counts the resident model as reclaimable (sc-11023, epic 10765)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -4068,14 +4068,26 @@ async fn generate_candle_stream(
     // the tier's MEASURED sequential peak (`candle.sequentialPeakGb`) is known and STILL won't fit, reject
     // instead of running into a reactive OOM. Honors `SCENEWORKS_CUDA_VRAM_CAP_GB` to emulate a small
     // card. Unmeasured models (no `candle` block) and non-NVIDIA hosts yield `Unknown` → never block.
+    let budget = crate::vram_gate::apply_vram_cap(
+        crate::gpu::nvidia_vram_budget_gb(&settings.gpu_id).await,
+        crate::vram_gate::cuda_vram_cap_gb(),
+    );
+    // sc-11023: the single-slot generator cache evicts its current occupant BEFORE the incoming load,
+    // and cudarc's caching allocator reuses those freed pages in-process — nvidia-smi `free` never rises
+    // after an in-process evict (the epic 10765 caching-allocator note). So the VRAM this process already
+    // holds is RECLAIMABLE by the incoming load; budget against `free + reclaimable` (capped to total),
+    // else a warm/swap re-gate falsely rejects a load that will actually fit (the "even with sequential
+    // residency" 2nd-run reject a resident bf16 tier hits on the next generation).
+    let budget = budget.map(|budget| {
+        crate::vram_gate::with_reclaimable(
+            budget,
+            crate::vram_gate::reclaimable_pool_gb(&settings.gpu_id),
+        )
+    });
+    let tier =
+        crate::vram_gate::requested_tier_key(&request.advanced, &request.model_manifest_entry);
+    let needed = crate::vram_gate::predicted_peak_gb(&request.model_manifest_entry, tier);
     let use_sequential = {
-        let budget = crate::vram_gate::apply_vram_cap(
-            crate::gpu::nvidia_vram_budget_gb(&settings.gpu_id).await,
-            crate::vram_gate::cuda_vram_cap_gb(),
-        );
-        let tier =
-            crate::vram_gate::requested_tier_key(&request.advanced, &request.model_manifest_entry);
-        let needed = crate::vram_gate::predicted_peak_gb(&request.model_manifest_entry, tier);
         // The candle FLUX.1 (sc-10769), FLUX.2 txt2img (sc-10868), and Qwen-Image txt2img (sc-10867)
         // lanes have wired sequential residency (load→encode→drop the text encoder before the DiT);
         // other families reject-before-OOM. FLUX.2 is the biggest win off-Mac — the 32B `flux2_dev`'s
@@ -4144,6 +4156,20 @@ async fn generate_candle_stream(
             _ => false,
         }
     };
+    // sc-11023: record this admitted load's incurred peak as the reclaimable high-water for the NEXT
+    // gate. Sequential residency peaks at the largest single component; a resident load at the whole-
+    // model peak. cudarc's pool never returns pages to the driver, so the max we have ever loaded is
+    // exactly what a later swap-in reclaims after the single-slot cache evicts this model. Reached only
+    // when the gate ADMITTED the load (the reject arms `return` above), so we never record a peak we
+    // didn't actually attempt to allocate.
+    let incurred_peak = if use_sequential {
+        crate::vram_gate::predicted_sequential_peak_gb(&request.model_manifest_entry, tier)
+    } else {
+        needed
+    };
+    if let Some(peak_gb) = incurred_peak {
+        crate::vram_gate::note_loaded_peak(&settings.gpu_id, peak_gb);
+    }
     let mut spec = load_spec(weights_dir, quant, adapters, None);
     if use_sequential {
         // Ask the provider (candle FLUX) to load→use→drop each component in phase order (sc-10821).

--- a/crates/sceneworks-worker/src/vram_gate.rs
+++ b/crates/sceneworks-worker/src/vram_gate.rs
@@ -89,6 +89,59 @@ pub(crate) fn apply_vram_cap(real: Option<VramBudget>, cap: Option<f64>) -> Opti
     }
 }
 
+/// Fold this process's RECLAIMABLE in-process VRAM pool into the live budget (sc-11023): add
+/// `reclaimable_gb` to `free_gb`, clamped to the physical `total_gb`. The candle generator cache is a
+/// single exclusive slot that evicts its current occupant BEFORE loading the incoming model, and
+/// cudarc's caching allocator reuses the freed pages in-process (nvidia-smi `free` never rises after an
+/// evict — see the module caveat). So the VRAM this process already holds will be available to the next
+/// load; without this, a warm same-model re-gate or a swap-in is measured against `free` that still
+/// counts the model it is about to replace, falsely rejecting a load that fits. A no-op when
+/// `reclaimable_gb == 0` (nothing loaded yet), so a genuine cold first-load is gated exactly as before.
+pub(crate) fn with_reclaimable(budget: VramBudget, reclaimable_gb: f64) -> VramBudget {
+    VramBudget {
+        free_gb: (budget.free_gb + reclaimable_gb.max(0.0)).min(budget.total_gb),
+        total_gb: budget.total_gb,
+    }
+}
+
+/// Per-GPU high-water of the peak VRAM (GB) this process has admitted a load at — the size of the
+/// reclaimable cudarc pool (sc-11023). Keyed by `gpu_id` (a worker process is pinned to one card, but
+/// keying is defensive + explicit). The pool only ever grows (no `empty_cache`/trim), so the running
+/// MAX is exactly what a later swap-in can reuse.
+fn reclaimable_pool_store() -> &'static std::sync::Mutex<std::collections::HashMap<String, f64>> {
+    static STORE: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<String, f64>>> =
+        std::sync::OnceLock::new();
+    STORE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// Record the peak VRAM (GB) an admitted load will occupy on `gpu_id`, as a monotonic high-water
+/// (sc-11023). Called only after the fit-gate ADMITS a load, so it reflects a real allocation attempt.
+/// A non-positive peak is ignored.
+pub(crate) fn note_loaded_peak(gpu_id: &str, peak_gb: f64) {
+    // Ignore a non-positive, NaN, or infinite peak (defensive — a real measured peak is finite > 0).
+    if !peak_gb.is_finite() || peak_gb <= 0.0 {
+        return;
+    }
+    let mut store = reclaimable_pool_store()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    let entry = store.entry(gpu_id.to_owned()).or_insert(0.0);
+    if peak_gb > *entry {
+        *entry = peak_gb;
+    }
+}
+
+/// The reclaimable in-process VRAM pool (GB) for `gpu_id` — the [`note_loaded_peak`] high-water, or
+/// `0.0` when nothing has loaded on this card yet (so [`with_reclaimable`] is a no-op on a cold start).
+pub(crate) fn reclaimable_pool_gb(gpu_id: &str) -> f64 {
+    reclaimable_pool_store()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .get(gpu_id)
+        .copied()
+        .unwrap_or(0.0)
+}
+
 /// The tier key (`bf16`/`q8`/`q4`) the request selected — derived the SAME way the tier-subdir
 /// resolvers pick their folder (`advanced.mlxQuantize` → manifest `mlx.quantize` → `q8` default;
 /// `<= 0` ⇒ `bf16`; `<= 4` ⇒ `q4`; else `q8`). Deliberately NOT derived from the resolved `Quant`,
@@ -408,6 +461,66 @@ mod tests {
         assert_eq!(sequential_overflow_gb(None, Some(budget)), None);
         // No live budget ⇒ never block (None).
         assert_eq!(sequential_overflow_gb(Some(32.0), None), None);
+    }
+
+    #[test]
+    fn with_reclaimable_adds_the_pool_and_clamps_to_total() {
+        let budget = VramBudget {
+            free_gb: 14.0,
+            total_gb: 96.0,
+        };
+        // A resident ~82 GB model is reclaimable → the incoming load sees free + 82, capped to total.
+        // This is the sc-11023 fix: raw free (14) would reject a bf16 re-load that actually fits.
+        assert_eq!(
+            with_reclaimable(budget, 82.0),
+            VramBudget {
+                free_gb: 96.0,
+                total_gb: 96.0,
+            }
+        );
+        // Partial reclaim stays below total.
+        assert_eq!(
+            with_reclaimable(budget, 20.0),
+            VramBudget {
+                free_gb: 34.0,
+                total_gb: 96.0,
+            }
+        );
+        // Nothing reclaimable (cold start) ⇒ budget unchanged.
+        assert_eq!(with_reclaimable(budget, 0.0), budget);
+        // Negative is treated as zero (defensive).
+        assert_eq!(with_reclaimable(budget, -5.0), budget);
+        // Never exceeds the physical total, even with a huge/stale high-water.
+        assert_eq!(
+            with_reclaimable(budget, 1000.0),
+            VramBudget {
+                free_gb: 96.0,
+                total_gb: 96.0,
+            }
+        );
+    }
+
+    #[test]
+    fn reclaimable_pool_is_a_per_gpu_monotonic_high_water() {
+        // Distinct gpu_ids so this test can't race the process-global against other tests.
+        let gpu = "test-reclaimable-gpu-a";
+        let other = "test-reclaimable-gpu-b";
+        // Nothing loaded yet ⇒ 0 (so `with_reclaimable` no-ops on a cold card).
+        assert_eq!(reclaimable_pool_gb(gpu), 0.0);
+        note_loaded_peak(gpu, 30.0);
+        assert_eq!(reclaimable_pool_gb(gpu), 30.0);
+        // A bigger load raises the high-water…
+        note_loaded_peak(gpu, 82.0);
+        assert_eq!(reclaimable_pool_gb(gpu), 82.0);
+        // …a smaller later load does NOT lower it — the cudarc pool never returns pages to the driver.
+        note_loaded_peak(gpu, 54.0);
+        assert_eq!(reclaimable_pool_gb(gpu), 82.0);
+        // Non-positive peaks are ignored.
+        note_loaded_peak(gpu, 0.0);
+        note_loaded_peak(gpu, -1.0);
+        assert_eq!(reclaimable_pool_gb(gpu), 82.0);
+        // Keyed per GPU — a different card is independent.
+        assert_eq!(reclaimable_pool_gb(other), 0.0);
     }
 
     /// Live real-hardware validation (sc-10766): exercises the REAL `nvidia-smi` VRAM reading on GPU 0


### PR DESCRIPTION
## Symptom
On a card that fits a tier on the FIRST (cold) generation, the SECOND generation can hard-reject:
> `<model> at the <tier> tier needs ~N GB of VRAM even with sequential component residency … but GPU X has ~M GB available. Pick a lower tier …`

Reproduced reasoning through a repeated **bf16 `qwen_image`** render on a clear 96 GB card: run 1 loads and generates, run 2 is rejected even though the model is already resident and would fit.

## Root cause — the fit-gate budgets on raw free VRAM, ignoring the reclaimable resident model
The candle VRAM fit-gate (`image_jobs/base.rs`, `generate_candle_stream`) runs **before** `start_cached_gen_stream` and budgets on live `nvidia-smi memory.free` (`gpu::nvidia_vram_budget_gb` → `vram_gate::fit_decision(... budget.free_gb)`). Two facts make `free_gb` the wrong signal for a (re)load:

1. **Single-slot exclusive cache.** `GeneratorCache` holds one entry; `GeneratorCacheKey` excludes `offload_policy`. `with_generator` does `self.entry = None` (evict → free to the cudarc pool) *before* `gen_core::load`, so the incoming load always gets exclusive residency — the outgoing model's VRAM is reclaimable.
2. **cudarc caching allocator, no `empty_cache`** (this epic's core constraint). The evicted pages return to *this process's* pool and are reused by the next load — but `nvidia-smi memory.free` does **not** rise.

So the gate decides against **post-eviction demand but pre-eviction supply**, rejecting a warm same-model re-gate (which needs zero new allocation) or a swap-in that would actually fit. The MLX gate (`apply_residency_policy`) avoids this by sitting *inside* the cache cold-load branch (skipped on warm hits) and budgeting on total unified memory; the candle gate did neither.

## Fix (worker-only — no candle-gen change / pin bump)
Budget the incoming load against `free + reclaimable`, where `reclaimable` is this process's **monotonic high-water GPU footprint**. Because the cudarc pool never trims, the max we've ever loaded is exactly what a later swap-in reclaims — so no eviction bookkeeping is needed (an idle-evicted entry is harmless; its pages are still poolable).

- **`vram_gate.rs`**: pure `with_reclaimable(budget, gb)` (clamped to `total_gb`); a per-GPU monotonic high-water store (`note_loaded_peak` / `reclaimable_pool_gb`); 2 unit tests.
- **`base.rs`**: augment the budget before `fit_decision` / `sequential_overflow_gb`; after the gate **admits** a load, record its incurred peak (sequential peak if offloading, else resident) as the high-water. The reject arms `return` first, so an unattempted load is never recorded. Cold first-load behavior is unchanged (reclaimable = 0).

Deliberately does **not** use `nvidia-smi --query-compute-apps` per-process memory — frequently `N/A` under Windows WDDM; the tracked high-water sidesteps it.

## Verification
- `cargo check -p sceneworks-worker --features backend-candle --tests` → clean (against main's current candle-gen pin).
- `cargo test -p sceneworks-worker --lib --features backend-candle vram_gate` → 10 passed (incl. 2 new), 1 ignored.
- `cargo clippy -p sceneworks-worker --features backend-candle --all-targets -- -D warnings` → clean.
- Under `SCENEWORKS_CUDA_VRAM_CAP_GB` the bug can't repro (real free never drops below the cap on the 96 GB box), so runtime coverage is the pure unit tests. **GPU repro on the box (warm 2nd bf16 `qwen_image` render currently rejects → passes after fix) pending.**

Story: sc-11023 (epic 10765). Relates: sc-10766 (Phase 0 fit-gate), sc-10856 (sequential second-stage), sc-11020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)