### PR TITLE
fix(worker): heartbeat-wrap the two silent blocking phases so the stale sweep can't false-interrupt them (sc-11155)

### DIFF
--- a/crates/sceneworks-worker/src/control_dataset_prep.rs
+++ b/crates/sceneworks-worker/src/control_dataset_prep.rs
@@ -44,6 +44,12 @@ use crate::{WorkerError, WorkerResult};
 /// Doctor's richer quality pass runs separately); only genuinely tiny images are dropped.
 pub(crate) const DEFAULT_MIN_EDGE: u32 = 256;
 
+/// Message the prep loop raises when it observes a tripped [`gen_core::CancelFlag`] between items
+/// (sc-11155). The B1 studio job posts its own terminal `Canceled` once the blocking task has stopped,
+/// so this is the internal signal; a descriptive string keeps any bare surfacing readable.
+pub(crate) const PREP_CANCEL_MESSAGE: &str =
+    "ControlNet training canceled while rendering conditions.";
+
 /// Optional person-presence gate for pose/people corpora: drop targets with no detected person so a
 /// pose ControlNet isn't trained on empty skeletons. Uses the worker's YOLO11 person detector
 /// (`person_jobs::detect_people_blocking`), so it is only available on a neural-inference build.
@@ -229,10 +235,17 @@ pub(crate) fn write_manifest(
 /// The preprocessor is built ONCE and reused across the corpus. Skipped inputs are collected in the
 /// report, not fatal. Blocking (decode + preprocess + PNG encode per image) — call under
 /// `spawn_blocking`; `on_progress(done, total)` is invoked before each item and once at the end.
+///
+/// `cancel` is polled between items (sc-11155/sc-9123): the B1 studio job supervises this loop under
+/// the heartbeat+progress scaffold and trips the shared flag on a user cancel, so the render stops at
+/// the next item boundary with a typed [`WorkerError::Canceled`] instead of running the whole corpus
+/// to its natural end. Any pairs already written sit in the caller's job-scoped cache dir and are
+/// inert.
 pub(crate) fn prepare_control_dataset(
     inputs: &[ControlPrepInput],
     config: &ControlPrepConfig,
     out_dir: &Path,
+    cancel: &gen_core::CancelFlag,
     mut on_progress: impl FnMut(usize, usize),
 ) -> WorkerResult<PrepReport> {
     let label = control_kind_label(&config.kind);
@@ -248,6 +261,12 @@ pub(crate) fn prepare_control_dataset(
     let mut skipped: Vec<(PathBuf, SkipReason)> = Vec::new();
 
     for (index, input) in inputs.iter().enumerate() {
+        // Worker-code cancel checkpoint (sc-11155/sc-9123): bail between items when the studio job's
+        // heartbeat loop trips the shared flag, so a user cancel stops the render at the next item
+        // boundary instead of running the whole corpus to its natural end.
+        if cancel.is_cancelled() {
+            return Err(WorkerError::Canceled(PREP_CANCEL_MESSAGE.to_owned()));
+        }
         on_progress(index, total);
         let id = format!("{:06}", index + 1);
 
@@ -351,9 +370,11 @@ mod tests {
         }];
         let out = dir.path().join("dataset");
         let mut ticks = Vec::new();
-        let report =
-            prepare_control_dataset(&inputs, &canny_config(), &out, |d, t| ticks.push((d, t)))
-                .expect("prep");
+        let cancel = gen_core::CancelFlag::new();
+        let report = prepare_control_dataset(&inputs, &canny_config(), &out, &cancel, |d, t| {
+            ticks.push((d, t))
+        })
+        .expect("prep");
 
         assert_eq!(report.items.len(), 1, "one pair written");
         assert!(report.skipped.is_empty(), "nothing skipped");
@@ -421,8 +442,9 @@ mod tests {
             },
         ];
         let out = dir.path().join("ds");
-        let report =
-            prepare_control_dataset(&inputs, &canny_config(), &out, |_, _| {}).expect("prep");
+        let cancel = gen_core::CancelFlag::new();
+        let report = prepare_control_dataset(&inputs, &canny_config(), &out, &cancel, |_, _| {})
+            .expect("prep");
 
         assert_eq!(report.items.len(), 1, "only the good image is written");
         assert_eq!(report.skipped.len(), 2);
@@ -436,6 +458,65 @@ mod tests {
             .any(|(_, r)| matches!(r, SkipReason::TooSmall { .. })));
         // The good image is renumbered by input index, so its id reflects position (000003).
         assert_eq!(report.items[0].id, "000003");
+    }
+
+    #[test]
+    fn bails_between_items_when_cancel_is_tripped() {
+        // A pre-tripped flag stops the render before the first item is written, returning the typed
+        // `Canceled` (sc-11155): the studio job's heartbeat loop trips this same flag on a user cancel.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let good = dir.path().join("good.png");
+        sample_image(320, 320).save(&good).unwrap();
+        let inputs = vec![ControlPrepInput {
+            target_path: good,
+            caption: "z".to_owned(),
+        }];
+        let out = dir.path().join("ds");
+        let cancel = gen_core::CancelFlag::new();
+        cancel.cancel();
+
+        let mut ticks = Vec::new();
+        let result = prepare_control_dataset(&inputs, &canny_config(), &out, &cancel, |d, t| {
+            ticks.push((d, t))
+        });
+        assert!(
+            matches!(result, Err(WorkerError::Canceled(_))),
+            "prep bails with a typed Canceled"
+        );
+        assert!(
+            ticks.is_empty(),
+            "no item progress emitted once cancel is observed before the first item"
+        );
+    }
+
+    #[test]
+    fn streams_per_item_progress_then_the_final_tick() {
+        // The `on_progress(done, total)` callback fires before each item AND once at the end so the
+        // studio job can stream render progress (sc-11155 — the callback was previously discarded).
+        let dir = tempfile::tempdir().expect("tempdir");
+        let inputs: Vec<ControlPrepInput> = (0..3)
+            .map(|i| {
+                let path = dir.path().join(format!("img{i}.png"));
+                sample_image(320, 320).save(&path).unwrap();
+                ControlPrepInput {
+                    target_path: path,
+                    caption: format!("caption {i}"),
+                }
+            })
+            .collect();
+        let out = dir.path().join("ds");
+        let cancel = gen_core::CancelFlag::new();
+        let mut ticks = Vec::new();
+        prepare_control_dataset(&inputs, &canny_config(), &out, &cancel, |d, t| {
+            ticks.push((d, t))
+        })
+        .expect("prep");
+
+        assert_eq!(
+            ticks,
+            vec![(0, 3), (1, 3), (2, 3), (3, 3)],
+            "one pre-item tick per input plus the terminal (total,total)"
+        );
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/control_training_jobs.rs
+++ b/crates/sceneworks-worker/src/control_training_jobs.rs
@@ -34,7 +34,7 @@ mod imp {
 
     use crate::control_dataset_prep::{
         prepare_control_dataset, ControlPrepConfig, ControlPrepInput, PersonFilter,
-        DEFAULT_MIN_EDGE,
+        DEFAULT_MIN_EDGE, PREP_CANCEL_MESSAGE,
     };
     use crate::control_preprocess::{control_kind_label, PreprocessResources};
     use crate::downloads::DownloadContext;
@@ -180,8 +180,16 @@ mod imp {
         )
         .await?;
 
-        // A2 prep is blocking (decode + neural preprocess + PNG encode per image); run it off the
-        // async runtime. Ownership moves into the closure; the report + work dir come back out.
+        // A2 prep is a multi-minute blocking phase (per-image decode + neural preprocess + PNG encode);
+        // run it off the async runtime under the same heartbeat + cancel + per-item progress scaffold
+        // the batched analysis jobs use (`analysis_jobs_common`, sc-8836), so the API's ~90s stale-sweep
+        // can't false-interrupt a moderately sized dataset mid-render (sc-11155). The keepalive is the
+        // `heartbeat` ping on the interval tick below — posting job progress does NOT refresh the
+        // worker's `last_seen` (only the heartbeat does), so the loop must tick even between per-item
+        // progress posts. The prep loop is worker code, so it takes a REAL `CancelFlag` (sc-9123) that
+        // `prepare_control_dataset` polls between items and bails with the typed `Canceled`; any pairs
+        // already written sit in the job-scoped cache dir and are inert. `on_progress` is streamed over
+        // `tx` (previously discarded) so the studio job shows render progress.
         let config = ControlPrepConfig {
             kind,
             resources,
@@ -189,11 +197,93 @@ mod imp {
             person_filter,
         };
         let prep_dir = work_dir.clone();
-        let report = tokio::task::spawn_blocking(move || {
-            prepare_control_dataset(&inputs, &config, &prep_dir, |_done, _total| {})
-        })
-        .await
-        .map_err(|error| WorkerError::Engine(format!("control prep task panicked: {error}")))??;
+        let cancel = gen_core::CancelFlag::new();
+        let task_cancel = cancel.clone();
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<(usize, usize)>(64);
+        let blocking = tokio::task::spawn_blocking(move || {
+            prepare_control_dataset(&inputs, &config, &prep_dir, &task_cancel, |done, total| {
+                // A closed channel means the consumer loop returned early (POST failure / 409 stale-
+                // sweep reclaim); trip the cancel flag so the prep bails at its next per-item check
+                // instead of rendering the whole corpus to its natural end (sc-8804, F-003 — the
+                // swallowed-closed-channel leak).
+                if tx.blocking_send((done, total)).is_err() {
+                    task_cancel.cancel();
+                }
+            })
+        });
+
+        // Bind the blocking prep to its cancel flag (sc-8804, F-003): every `update_job`/`heartbeat`
+        // `?` below returns early on a transient POST failure or a 409 reclaim; on that early return the
+        // guard trips `cancel` and bounded-joins the prep thread instead of dropping-and-running it.
+        let mut guard = CancelJoinGuard::new(cancel.clone(), blocking);
+        let mut interval = tokio::time::interval(progress_report_interval(settings));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // Defer the terminal `Canceled`: a cancel poll only trips the engine flag (so the prep stops at
+        // its next item boundary) and marks `canceled`; the terminal write happens AFTER the task stops,
+        // so the worker row isn't freed while the render is still on the GPU (sc-8917, mirrors
+        // `consume_training_events` / `run_batched_analysis_job`).
+        let mut canceled = false;
+        let loop_result: WorkerResult<()> = async {
+            loop {
+                tokio::select! {
+                    event = rx.recv() => {
+                        match event {
+                            Some((done, total)) => {
+                                // Per-item render progress scaled into the prep band 0.05..0.20 (the
+                                // plan rewrite + training take the rest). This is a UI signal only; the
+                                // stale-sweep keepalive is the heartbeat on the interval tick.
+                                let frac = done as f64 / total.max(1) as f64;
+                                update_job(
+                                    api,
+                                    &job.id,
+                                    training_progress(
+                                        JobStatus::Preparing,
+                                        ProgressStage::Preparing,
+                                        0.05 + 0.15 * frac,
+                                        &format!(
+                                            "Rendering {label} conditions ({done}/{total})."
+                                        ),
+                                        None,
+                                        backend,
+                                    ),
+                                )
+                                .await?;
+                            }
+                            None => break,
+                        }
+                    }
+                    _ = interval.tick() => {
+                        heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+                        // sc-9618: a process shutdown is a cancel checkpoint too — short-circuit the API
+                        // poll (a local flag read) so a quit stops the render at its next item check.
+                        if !canceled
+                            && (shutdown_requested() || cancel_requested_peek(api, &job.id).await)
+                        {
+                            cancel.cancel();
+                            canceled = true;
+                        }
+                    }
+                }
+            }
+            Ok(())
+        }
+        .await;
+        if let Err(error) = loop_result {
+            guard.cancel_and_join().await;
+            return Err(error);
+        }
+
+        // Loop exited cleanly (channel closed) — reclaim the handle (disarming the drop-guard) and join.
+        let join_result = guard
+            .into_handle()
+            .await
+            .map_err(|error| task_join_error("control prep task", error))?;
+        if canceled {
+            // The prep has actually stopped now, so post the TERMINAL `Canceled` here.
+            mark_job_canceled(api, &job.id, PREP_CANCEL_MESSAGE).await?;
+            return Err(WorkerError::Canceled(PREP_CANCEL_MESSAGE.to_owned()));
+        }
+        let report = join_result?;
 
         // Surface the per-image skip tally rather than silently shrinking the corpus (the report
         // exists for exactly this). The manifest path + the individual reasons go to the log; the

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -1308,46 +1308,51 @@ pub(crate) async fn run_model_convert_job(
     // weights), so honor cancel up front and run on a blocking thread. On any failure the partial
     // temp dir is removed so it can never be promoted by the atomic rename below. The Flux2 path's
     // borrowed vae/text-encoder/tokenizer are absolute symlinks that survive the rename.
-    check_cancel(
-        api,
-        &job.id,
-        &format!("{backend} conversion canceled by user."),
-    )
-    .await?;
+    let convert_cancel_message = format!("{backend} conversion canceled by user.");
+    check_cancel(api, &job.id, &convert_cancel_message).await?;
     let temp = temp_dir.clone();
     // An LTX conversion is always the eros fine-tune (the base model installs as a pre-converted
     // turnkey bundle and never hits this path), and its bare checkpoint ships no bundled Gemma-3 text
     // encoder — provision the bundle `gemma/` after promotion so the install is self-contained.
     let plan_is_ltx = matches!(plan, ConvertPlan::Ltx { .. });
-    let outcome = match plan {
+    // Each native converter maps its `Result<(), String>` into a `WorkerResult<()>` so the whole
+    // convert can ride `run_blocking_with_heartbeat` below — the failure detail keeps the same
+    // "{backend} conversion failed. {detail}" shape the old inline match produced.
+    let convert_task = match plan {
         ConvertPlan::Flux2 {
             source_file,
             base_dir,
         } => {
+            let backend = backend.clone();
             tokio::task::spawn_blocking(move || {
-                convert_flux2_klein_diffusers(&source_file, &base_dir, &temp)
+                convert_flux2_klein_diffusers(&source_file, &base_dir, &temp).map_err(|detail| {
+                    WorkerError::Engine(format!("{backend} conversion failed. {detail}"))
+                })
             })
-            .await
         }
         ConvertPlan::Ltx {
             source_file,
             upscaler_dir,
             bits,
         } => {
+            let backend = backend.clone();
             tokio::task::spawn_blocking(move || {
-                convert_ltx_native(&source_file, &upscaler_dir, &temp, bits)
+                convert_ltx_native(&source_file, &upscaler_dir, &temp, bits).map_err(|detail| {
+                    WorkerError::Engine(format!("{backend} conversion failed. {detail}"))
+                })
             })
-            .await
         }
         ConvertPlan::Flux2Dev {
             source_dir,
             bits,
             group_size,
         } => {
+            let backend = backend.clone();
             tokio::task::spawn_blocking(move || {
-                convert_flux2_dev_prequant(&source_dir, &temp, bits, group_size)
+                convert_flux2_dev_prequant(&source_dir, &temp, bits, group_size).map_err(|detail| {
+                    WorkerError::Engine(format!("{backend} conversion failed. {detail}"))
+                })
             })
-            .await
         }
         ConvertPlan::Sd3 {
             source_dir,
@@ -1355,10 +1360,12 @@ pub(crate) async fn run_model_convert_job(
             bits,
             group_size,
         } => {
+            let backend = backend.clone();
             tokio::task::spawn_blocking(move || {
-                convert_sd3_prequant(&source_dir, &temp, variant, bits, group_size)
+                convert_sd3_prequant(&source_dir, &temp, variant, bits, group_size).map_err(
+                    |detail| WorkerError::Engine(format!("{backend} conversion failed. {detail}")),
+                )
             })
-            .await
         }
         ConvertPlan::Anima {
             dit_source,
@@ -1367,6 +1374,7 @@ pub(crate) async fn run_model_convert_job(
             dit_filename,
             group_size,
         } => {
+            let backend = backend.clone();
             tokio::task::spawn_blocking(move || {
                 convert_anima_prequant(
                     &dit_source,
@@ -1376,25 +1384,34 @@ pub(crate) async fn run_model_convert_job(
                     &temp,
                     group_size,
                 )
+                .map_err(|detail| {
+                    WorkerError::Engine(format!("{backend} conversion failed. {detail}"))
+                })
             })
-            .await
         }
     };
-    match outcome {
-        Ok(Ok(())) => {}
-        Ok(Err(detail)) => {
-            let _ = tokio::fs::remove_dir_all(&temp_dir).await;
-            return Err(WorkerError::Engine(format!(
-                "{backend} conversion failed. {detail}"
-            )));
-        }
-        Err(join_error) => {
-            let _ = tokio::fs::remove_dir_all(&temp_dir).await;
-            return Err(task_join_error(
-                &format!("{backend} conversion task"),
-                join_error,
-            ));
-        }
+    // The native converters are multi-minute blocking phases with no internal heartbeat loop, so a
+    // large conversion used to run silent past the API's ~90s stale-sweep and get flipped to
+    // `interrupted` mid-work — then the terminal `Completed` POST 409'd, surfacing a confusing "failed
+    // install" even though the output was promoted (sc-11155). Wrap them in `run_blocking_with_heartbeat`
+    // so the worker keeps pinging `Busy` across the convert. `cancel = None` is the explicit per-engine
+    // decision: the converters are one bounded native pass with no per-step loop for a flag to poll, so
+    // the bounded join already gives everything a cancel flag would (the missing piece was only the
+    // keepalive); the up-front `check_cancel` above still honors a cancel requested before it starts.
+    if let Err(error) = run_blocking_with_heartbeat(
+        api,
+        settings,
+        &job.id,
+        None,
+        &convert_cancel_message,
+        "model conversion task",
+        crate::no_cancel_ack(),
+        convert_task,
+    )
+    .await
+    {
+        let _ = tokio::fs::remove_dir_all(&temp_dir).await;
+        return Err(error);
     }
 
     // Promote the completed conversion atomically; on any rename failure the partial


### PR DESCRIPTION
## Summary

Fixes **sc-11155** (High, F-002; epic 11147). Two multi-minute blocking phases were awaited as bare `spawn_blocking` with **no heartbeat loop**, so a moderately sized job ran silent past the API's ~90s stale-sweep, got flipped to `interrupted` mid-work, and its terminal `Completed` POST then 409'd — a confusing "failed install" even though the output dir was promoted. Crucially, **posting job progress does not refresh `last_seen`** (only the heartbeat ping does — see `training_jobs.rs`), so the keepalive must ride the heartbeat interval tick, not per-item progress. This is the same sc-8804/sc-8390 class already fixed everywhere else; these two sites were missed.

## What changed

### Site 1 — `control_training_jobs.rs` A2 control-dataset prep
`crates/sceneworks-worker/src/control_training_jobs.rs` (the prep block, ~L183 old)

- Routes the blocking prep through the same **heartbeat + cancel + per-item-progress channel-select scaffold** the batched analysis jobs use (`analysis_jobs_common`): `CancelJoinGuard` bound to the task, a `select!` loop that posts progress on `rx.recv()` and pings `heartbeat(Busy)` + polls cancel on the interval tick, deferred terminal `Canceled`, and bounded-join teardown on any `?`-error.
- Threads a **real `gen_core::CancelFlag`** into `prepare_control_dataset`'s per-item loop (`control_dataset_prep.rs`): it polls the flag between items and bails with a typed `WorkerError::Canceled`, so a user cancel is honored per-image instead of running the whole corpus to its natural end.
- **Streams the `on_progress` callback** over a bounded channel (previously discarded as `|_done,_total| {}`) so the studio job shows render progress, scaled into the `0.05..0.20` prep band.

### Site 2 — `model_jobs.rs` `run_model_convert_job` native converters
`crates/sceneworks-worker/src/model_jobs.rs` (the convert match, ~L1317 old)

- Routes the FLUX.2-klein / FLUX.2-dev / SD3 / LTX / Anima native converters through **`run_blocking_with_heartbeat`** for the keepalive. Each converter's `Result<(), String>` is mapped into `WorkerResult<()>` preserving the `"{backend} conversion failed. {detail}"` message shape; the failure path still removes the partial temp dir so it can't be promoted.
- **`cancel = None`** is the explicit per-engine decision per the finding: the converters are one bounded native pass with no per-step loop for a flag to poll, so the bounded join already gives everything a cancel flag would — the missing piece was only the heartbeat. The up-front `check_cancel` still honors a cancel requested before the convert starts.

## Scope vs AC
Both sites fixed; cancel threading (prep) + progress streaming (prep) + heartbeat keepalive (both) all covered. No behavior change to the converters themselves or to the prep's output.

Note on the fix directive: the finding said "route both through `run_blocking_with_heartbeat`". For the prep I used the channel-select scaffold (`analysis_jobs_common` shape) rather than the literal `run_blocking_with_heartbeat`, because that helper pings heartbeat but cannot post the per-item job progress the finding also requires ("stream its on_progress callback"). The channel-select loop is a strict superset — heartbeat + cancel + progress — and is the established house pattern for progress-bearing blocking tasks. Convert uses `run_blocking_with_heartbeat` directly as specified.

## Tests
- New `control_dataset_prep` unit tests: `bails_between_items_when_cancel_is_tripped` (pre-tripped flag → typed `Canceled`, no progress emitted) and `streams_per_item_progress_then_the_final_tick` (per-item + terminal ticks). Existing prep tests updated for the new `cancel` param.
- The heartbeat-loop wiring itself isn't directly unit-testable (needs a live API/job); it mirrors the vetted `analysis_jobs_common` / `run_blocking_with_heartbeat` scaffolds and is covered by build + the existing `cancel_and_heartbeat` suite.

## Verification
- `cargo build -p sceneworks-worker` ✅
- `cargo clippy -p sceneworks-worker --all-targets -- -D warnings` ✅
- `cargo test -p sceneworks-worker` ✅ (737 passed, 157 ignored real-weight, 0 failed)
- `cargo fmt -p sceneworks-worker -- --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)