### PR TITLE
feat(krea): Krea image-edit UI + two-reference (scene+person) — epic 10871 P4.1/P1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -643,9 +643,10 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-gen",
+ "candle-gen-boogu",
  "candle-gen-pid",
  "candle-gen-qwen-image",
  "inventory",
@@ -658,7 +659,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -673,7 +674,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -686,7 +687,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-gen",
  "image",
@@ -696,7 +697,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -713,7 +714,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -727,7 +728,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -738,7 +739,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -753,7 +754,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -770,7 +771,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -790,7 +791,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -801,7 +802,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -814,7 +815,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -825,7 +826,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -838,7 +839,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=95a2ebcca5930323acd8de440f83602ebd681ca0#95a2ebcca5930323acd8de440f83602ebd681ca0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -3674,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3688,7 +3689,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "image",
  "inventory",
@@ -3701,7 +3702,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "image",
  "inventory",
@@ -3715,7 +3716,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "image",
  "inventory",
@@ -3729,7 +3730,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3743,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3754,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3763,7 +3764,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3772,7 +3773,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3786,7 +3787,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3799,7 +3800,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3812,7 +3813,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3824,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3834,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "image",
  "inventory",
@@ -3847,7 +3848,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "image",
  "inventory",
@@ -3862,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "image",
  "inventory",
@@ -3876,7 +3877,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "image",
  "inventory",
@@ -3888,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3899,7 +3900,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3911,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3923,7 +3924,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3932,7 +3933,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3941,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3951,7 +3952,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3963,7 +3964,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "image",
  "inventory",
@@ -3978,7 +3979,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "image",
  "inventory",
@@ -3992,7 +3993,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4003,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4015,7 +4016,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4026,7 +4027,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "image",
  "inventory",
@@ -4040,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "image",
  "inventory",
@@ -5874,7 +5875,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=19573a9ab01fe7efaf6830c6f1693e687fcb1b6f#19573a9ab01fe7efaf6830c6f1693e687fcb1b6f"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
 dependencies = [
  "core-llm",
  "inventory",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -659,7 +659,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -674,7 +674,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -687,7 +687,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-gen",
  "image",
@@ -697,7 +697,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -714,7 +714,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -739,7 +739,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -754,7 +754,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -771,7 +771,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -791,7 +791,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -802,7 +802,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -815,7 +815,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -826,7 +826,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -839,7 +839,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439#8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",

--- a/apps/web/src/imageStudioValidation.js
+++ b/apps/web/src/imageStudioValidation.js
@@ -24,6 +24,8 @@ export function imageGenerateValidation({
   prompt,
   mode,
   characterId,
+  editSourceMissing = false,
+  editLoraMissing = false,
   presetMissing = [],
   presetIncompatible = [],
   loraIncompatible = [],
@@ -44,6 +46,16 @@ export function imageGenerateValidation({
   }
   if (mode === "character_image" && !characterId) {
     issues.push(issue.requirement("character", "Choose a character"));
+  }
+  // Edit mode needs a source image to edit — silent, the empty source picker is the affordance.
+  if (editSourceMissing) {
+    issues.push(issue.requirement("source", "Select a source image to edit"));
+  }
+  // A Krea-style edit LoRA that isn't downloaded yet (epic 10871): a silent gate — the edit
+  // source band renders the actionable "required to edit — Download" note, so this only blocks
+  // Generate without duplicating that message.
+  if (editLoraMissing) {
+    issues.push(issue.requirement("editLora", "Download the required edit LoRA to run edits"));
   }
   issues.push(...presetLoraIssues({ presetMissing, presetIncompatible, loraIncompatible, modelName }));
   return issues;

--- a/apps/web/src/imageStudioValidation.test.js
+++ b/apps/web/src/imageStudioValidation.test.js
@@ -53,6 +53,25 @@ describe("imageGenerateValidation", () => {
     expect(summarize(issues).surfaced).toEqual([]);
   });
 
+  it("requires a source image in edit mode, silently (epic 10871)", () => {
+    const issues = imageGenerateValidation({ ...whole, mode: "edit_image", editSourceMissing: true });
+    expect(kinds(issues, "source")).toEqual(["requirement"]);
+    expect(summarize(issues).surfaced).toEqual([]);
+    expect(summarize(issues).ready).toBe(false);
+  });
+
+  it("does not require a source once one is picked", () => {
+    const issues = imageGenerateValidation({ ...whole, mode: "edit_image", editSourceMissing: false });
+    expect(kinds(issues, "source")).toEqual([]);
+  });
+
+  it("gates on a missing edit LoRA silently — the source band carries the download note (epic 10871)", () => {
+    const issues = imageGenerateValidation({ ...whole, mode: "edit_image", editLoraMissing: true });
+    expect(kinds(issues, "editLora")).toEqual(["requirement"]);
+    expect(summarize(issues).surfaced).toEqual([]);
+    expect(summarize(issues).ready).toBe(false);
+  });
+
   it("surfaces preset-missing, preset-incompatible and lora-incompatible as errors", () => {
     const issues = imageGenerateValidation({
       ...whole,

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -213,6 +213,38 @@ export function loraLooksLikeIcLora(lora) {
   return text.includes("ic-lora") || text.includes("ltx-2-3-ic-");
 }
 
+// A Krea-style image-edit LoRA (epic 10871): declares `conditioningRole: image_edit` (the image
+// sibling of `ic_lora`). Unlike IC-LoRAs there is no filename/id convention to fall back on — the
+// role is the only signal — so this is a strict role/flag test, matching the worker's
+// `lora_declares_image_edit_role`. Selecting one activates the dual-conditioning edit recipe; the
+// base can't edit without it.
+export function loraLooksLikeImageEditLora(lora) {
+  if (lora?.imageEditLora === true) {
+    return true;
+  }
+  return (
+    String(lora?.conditioningRole ?? "").trim().toLowerCase().replaceAll("-", "_") === "image_edit"
+  );
+}
+
+// The image-edit LoRA a model's edit mode requires, resolved from the LoRA catalog (installed or
+// not), or null. A model "needs an edit LoRA" exactly when a compatible `image_edit`-role LoRA
+// exists — today only Krea 2 (the `krea2_identity_edit` builtin, family `krea_2`); other edit
+// models (Qwen-Image-Edit, FLUX.2) have none, so this returns null and their edit is unaffected.
+export function findModelEditLora(loras, model) {
+  if (!Array.isArray(loras) || !model) {
+    return null;
+  }
+  return loras.find((lora) => loraLooksLikeImageEditLora(lora) && loraMatchesModel(lora, model)) ?? null;
+}
+
+// Whether a catalog LoRA's weights are present locally (downloaded). Built-in LoRAs referenced
+// from Hugging Face start `installState: "missing"` until fetched; the worker can't load a missing
+// file (it does not download at job time), so an auto-applied edit LoRA must clear this first.
+export function loraIsInstalled(lora) {
+  return Boolean(lora) && lora.installState !== "missing";
+}
+
 export function presetMatchesWorkflow(preset, mode) {
   // A preset has one primary workflow for persistence, but modes describe every
   // Studio entry point where the picker should surface it.
@@ -299,6 +331,14 @@ export function serializeLora(lora, override = {}) {
     installedPath: lora.installedPath ?? null,
     sourcePath: lora.sourcePath ?? null,
     source: lora.source ?? null,
+    // The conditioning role (`ic_lora` / `image_edit`) is what tells the worker a LoRA
+    // is more than a plain style adapter — an LTX IC-LoRA or a Krea image-edit LoRA
+    // (epic 10871). The worker reads it straight off the payload `loras` entry (no catalog
+    // re-lookup), so it MUST round-trip here: without it, a selected edit LoRA fails the
+    // edit lane's role check (R5) even though the user picked it. `icLora` rides along for
+    // the flag-based half of the same test.
+    conditioningRole: lora.conditioningRole ?? null,
+    icLora: lora.icLora ?? false,
     // `installedPath` points at the LoRA directory; for trained LoRAs that
     // directory also holds step checkpoints, so the worker must be told the
     // exact adapter file. Forward the manifest's declared `files`/`file` —

--- a/apps/web/src/presetUtils.test.jsx
+++ b/apps/web/src/presetUtils.test.jsx
@@ -5,13 +5,17 @@ import {
   cleanPresetDefaults,
   clearPresetDefault,
   editModelForAsset,
+  findModelEditLora,
   finiteNumberOrUndefined,
   loraHasResolvableFamily,
+  loraIsInstalled,
+  loraLooksLikeImageEditLora,
   loraMatchesModel,
   loraWeight,
   normalizeLoraFamily,
   presetMatchesModel,
   presetNameTaken,
+  serializeLora,
   slugifyPresetId,
   workflowForMode,
 } from "./presetUtils.js";
@@ -319,5 +323,69 @@ describe("editModelForAsset", () => {
   it("returns null for assets without a recipe model", () => {
     expect(editModelForAsset({ recipe: {} }, models)).toBe(null);
     expect(editModelForAsset(null, models)).toBe(null);
+  });
+});
+
+// epic 10871 (Krea image edit): the payload must carry the conditioning role so the worker's
+// edit lane can see it (it reads the role straight off `request.loras`, no catalog re-lookup).
+describe("serializeLora round-trips the conditioning role (epic 10871)", () => {
+  it("forwards conditioningRole and icLora", () => {
+    const out = serializeLora({ id: "krea2_identity_edit", family: "krea_2", conditioningRole: "image_edit" });
+    expect(out.conditioningRole).toBe("image_edit");
+    expect(out.icLora).toBe(false);
+  });
+
+  it("preserves an explicit icLora flag (LTX IC-LoRA)", () => {
+    const out = serializeLora({ id: "ltx_ic", conditioningRole: "ic_lora", icLora: true });
+    expect(out.conditioningRole).toBe("ic_lora");
+    expect(out.icLora).toBe(true);
+  });
+
+  it("defaults role to null / flag to false for a plain style LoRA", () => {
+    const out = serializeLora({ id: "plain" });
+    expect(out.conditioningRole).toBe(null);
+    expect(out.icLora).toBe(false);
+  });
+});
+
+describe("loraLooksLikeImageEditLora (epic 10871)", () => {
+  it("matches the image_edit conditioning role (case / separator insensitive)", () => {
+    expect(loraLooksLikeImageEditLora({ conditioningRole: "image_edit" })).toBe(true);
+    expect(loraLooksLikeImageEditLora({ conditioningRole: "Image-Edit" })).toBe(true);
+    expect(loraLooksLikeImageEditLora({ imageEditLora: true })).toBe(true);
+  });
+
+  it("does not match an IC-LoRA or a plain LoRA (role is the only signal)", () => {
+    expect(loraLooksLikeImageEditLora({ conditioningRole: "ic_lora" })).toBe(false);
+    expect(loraLooksLikeImageEditLora({ id: "krea2_identity_edit", name: "Krea 2 Identity Edit" })).toBe(false);
+    expect(loraLooksLikeImageEditLora({})).toBe(false);
+  });
+});
+
+describe("findModelEditLora (epic 10871)", () => {
+  const kreaEdit = { id: "krea2_identity_edit", family: "krea_2", conditioningRole: "image_edit" };
+  const kreaStyle = { id: "krea_style", family: "krea_2" };
+  const catalogLoras = [kreaStyle, kreaEdit];
+
+  it("finds the compatible image_edit LoRA for the model", () => {
+    expect(findModelEditLora(catalogLoras, { id: "krea_2_raw", family: "krea_2" })).toBe(kreaEdit);
+  });
+
+  it("returns null for a model with no compatible image_edit LoRA (Qwen/FLUX edit)", () => {
+    expect(findModelEditLora(catalogLoras, { id: "qwen_image_edit", family: "qwen-image" })).toBe(null);
+  });
+
+  it("returns null on missing inputs", () => {
+    expect(findModelEditLora(null, { family: "krea_2" })).toBe(null);
+    expect(findModelEditLora(catalogLoras, null)).toBe(null);
+  });
+});
+
+describe("loraIsInstalled (epic 10871)", () => {
+  it("is false only when the catalog row is explicitly missing", () => {
+    expect(loraIsInstalled({ installState: "installed" })).toBe(true);
+    expect(loraIsInstalled({})).toBe(true); // installed local rows carry no installState
+    expect(loraIsInstalled({ installState: "missing" })).toBe(false);
+    expect(loraIsInstalled(null)).toBe(false);
   });
 });

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -102,6 +102,8 @@ function defaultCharacterPrompt(character) {
 }
 import {
   finiteNumberOrUndefined,
+  findModelEditLora,
+  loraIsInstalled,
   serializeLora,
   noPresetId,
 } from "../presetUtils.js";
@@ -279,6 +281,7 @@ export function ImageStudio() {
     imageCaption,
     imageDescribe,
     createModelDownloadJob,
+    createLoraDownloadJob,
     deleteAsset,
     purgeAsset,
     gpuOptions,
@@ -508,6 +511,11 @@ export function ImageStudio() {
   const [referenceAssetIds, setReferenceAssetIds] = useState(() =>
     Array.isArray(saved.referenceAssetIds) ? saved.referenceAssetIds : [],
   );
+  // Optional SECOND (person) source for a Krea-style two-reference edit (epic 10871 P1.3). Scene =
+  // the `sourceAssetId` above (image 1), person = this (image 2), a fixed order. Only surfaced when
+  // the model declares `ui.editReferences`; empty otherwise. When set, submit sends an ordered
+  // `referenceAssetIds: [scene, person]` pair instead of the single `sourceAssetId`.
+  const [editPersonAssetId, setEditPersonAssetId] = useState("");
   // Edit fit mode (epic 2551): how the source is fitted to the output W×H. Never stretch.
   const [fitMode, setFitMode] = useState(saved.fitMode ?? "crop");
   const [characterId, setCharacterId] = useState("");
@@ -902,6 +910,23 @@ export function ImageStudio() {
   // multi-select reference picker (plural `referenceAssetIds`) instead of the single source picker.
   // FLUX.2-dev only (its DiT sequence-gated chunking keeps the multi-reference edit under 96 GB).
   const multiReference = Boolean(selectedModel?.ui?.multiReference);
+  // Krea-style two-reference edit (epic 10871 P1.3): a model whose `ui.editReferences` adds an optional
+  // SECOND (person) source to the single-source edit — scene = image 1, person = image 2, fixed order.
+  // Only in single-source edit mode (never alongside the flat `multiReference` multi-select). Null →
+  // the plain single-source edit for every other model/mode.
+  const editReferences =
+    mode === "edit_image" && !multiReference ? (selectedModel?.ui?.editReferences ?? null) : null;
+  // The ordered [scene, person] pair, sent as `referenceAssetIds` when a person is chosen; null → the
+  // single `sourceAssetId` path. The scene is required too (a person with no scene is meaningless).
+  const editPersonPair =
+    editReferences && sourceAssetId && editPersonAssetId ? [sourceAssetId, editPersonAssetId] : null;
+  // Drop a stale person selection when the two-reference edit surface goes away (model/mode change),
+  // so it can never leak into a payload for a model that doesn't support it.
+  useEffect(() => {
+    if (!editReferences) {
+      setEditPersonAssetId("");
+    }
+  }, [editReferences]);
   // Mac UI gating (sc-3486): disable the per-model feature controls the selected model can't run
   // in the Rust/MLX flow on Mac, so the user never reaches a `mlx_unsupported` error after submit.
   const macEditBlock = macModelFeatureBlock(selectedModel, macCapabilities, "edit");
@@ -1250,6 +1275,59 @@ export function ImageStudio() {
     initialLoraWeights: saved.loraWeights ?? {},
     initialShowIncompatibleLoras: saved.showIncompatibleLoras ?? false,
   });
+
+  // ---- Krea-style image edit LoRA (epic 10871, P4.1) ----
+  // The Krea 2 edit surface REQUIRES a dual-conditioning `image_edit` LoRA (R5) that the base
+  // can't edit without. We MANAGE it for the user — no manual LoRA picking — rather than leave it
+  // in the picker: auto-applied to the payload when installed, or surfaced as a one-click download
+  // when not. `findModelEditLora` returns null for edit models that need no such LoRA (Qwen-Image-
+  // Edit, FLUX.2), so this whole block is inert for them.
+  const editLora = useMemo(
+    () => (mode === "edit_image" ? findModelEditLora(loras, selectedModel) : null),
+    [mode, loras, selectedModel],
+  );
+  const editLoraInstalled = loraIsInstalled(editLora);
+  // The managed LoRA is applied automatically; hide it from the manual picker so it isn't
+  // double-shown or accidentally toggled. Still deduped at payload time in case a saved selection
+  // carries it.
+  const managedEditLoraId = editLora && editLoraInstalled ? editLora.id : null;
+  const editLoraRequiredMissing = Boolean(editLora) && !editLoraInstalled;
+  const [editLoraDownloadRequested, setEditLoraDownloadRequested] = useState(false);
+  // Clear the transient "requested" state once the download lands (installState flips) or the
+  // edit LoRA leaves the picture (model/mode change).
+  useEffect(() => {
+    if (!editLoraRequiredMissing) {
+      setEditLoraDownloadRequested(false);
+    }
+  }, [editLoraRequiredMissing]);
+  const requestEditLoraDownload = useCallback(() => {
+    if (!editLora) {
+      return;
+    }
+    setEditLoraDownloadRequested(true);
+    createLoraDownloadJob?.(editLora);
+  }, [editLora, createLoraDownloadJob]);
+  // Serialize the outgoing LoRA payload, appending the auto-applied (managed) edit LoRA unless a
+  // saved selection already carries it — the worker's edit lane requires it (R5). Used by both the
+  // single-generate and batch submit paths so they stay identical.
+  const buildLorasPayload = useCallback(() => {
+    const out = selectedLoras.map((lora) => serializeLora(lora, { weight: effectiveLoraWeight(lora) }));
+    if (managedEditLoraId && !out.some((lora) => lora.id === managedEditLoraId)) {
+      out.push(serializeLora(editLora, { weight: effectiveLoraWeight(editLora) }));
+    }
+    return out;
+  }, [selectedLoras, effectiveLoraWeight, managedEditLoraId, editLora]);
+  // The manual LoRA picker hides the managed edit LoRA (it's applied automatically in the source
+  // band above), so it can't be double-shown or accidentally toggled off.
+  const pickerCompatibleLoras = managedEditLoraId
+    ? compatibleLoras.filter((lora) => lora.id !== managedEditLoraId)
+    : compatibleLoras;
+  const pickerSelectedLoras = managedEditLoraId
+    ? selectedLoras.filter((lora) => lora.id !== managedEditLoraId)
+    : selectedLoras;
+  const pickerSelectedLoraIds = managedEditLoraId
+    ? selectedLoraIds.filter((id) => id !== managedEditLoraId)
+    : selectedLoraIds;
   // sc-10516: a preset launch (Presets → "Use in Studio"). `availablePresets` filters on
   // mode + model, so the preset only resolves once both match — set them alongside the id.
   // Changing the model otherwise wipes the steps/guidance overrides (the advanced-defaults
@@ -1703,13 +1781,20 @@ export function ImageStudio() {
         // (strict_control.rs `resolve_control_source`). Passthrough mode uses `advanced.controlImage`.
         sourceAssetId:
           mode === "edit_image" && !multiReference
-            ? sourceAssetId || null
+            ? // A two-reference edit sends the ordered [scene, person] pair as referenceAssetIds instead
+              // (epic 10871 P1.3), so the single sourceAssetId is dropped when a person is chosen.
+              editPersonPair
+              ? null
+              : sourceAssetId || null
             : controlPreprocessSourceId,
         // Multi-reference edit (sc-6211): the plural reference set the FLUX.2-dev edit conditions on.
         // Only sent in edit_image mode for a multiReference model; the worker routes a non-empty list
-        // to Conditioning::MultiReference (one image ⇒ a normal single-reference edit).
+        // to Conditioning::MultiReference (one image ⇒ a normal single-reference edit). The Krea
+        // two-reference edit (epic 10871 P1.3) reuses this channel with the ordered [scene, person] pair.
         referenceAssetIds:
-          mode === "edit_image" && multiReference && referenceAssetIds.length ? referenceAssetIds : undefined,
+          mode === "edit_image" && multiReference && referenceAssetIds.length
+            ? referenceAssetIds
+            : (editPersonPair ?? undefined),
         // Fit mode applies to edits only; coerced so a stale "outpaint" never reaches a
         // non-inpaint model (epic 2551). Omitted for non-edit modes (worker default crop).
         fitMode: mode === "edit_image" ? effectiveFitMode(fitMode, editInpaintCapable) : undefined,
@@ -1722,7 +1807,7 @@ export function ImageStudio() {
             : supportsImg2img
               ? img2imgReferenceAssetId || null
               : null,
-        loras: selectedLoras.map((lora) => serializeLora(lora, { weight: effectiveLoraWeight(lora) })),
+        loras: buildLorasPayload(),
         ...(upscaleEnabled
           ? {
               upscale: {
@@ -1809,12 +1894,18 @@ export function ImageStudio() {
     characterId: mode === "character_image" ? characterId || null : null,
     characterLookId: mode === "character_image" ? characterLookId || null : null,
     sourceAssetId:
-      mode === "edit_image" && !multiReference ? sourceAssetId || null : controlPreprocessSourceId,
+      mode === "edit_image" && !multiReference
+        ? editPersonPair
+          ? null
+          : sourceAssetId || null
+        : controlPreprocessSourceId,
     referenceAssetIds:
-      mode === "edit_image" && multiReference && referenceAssetIds.length ? referenceAssetIds : undefined,
+      mode === "edit_image" && multiReference && referenceAssetIds.length
+        ? referenceAssetIds
+        : (editPersonPair ?? undefined),
     fitMode: mode === "edit_image" ? effectiveFitMode(fitMode, editInpaintCapable) : undefined,
     referenceAssetId: mode === "character_image" ? referenceAssetId || null : null,
-    loras: selectedLoras.map((lora) => serializeLora(lora, { weight: effectiveLoraWeight(lora) })),
+    loras: buildLorasPayload(),
     ...(upscaleEnabled
       ? {
           upscale: {
@@ -1998,6 +2089,12 @@ export function ImageStudio() {
       prompt,
       mode,
       characterId,
+      // Edit needs a source (single) or ≥1 reference (multiReference); a required edit LoRA must be
+      // downloaded first. Both silently gate Generate — the empty picker / the source-band download
+      // note are the visible affordances.
+      editSourceMissing:
+        mode === "edit_image" && (multiReference ? !referenceAssetIds.length : !sourceAssetId),
+      editLoraMissing: editLoraRequiredMissing,
       presetMissing: presetValidationResult.missing,
       presetIncompatible: presetValidationResult.incompatible,
       loraIncompatible: selectedLoraValidationResult.incompatible,
@@ -2010,6 +2107,10 @@ export function ImageStudio() {
       prompt,
       mode,
       characterId,
+      multiReference,
+      referenceAssetIds,
+      sourceAssetId,
+      editLoraRequiredMissing,
       presetValidationResult,
       selectedLoraValidationResult,
       selectedModel,
@@ -2452,23 +2553,70 @@ export function ImageStudio() {
                     values={referenceAssetIds}
                   />
                 ) : (
-                  <ImageEditSourcePickerField
-                    assets={editImageAssets}
-                    buttonLabel="Select image"
-                    characters={characters}
-                    emptyLabel="No source image selected"
-                    importAsset={importAsset}
-                    label="Source image"
-                    onChange={setSourceAssetId}
-                    projectId={activeProject?.id}
-                    value={sourceAssetId}
-                  />
+                  <>
+                    <ImageEditSourcePickerField
+                      assets={editImageAssets}
+                      buttonLabel="Select image"
+                      characters={characters}
+                      emptyLabel="No source image selected"
+                      importAsset={importAsset}
+                      label={editReferences ? "Source image (scene)" : "Source image"}
+                      onChange={setSourceAssetId}
+                      projectId={activeProject?.id}
+                      value={sourceAssetId}
+                    />
+                    {/* Optional second (person) source for a two-reference edit (epic 10871 P1.3).
+                        Fixed order: the source above is the scene (image 1); this is the person
+                        (image 2). Only rendered when the model declares `ui.editReferences`. */}
+                    {editReferences ? (
+                      <>
+                        <ImageEditSourcePickerField
+                          assets={editImageAssets}
+                          buttonLabel="Select image"
+                          characters={characters}
+                          emptyLabel="No person image selected (optional)"
+                          importAsset={importAsset}
+                          label={editReferences.secondaryLabel ?? "Second image (optional)"}
+                          onChange={setEditPersonAssetId}
+                          projectId={activeProject?.id}
+                          value={editPersonAssetId}
+                        />
+                        {editReferences.secondaryHint ? (
+                          <p className="field-hint">{editReferences.secondaryHint}</p>
+                        ) : null}
+                      </>
+                    ) : null}
+                  </>
                 )}
                 <FitModeControl
                   value={effectiveFitMode(fitMode, editInpaintCapable)}
                   onChange={setFitMode}
                   inpaintCapable={editInpaintCapable}
                 />
+                {/* Krea-style edit LoRA (epic 10871, P4.1): managed for the user — no manual
+                    picking. Applied automatically once installed; a one-click download when not
+                    (the base can't edit without it, R5). Inert for edit models that need none. */}
+                {editLora ? (
+                  editLoraInstalled ? (
+                    <p className="field-hint" role="status">
+                      <Icon.Sparkle size={13} /> {editLora.name} is applied automatically for editing.
+                    </p>
+                  ) : (
+                    <div className="inline-warning edit-lora-download">
+                      <span>
+                        {editLora.name} is required to edit — the base can’t edit without it.
+                      </span>
+                      <button
+                        type="button"
+                        className="secondary-action"
+                        onClick={requestEditLoraDownload}
+                        disabled={editLoraDownloadRequested}
+                      >
+                        {editLoraDownloadRequested ? "Downloading…" : "Download"}
+                      </button>
+                    </div>
+                  )
+                ) : null}
               </>
             ) : null}
 
@@ -3006,9 +3154,9 @@ export function ImageStudio() {
               </label>
               <LoraPickerSection
                 selectedModel={selectedModel}
-                selectedLoras={selectedLoras}
-                selectedLoraIds={selectedLoraIds}
-                compatibleLoras={compatibleLoras}
+                selectedLoras={pickerSelectedLoras}
+                selectedLoraIds={pickerSelectedLoraIds}
+                compatibleLoras={pickerCompatibleLoras}
                 userSelectedLoraCount={userSelectedLoraCount}
                 showIncompatibleLoras={showIncompatibleLoras}
                 setShowIncompatibleLoras={setShowIncompatibleLoras}

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -577,6 +577,202 @@ describe("ImageStudio edit source picker", () => {
   });
 });
 
+// The Krea 2 image-edit surface (epic 10871, P4.1): edit REQUIRES the `image_edit`-role LoRA (R5),
+// which the studio MANAGES for the user — auto-applied when installed, a one-click download when
+// not — rather than leaving it to be hand-picked.
+describe("ImageStudio Krea image edit LoRA (epic 10871)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  const KREA_RAW = {
+    ...Z_IMAGE,
+    id: "krea_2_raw",
+    name: "Krea 2 Raw",
+    family: "krea_2",
+    capabilities: ["text_to_image", "edit_image"],
+  };
+  const EDIT_LORA = {
+    id: "krea2_identity_edit",
+    name: "Krea 2 Identity Edit",
+    family: "krea_2",
+    conditioningRole: "image_edit",
+    defaultWeight: 1,
+    scope: "builtin",
+    installedPath: "/loras/krea2_identity_edit",
+    installState: "installed",
+  };
+  const SOURCE = { id: "src-plate", projectId: "project_1", type: "image", displayName: "Plate", status: {} };
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <ImageStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+  const enterEdit = () =>
+    click([...document.body.querySelectorAll(".mode-tabs button")].find((b) => b.textContent === "Edit"));
+
+  it("auto-applies the installed edit LoRA to the payload with its conditioning role (R5)", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    await render(
+      baseContext({ createImageJob, imageModels: [KREA_RAW], loras: [EDIT_LORA], assets: [SOURCE], selectedAsset: null }),
+    );
+    await enterEdit();
+    // The managed note tells the user it's automatic — no manual picking.
+    expect(container.textContent).toContain("applied automatically");
+
+    // Pick the source image, then generate.
+    await click([...document.body.querySelectorAll(".asset-picker-head button")].find((b) => b.textContent === "Select image"));
+    const dialog = document.body.querySelector('[role="dialog"]');
+    await act(async () => dialog.querySelector(".asset-picker-card").click());
+    await click([...dialog.querySelectorAll("button")].find((b) => b.textContent === "Use Selection"));
+    await click([...document.body.querySelectorAll("button")].find((b) => b.textContent === "Generate"));
+
+    const payload = createImageJob.mock.calls[0][0];
+    expect(payload.mode).toBe("edit_image");
+    expect(payload.sourceAssetId).toBe("src-plate");
+    const editEntry = payload.loras.find((l) => l.id === "krea2_identity_edit");
+    expect(editEntry).toBeTruthy();
+    expect(editEntry.conditioningRole).toBe("image_edit");
+    // Deduped — auto-applied exactly once.
+    expect(payload.loras.filter((l) => l.id === "krea2_identity_edit")).toHaveLength(1);
+  });
+
+  it("offers a one-click download and blocks Generate when the edit LoRA is not installed", async () => {
+    const createLoraDownloadJob = vi.fn();
+    await render(
+      baseContext({
+        imageModels: [KREA_RAW],
+        loras: [{ ...EDIT_LORA, installState: "missing", installedPath: null }],
+        assets: [SOURCE],
+        createLoraDownloadJob,
+      }),
+    );
+    await enterEdit();
+
+    const download = [...document.body.querySelectorAll("button")].find((b) => b.textContent === "Download");
+    expect(download).toBeTruthy();
+    const generate = [...document.body.querySelectorAll("button")].find((b) => b.textContent === "Generate");
+    expect(generate.disabled).toBe(true);
+
+    await click(download);
+    expect(createLoraDownloadJob).toHaveBeenCalledWith(expect.objectContaining({ id: "krea2_identity_edit" }));
+  });
+
+  it("keeps the managed edit LoRA out of the manual picker while still offering other LoRAs", async () => {
+    const KREA_STYLE = { id: "krea_style", name: "Krea Style", family: "krea_2", scope: "global", installState: "installed", installedPath: "/loras/krea_style" };
+    await render(baseContext({ imageModels: [KREA_RAW], loras: [EDIT_LORA, KREA_STYLE], assets: [SOURCE] }));
+    await enterEdit();
+    await click(document.body.querySelector(".advanced-section-toggle"));
+
+    // The managed edit LoRA is filtered out — only the non-managed style LoRA is on offer.
+    const addButton = document.body.querySelector(".lora-add");
+    expect(addButton.getAttribute("data-count")).toBe("· 1 available");
+    await click(addButton);
+    const rows = [...document.body.querySelectorAll(".lora-pick-row")].map((node) => node.textContent);
+    expect(rows.some((text) => text.includes("Krea Style"))).toBe(true);
+    expect(rows.some((text) => text.includes("Krea 2 Identity Edit"))).toBe(false);
+  });
+
+  // Two-reference edit (epic 10871 P1.3): a model whose `ui.editReferences` adds an optional second
+  // (person) source — scene = image 1, person = image 2, fixed order.
+  const KREA_RAW_TWOREF = {
+    ...KREA_RAW,
+    ui: {
+      editReferences: {
+        secondaryLabel: "Person image",
+        secondaryHint: "Optional — a person to place into the scene.",
+      },
+    },
+  };
+  const SCENE = { id: "scene-plate", projectId: "project_1", type: "image", displayName: "Scene Plate", status: {} };
+  const PERSON = { id: "person-plate", projectId: "project_1", type: "image", displayName: "Person Plate", status: {} };
+
+  // Select an asset into the next empty source picker (the scene picker's button flips to "Change"
+  // once set, so the remaining "Select image" button is always the next empty slot).
+  async function pickNextSource(assetName) {
+    const btn = [...document.body.querySelectorAll(".asset-picker-head button")].find(
+      (b) => b.textContent === "Select image",
+    );
+    await click(btn);
+    const dialog = document.body.querySelector('[role="dialog"]');
+    const card = [...dialog.querySelectorAll(".asset-picker-card")].find((c) => c.textContent.includes(assetName));
+    await act(async () => card.click());
+    await click([...dialog.querySelectorAll("button")].find((b) => b.textContent === "Use Selection"));
+  }
+
+  it("renders the optional person picker only when the model declares ui.editReferences", async () => {
+    const { root: root2, container: c2 } = mountRoot();
+    // Plain Krea (no editReferences) → no person slot.
+    await act(async () => {
+      root2.render(
+        <AppContext.Provider value={baseContext({ imageModels: [KREA_RAW], loras: [EDIT_LORA], assets: [SCENE] })}>
+          <ImageStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+    await click([...document.body.querySelectorAll(".mode-tabs button")].find((b) => b.textContent === "Edit"));
+    expect(document.body.textContent).not.toContain("Person image");
+    await unmountRoot(root2, c2);
+
+    // Krea with editReferences → the labeled optional person slot appears.
+    await render(baseContext({ imageModels: [KREA_RAW_TWOREF], loras: [EDIT_LORA], assets: [SCENE, PERSON] }));
+    await enterEdit();
+    expect(container.textContent).toContain("Person image");
+    expect(container.textContent).toContain("No person image selected (optional)");
+  });
+
+  it("sends the ordered [scene, person] pair as referenceAssetIds when a person is chosen", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    await render(
+      baseContext({ createImageJob, imageModels: [KREA_RAW_TWOREF], loras: [EDIT_LORA], assets: [SCENE, PERSON], selectedAsset: null }),
+    );
+    await enterEdit();
+    await pickNextSource("Scene Plate"); // → sourceAssetId (scene, image 1)
+    await pickNextSource("Person Plate"); // → editPersonAssetId (person, image 2)
+    await click([...document.body.querySelectorAll("button")].find((b) => b.textContent === "Generate"));
+
+    const payload = createImageJob.mock.calls[0][0];
+    expect(payload.mode).toBe("edit_image");
+    // Fixed order preserved: scene first, person second.
+    expect(payload.referenceAssetIds).toEqual(["scene-plate", "person-plate"]);
+    // The single sourceAssetId is dropped in favor of the ordered pair.
+    expect(payload.sourceAssetId).toBeNull();
+    // The edit LoRA is still auto-applied (R5).
+    expect(payload.loras.some((l) => l.id === "krea2_identity_edit")).toBe(true);
+  });
+
+  it("falls back to the single sourceAssetId when no person is chosen (person is optional)", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    await render(
+      baseContext({ createImageJob, imageModels: [KREA_RAW_TWOREF], loras: [EDIT_LORA], assets: [SCENE, PERSON], selectedAsset: null }),
+    );
+    await enterEdit();
+    await pickNextSource("Scene Plate");
+    await click([...document.body.querySelectorAll("button")].find((b) => b.textContent === "Generate"));
+
+    const payload = createImageJob.mock.calls[0][0];
+    expect(payload.sourceAssetId).toBe("scene-plate");
+    expect(payload.referenceAssetIds).toBeUndefined();
+  });
+});
+
 describe("ImageStudio model picker capability gating", () => {
   let container;
   let root;

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2668,6 +2668,15 @@
         // candle/Windows-Linux twin is sc-10226.
         "img2img": true,
         "img2imgStrength": { "label": "Reference strength", "default": 0.5, "min": 0.0, "max": 1.0, "step": 0.05 },
+        // Two-reference Kontext edit (epic 10871 P1.3): the `krea2_identity_edit` edit optionally takes a
+        // SECOND source — scene = image 1 (the required Source image), person = image 2 (optional) — in a
+        // FIXED order (swapping degrades identity per the LoRA authors). Presence of this object makes the
+        // Studio render the optional person slot in Edit mode; the worker + engine (`krea_2_edit`
+        // MultiReference) cap at two and preserve order. Ignored outside `edit_image` (t2i/img2img).
+        "editReferences": {
+          "secondaryLabel": "Person image",
+          "secondaryHint": "Optional — a person to place into the scene. Fixed order: the Source image is the scene (image 1), this is the person (image 2)."
+        },
         "label": "Krea 2 Raw",
         "description": "Krea 2 Raw — Krea AI's undistilled 12B single-stream rectified-flow DiT with a Qwen3-VL-4B text encoder, native MLX (Apple Silicon). The full-fidelity, TRUE classifier-free-guidance counterpart to the fast CFG-free Krea 2 Turbo: run ~52 steps with a real guidance scale (~3.5) and an optional negative prompt for the highest quality and the most control. Pre-quantized Q8 (~20.5 GB download, default); the dense bf16 tier doubles as the Krea 2 LoRA training base. Krea 2 Community License (non-commercial). Runs on Apple Silicon (MLX) and Windows/Linux NVIDIA GPUs (candle/CUDA, sc-9994); needs a 48 GB-class Mac or a ~32 GB-class CUDA GPU.",
         "recommendedFor": ["text_to_image"],

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -534,7 +534,7 @@ sceneworks-core = { path = "../sceneworks-core" }
 # reports exactly one). NOTE: this bump FIXES a live bug — on 6a10ae1, every Anima LoRA/LoKr failed at
 # model load, because the worker defaults spec.quantize to Some(Q8) for every MLX model and mlx-gen-anima
 # rejected quant+adapter together. See test `anima_default_tier_with_adapter_builds_loadable_spec`.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -891,7 +891,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -907,23 +907,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -931,7 +931,7 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
 # mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
 # mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
@@ -939,7 +939,7 @@ mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9
 # conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
 # DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
 # generator-cache load path drives.
-mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # Anima 2B anime t2i provider (native MLX, CircleStone Labs Non-Commercial License v1.2; epic 10512,
 # sc-10523). Same git rev as mlx-gen so MLX builds once. Self-registers `anima_base` / `anima_aesthetic`
 # / `anima_turbo` (Cosmos-Predict2 DiT + Qwen3-0.6B T5-query-token adapter conditioner + Qwen-Image VAE)
@@ -948,59 +948,59 @@ mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a
 # scheduler (sc-10519) and strong prompt-weighting on the T5 query tokens (sc-10566). Carries the
 # install-time q4/q8/bf16 converter the model_jobs.rs Anima path drives (sc-10517). Pinned to merged
 # mlx-gen main 6a10ae1 (PR #680), which carries both the Anima crate and gen-core's is_hidden_file.
-mlx-gen-anima = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-anima = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -1009,19 +1009,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -1030,7 +1030,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -1038,7 +1038,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -1049,7 +1049,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1957
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -1060,7 +1060,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -1082,7 +1082,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -1093,7 +1093,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "195
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -1125,7 +1125,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "19573a9ab01fe7efaf6830c6f1693e687fcb1b6f" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1640,15 +1640,26 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "1957
 # #412 bernini — additive candle-only, no worker surface change). Both the default lane AND
 # `--features backend-candle --target all` resolve the SINGLE gen-core rev `19573a9a`. ALL mlx-gen-* +
 # candle-gen-* pins move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+#
+# Bumped mlx-gen `19573a9a` -> `ab46fcbf` + candle-gen `95a2ebcc` -> `8cc3ea4c` IN LOCKSTEP (epic 10871
+# P1.3, Krea two-reference edit): mlx-gen #698 makes the `krea_2_edit` seam accept a scene+person
+# `Conditioning::MultiReference` (the `KreaEdit` lane now passes two ordered sources). `ab46fcbf` is
+# mlx-gen main HEAD (the #698 merge; a superset of the sc-8465 krea-mlx-control #697). `git diff
+# 19573a9a..ab46fcbf -- gen-core/ gen-core-testkit/` is EMPTY (gen-core BYTE-IDENTICAL — #698 touches
+# mlx-gen-krea only), but the skew gate keys on the git REV, so candle-gen re-pins its gen-core in
+# lockstep. `8cc3ea4c` is candle-gen #424 (gen-core `951227a` -> `ab46fcbf` rev-align, off candle-gen
+# main #423). Both lanes resolve the SINGLE gen-core rev `ab46fcbf`. (candle two-reference itself still
+# needs the candle `krea_2_edit` seam registration — sc-11085.) ALL mlx-gen-* + candle-gen-* pins move
+# together.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1662,7 +1673,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1670,17 +1681,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1690,7 +1701,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1698,21 +1709,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1721,17 +1732,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "9
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1740,7 +1751,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1773,7 +1784,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1782,12 +1793,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1795,7 +1806,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2e
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1804,7 +1815,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1812,7 +1823,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1826,7 +1837,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1853,7 +1864,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1864,7 +1875,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "95a2ebcca5930323acd8de440f83602ebd681ca0", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1682,19 +1682,19 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46
 # `ab46fcbf` is mlx-gen main HEAD (the #698 merge; a superset of `951227a9`, also carrying #697 krea
 # pose-ControlNet MLX). `git diff 951227a9..ab46fcbf -- gen-core/ gen-core-testkit/` is EMPTY (gen-core
 # BYTE-IDENTICAL — #698/#697 touch mlx-gen-krea only), but the skew gate keys on the git REV, so
-# candle-gen re-pins in lockstep. `8cc3ea4c` is candle-gen #424 (gen-core `951227a9` -> `ab46fcbf`
-# rev-align, off candle-gen main #423 — a superset of `f8443050`). Both skew lanes resolve the SINGLE
+# candle-gen re-pins in lockstep. `f08051c3` is candle-gen main HEAD (the #424 SQUASH-merge — gen-core
+# `951227a9` -> `ab46fcbf` rev-align; the pre-squash branch head `8cc3ea4c` was orphaned). Both skew lanes resolve the SINGLE
 # gen-core rev `ab46fcbf`. (candle two-reference itself still needs the candle `krea_2_edit` seam
 # registration — sc-11085.) ALL mlx-gen-* + candle-gen-* pins move together.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1708,7 +1708,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1716,17 +1716,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1736,7 +1736,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1744,21 +1744,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1767,17 +1767,17 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1786,7 +1786,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1819,7 +1819,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1828,12 +1828,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1841,7 +1841,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3e
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1850,7 +1850,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1858,7 +1858,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1872,7 +1872,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1899,7 +1899,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1910,7 +1910,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8cc3ea4c9ffb0a07cd79ddfa2c9d211a99b3f439", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/krea_edit.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_edit.rs
@@ -2,19 +2,27 @@
 // Krea 2 image-edit (macOS, epic 10871): the Kontext-style dual-conditioned edit
 // surface. Routed here from `ImageRoute::KreaEdit` — an `edit_image` job on
 // `krea_2_raw` carrying a source image. Loads the `krea_2_edit` registry generator
-// (the Raw pipeline routed to `generate_edit_with_progress`: the source rides as
+// (the Raw pipeline routed to `generate_edit_with_progress`: each source rides as
 // in-context VAE tokens at a distinct RoPE frame AND grounds the Qwen3-VL vision
-// tower), passing the source as a single `Conditioning::Reference`. One output per
-// requested count, each an edit of the same source under the instruction prompt.
-// Krea is MLX-only, so this is the only Krea edit path (the candle mirror is a
-// separate slice, P1.2/P2.2). Mirrors `generate_flux2_edit_stream`'s blocking-
-// thread + streamed-events shape and reuses `consume_gen_events`.
+// tower). Conditions on one source (`Conditioning::Reference`) or two in FIXED order
+// — scene = image 1, person = image 2 (`Conditioning::MultiReference`, epic 10871
+// P1.3). One output per requested count, each an edit of the same source(s) under the
+// instruction prompt. Krea is MLX-only, so this is the only Krea edit path (the candle
+// mirror is a separate slice, P1.2/P2.2 + the sc-11085 seam registration). Mirrors
+// `generate_flux2_edit_stream`'s blocking-thread + streamed-events shape and reuses
+// `consume_gen_events`.
 // ---------------------------------------------------------------------------
 
 /// The engine registry id the edit lane loads: the Raw pipeline routed to the Kontext edit entrypoint
 /// (mlx-gen `krea_2_edit`, epic 10871). Distinct from the `krea_2_raw` t2i/img2img generator — the
 /// distinct id is what tells the engine to treat the source `Reference` as an edit, not an img2img init.
 const KREA_EDIT_ENGINE_ID: &str = "krea_2_edit";
+
+/// The most source images a Krea edit conditions on (epic 10871 P1.3): scene = image 1, person =
+/// image 2, a FIXED order (swapping degrades identity per the LoRA authors). Mirrors the engine cap
+/// (`mlx-gen-krea` / `candle-gen-krea` `MAX_EDIT_REFERENCES`); the worker rejects a longer list up
+/// front so the error is clear rather than surfacing from the engine seam.
+const KREA_MAX_EDIT_REFERENCES: usize = 2;
 
 /// True when a selected LoRA declares the image-edit conditioning role (`conditioningRole: image_edit`,
 /// e.g. the builtin `krea2_identity_edit`). The image-edit sibling of the LTX IC-LoRA detector
@@ -120,9 +128,10 @@ fn krea_edit_generate_one(
 }
 
 /// Real Krea 2 edit generation: load the `krea_2_edit` generator once, then one output per requested
-/// count, each an edit of the shared source under the instruction prompt. Mirrors
+/// count, each an edit of the shared source(s) under the instruction prompt. Mirrors
 /// [`generate_flux2_edit_stream`]'s blocking-thread + streamed-events shape and reuses
-/// [`consume_gen_events`]; differs in the required edit LoRA (R5) and the single-source conditioning.
+/// [`consume_gen_events`]; differs in the required edit LoRA (R5) and the scene+person edit
+/// conditioning (one `Reference` or a two-source `MultiReference`, epic 10871 P1.3).
 async fn generate_krea_edit_stream(
     api: &ApiClient,
     settings: &Settings,
@@ -158,32 +167,46 @@ async fn generate_krea_edit_stream(
     let repo = model_repo(request, &model);
     let adapter_label = model.adapter_label();
 
-    // Resolve the source image on the async side (decode → Send Image moved into the worker thread).
-    // Krea edit is single-source for now — the `krea_2_edit` generator conditions on exactly one
-    // `Reference` (a second person reference is P1.3). Take the first resolved edit reference.
+    // Resolve the source image(s) on the async side (decode → Send Image moved into the worker thread).
+    // Krea edit conditions on scene = image 1, person = image 2 (fixed order, epic 10871 P1.3): the
+    // multi-image picker sends the plural `referenceAssetIds`, and a single Image-Edit `sourceAssetId`
+    // is the one-source case (both via `edit_reference_ids`). Capped at [`KREA_MAX_EDIT_REFERENCES`] —
+    // `build_edit_conditioning` then emits a single `Reference` (1) or a `MultiReference` (2), which the
+    // `krea_2_edit` generator VAE-encodes at successive RoPE frames.
     let reference_ids = edit_reference_ids(request);
-    let source_id = reference_ids.first().ok_or_else(|| {
-        WorkerError::InvalidPayload("Krea 2 edit requires a source image (sourceAssetId).".to_owned())
-    })?;
-    let source = load_reference_image(
-        &settings.data_dir,
-        &request.project_id,
-        source_id,
-        project_path,
-    )?;
-    // Pre-fit the source to the target W×H (crop / pad / outpaint→pad) so an off-aspect source isn't
-    // squished into the latent grid; `stretch` keeps the legacy resize. Shared with the other edit lanes.
-    let source = fit_edit_references(vec![source], request, request.width, request.height)?
-        .pop()
-        .expect("fit_edit_references preserves the single source");
+    if reference_ids.is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "Krea 2 edit requires a source image (sourceAssetId).".to_owned(),
+        ));
+    }
+    if reference_ids.len() > KREA_MAX_EDIT_REFERENCES {
+        return Err(WorkerError::InvalidPayload(format!(
+            "Krea 2 edit takes at most {KREA_MAX_EDIT_REFERENCES} images (scene, then person)."
+        )));
+    }
+    let mut sources = Vec::with_capacity(reference_ids.len());
+    for id in &reference_ids {
+        sources.push(load_reference_image(
+            &settings.data_dir,
+            &request.project_id,
+            id,
+            project_path,
+        )?);
+    }
+    // Pre-fit each source to the target W×H (crop / pad / outpaint→pad) so an off-aspect source isn't
+    // squished into the latent grid; `stretch` keeps the legacy resize. Fixed order preserved. Shared
+    // with the other edit lanes.
+    let sources = fit_edit_references(sources, request, request.width, request.height)?;
+    let reference_count = sources.len();
 
-    // Plain per-image work: `request.count` edits of the same source, each its own seed + the base
+    // Plain per-image work: `request.count` edits of the same source(s), each its own seed + the base
     // instruction prompt (Krea edit has no angle/pose grouping — that is the character_image path).
     let work: Vec<(i64, String)> = (0..request.count as usize)
         .map(|index| (resolve_seed(request, index), request.prompt.clone()))
         .collect();
     let total = work.len();
-    let raw_settings = krea_edit_raw_settings(request, &repo, steps, quant_bits, guidance, 1);
+    let raw_settings =
+        krea_edit_raw_settings(request, &repo, steps, quant_bits, guidance, reference_count);
 
     let (width, height) = (request.width, request.height);
     let adapter_count = adapters.len();
@@ -199,7 +222,7 @@ async fn generate_krea_edit_stream(
                 if cancel.is_cancelled() {
                     return Ok(None);
                 }
-                let conditioning = build_edit_conditioning(std::slice::from_ref(&source));
+                let conditioning = build_edit_conditioning(&sources);
                 let (out_w, out_h, pixels) = krea_edit_generate_one(
                     generator,
                     &prompt,


### PR DESCRIPTION
Ships the **Krea 2 image-edit UI** (P4.1, sc-10885) and the SceneWorks side of **two-reference edit** (P1.3, sc-10878), on the MLX/macOS path.

Requires **[SceneWorks/mlx-gen#698](https://github.com/SceneWorks/mlx-gen/pull/698)** (merged, `ab46fcb`) + candle-gen re-pin **[#424](https://github.com/SceneWorks/candle-gen/pull/424)** (merge for the gen-core lockstep).

## P4.1 — the edit UI (sc-10885)
The Image Studio `edit_image` mode is capability-driven, so the Edit tab/source-picker/payload already light up for `krea_2_raw` from the Phase-3 manifest. The real work was the **required edit LoRA (R5)**:
- **Fix `serializeLora`** — it dropped `conditioningRole`/`icLora`, so the worker's `image_edit`-role check couldn't see a selected edit LoRA even when picked (LTX IC-LoRAs escape via a name marker; Krea's name has none). Now forwarded (also fixes the canvas ImageEditor path).
- **Auto-applied managed edit LoRA** — `krea2_identity_edit` is injected + deduped in Krea edit mode, hidden from the manual picker, with a managed note; a one-click **Download** when it isn't installed. Generic by conditioning-role (inert for Qwen/FLUX edit).
- Source-required + edit-LoRA-missing validation (epic-10644 vocabulary).

## P1.3 — two-reference (scene + person), SceneWorks side (sc-10878)
- **Worker** `krea_edit.rs` loads up to **2 ordered** refs (scene = image 1, person = image 2), caps at `KREA_MAX_EDIT_REFERENCES=2`, `build_edit_conditioning` → `MultiReference`.
- **Manifest** `ui.editReferences` + Studio optional **"Person image"** slot; submit emits ordered `referenceAssetIds: [scene, person]` (drops the single `sourceAssetId` when a person is chosen); reset-on-mode-change.
- Consumes mlx-gen #698's `krea_2_edit` `MultiReference` seam.

## Pin bump (lockstep)
mlx-gen `951227a → ab46fcb` (#698, +#697 krea pose-ControlNet MLX) + candle-gen `f8443050 → 8cc3ea4` (#424 gen-core rev-align). gen-core **byte-identical** across the bump; single rev `ab46fcb`. Merged main (incl. #1432 candle KreaEdit lane, #1428 MLX pose lane); my pins are a clean superset of main's.

## Verification
- **Real weights, on Metal, through the production `Generator` seam:** a goblin scene + an elf person → `MultiReference` → both composited into a joint bar scene, **both identities preserved**.
- Worker compiles against `ab46fcb`; krea core+worker tests, `fmt`, `clippy` clean. Web **1640** tests pass (+18 across P4.1 auto-apply, validation, and two-ref UI).

## Not here (tracked)
- **candle two-reference** is blocked on **sc-11085**: candle's `krea_2_edit` generator isn't registered (its edit pipeline has the two-ref support but isn't reachable via `Generator::generate`). This PR is MLX-only.
- Canvas ImageEditor auto-apply parity (sc-11069).

🤖 Generated with [Claude Code](https://claude.com/claude-code)