### PR TITLE
fix(worker): repoint candle Bernini weights to SceneWorks/bernini + register repo (sc-11003, epic 6562)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -6504,6 +6504,24 @@
           // under bf16/ for the uniform tier layout (~81.6 GiB measured).
           "estimatedSizeBytes": 87591990679,
           "footprint": { "diskSizeBytes": 87591990679, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          // Windows/Linux candle (sc-10997 video / sc-10996 image, epic 6562): the candle `bernini`
+          // engine (candle-gen-bernini) reads a DISTINCT turnkey — the converted full-Bernini candle tree
+          // (transformer/ + transformer_2/ + text_encoder/ + vae/ + tokenizer/ + mllm/ + connector/ +
+          // vit_decoder/), a different tensor layout than the MLX `-mlx` repo — published PUBLIC at
+          // `SceneWorks/bernini` with bf16/Q8/Q4 tiers (sc-11003). Whole-repo download (empty files list);
+          // the candle worker resolves it by string from the HF cache (`CANDLE_BERNINI_REPO`,
+          // image_jobs/bernini.rs; overridable via SCENEWORKS_CANDLE_BERNINI_DIR), independent of
+          // `paths.model`, and the video lane reuses the same resolver. Without this entry the off-Mac
+          // candle Bernini lane dead-ended with no way to install the snapshot. Shared by bernini +
+          // bernini_image (one repo, HF cache dedupes). Loads dense today (the off-Mac packed-tier select
+          // is a follow-up). Size is the bf16 tier estimate (candle loads the converted tree dense).
+          "provider": "huggingface",
+          "repo": "SceneWorks/bernini",
+          "files": [],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 87591990679
         }
       ],
       "paths": {
@@ -6624,6 +6642,20 @@
           "platforms": ["macos"],
           "estimatedSizeBytes": 87591990679,
           "footprint": { "diskSizeBytes": 87591990679, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          // Windows/Linux candle (sc-10996, epic 6562): the SAME distinct candle turnkey the video `bernini`
+          // id installs — the converted full-Bernini candle tree published PUBLIC at `SceneWorks/bernini`
+          // with bf16/Q8/Q4 tiers (sc-11003), a different tensor layout than the MLX `-mlx` repo. Whole-repo
+          // download (empty files list); the candle worker's `resolve_candle_bernini_model_dir` resolves it
+          // by string from the HF cache (`CANDLE_BERNINI_REPO`, image_jobs/bernini.rs; overridable via
+          // SCENEWORKS_CANDLE_BERNINI_DIR), independent of `paths.model`. One repo shared with the video id
+          // (HF cache dedupes). Loads dense today (off-Mac packed-tier select is a follow-up).
+          "provider": "huggingface",
+          "repo": "SceneWorks/bernini",
+          "files": [],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 87591990679
         }
       ],
       "paths": {

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -4688,7 +4688,7 @@ mod candle_routing_tests {
         // sc-10997 (epic 6562): the candle Bernini VIDEO lane serves t2v + the editing/reference/
         // multi-source modes on the distinct `bernini` engine — the off-Mac parity of the MLX
         // `video_mode_is_mlx_eligible(bernini, mode)` gate. Each mode claims the candle lane (routed on
-        // id + mode; the worker validates the per-mode media + `SceneWorks/bernini-candle` weights loudly,
+        // id + mode; the worker validates the per-mode media + `SceneWorks/bernini` weights loudly,
         // sc-11003). The story's "i2v"/"edit" map onto Bernini's `video_to_video` — its Wan2.2-T2V
         // renderer has no classic still-image-to-video (mirrors the MLX lane's mode set exactly).
         for (mode, payload) in [

--- a/crates/sceneworks-core/src/jobs_store/routing/candle.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/candle.rs
@@ -591,7 +591,7 @@ pub(crate) fn scail2_replace_candle_eligible(model: &str, payload: &Map<String, 
 /// served modes), expressed as a candle-claim gate: `text_to_video` (base), `video_to_video` (v2v edit),
 /// `reference_to_video` (r2v), `reference_video_to_video` (rv2v), `multi_video_to_video` (mv2v), and
 /// `ads2v`. Routed on the model id + mode, not weight availability — the worker's dedicated
-/// `CandleVideoRoute::Bernini` dispatch resolves-or-errors loudly if the `SceneWorks/bernini-candle`
+/// `CandleVideoRoute::Bernini` dispatch resolves-or-errors loudly if the `SceneWorks/bernini`
 /// snapshot is unprovisioned (sc-11003), and validates the per-mode source media when it assembles the
 /// conditioning. No LoRA (the engine reports `supports_lora=false`); an explicit `mlxQuantize` is
 /// recorded for lineage but does NOT push the job off candle (the loader reads the converted tree dense,

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -646,7 +646,7 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
     // `bernini_image` `edit_image` branch in `image_job_is_candle_eligible` (a `sourceAssetId` edit, the
     // bespoke `generate_candle_bernini_image_stream` lane — like the MLX `bernini_image_mlx_eligible`).
     // NOT `candle_quant`: the descriptor advertises Q4/Q8, but the off-Mac packed-tier select is deferred
-    // until the `SceneWorks/bernini-candle` tier layout lands (sc-11003) — the candle lane loads the
+    // until the `SceneWorks/bernini` tier layout lands (sc-11003) — the candle lane loads the
     // converted snapshot dense today. The video `bernini` id lives in the video table below (still
     // MLX-only — no candle video route wired yet).
     ModelCaps::new("bernini_image", true, true, false, false, false),
@@ -731,7 +731,7 @@ pub(crate) const VIDEO_MODEL_CAPS: &[VideoModelCaps] = &[
     // rv2v / mv2v / ads2v) on both lanes; the candle worker routes those via the dedicated
     // `bernini_video_candle_eligible` gate + the `CandleVideoRoute::Bernini` dispatch (NOT the generic
     // wan/ltx txt2video arm — Bernini is a distinct engine). Not an i2v/VACE model, so those columns
-    // stay false. Off-Mac packed-tier select is deferred until the `SceneWorks/bernini-candle` tier
+    // stay false. Off-Mac packed-tier select is deferred until the `SceneWorks/bernini` tier
     // layout lands (sc-11003) — the candle lane loads the converted snapshot dense today.
     VideoModelCaps::new("bernini", true, true, false, false),
     // SCAIL-2 (epic 5439 / sc-5448): MLX end-to-end character animation; the candle SCAIL-2 engine

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1740,8 +1740,8 @@ candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # generator (`candle-gen-bernini/src/bernini.rs`, `gen_core::load("bernini")`) into the shared gen_core
 # inventory; force-linked in image_jobs.rs (`use candle_gen_bernini as _;`) and reached by the dedicated
 # `generate_candle_bernini_image_stream` (forces `frames:1` + `video_mode:"t2i"|"i2i"` so the engine
-# returns a single still). Weights = the converted `SceneWorks/bernini-candle` snapshot (sc-11003, not
-# yet published → GPU-val blocked). Same git rev as every candle-gen provider above (c26c6fb = candle-gen
+# returns a single still). Weights = the converted `SceneWorks/bernini` snapshot (sc-11003, published
+# PUBLIC with bf16/Q8/Q4 tiers). Same git rev as every candle-gen provider above (c26c6fb = candle-gen
 # main HEAD, the merged #421 planner-components commit — contains the #419 full generator sc-10995) — its
 # gen-core pin (951227a) MATCHES the worker's mlx pin, so `--features backend-candle --target all`
 # resolves ONE gen-core rev (no skew).

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -328,7 +328,7 @@ fn resolve_candle_image_route(
         // generic `is_candle_engine` txt2img arm below — `bernini_image` is NOT an `is_candle_engine` id
         // (its engine is `Modality::Video`, reached with `frames:1`), so it would otherwise fall through
         // to `None` and stub. Routed on the model id alone (like the sdxl txt2img arm) — a missing
-        // `SceneWorks/bernini-candle` snapshot fails loud at load, never silently stubs (the MLX
+        // `SceneWorks/bernini` snapshot fails loud at load, never silently stubs (the MLX
         // `ImageRoute::Bernini` weight-gates instead only because it must fall through to `mlx_available`).
         Some(CandleImageRoute::Bernini)
     } else if is_candle_engine(&request.model)

--- a/crates/sceneworks-worker/src/image_jobs/bernini.rs
+++ b/crates/sceneworks-worker/src/image_jobs/bernini.rs
@@ -304,7 +304,7 @@ async fn generate_bernini_image_stream(
 // `generate_candle_stream` txt2img lane. Shares the neutral harness (`load_spec` /
 // `start_cached_gen_stream` / `drive_gen_items` / `bernini_image_generate_one` / `consume_gen_events`)
 // and the backend-neutral resolvers (`resolve_steps` / `resolve_guidance` / `resolve_negative_prompt`)
-// with the MLX path. GPU-val is BLOCKED on the converted `SceneWorks/bernini-candle` weights (sc-11003,
+// with the MLX path. GPU-val is BLOCKED on the converted `SceneWorks/bernini` weights (sc-11003,
 // the 168 GB conversion, not yet published), so this delivers routing + lane wiring; a missing snapshot
 // fails loud at load (never a silent stub).
 // ---------------------------------------------------------------------------
@@ -318,9 +318,9 @@ const CANDLE_BERNINI_IMAGE_ADAPTER: &str = "candle_bernini";
 /// The turnkey candle Bernini snapshot repo (sc-11003): the converted full-Bernini tree (`transformer/`
 /// `transformer_2/` `text_encoder/` `vae/` `tokenizer/` `mllm/` `connector/` `vit_decoder/`) the
 /// `candle-gen-bernini` `load` reads. Distinct from the MLX `SceneWorks/bernini-mlx` turnkey (different
-/// tensor layout). NOT yet published — GPU-val is blocked on it (sc-11003).
+/// tensor layout). Published PUBLIC at `SceneWorks/bernini` with bf16/Q8/Q4 tiers (sc-11003).
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-const CANDLE_BERNINI_REPO: &str = "SceneWorks/bernini-candle";
+const CANDLE_BERNINI_REPO: &str = "SceneWorks/bernini";
 
 /// True when this is a candle Bernini still-image job: the `bernini_image` id. Routed on the model id
 /// alone (like the sdxl candle txt2img arm) — NOT weight-gated — so a missing snapshot fails loud at
@@ -332,7 +332,7 @@ fn bernini_image_candle_available(request: &ImageRequest) -> bool {
 }
 
 /// Resolve the candle Bernini snapshot dir: `SCENEWORKS_CANDLE_BERNINI_DIR` override → app-managed
-/// `<data>/models/candle/bernini` → the turnkey `SceneWorks/bernini-candle` HF snapshot. Sentinel = the
+/// `<data>/models/candle/bernini` → the turnkey `SceneWorks/bernini` HF snapshot. Sentinel = the
 /// `transformer/` subdir (the converted renderer's first DiT expert; the `candle-gen-bernini` `load`
 /// validates the full component set and reports the precise gap). Errors loudly when absent — like the
 /// candle SCAIL-2 / Wan-VACE resolvers, a missing checkpoint surfaces a clear re-download error instead
@@ -367,7 +367,7 @@ pub(crate) fn resolve_candle_bernini_model_dir(settings: &Settings) -> WorkerRes
 
 /// Real candle Bernini still-image generation (sc-10996, epic 6562): the off-Mac sibling of
 /// [`generate_bernini_image_stream`]. Loads the full candle planner+renderer once from the converted
-/// `SceneWorks/bernini-candle` snapshot (dense — the candle loader reads the converted tree as-is), then
+/// `SceneWorks/bernini` snapshot (dense — the candle loader reads the converted tree as-is), then
 /// one image per seed: t2i from the prompt alone, or i2i conditioned on the `sourceAssetId` source (the
 /// engine ViT/VAE-encodes it at native resolution, no worker-side fit). Forces `frames:1` + the engine
 /// task string so the video-modality engine returns a single still. Standard guidance family (no LoRA;
@@ -410,7 +410,7 @@ async fn generate_candle_bernini_image_stream(
     let task = bernini_image_engine_task(&request.mode);
     // Requested tier bits (advanced `mlxQuantize`) recorded for lineage only — the candle lane loads the
     // converted snapshot DENSE (the loader reads the tree as-is; the descriptor advertises Q4/Q8 but the
-    // off-Mac packed-tier select is a follow-up once the `bernini-candle` tier layout lands, sc-11003).
+    // off-Mac packed-tier select is a follow-up once the `SceneWorks/bernini` tier layout lands, sc-11003).
     let tier_bits = request
         .advanced
         .get("mlxQuantize")

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -4521,7 +4521,7 @@ fn candle_image_route_gates_on_flag_then_pose_reject_then_txt2img() {
 // (`CandleImageRoute::Bernini` → `generate_candle_bernini_image_stream`), NOT the generic txt2img arm
 // (the engine is `Modality::Video`, so `bernini_image` is not an `is_candle_engine` id). Routed on the
 // model id alone (no staged weights), the candle sibling of the MLX `ImageRoute::Bernini` arm — this is
-// the dispatch proof for the story (GPU-val is blocked on the `SceneWorks/bernini-candle` weights,
+// the dispatch proof for the story (GPU-val is blocked on the `SceneWorks/bernini` weights,
 // sc-11003).
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 #[test]

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -301,7 +301,7 @@ fn resolve_candle_video_route(request: &VideoRequest, settings: &Settings) -> Ca
         // the editing/reference/multi-source modes (v2v / r2v / rv2v / mv2v / ads2v). A DISTINCT engine
         // (`gen_core::load("bernini")`), NOT a wan/ltx `is_candle_video_engine` id, so it is routed off the
         // model id BEFORE the generic candle-video arm below. Routed by model id, not weight availability —
-        // `generate_candle_bernini` resolves-or-errors loudly if the `SceneWorks/bernini-candle` snapshot is
+        // `generate_candle_bernini` resolves-or-errors loudly if the `SceneWorks/bernini` snapshot is
         // unprovisioned (sc-11003), never degrading to a stub. The per-mode source media is validated when
         // the conditioning is assembled (`resolve_candle_bernini_conditioning`), mirroring the MLX lane.
         CandleVideoRoute::Bernini(engine_id)
@@ -690,7 +690,7 @@ pub(crate) async fn run_video_generate_job(
                 // the planner conditioning (`resolve_candle_bernini_conditioning`) — empty for t2v, one or
                 // more `VideoClip`s for the edit modes, `MultiReference` for the reference modes. The off-Mac
                 // sibling of the macOS `generate_bernini`; resolves-or-errors loudly (no torch fallback — a
-                // distinct candle engine, GPU-val gated on the `SceneWorks/bernini-candle` weights, sc-11003).
+                // distinct candle engine, GPU-val gated on the `SceneWorks/bernini` weights, sc-11003).
                 let decoded = generate_candle_bernini(
                     api,
                     settings,
@@ -6654,9 +6654,9 @@ async fn generate_bernini(
 // from dropping the registration). Serves `text_to_video` + the editing/reference/multi-source video
 // modes (v2v / r2v / rv2v / mv2v / ads2v); `generate_candle_bernini` maps the SceneWorks mode to the
 // engine guidance task and resolves the source media into the planner conditioning. Loads the converted
-// `SceneWorks/bernini-candle` snapshot DENSE (the candle loader reads the tree as-is; the off-Mac
-// packed-tier select is deferred WITH the still lane until the `bernini-candle` tier layout lands —
-// GPU-val is gated on sc-11003, the not-yet-published weights). No LoRA (the engine reports
+// `SceneWorks/bernini` snapshot DENSE (the candle loader reads the tree as-is; the off-Mac
+// packed-tier select is deferred WITH the still lane until the `SceneWorks/bernini` tier layout lands —
+// GPU-val is gated on sc-11003). No LoRA (the engine reports
 // `supports_lora=false`). A distinct candle engine — NO torch fallback (a missing snapshot fails loud
 // at load, never a silent stub).
 // ---------------------------------------------------------------------------
@@ -6816,7 +6816,7 @@ async fn resolve_candle_bernini_conditioning(
 /// shared [`generate_video`] path. The SceneWorks mode resolves to the engine `video_mode` task
 /// ([`candle_bernini_engine_video_mode`]) and the source media into the planner conditioning
 /// ([`resolve_candle_bernini_conditioning`]) — empty for t2v, one or more `VideoClip`s for
-/// v2v/mv2v/rv2v/ads2v, and `MultiReference` for r2v/rv2v/ads2v. The converted `SceneWorks/bernini-candle`
+/// v2v/mv2v/rv2v/ads2v, and `MultiReference` for r2v/rv2v/ads2v. The converted `SceneWorks/bernini`
 /// snapshot loads DENSE (no load-time quant — the off-Mac packed-tier select is deferred with the still
 /// lane, sc-11003), resolved via the shared [`crate::image_jobs::resolve_candle_bernini_model_dir`] so
 /// video + still load from the same tier. No LoRA (the engine reports `supports_lora=false`); steps /
@@ -10139,7 +10139,7 @@ mod tests {
     /// sc-10997 (epic 6562): the candle Bernini VIDEO lane routes t2v + every editing/reference/
     /// multi-source mode to `CandleVideoRoute::Bernini` (a DISTINCT engine, NOT the generic wan/ltx
     /// txt2video arm), and only when the backend-candle flag is on. This per-mode dispatch is the
-    /// story's validation (GPU-val is gated on the `SceneWorks/bernini-candle` weights, sc-11003).
+    /// story's validation (GPU-val is gated on the `SceneWorks/bernini` weights, sc-11003).
     #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
     #[test]
     fn candle_video_route_bernini_every_mode() {


### PR DESCRIPTION
## What

The candle Bernini turnkey is published PUBLIC at **`SceneWorks/bernini`** (bf16/Q8/Q4 tiers), not the placeholder `SceneWorks/bernini-candle`. This repoints the SceneWorks worker + registers the repo so the cache-only resolver can auto-download it off-Mac.

- `crates/sceneworks-worker/src/image_jobs/bernini.rs` — `resolve_candle_bernini_model_dir` (`CANDLE_BERNINI_REPO`) default HF repo id changed `SceneWorks/bernini-candle` → `SceneWorks/bernini`. Env override (`SCENEWORKS_CANDLE_BERNINI_DIR`) + app-managed path logic unchanged. The **video lane (sc-10997) reuses this same resolver**, so one change covers both image + video.
- Updated every remaining `bernini-candle` doc reference across the worker + core routing (base.rs, tests.rs, video_jobs.rs, jobs_store.rs, routing/candle.rs, routing/catalog.rs, worker Cargo.toml comment) — no `bernini-candle` string remains anywhere in the repo.
- `config/manifests/builtin.models.jsonc` — registered `SceneWorks/bernini` on **both** the `bernini` (video) and `bernini_image` entries as a Windows/Linux candle download with an **empty files list** (whole-repo, per the model-download convention), mirroring the `wan_2_2_vace_fun_14b` off-Mac candle download pattern. Without this the off-Mac candle Bernini lane had no way to install the snapshot.

No `Cargo.toml`/`Cargo.lock` pin lines touched (non-pin diff — no merge treadmill).

## Tests
- `cargo check -p sceneworks-worker --features backend-candle` (vcvars 14.44, CUDA_COMPUTE_CAP=120) — green
- `cargo test -p sceneworks-core` — 32 passed (routing/catalog snapshots green)
- `node scripts/check-scaffold.mjs` — passed
- `node scripts/check-no-nc-weights.mjs` — passed
- `cargo fmt --check` on sceneworks-worker + sceneworks-core — clean

Story: sc-11003 (epic 6562)

🤖 Generated with [Claude Code](https://claude.com/claude-code)