### PR TITLE
feat(worker): candle bernini_image t2i/i2i lane + routing flip (sc-10996, epic 6562)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -491,9 +491,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-gen-bernini"
+version = "0.0.0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+dependencies = [
+ "candle-gen",
+ "candle-gen-wan",
+ "image",
+ "inventory",
+ "safetensors 0.7.0",
+ "serde_json",
+ "tokenizers 0.22.2",
+]
+
+[[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -507,7 +521,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -522,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -536,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -546,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -556,7 +570,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -574,7 +588,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -589,7 +603,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -604,7 +618,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -617,7 +631,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -627,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -643,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -659,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -674,7 +688,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -687,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-gen",
  "image",
@@ -697,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -714,7 +728,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -728,7 +742,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -739,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -754,7 +768,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -771,7 +785,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -791,7 +805,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -802,7 +816,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -815,7 +829,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -826,7 +840,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -839,7 +853,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f84430501b1ca11715aa3a667b1aae8f204eb94e#f84430501b1ca11715aa3a667b1aae8f204eb94e"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -5959,6 +5973,7 @@ dependencies = [
  "axum",
  "candle-gen",
  "candle-gen-anima",
+ "candle-gen-bernini",
  "candle-gen-boogu",
  "candle-gen-chroma",
  "candle-gen-clip",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3539,11 +3539,13 @@ mod candle_routing_tests {
 
     #[test]
     fn non_candle_families_and_variants_are_never_candle_eligible() {
-        // A family with no candle provider at all (`bernini_image`) AND the still-unwired weight/shape
-        // variants of wired families (edit ids) all stay on the Python torch worker.
+        // A family with no candle provider at all (`sana_1600m` — MLX-only) AND the still-unwired
+        // weight/shape variants of wired families (edit ids) all stay on the Python torch worker.
         // (chroma / kolors / sensenova ARE candle-routed now — sc-5484 / sc-5576 — for txt2img; the
-        // FLUX.2-klein `_kv` / `_true_v2` weight variants are too — sc-7459 — see the dedicated test below.)
-        for model in ["bernini_image", "z_image_edit", "qwen_image_edit"] {
+        // FLUX.2-klein `_kv` / `_true_v2` weight variants are too — sc-7459 — see the dedicated test below.
+        // `bernini_image` is now candle-routed off-Mac too — sc-10996 — see `bernini_candle_txt2img_and_\
+        // i2i_route_to_candle` below.)
+        for model in ["sana_1600m", "z_image_edit", "qwen_image_edit"] {
             assert!(
                 !image_request_candle_eligible(model, &object(json!({ "prompt": "p" }))),
                 "{model} must fall back to the Python worker"
@@ -3677,6 +3679,55 @@ mod candle_routing_tests {
                 &object(json!({ "referenceAssetId": "a" }))
             ));
         }
+    }
+
+    #[test]
+    fn bernini_candle_txt2img_and_i2i_route_to_candle() {
+        // sc-10996 (epic 6562): the candle parity of the MLX `bernini_image` still lane. `bernini_image`
+        // is in `CANDLE_ROUTED_MODELS`, so plain t2i routes to candle via the generic
+        // `image_request_candle_eligible` gate; i2i (`edit_image` + a `sourceAssetId`) routes via the
+        // bespoke `bernini_image_edit_candle_eligible` branch in `image_job_is_candle_eligible` (the
+        // dedicated `generate_candle_bernini_image_stream` worker lane, `frames:1`). Mirrors the MLX
+        // `bernini_image_mlx_eligible` predicate exactly.
+        //
+        // Plain t2i → the generic gate.
+        assert!(
+            image_request_candle_eligible(
+                "bernini_image",
+                &object(json!({ "prompt": "a marble bust" }))
+            ),
+            "bernini_image plain t2i must be candle-eligible"
+        );
+        assert!(image_job_is_candle_eligible(&image_generate_job(json!({
+            "model": "bernini_image", "prompt": "a marble bust"
+        }))));
+        // i2i → the bespoke edit branch (needs a source).
+        let i2i =
+            json!({ "model": "bernini_image", "mode": "edit_image", "sourceAssetId": "asset_1" });
+        assert!(bernini_image_edit_candle_eligible(&object(i2i.clone())));
+        assert!(
+            image_job_is_candle_eligible(&image_edit_job(i2i.clone())),
+            "bernini_image i2i job must route to candle"
+        );
+        // The generic txt2img gate still rejects the edit_image family (the bespoke lane handles it).
+        assert!(!image_request_candle_eligible(
+            "bernini_image",
+            &object(i2i)
+        ));
+        // `edit_image` WITHOUT a source → nothing to edit → not this lane (mirrors `bernini_image_mlx_eligible`).
+        assert!(!bernini_image_edit_candle_eligible(&object(json!({
+            "model": "bernini_image", "mode": "edit_image"
+        }))));
+        assert!(!image_job_is_candle_eligible(&image_edit_job(json!({
+            "model": "bernini_image", "mode": "edit_image"
+        }))));
+        // NOT `candle_quant` (sc-10996): the off-Mac packed-tier select is deferred (sc-11003), so an
+        // explicit `mlxQuantize` request defers to torch rather than staying on candle — the descriptor
+        // advertises Q4/Q8 but no consumable off-Mac tier exists yet.
+        assert!(!image_request_candle_eligible(
+            "bernini_image",
+            &object(json!({ "prompt": "a marble bust", "advanced": { "mlxQuantize": 8 } }))
+        ));
     }
 
     #[test]
@@ -4039,6 +4090,9 @@ mod candle_routing_tests {
             "kolors",
             "sensenova_u1_8b",
             "sensenova_u1_8b_fast",
+            // sc-10996 (epic 6562): the candle Bernini still-image companion routes to candle for plain
+            // t2i (the dedicated `generate_candle_bernini_image_stream` lane, `frames:1`).
+            "bernini_image",
         ] {
             assert!(
                 worker_supports_job(
@@ -4048,11 +4102,11 @@ mod candle_routing_tests {
                 "candle worker should claim {model} plain txt2img"
             );
         }
-        // Refuses a family with no candle provider, and a conditioning shape on a wired family —
-        // both defer to torch.
+        // Refuses a family with no candle provider (`sana_1600m` — MLX-only, candle_routed=false), and a
+        // conditioning shape on a wired family — both defer to torch.
         assert!(!worker_supports_job(
             &candle,
-            &image_generate_job(json!({ "model": "bernini_image", "prompt": "p" }))
+            &image_generate_job(json!({ "model": "sana_1600m", "prompt": "p" }))
         ));
         assert!(!worker_supports_job(
             &candle,
@@ -4209,10 +4263,11 @@ mod candle_routing_tests {
         // the candle worker now owns-to-reject (sc-5968, asserted at the end of this test): torch
         // declines those so it can't silently render an unconditioned T2I image.
         let torch = gpu_worker(TORCH_CAPS);
-        // A family with no candle provider, and a conditioning shape on a wired family.
+        // A family with no candle provider (`sana_1600m` — MLX-only, candle_routed=false; `bernini_image`
+        // is now candle-routed off-Mac, sc-10996), and a conditioning shape on a wired family.
         assert!(worker_supports_job(
             &torch,
-            &image_generate_job(json!({ "model": "bernini_image", "prompt": "p" }))
+            &image_generate_job(json!({ "model": "sana_1600m", "prompt": "p" }))
         ));
         assert!(worker_supports_job(
             &torch,

--- a/crates/sceneworks-core/src/jobs_store/routing/candle.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/candle.rs
@@ -150,6 +150,16 @@ pub(crate) fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     if model == "krea_2_raw" && krea_edit_candle_eligible(&job.payload) {
         return true;
     }
+    // Bernini still-image i2i (sc-10996, epic 6562): a `bernini_image` `edit_image` job with a source
+    // image runs the candle `candle-gen-bernini` still lane (`generate_candle_bernini_image_stream`,
+    // engine id `bernini`, `frames:1`) — NOT the generic txt2img gate, which rejects the whole
+    // `edit_image` family. The source is fed to the engine as `Conditioning::Reference` (the planner
+    // ViT/VAE-encodes it, a structural re-render). Plain t2i (any non-edit mode) is the generic gate
+    // below (`bernini_image` is now in CANDLE_ROUTED_MODELS). Branch it out here, gated to the id.
+    // Mirrors the worker's dedicated `CandleImageRoute::Bernini` dispatch + the MLX `bernini_image_mlx_eligible`.
+    if model == "bernini_image" && bernini_image_edit_candle_eligible(&job.payload) {
+        return true;
+    }
     // SDXL IP-Adapter-Plus reference conditioning (sc-5488, epic 5480): an sdxl-family model with a
     // reference image is a bespoke candle lane (`generate_candle_sdxl_ipadapter_stream`), NOT txt2img —
     // the `image_request_candle_eligible` gate below rejects `referenceAssetId`. Branch it out first
@@ -728,6 +738,25 @@ pub(crate) fn boogu_edit_candle_eligible(payload: &Map<String, Value>) -> bool {
                 .any(|v| v.as_str().is_some_and(|s| !s.trim().is_empty()))
         });
     single || plural
+}
+
+/// Bernini still-image i2i candle-routing conditions (sc-10996, epic 6562). The candle
+/// `candle-gen-bernini` still lane serves `edit_image` mode with a `sourceAssetId` — the source is fed
+/// to the engine as `Conditioning::Reference` (the planner ViT/VAE-encodes it into a structural
+/// re-render; the reference strength is ignored). Same payload predicate as the other edit gates (a
+/// `sourceAssetId` is required — an `edit_image` job with nothing to edit stays off candle), gated to
+/// `bernini_image` by the caller. Unlike Ideogram/Boogu (which edit on their SAME txt2img engine in the
+/// generic stream), Bernini has a DEDICATED worker stream (`generate_candle_bernini_image_stream`,
+/// `frames:1`) — but the routing predicate is identical. The exact candle twin of the MLX
+/// `bernini_image_mlx_eligible` (mlx.rs).
+pub(crate) fn bernini_image_edit_candle_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) != Some("edit_image") {
+        return false;
+    }
+    payload
+        .get("sourceAssetId")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty())
 }
 
 /// SDXL IP-Adapter-Plus candle-routing conditions (sc-5488, epic 5480). The candle `IpAdapterSdxl`

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -638,9 +638,18 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
     // torch-only image epic seam matched nothing and was retired (sc-8951).
     ModelCaps::new("lens", true, true, false, false, true),
     ModelCaps::new("lens_turbo", true, true, false, false, true),
-    // Bernini still-image companion (epic 4699 / sc-5424): MLX-only id — `engine_id:"bernini"`
-    // planner+renderer with `frames:1`. The video `bernini` id lives in the video table below.
-    ModelCaps::new("bernini_image", true, false, false, false, false),
+    // Bernini still-image companion (epic 4699 / sc-5424 MLX; sc-10996 candle): `engine_id:"bernini"`
+    // planner+renderer with `frames:1`. Both backends wired — `mlx-gen-bernini` (macOS) +
+    // `candle-gen-bernini` (Windows/CUDA, sc-10996 epic 6562: the full planner+renderer `bernini`
+    // generator, `gen_core::load("bernini")` with `frames:1`), so `candle_routed = true`. Both still
+    // tasks route to candle: t2i via the generic `image_request_candle_eligible` gate, i2i via the
+    // `bernini_image` `edit_image` branch in `image_job_is_candle_eligible` (a `sourceAssetId` edit, the
+    // bespoke `generate_candle_bernini_image_stream` lane — like the MLX `bernini_image_mlx_eligible`).
+    // NOT `candle_quant`: the descriptor advertises Q4/Q8, but the off-Mac packed-tier select is deferred
+    // until the `SceneWorks/bernini-candle` tier layout lands (sc-11003) — the candle lane loads the
+    // converted snapshot dense today. The video `bernini` id lives in the video table below (still
+    // MLX-only — no candle video route wired yet).
+    ModelCaps::new("bernini_image", true, true, false, false, false),
     // Ideogram 4 + Turbo (epic 4725 MLX; sc-6597 candle): 9.3B flow DiT + Qwen3-VL-8B TE. T2I + edit on
     // MLX (sc-6303); candle serves txt2img + the in-lane edit path (sc-6598) via the generic stream.
     // Candle advertises Q4/Q8 (sc-9607 flipped `supported_quants: [Q4, Q8]`, dropping the loader's
@@ -1011,6 +1020,8 @@ mod tests {
         "qwen_image",
         "lens",
         "lens_turbo",
+        // sc-10996 (epic 6562): the candle Bernini still-image companion joins the routed set.
+        "bernini_image",
         "chroma1_hd",
         "chroma1_base",
         "chroma1_flash",

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -2611,14 +2611,17 @@ fn candle_supported_rejects_unsupported_strict_pose() {
 
 #[test]
 fn candle_supported_flags_a_torch_only_image_model() {
+    // `sana_1600m` is MLX-only (no candle provider, not in CANDLE_ROUTED_MODELS), so the candle/CUDA
+    // oracle must flag it as an unsupported image model off-Mac. (`bernini_image` used to be the example
+    // here but is now candle-routed — sc-10996, epic 6562.)
     let store = store("candle-oracle-torch-model");
     let job = job_of(
         &store,
         JobType::ImageGenerate,
-        json!({ "model": "bernini_image", "prompt": "p" }),
+        json!({ "model": "sana_1600m", "prompt": "p" }),
     );
     let reason = candle_supported(&job).unwrap_err();
-    assert_eq!(reason.model.as_deref(), Some("bernini_image"));
+    assert_eq!(reason.model.as_deref(), Some("sana_1600m"));
     assert!(reason
         .candle_error_message()
         .starts_with("candle_unsupported:"));

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -644,6 +644,11 @@ backend-candle = [
     # `scail2_14b` into the shared gen_core inventory; the worker candle video lane reaches it via
     # `gen_core::load` (`generate_candle_scail2` / `generate_candle_scail2_replace`).
     "dep:candle-gen-scail2",
+    # sc-10996 (epic 6562): the candle Bernini still-image companion (`bernini_image`, engine id
+    # `bernini`, `frames:1`) — the Windows/CUDA sibling of `mlx-gen-bernini`. Self-registers the full
+    # planner+renderer `bernini` generator into the shared gen_core inventory; the worker image lane
+    # reaches it via `gen_core::load("bernini")` (`generate_candle_bernini_image_stream`).
+    "dep:candle-gen-bernini",
     # sc-5098 (epic 5095): the candle JoyCaption captioner (image->text), wired into the worker's
     # caption job path via the neutral `gen_core::load_captioner` seam.
     "dep:candle-gen-joycaption",
@@ -1640,49 +1645,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9512
 # #412 bernini — additive candle-only, no worker surface change). Both the default lane AND
 # `--features backend-candle --target all` resolve the SINGLE gen-core rev `19573a9a`. ALL mlx-gen-* +
 # candle-gen-* pins move together.
-# Bumped candle-gen `95a2ebcc` -> `c20a589c` (epic 10871, sc-10882/10883): candle-gen #416 is the candle
-# Krea 2 image-edit ENGINE (Kontext seq-concat edit forward + Qwen3-VL vision-tower grounding). The new
-# candle `KreaEdit` worker lane (`krea_edit_candle.rs`) consumes its `candle_gen_krea::pipeline::{
-# load_components, load_edit_components, render_edit}`. candle-gen-ONLY this time — `c20a589c` re-pins the
-# SAME gen-core `19573a9a` (mlx-gen HEAD, unchanged), so the skew gate stays satisfied with NO mlx-gen
-# move (the edit engine is additive to candle-gen-krea; `git diff 95a2ebcc..c20a589c -- gen-core*` empty).
-# Bumped mlx-gen `19573a9a` -> `0d2a2be6` + candle-gen `c20a589c` -> `1086bd0f` IN LOCKSTEP (sc-11006,
-# epic 10834): qwen-image-EDIT + qwen-image-CONTROL sequential component residency (the fan-out completion
-# of the qwen family after sc-11000; PURE mlx-gen-qwen-image provider Rust, mlx-gen #695). `git diff
-# 19573a9a..0d2a2be6 -- gen-core/ gen-core-testkit/` is EMPTY (gen-core BYTE-IDENTICAL) — but the skew gate
-# keys on the git REV, so candle-gen moves too. `0d2a2be6` is mlx-gen main HEAD (the #695 merge, a superset
-# of `19573a9a`/#693). `1086bd0f` is candle-gen main HEAD after #417 (the gen-core `19573a9a` -> `0d2a2be6`
-# rev-align), a DIRECT descendant of the prior `c20a589c`/#416 pin (adds only #417) — candle-gen-krea +
-# every candle provider unchanged, no regression. The worker also adds `"qwen_image_edit"` +
-# `"qwen_image_control"` to `SEQUENTIAL_CAPABLE_ENGINES` and folds `spec.control` bytes into the fit-gate
-# heavy side (mlx_fit_gate.rs). Both skew lanes resolve the SINGLE gen-core rev `0d2a2be6`. ALL mlx-gen-* +
-# candle-gen-* pins move together.
-# Bumped candle-gen `1086bd0f` -> `194b9959` (sc-11028, unblocks sc-10680): candle-gen #420 fixes the
-# shared `QLinear` dense->QTensor fold silently quantizing the WRONG rows for an offset view
-# (`QTensor::quantize{,_onto}` reads raw backing storage, ignoring a narrow's start offset) — the flux2
-# ComfyUI in-place fp8 DiT (sc-10680) loaded every double block's to_k/to_v as a copy of to_q, an
-# incoherent render. candle-gen-ONLY: `194b9959` is candle-gen main HEAD (the #420 squash-merge), the
-# DIRECT child of the `1086bd0f` pin above — same gen-core `0d2a2be6`, so the skew gate stays satisfied
-# with NO mlx-gen move and both skew lanes keep the SINGLE gen-core rev. GPU-validated on the sm_120 box:
-# the sc-10680 comfyui lane renders coherent (seed-42 rusty-robot A/B vs the packed-q8 baseline).
-# Bumped mlx-gen `0d2a2be6` -> `951227a9` + candle-gen `194b9959` -> `f8443050` IN LOCKSTEP (sc-11030,
-# epic 10834): mlx-gen #696 adds lens/lens_turbo sequential component residency + the consuming gpt-oss
-# encoder loader; this wiring adds `"lens"`/`"lens_turbo"` to `SEQUENTIAL_CAPABLE_ENGINES` (mlx_fit_gate.rs).
-# `951227a9` is mlx-gen main HEAD (the #696 merge). `git diff 0d2a2be6..951227a9 -- gen-core/
-# gen-core-testkit/` is EMPTY (gen-core BYTE-IDENTICAL — PURE mlx-gen-lens provider Rust + an additive
-# `src/weights.rs` `remove`/`remove_prefix`), but the skew gate keys on the git REV, so candle-gen re-pins
-# in lockstep. `f8443050` is candle-gen main HEAD (the #418 merge, the DIRECT child of `194b9959` above —
-# it carries the sc-11028 fp8 fix + the gen-core `0d2a2be6` -> `951227a9` rev-align). Both skew lanes
-# resolve the SINGLE gen-core rev `951227a9`. ALL mlx-gen-* + candle-gen-* pins move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1696,7 +1667,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1704,17 +1675,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1724,7 +1695,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1732,21 +1703,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1755,17 +1726,29 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+# Candle Bernini still-image companion (sc-10996, epic 6562) — the Windows/CUDA sibling of
+# `mlx-gen-bernini`, built ON candle-gen-wan (the full Qwen2.5-VL/MAR semantic planner driving a
+# Wan2.2-A14B dual-expert renderer, `frames:1` for a single still). Self-registers the full `bernini`
+# generator (`candle-gen-bernini/src/bernini.rs`, `gen_core::load("bernini")`) into the shared gen_core
+# inventory; force-linked in image_jobs.rs (`use candle_gen_bernini as _;`) and reached by the dedicated
+# `generate_candle_bernini_image_stream` (forces `frames:1` + `video_mode:"t2i"|"i2i"` so the engine
+# returns a single still). Weights = the converted `SceneWorks/bernini-candle` snapshot (sc-11003, not
+# yet published → GPU-val blocked). Same git rev as every candle-gen provider above (c26c6fb = candle-gen
+# main HEAD, the merged #421 planner-components commit — contains the #419 full generator sc-10995) — its
+# gen-core pin (951227a) MATCHES the worker's mlx pin, so `--features backend-candle --target all`
+# resolves ONE gen-core rev (no skew).
+candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1774,7 +1757,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1807,7 +1790,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1816,12 +1799,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1829,7 +1812,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f8443
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1838,7 +1821,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1846,7 +1829,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1860,7 +1843,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1887,7 +1870,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1898,7 +1881,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f84430501b1ca11715aa3a667b1aae8f204eb94e", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -186,6 +186,14 @@ use candle_gen_kolors as _;
 use candle_gen_sensenova as _;
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_z_image as _;
+// Candle Bernini still-image companion (sc-10996, epic 6562): the full planner+renderer `Generator`
+// self-registers under `bernini` (`Modality::Video`, `frames:1` yields a single still); the image
+// path reaches it via `gen_core::load("bernini")` (no direct type contact). Force-link here — the
+// Windows/CUDA sibling of the `mlx_gen_bernini` anchor above — so the MSVC release linker keeps the
+// `register_generators!` registration (else `gen_core::load("bernini")` returns "no generator
+// registered"). The dedicated `generate_candle_bernini_image_stream` drives it (image_jobs/bernini.rs).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use candle_gen_bernini as _;
 // Lens / Lens-Turbo (epic 5107 engine / sc-5126 cutover) — the candle Windows/CUDA sibling of the
 // `mlx_gen_lens` anchor above, and the 8th candle image family (effectively). Self-registers `lens`
 // (20-step/CFG-5) + `lens_turbo` (4-step/g-1.0) into the shared gen_core inventory registry; the
@@ -799,6 +807,23 @@ pub(crate) async fn run_image_generate_job(
                 // + BFL→diffusers remap; TE/VAE/tokenizer from a resident FLUX.2-dev snapshot).
                 CandleImageRoute::Flux2Comfyui => {
                     generate_candle_flux2_comfyui_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
+                // Bernini still-image companion (sc-10996, epic 6562): `bernini_image` t2i / i2i on the
+                // `engine_id:"bernini"` planner+renderer with `frames:1` — the Windows/CUDA sibling of the
+                // macOS `ImageRoute::Bernini` arm. NOT `is_candle_engine` (its engine is `Modality::Video`),
+                // so it has its own bespoke stream that forces `frames:1` + the engine task string, exactly
+                // like the MLX `generate_bernini_image_stream`.
+                CandleImageRoute::Bernini => {
+                    generate_candle_bernini_image_stream(
                         api,
                         settings,
                         job,
@@ -1755,8 +1780,15 @@ include!("image_jobs/krea_control.rs");
 #[cfg(target_os = "macos")]
 // SenseNova edit routing.
 include!("image_jobs/sensenova.rs");
-#[cfg(target_os = "macos")]
-// Bernini still-image (t2i/i2i) routing.
+// Bernini still-image (t2i/i2i) routing. Included on macOS (the MLX `generate_bernini_image_stream`)
+// AND the candle lane (sc-10996: `generate_candle_bernini_image_stream` + the shared task/raw-settings/
+// generate-one helpers); each item inside is cfg-gated to its backend, so the neither build pulls in
+// nothing. (Unlike the other macOS-only routing files above, whose candle siblings live in dedicated
+// `*_candle.rs` files, Bernini keeps both lanes in one file to share the neutral still-image helpers.)
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 include!("image_jobs/bernini.rs");
 #[cfg(target_os = "macos")]
 // SDXL advanced routing.

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -243,6 +243,12 @@ enum CandleImageRoute {
     /// `generate_candle_flux2_comfyui_stream` (epic 10451 Phase 2e, sc-10680). Not an `is_candle_engine`
     /// id — routed off the forwarded row.
     Flux2Comfyui,
+    /// Bernini still-image companion (`bernini_image`, engine id `bernini`, `frames:1`) → the dedicated
+    /// `generate_candle_bernini_image_stream` (sc-10996, epic 6562). NOT an `is_candle_engine` txt2img id
+    /// (the engine is `Modality::Video`, reached with `frames:1`), so — like the MLX `ImageRoute::Bernini`
+    /// arm — it is routed on the model id BEFORE the generic txt2img arm; both t2i and i2i (`edit_image`)
+    /// route here.
+    Bernini,
     /// A plain candle txt2img engine id → `generate_candle_stream`.
     CandleTxt2Img,
 }
@@ -316,6 +322,15 @@ fn resolve_candle_image_route(
         // In-place ComfyUI FLUX.2-dev base (sc-10680): sibling of the Qwen-Image comfyui lane — an
         // `external_base_*` id routed off the forwarded row (family=="flux2", usable).
         Some(CandleImageRoute::Flux2Comfyui)
+    } else if bernini_image_candle_available(request) {
+        // Bernini still-image companion (sc-10996, epic 6562): t2i / i2i on the `bernini_image` id,
+        // routed to the same `engine_id:"bernini"` planner+renderer with `frames:1`. Must win over the
+        // generic `is_candle_engine` txt2img arm below — `bernini_image` is NOT an `is_candle_engine` id
+        // (its engine is `Modality::Video`, reached with `frames:1`), so it would otherwise fall through
+        // to `None` and stub. Routed on the model id alone (like the sdxl txt2img arm) — a missing
+        // `SceneWorks/bernini-candle` snapshot fails loud at load, never silently stubs (the MLX
+        // `ImageRoute::Bernini` weight-gates instead only because it must fall through to `mlx_available`).
+        Some(CandleImageRoute::Bernini)
     } else if is_candle_engine(&request.model)
         && !matches!(
             request.model.as_str(),

--- a/crates/sceneworks-worker/src/image_jobs/bernini.rs
+++ b/crates/sceneworks-worker/src/image_jobs/bernini.rs
@@ -37,8 +37,12 @@ fn bernini_image_available(request: &ImageRequest, settings: &Settings) -> bool 
 
 /// The Bernini engine task string for a SceneWorks image mode: `edit_image` → `i2i` (source-image
 /// edit), everything else → `t2i` (text→image). Selects the engine guidance/conditioning path
-/// (`resolve_vit_mode`/`task_to_vit_mode`); both still tasks resolve to `vae_txt_vit_wapg`.
-#[cfg(target_os = "macos")]
+/// (`resolve_vit_mode`/`task_to_vit_mode`); both still tasks resolve to `vae_txt_vit_wapg`. Shared by
+/// the MLX and candle (sc-10996) still lanes — the engine task string is backend-neutral.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 fn bernini_image_engine_task(mode: &str) -> &'static str {
     if mode == "edit_image" {
         "i2i"
@@ -65,10 +69,15 @@ fn resolve_bernini_image_quant(request: &ImageRequest) -> (Option<Quant>, Option
     }
 }
 
-/// Flat telemetry for a real MLX Bernini image generation (parity with the other edit handlers +
+/// Flat telemetry for a real Bernini image generation (parity with the other edit handlers +
 /// `bernini_raw_settings`). Records the engine task so the lineage shows whether the planner ran t2i
-/// or i2i, plus the standard repo/steps/guidance/quant knobs.
-#[cfg(target_os = "macos")]
+/// or i2i, plus the standard repo/steps/guidance/quant knobs. Shared by the MLX and candle (sc-10996)
+/// still lanes — the recorded knobs are backend-neutral (the candle lane records `candle` in `backend`
+/// and `editEngine` stays `bernini`).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 fn bernini_image_raw_settings(
     request: &ImageRequest,
     repo: &str,
@@ -99,7 +108,10 @@ fn bernini_image_raw_settings(
 /// shared `conditioning`. Standard guidance family (`guidance` carries the CFG scale, negative prompt
 /// forwarded); no LoRA.
 #[allow(clippy::too_many_arguments)]
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 fn bernini_image_generate_one(
     generator: &dyn Generator,
     prompt: &str,
@@ -271,6 +283,213 @@ async fn generate_bernini_image_stream(
         project_path,
         backend,
         BERNINI_IMAGE_ADAPTER,
+        &raw_settings,
+        count,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// Candle (Windows/CUDA) Bernini still-image lane (sc-10996, epic 6562)
+//
+// The off-Mac sibling of `generate_bernini_image_stream` above: the full candle Bernini planner+renderer
+// `Generator` (candle-gen-bernini, engine id `bernini`, `Modality::Video`) is reached via
+// `gen_core::load("bernini")` with `frames:1` + `video_mode:"t2i"|"i2i"` so it returns a SINGLE still —
+// exactly the MLX shape, only the tensor backend + weights snapshot differ. Not `is_candle_engine` (the
+// engine is video-modality), so it rides this dedicated stream rather than the generic
+// `generate_candle_stream` txt2img lane. Shares the neutral harness (`load_spec` /
+// `start_cached_gen_stream` / `drive_gen_items` / `bernini_image_generate_one` / `consume_gen_events`)
+// and the backend-neutral resolvers (`resolve_steps` / `resolve_guidance` / `resolve_negative_prompt`)
+// with the MLX path. GPU-val is BLOCKED on the converted `SceneWorks/bernini-candle` weights (sc-11003,
+// the 168 GB conversion, not yet published), so this delivers routing + lane wiring; a missing snapshot
+// fails loud at load (never a silent stub).
+// ---------------------------------------------------------------------------
+
+/// Adapter id recorded on a real candle Bernini image asset — the `candle_<family>` sibling of the MLX
+/// `mlx_bernini` label (parity with `candle_adapter_label`, though Bernini's bespoke stream passes it
+/// directly rather than through that generic map).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const CANDLE_BERNINI_IMAGE_ADAPTER: &str = "candle_bernini";
+
+/// The turnkey candle Bernini snapshot repo (sc-11003): the converted full-Bernini tree (`transformer/`
+/// `transformer_2/` `text_encoder/` `vae/` `tokenizer/` `mllm/` `connector/` `vit_decoder/`) the
+/// `candle-gen-bernini` `load` reads. Distinct from the MLX `SceneWorks/bernini-mlx` turnkey (different
+/// tensor layout). NOT yet published — GPU-val is blocked on it (sc-11003).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const CANDLE_BERNINI_REPO: &str = "SceneWorks/bernini-candle";
+
+/// True when this is a candle Bernini still-image job: the `bernini_image` id. Routed on the model id
+/// alone (like the sdxl candle txt2img arm) — NOT weight-gated — so a missing snapshot fails loud at
+/// load rather than silently stubbing, and the routing decision needs no staged 168 GB weights. Both
+/// t2i and i2i (`edit_image`) route here; the stream enforces the i2i source (`sourceAssetId`).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn bernini_image_candle_available(request: &ImageRequest) -> bool {
+    request.model == "bernini_image"
+}
+
+/// Resolve the candle Bernini snapshot dir: `SCENEWORKS_CANDLE_BERNINI_DIR` override → app-managed
+/// `<data>/models/candle/bernini` → the turnkey `SceneWorks/bernini-candle` HF snapshot. Sentinel = the
+/// `transformer/` subdir (the converted renderer's first DiT expert; the `candle-gen-bernini` `load`
+/// validates the full component set and reports the precise gap). Errors loudly when absent — like the
+/// candle SCAIL-2 / Wan-VACE resolvers, a missing checkpoint surfaces a clear re-download error instead
+/// of degrading to a stub. The candle sibling of the MLX `resolve_bernini_model_dir` (video_jobs.rs).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn resolve_candle_bernini_model_dir(settings: &Settings) -> WorkerResult<PathBuf> {
+    if let Ok(dir) = std::env::var("SCENEWORKS_CANDLE_BERNINI_DIR") {
+        let path = PathBuf::from(dir.trim());
+        if path.join("transformer").is_dir() {
+            return Ok(path);
+        }
+    }
+    let managed = settings
+        .data_dir
+        .join("models")
+        .join("candle")
+        .join("bernini");
+    if managed.join("transformer").is_dir() {
+        return Ok(managed);
+    }
+    if let Some(dir) = huggingface_snapshot_dir(&settings.data_dir, CANDLE_BERNINI_REPO) {
+        return Ok(dir);
+    }
+    Err(WorkerError::InvalidPayload(format!(
+        "bernini (candle): no weights found. Download the turnkey {CANDLE_BERNINI_REPO} snapshot via \
+         the Model Manager, set $SCENEWORKS_CANDLE_BERNINI_DIR, or place a converted full-Bernini \
+         snapshot (transformer/ + transformer_2/ + text_encoder/ + vae/ + tokenizer/ + mllm/ + \
+         connector/ + vit_decoder/) at {}.",
+        managed.display(),
+    )))
+}
+
+/// Real candle Bernini still-image generation (sc-10996, epic 6562): the off-Mac sibling of
+/// [`generate_bernini_image_stream`]. Loads the full candle planner+renderer once from the converted
+/// `SceneWorks/bernini-candle` snapshot (dense — the candle loader reads the converted tree as-is), then
+/// one image per seed: t2i from the prompt alone, or i2i conditioned on the `sourceAssetId` source (the
+/// engine ViT/VAE-encodes it at native resolution, no worker-side fit). Forces `frames:1` + the engine
+/// task string so the video-modality engine returns a single still. Standard guidance family (no LoRA;
+/// the descriptor reports `supports_lora:false`).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+async fn generate_candle_bernini_image_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    _device_backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    // Join the MODEL_TABLE `bernini_image` row with the linked candle `bernini` descriptor (the same
+    // backend-neutral resolver the MLX path + `generate_candle_stream` use). `None` means the candle
+    // provider crate wasn't linked/registered — fail loud rather than silently stubbing.
+    let model = mlx_model(&request.model).ok_or_else(|| {
+        WorkerError::Engine(format!(
+            "candle backend not linked for model {} (no registered generator)",
+            request.model
+        ))
+    })?;
+    let engine_id = model.engine_id();
+    // Report the descriptor's tensor backend ("candle") on the streamed events (parity with
+    // `generate_candle_stream`), so the worker log + the UI architecture pill attribute the run to Candle.
+    let backend = if model.backend().is_empty() {
+        "candle"
+    } else {
+        model.backend()
+    };
+    let weights_dir = resolve_candle_bernini_model_dir(settings)?;
+    let steps = resolve_steps(request, &model);
+    // Standard guidance family: `guidance` carries the CFG scale (engine `omega_txt`); the negative
+    // prompt is forwarded (the descriptor advertises both). No true-CFG.
+    let guidance = resolve_guidance(request, &model);
+    let negative_prompt = resolve_negative_prompt(request, &model);
+    let repo = model_repo(request, &model);
+    let task = bernini_image_engine_task(&request.mode);
+    // Requested tier bits (advanced `mlxQuantize`) recorded for lineage only — the candle lane loads the
+    // converted snapshot DENSE (the loader reads the tree as-is; the descriptor advertises Q4/Q8 but the
+    // off-Mac packed-tier select is a follow-up once the `bernini-candle` tier layout lands, sc-11003).
+    let tier_bits = request
+        .advanced
+        .get("mlxQuantize")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()));
+
+    // i2i (`edit_image`): resolve the source image into the engine's `Conditioning::Reference` (the
+    // engine ViT/VAE-encodes it at native resolution, no worker-side fit, and ignores the reference
+    // strength — a planner-guided structural re-render). t2i has no conditioning. The routing gate
+    // (`bernini_image_edit_candle_eligible`) already requires a `sourceAssetId` for `edit_image`, so
+    // this is defense in depth. Mirrors the MLX path exactly.
+    let conditioning: Vec<Conditioning> = if task == "i2i" {
+        let source_id = request
+            .source_asset_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                WorkerError::InvalidPayload(
+                    "bernini_image edit_image requires a source image (sourceAssetId).".to_owned(),
+                )
+            })?;
+        let image = load_reference_image(
+            &settings.data_dir,
+            &request.project_id,
+            source_id,
+            project_path,
+        )?;
+        vec![Conditioning::Reference {
+            image,
+            strength: None,
+        }]
+    } else {
+        Vec::new()
+    };
+
+    let raw_settings =
+        bernini_image_raw_settings(request, &repo, steps, tier_bits, guidance, task);
+    let count = request.count as usize;
+    let seeds: Vec<i64> = (0..count).map(|index| resolve_seed(request, index)).collect();
+    let prompt = request.prompt.clone();
+    let (width, height) = (request.width, request.height);
+
+    // Dense load (quant None): the converted snapshot is read as-is by the candle loader.
+    let spec = load_spec(weights_dir, None, Vec::new(), None);
+    let (cancel, rx, blocking) = start_cached_gen_stream(
+        job.id.clone(),
+        engine_id,
+        0,
+        spec,
+        format!("{engine_id} load failed"),
+        move |generator, tx, cancel| {
+            drive_gen_items(tx, seeds, move |_index, seed, on_progress| {
+                let (out_w, out_h, pixels) = bernini_image_generate_one(
+                    generator,
+                    &prompt,
+                    negative_prompt.clone(),
+                    width,
+                    height,
+                    seed,
+                    steps,
+                    guidance,
+                    task,
+                    conditioning.clone(),
+                    &cancel,
+                    on_progress,
+                )?;
+                Ok(Some((seed, out_w, out_h, pixels)))
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        CANDLE_BERNINI_IMAGE_ADAPTER,
         &raw_settings,
         count,
         rx,

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -4517,6 +4517,39 @@ fn candle_image_route_gates_on_flag_then_pose_reject_then_txt2img() {
     assert_eq!(resolve_candle_image_route(&unknown, &settings), None);
 }
 
+// sc-10996 (epic 6562): `bernini_image` t2i / i2i route to the dedicated candle Bernini lane
+// (`CandleImageRoute::Bernini` → `generate_candle_bernini_image_stream`), NOT the generic txt2img arm
+// (the engine is `Modality::Video`, so `bernini_image` is not an `is_candle_engine` id). Routed on the
+// model id alone (no staged weights), the candle sibling of the MLX `ImageRoute::Bernini` arm — this is
+// the dispatch proof for the story (GPU-val is blocked on the `SceneWorks/bernini-candle` weights,
+// sc-11003).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn candle_image_route_selects_bernini_lane_for_bernini_image() {
+    let mut settings = Settings::from_env();
+
+    // Candle disabled (default) → None (the job stubs), regardless of model.
+    settings.backend_candle_enabled = false;
+    let t2i = request(json!({ "projectId": "p", "model": "bernini_image", "count": 1 }));
+    assert_eq!(resolve_candle_image_route(&t2i, &settings), None);
+
+    settings.backend_candle_enabled = true;
+    // Plain t2i → the dedicated Bernini lane (not CandleTxt2Img — bernini_image is not is_candle_engine).
+    assert_eq!(
+        resolve_candle_image_route(&t2i, &settings),
+        Some(CandleImageRoute::Bernini),
+    );
+    // i2i (edit_image + a source) → the SAME Bernini lane (the stream forces the engine i2i task).
+    let i2i = request(json!({
+        "projectId": "p", "model": "bernini_image", "count": 1,
+        "mode": "edit_image", "sourceAssetId": "asset_1"
+    }));
+    assert_eq!(
+        resolve_candle_image_route(&i2i, &settings),
+        Some(CandleImageRoute::Bernini),
+    );
+}
+
 #[cfg(target_os = "macos")]
 #[test]
 fn generic_lane_conditioning_defaults_when_no_reference() {


### PR DESCRIPTION
## sc-10996 — Worker candle image lane: `bernini_image` t2i/i2i

Routes the still-image companion `bernini_image` (engine id `bernini`, `frames:1`) through the SceneWorks candle worker for **t2i** and **i2i** (`edit_image`), the Windows/CUDA sibling of the MLX `generate_bernini_image_stream`. Mirrors the ideogram/scail2 candle wiring pattern exactly.

### Pin bump (lockstep — gen-core skew verified)
- `mlx-gen*` + `sceneworks-gen-core`: `19573a9` → `951227a`
- `candle-gen*`: `95a2ebc` → `c26c6fb` (candle-gen main HEAD — contains the full `candle-gen-bernini` generator: sc-10995 #419 + planner-components #421)
- **gen-core AND gen-core-testkit trees are BYTE-IDENTICAL** between mlx-gen `19573a9` and `951227a` (same tree SHAs `184d6bac` / `59834dd4`); the mlx-gen delta is provider-only (lens + qwen-image sequential residency, sc-11030/sc-11006). candle-gen `c26c6fb` pins gen-core `951227a`, so **all three lanes resolve ONE gen-core rev** — `Cargo.lock` has a single `sceneworks-gen-core` source (skew gate green). This is a safe lockstep re-pin, **not** the STOP-CONDITION skew (which requires a divergent gen-core *content* change).
- Lock regenerated via `cargo metadata` (no hand-edit); diff is git-rev-only + the new `candle-gen-bernini` node (deps already in the graph). Verified: exactly one `mlx-gen?rev=`, one `candle-gen?rev=`, one gen-core.
- Added `candle-gen-bernini = { rev = c26c6fb, features=["cuda"], optional }` + `dep:candle-gen-bernini` in the `backend-candle` feature.

### Routing
- `catalog.rs`: flip `bernini_image` `candle_routed` → `true` (+ `EXPECTED_CANDLE_ROUTED_MODELS` snapshot).
- `candle.rs`: new `bernini_image_edit_candle_eligible` + the i2i branch in `image_job_is_candle_eligible` — t2i via the generic `image_request_candle_eligible` gate, i2i (`edit_image` + `sourceAssetId`) via the branch. The exact twin of the MLX `bernini_image_mlx_eligible`.
- **Not** `candle_quant`: the descriptor advertises Q4/Q8, but the off-Mac packed-tier select is deferred until the `SceneWorks/bernini-candle` tier layout lands (sc-11003) — the candle lane loads the converted snapshot dense today, and an explicit `mlxQuantize` request defers rather than silently running dense.

### Worker image lane
- `CandleImageRoute::Bernini` variant + resolver arm (routed on the model id **before** the `is_candle_engine` txt2img arm — the engine is `Modality::Video`, reached with `frames:1`, so it is not an `is_candle_engine` id). Routed on id alone, like the sdxl txt2img arm — a missing snapshot fails loud at load, never a silent stub.
- `generate_candle_bernini_image_stream` (`image_jobs/bernini.rs`): forces `frames:1` + the engine task string (`t2i`/`i2i`), resolves weights via `resolve_candle_bernini_model_dir` (`SCENEWORKS_CANDLE_BERNINI_DIR` → app-managed `<data>/models/candle/bernini` → `SceneWorks/bernini-candle`), reusing the neutral still-image helpers (`bernini_image_generate_one` / `bernini_image_engine_task` / `bernini_image_raw_settings`, cfg-widened to the candle lane). Force-linked `use candle_gen_bernini as _;`. The `bernini.rs` include cfg was widened from macOS-only to `any(macos, candle)`.

### Tests / build
- **sceneworks-core** (438 passed): `bernini_candle_txt2img_and_i2i_route_to_candle` (t2i → candle, i2i → candle, no-source rejects, tier-select defers), `routed_model_lists_match_snapshot`, and the updated `non_candle_families_*` / `candle_worker_claims_txt2img` / `torch_worker_claims_*` (swapped the stale `bernini_image` negative example for `sana_1600m`).
- **sceneworks-worker `--features backend-candle`** (MSVC 14.44 vcvars + `CUDA_COMPUTE_CAP=120`): lib+test build **clean, zero warnings**; `candle_image_route_selects_bernini_lane_for_bernini_image` + the full `image_jobs::tests` module (33) green.

### GPU-val — **pending sc-11003**
Real end-to-end generation needs the converted `SceneWorks/bernini-candle` weights (the 168 GB conversion, sc-11003, not yet published), so GPU-val is **blocked on sc-11003**. No weights were downloaded and no GPU run was faked. The dispatch unit test proving `bernini_image` t2i/i2i → the candle Bernini lane is this story's validation; a missing snapshot fails loud at load.

Relates to epic 6562. GPU-val follow-up gated on sc-11003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)