### PR TITLE
feat(krea-edit): candle KreaEdit worker lane + routing (epic 10871, sc-10882/10883)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -643,9 +643,10 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-gen",
+ "candle-gen-boogu",
  "candle-gen-pid",
  "candle-gen-qwen-image",
  "inventory",
@@ -658,7 +659,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -673,7 +674,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -686,7 +687,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-gen",
  "image",
@@ -696,7 +697,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -713,7 +714,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -727,7 +728,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -738,7 +739,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -753,7 +754,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -770,7 +771,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -790,7 +791,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -801,7 +802,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -814,7 +815,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -825,7 +826,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -838,7 +839,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c20a589c37913f5717172268e477768a793918da#c20a589c37913f5717172268e477768a793918da"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",

--- a/crates/sceneworks-core/src/jobs_store/routing/candle.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/candle.rs
@@ -142,6 +142,14 @@ pub(crate) fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     if model == "boogu_image_edit" && boogu_edit_candle_eligible(&job.payload) {
         return true;
     }
+    // Krea 2 Kontext-style dual-conditioned image-edit (epic 10871): a `krea_2_raw` `edit_image` job with
+    // a source image is the bespoke candle `KreaEdit` lane (`generate_candle_krea_edit_stream`), NOT
+    // txt2img — `krea_2_raw` is MLX-only for t2i (not a candle txt2img id), so an off-Mac Krea edit would
+    // otherwise fall through to torch. Branch it out here (disjoint from the Krea control lane below,
+    // which is `krea_2_turbo` + `advanced.poses`). Mirrors the worker's `krea_edit_candle_available`.
+    if model == "krea_2_raw" && krea_edit_candle_eligible(&job.payload) {
+        return true;
+    }
     // SDXL IP-Adapter-Plus reference conditioning (sc-5488, epic 5480): an sdxl-family model with a
     // reference image is a bespoke candle lane (`generate_candle_sdxl_ipadapter_stream`), NOT txt2img —
     // the `image_request_candle_eligible` gate below rejects `referenceAssetId`. Branch it out first
@@ -648,6 +656,23 @@ pub(crate) fn qwen_edit_candle_eligible(payload: &Map<String, Value>) -> bool {
 /// worker's `zimage_edit_candle_available` gate (minus the local weight-resolve check) so the router and
 /// worker agree. Candle-only — macOS keeps the MLX `z_image_turbo` registry generator's `Reference` path.
 pub(crate) fn zimage_edit_candle_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) != Some("edit_image") {
+        return false;
+    }
+    payload
+        .get("sourceAssetId")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty())
+}
+
+/// Krea 2 Kontext-style dual-conditioned image-edit candle-routing conditions (epic 10871). The bespoke
+/// candle Krea edit lane (`generate_candle_krea_edit_stream`) serves `edit_image` mode with a
+/// `sourceAssetId` on `krea_2_raw` — the source rides as in-context VAE tokens AND grounds the Qwen3-VL
+/// vision tower, requiring the `krea2_identity_edit` LoRA (checked worker-side, R5). Same payload
+/// predicate as the other edit gates, gated to `krea_2_raw` by the caller. Mirrors the worker's
+/// `krea_edit_candle_available` gate (minus the local weight-resolve check) so the router and worker
+/// agree. Candle-only — macOS keeps the MLX `krea_2_edit` registry generator's edit path (`krea_edit.rs`).
+pub(crate) fn krea_edit_candle_eligible(payload: &Map<String, Value>) -> bool {
     if payload.get("mode").and_then(Value::as_str) != Some("edit_image") {
         return false;
     }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1640,15 +1640,21 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1957
 # #412 bernini — additive candle-only, no worker surface change). Both the default lane AND
 # `--features backend-candle --target all` resolve the SINGLE gen-core rev `19573a9a`. ALL mlx-gen-* +
 # candle-gen-* pins move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+# Bumped candle-gen `95a2ebcc` -> `c20a589c` (epic 10871, sc-10882/10883): candle-gen #416 is the candle
+# Krea 2 image-edit ENGINE (Kontext seq-concat edit forward + Qwen3-VL vision-tower grounding). The new
+# candle `KreaEdit` worker lane (`krea_edit_candle.rs`) consumes its `candle_gen_krea::pipeline::{
+# load_components, load_edit_components, render_edit}`. candle-gen-ONLY this time — `c20a589c` re-pins the
+# SAME gen-core `19573a9a` (mlx-gen HEAD, unchanged), so the skew gate stays satisfied with NO mlx-gen
+# move (the edit engine is additive to candle-gen-krea; `git diff 95a2ebcc..c20a589c -- gen-core*` empty).
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1662,7 +1668,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1670,17 +1676,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1690,7 +1696,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1698,21 +1704,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1721,17 +1727,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1740,7 +1746,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1773,7 +1779,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1782,12 +1788,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1795,7 +1801,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2e
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1804,7 +1810,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1812,7 +1818,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1826,7 +1832,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1853,7 +1859,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1864,7 +1870,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c20a589c37913f5717172268e477768a793918da", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -948,6 +948,21 @@ pub(crate) async fn run_image_generate_job(
                     )
                     .await?;
                 }
+                // Krea 2 Kontext-style dual-conditioned edit (epic 10871) — `krea_2_raw` + `edit_image` +
+                // a source, routed to the bespoke candle KreaEdit stream (disjoint from the Krea control
+                // lane, which is `krea_2_turbo` + `advanced.poses`).
+                CandleImageRoute::KreaEdit => {
+                    generate_candle_krea_edit_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
                 // No-silent-T2I (sc-5968): a strict-pose job on a candle model with NO pose lane (e.g.
                 // sdxl) must be REJECTED with a clear error, not silently rendered as plain txt2img (poses
                 // dropped) and not bounced to torch. The candle worker CLAIMS these (jobs_store
@@ -1759,6 +1774,11 @@ include!("image_jobs/flux2_edit_candle.rs");
 // candle-exclusive.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 include!("image_jobs/qwen_edit_candle.rs");
+// Krea 2 Kontext-style dual-conditioned image-edit — the Windows/CUDA candle lane ONLY (epic 10871).
+// macOS keeps the MLX Krea edit path (krea_edit.rs, the `krea_2_edit` registry generator); the candle
+// Krea edit is a bespoke pipeline, so this is candle-exclusive.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+include!("image_jobs/krea_edit_candle.rs");
 // Kolors IP-Adapter-Plus reference conditioning — the Windows/CUDA candle lane ONLY (sc-5488). macOS
 // keeps the MLX Kolors IP path (kolors.rs, the registry `Reference` route); the candle `IpAdapterKolors`
 // is a bespoke provider, so this is candle-exclusive.

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -198,6 +198,9 @@ enum CandleImageRoute {
     QwenEdit,
     /// Z-Image img2img / edit (sc-6595).
     ZimageEdit,
+    /// Krea 2 Kontext-style dual-conditioned image-edit — `krea_2_raw` + `edit_image` + a source, with
+    /// the required `krea2_identity_edit` LoRA (epic 10871).
+    KreaEdit,
     /// Z-Image identity-init for Image Studio "With Character" (sc-8409).
     ZimageIdentity,
     /// SDXL IP-Adapter-Plus reference conditioning (sc-5488).
@@ -287,6 +290,12 @@ fn resolve_candle_image_route(
         // `Krea2Control` lane, diverted before the registry txt2img arm (which would render it as plain
         // txt2img and drop the poses). Mirrors `jobs_store::krea_control_candle_eligible`.
         Some(CandleImageRoute::KreaControl)
+    } else if krea_edit_candle_available(request, settings) {
+        // Krea 2 Kontext-style edit (epic 10871): `krea_2_raw` + `edit_image` + a source is the bespoke
+        // candle `KreaEdit` lane (`generate_candle_krea_edit_stream`), NOT txt2img — `krea_2_raw` is
+        // MLX-only for t2i (absent from `is_candle_engine`), so without this arm an off-Mac Krea edit had
+        // no candle lane. Mirrors `jobs_store::krea_edit_candle_eligible`.
+        Some(CandleImageRoute::KreaEdit)
     } else if zimage_comfyui_available(request, settings) {
         // In-place ComfyUI Z-Image base (sc-10668): an `external_base_*` id, so it matches no
         // `is_candle_engine` arm below — route it here off the forwarded `modelManifestEntry`.

--- a/crates/sceneworks-worker/src/image_jobs/krea_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_edit_candle.rs
@@ -1,0 +1,314 @@
+// Candle (Windows/CUDA) Krea 2 image-edit route (epic 10871) — the Kontext-style dual-conditioned edit
+// surface off-Mac via `candle_gen_krea::pipeline::{load_components, load_edit_components, render_edit}`.
+// The candle sibling of the macOS `krea_edit.rs` (`generate_krea_edit_stream`): an `edit_image` job on
+// `krea_2_raw` carrying a source image (+ optional 2nd) is routed here rather than the plain Raw t2i path.
+// The source(s) ride as in-context VAE tokens at distinct RoPE frames AND ground the Qwen3-VL vision
+// tower (R2 dual conditioning); the trained `krea2_identity_edit` LoRA is what makes that conditioning
+// steer the edit (R5 — the base leaves it inert).
+//
+// **Candle-only.** macOS keeps the MLX Krea edit path (`krea_edit.rs`, `krea_2_edit` registry generator);
+// the candle Krea edit is a bespoke pipeline (no registered `krea_2_edit` candle generator — the candle
+// edit providers are all driven directly by the worker), so this whole file is gated to the Windows/CUDA
+// candle build (the `include!` in image_jobs.rs carries the cfg). It is `include!`d into the `image_jobs`
+// module, so it shares that module's imports (ImageRequest/Settings/WorkerResult/WorkerError/
+// `load_reference_image`/`fit_engine_image`/`resolve_weights_dir`/`resolve_adapters`/`resolve_seed`/
+// `resolve_advanced_or_manifest_u32`/`start_gen_stream`/`drive_gen_items`/`consume_gen_events`/`non_empty`/
+// `gen_core`/`AdapterSpec`/… all in scope).
+//
+// Edit is Krea 2 **Raw** only (the full-CFG variant the `krea2_identity_edit` LoRA targets; Turbo has no
+// validated edit recipe). One or two references in fixed order — scene = image 1, person = image 2
+// ([`KREA_EDIT_CANDLE_MAX_REFERENCES`]).
+
+/// Krea edit denoise steps default — Raw undistilled, full-CFG (mirrors `candle_gen_krea` `RAW_STEPS`).
+const KREA_EDIT_CANDLE_DEFAULT_STEPS: u32 = 52;
+/// Raw full-CFG guidance default (mirrors `candle_gen_krea` `RAW_GUIDANCE`).
+const KREA_EDIT_CANDLE_DEFAULT_GUIDANCE: f32 = 3.5;
+/// The adapter/engine id recorded on candle Krea edit assets + telemetry (distinct from the `candle_krea`
+/// txt2img lane — the edit is a separate surface with the required edit LoRA).
+const KREA_EDIT_CANDLE_ENGINE: &str = "candle_krea_edit";
+/// Reference cap — the edit LoRA's fixed-order contract: scene = image 1, person = image 2. Swapping the
+/// order degrades results (the LoRA authors' note); more than two is off-contract.
+const KREA_EDIT_CANDLE_MAX_REFERENCES: usize = 2;
+
+/// True when a selected LoRA declares the image-edit conditioning role (`conditioningRole: image_edit`,
+/// e.g. the builtin `krea2_identity_edit`). The candle twin of the macOS
+/// `krea_edit.rs::lora_declares_image_edit_role` — that file is `#[cfg(target_os = "macos")]`, so the
+/// tiny check is duplicated here for the candle build. This LoRA is what makes the in-context source
+/// actually steer the edit; the base weights leave it inert (R5).
+fn krea_edit_candle_lora_role(lora: &Value) -> bool {
+    lora.as_object()
+        .and_then(|obj| obj.get("conditioningRole"))
+        .and_then(Value::as_str)
+        .map(|role| role.trim().to_lowercase().replace('-', "_") == "image_edit")
+        .unwrap_or(false)
+}
+
+/// Whether the job carries an image-edit LoRA (any selected LoRA with `conditioningRole: image_edit`).
+fn krea_edit_candle_has_lora(request: &ImageRequest) -> bool {
+    request.loras.iter().any(krea_edit_candle_lora_role)
+}
+
+/// Reference asset ids for a Krea edit, in fixed order (scene = image 1, person = image 2), capped at
+/// [`KREA_EDIT_CANDLE_MAX_REFERENCES`]. The multi-image picker sends the plural `referenceAssetIds`; with
+/// no plural list it falls back to the single Image-Edit `sourceAssetId`. Mirrors
+/// `flux2_edit_candle_reference_ids` (capped to the Krea 1..=2 contract).
+fn krea_edit_candle_reference_ids(request: &ImageRequest) -> Vec<String> {
+    if !request.reference_asset_ids.is_empty() {
+        return request
+            .reference_asset_ids
+            .iter()
+            .take(KREA_EDIT_CANDLE_MAX_REFERENCES)
+            .cloned()
+            .collect();
+    }
+    if let Some(id) = request
+        .source_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    {
+        return vec![id.to_owned()];
+    }
+    Vec::new()
+}
+
+/// True when this is a Krea edit job: `krea_2_raw` + `edit_image` mode + at least one source reference.
+/// Mirrors the core router's `krea_edit_candle_eligible` + the macOS `krea_edit_available` (minus the
+/// weight-resolve check).
+fn krea_edit_candle_mode(request: &ImageRequest) -> bool {
+    request.model == "krea_2_raw"
+        && request.mode == "edit_image"
+        && !krea_edit_candle_reference_ids(request).is_empty()
+}
+
+/// True when this is a candle-eligible Krea edit job whose Raw weights resolve locally. Mirrors
+/// `flux2_edit_candle_available` (Krea resolves through the shared `resolve_weights_dir` → the
+/// `krea_2_raw` tier subdir).
+fn krea_edit_candle_available(request: &ImageRequest, settings: &Settings) -> bool {
+    krea_edit_candle_mode(request)
+        && matches!(resolve_weights_dir(request, settings), Ok(Some(_)))
+}
+
+/// Resolve denoise steps: `advanced.steps` (clamped 1..=100) → manifest `steps` → the Raw default (52).
+fn krea_edit_candle_steps(request: &ImageRequest) -> u32 {
+    resolve_advanced_or_manifest_u32(request, "steps", KREA_EDIT_CANDLE_DEFAULT_STEPS, 1..=100)
+}
+
+/// Resolve guidance: `advanced.guidanceScale` → manifest `guidanceScale` → the Raw default (3.5).
+fn krea_edit_candle_guidance(request: &ImageRequest) -> f32 {
+    resolve_advanced_or_manifest_f32(
+        request,
+        "guidanceScale",
+        KREA_EDIT_CANDLE_DEFAULT_GUIDANCE,
+        0.0..=30.0,
+    )
+}
+
+/// Load the Krea edit reference set: the 1..=2 references (plural `referenceAssetIds`, else the single
+/// `sourceAssetId`), each pre-fit to the render W×H (crop / pad / outpaint→pad; `stretch` keeps the legacy
+/// resize). `render_edit` VAE-encodes each at the target resolution, so pre-fitting keeps an off-aspect
+/// source from stretching. Errors if no source. Shares the geometry with the other edit lanes
+/// ([`fit_engine_image`]).
+fn load_krea_edit_candle_references(
+    request: &ImageRequest,
+    project_path: &Path,
+    settings: &Settings,
+    width: u32,
+    height: u32,
+) -> WorkerResult<Vec<Image>> {
+    let ids = krea_edit_candle_reference_ids(request);
+    if ids.is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "Krea 2 edit requires a source image (sourceAssetId).".to_owned(),
+        ));
+    }
+    let mut references = Vec::with_capacity(ids.len());
+    for id in &ids {
+        let source =
+            load_reference_image(&settings.data_dir, &request.project_id, id, project_path)?;
+        let fitted = if request.fit_mode == "stretch" {
+            source
+        } else {
+            fit_engine_image(source, width, height, &request.fit_mode)?
+        };
+        references.push(fitted);
+    }
+    Ok(references)
+}
+
+/// Flat telemetry recorded on candle Krea edit assets (parity with the macOS `krea_edit_raw_settings`).
+fn krea_edit_candle_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    guidance: f32,
+    reference_count: usize,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw.insert("guidanceScale".to_owned(), json!(guidance));
+    raw.insert("referenceCount".to_owned(), json!(reference_count));
+    raw.insert(
+        "editEngine".to_owned(),
+        Value::String(KREA_EDIT_CANDLE_ENGINE.to_owned()),
+    );
+    raw
+}
+
+/// Real candle Krea 2 edit generation: resolve the Raw weights + source references on the async side,
+/// pre-fit each to the render geometry, then load the Krea components (the edit LoRA folded into the DiT)
+/// plus the edit components (Qwen3-VL vision tower and VAE encoder) once on the blocking thread and render
+/// each image — `request.count` edits of the same reference set, each its own seed. Mirrors
+/// [`generate_candle_flux2_edit_stream`]'s blocking-thread + streamed-events shape and reuses
+/// [`consume_gen_events`]; differs in the required edit LoRA (R5) and the direct pipeline-function API
+/// (`render_edit` with `count = 1` per streamed item).
+async fn generate_candle_krea_edit_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    if !krea_edit_candle_mode(request) {
+        return Err(WorkerError::InvalidPayload(
+            "Krea 2 edit requires edit_image mode + a source image".to_owned(),
+        ));
+    }
+    let weights_dir = resolve_weights_dir(request, settings)?
+        .ok_or_else(|| WorkerError::InvalidPayload("Krea 2 Raw weights not found".to_owned()))?;
+
+    // R5 (epic 10871): the base cannot edit without the edit LoRA — its in-context/grounded source
+    // conditioning is inert without the trained weights (a VAE-only render is off-distribution, not
+    // shippable). Require an `image_edit`-role LoRA (the builtin `krea2_identity_edit`). Checked before
+    // loading weights so the error is fast + clear (parity with the macOS lane).
+    if !krea_edit_candle_has_lora(request) {
+        return Err(WorkerError::InvalidPayload(
+            "Krea 2 edit requires the Krea 2 Identity Edit LoRA (or another image-edit LoRA): without \
+             it the source-image conditioning is inert. Select it in the LoRA picker."
+                .to_owned(),
+        ));
+    }
+
+    let steps = krea_edit_candle_steps(request);
+    let guidance = krea_edit_candle_guidance(request);
+    let negative = request.negative_prompt.clone();
+    // The selected LoRAs → adapter specs (the edit LoRA + any user LoRAs), folded into the DiT at load.
+    let adapters = resolve_adapters(request, settings)?;
+    let adapter_count = adapters.len();
+    // Telemetry `repo` — the manifest `repo` else the Krea 2 Raw default.
+    let repo = request
+        .model_manifest_entry
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("SceneWorks/krea-2-raw-mlx")
+        .to_owned();
+
+    let (width, height) = (request.width, request.height);
+    let references = load_krea_edit_candle_references(request, project_path, settings, width, height)?;
+    let raw_settings =
+        krea_edit_candle_raw_settings(request, &repo, steps, guidance, references.len());
+
+    // Per-image work items: (seed, prompt) — `request.count` edits of the same reference set.
+    let work: Vec<(i64, String)> = (0..request.count as usize)
+        .map(|index| (resolve_seed(request, index), request.prompt.clone()))
+        .collect();
+    let total = work.len();
+
+    let (cancel, rx, blocking) = start_gen_stream(
+        job.id.clone(),
+        "krea_edit",
+        adapter_count,
+        move || {
+            let device = candle_gen::default_device()
+                .map_err(|error| WorkerError::Engine(format!("Krea edit device init: {error}")))?;
+            // Load the Krea Raw components with the edit LoRA merged into the DiT (R5), plus the edit-only
+            // components (Qwen3-VL vision tower + VAE encoder) — both cached for the whole batch.
+            let comps = candle_gen_krea::pipeline::load_components(
+                &weights_dir,
+                &device,
+                &adapters,
+                None,
+            )
+            .map_err(|error| WorkerError::Engine(format!("Krea edit load failed: {error}")))?;
+            let edit = candle_gen_krea::pipeline::load_edit_components(&weights_dir, &device)
+                .map_err(|error| {
+                    WorkerError::Engine(format!("Krea edit components load failed: {error}"))
+                })?;
+            Ok(((comps, edit, device), references))
+        },
+        move |(components, references), tx, cancel| {
+            let (comps, edit, device) = components;
+            drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
+                if cancel.is_cancelled() {
+                    return Ok(None);
+                }
+                // One image per streamed item: `render_edit` batches on `count`, so pass `count = 1` and
+                // the item's seed. The scene/person references are passed directly (not via
+                // `conditioning`) in fixed order.
+                let req = gen_core::GenerationRequest {
+                    prompt,
+                    // The worker's `negative_prompt` is a plain String; the engine wants `Option` (empty
+                    // ⇒ no user negative, the Raw CFG uncond branch falls back to "").
+                    negative_prompt: if negative.trim().is_empty() {
+                        None
+                    } else {
+                        Some(negative.clone())
+                    },
+                    width,
+                    height,
+                    count: 1,
+                    seed: Some(seed as u64),
+                    steps: Some(steps),
+                    guidance: Some(guidance),
+                    cancel: cancel.clone(),
+                    ..Default::default()
+                };
+                let result = candle_gen_krea::pipeline::render_edit(
+                    &comps,
+                    &edit,
+                    &req,
+                    &references,
+                    &device,
+                    &mut *on_progress,
+                );
+                let mut images = match result {
+                    Ok(images) => images,
+                    Err(_) if cancel.is_cancelled() => return Ok(None),
+                    Err(error) => {
+                        return Err(WorkerError::Engine(format!(
+                            "Krea edit generation failed: {error}"
+                        )));
+                    }
+                };
+                let image = images.pop().ok_or_else(|| {
+                    WorkerError::Engine("Krea edit produced no image".to_owned())
+                })?;
+                Ok(Some((seed, image.width, image.height, image.pixels)))
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        KREA_EDIT_CANDLE_ENGINE,
+        &raw_settings,
+        total,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}


### PR DESCRIPTION
Completes the **candle (Windows/CUDA)** side of the Krea 2 image-edit surface (epic 10871). The MLX lane (`krea_edit.rs`, the `krea_2_edit` registry generator) and all shared pieces — the `krea_2_raw` `edit_image` manifest capability and the `krea2_identity_edit` builtin LoRA with `conditioningRole: image_edit` — already landed; this wires the candle lane that consumes the merged candle-gen [#416](https://github.com/SceneWorks/candle-gen/pull/416) edit engine.

## What lands
- **`image_jobs/krea_edit_candle.rs`** (new) — the bespoke candle `KreaEdit` lane. Loads Krea 2 Raw with the edit LoRA folded into the DiT (**R5** — required; the base leaves the source conditioning inert) + the edit components (Qwen3-VL vision tower + VAE encoder), then renders via `candle_gen_krea::pipeline::render_edit` (**dual conditioning**: in-context VAE tokens + image-grounded Qwen3-VL encoding). One or two references in **fixed order** (scene = image 1, person = image 2). Mirrors `generate_candle_flux2_edit_stream`'s blocking-thread + streamed-events shape; calls the pipeline functions directly (`count = 1` per streamed item), since the candle edit providers are worker-driven (no registered candle `krea_2_edit` generator).
- **Routing** — `CandleImageRoute::KreaEdit` variant + `krea_edit_candle_available` arm (before the txt2img arm; `krea_2_raw` is MLX-only for t2i) + dispatch arm + cfg-gated `include!`.
- **Core mirror** — `krea_edit_candle_eligible` + the `krea_2_raw` edit branch in `jobs_store::routing::candle`, so the router and worker agree on the lane boundary.
- **Pin bump** — `candle-gen*` `95a2ebc` → `c20a589` (#416, the edit engine) across all 27 pins. **candle-gen-only**: `c20a589` re-pins the SAME gen-core `19573a9` the worker already carries, so the skew gate stays satisfied with **no mlx-gen move** (avoids the fragile lockstep).

## Verification
- `sceneworks-core`: clippy `-D warnings` clean, 437 lib tests green.
- `sceneworks-worker --features backend-candle`: `cargo check` + `clippy -D warnings` clean; fmt clean.
- The engine itself was **GPU-validated** in candle-gen #416 — a real identity-preserving edit (pink dress → emerald green, face/pose/setting preserved) on the 12.9B Krea-2-Raw + `krea2_identity_edit` LoRA + Qwen3-VL vision tower.

Closes the candle half of **sc-10882** (routing/caps) and **sc-10883** (conditioning assembly + job wiring + LoRA auto-apply). Two-reference is code-complete (single-ref GPU-validated; the N-ref path is identical); a two-ref GPU run + formal parity/ArcFace is P4.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)