### PR TITLE
[sc-11159] Sanitize request.model in asset filenames + reject path-unsafe model id at enqueue (path traversal)

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -2473,10 +2473,46 @@ fn validate_prompt_extras(negative_prompt: &str, advanced: &JsonObject) -> Resul
     Ok(())
 }
 
+/// Reject a `model` id that is not a safe single path component (F-003 / sc-11159).
+///
+/// The id flows verbatim from the untrusted job payload into the worker's asset
+/// filename — `write_image_asset` / `write_upscaled_asset` / `VideoPlan::new` each
+/// `format!(".._{model}_..")` a project-relative path, then `create_dir_all` +
+/// atomic-rename the file into place. A `model` containing `../`, `..\`, or an
+/// absolute path would therefore traverse out of the project dir and hand a remote
+/// caller an arbitrary-write primitive. The worker now slugifies the id as a last
+/// line of defense, but the API is the first gate and rejects such ids outright,
+/// mirroring the worker's `safe_weight_filename` posture for payload-supplied
+/// filename components.
+///
+/// SCOPE (sc-11159): this enforces *path-safety only*, NOT catalog membership. The
+/// worker's stub lane deliberately serves uncatalogued model ids for dev/testing,
+/// and the API test harness (which does not seed the shipped model manifests)
+/// routinely enqueues real-but-uncatalogued ids and expects success, so a catalog
+/// rejection here would break that legitimate lane. Path-safety alone fully closes
+/// the traversal/arbitrary-write vulnerability: an uncatalogued-but-path-safe id
+/// can never escape the project dir.
+fn validate_model_id(model: &str) -> Result<(), ApiError> {
+    let trimmed = model.trim();
+    if trimmed.is_empty() {
+        return Err(ApiError::bad_request("model is required"));
+    }
+    let mut components = std::path::Path::new(trimmed).components();
+    let single_normal = matches!(components.next(), Some(std::path::Component::Normal(_)))
+        && components.next().is_none();
+    if !single_normal || trimmed.contains('/') || trimmed.contains('\\') {
+        return Err(ApiError::bad_request(
+            "model must be a plain model id (no path separators or '..')",
+        ));
+    }
+    Ok(())
+}
+
 fn validate_image_job(payload: &ImageJobRequest) -> Result<(), ApiError> {
     if payload.project_id.is_empty() {
         return Err(ApiError::bad_request("projectId is required"));
     }
+    validate_model_id(&payload.model)?;
     if payload.prompt.is_empty() || payload.prompt.chars().count() > MAX_PROMPT_CHARS {
         return Err(ApiError::bad_request(
             "prompt must be between 1 and 4000 characters",
@@ -2527,6 +2563,7 @@ fn validate_video_job(payload: &VideoJobRequest) -> Result<(), ApiError> {
     if payload.project_id.is_empty() {
         return Err(ApiError::bad_request("projectId is required"));
     }
+    validate_model_id(&payload.model)?;
     if payload.prompt.is_empty() || payload.prompt.chars().count() > MAX_PROMPT_CHARS {
         return Err(ApiError::bad_request(
             "prompt must be between 1 and 4000 characters",

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -11,9 +11,9 @@ use super::{
     parse_inprocess_utility_worker_count, safe_download_dir, seed_mode_for_config_dir,
     serialize_job_lora, should_warn_open_bind, strip_jsonc_comments,
     sweep_stale_asset_uploads_before, sweep_stale_lora_uploads_before, sweep_stale_uploads,
-    Settings, WorkerCapability, WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER,
-    DEFAULT_API_HOST, EVENT_BUFFER_SIZE, HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE,
-    TEST_MAX_LORA_UPLOAD_BYTES,
+    validate_model_id, Settings, WorkerCapability, WorkerSnapshot, WorkerStatus,
+    API_MANAGED_MANIFEST_HEADER, DEFAULT_API_HOST, EVENT_BUFFER_SIZE, HEARTBEAT_SSE_DATA,
+    HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
 };
 use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
@@ -29,6 +29,82 @@ fn default_api_host_is_loopback() {
     // sc-4201 (F-API-1): an out-of-the-box bind must not expose the API to the LAN.
     let ip: std::net::IpAddr = DEFAULT_API_HOST.parse().expect("default host parses");
     assert!(ip.is_loopback(), "default API host must be loopback");
+}
+
+/// F-003 / sc-11159: the enqueue gate must reject a path-unsafe `model` id (traversal /
+/// separators / absolute), since it flows verbatim into the worker's asset filename. A
+/// plain single-component id — including an uncatalogued one the stub lane serves — is
+/// accepted (path-safety only, not catalog membership).
+#[test]
+fn validate_model_id_rejects_traversal_and_separators() {
+    // Path-unsafe ids are rejected.
+    for evil in [
+        "../../../../etc/passwd",
+        "..\\..\\..\\windows\\system32",
+        "/etc/cron.d/pwn",
+        "a/b",
+        "a\\b",
+        "..",
+        ".",
+        "",
+        "   ",
+    ] {
+        assert!(
+            validate_model_id(evil).is_err(),
+            "expected {evil:?} to be rejected as an unsafe model id"
+        );
+    }
+    // Legitimate single-component ids (incl. uncatalogued stub-lane ids) are accepted.
+    for ok in [
+        "z_image_turbo",
+        "ltx_2_3",
+        "ideogram_4",
+        "vid-model",
+        "external_base_my-comfy-model",
+        "unknown_stub_model",
+    ] {
+        assert!(
+            validate_model_id(ok).is_ok(),
+            "expected {ok:?} to be accepted as a safe model id"
+        );
+    }
+}
+
+/// F-003 / sc-11159: a path-traversal `model` id is rejected at the POST boundary for BOTH
+/// the image and video enqueue lanes (before any job is created), closing the remote
+/// arbitrary-write primitive the worker filename builders would otherwise expose.
+#[tokio::test]
+async fn image_and_video_jobs_reject_path_unsafe_model_id() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    for (endpoint, mode) in [
+        ("/api/v1/image/jobs", "text_to_image"),
+        ("/api/v1/video/jobs", "text_to_video"),
+    ] {
+        for evil in ["../../../../etc/passwd", "..\\..\\evil", "/abs/pwn", "a/b"] {
+            let (status, body) = request(
+                app.clone(),
+                "POST",
+                endpoint,
+                json!({
+                    "projectId": "project-1",
+                    "mode": mode,
+                    "prompt": "a fox",
+                    "model": evil,
+                }),
+            )
+            .await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{endpoint} {evil:?}");
+            assert!(
+                body["detail"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .contains("model must be a plain model id"),
+                "{endpoint} {evil:?}: unexpected error {body}"
+            );
+        }
+    }
 }
 
 #[test]

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1243,10 +1243,16 @@ pub(crate) fn write_image_asset(
     let rgb_image = image::RgbImage::from_raw(width, height, pixels)
         .ok_or_else(|| WorkerError::InvalidPayload("image buffer size mismatch".to_owned()))?;
 
+    // Sanitize the payload-supplied model id before it becomes a path component: it
+    // arrives verbatim from the untrusted job payload, and a `../` / `\` / absolute id
+    // would otherwise traverse out of the project dir here (F-003 / sc-11159). rust-api
+    // now rejects such ids at enqueue, but the worker is the trust boundary and must
+    // re-confine — slugify neutralizes any separator/`..` to a single readable component.
+    let model_slug = slugify(&request.model, "model", None);
     let filename = format!(
         "{}_{}_{}_{:04}.png",
         &plan.created_at[..10],
-        request.model,
+        model_slug,
         plan.slug,
         index + 1
     );
@@ -1458,10 +1464,13 @@ fn write_upscaled_asset(
     let index = base_fact.get("index").and_then(Value::as_u64).unwrap_or(0) as usize;
     let (width, height) = (upscaled.width(), upscaled.height());
 
+    // Sanitize the untrusted model id before it becomes a path component (F-003 / sc-11159),
+    // mirroring `write_image_asset` so the upscaled variant is confined identically.
+    let model_slug = slugify(&request.model, "model", None);
     let filename = format!(
         "{}_{}_{}_{:04}_up{factor}x.png",
         &plan.created_at[..10],
-        request.model,
+        model_slug,
         plan.slug,
         index + 1
     );

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -78,6 +78,56 @@ fn render_and_save_writes_png_and_contract_fact() {
     );
 }
 
+/// F-003 / sc-11159: a path-traversal / absolute model id in the payload must NOT let the
+/// written PNG escape the project dir. The model id becomes a filename component, so a `../`,
+/// `..\`, or `/abs` id would otherwise land the asset (and its `create_dir_all` + rename)
+/// outside `project_path`. Assert the resolved media path stays confined for each vector.
+#[test]
+fn write_image_asset_confines_malicious_model_id() {
+    for evil in [
+        "../../../../etc/passwd",
+        "..\\..\\..\\windows\\system32\\evil",
+        "/etc/cron.d/pwn",
+        "sub/dir/model",
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let project_path = dir.path();
+        std::fs::create_dir_all(project_path.join("assets").join("images")).unwrap();
+        let req = request(json!({
+            "projectId": "p", "model": evil, "prompt": "Mist over hills",
+            "count": 1, "width": 256, "height": 256, "seed": 1
+        }));
+        let plan = ImagePlan::new(&req);
+        let pixels = stub_rgb8(req.width, req.height, 1);
+        let fact = write_image_asset(
+            &plan,
+            0,
+            1,
+            req.width,
+            req.height,
+            pixels,
+            STUB_ADAPTER,
+            stub_raw_settings(&req),
+            project_path,
+        )
+        .unwrap();
+
+        let media_rel = fact.get("mediaPath").and_then(Value::as_str).unwrap();
+        // The sanitized model slug carries no separator, so the relative path is a single
+        // segment under `assets/images/<genset>/` and never contains `..`.
+        assert!(
+            !media_rel.contains(".."),
+            "media path must not contain `..` for model id {evil:?}: {media_rel}"
+        );
+        let resolved =
+            std::fs::canonicalize(project_path.join(media_rel)).expect("written asset resolves");
+        assert!(
+            resolved.starts_with(std::fs::canonicalize(project_path).unwrap()),
+            "written asset {resolved:?} escaped project dir for model id {evil:?}"
+        );
+    }
+}
+
 #[test]
 fn resolve_seed_matches_python_precedence() {
     // base seed wins (seed + index), even over an explicit seeds list.
@@ -4355,6 +4405,64 @@ fn inline_upscaled_asset_links_back_to_base_for_library_fold() {
         !fact.contains_key("upscaledFrom"),
         "the unread `upscaledFrom` field must not be written"
     );
+}
+
+/// F-003 / sc-11159: the upscaled variant builds its own `_up{factor}x.png` filename from the
+/// same payload model id, so it must be confined identically to the base PNG.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[test]
+fn write_upscaled_asset_confines_malicious_model_id() {
+    for evil in ["../../../../etc/passwd", "..\\..\\evil", "/abs/pwn"] {
+        let dir = tempfile::tempdir().unwrap();
+        let project_path = dir.path();
+        std::fs::create_dir_all(project_path.join("assets").join("images")).unwrap();
+        let req = request(json!({
+            "projectId": "p", "model": evil, "prompt": "Mist over hills",
+            "count": 1, "width": 256, "height": 256, "seed": 1
+        }));
+        let plan = ImagePlan::new(&req);
+        let pixels = stub_rgb8(req.width, req.height, 1);
+        let base_fact = write_image_asset(
+            &plan,
+            0,
+            1,
+            req.width,
+            req.height,
+            pixels,
+            STUB_ADAPTER,
+            stub_raw_settings(&req),
+            project_path,
+        )
+        .unwrap();
+
+        let upscaled =
+            image::RgbImage::from_pixel(req.width * 2, req.height * 2, image::Rgb([1, 2, 3]));
+        let fact = write_upscaled_asset(
+            &plan,
+            &base_fact,
+            &upscaled,
+            "seedvr2",
+            2,
+            0.5,
+            project_path,
+        )
+        .unwrap();
+
+        let media_rel = fact.get("mediaPath").and_then(Value::as_str).unwrap();
+        assert!(
+            !media_rel.contains(".."),
+            "upscaled media path must not contain `..` for model id {evil:?}: {media_rel}"
+        );
+        let resolved = std::fs::canonicalize(project_path.join(media_rel))
+            .expect("written upscaled asset resolves");
+        assert!(
+            resolved.starts_with(std::fs::canonicalize(project_path).unwrap()),
+            "upscaled asset {resolved:?} escaped project dir for model id {evil:?}"
+        );
+    }
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -800,12 +800,18 @@ impl VideoPlan {
         let created_at = now_rfc3339();
         let family = resolve_family(request);
         let slug = slugify(&request.prompt, "video", Some(42));
+        // Sanitize the untrusted model id before it becomes a path component: it arrives
+        // verbatim from the job payload, and a `../` / `\` / absolute id would otherwise
+        // traverse out of the project dir here (F-003 / sc-11159). rust-api rejects such ids
+        // at enqueue, but the worker is the trust boundary and must re-confine — slugify
+        // collapses any separator/`..` to a single readable component (mirrors write_image_asset).
+        let model_slug = slugify(&request.model, "model", None);
         // Nest under the per-generation id so two renders sharing date+model+slug
         // cannot collide on a flat path (mirrors the image + Python video adapters).
         let media_rel = format!(
             "assets/videos/{genset_id}/{}_{}_{slug}.mp4",
             &created_at[..10],
-            request.model
+            model_slug
         );
         let media_path = project_path.join(&media_rel);
         Self {
@@ -10242,13 +10248,50 @@ mod tests {
             .media_rel
             .starts_with(&format!("assets/videos/{}/", plan.genset_id)));
         assert!(plan.media_rel.ends_with(".mp4"));
-        assert!(plan.media_rel.contains("_ltx_2_3_"));
+        // The model id is slugified into the filename (F-003 / sc-11159): `ltx_2_3` -> `ltx-2-3`.
+        assert!(plan.media_rel.contains("_ltx-2-3_"));
         assert!(plan.asset_id.starts_with("asset_"));
         assert_eq!(plan.family, "ltx-video");
         assert_eq!(
             plan.media_path,
             Path::new("/tmp/project").join(&plan.media_rel)
         );
+    }
+
+    /// F-003 / sc-11159: a path-traversal / absolute model id in the payload must NOT let the
+    /// rendered `.mp4` escape the project dir. The model id becomes a filename component in
+    /// `media_rel`, so a `../`, `..\`, or `/abs` id would otherwise place the media path (and
+    /// its later `create_dir_all` + write) outside `project_path`. Assert confinement per vector.
+    #[test]
+    fn plan_confines_malicious_model_id() {
+        let project = Path::new("/tmp/project");
+        for evil in [
+            "../../../../etc/passwd",
+            "..\\..\\..\\windows\\evil",
+            "/etc/cron.d/pwn",
+            "sub/dir/model",
+        ] {
+            let request = request(json!({
+                "projectId": "p", "model": evil, "prompt": "A red fox runs"
+            }));
+            let plan = VideoPlan::new(&request, project);
+            assert!(
+                !plan.media_rel.contains(".."),
+                "media_rel must not contain `..` for model id {evil:?}: {}",
+                plan.media_rel
+            );
+            assert!(
+                plan.media_rel
+                    .starts_with(&format!("assets/videos/{}/", plan.genset_id)),
+                "media_rel escaped the videos dir for model id {evil:?}: {}",
+                plan.media_rel
+            );
+            assert!(
+                plan.media_path.starts_with(project),
+                "media_path {:?} escaped project dir for model id {evil:?}",
+                plan.media_path
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes the **F-003 (High)** path-traversal / arbitrary-write finding: `request.model` arrives verbatim from the untrusted job payload and flowed straight into the worker's asset filename. `write_image_asset`, `write_upscaled_asset`, and `VideoPlan::new` each `format!` the model id into a project-relative path and then `create_dir_all(parent)` + atomic-rename the PNG/MP4 into place. A crafted model id containing `../`, `..\`, or an absolute path traversed out of the project dir — a remote arbitrary-write primitive. The rust-api create handlers never validated the id (`resolve_model_manifest_entry` returns `{}` for unknown ids and the job was created anyway).

Fixes **both** layers (defense in depth):

### Worker — filename sanitization (last line of defense)
- `crates/sceneworks-worker/src/image_jobs.rs` — `write_image_asset` and `write_upscaled_asset`
- `crates/sceneworks-worker/src/video_jobs.rs` — `VideoPlan::new`

Each now runs `request.model` through the house `slugify` (`sceneworks_core::slug::slugify`) before it becomes a path component, so any separator / `..` collapses to a stable, readable single segment that cannot escape the project dir. `slugify` never errors, so the AC's "yields a confined filename" holds for every input (e.g. `ltx_2_3` → `ltx-2-3`).

### rust-api — reject at enqueue (first gate)
- `apps/rust-api/src/lib.rs` — new `validate_model_id` helper, wired into **both** `validate_image_job` and `validate_video_job`.

Rejects a `model` id that is not a safe single path component (empty / separators / `..` / absolute) with the repo's standard `ApiError::bad_request`, mirroring the worker's existing `safe_weight_filename` posture for payload-supplied filename components.

### Scope decision (path-safety, not catalog membership)
Enqueue enforces **path-safety only**, not catalog membership. The worker's stub lane deliberately serves uncatalogued ids for dev/testing, and the rust-api test harness (`create_app` does **not** seed the shipped model manifests — seeding lives in `server.rs`) routinely enqueues real-but-uncatalogued ids (`ideogram_4`, `flux_dev`, …) and expects success. A catalog rejection at enqueue would break that legitimate lane and a large, unrelated test surface. Path-safety alone fully closes the traversal/arbitrary-write vulnerability — an uncatalogued-but-path-safe id can never escape the project dir. This matches the story's explicit fallback allowance ("reject path-unsafe ids at minimum").

## Tests
- **Worker:** `write_image_asset_confines_malicious_model_id` (png), `write_upscaled_asset_confines_malicious_model_id` (upscaled png, cfg-gated to the macOS/candle lanes), and `plan_confines_malicious_model_id` (mp4) each assert the resolved media path stays under `project_path` for `../`, `..\`, and absolute model ids. Updated `plan_builds_nested_media_path` (`_ltx_2_3_` → `_ltx-2-3_`).
- **rust-api:** `validate_model_id_rejects_traversal_and_separators` (unit) and `image_and_video_jobs_reject_path_unsafe_model_id` (HTTP, both lanes → 400) plus acceptance of safe single-component ids including uncatalogued ones.

## Verification (touched crates)
- `cargo build -p sceneworks-worker -p sceneworks-rust-api` — clean
- `cargo test -p sceneworks-worker` — 741 passed / 157 ignored; `cargo test -p sceneworks-rust-api` — 267 passed
- `cargo clippy -p sceneworks-worker -p sceneworks-rust-api --all-targets -- -D warnings` — clean
- `cargo fmt -p sceneworks-worker -p sceneworks-rust-api --check` — clean

Refs sc-11159, epic 11147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)