### PR TITLE
feat(api): built-in Krea pose control-overlay catalog entry (Training Studio / epic 8459 S6, sc-8466)

### DIFF
--- a/apps/rust-api/src/control_overlays.rs
+++ b/apps/rust-api/src/control_overlays.rs
@@ -28,28 +28,44 @@ pub(crate) async fn list_control_overlays(
     Ok(Json(items))
 }
 
-/// Assemble the control-overlay catalog: user-global (`user.control_overlays.jsonc`) + the project
-/// manifest (`<project>/control-overlays/manifest.jsonc`) when a project id is given. Each entry is
-/// normalized (installedPath / installState / manifestPath) via the shared [`normalize_lora_entry`] — the
-/// resolution is identical (a relative `source.path` under the scope root; the training provider carries
-/// no HF repo, so the local-path branch resolves it). No builtin control overlays yet — a hosted catalog
-/// (`builtin.control_overlays.jsonc`) lands with sc-8466.
+/// Assemble the control-overlay catalog: builtin/hosted (`builtin.control_overlays.jsonc`, sc-8466) +
+/// user-global (`user.control_overlays.jsonc`) + the project manifest
+/// (`<project>/control-overlays/manifest.jsonc`) when a project id is given, merged by id (a later scope
+/// overrides an earlier one — the `lora_catalog` pattern). Each entry is normalized (installedPath /
+/// installState / manifestPath) via the shared [`normalize_lora_entry`]: a hosted entry
+/// (`source.provider="huggingface"` + `source.repo`) resolves its install state from the HF cache, while a
+/// studio-trained entry (a relative `source.path` under the scope root) resolves the local path.
 pub(crate) async fn control_overlay_catalog(
     state: &AppState,
     project_id: Option<&str>,
 ) -> Result<Vec<Value>, ApiError> {
     let manifest_dir = state.settings.config_dir.join("manifests");
+    let builtin_manifest = manifest_dir.join("builtin.control_overlays.jsonc");
+    let builtin = load_manifest_entries(state, &builtin_manifest, "controlOverlays").await?;
     let user_manifest = manifest_dir.join("user.control_overlays.jsonc");
     let user = load_manifest_entries(state, &user_manifest, "controlOverlays").await?;
     let data_dir = state.settings.data_dir.clone();
 
+    // Normalize builtin (hosted) + user (global) install-state off the async executor, then merge by id so
+    // a user override replaces a builtin of the same id.
     let mut overlays = {
         let data_dir = data_dir.clone();
+        let builtin_manifest = builtin_manifest.clone();
         let user_manifest = user_manifest.clone();
         tokio::task::spawn_blocking(move || -> Result<Vec<Value>, ApiError> {
-            let mut out = Vec::new();
+            let mut builtin_out = Vec::new();
+            for entry in builtin {
+                builtin_out.push(crate::loras::normalize_lora_entry(
+                    entry,
+                    "builtin",
+                    &builtin_manifest,
+                    &data_dir,
+                    &data_dir,
+                )?);
+            }
+            let mut user_out = Vec::new();
             for entry in user {
-                out.push(crate::loras::normalize_lora_entry(
+                user_out.push(crate::loras::normalize_lora_entry(
                     entry,
                     "global",
                     &user_manifest,
@@ -57,7 +73,7 @@ pub(crate) async fn control_overlay_catalog(
                     &data_dir,
                 )?);
             }
-            Ok(out)
+            Ok(crate::manifest::merge_entries_by_id(builtin_out, user_out))
         })
         .await
         .map_err(|error| ApiError::internal(error.to_string()))??
@@ -84,19 +100,21 @@ pub(crate) async fn control_overlay_catalog(
             })
             .await
             .map_err(|error| ApiError::internal(error.to_string()))??;
-        overlays.extend(project_overlays);
+        overlays = crate::manifest::merge_entries_by_id(overlays, project_overlays);
     }
 
     Ok(overlays)
 }
 
 /// Resolve a selected control overlay id (`advanced.controlWeights.overlayId`, set by the Studio's
-/// ControlPanel picker) to its installed `.safetensors` path, written back as
-/// `advanced.controlWeights.path` — the field the worker strict-control lane
-/// (`ensure_krea_control_weights`) reads (sc-10165, epic 10159 B4). A no-op when no overlay is selected.
-/// A selected-but-unknown/uninstalled overlay is a clean 400 rather than a deep worker error. Mirrors the
-/// LoRA id→path resolution (`validate_job_lora_compatibility_with`): one catalog snapshot, in-place
-/// `advanced` mutation.
+/// ControlPanel picker) to what the worker strict-control lane (`ensure_krea_control_weights`) reads
+/// (sc-10165 B4 + sc-8466). An INSTALLED overlay resolves to its `.safetensors` path
+/// (`advanced.controlWeights.path`, studio-trained/registered or an already-cached hosted overlay); a
+/// hosted overlay not yet on disk (the built-in beta or any un-cached hosted entry) resolves to
+/// `advanced.controlWeights.{repo,filename}` so the worker lazy-downloads it on first use (the FLUX.2
+/// control precedent). A no-op when no overlay is selected. A selected-but-unknown overlay, or a
+/// training/local overlay that is not installed, is a clean 400 rather than a deep worker error. Mirrors
+/// the LoRA id→path resolution: one catalog snapshot, in-place `advanced` mutation.
 pub(crate) async fn resolve_control_overlay_selection(
     state: &AppState,
     project_id: Option<&str>,
@@ -121,25 +139,35 @@ pub(crate) async fn resolve_control_overlay_selection(
         .into_iter()
         .find(|item| item.get("id").and_then(Value::as_str) == Some(overlay_id.as_str()))
         .ok_or_else(|| ApiError::bad_request(format!("Control overlay not found: {overlay_id}")))?;
-    if overlay.get("installState").and_then(Value::as_str) != Some("installed") {
+
+    // What the worker resolves the overlay from: an installed local `.safetensors` (`controlWeights.path`
+    // — studio-trained/registered, or an already-cached hosted overlay), else a hosted repo/filename it
+    // lazy-downloads on first use (`controlWeights.{repo,filename}` — the built-in beta or any not-yet-
+    // cached hosted overlay). A training/local overlay that is not installed is a real 400.
+    let installed = overlay.get("installState").and_then(Value::as_str) == Some("installed");
+    let weights: Vec<(&str, String)> = if installed {
+        let installed_path = overlay
+            .get("installedPath")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                ApiError::bad_request(format!(
+                    "Control overlay '{overlay_id}' has no installed weights"
+                ))
+            })?;
+        let weights_path = resolve_overlay_weights_file(installed_path, overlay.get("files"))
+            .ok_or_else(|| {
+                ApiError::bad_request(format!(
+                    "Control overlay '{overlay_id}' weights (.safetensors) not found under {installed_path}"
+                ))
+            })?;
+        vec![("path", weights_path)]
+    } else if let Some((repo, filename)) = hosted_overlay_repo_file(&overlay) {
+        vec![("repo", repo), ("filename", filename)]
+    } else {
         return Err(ApiError::bad_request(format!(
             "Control overlay '{overlay_id}' is not installed"
         )));
-    }
-    let installed_path = overlay
-        .get("installedPath")
-        .and_then(Value::as_str)
-        .ok_or_else(|| {
-            ApiError::bad_request(format!(
-                "Control overlay '{overlay_id}' has no installed weights"
-            ))
-        })?;
-    let weights_path = resolve_overlay_weights_file(installed_path, overlay.get("files"))
-        .ok_or_else(|| {
-            ApiError::bad_request(format!(
-                "Control overlay '{overlay_id}' weights (.safetensors) not found under {installed_path}"
-            ))
-        })?;
+    };
 
     let advanced = job_payload
         .entry("advanced".to_owned())
@@ -149,10 +177,43 @@ pub(crate) async fn resolve_control_overlay_selection(
             .entry("controlWeights".to_owned())
             .or_insert_with(|| Value::Object(JsonObject::new()));
         if let Some(control_weights) = control_weights.as_object_mut() {
-            control_weights.insert("path".to_owned(), Value::String(weights_path));
+            for (key, value) in weights {
+                control_weights.insert(key.to_owned(), Value::String(value));
+            }
         }
     }
     Ok(())
+}
+
+/// The (repo, filename) of a hosted overlay entry (`source.provider="huggingface"` + `source.repo` +
+/// `files[0]`/`source.file`) — the worker lazy-downloads these when the overlay is not yet cached,
+/// mirroring the built-in default in `ensure_krea_control_weights`. `None` for a training/local overlay.
+fn hosted_overlay_repo_file(overlay: &Value) -> Option<(String, String)> {
+    let source = overlay.get("source").and_then(Value::as_object);
+    let provider = source
+        .and_then(|s| s.get("provider"))
+        .or_else(|| overlay.get("provider"))
+        .and_then(Value::as_str)?;
+    if provider != "huggingface" {
+        return None;
+    }
+    let repo = source
+        .and_then(|s| s.get("repo"))
+        .or_else(|| overlay.get("repo"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|v| !v.is_empty())?
+        .to_owned();
+    let filename = overlay
+        .get("files")
+        .and_then(Value::as_array)
+        .and_then(|files| files.first())
+        .and_then(Value::as_str)
+        .or_else(|| source.and_then(|s| s.get("file")).and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|v| !v.is_empty())?
+        .to_owned();
+    Some((repo, filename))
 }
 
 /// The overlay's registered `installedPath` may be the overlay dir (the normalized `source.path`) or the
@@ -169,4 +230,54 @@ fn resolve_overlay_weights_file(installed_path: &str, files: Option<&Value>) -> 
         .and_then(Value::as_str)?;
     let candidate = base.join(file);
     candidate.is_file().then(|| candidate.display().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn hosted_overlay_repo_file_reads_huggingface_source() {
+        // A built-in/hosted overlay: the picker-selected id resolves to (repo, files[0]) for the worker to
+        // lazy-download — `files[0]` wins over `source.file`.
+        let overlay = json!({
+            "id": "krea_2_pose_beta",
+            "source": {
+                "provider": "huggingface",
+                "repo": "SceneWorks/krea2-pose-controlnet-beta",
+                "file": "should-not-win.safetensors"
+            },
+            "files": ["control_step5000.safetensors"]
+        });
+        assert_eq!(
+            hosted_overlay_repo_file(&overlay),
+            Some((
+                "SceneWorks/krea2-pose-controlnet-beta".to_owned(),
+                "control_step5000.safetensors".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn hosted_overlay_repo_file_falls_back_to_source_file() {
+        let overlay = json!({
+            "source": { "provider": "huggingface", "repo": "acme/x", "file": "w.safetensors" }
+        });
+        assert_eq!(
+            hosted_overlay_repo_file(&overlay),
+            Some(("acme/x".to_owned(), "w.safetensors".to_owned()))
+        );
+    }
+
+    #[test]
+    fn hosted_overlay_repo_file_none_for_training_overlay() {
+        // A studio-trained/registered overlay carries a local `source.path`, not an HF repo — so resolve
+        // must NOT treat "not installed" as a lazy-download (it is a real 400 instead).
+        let overlay = json!({
+            "source": { "provider": "training", "path": "control-overlays/my-overlay" },
+            "files": ["overlay.safetensors"]
+        });
+        assert_eq!(hosted_overlay_repo_file(&overlay), None);
+    }
 }

--- a/config/manifests/builtin.control_overlays.jsonc
+++ b/config/manifests/builtin.control_overlays.jsonc
@@ -1,0 +1,51 @@
+{
+  // Built-in (hosted) control-overlay catalog — the third source of the shared control-overlay registry
+  // (sc-8466, epic 8459 S6), alongside the user-global `user.control_overlays.jsonc` and per-project
+  // `<project>/control-overlays/manifest.jsonc` that studio-trained overlays register into (B4/sc-10165).
+  // The API `control_overlay_catalog` merges builtin → user → project by id (later scopes override), the
+  // exact `builtin.loras.jsonc` pattern — do NOT build a parallel registry.
+  //
+  // Each entry reuses the LoRA entry shape so it normalizes through `normalize_lora_entry`: a
+  // `source.provider="huggingface"` + `source.repo` hosted overlay resolves its `installState` from the HF
+  // cache, and the ControlPanel picker (`GET /api/v1/control-overlays?baseModel=…`) lists it. The candle
+  // worker lane (`ensure_krea_control_weights`) already defaults to the same repo and lazy-downloads it, so
+  // pose control works out-of-box even before the overlay is explicitly picked; a studio-trained overlay
+  // always overrides the built-in.
+  "schemaVersion": 1,
+  "controlOverlays": [
+    {
+      "id": "krea_2_pose_beta",
+      "name": "Krea 2 Pose ControlNet (beta)",
+      // The frozen INFERENCE base the overlay applies on (Krea 2 Turbo), NOT the training base
+      // (krea_2_raw). `list_control_overlays` filters the picker by this; the ControlPanel offers it only
+      // for `krea_2_turbo`.
+      "baseModel": "krea_2_turbo",
+      "controlType": "pose",
+      // Mirrors the worker STRICT_CONTROL_ENGINES `krea_2_turbo_control` (supported_kinds = {Pose}).
+      "controlEngine": "krea_2_turbo_control",
+      "backbone": "krea_2",
+      "kind": "pose_control_branch",
+      // EXPERIMENTAL: the S0 feasibility spike (5,000-step, ~30k COCO GT skeletons, body-18 + head
+      // direction, no hands/dense-face). Usable pose-lock ~0.5–0.85 (S0 GO verdict); not-for-production.
+      // The production overlay from the full-corpus run (S3/sc-8463) will supersede this entry.
+      "experimental": true,
+      "source": {
+        "provider": "huggingface",
+        "repo": "SceneWorks/krea2-pose-controlnet-beta",
+        // Pinned for defense-in-depth (parity with the worker's KREA_CONTROL_OVERLAY_REVISION) so a repo
+        // re-push can't swap the checkpoint under the cache install-state probe.
+        "revision": "cb3a0ac7590f5ec594a4eeb43b95ee1da0b5a0ac",
+        "file": "control_step5000.safetensors"
+      },
+      "files": ["control_step5000.safetensors"],
+      "provenance": {
+        "epic": "8459",
+        "story": "8466",
+        "spike": "sc-8460 S0",
+        "notForProduction": true
+      },
+      "createdAt": "2026-07-09T00:00:00Z",
+      "updatedAt": "2026-07-09T00:00:00Z"
+    }
+  ]
+}

--- a/crates/sceneworks-core/src/builtin_manifests.rs
+++ b/crates/sceneworks-core/src/builtin_manifests.rs
@@ -32,6 +32,10 @@ pub const BUILTIN_MANIFESTS: &[(&str, &str)] = &[
         "builtin.recipe-presets.jsonc",
         include_str!("../../../config/manifests/builtin.recipe-presets.jsonc"),
     ),
+    (
+        "builtin.control_overlays.jsonc",
+        include_str!("../../../config/manifests/builtin.control_overlays.jsonc"),
+    ),
 ];
 
 /// How an existing manifest file is treated when seeding.


### PR DESCRIPTION
## What

Surface the hosted Krea pose overlay in the **shared control-overlay registry** so the Studio ControlPanel picker lists it — extending the B4/sc-10165 registry rather than adding a parallel one (the registry design was explicitly deferred to sc-8466).

Second PR of **sc-8466 (S6)**; builds on the worker default-repo provisioning in #1424.

## How

- **`config/manifests/builtin.control_overlays.jsonc`** (new): one entry for the published beta overlay — `SceneWorks/krea2-pose-controlnet-beta` / `control_step5000.safetensors`, pinned rev `cb3a0ac`, `baseModel: krea_2_turbo`, `controlEngine: krea_2_turbo_control`, flagged experimental/not-for-production. Reuses the LoRA entry shape so it normalizes through `normalize_lora_entry` (installState resolved from the HF cache). Registered in `BUILTIN_MANIFESTS` so it's embedded + seeded like the other builtin catalogs — the `seeds_every_manifest_into_a_fresh_dir` test now covers it.
- **`control_overlay_catalog`**: loads builtin + user + project and merges by id (later scope overrides), mirroring `lora_catalog`.
- **`resolve_control_overlay_selection`**: an INSTALLED overlay still resolves to `controlWeights.path` (studio-trained/registered, or an already-cached hosted overlay); a hosted overlay **not yet on disk** (the built-in beta, or any un-cached hosted entry) now resolves to `controlWeights.{repo,filename}` so the worker lazy-downloads it on first use (the FLUX.2 control precedent) instead of a 400. A training/local overlay that is missing stays a clean 400.

## Coherence with the worker (#1424)

The worker's `ensure_krea_control_weights` resolution order is `path` → `{repo,filename}` → default beta repo. So:
- Pick the built-in **before** it's downloaded → API writes `{repo,filename}` → worker downloads it.
- Pick it **after** download (installState installed) → API writes `path`.
- Pick nothing → worker default repo (same beta).
- Pick a studio-trained overlay → API writes its local `path`, overriding the built-in.

## Validation

- `cargo clippy -p sceneworks-rust-api -p sceneworks-core --all-targets` — green
- `cargo fmt --check` — green
- 3 new unit tests on the hosted-vs-local branch (`hosted_overlay_repo_file`); `seeds_every_manifest_into_a_fresh_dir` green with the new manifest.

## Follow-up

PR3 (web): the ControlOverlayPicker currently filters to `installState === "installed"`, so the built-in shows once cached; PR3 will present it/its install state on first run so pose control reads coherently before the first download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)