### PR TITLE
feat(web): surface the built-in Krea pose overlay in the ControlPanel picker (Training Studio / epic 8459 S6, sc-8466)

### DIFF
--- a/apps/web/src/components/ControlOverlayPicker.jsx
+++ b/apps/web/src/components/ControlOverlayPicker.jsx
@@ -27,9 +27,17 @@ export function ControlOverlayPicker({ baseModel, selectedOverlayId, onOverlayCh
       signal: controller.signal,
     })
       .then((items) => {
+        // Show installed overlays (studio-trained/registered, or a cached hosted one) AND hosted
+        // overlays not yet on disk (the built-in beta) — the latter lazy-download on first use, so they
+        // are selectable. A studio-trained overlay that is merely "missing" (no HF repo) is hidden: the
+        // API would 400 it. sc-8466.
         setOverlays(
           Array.isArray(items)
-            ? items.filter((overlay) => overlay.installState === "installed")
+            ? items.filter(
+                (overlay) =>
+                  overlay.installState === "installed" ||
+                  overlay.source?.provider === "huggingface",
+              )
             : [],
         );
         setStatus("ready");
@@ -43,6 +51,10 @@ export function ControlOverlayPicker({ baseModel, selectedOverlayId, onOverlayCh
     return () => controller.abort();
   }, [baseModel, activeProject?.id, token]);
 
+  // A built-in (hosted) overlay ships with the app for this backbone, so leaving the picker unselected
+  // still gets pose control (the worker defaults to it); the picker is for choosing a specific overlay.
+  const hasBuiltin = overlays.some((overlay) => overlay.scope === "builtin");
+
   return (
     <div className="control-overlay-field">
       <label htmlFor="control-overlay-select">ControlNet overlay</label>
@@ -51,18 +63,29 @@ export function ControlOverlayPicker({ baseModel, selectedOverlayId, onOverlayCh
       ) : status === "error" ? (
         <p className="muted">Couldn&apos;t load control overlays.</p>
       ) : overlays.length ? (
-        <select
-          id="control-overlay-select"
-          onChange={(event) => onOverlayChange?.(event.target.value || null)}
-          value={selectedOverlayId ?? ""}
-        >
-          <option value="">Select a trained overlay…</option>
-          {overlays.map((overlay) => (
-            <option key={overlay.id} value={overlay.id}>
-              {overlay.name ?? overlay.id}
+        <>
+          <select
+            id="control-overlay-select"
+            onChange={(event) => onOverlayChange?.(event.target.value || null)}
+            value={selectedOverlayId ?? ""}
+          >
+            <option value="">
+              {hasBuiltin ? "Built-in beta overlay (default)" : "Select a trained overlay…"}
             </option>
-          ))}
-        </select>
+            {overlays.map((overlay) => (
+              <option key={overlay.id} value={overlay.id}>
+                {(overlay.name ?? overlay.id) +
+                  (overlay.installState === "installed" ? "" : " (downloads on first use)")}
+              </option>
+            ))}
+          </select>
+          {hasBuiltin ? (
+            <p className="muted">
+              Leave unselected to use the built-in beta pose overlay (an experimental feasibility
+              spike) — or train your own in the Training Studio for a custom one.
+            </p>
+          ) : null}
+        </>
       ) : (
         <p className="muted">
           No pose ControlNet installed for this model yet — train one in the Training Studio to


### PR DESCRIPTION
## What

Make the ControlPanel overlay picker **built-in-aware** so the hosted Krea pose overlay (sc-8466) reads coherently. Third PR of **sc-8466 (S6)**; pairs with the worker default (#1424) and the built-in catalog entry (#1425).

Before: the picker filtered to `installState === "installed"`, so the built-in beta overlay — hosted, not on disk until first use — never showed, and the empty state told the user to "train one first" even though pose control now works out-of-box via the worker default.

## How

- List installed overlays **and** hosted overlays not yet cached (the built-in beta, which lazy-downloads on first use — the API resolves its id to `repo/filename`). A studio-trained overlay that is merely "missing" (no HF repo) stays hidden (the API would 400 it).
- Annotate a not-yet-cached hosted option with **"(downloads on first use)"**.
- When a built-in exists, the empty option reads **"Built-in beta overlay (default)"** and a hint explains that leaving it unselected uses the built-in (an experimental spike) — or train your own for a custom one.

## Validation

- eslint — clean
- `npm run build` (vite) — green
- `npm test` (full vitest, `--environment jsdom`) — **119 files / 1622 tests pass**, including `ControlPanel.test.jsx` which renders the picker.

## Closes the candle half of S6

Register (B4/#1415) → list → resolve (#1416 + #1425) → **worker default download (#1424)** → **built-in surfaced in picker (this)**. Pose control for Krea 2 is now selectable + runnable out-of-box off a hosted overlay. The **MLX overlay artifact** ("cover both candle and MLX") remains tracked by **S5/sc-8465** (Backlog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)