### PR TITLE
feat(worker): candle bernini VIDEO lane (t2v + edit/reference + mv2v/ads2v) + routing flip (sc-10997, epic 6562)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -4684,6 +4684,107 @@ mod candle_routing_tests {
     }
 
     #[test]
+    fn bernini_video_candle_serves_every_mode_in_native_shape() {
+        // sc-10997 (epic 6562): the candle Bernini VIDEO lane serves t2v + the editing/reference/
+        // multi-source modes on the distinct `bernini` engine — the off-Mac parity of the MLX
+        // `video_mode_is_mlx_eligible(bernini, mode)` gate. Each mode claims the candle lane (routed on
+        // id + mode; the worker validates the per-mode media + `SceneWorks/bernini-candle` weights loudly,
+        // sc-11003). The story's "i2v"/"edit" map onto Bernini's `video_to_video` — its Wan2.2-T2V
+        // renderer has no classic still-image-to-video (mirrors the MLX lane's mode set exactly).
+        for (mode, payload) in [
+            (
+                "text_to_video",
+                json!({ "model": "bernini", "mode": "text_to_video", "prompt": "a kite" }),
+            ),
+            (
+                "video_to_video",
+                json!({ "model": "bernini", "mode": "video_to_video", "sourceClipAssetId": "clip_1" }),
+            ),
+            (
+                "reference_to_video",
+                json!({ "model": "bernini", "mode": "reference_to_video", "referenceAssetIds": ["ref_1"] }),
+            ),
+            (
+                "reference_video_to_video",
+                json!({
+                    "model": "bernini",
+                    "mode": "reference_video_to_video",
+                    "sourceClipAssetId": "clip_1",
+                    "referenceAssetIds": ["ref_1"]
+                }),
+            ),
+            (
+                "multi_video_to_video",
+                json!({
+                    "model": "bernini",
+                    "mode": "multi_video_to_video",
+                    "sourceClipAssetIds": ["clip_1", "clip_2"]
+                }),
+            ),
+            (
+                "ads2v",
+                json!({
+                    "model": "bernini",
+                    "mode": "ads2v",
+                    "sourceClipAssetId": "clip_1",
+                    "referenceClipAssetId": "clip_2",
+                    "referenceAssetIds": ["ref_1"]
+                }),
+            ),
+        ] {
+            assert!(
+                bernini_video_candle_eligible("bernini", &object(payload.clone())),
+                "bernini {mode} must be candle-eligible"
+            );
+            // Through the full VideoGenerate claim gate (the OR-in wiring reaches the candle worker).
+            assert!(
+                video_job_is_candle_eligible(&video_generate_job(payload.clone())),
+                "bernini {mode} must route to the candle worker via video_job_is_candle_eligible"
+            );
+        }
+        // An explicit tier request (`mlxQuantize`) is lineage-only — it does NOT push Bernini off candle
+        // (the loader reads the converted tree dense; there is no torch Bernini to fall back to, sc-11003).
+        let mut quant = object(json!({ "model": "bernini", "mode": "text_to_video" }));
+        quant.insert("advanced".into(), json!({ "mlxQuantize": 8 }));
+        assert!(
+            bernini_video_candle_eligible("bernini", &quant),
+            "a tier-requesting bernini job stays on candle (dense load + lineage bits)"
+        );
+    }
+
+    #[test]
+    fn bernini_video_candle_rejects_wrong_model_or_mode() {
+        // Only the `bernini` id claims the Bernini candle VIDEO lane; other video models (and the still
+        // `bernini_image` id) keep their own routing.
+        for model in ["wan_2_2", "scail2_14b", "bernini_image", "ltx_2_3"] {
+            assert!(
+                !bernini_video_candle_eligible(model, &object(json!({ "mode": "text_to_video" }))),
+                "{model} must not claim the bernini video candle lane"
+            );
+        }
+        // A mode Bernini does not serve (no classic i2v; replace/animate/clip modes belong to other
+        // engines) is not this lane — mirrors the MLX `video_mode_is_mlx_eligible(bernini, ..)` set.
+        for mode in [
+            "image_to_video",
+            "replace_person",
+            "animate_character",
+            "first_last_frame",
+            "extend_clip",
+            "",
+        ] {
+            assert!(
+                !bernini_video_candle_eligible("bernini", &object(json!({ "mode": mode }))),
+                "bernini {mode:?} is not a served candle video mode"
+            );
+        }
+        // No mode at all → not eligible (a real bernini job always carries an explicit mode).
+        assert!(!bernini_video_candle_eligible(
+            "bernini",
+            &object(json!({ "prompt": "p" }))
+        ));
+    }
+
+    #[test]
     fn scail2_candle_rejects_incomplete_or_wrong_shape() {
         // animate_character needs BOTH a reference image and a driving clip.
         assert!(!scail2_animate_candle_eligible(

--- a/crates/sceneworks-core/src/jobs_store/routing/candle.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/candle.rs
@@ -358,9 +358,11 @@ pub(crate) fn candle_request_wants_quant(payload: &Map<String, Value>) -> bool {
 /// (reference/mask/first-last-frame conditioning, LoRAs) must fall back to the Python torch worker, so
 /// the candle worker refuses it here. SCAIL-2 (`scail2_14b`) adds a DISTINCT candle engine off-Mac —
 /// `animate_character` + `replace_person` (sc-6837, epic 6563) — gated separately (it is not a VACE
-/// model). The per-model shape gates are [`video_request_candle_eligible`] (base),
-/// [`video_request_candle_vace_eligible`] (VACE modes), and
-/// [`scail2_animate_candle_eligible`] / [`scail2_replace_candle_eligible`].
+/// model). Bernini (`bernini`) adds another DISTINCT candle engine off-Mac — t2v + the editing/
+/// reference/multi-source video modes (sc-10997, epic 6562) — also gated separately. The per-model
+/// shape gates are [`video_request_candle_eligible`] (base),
+/// [`video_request_candle_vace_eligible`] (VACE modes), [`bernini_video_candle_eligible`] (Bernini),
+/// and [`scail2_animate_candle_eligible`] / [`scail2_replace_candle_eligible`].
 pub(crate) fn video_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     let Some(model) = job.payload.get("model").and_then(Value::as_str) else {
         return false;
@@ -371,6 +373,9 @@ pub(crate) fn video_job_is_candle_eligible(job: &JobSnapshot) -> bool {
         JobType::VideoGenerate => {
             video_request_candle_eligible(model, &job.payload)
                 || scail2_animate_candle_eligible(model, &job.payload)
+                // Bernini (sc-10997, epic 6562): t2v + the editing/reference/multi-source modes on the
+                // distinct candle `bernini` engine — its own gate (not the generic txt2video path).
+                || bernini_video_candle_eligible(model, &job.payload)
         }
         // replace_person → candle Wan-VACE (sc-5494) OR candle SCAIL-2 (sc-6837, routed by model id).
         JobType::PersonReplace => {
@@ -576,6 +581,37 @@ pub(crate) fn scail2_replace_candle_eligible(model: &str, payload: &Map<String, 
         return false;
     }
     true
+}
+
+/// Candle Bernini VIDEO eligibility (sc-10997, epic 6562). Bernini is a DISTINCT candle engine (the
+/// full Qwen planner + Wan2.2-T2V-A14B renderer, `gen_core::load("bernini")`), so it has its own gate
+/// rather than routing through the generic [`video_request_candle_eligible`] txt2video path — that
+/// path only admits `text_to_video`, but Bernini also serves the editing/reference/multi-source modes.
+/// Mirrors the MLX `video_mode_is_mlx_eligible(bernini, mode)` shape (mode-only, `bernini` id + the six
+/// served modes), expressed as a candle-claim gate: `text_to_video` (base), `video_to_video` (v2v edit),
+/// `reference_to_video` (r2v), `reference_video_to_video` (rv2v), `multi_video_to_video` (mv2v), and
+/// `ads2v`. Routed on the model id + mode, not weight availability — the worker's dedicated
+/// `CandleVideoRoute::Bernini` dispatch resolves-or-errors loudly if the `SceneWorks/bernini-candle`
+/// snapshot is unprovisioned (sc-11003), and validates the per-mode source media when it assembles the
+/// conditioning. No LoRA (the engine reports `supports_lora=false`); an explicit `mlxQuantize` is
+/// recorded for lineage but does NOT push the job off candle (the loader reads the converted tree dense,
+/// exactly like the still lane, sc-10996) — there is no torch Bernini to fall back to. Factored out so
+/// the routing tests can probe it with synthetic payloads (parity with [`video_request_candle_eligible`]).
+pub(crate) fn bernini_video_candle_eligible(model: &str, payload: &Map<String, Value>) -> bool {
+    if model != "bernini" {
+        return false;
+    }
+    matches!(
+        payload.get("mode").and_then(Value::as_str),
+        Some(
+            "text_to_video"
+                | "video_to_video"
+                | "reference_to_video"
+                | "reference_video_to_video"
+                | "multi_video_to_video"
+                | "ads2v"
+        )
+    )
 }
 
 /// InstantID candle-routing conditions (sc-5491, epic 5480). The candle `candle-gen-instantid`

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -724,8 +724,16 @@ pub(crate) const VIDEO_MODEL_CAPS: &[VideoModelCaps] = &[
     VideoModelCaps::new("wan_2_2_i2v_14b", true, true, true, true),
     // SVD (`svd` → `svd_xt`, sc-3523 MLX; sc-5493 candle): image→video ONLY. Not a VACE model.
     VideoModelCaps::new("svd", true, true, true, false),
-    // Bernini (epic 4699 / sc-4707): MLX-only — Qwen2.5-VL planner + Wan2.2-T2V-A14B renderer.
-    VideoModelCaps::new("bernini", true, false, false, false),
+    // Bernini (epic 4699 / sc-4707 MLX; sc-10997 candle): Qwen2.5-VL planner + Wan2.2-T2V-A14B
+    // renderer. Both backends wired — `mlx-gen-bernini` (macOS) + `candle-gen-bernini` (Windows/CUDA,
+    // the full planner+renderer `bernini` generator, `gen_core::load("bernini")`), so
+    // `candle_video_routed = true`. Serves t2v + the editing/reference/multi-source modes (v2v / r2v /
+    // rv2v / mv2v / ads2v) on both lanes; the candle worker routes those via the dedicated
+    // `bernini_video_candle_eligible` gate + the `CandleVideoRoute::Bernini` dispatch (NOT the generic
+    // wan/ltx txt2video arm — Bernini is a distinct engine). Not an i2v/VACE model, so those columns
+    // stay false. Off-Mac packed-tier select is deferred until the `SceneWorks/bernini-candle` tier
+    // layout lands (sc-11003) — the candle lane loads the converted snapshot dense today.
+    VideoModelCaps::new("bernini", true, true, false, false),
     // SCAIL-2 (epic 5439 / sc-5448): MLX end-to-end character animation; the candle SCAIL-2 engine
     // (sc-6837) is a DISTINCT engine gated by its own predicates, NOT Wan-VACE membership — so its
     // candle-video columns are all false (it is deliberately absent from `CANDLE_VIDEO_*`).
@@ -1096,6 +1104,9 @@ mod tests {
         "wan_2_2_t2v_14b",
         "wan_2_2_i2v_14b",
         "svd",
+        // Bernini VIDEO lane (sc-10997, epic 6562): the full candle planner+renderer serves t2v + the
+        // editing/reference/multi-source modes. Not in the i2v/VACE subsets (a distinct engine).
+        "bernini",
     ];
 
     const EXPECTED_CANDLE_VIDEO_I2V_ROUTED_MODELS: &[&str] = &["wan_2_2_i2v_14b", "svd"];

--- a/crates/sceneworks-worker/src/image_jobs/bernini.rs
+++ b/crates/sceneworks-worker/src/image_jobs/bernini.rs
@@ -338,7 +338,7 @@ fn bernini_image_candle_available(request: &ImageRequest) -> bool {
 /// candle SCAIL-2 / Wan-VACE resolvers, a missing checkpoint surfaces a clear re-download error instead
 /// of degrading to a stub. The candle sibling of the MLX `resolve_bernini_model_dir` (video_jobs.rs).
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-fn resolve_candle_bernini_model_dir(settings: &Settings) -> WorkerResult<PathBuf> {
+pub(crate) fn resolve_candle_bernini_model_dir(settings: &Settings) -> WorkerResult<PathBuf> {
     if let Ok(dir) = std::env::var("SCENEWORKS_CANDLE_BERNINI_DIR") {
         let path = PathBuf::from(dir.trim());
         if path.join("transformer").is_dir() {

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -107,6 +107,14 @@ use candle_gen_seedvr2 as _;
 // anchor above.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle_gen_scail2 as _;
+// Candle Bernini (sc-10997, epic 6562): the full Qwen planner + Wan2.2-T2V-A14B renderer `Generator`
+// registers under `bernini` via `inventory::submit!`; force-link so the registration survives the MSVC
+// release linker (reached only through `gen_core::load("bernini")`, no direct type contact — the "no
+// generator registered" trap). The off-Mac VIDEO sibling of the macOS `mlx_gen_bernini` anchor above
+// (image_jobs.rs already force-links the same crate for the still lane; inventory is global, but the
+// video lane keeps its own anchor for parity with the `candle_gen_scail2` video anchor).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use candle_gen_bernini as _;
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
@@ -254,6 +262,11 @@ enum CandleVideoRoute {
     AnimateScail2(&'static str),
     /// `extend_clip` / `video_bridge` → candle Wan-VACE extend/bridge (sc-5494).
     WanVaceExtendBridge,
+    /// A `bernini` VIDEO job (t2v + the editing/reference/multi-source modes) → `generate_candle_bernini`
+    /// (sc-10997, epic 6562). A DISTINCT engine (the full Qwen planner + Wan2.2-T2V-A14B renderer), NOT a
+    /// wan/ltx `is_candle_video_engine` id, so it is routed off the model id before the generic arm below.
+    /// Carries the resolved engine id.
+    Bernini(&'static str),
     /// A candle txt2video engine id → `generate_candle_video` (sc-5097).
     CandleVideo,
     /// An in-place ComfyUI Wan2.2 base model (`external_base_*`) → `generate_candle_wan_comfyui`
@@ -283,6 +296,15 @@ fn resolve_candle_video_route(request: &VideoRequest, settings: &Settings) -> Ca
         CandleVideoRoute::AnimateScail2(engine_id)
     } else if matches!(request.mode.as_str(), "extend_clip" | "video_bridge") {
         CandleVideoRoute::WanVaceExtendBridge
+    } else if let Some(engine_id) = candle_bernini_engine_id(&request.model) {
+        // Bernini (sc-10997, epic 6562): the full Qwen planner + Wan2.2-T2V-A14B renderer serves t2v +
+        // the editing/reference/multi-source modes (v2v / r2v / rv2v / mv2v / ads2v). A DISTINCT engine
+        // (`gen_core::load("bernini")`), NOT a wan/ltx `is_candle_video_engine` id, so it is routed off the
+        // model id BEFORE the generic candle-video arm below. Routed by model id, not weight availability —
+        // `generate_candle_bernini` resolves-or-errors loudly if the `SceneWorks/bernini-candle` snapshot is
+        // unprovisioned (sc-11003), never degrading to a stub. The per-mode source media is validated when
+        // the conditioning is assembled (`resolve_candle_bernini_conditioning`), mirroring the MLX lane.
+        CandleVideoRoute::Bernini(engine_id)
     } else if wan_comfyui_available(request, settings) {
         // In-place ComfyUI Wan2.2 base (sc-10671): an `external_base_*` id, so it matches no
         // `is_candle_video_engine` arm below — route it off the forwarded `modelManifestEntry`.
@@ -658,6 +680,31 @@ pub(crate) async fn run_video_generate_job(
                     decoded,
                     CANDLE_WAN_VACE_ADAPTER,
                     wan_vace_extend_raw_settings(&request),
+                    None::<Value>,
+                )
+            }
+            CandleVideoRoute::Bernini(engine_id) => {
+                // sc-10997 (epic 6562): the candle Bernini VIDEO lane — the full Qwen planner +
+                // Wan2.2-T2V-A14B renderer. `generate_candle_bernini` maps the SceneWorks mode to the engine
+                // `video_mode` task (t2v / v2v / r2v / rv2v / mv2v / ads2v) and resolves the source media into
+                // the planner conditioning (`resolve_candle_bernini_conditioning`) — empty for t2v, one or
+                // more `VideoClip`s for the edit modes, `MultiReference` for the reference modes. The off-Mac
+                // sibling of the macOS `generate_bernini`; resolves-or-errors loudly (no torch fallback — a
+                // distinct candle engine, GPU-val gated on the `SceneWorks/bernini-candle` weights, sc-11003).
+                let decoded = generate_candle_bernini(
+                    api,
+                    settings,
+                    job,
+                    &request,
+                    &project_path,
+                    engine_id,
+                    backend,
+                )
+                .await?;
+                (
+                    decoded,
+                    CANDLE_BERNINI_ADAPTER,
+                    candle_bernini_raw_settings(&request),
                     None::<Value>,
                 )
             }
@@ -6600,6 +6647,213 @@ async fn generate_bernini(
 }
 
 // ---------------------------------------------------------------------------
+// Real candle Bernini VIDEO generation (Windows/CUDA, via candle-gen-bernini, sc-10997 / epic 6562):
+// the off-Mac sibling of the macOS `generate_bernini` above. The full Qwen2.5-VL planner + Wan2.2-T2V-
+// A14B renderer registers under `bernini` (`Modality::Video`); the video path reaches it via
+// `gen_core::load("bernini")` (no direct type contact — the force-link near the top keeps the linker
+// from dropping the registration). Serves `text_to_video` + the editing/reference/multi-source video
+// modes (v2v / r2v / rv2v / mv2v / ads2v); `generate_candle_bernini` maps the SceneWorks mode to the
+// engine guidance task and resolves the source media into the planner conditioning. Loads the converted
+// `SceneWorks/bernini-candle` snapshot DENSE (the candle loader reads the tree as-is; the off-Mac
+// packed-tier select is deferred WITH the still lane until the `bernini-candle` tier layout lands —
+// GPU-val is gated on sc-11003, the not-yet-published weights). No LoRA (the engine reports
+// `supports_lora=false`). A distinct candle engine — NO torch fallback (a missing snapshot fails loud
+// at load, never a silent stub).
+// ---------------------------------------------------------------------------
+
+/// Adapter id recorded on a real candle Bernini VIDEO asset — the `candle_<family>` sibling of the MLX
+/// `mlx_bernini` label (same spelling as the still lane's `CANDLE_BERNINI_IMAGE_ADAPTER`).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const CANDLE_BERNINI_ADAPTER: &str = "candle_bernini";
+
+/// SceneWorks Bernini model id → candle registry id, or `None` if `model` is not the Bernini video
+/// family. The candle sibling of the macOS `bernini_engine_id`; drives the `CandleVideoRoute::Bernini`
+/// arm (routed on the model id, not weight availability).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_bernini_engine_id(model: &str) -> Option<&'static str> {
+    (model == "bernini").then_some("bernini")
+}
+
+/// Map a SceneWorks video mode to the Bernini engine `video_mode` task string (which selects the
+/// renderer guidance mode). The candle sibling of the macOS `bernini_engine_video_mode` — the identical
+/// mapping so the two lanes render the same mode for the same request. Unknown / `text_to_video` ⇒
+/// plain `t2v`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_bernini_engine_video_mode(mode: &str) -> &'static str {
+    match mode {
+        "video_to_video" => "v2v",
+        "reference_to_video" => "r2v",
+        "reference_video_to_video" => "rv2v",
+        // Multi-source-video modes (sc-5425): mv2v (multiple source clips) and ads2v (source video +
+        // reference video + reference images). Both resolve to the engine's `V2vApg` guidance; they
+        // differ only in the supplied media.
+        "multi_video_to_video" => "mv2v",
+        "ads2v" => "ads2v",
+        _ => "t2v",
+    }
+}
+
+/// Raw-settings recorded on a real candle Bernini VIDEO asset (mirrors the macOS `bernini_raw_settings`).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_bernini_raw_settings(request: &VideoRequest) -> Value {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("model".to_owned(), Value::String(request.model.clone()));
+    raw.insert("frameCount".to_owned(), json!(request.frame_count()));
+    raw.insert("fps".to_owned(), json!(request.fps));
+    // The engine guidance task the SceneWorks mode resolved to (lineage / observability).
+    raw.insert(
+        "berniniTask".to_owned(),
+        Value::String(candle_bernini_engine_video_mode(&request.mode).to_owned()),
+    );
+    Value::Object(raw)
+}
+
+/// Resolve the source media for a candle Bernini editing/reference request into the planner
+/// conditioning — the candle sibling of the macOS `resolve_bernini_conditioning`. Source clips →
+/// [`Conditioning::VideoClip`] (the edit structure, VAE/ViT-encoded by the engine) and subject
+/// reference images → [`Conditioning::MultiReference`]. `text_to_video` needs none. The single-clip
+/// modes (v2v / rv2v / ads2v) use `sourceClipAssetId`; mv2v supplies several via `sourceClipAssetIds`;
+/// ads2v additionally appends the reference video (`referenceClipAssetId`) as a second clip after the
+/// source clip (sc-5425). Clips are emitted videos-first, in submission order, then images — matching
+/// the engine's `collect_conditioning` / `assign_source_ids` ordering. Each mode's required media is
+/// enforced here (defense in depth — the API validates the same), so a mis-built request fails loud
+/// instead of silently rendering an unconditioned clip. Clips decode to the output frame count via the
+/// candle-shared [`extract_clip_frames`]; reference images load via the shared `load_reference_image`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+async fn resolve_candle_bernini_conditioning(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    project_path: &Path,
+) -> WorkerResult<Vec<Conditioning>> {
+    let mode = request.mode.as_str();
+
+    // Source video clips, in the order the engine assigns source ids (videos first; for ads2v the
+    // source clip leads the reference video).
+    let mut clip_ids: Vec<&str> = Vec::new();
+    match mode {
+        "video_to_video" | "reference_video_to_video" | "ads2v" => {
+            let clip_id = request.source_clip_asset_id.as_deref().ok_or_else(|| {
+                WorkerError::InvalidPayload(format!(
+                    "bernini {} requires a source clip (sourceClipAssetId).",
+                    request.mode.replace('_', " ")
+                ))
+            })?;
+            clip_ids.push(clip_id);
+        }
+        "multi_video_to_video" => {
+            if request.source_clip_asset_ids.len() < 2 {
+                return Err(WorkerError::InvalidPayload(
+                    "bernini multi video to video requires at least two source clips \
+                     (sourceClipAssetIds)."
+                        .to_owned(),
+                ));
+            }
+            clip_ids.extend(request.source_clip_asset_ids.iter().map(String::as_str));
+        }
+        _ => {}
+    }
+    if mode == "ads2v" {
+        let ref_clip_id = request.reference_clip_asset_id.as_deref().ok_or_else(|| {
+            WorkerError::InvalidPayload(
+                "bernini ads2v requires a reference video (referenceClipAssetId).".to_owned(),
+            )
+        })?;
+        clip_ids.push(ref_clip_id);
+    }
+
+    let mut conditioning = Vec::new();
+    for clip_id in clip_ids {
+        let frames = extract_clip_frames(
+            api,
+            settings,
+            job,
+            &request.project_id,
+            project_path,
+            clip_id,
+            request.width,
+            request.height,
+            wan_frame_count(request.raw_frame_count()),
+        )
+        .await?;
+        conditioning.push(Conditioning::VideoClip {
+            frames,
+            frame_idx: 0,
+            strength: 1.0,
+        });
+    }
+
+    // Subject reference images → MultiReference (r2v / rv2v / ads2v).
+    let needs_refs = matches!(
+        mode,
+        "reference_to_video" | "reference_video_to_video" | "ads2v"
+    );
+    if needs_refs {
+        if request.reference_asset_ids.is_empty() {
+            return Err(WorkerError::InvalidPayload(format!(
+                "bernini {} requires at least one reference image (referenceAssetIds).",
+                request.mode.replace('_', " ")
+            )));
+        }
+        let mut images = Vec::with_capacity(request.reference_asset_ids.len());
+        for asset_id in &request.reference_asset_ids {
+            images.push(crate::image_jobs::load_reference_image(
+                &settings.data_dir,
+                &request.project_id,
+                asset_id,
+                project_path,
+            )?);
+        }
+        conditioning.push(Conditioning::MultiReference { images });
+    }
+
+    Ok(conditioning)
+}
+
+/// Real candle Bernini video generation (sc-10997 / epic 6562): build the `VideoGenInput` and run the
+/// shared [`generate_video`] path. The SceneWorks mode resolves to the engine `video_mode` task
+/// ([`candle_bernini_engine_video_mode`]) and the source media into the planner conditioning
+/// ([`resolve_candle_bernini_conditioning`]) — empty for t2v, one or more `VideoClip`s for
+/// v2v/mv2v/rv2v/ads2v, and `MultiReference` for r2v/rv2v/ads2v. The converted `SceneWorks/bernini-candle`
+/// snapshot loads DENSE (no load-time quant — the off-Mac packed-tier select is deferred with the still
+/// lane, sc-11003), resolved via the shared [`crate::image_jobs::resolve_candle_bernini_model_dir`] so
+/// video + still load from the same tier. No LoRA (the engine reports `supports_lora=false`); steps /
+/// guidance stay at the engine defaults. Frame count uses the Wan 1-mod-4 stride (the renderer is Wan).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+async fn generate_candle_bernini(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    project_path: &Path,
+    engine_id: &'static str,
+    backend: &str,
+) -> WorkerResult<DecodedVideo> {
+    let negative_prompt = non_empty_negative_prompt(request);
+    let conditioning =
+        resolve_candle_bernini_conditioning(api, settings, job, request, project_path).await?;
+    let input = VideoGenInput {
+        sampler: None,
+        scheduler: None,
+        engine_id,
+        model_dir: crate::image_jobs::resolve_candle_bernini_model_dir(settings)?,
+        conditioning,
+        prompt: request.prompt.clone(),
+        negative_prompt,
+        width: request.width,
+        height: request.height,
+        frames: wan_frame_count(request.raw_frame_count()),
+        fps: request.fps,
+        seed: resolve_video_seed(request) as u64,
+        video_mode: Some(candle_bernini_engine_video_mode(&request.mode).to_owned()),
+        ..VideoGenInput::default()
+    };
+    generate_video(api, settings, job, backend, &request.advanced, input).await
+}
+
+// ---------------------------------------------------------------------------
 // Real MLX SCAIL-2 generation (macOS, via mlx-gen-scail2, epic 5439 / sc-5448): end-to-end character
 // animation — a reference character image + a driving video → an animated clip of the character
 // performing the driving motion. The worker paints the color-coded segmentation masks the engine
@@ -8005,7 +8259,16 @@ fn resolve_clip_media_path(
 /// generation's snapped frame count (`8k+1`); a clip shorter than `count` yields fewer frames,
 /// which the engine VAE encode accepts. Extracted via the shared [`run_ffmpeg`] (binary
 /// resolution + heartbeat/cancel), then loaded off the async runtime.
-#[cfg(target_os = "macos")]
+///
+/// Shared by the macOS MLX Bernini conditioning and the candle Bernini VIDEO lane (sc-10997): both
+/// resolve arbitrary source-clip asset ids (mv2v supplies several via `sourceClipAssetIds`, ads2v
+/// appends the reference video) into planner `VideoClip` conditioning, so the per-asset-id loader is
+/// gated to both lanes (unlike `load_source_video_frames`, which reads only the request's single
+/// `sourceClipAssetId`).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 #[allow(clippy::too_many_arguments)]
 async fn extract_clip_frames(
     api: &ApiClient,
@@ -9871,6 +10134,74 @@ mod tests {
             resolve_candle_video_route(&extend, &settings),
             CandleVideoRoute::WanVaceExtendBridge,
         );
+    }
+
+    /// sc-10997 (epic 6562): the candle Bernini VIDEO lane routes t2v + every editing/reference/
+    /// multi-source mode to `CandleVideoRoute::Bernini` (a DISTINCT engine, NOT the generic wan/ltx
+    /// txt2video arm), and only when the backend-candle flag is on. This per-mode dispatch is the
+    /// story's validation (GPU-val is gated on the `SceneWorks/bernini-candle` weights, sc-11003).
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    #[test]
+    fn candle_video_route_bernini_every_mode() {
+        let mut settings = Settings::from_env();
+        settings.backend_candle_enabled = true;
+        let engine = candle_bernini_engine_id("bernini").expect("bernini engine id");
+        for mode in [
+            "text_to_video",
+            "video_to_video",
+            "reference_to_video",
+            "reference_video_to_video",
+            "multi_video_to_video",
+            "ads2v",
+        ] {
+            let req = request(json!({ "projectId": "p", "model": "bernini", "mode": mode }));
+            assert_eq!(
+                resolve_candle_video_route(&req, &settings),
+                CandleVideoRoute::Bernini(engine),
+                "bernini {mode} must route to CandleVideoRoute::Bernini",
+            );
+        }
+        // Backend-candle off → Stub (routing unchanged until the flag is set), even for bernini.
+        settings.backend_candle_enabled = false;
+        let off = request(json!({
+            "projectId": "p", "model": "bernini", "mode": "text_to_video",
+        }));
+        assert_eq!(
+            resolve_candle_video_route(&off, &settings),
+            CandleVideoRoute::Stub,
+        );
+    }
+
+    /// sc-10997: the candle Bernini engine id + the SceneWorks-mode → engine `video_mode` task mapping,
+    /// the byte-identical twin of the MLX `bernini_engine_id` / `bernini_engine_video_mode`.
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    #[test]
+    fn candle_bernini_engine_id_and_video_mode_mapping() {
+        assert_eq!(candle_bernini_engine_id("bernini"), Some("bernini"));
+        // The still `bernini_image` id + every other video family keep their own routing.
+        assert_eq!(candle_bernini_engine_id("bernini_image"), None);
+        assert_eq!(candle_bernini_engine_id("wan_2_2"), None);
+        assert_eq!(candle_bernini_engine_id("scail2_14b"), None);
+        assert_eq!(candle_bernini_engine_id(""), None);
+
+        assert_eq!(candle_bernini_engine_video_mode("text_to_video"), "t2v");
+        assert_eq!(candle_bernini_engine_video_mode("video_to_video"), "v2v");
+        assert_eq!(
+            candle_bernini_engine_video_mode("reference_to_video"),
+            "r2v"
+        );
+        assert_eq!(
+            candle_bernini_engine_video_mode("reference_video_to_video"),
+            "rv2v"
+        );
+        assert_eq!(
+            candle_bernini_engine_video_mode("multi_video_to_video"),
+            "mv2v"
+        );
+        assert_eq!(candle_bernini_engine_video_mode("ads2v"), "ads2v");
+        // Unknown / image_to_video ⇒ plain t2v (the renderer is text-conditioned Wan2.2-T2V).
+        assert_eq!(candle_bernini_engine_video_mode("image_to_video"), "t2v");
+        assert_eq!(candle_bernini_engine_video_mode(""), "t2v");
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
## What

Wires the video `bernini` id (engine id `bernini`, VIDEO modality) through the **candle** worker — the Windows/CUDA VIDEO sibling of the MLX `generate_bernini`, and the companion to the still lane flipped in **sc-10996** (#1434). This is the VIDEO half of epic 6562.

**No pin bump.** SceneWorks `main` already pins `candle-gen` c26c6fb (#1434), which ships the full `candle-gen-bernini` generator with all source-conditioning modes (sc-11004) + the planner pipeline (sc-10995). This story only wires SceneWorks routing + per-mode lane dispatch. Diff is confined to `video_jobs.rs` + `catalog.rs`/`candle.rs` + tests (plus a one-word `pub(crate)` on the shared weights resolver).

## Per-mode routing (t2v / edit / reference / mv2v / ads2v)

Flipping `candle_video_routed` alone would only make **t2v** eligible — the generic `video_request_candle_eligible` gate admits `text_to_video` only and rejects any source/reference shape. Bernini's editing/reference/multi-source modes therefore get a **dedicated** gate, exactly like the image lane's dedicated `bernini_image` edit branch:

- **`bernini_video_candle_eligible`** (candle.rs) — mirrors `video_mode_is_mlx_eligible(bernini, ..)` exactly: `text_to_video`, `video_to_video` (v2v edit), `reference_to_video` (r2v), `reference_video_to_video` (rv2v), `multi_video_to_video` (mv2v), `ads2v`. OR-ed into `video_job_is_candle_eligible`'s `VideoGenerate` arm.
- **`CandleVideoRoute::Bernini`** (video_jobs.rs) — routed on the model id **before** the generic wan/ltx `is_candle_video_engine` arm (Bernini is a distinct engine, not a wan/ltx id). `generate_candle_bernini` maps the SceneWorks mode → engine `video_mode` task and assembles the planner conditioning (`resolve_candle_bernini_conditioning`: source clips → `VideoClip`, reference images → `MultiReference`, per-mode media enforced loud). `extract_clip_frames`' cfg widened to the candle lane so mv2v/ads2v load arbitrary clips by asset id.

**Note on "i2v":** Bernini's renderer is text-conditioned Wan2.2-T2V-A14B — it has **no classic still-image-to-video**. The story's "i2v"/"edit" framing maps onto `video_to_video`; the served mode set mirrors the MLX lane precisely (documented in the mode-mapping test).

## Weights

Reuses `image_jobs::resolve_candle_bernini_model_dir` (now `pub(crate)`) so video + still load the same `SceneWorks/bernini-candle` snapshot **dense** (`SCENEWORKS_CANDLE_BERNINI_DIR` → app-managed → HF turnkey). A missing snapshot fails **loud** at load — never a silent stub. Off-Mac packed-tier select is deferred with the still lane until the tier layout lands (sc-11003). An explicit `mlxQuantize` is recorded for lineage but does not push the job off candle (no torch Bernini to fall back to).

## Tests

- **core (`cargo test -p sceneworks-core`, green):** `bernini_video_candle_serves_every_mode_in_native_shape` (all six modes route to candle, through the full `video_job_is_candle_eligible` gate) + `bernini_video_candle_rejects_wrong_model_or_mode` + the `routed_model_lists_match_snapshot` EXPECTED-set update.
- **worker (`--features backend-candle`, green):** `candle_video_route_bernini_every_mode` (every mode → `CandleVideoRoute::Bernini`, and Stub when `backend_candle_enabled` is off) + `candle_bernini_engine_id_and_video_mode_mapping`.
- `cargo build -p sceneworks-worker --features backend-candle` green (MSVC 14.44, `CUDA_COMPUTE_CAP=120`). `cargo fmt --check` clean.

## GPU-val

**Pending sc-11003** — the real `SceneWorks/bernini-candle` weights are not yet published, so no GPU run here (no weights downloaded, no fake run). The per-mode **route-selection** tests are this story's validation; they prove each SceneWorks video mode resolves to the candle Bernini lane + dispatch under `backend-candle`.

sc-10997

🤖 Generated with [Claude Code](https://claude.com/claude-code)