### PR TITLE
feat(worker): fit-gate wires sequential residency for the krea_2 family; pin-bump mlx-gen 592419c + candle-gen lockstep (sc-11101, epic 10834)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -570,7 +570,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-gen",
  "image",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -768,7 +768,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -805,7 +805,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -816,7 +816,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -829,7 +829,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -840,7 +840,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -853,7 +853,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f08051c3c22fa7b70c9f35ac63db14b6056192b1#f08051c3c22fa7b70c9f35ac63db14b6056192b1"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -3689,7 +3689,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3703,7 +3703,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "image",
  "inventory",
@@ -3716,7 +3716,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "image",
  "inventory",
@@ -3730,7 +3730,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "image",
  "inventory",
@@ -3744,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3758,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3769,7 +3769,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3787,7 +3787,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3801,7 +3801,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3814,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3827,7 +3827,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3839,7 +3839,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3849,7 +3849,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "image",
  "inventory",
@@ -3862,7 +3862,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "image",
  "inventory",
@@ -3877,7 +3877,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "image",
  "inventory",
@@ -3891,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "image",
  "inventory",
@@ -3903,7 +3903,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3914,7 +3914,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3926,7 +3926,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3938,7 +3938,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3947,7 +3947,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3956,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3966,7 +3966,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3978,7 +3978,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "image",
  "inventory",
@@ -3993,7 +3993,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "image",
  "inventory",
@@ -4007,7 +4007,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4030,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4041,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "image",
  "inventory",
@@ -4055,7 +4055,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "image",
  "inventory",
@@ -5889,7 +5889,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a#ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=592419ca926d58dfb4f888228a2c4c04c839e806#592419ca926d58dfb4f888228a2c4c04c839e806"
 dependencies = [
  "core-llm",
  "inventory",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -534,7 +534,7 @@ sceneworks-core = { path = "../sceneworks-core" }
 # reports exactly one). NOTE: this bump FIXES a live bug — on 6a10ae1, every Anima LoRA/LoKr failed at
 # model load, because the worker defaults spec.quantize to Some(Q8) for every MLX model and mlx-gen-anima
 # rejected quant+adapter together. See test `anima_default_tier_with_adapter_builds_loadable_spec`.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -896,7 +896,15 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # e59ffd88 -> b6e4e56 (the opt-in gradient-checkpointing primitive lives partly in the
 # fork — mlx-rs PR #8 / sc-4874), so the direct `mlx-rs` pin below MUST track it in
 # lockstep or the worker links two incompatible `Exception`/`Error` types.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+# Bumped `ab46fcb` -> `592419c` (sc-11101, epic 10834): mlx-gen #700 wires the WHOLE krea_2 family
+# (krea_2_turbo/raw/edit/turbo_control) into MLX sequential component residency — KreaPipeline split into
+# KreaText (tok + Qwen3-VL-4B TE + vision) + KreaHeavy (DiT + VAE), `Residency` on Krea + KreaTurboControl
+# (the pose branch stays heavy-side). PURE mlx-gen-krea provider Rust; `git diff ab46fcb..592419c --
+# gen-core/ gen-core-testkit/` is EMPTY (gen-core byte-identical), so the candle-gen pin below moves in
+# lockstep to f2ec6e3 (candle-gen #428, which re-pins gen-core to THIS 592419c) and the skew gate resolves
+# ONE gen-core rev on BOTH lanes. Real-weight A/B (byte-identical): turbo 22.4->18.1, raw 22.0->18.1, edit
+# 25.7->20.2 (Q8), control 42.8->35.5 GiB (bf16). Adds the 4 krea ids to SEQUENTIAL_CAPABLE_ENGINES below.
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -912,23 +920,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7c
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -936,7 +944,7 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fc
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
 # mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
 # mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
@@ -944,7 +952,7 @@ mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcb
 # conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
 # DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
 # generator-cache load path drives.
-mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # Anima 2B anime t2i provider (native MLX, CircleStone Labs Non-Commercial License v1.2; epic 10512,
 # sc-10523). Same git rev as mlx-gen so MLX builds once. Self-registers `anima_base` / `anima_aesthetic`
 # / `anima_turbo` (Cosmos-Predict2 DiT + Qwen3-0.6B T5-query-token adapter conditioner + Qwen-Image VAE)
@@ -953,59 +961,59 @@ mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fc
 # scheduler (sc-10519) and strong prompt-weighting on the T5 query tokens (sc-10566). Carries the
 # install-time q4/q8/bf16 converter the model_jobs.rs Anima path drives (sc-10517). Pinned to merged
 # mlx-gen main 6a10ae1 (PR #680), which carries both the Anima crate and gen-core's is_hidden_file.
-mlx-gen-anima = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-anima = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -1014,19 +1022,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fc
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -1035,7 +1043,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46f
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -1043,7 +1051,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "a
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -1054,7 +1062,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -1065,7 +1073,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46f
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -1087,7 +1095,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fc
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -1098,7 +1106,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab4
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -1130,7 +1138,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46fcbfd7ccdade605d65dfe8e6cb97dd51d21a" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "592419ca926d58dfb4f888228a2c4c04c839e806" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1652,15 +1660,22 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "ab46
 # satisfied with NO mlx-gen move. `e350e9b` is a direct descendant of the `c26c6fb`/#421 pin (adds only
 # #422). Drives the flux2_klein_9b `candle` block to measured:true (q4 46.2/24.2, q8 50.6/28.7, bf16 75.5/
 # 53.3, all GPU-measured on sm_120). Worker backend-candle check --locked green.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+# Bumped candle-gen `f08051c` -> `f2ec6e3` (sc-11101, epic 10834): candle-gen #428 re-pins gen-core to the
+# mlx-gen krea-residency rev `592419c` (the mlx-gen block above), so the worker's `--features
+# backend-candle` skew gate resolves ONE gen-core rev. `git diff f08051c..f2ec6e3 -- gen-core/
+# gen-core-testkit/` is EMPTY (gen-core byte-identical); the f08051c..f2ec6e3 range also catches candle-gen
+# up to main (candle-gen #425 shared-core AdaptLinear + #426 CI + #427 krea_2_edit Generator registration),
+# all additive candle-provider work with no worker-surface change. ALL mlx-gen-* + candle-gen-* pins move
+# together; backend-candle check --locked green.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1674,7 +1689,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1682,17 +1697,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1702,7 +1717,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1710,21 +1725,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1733,7 +1748,7 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # Candle Bernini still-image companion (sc-10996, epic 6562) — the Windows/CUDA sibling of
 # `mlx-gen-bernini`, built ON candle-gen-wan (the full Qwen2.5-VL/MAR semantic planner driving a
 # Wan2.2-A14B dual-expert renderer, `frames:1` for a single still). Self-registers the full `bernini`
@@ -1745,17 +1760,17 @@ candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # main HEAD, the merged #421 planner-components commit — contains the #419 full generator sc-10995) — its
 # gen-core pin (951227a) MATCHES the worker's mlx pin, so `--features backend-candle --target all`
 # resolves ONE gen-core rev (no skew).
-candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1764,7 +1779,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1797,7 +1812,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1806,12 +1821,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1819,7 +1834,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f0805
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1828,7 +1843,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1836,7 +1851,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1850,7 +1865,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1877,7 +1892,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1888,7 +1903,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f08051c3c22fa7b70c9f35ac63db14b6056192b1", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/mlx_fit_gate.rs
+++ b/crates/sceneworks-worker/src/mlx_fit_gate.rs
@@ -53,6 +53,10 @@ const SEQUENTIAL_CAPABLE_ENGINES: &[&str] = &[
     "qwen_image_control",
     "lens",
     "lens_turbo",
+    "krea_2_turbo",
+    "krea_2_raw",
+    "krea_2_edit",
+    "krea_2_turbo_control",
 ];
 
 /// Whether `engine_id`'s provider drops components in phase order under [`OffloadPolicy::Sequential`].
@@ -581,6 +585,13 @@ mod tests {
         // loader — see mlx-gen-lens `with_selected_layers`.
         assert!(engine_supports_sequential("lens"));
         assert!(engine_supports_sequential("lens_turbo"));
+        // The sc-11101 fan-out wired the WHOLE krea_2 family (one crate, TE < DiT — the qwen pattern):
+        // turbo/raw/edit (Q8, 22→18 / 26→20 GiB at 768²) + turbo_control (bf16, 43→35 GiB). The control
+        // branch's `spec.control` bytes are already counted by the fit-gate (sc-11006).
+        assert!(engine_supports_sequential("krea_2_turbo"));
+        assert!(engine_supports_sequential("krea_2_raw"));
+        assert!(engine_supports_sequential("krea_2_edit"));
+        assert!(engine_supports_sequential("krea_2_turbo_control"));
         // Not-yet-wired providers must NOT be offered sequential (they'd ignore it and SIGKILL).
         assert!(!engine_supports_sequential("z_image_turbo_control"));
         assert!(!engine_supports_sequential("flux"));


### PR DESCRIPTION
## What

Completes the sc-11101 3-repo lockstep (epic 10834 Phase 1 fan-out, umbrella sc-10840). Adds the **whole krea_2 MLX family** — `krea_2_turbo`, `krea_2_raw`, `krea_2_edit`, `krea_2_turbo_control` — to `SEQUENTIAL_CAPABLE_ENGINES`, so the MLX unified-memory fit-gate selects `OffloadPolicy::Sequential` when the predicted resident peak won't fit.

mlx-gen [#700](https://github.com/SceneWorks/mlx-gen/pull/700) wired the provider side: `KreaPipeline` split into `KreaText` (tok + Qwen3-VL-4B TE + vision) + `KreaHeavy` (single-stream DiT + Qwen-Image VAE), with `Residency::{Resident,Sequential}` on `Krea` (turbo/raw/edit) and `KreaTurboControl` (the pose `Krea2ControlBranch` stays heavy-side, the qwen-control precedent). Krea's TE (~4B) < the 12B DiT — the qwen-image pattern, no gpt-oss consuming-loader gotcha.

The sc-11006 fit-gate `spec.control`-bytes accounting already counts `krea_2_turbo_control`'s overlay, so **no new gate work**.

## Real-weight A/B (byte-identical + peak-bounded)

| engine | tier | Resident → Sequential | saved |
|---|---|---|---|
| `krea_2_turbo` | Q8 768²/8-step | 22.36 → 18.14 GiB | −18.9% |
| `krea_2_raw` (full CFG) | Q8 768²/12-step | 22.02 → 18.14 GiB | −17.6% |
| `krea_2_edit` (grounded + LoRA) | Q8 768²/8-step | 25.65 → 20.22 GiB | −21.2% |
| `krea_2_turbo_control` (pose) | bf16 768²/8-step | 42.77 → 35.46 GiB | −17.1% |

## Pin bumps (3-repo lockstep)

- **mlx-gen** `ab46fcb → 592419c` (#700)
- **candle-gen** `f08051c → f2ec6e3` (#428 — re-pins gen-core to `592419c`; also catches candle-gen up to main: #425 shared-core AdaptLinear + #426 CI + #427 krea_2_edit Generator registration, all additive candle-provider work with no worker-surface change)

`git diff` of `gen-core/` across both ranges is **empty** (byte-identical). The skew gate resolves ONE gen-core rev (`592419c`) on both the default and `--features backend-candle` lanes; `cargo fmt --check` clean; `mlx_fit_gate` allowlist test updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)