### PR TITLE
feat(worker): candle Bernini tier-select + candle-gen pin bump for GPU render (sc-11003)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -570,7 +570,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-gen",
  "image",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -768,7 +768,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -805,7 +805,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -816,7 +816,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -829,7 +829,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -840,7 +840,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -853,7 +853,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f2ec6e33e459da4a699a2e1cf74a0a3f749d621a#f2ec6e33e459da4a699a2e1cf74a0a3f749d621a"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=b11db05b738c9d82e14a153db57dbc518b45fe7f#b11db05b738c9d82e14a153db57dbc518b45fe7f"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1667,15 +1667,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "5924
 # up to main (candle-gen #425 shared-core AdaptLinear + #426 CI + #427 krea_2_edit Generator registration),
 # all additive candle-provider work with no worker-surface change. ALL mlx-gen-* + candle-gen-* pins move
 # together; backend-candle check --locked green.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1689,7 +1689,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1697,17 +1697,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1717,7 +1717,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1725,21 +1725,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1748,7 +1748,7 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # Candle Bernini still-image companion (sc-10996, epic 6562) — the Windows/CUDA sibling of
 # `mlx-gen-bernini`, built ON candle-gen-wan (the full Qwen2.5-VL/MAR semantic planner driving a
 # Wan2.2-A14B dual-expert renderer, `frames:1` for a single still). Self-registers the full `bernini`
@@ -1760,17 +1760,17 @@ candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # main HEAD, the merged #421 planner-components commit — contains the #419 full generator sc-10995) — its
 # gen-core pin (951227a) MATCHES the worker's mlx pin, so `--features backend-candle --target all`
 # resolves ONE gen-core rev (no skew).
-candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1779,7 +1779,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1812,7 +1812,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1821,12 +1821,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1834,7 +1834,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1843,7 +1843,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1851,7 +1851,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1865,7 +1865,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1892,7 +1892,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1903,7 +1903,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f2ec6e33e459da4a699a2e1cf74a0a3f749d621a", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "b11db05b738c9d82e14a153db57dbc518b45fe7f", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/bernini.rs
+++ b/crates/sceneworks-worker/src/image_jobs/bernini.rs
@@ -331,17 +331,46 @@ fn bernini_image_candle_available(request: &ImageRequest) -> bool {
     request.model == "bernini_image"
 }
 
-/// Resolve the candle Bernini snapshot dir: `SCENEWORKS_CANDLE_BERNINI_DIR` override → app-managed
-/// `<data>/models/candle/bernini` → the turnkey `SceneWorks/bernini` HF snapshot. Sentinel = the
-/// `transformer/` subdir (the converted renderer's first DiT expert; the `candle-gen-bernini` `load`
-/// validates the full component set and reports the precise gap). Errors loudly when absent — like the
-/// candle SCAIL-2 / Wan-VACE resolvers, a missing checkpoint surfaces a clear re-download error instead
-/// of degrading to a stub. The candle sibling of the MLX `resolve_bernini_model_dir` (video_jobs.rs).
+/// The candle Bernini quant-tier subfolders published under the turnkey `SceneWorks/bernini` root
+/// (sc-11003): each holds a full component tree (`transformer/` `transformer_2/` `mllm/` `connector/`
+/// `vit_decoder/` `vae/` …) at that precision. `bf16/` is the dense default; `q8/`/`q4/` are the
+/// packed tiers (validated clean on sm_120, sc-11003). Mirrors the MLX `q4`/`q8`/`bf16` convention
+/// ([`crate::video_jobs::bernini_tier_subdir`]).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const CANDLE_BERNINI_TIERS: &[&str] = &["bf16", "q8", "q4"];
+
+/// True when `dir` carries a Bernini component tree — sentinel = the `transformer/` subdir (the
+/// converted renderer's first DiT expert; the `candle-gen-bernini` `load` validates the full set and
+/// reports the precise gap). Used both for a tier subfolder (`<root>/bf16/transformer`) and a legacy
+/// flat snapshot (`<root>/transformer`).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_bernini_tree_present(dir: &Path) -> bool {
+    dir.join("transformer").is_dir()
+}
+
+/// True when `root` is a usable candle Bernini snapshot: it either nests the published tier
+/// subfolders (`bf16/`|`q8/`|`q4/` each with a `transformer/` tree) or is a legacy flat tree
+/// (`transformer/` AT root). The env/managed sentinels accept either shape.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_bernini_snapshot_ok(root: &Path) -> bool {
+    candle_bernini_tree_present(root)
+        || CANDLE_BERNINI_TIERS
+            .iter()
+            .any(|tier| candle_bernini_tree_present(&root.join(tier)))
+}
+
+/// Resolve the candle Bernini snapshot ROOT: `SCENEWORKS_CANDLE_BERNINI_DIR` override → app-managed
+/// `<data>/models/candle/bernini` → the turnkey `SceneWorks/bernini` HF snapshot. Sentinel =
+/// [`candle_bernini_snapshot_ok`] (a `transformer/` tree at root OR under a `bf16/`|`q8/`|`q4/` tier
+/// subfolder — the published layout, sc-11003). Errors loudly when absent — like the candle SCAIL-2 /
+/// Wan-VACE resolvers, a missing checkpoint surfaces a clear re-download error instead of degrading to
+/// a stub. The candle sibling of the MLX `resolve_bernini_model_dir` (video_jobs.rs). Callers descend
+/// into the requested quant tier via [`resolve_candle_bernini_tier_dir_and_quant`].
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 pub(crate) fn resolve_candle_bernini_model_dir(settings: &Settings) -> WorkerResult<PathBuf> {
     if let Ok(dir) = std::env::var("SCENEWORKS_CANDLE_BERNINI_DIR") {
         let path = PathBuf::from(dir.trim());
-        if path.join("transformer").is_dir() {
+        if candle_bernini_snapshot_ok(&path) {
             return Ok(path);
         }
     }
@@ -350,7 +379,7 @@ pub(crate) fn resolve_candle_bernini_model_dir(settings: &Settings) -> WorkerRes
         .join("models")
         .join("candle")
         .join("bernini");
-    if managed.join("transformer").is_dir() {
+    if candle_bernini_snapshot_ok(&managed) {
         return Ok(managed);
     }
     if let Some(dir) = huggingface_snapshot_dir(&settings.data_dir, CANDLE_BERNINI_REPO) {
@@ -359,9 +388,71 @@ pub(crate) fn resolve_candle_bernini_model_dir(settings: &Settings) -> WorkerRes
     Err(WorkerError::InvalidPayload(format!(
         "bernini (candle): no weights found. Download the turnkey {CANDLE_BERNINI_REPO} snapshot via \
          the Model Manager, set $SCENEWORKS_CANDLE_BERNINI_DIR, or place a converted full-Bernini \
-         snapshot (transformer/ + transformer_2/ + text_encoder/ + vae/ + tokenizer/ + mllm/ + \
-         connector/ + vit_decoder/) at {}.",
+         snapshot (bf16/|q8/|q4/ tier subfolders — or a flat tree — each with transformer/ + \
+         transformer_2/ + text_encoder/ + vae/ + tokenizer/ + mllm/ + connector/ + vit_decoder/) at {}.",
         managed.display(),
+    )))
+}
+
+/// The candle Bernini tier search order for a request's `mlxQuantize` bits — preferred tier first,
+/// then the always-present fallbacks so a partial repo still loads (mirrors
+/// [`crate::video_jobs::bernini_tier_order`]). The candle DEFAULT is **bf16 dense** (no explicit pick
+/// ⇒ `bf16`), NOT the MLX q4-first default: off-Mac the box has ample VRAM and the dense path is the
+/// validated baseline, so a packed tier is strictly opt-in (`mlxQuantize:4`|`:8`). `<= 0` also pins
+/// bf16.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_bernini_tier_order(bits: Option<i64>) -> &'static [&'static str] {
+    match bits {
+        None => &["bf16", "q8", "q4"],
+        Some(b) if b <= 0 => &["bf16", "q8", "q4"],
+        Some(b) if b <= 4 => &["q4", "q8", "bf16"],
+        Some(_) => &["q8", "q4", "bf16"],
+    }
+}
+
+/// The load-time [`Quant`] a resolved candle Bernini tier subfolder loads at: `q4/` ⇒ [`Quant::Q4`],
+/// `q8/` ⇒ [`Quant::Q8`], `bf16/` ⇒ `None` (dense). Passed to [`load_spec`] so the packed tiers
+/// (validated clean on sm_120, sc-11003) build packed while the default stays dense.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_bernini_tier_quant(tier: &str) -> Option<Quant> {
+    match tier {
+        "q4" => Some(Quant::Q4),
+        "q8" => Some(Quant::Q8),
+        _ => None,
+    }
+}
+
+/// Resolve the candle Bernini `(weights_dir, load-time quant)` for a generation: descend the resolved
+/// snapshot root into the requested quant-tier subfolder (`bf16/`|`q8/`|`q4/`, sc-11003) and pair it
+/// with the matching load quant. The published `SceneWorks/bernini` layout nests each tier's component
+/// tree under a tier subdir, so the dense/default path loads `bf16/` (quant `None`) and an explicit
+/// Q4/Q8 pick loads `q4/`|`q8/` with [`Quant::Q4`]/[`Quant::Q8`]. Falls back through the smaller
+/// complete tiers so a partial repo still loads, then to `root` itself when it is a legacy flat tree
+/// (`transformer/` AT root, dense). Errors loud when neither a tier subfolder nor the root carries a
+/// `transformer/` tree (defense in depth — the root resolver already gates on the same sentinel).
+/// Shared by the still ([`generate_candle_bernini_image_stream`]) and video
+/// ([`crate::video_jobs::generate_candle_bernini`]) lanes so both load the same tier.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+pub(crate) fn resolve_candle_bernini_tier_dir_and_quant(
+    settings: &Settings,
+    bits: Option<i64>,
+) -> WorkerResult<(PathBuf, Option<Quant>)> {
+    let root = resolve_candle_bernini_model_dir(settings)?;
+    for tier in candle_bernini_tier_order(bits) {
+        let dir = root.join(tier);
+        if candle_bernini_tree_present(&dir) {
+            return Ok((dir, candle_bernini_tier_quant(tier)));
+        }
+    }
+    // Legacy flat snapshot: the component tree sits directly at the root (dense, no tier subdirs).
+    if candle_bernini_tree_present(&root) {
+        return Ok((root, None));
+    }
+    Err(WorkerError::InvalidPayload(format!(
+        "bernini (candle): the resolved snapshot at {} has no tier subfolder (bf16/|q8/|q4/) with a \
+         transformer/ tree, nor a flat transformer/ at root. Re-download the turnkey \
+         {CANDLE_BERNINI_REPO} snapshot via the Model Manager.",
+        root.display(),
     )))
 }
 
@@ -400,7 +491,6 @@ async fn generate_candle_bernini_image_stream(
     } else {
         model.backend()
     };
-    let weights_dir = resolve_candle_bernini_model_dir(settings)?;
     let steps = resolve_steps(request, &model);
     // Standard guidance family: `guidance` carries the CFG scale (engine `omega_txt`); the negative
     // prompt is forwarded (the descriptor advertises both). No true-CFG.
@@ -408,13 +498,15 @@ async fn generate_candle_bernini_image_stream(
     let negative_prompt = resolve_negative_prompt(request, &model);
     let repo = model_repo(request, &model);
     let task = bernini_image_engine_task(&request.mode);
-    // Requested tier bits (advanced `mlxQuantize`) recorded for lineage only — the candle lane loads the
-    // converted snapshot DENSE (the loader reads the tree as-is; the descriptor advertises Q4/Q8 but the
-    // off-Mac packed-tier select is a follow-up once the `SceneWorks/bernini` tier layout lands, sc-11003).
+    // Requested tier bits (advanced `mlxQuantize`): selects WHICH published tier subfolder
+    // (`bf16/`|`q8/`|`q4/`) the candle lane loads and the matching load-time quant (sc-11003). No
+    // explicit pick ⇒ bf16 dense (the off-Mac validated baseline); `mlxQuantize:4`|`:8` opt into the
+    // packed tiers (validated clean on sm_120, sc-11003).
     let tier_bits = request
         .advanced
         .get("mlxQuantize")
         .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()));
+    let (weights_dir, quant) = resolve_candle_bernini_tier_dir_and_quant(settings, tier_bits)?;
 
     // i2i (`edit_image`): resolve the source image into the engine's `Conditioning::Reference` (the
     // engine ViT/VAE-encodes it at native resolution, no worker-side fit, and ignores the reference
@@ -453,8 +545,9 @@ async fn generate_candle_bernini_image_stream(
     let prompt = request.prompt.clone();
     let (width, height) = (request.width, request.height);
 
-    // Dense load (quant None): the converted snapshot is read as-is by the candle loader.
-    let spec = load_spec(weights_dir, None, Vec::new(), None);
+    // Load the resolved tier subfolder at its matching quant: `bf16/` dense (quant `None`), or the
+    // packed `q4/`|`q8/` tree with `Quant::Q4`|`Quant::Q8` (sc-11003).
+    let spec = load_spec(weights_dir, quant, Vec::new(), None);
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
         engine_id,

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -881,6 +881,55 @@ fn bernini_image_task_and_quant_mapping() {
     ));
 }
 
+/// Candle Bernini tier-subdir selection (sc-11003): the published `SceneWorks/bernini` layout nests
+/// `bf16/`|`q8/`|`q4/` component trees, so the candle lane descends into the requested quant tier and
+/// pairs it with the matching load quant. Asserts the pure selection helpers: bf16-dense DEFAULT
+/// (unlike the MLX q4-first video default), explicit Q4/Q8 opt-in, the smaller-tier fallback when the
+/// preferred subfolder is absent, and the legacy flat-tree (`transformer/` at root) path. Runs in CI
+/// on the candle build (no weights — just directory sentinels).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn candle_bernini_tier_subdir_selection() {
+    // Tier order: no pick / <=0 ⇒ bf16-first; explicit 4 ⇒ q4-first; >=8 ⇒ q8-first (all with the
+    // always-present smaller fallbacks).
+    assert_eq!(candle_bernini_tier_order(None), &["bf16", "q8", "q4"]);
+    assert_eq!(candle_bernini_tier_order(Some(0)), &["bf16", "q8", "q4"]);
+    assert_eq!(candle_bernini_tier_order(Some(4)), &["q4", "q8", "bf16"]);
+    assert_eq!(candle_bernini_tier_order(Some(8)), &["q8", "q4", "bf16"]);
+    // Tier → load quant: q4/q8 packed, bf16 dense (None).
+    assert!(matches!(
+        candle_bernini_tier_quant("q4"),
+        Some(gen_core::Quant::Q4)
+    ));
+    assert!(matches!(
+        candle_bernini_tier_quant("q8"),
+        Some(gen_core::Quant::Q8)
+    ));
+    assert!(candle_bernini_tier_quant("bf16").is_none());
+
+    // Sentinels on a temp root: a tier subfolder with a `transformer/` tree, plus a bare root.
+    let root = std::env::temp_dir().join(format!("candle-bernini-tier-{}", std::process::id()));
+    std::fs::remove_dir_all(&root).ok();
+    let make_tier = |tier: &str| {
+        std::fs::create_dir_all(root.join(tier).join("transformer")).unwrap();
+    };
+    make_tier("q8");
+    make_tier("q4");
+    // A tier root (has subfolders) is a usable snapshot; a bare/empty dir is not.
+    assert!(candle_bernini_snapshot_ok(&root));
+    let empty = root.join("empty");
+    std::fs::create_dir_all(&empty).unwrap();
+    assert!(!candle_bernini_snapshot_ok(&empty));
+    // `transformer/` sentinel resolves the tier tree, not a bare dir.
+    assert!(candle_bernini_tree_present(&root.join("q4")));
+    assert!(!candle_bernini_tree_present(&root));
+    // A legacy flat tree (`transformer/` AT root) is accepted as a snapshot too.
+    let flat = root.join("flat");
+    std::fs::create_dir_all(flat.join("transformer")).unwrap();
+    assert!(candle_bernini_snapshot_ok(&flat));
+    std::fs::remove_dir_all(&root).ok();
+}
+
 /// Resolve the Bernini MLX snapshot dir for the real-weight smokes: env override → the local
 /// mlx-gen-models conversion caches / app-managed dir → the turnkey `SceneWorks/bernini-mlx` HF-cache
 /// snapshot. Mirrors the video test's `bernini_dir()` candidate list. `None` ⇒ skip (weights live

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -6817,10 +6817,11 @@ async fn resolve_candle_bernini_conditioning(
 /// ([`candle_bernini_engine_video_mode`]) and the source media into the planner conditioning
 /// ([`resolve_candle_bernini_conditioning`]) — empty for t2v, one or more `VideoClip`s for
 /// v2v/mv2v/rv2v/ads2v, and `MultiReference` for r2v/rv2v/ads2v. The converted `SceneWorks/bernini`
-/// snapshot loads DENSE (no load-time quant — the off-Mac packed-tier select is deferred with the still
-/// lane, sc-11003), resolved via the shared [`crate::image_jobs::resolve_candle_bernini_model_dir`] so
-/// video + still load from the same tier. No LoRA (the engine reports `supports_lora=false`); steps /
-/// guidance stay at the engine defaults. Frame count uses the Wan 1-mod-4 stride (the renderer is Wan).
+/// snapshot descends into the requested quant tier subfolder (`bf16/`|`q8/`|`q4/`, sc-11003) via the
+/// shared [`crate::image_jobs::resolve_candle_bernini_tier_dir_and_quant`] so video + still load from
+/// the same tier: no explicit `mlxQuantize` ⇒ bf16 dense, `:4`|`:8` opt into the packed tiers. No LoRA
+/// (the engine reports `supports_lora=false`); steps / guidance stay at the engine defaults. Frame
+/// count uses the Wan 1-mod-4 stride (the renderer is Wan).
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 async fn generate_candle_bernini(
     api: &ApiClient,
@@ -6834,11 +6835,20 @@ async fn generate_candle_bernini(
     let negative_prompt = non_empty_negative_prompt(request);
     let conditioning =
         resolve_candle_bernini_conditioning(api, settings, job, request, project_path).await?;
+    // Select the published tier subfolder + matching load quant (sc-11003): parse `mlxQuantize` (int
+    // or numeric string) the same way the still lane does, defaulting to bf16 dense.
+    let tier_bits = request
+        .advanced
+        .get("mlxQuantize")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()));
+    let (model_dir, quant) =
+        crate::image_jobs::resolve_candle_bernini_tier_dir_and_quant(settings, tier_bits)?;
     let input = VideoGenInput {
         sampler: None,
         scheduler: None,
         engine_id,
-        model_dir: crate::image_jobs::resolve_candle_bernini_model_dir(settings)?,
+        model_dir,
+        quant,
         conditioning,
         prompt: request.prompt.clone(),
         negative_prompt,


### PR DESCRIPTION
Completion PR for sc-11003's worker side: deliver the candle Bernini GPU fix (pin bump) and the published-layout tier select.

## A) candle-gen pin bump (GPU render fix)
Bumps all 28 `candle-gen*` pins `f2ec6e33` -> `b11db05b` (candle-gen main HEAD), which carries:
- **#434 (sc-11003)** — planner ids/pos/mask moved to device + ViT computed in weight dtype so the candle GPU path runs (without it the planner NaNs/faults off-CPU).
- **#431 (sc-11150)** — vision-tower inputs cast to the weight dtype (conditioned-request blocker).

**gen-core LOCKSTEP (no skew):** `b11db05b` pins mlx-gen gen-core `592419ca`, byte-identical to the worker's mlx-gen gen-core. `Cargo.lock` resolves a single `sceneworks-gen-core` source. Lock regenerated via `cargo metadata` (no hand-edit); `cargo metadata --locked` green.

## B) Bernini tier-subdir select (published `SceneWorks/bernini` layout)
The repo was published with tiers as SUBFOLDERS (`bf16/` `q8/` `q4/`), each containing the full component tree (`transformer/` `transformer_2/` `mllm/` `connector/` `vit_decoder/` `vae/` …). The merged resolver returned the snapshot ROOT and loaded DENSE, expecting `transformer/` AT root — so it failed against the published layout.

- `resolve_candle_bernini_tier_dir_and_quant(settings, bits)`: descends the resolved root into the requested quant tier subfolder + matching load quant. Default/no-pick -> `bf16/` dense (quant `None`, the off-Mac validated baseline); `mlxQuantize:4` -> `q4/` `Quant::Q4`; `>=8` -> `q8/` `Quant::Q8` (packed tiers validated clean on sm_120 in sc-11003). Falls back through smaller complete tiers, then a legacy flat root; errors LOUD when no `transformer/` tree is present.
- Env-override / app-managed sentinels now accept either a tier subfolder with `transformer/` or a flat `transformer/` at root.
- Wired both lanes off one resolver: image (`image_jobs/bernini.rs`) passes the resolved quant to `load_spec`; video (`video_jobs.rs::generate_candle_bernini`) sets `VideoGenInput.model_dir` + `quant`, so still + video load the same tier.
- Added candle-gated unit test `candle_bernini_tier_subdir_selection`.

## Tests
- `cargo check -p sceneworks-worker --features backend-candle` (vcvars 14.44 + CUDA_COMPUTE_CAP=120) — green
- `cargo test -p sceneworks-worker --lib --features backend-candle` — 547 passed, 0 failed
- `cargo test -p sceneworks-core` — 32 passed
- `cargo fmt -p sceneworks-worker --check` — clean
- `cargo metadata --locked` — green (single gen-core source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)