### PR TITLE
feat(worker): measure candle Qwen-Image-Edit sequential peaks; edit fit-gate candle blocks + reject test (sc-11019, epic 10765)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -610,6 +610,28 @@
         "families": ["qwen-image"],
         "types": ["style", "enhance", "character"]
       },
+      // candle/CUDA VRAM gate (epic 10765 sc-11019, the EDIT measure-sibling of the qwen txt2img sc-10969
+      // + flux2 sc-10920) — MEASURED on an RTX PRO 6000 (Blackwell sm_120) at 1024²/8-step via the
+      // candle-gen-qwen-image edit offload A/B harness (qwen_edit_probed_generate_for_offload_ab,
+      // device-level nvidia-smi peak on an idle GPU 0), pointed at each staged
+      // SceneWorks/qwen-image-edit-2511-mlx tier. Two peaks per tier: `vramGbByTier` = RESIDENT (the dense
+      // Qwen2.5-VL TE + MMDiT + Qwen-Image VAE co-resident, the default cross-request-cached path);
+      // `sequentialPeakGb` = SEQUENTIAL residency (the ~16 GB dense bf16 Qwen2.5-VL text encoder — loaded
+      // f32, ~32 GB — plus the VAE encoder DROPPED after they encode the reference, before the MMDiT
+      // loads, sc-10968) — always lower, and the resident/sequential pixels are byte-identical (q8 md5
+      // 5b7ae2ee…, bf16 md5 4b53dc72…). The edit fit-gate (qwen_edit_candle.rs, sc-10968) compares the
+      // resident peak against free VRAM to choose sequential-offload vs reject, then (sc-10856) REJECTS if
+      // even the sequential peak won't fit rather than run into a reactive OOM. q4 resident/sequential
+      // from the sc-10968 GPU A/B (56.7 / 36.9); q8 (69.0 / 39.3) + bf16 (81.7 / 52.2) measured here. bf16
+      // is the dense 5-shard DiT + dense f32 TE (81.7 GB resident) — it fits a 96 GB card but overflows
+      // the epic's small-card targets even sequentially, so the gate rejects it there. minMemoryGb 59
+      // gates the DEFAULT (q4) tier (resident 56.7 GB).
+      "candle": {
+        "minMemoryGb": 59,
+        "vramGbByTier": { "q4": 56.7, "q8": 69.0, "bf16": 81.7 },
+        "sequentialPeakGb": { "q4": 36.9, "q8": 39.3, "bf16": 52.2 },
+        "measured": true
+      },
       "ui": {
         "label": "Qwen Image Edit (2511)",
         "description": "December 2025 iteration of Qwen-Image-Edit (Qwen/Qwen-Image-Edit-2511) on the multi-image `QwenImageEditPlusPipeline`. Mitigates image drift, improves character consistency in multi-person scenes, integrates popular LoRAs into the base, and strengthens geometric reasoning. Apache-2.0, ungated. Recommended 40 steps at trueCfgScale 4.0 / guidanceScale 1.0; bf16 MPS-supported per Qwen. trueCfgScale is the slider lever — identity stays steady across the range, the knob is a prompt-adherence vs reference-surroundings tradeoff (sc-2013 spike on the 2509 release; same Plus pipeline shape).",
@@ -706,6 +728,21 @@
       "loraCompatibility": {
         "families": ["qwen-image"],
         "types": ["style", "enhance", "character"]
+      },
+      // candle/CUDA VRAM gate (epic 10765 sc-11019) — the Lightning distill shares the IDENTICAL
+      // Qwen-Image-Edit-2511 base weights (the same SceneWorks/qwen-image-edit-2511-mlx q4/q8/bf16 tiers)
+      // and the identical dense Qwen2.5-VL sequential floor, so it carries the base (true-CFG, 8-step)
+      // measurements from `qwen_image_edit_2511`. Lightning runs 4-step CFG-OFF (a single MMDiT forward,
+      // no cond/uncond batch doubling), so its real peaks are ≤ these — a conservative upper bound that
+      // never under-admits. measured:false — the CFG-off distill path (with the lightx2v LoRA fused) was
+      // not itself A/B-measured (needs the harness lightning flag + the distill LoRA staged); tracked as a
+      // follow-up. The numbers still drive the edit fit-gate identically: it reads vramGbByTier /
+      // sequentialPeakGb regardless of the `measured` provenance flag.
+      "candle": {
+        "minMemoryGb": 59,
+        "vramGbByTier": { "q4": 56.7, "q8": 69.0, "bf16": 81.7 },
+        "sequentialPeakGb": { "q4": 36.9, "q8": 39.3, "bf16": 52.2 },
+        "measured": false
       },
       "ui": {
         "label": "Qwen Image Edit (2511) Lightning",

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -541,6 +541,104 @@ fn flux2_candle_blocks_drive_the_fit_gate_and_reject() {
     );
 }
 
+/// epic 10765 sc-11019: the Qwen-Image-Edit `candle` blocks drive the EDIT fit-gate (qwen_edit_candle.rs,
+/// sc-10968) end-to-end against the SHIPPED manifest bytes — resident-fits → sequential-offload →
+/// reject-before-OOM. The edit sibling of `flux2_candle_blocks_drive_the_fit_gate_and_reject`: guards the
+/// DATA half — a manifest edit dropping the qwen-edit `vramGbByTier` / `sequentialPeakGb` makes
+/// `predicted_*` return `None` → the edit gate goes INERT (the exact "candle block missing" failure the
+/// story targets). The edit lane is unconditionally sequential-capable (sc-10968 wired
+/// `QwenEdit::generate_sequential`), so this exercises `resolve_offload` with `sequential_capable=true`.
+/// Both the base entry (measured q4/q8/bf16) and the Lightning entry (the same conservative base numbers,
+/// `measured:false`) are asserted to carry a candle block so BOTH edit gates are live.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn qwen_edit_candle_blocks_drive_the_fit_gate_and_reject() {
+    use crate::vram_gate::{
+        apply_vram_cap, fit_decision, predicted_peak_gb, predicted_sequential_peak_gb,
+        resolve_offload, sequential_overflow_gb, FitDecision,
+    };
+
+    let edit = builtin_model_entry("qwen_image_edit_2511");
+    // `predicted_*` take the MODEL ENTRY (they read `.candle` internally), not the candle sub-object.
+    let edit_entry = edit.as_object().expect("qwen_image_edit_2511 entry object");
+    assert!(
+        edit_entry.get("candle").and_then(Value::as_object).is_some(),
+        "qwen_image_edit_2511 candle block present (absent ⇒ edit fit-gate inert)"
+    );
+
+    // Measured q4 (sc-10968): resident 56.7 / sequential 36.9, each + the gate's 2 GB headroom.
+    let q4_res = predicted_peak_gb(edit_entry, "q4").expect("q4 resident predicted");
+    let q4_seq = predicted_sequential_peak_gb(edit_entry, "q4").expect("q4 sequential predicted");
+    assert!(
+        (q4_res - 58.7).abs() < 1e-6,
+        "q4 resident 56.7 + 2 headroom, got {q4_res}"
+    );
+    assert!(
+        (q4_seq - 38.9).abs() < 1e-6,
+        "q4 sequential 36.9 + 2 headroom, got {q4_seq}"
+    );
+    assert!(q4_seq < q4_res, "sequential is the lower peak");
+
+    // A 96 GB card fits q4 resident outright — no offload.
+    let card96 = apply_vram_cap(None, Some(96.0));
+    assert_eq!(fit_decision(Some(q4_res), card96), FitDecision::Fits);
+
+    // A 48 GB card: resident 58.7 won't fit, but sequential 38.9 does → OFFLOAD, run sequentially.
+    let card48 = apply_vram_cap(None, Some(48.0));
+    let at48 = resolve_offload(fit_decision(Some(q4_res), card48), true);
+    assert!(matches!(at48, FitDecision::Offload { .. }), "48 GB → offload");
+    assert_eq!(
+        sequential_overflow_gb(Some(q4_seq), card48),
+        None,
+        "sequential 38.9 fits 48 GB → run"
+    );
+
+    // A 30 GB card: even the sequential 38.9 peak won't fit → REJECT-before-OOM (sc-10856 gate).
+    let card30 = apply_vram_cap(None, Some(30.0));
+    let at30 = resolve_offload(fit_decision(Some(q4_res), card30), true);
+    assert!(matches!(at30, FitDecision::Offload { .. }), "30 GB → offload attempt");
+    assert_eq!(
+        sequential_overflow_gb(Some(q4_seq), card30),
+        Some(q4_seq),
+        "sequential 38.9 > 30 GB → reject carrying the number"
+    );
+
+    // Measured q8 (69.0 / 39.3) + bf16 (81.7 / 52.2) present too, each + headroom.
+    assert!((predicted_peak_gb(edit_entry, "q8").unwrap() - 71.0).abs() < 1e-6);
+    assert!((predicted_sequential_peak_gb(edit_entry, "q8").unwrap() - 41.3).abs() < 1e-6);
+    let bf16_res = predicted_peak_gb(edit_entry, "bf16").expect("bf16 resident");
+    let bf16_seq = predicted_sequential_peak_gb(edit_entry, "bf16").expect("bf16 seq");
+    assert!(
+        (bf16_res - 83.7).abs() < 1e-6,
+        "bf16 resident 81.7 + 2 headroom, got {bf16_res}"
+    );
+    assert!(
+        (bf16_seq - 54.2).abs() < 1e-6,
+        "bf16 sequential 52.2 + 2 headroom, got {bf16_seq}"
+    );
+    // Dense bf16 fits a 96 GB card resident, but on a 48 GB card even sequential overflows → reject.
+    assert_eq!(fit_decision(Some(bf16_res), card96), FitDecision::Fits);
+    assert_eq!(
+        sequential_overflow_gb(Some(bf16_seq), card48),
+        Some(bf16_seq),
+        "bf16 sequential 54.2 > 48 GB → reject on the smaller card"
+    );
+
+    // The Lightning entry carries the same conservative base block so ITS edit gate is live too.
+    let lightning = builtin_model_entry("qwen_image_edit_2511_lightning");
+    let lightning_entry = lightning.as_object().expect("lightning entry object");
+    assert!(
+        lightning_entry.get("candle").and_then(Value::as_object).is_some(),
+        "qwen_image_edit_2511_lightning candle block present"
+    );
+    let l_seq = predicted_sequential_peak_gb(lightning_entry, "q4").expect("lightning q4 seq");
+    assert_eq!(
+        sequential_overflow_gb(Some(l_seq), card30),
+        Some(l_seq),
+        "lightning sequential 38.9 > 30 GB → reject (gate live for the distill entry too)"
+    );
+}
+
 /// sc-7875 (SD3.5 S6, MLX-path validation boundary): the three SD3.5 builtin-manifest entries gate
 /// correctly at the catalog layer — `macOnly: false` (cross-platform now that the candle off-Mac lane
 /// is wired, sc-7880/epic 7982; availability is driven by the routing tables, not this flag),


### PR DESCRIPTION
## What

The [sc-10969](https://app.shortcut.com/trefry/story/10969) / [sc-10920](https://app.shortcut.com/trefry/story/10920) measure-sibling for the **edit** lane ([sc-11019](https://app.shortcut.com/trefry/story/11019), epic 10765).

The [sc-10968](https://app.shortcut.com/trefry/story/10968) edit fit-gate (`qwen_edit_candle.rs`) was **inert in-app**: the qwen edit manifest entries carried no `candle` block, so `predicted_peak_gb` returned `None` → `Unknown` → the gate always ran resident, never a reject-before-OOM. This adds the measured block so the edit gate fires.

## Measured

RTX PRO 6000 (Blackwell sm_120), idle GPU 0, 1024²/8-step, via the candle-gen-qwen-image edit offload A/B harness (`qwen_edit_probed_generate_for_offload_ab`, device-level nvidia-smi peak), against each staged `SceneWorks/qwen-image-edit-2511-mlx` tier:

| tier | resident | sequential | reclaim | parity |
|------|----------|-----------|---------|--------|
| q4 (sc-10968) | 56.7 GB | 36.9 GB | 19.8 | ✓ |
| **q8** | **69.0 GB** | **39.3 GB** | 29.7 | md5 5b7ae2ee ✓ |
| **bf16** | **81.7 GB** | **52.2 GB** | 29.5 | md5 4b53dc72 ✓ |

Resident and sequential pixels are byte-identical per tier. The ~30 GB reclaim is the dense bf16 Qwen2.5-VL TE (loaded f32 ~32 GB) dropped before the DiT.

## Changes

- **`qwen_image_edit_2511`**: `candle` block (resident `vramGbByTier` + `sequentialPeakGb`, `measured:true`); `minMemoryGb 59` gates the default q4 tier.
- **`qwen_image_edit_2511_lightning`**: carries the same base numbers with `measured:false` — it shares the identical weights + the identical dense Qwen2.5-VL sequential floor and runs 4-step **CFG-off** (single forward), so the base is a conservative upper bound that never under-admits. The gate reads `vramGbByTier`/`sequentialPeakGb` regardless of the `measured` flag, so it fires for this entry too. Precise CFG-off re-measure (needs a harness lightning flag + staged distill LoRA) filed as follow-up **[sc-11066](https://app.shortcut.com/trefry/story/11066)**.
- **`qwen_edit_candle_blocks_drive_the_fit_gate_and_reject`** (gpu_and_manifest.rs, candle-gated) mirroring the flux2 test: Fits@96 / Offload@48 / reject@30, plus the dense bf16 reject on a smaller card.

## Test

`cargo test -p sceneworks-worker --lib --features backend-candle` → 13 pass incl. the new test; `fmt` + `check-scaffold` clean. (backend-candle tests don't run in CI — validated locally on the sm_120 box.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)