### PR TITLE
feat(worker): flux2_klein_9b candle q4/q8/bf16 all MEASURED + candle-gen pin bump (sc-11031)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -570,7 +570,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-gen",
  "image",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -768,7 +768,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -805,7 +805,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -816,7 +816,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -829,7 +829,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -840,7 +840,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -853,7 +853,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c26c6fbc32334c4a038be43990f25df87ba21e49#c26c6fbc32334c4a038be43990f25df87ba21e49"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=e350e9b555f584aa481a8c1e0e6795d8909ac080#e350e9b555f584aa481a8c1e0e6795d8909ac080"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2802,28 +2802,27 @@
         "minMemoryGb": 42,
         "quantize": 4
       },
-      // candle/CUDA VRAM gate (epic 10765). bf16 DIRECTLY MEASURED (sc-11008) on an RTX PRO 6000 (Blackwell
+      // candle/CUDA VRAM gate (epic 10765). ALL TIERS DIRECTLY MEASURED on an RTX PRO 6000 (Blackwell
       // sm_120) at 1024²/4-step CFG-free via the candle-gen-flux2 klein offload A/B harness
       // (flux2_klein_probed_generate_for_offload_ab, device-level nvidia-smi PeakSampler on an idle GPU 0),
-      // the FLUX.2-dev (sc-10920) methodology: resident 77284 MiB = 75.5 GB (dense Qwen3 TE + 9B DiT + VAE
-      // co-resident); sequential 54564 MiB = 53.3 GB (sc-10868 — the 8B Qwen3 TE dropped before the DiT
-      // loads); pixels byte-identical (md5 4e36816e). The 22.7 GB reclaim is large because, like flux2-dev,
-      // klein runs reference/attention math in f32, so the dense TE + f32 activations are huge — this CORRECTS
-      // the old sc-10920 arch-scale (bf16 39/23), which was ~2× low. q4/q8 are DERIVED (still measured:false)
-      // from the measured bf16 by subtracting the on-disk transformer quant delta (only the 9B DiT packs; the
-      // 8B Qwen3 TE stays dense bf16 in EVERY tier — DENSE_TE_TIER): bf16->q4 -12.0 GB, bf16->q8 -7.9 GB. They
-      // CANNOT be run or directly measured on candle today — the SceneWorks/flux2-klein-9b-mlx q4/q8 tiers are
-      // MLX-format (not candle-loadable) and load_klein rejects on-the-fly quant; a candle klein packed-quant
-      // loader (sc-11031) is the prerequisite to run/measure them and flip measured:true. Behavior: on the
-      // epic's 8–16 GB target cards klein rejects every tier (the 16 GB dense TE alone overflows them); even
-      // q4 needs ~41 GB sequential, so off-Mac klein is a big-card/offload family. minMemoryGb 42 is the
-      // conservative static admit floor (≈ q4 sequential); the dynamic fit-gate drives the true per-card
-      // resident/sequential/reject decision.
+      // two separate processes per tier (resident vs sequential), the FLUX.2-dev (sc-10920) methodology.
+      // bf16 = sc-11008; q4/q8 = sc-11031 after candle klein DiT quant landed (candle-gen #422 — the 9B
+      // DiT quantizes on-the-fly, the 8B Qwen3 TE stays dense in EVERY tier, DENSE_TE). vramGbByTier =
+      // RESIDENT (TE + DiT + VAE co-resident); sequentialPeakGb = TE dropped before the DiT loads. Pixels
+      // byte-identical resident vs sequential per tier (md5 q4 69cbac63 / q8 7fb8686f / bf16 4e36816e).
+      // MEASURED (MiB/1024): q4 res 47300=46.2 / seq 24740=24.2; q8 res 51812=50.6 / seq 29380=28.7;
+      // bf16 res 77284=75.5 / seq 54564=53.3. The ~22 GB reclaim is CONSTANT across tiers because candle
+      // runs at dtype=F32, so the dense Qwen3 TE is ~32 GB F32 resident (NOT ~16 GB bf16) and IS the
+      // sequential floor — dropping it dominates the reclaim regardless of DiT tier. This CORRECTS the
+      // sc-11008 re-anchored ESTIMATES (q4 63.5/41.3, q8 67.6/45.4), which under-counted the F32 TE by
+      // ~17–23 GB. Behavior: on the epic's 8–16 GB target cards klein rejects every tier (the 32 GB F32
+      // TE alone overflows them); even q4 needs ~24 GB sequential, so off-Mac klein is a big-card/offload
+      // family. minMemoryGb 25 ≈ the q4 sequential floor; the dynamic fit-gate drives the per-card decision.
       "candle": {
-        "minMemoryGb": 42,
-        "vramGbByTier": { "q4": 63.5, "q8": 67.6, "bf16": 75.5 },
-        "sequentialPeakGb": { "q4": 41.3, "q8": 45.4, "bf16": 53.3 },
-        "measured": false
+        "minMemoryGb": 25,
+        "vramGbByTier": { "q4": 46.2, "q8": 50.6, "bf16": 75.5 },
+        "sequentialPeakGb": { "q4": 24.2, "q8": 28.7, "bf16": 53.3 },
+        "measured": true
       },
       // SceneWorks public/ungated re-host (LICENSE.md travels with the weights). FLUX
       // Non-Commercial License — generations are non-commercial use only, matching SceneWorks's

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1645,15 +1645,22 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "9512
 # #412 bernini — additive candle-only, no worker surface change). Both the default lane AND
 # `--features backend-candle --target all` resolve the SINGLE gen-core rev `19573a9a`. ALL mlx-gen-* +
 # candle-gen-* pins move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+# Bumped candle-gen `c26c6fb` -> `e350e9b` (sc-11031, epic 10765): candle-gen #422 enables FLUX.2-klein
+# on-the-fly Q4/Q8 DiT quant (only the 9B DiT quantizes; the 8B Qwen3 TE stays dense bf16 in EVERY tier —
+# DENSE_TE), making klein's q4/q8 candle tiers directly GPU-measurable. candle-gen-ONLY: `e350e9b` re-pins
+# gen-core to mlx-gen `951227a` (via #418), which this worker ALREADY pins, so the skew gate stays
+# satisfied with NO mlx-gen move. `e350e9b` is a direct descendant of the `c26c6fb`/#421 pin (adds only
+# #422). Drives the flux2_klein_9b `candle` block to measured:true (q4 46.2/24.2, q8 50.6/28.7, bf16 75.5/
+# 53.3, all GPU-measured on sm_120). Worker backend-candle check --locked green.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1667,7 +1674,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1675,17 +1682,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1695,7 +1702,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1703,21 +1710,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1726,7 +1733,7 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # Candle Bernini still-image companion (sc-10996, epic 6562) — the Windows/CUDA sibling of
 # `mlx-gen-bernini`, built ON candle-gen-wan (the full Qwen2.5-VL/MAR semantic planner driving a
 # Wan2.2-A14B dual-expert renderer, `frames:1` for a single still). Self-registers the full `bernini`
@@ -1738,17 +1745,17 @@ candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # main HEAD, the merged #421 planner-components commit — contains the #419 full generator sc-10995) — its
 # gen-core pin (951227a) MATCHES the worker's mlx pin, so `--features backend-candle --target all`
 # resolves ONE gen-core rev (no skew).
-candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1757,7 +1764,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1790,7 +1797,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1799,12 +1806,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1812,7 +1819,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1821,7 +1828,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1829,7 +1836,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1843,7 +1850,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1870,7 +1877,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1881,7 +1888,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c26c6fbc32334c4a038be43990f25df87ba21e49", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "e350e9b555f584aa481a8c1e0e6795d8909ac080", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -524,8 +524,8 @@ fn flux2_candle_blocks_drive_the_fit_gate_and_reject() {
     );
 
     // klein carries a candle block so ITS fit-gate is live: on a 16 GB epic-target card klein rejects
-    // even sequentially (the ~16 GB dense Qwen3 TE is the sequential floor). q4 sequential is now the
-    // MEASURED-anchored ~41 GB (sc-11008 bf16 A/B, q4 derived) — well over 16 either way.
+    // even sequentially (the ~32 GB F32-resident Qwen3 TE is the sequential floor). q4 sequential is the
+    // MEASURED ~24 GB (sc-11031 klein DiT-quant A/B) — well over the 16 GB card either way.
     let klein = builtin_model_entry("flux2_klein_9b");
     let klein_entry = klein.as_object().expect("flux2_klein_9b entry object");
     assert!(
@@ -538,7 +538,7 @@ fn flux2_candle_blocks_drive_the_fit_gate_and_reject() {
     assert_eq!(
         sequential_overflow_gb(Some(klein_seq), card16),
         Some(klein_seq),
-        "klein sequential ~41 > 16 GB → reject on the epic's small-card target"
+        "klein sequential ~24 > 16 GB → reject on the epic's small-card target"
     );
 }
 


### PR DESCRIPTION
## What
Completes sc-11031: with candle-gen #422 (klein on-the-fly DiT quant) merged, **all three klein candle tiers are now directly GPU-measured**. Replaces sc-11008's bf16-only + re-anchored q4/q8 *estimates* (from the merged #1433) with real numbers and flips `measured:true`.

| tier | resident | sequential | reclaim | parity |
|---|---|---|---|---|
| q4 | 46.2 GB | 24.2 GB | −22.0 | `69cbac63` |
| q8 | 50.6 GB | 28.7 GB | −21.9 | `7fb8686f` |
| bf16 | 75.5 GB | 53.3 GB | −22.2 | `4e36816e` |

RTX PRO 6000 sm_120, 1024²/4-step CFG-free, idle GPU0, two processes per tier, byte-identical resident↔sequential.

## Correction to the merged estimates
The measured q4/q8 are **~17-23 GB below** #1433's estimates (q4 63.5 / q8 67.6). candle runs at `dtype=F32`, so the "dense bf16" Qwen3 TE is really **~32 GB F32 resident**, not ~16 GB — and it's the sequential floor, which is why the ~22 GB reclaim is constant across tiers (dropping that F32 TE dominates regardless of DiT tier). `minMemoryGb` 42→**25** (q4 sequential floor).

## Pin bump (candle-gen-only)
- candle-gen `c26c6fb`→**`e350e9b`** (28 pins; adds #422 atop main's current #421 pin).
- **mlx-gen unchanged at `951227a`** — candle-gen@e350e9b re-pins gen-core to 951227a (via #418), which main already carries, so the skew gate stays satisfied with **no mlx-gen move**. `git diff` shows a single candle-gen rev + single mlx-gen rev; lock regenerated via `cargo metadata` (rev-only). Pin-ledger entry appended. Rebased forward past main's concurrent #420/#421 pin bumps.

## Checks
`cargo check -p sceneworks-worker --features backend-candle --tests --locked` ✅ · scaffold ✅ · manifest-audit pytest (7) ✅ · worker fmt ✅. `flux2_candle_blocks_drive_the_fit_gate_and_reject` reads the block dynamically; klein assertion still holds (q4 seq ~24 > 16 → reject); comment refreshed.

Relates: sc-11008 (#1433 bf16), candle-gen #422, sc-10920, epic 10765.

🤖 Generated with [Claude Code](https://claude.com/claude-code)