### PR TITLE
fix(worker): Krea MLX pose lane loads the hosted candle overlay directly (sc-8465)

### DIFF
--- a/config/manifests/builtin.control_overlays.jsonc
+++ b/config/manifests/builtin.control_overlays.jsonc
@@ -33,23 +33,16 @@
         "provider": "huggingface",
         "repo": "SceneWorks/krea2-pose-controlnet-beta",
         // Pinned for defense-in-depth (parity with the worker's KREA_CONTROL_OVERLAY_REVISION) so a repo
-        // re-push can't swap the checkpoint under the cache install-state probe. `file` is the candle-lane
-        // artifact; the MLX lane resolves its own sibling `control_step5000.mlx.safetensors` (below).
+        // re-push can't swap the checkpoint under the cache install-state probe.
         "revision": "cb3a0ac7590f5ec594a4eeb43b95ee1da0b5a0ac",
         "file": "control_step5000.safetensors"
       },
-      // Both backend artifacts live in the one repo (the entry is backend-NEUTRAL — `controlEngine`
-      // `krea_2_turbo_control` covers both lanes; the OS/feature cfg picks the provider). The candle lane
-      // (`krea_control_candle.rs`) loads `control_step5000.safetensors`; the macOS MLX lane
-      // (`krea_control.rs`, sc-8465 S5) loads `control_step5000.mlx.safetensors` — the epic-5594
-      // convert-once twin (candle `*.weight_p1` RMSNorm scales un-folded to the raw `*.weight` MLX
-      // re-folds at load; `examples/krea-control-convert.rs`). The MLX file is re-hosted alongside the
-      // candle one; bump `revision` to the commit that carries it once uploaded (currently the candle-only
-      // commit above — the MLX worker lane resolves the file from `main` until then).
-      "files": [
-        "control_step5000.safetensors",
-        "control_step5000.mlx.safetensors"
-      ],
+      // One artifact, both backends: the entry is backend-NEUTRAL (`controlEngine` `krea_2_turbo_control`
+      // covers both lanes; the OS/feature cfg picks the provider). The candle lane (`krea_control_candle.rs`)
+      // AND the macOS MLX lane (`krea_control.rs`, sc-8465 S5) both load THIS `control_step5000.safetensors`
+      // — the MLX branch reads the candle checkpoint DIRECTLY (mlx-gen `RmsScale` accepts the candle
+      // `*.weight_p1` norm convention verbatim), so there is no separate MLX artifact to host.
+      "files": ["control_step5000.safetensors"],
       "provenance": {
         "epic": "8459",
         "story": "8466",

--- a/crates/sceneworks-worker/src/image_jobs/krea_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control.rs
@@ -35,12 +35,16 @@ const KREA_CONTROL_BASE_ENV: &str = "SCENEWORKS_KREA_CONTROL_BASE";
 /// Env override → a converted MLX control-branch overlay `.safetensors` (validation / bring-your-own).
 const KREA_CONTROL_WEIGHTS_ENV: &str = "SCENEWORKS_CONTROLNET_KREA";
 /// Default published Krea pose control-branch overlay repo (sc-8466) — the S0 spike (5,000-step)
-/// checkpoint. The MLX file is the epic-5594 convert-once artifact re-hosted alongside the candle
-/// `.safetensors` (a sibling `.mlx.safetensors` in the same repo). EXPERIMENTAL / not-for-production.
+/// checkpoint. EXPERIMENTAL / not-for-production.
 const KREA_CONTROL_OVERLAY_REPO: &str = "SceneWorks/krea2-pose-controlnet-beta";
-/// The MLX overlay file within [`KREA_CONTROL_OVERLAY_REPO`] — the converted twin of the candle
-/// `control_step5000.safetensors` (RMSNorm scales un-folded to the raw `*.weight` MLX re-folds at load).
-const KREA_CONTROL_OVERLAY_FILE: &str = "control_step5000.mlx.safetensors";
+/// The overlay file within [`KREA_CONTROL_OVERLAY_REPO`] — the SAME candle `control_step5000.safetensors`
+/// the candle lane loads. The MLX branch reads it DIRECTLY (mlx-gen `RmsScale` accepts the candle
+/// `*.weight_p1` norm convention verbatim, sc-8465), so there is no separate MLX artifact to host.
+const KREA_CONTROL_OVERLAY_FILE: &str = "control_step5000.safetensors";
+/// Pinned revision for the default overlay repo (defense-in-depth, parity with the candle lane's
+/// `KREA_CONTROL_OVERLAY_REVISION` — a repo re-push can't swap the checkpoint under us). Applied ONLY to
+/// the default repo; a `controlWeights.repo` override keeps `main`.
+const KREA_CONTROL_OVERLAY_REVISION: &str = "cb3a0ac7590f5ec594a4eeb43b95ee1da0b5a0ac";
 
 /// Model ids the MLX Krea strict-pose control route accepts (the deployed base the overlay applies on).
 fn is_krea_control_model(model: &str) -> bool {
@@ -176,7 +180,14 @@ async fn ensure_krea_control_weights(
         .join("cache")
         .join("controlnet-krea")
         .join(&file);
-    ensure_hf_cached_file(&context, &repo, "main", &file, &dst).await?;
+    // Pin the exact commit for the default overlay repo so `main` moving under us can't swap the
+    // checkpoint (parity with the candle lane); a `controlWeights.repo` override carries its own layout.
+    let revision = if repo == KREA_CONTROL_OVERLAY_REPO {
+        KREA_CONTROL_OVERLAY_REVISION
+    } else {
+        "main"
+    };
+    ensure_hf_cached_file(&context, &repo, revision, &file, &dst).await?;
     Ok(dst)
 }
 


### PR DESCRIPTION
The **last piece of epic 8459 S5**. The mlx-gen pin now carries native-load (SceneWorks/mlx-gen#699), so the macOS Krea pose-ControlNet lane can read the candle checkpoint directly — mlx-gen's `RmsScale` accepts the candle `*.weight_p1` norm convention verbatim, no convert step.

## What changed
- `krea_control.rs`: `KREA_CONTROL_OVERLAY_FILE` → `control_step5000.safetensors` — the **same already-hosted file the candle lane loads** — instead of the never-hosted converted `control_step5000.mlx.safetensors`. Added a revision pin (`cb3a0ac`, parity with the candle lane's `KREA_CONTROL_OVERLAY_REVISION`) so a repo re-push can't swap the checkpoint under the cache probe; a `controlWeights.repo` override keeps `main`.
- `builtin.control_overlays.jsonc`: dropped the phantom `.mlx` sibling from `files[]` + the stale convert commentary — one candle artifact serves both backends now.

## Why this was needed
The engine (#697) and native-load (#699) were already in the pinned mlx-gen rev via the lockstep churn, but the worker still named the converted `.mlx` file that was deliberately never hosted — so a Krea pose job would have 404'd on its overlay (unreachable for normal users behind the base-resolution gate, but not actually functional). This flip closes that gap.

## Net result
Krea 2 Turbo pose control is now functional end-to-end on Apple Silicon — **no convert step, no separate MLX artifact, no HF re-host.** The one hosted candle overlay serves both the candle and MLX lanes.

## Verification
- `cargo check` / `clippy -D warnings` / `fmt --check` on `sceneworks-worker`, against the current pin (`592419ca`, which includes #697 + #699).
- The load+generate path is proven on real weights by mlx-gen's `krea_control_smoke`: loading this exact candle overlay directly renders a clean pose-locked T-pose at `control_scale 0.6` and a base passthrough at `0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)