### PR TITLE
feat(web): canvas Image Editor auto-applies the Krea edit LoRA (Studio parity) (sc-11069)

### DIFF
--- a/apps/web/src/imageJobs.js
+++ b/apps/web/src/imageJobs.js
@@ -4,6 +4,8 @@
 // editor is deliberately lazy-loaded to keep konva off the main/test path). ImageEditor.jsx
 // re-exports these so its public surface (and its tests) are unchanged.
 
+import { serializeLora } from "./presetUtils.js";
+
 // Models that can edit an existing image with a prompt — the manifest tags them
 // with an `edit_image`/`image_edit` capability (same filter the Image Studio uses).
 export function editCapableModels(imageModels) {
@@ -36,6 +38,7 @@ export function buildEditJobBody({
   height,
   fitMode = "crop",
   loras = null,
+  editLora = null,
   guidanceScale = null,
 }) {
   // Guidance override (sc-10275): only sent when the user set a finite value —
@@ -66,7 +69,17 @@ export function buildEditJobBody({
   };
   // Style/subject LoRAs (sc-10254): serialized top-level, same shape + resolver the
   // generation path uses (serializeLora → worker resolve_adapters). Omitted when empty.
-  if (loras && loras.length) body.loras = loras;
+  //
+  // Krea-style managed image-edit LoRA (epic 10871, sc-11069): the edit surface auto-applies the
+  // model's required `image_edit`-role LoRA (worker R5) the base can't edit without — appended here
+  // and deduped by id so a manual selection that already carries it isn't doubled. `editLora` is the
+  // raw catalog entry (its `conditioningRole` must round-trip via serializeLora, or the worker's edit
+  // lane rejects the run); it's null for edit models that need no such LoRA (Qwen-Image-Edit, FLUX.2).
+  const loraList = Array.isArray(loras) ? [...loras] : [];
+  if (editLora && !loraList.some((lora) => lora.id === editLora.id)) {
+    loraList.push(serializeLora(editLora));
+  }
+  if (loraList.length) body.loras = loraList;
   // Inpaint mask (sc-2436): only sent for inpaint-capable models with a painted
   // region; the worker confines the edit to it. Omitted entirely otherwise.
   if (maskAssetId) body.maskAssetId = maskAssetId;

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -10,7 +10,7 @@ import { assetUrl, assetCanRenderAsImage } from "../components/assetMedia.jsx";
 import { DatasetAddDialog } from "../components/DatasetAddDialog.jsx";
 import { FitModeControl, effectiveFitMode } from "../components/FitModeControl.jsx";
 import { useLoraSelection } from "../components/LoraPickerField.jsx";
-import { MAX_JOB_LORAS_TOTAL } from "../presetUtils.js";
+import { MAX_JOB_LORAS_TOTAL, findModelEditLora, loraIsInstalled } from "../presetUtils.js";
 import { guidanceDefaultFromModel } from "../samplerOptions.js";
 import {
   BLEND_MODES,
@@ -615,6 +615,9 @@ export function ImageEditor() {
     // Project LoRA catalog (sc-10254): fed to the AI Edit LoRA picker, gated to the
     // edit model's compatible families.
     loras = [],
+    // Managed image-edit LoRA download (epic 10871, sc-11069): a missing Krea edit LoRA
+    // offers a one-click fetch, mirroring the Image Studio Edit tab.
+    createLoraDownloadJob,
     // Global theme (sc-10244): the redesign top-bar ☾/☀ toggle drives the app-wide
     // data-theme, not a screen-local override — consistent with the rest of the app.
     theme = "light",
@@ -767,6 +770,35 @@ export function ImageEditor() {
   // serialization the studios use (useLoraSelection → serializeLora), threaded top-level
   // into buildEditJobBody; the worker's edit streams apply them via resolve_adapters.
   const editLoraSelection = useLoraSelection(loras, selectedEditModel);
+  // ---- Krea-style managed image-edit LoRA (epic 10871, sc-11069) — parity with the Studio ----
+  // The Krea 2 edit surface REQUIRES a dual-conditioning `image_edit` LoRA (worker R5) the base can't
+  // edit without. Manage it for the user — auto-applied to the payload when installed (via
+  // buildEditJobBody's `editLora`), surfaced as a one-click download when not — instead of leaving it
+  // in the manual picker. `findModelEditLora` returns null for edit models that need none
+  // (Qwen-Image-Edit, FLUX.2), so this whole block stays inert for them.
+  const editLora = useMemo(() => findModelEditLora(loras, selectedEditModel), [loras, selectedEditModel]);
+  const editLoraInstalled = loraIsInstalled(editLora);
+  // The managed LoRA is applied automatically; hide it from the manual picker so it can't be
+  // double-shown or accidentally toggled. Deduped again at payload time in case a stale selection
+  // carries it (buildEditJobBody dedups by id).
+  const managedEditLoraId = editLora && editLoraInstalled ? editLora.id : null;
+  const editLoraRequiredMissing = Boolean(editLora) && !editLoraInstalled;
+  const [editLoraDownloadRequested, setEditLoraDownloadRequested] = useState(false);
+  // Clear the transient "requested" state once the download lands (installState flips) or the edit
+  // LoRA leaves the picture (model change).
+  useEffect(() => {
+    if (!editLoraRequiredMissing) setEditLoraDownloadRequested(false);
+  }, [editLoraRequiredMissing]);
+  const requestEditLoraDownload = useCallback(() => {
+    if (!editLora) return;
+    setEditLoraDownloadRequested(true);
+    createLoraDownloadJob?.(editLora);
+  }, [editLora, createLoraDownloadJob]);
+  // The manual LoRA picker hides the managed edit LoRA (it's applied automatically), so it can't be
+  // double-shown or accidentally toggled — mirrors the Studio's pickerCompatibleLoras.
+  const pickerCompatibleLoras = managedEditLoraId
+    ? editLoraSelection.compatibleLoras.filter((lora) => lora.id !== managedEditLoraId)
+    : editLoraSelection.compatibleLoras;
   // Whether the edit model conditions on extra reference images (FLUX.2 multi-reference edit, sc-6107):
   // the manifest tags it `ui.multiReference`. Gates the reference picker; off-models hide it entirely.
   const multiRefCapable = Boolean(selectedEditModel?.ui?.multiReference);
@@ -1870,6 +1902,9 @@ export function ImageEditor() {
           width: working.width,
           height: working.height,
           fitMode: "crop",
+          // The boxes-layout edit runs the same edit model, so it also needs the managed
+          // image-edit LoRA when the model requires one (Krea R5) — sc-11069.
+          editLora: managedEditLoraId ? editLora : null,
         }),
     });
   }
@@ -2054,6 +2089,10 @@ export function ImageEditor() {
   async function runEdit() {
     const prompt = editPrompt.trim();
     if (!prompt || !editModel || !working) return;
+    // A required image-edit LoRA that isn't downloaded yet blocks the run (worker R5): the source
+    // band renders the actionable Download note (epic 10871, sc-11069). Defensive — the Generate
+    // button is already disabled on this condition.
+    if (editLoraRequiredMissing) return;
     // Canvas-extend / outpaint (sc-2556): resolve the output W×H from the chosen aspect
     // and fit mode (outpaint coerced away when the model can't inpaint). "match" keeps
     // the working size, so the existing same-size edit behavior is unchanged.
@@ -2098,6 +2137,9 @@ export function ImageEditor() {
           height: outHeight,
           fitMode,
           loras: editLoraSelection.serializedLoras,
+          // Auto-apply the model's managed image-edit LoRA (R5) when installed — deduped inside
+          // buildEditJobBody, so a run needs no manual picking (epic 10871, sc-11069).
+          editLora: managedEditLoraId ? editLora : null,
           guidanceScale: editGuidance,
         }),
     });
@@ -2823,7 +2865,9 @@ export function ImageEditor() {
   };
 
   const renderLoraSection = () => {
-    const { compatibleLoras, selectedLoraIds, toggleLora, weightFor, setWeight } = editLoraSelection;
+    const { selectedLoraIds, toggleLora, weightFor, setWeight } = editLoraSelection;
+    // The managed image-edit LoRA is applied automatically (sc-11069) — hidden from the manual list.
+    const compatibleLoras = pickerCompatibleLoras;
     const nextLora = compatibleLoras.find((lora) => !selectedLoraIds.includes(lora.id));
     const addDisabled = !nextLora || selectedLoraIds.length >= MAX_JOB_LORAS_TOTAL;
     const addHint = loraAddHint({
@@ -2919,7 +2963,30 @@ export function ImageEditor() {
           </div>
         </div>
 
-        {editLoraSelection.compatibleLoras.length ? renderLoraSection() : null}
+        {/* Managed image-edit LoRA (epic 10871, sc-11069): auto-applied for the user — a status note
+            when installed, a one-click download that gates the run when not. Inert for edit models
+            that need none. Placed right under the model so it reads as part of the edit surface. */}
+        {editLora ? (
+          editLoraInstalled ? (
+            <div className="ie-section">
+              <p className="ie-note">✨ {editLora.name} is applied automatically for editing.</p>
+            </div>
+          ) : (
+            <div className="ie-section">
+              <p className="ie-note">{editLora.name} is required to edit — the base can’t edit without it.</p>
+              <button
+                className="ie-btn block"
+                disabled={editLoraDownloadRequested}
+                onClick={requestEditLoraDownload}
+                type="button"
+              >
+                {editLoraDownloadRequested ? "Downloading…" : `Download ${editLora.name}`}
+              </button>
+            </div>
+          )
+        ) : null}
+
+        {pickerCompatibleLoras.length ? renderLoraSection() : null}
 
         <div className="ie-section">
           <div className="ie-sec-title">Output</div>
@@ -3146,7 +3213,12 @@ export function ImageEditor() {
               />
             </div>
           </div>
-          <button className="ie-btn block primary" disabled={!editPrompt.trim() || !!aiOp} onClick={runEdit} type="button">
+          <button
+            className="ie-btn block primary"
+            disabled={!editPrompt.trim() || !!aiOp || editLoraRequiredMissing}
+            onClick={runEdit}
+            type="button"
+          >
             {maskActive ? "Inpaint region" : "Generate edit"}
           </button>
         </div>

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -1030,6 +1030,50 @@ describe("AI prompt edit", () => {
     expect(body.advanced).toEqual({});
   });
 
+  it("auto-applies the managed image-edit LoRA, deduped, with its role round-tripped (epic 10871, sc-11069)", () => {
+    const base = {
+      project: { id: "p", name: "P" },
+      requestedGpu: "auto",
+      sourceAssetId: "a",
+      model: "krea_2_raw",
+      prompt: "x",
+      width: 10,
+      height: 10,
+    };
+    const editLora = {
+      id: "krea2_identity_edit",
+      name: "Krea 2 Identity Edit",
+      family: "krea_2",
+      conditioningRole: "image_edit",
+      defaultWeight: 1,
+    };
+    // Null editLora → nothing appended (edit models that need no such LoRA).
+    expect("loras" in buildEditJobBody(base)).toBe(false);
+
+    // With no manual picks, the managed LoRA is auto-applied — its `conditioningRole` MUST survive
+    // (serializeLora) or the worker's edit lane rejects the run (R5).
+    const auto = buildEditJobBody({ ...base, editLora });
+    expect(auto.loras).toHaveLength(1);
+    expect(auto.loras[0].id).toBe("krea2_identity_edit");
+    expect(auto.loras[0].conditioningRole).toBe("image_edit");
+
+    // Appended alongside manual picks, not replacing them.
+    const withManual = buildEditJobBody({
+      ...base,
+      loras: [{ id: "l1", name: "Film Grain", weight: 0.8 }],
+      editLora,
+    });
+    expect(withManual.loras.map((l) => l.id)).toEqual(["l1", "krea2_identity_edit"]);
+
+    // Deduped by id: a selection that already carries the managed LoRA isn't doubled.
+    const alreadyPresent = buildEditJobBody({
+      ...base,
+      loras: [{ id: "krea2_identity_edit", name: "Krea 2 Identity Edit", weight: 1, conditioningRole: "image_edit" }],
+      editLora,
+    });
+    expect(alreadyPresent.loras.filter((l) => l.id === "krea2_identity_edit")).toHaveLength(1);
+  });
+
   it("sends advanced.guidanceScale only for a finite override (sc-10275)", () => {
     const base = {
       project: { id: "p", name: "P" },


### PR DESCRIPTION
## What & why

[sc-11069](https://app.shortcut.com/trefry/story/11069) — follow-up from P4.1 (sc-10885). The Image Studio Edit tab already MANAGES the Krea `image_edit` LoRA (auto-applies it, hides it from the picker, one-click download when missing). The canvas **Image Editor** (`screens/ImageEditor.jsx`) is a second `edit_image` surface where Krea 2 Raw appears — it worked only if the user *manually* picked the LoRA, else they hit the worker's R5 error.

This brings the canvas editor to parity with the Studio for Krea (and any future `image_edit`-role model). Not a correctness gap (the path worked via manual selection) — a UX-parity polish.

## Changes

- **`imageJobs.js` — `buildEditJobBody`**: new `editLora` param (raw catalog entry, default `null`). The managed LoRA is `serializeLora`'d and appended to `loras`, **deduped by id**, so its `conditioningRole` round-trips (worker R5) and a manual selection that already carries it isn't doubled. This is the single choke point both the single-run and boxes-layout edits flow through; `batchOps.js` passes no `editLora` so it's unaffected.
- **`ImageEditor.jsx`**: compute the managed edit LoRA via `findModelEditLora` + `loraIsInstalled` (reused from `presetUtils.js`).
  - Auto-apply it (when installed) into both `buildEditJobBody` calls — AI Edit run + boxes-layout edit.
  - Managed status note when installed; a **one-click download** that **gates the run** (button `disabled` + defensive guard in `runEdit`) when missing.
  - Filter the managed LoRA out of the manual LoRA picker.
  - Inert for edit models that need no such LoRA (Qwen-Image-Edit, FLUX.2 → `findModelEditLora` returns `null`).

## Tests

- New `buildEditJobBody` cases in `ImageEditor.test.jsx`: auto-apply with `conditioningRole` preserved, appended alongside manual picks, deduped by id, and omitted when `editLora` is null.
- Full web suite green: `vitest run --environment jsdom` → **1641 passed**; `eslint src` clean.

Relates to epic 10871 (Krea 2 Image Edit) and sc-10885.

🤖 Generated with [Claude Code](https://claude.com/claude-code)