### PR TITLE
fix(jobs_store): truncate job-title prompt on UTF-8 char boundary (sc-11161)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2174,7 +2174,15 @@ fn derive_job_title(job_type: &JobType, payload: &Map<String, Value>) -> Option<
         if prompt.len() <= max {
             return prompt.to_owned();
         }
-        let mut cut = prompt[..max].to_owned();
+        // `max` is a byte budget. Prompts are arbitrary user text (CJK, emoji,
+        // accents), so slicing at a raw byte index can land mid-way through a
+        // multi-byte UTF-8 char and panic. Cut at the largest char boundary at
+        // or below `max`, keeping the byte-budget intent while never panicking.
+        let boundary = (0..=max)
+            .rev()
+            .find(|&i| prompt.is_char_boundary(i))
+            .unwrap_or(0);
+        let mut cut = prompt[..boundary].to_owned();
         if let Some(space) = cut.rfind(' ') {
             if space > (max * 6) / 10 {
                 cut.truncate(space);
@@ -3302,6 +3310,89 @@ fn sort_json_value(value: &mut Value) {
             }
         }
         Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+#[cfg(test)]
+mod derive_job_title_truncate_tests {
+    //! sc-11161 (F-004): `truncate_prompt` used to slice `prompt[..max]` at a
+    //! raw byte index. `max` (80/60) is a byte budget, so a prompt of multi-byte
+    //! UTF-8 (CJK/emoji/accents) whose byte at `max` fell mid-char panicked with
+    //! "byte index is not a char boundary". Because this runs inside
+    //! `derive_job_title`, which `row_to_job` calls on EVERY row read, one such
+    //! prompt bricked list/get/queue/claim/sweep for the whole project. These
+    //! guard that a long non-ASCII prompt truncates safely, never panicking.
+    use super::{derive_job_title, JobType};
+    use serde_json::{Map, Value};
+
+    fn payload_with_prompt(prompt: &str) -> Map<String, Value> {
+        let mut payload = Map::new();
+        payload.insert("prompt".to_owned(), Value::String(prompt.to_owned()));
+        payload
+    }
+
+    #[test]
+    fn long_cjk_prompt_truncates_without_panicking() {
+        // 40 three-byte CJK chars = 120 bytes; byte index 80 lands mid-char.
+        let prompt = "一二三四五六七八九十".repeat(4);
+        assert!(prompt.len() > 80);
+        let payload = payload_with_prompt(&prompt);
+
+        let title = derive_job_title(&JobType::ImageGenerate, &payload)
+            .expect("image generate yields a title");
+
+        assert!(title.starts_with("Generate Image — "));
+        assert!(
+            title.ends_with('…'),
+            "truncated title keeps the ellipsis: {title}"
+        );
+        // The rendered subject stays within the byte budget (+ ellipsis), and is
+        // valid UTF-8 by construction (a String was returned, no panic).
+        let subject = title.trim_start_matches("Generate Image — ");
+        assert!(subject.trim_end_matches('…').len() <= 80);
+    }
+
+    #[test]
+    fn long_emoji_prompt_truncates_without_panicking() {
+        // Four-byte emoji; byte index 80 (=20 emoji) falls on a boundary here,
+        // but a mixed run exercises the char-boundary walk under the budget.
+        let prompt = format!("{}sunset over the bay", "🌅".repeat(30));
+        assert!(prompt.len() > 80);
+        let payload = payload_with_prompt(&prompt);
+
+        let title = derive_job_title(&JobType::VideoGenerate, &payload)
+            .expect("video generate yields a title");
+
+        assert!(title.starts_with("Generate Video — "));
+        assert!(
+            title.ends_with('…'),
+            "truncated title keeps the ellipsis: {title}"
+        );
+    }
+
+    #[test]
+    fn short_non_ascii_prompt_is_untouched() {
+        let prompt = "日本語のプロンプト"; // < 80 bytes, no truncation
+        assert!(prompt.len() <= 80);
+        let payload = payload_with_prompt(prompt);
+
+        let title = derive_job_title(&JobType::ImageGenerate, &payload)
+            .expect("image generate yields a title");
+
+        assert_eq!(title, format!("Generate Image — {prompt}"));
+    }
+
+    #[test]
+    fn prompt_refine_60_byte_budget_truncates_safely() {
+        let prompt = "가나다라마바사아자차카타파하".repeat(4); // 3-byte Hangul, > 60 bytes
+        assert!(prompt.len() > 60);
+        let payload = payload_with_prompt(&prompt);
+
+        let title = derive_job_title(&JobType::PromptRefine, &payload)
+            .expect("prompt refine yields a title");
+
+        assert!(title.starts_with("Prompt Refine — "));
+        assert!(title.ends_with('…'));
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes **sc-11161** (F-004, High) — a UTF-8 byte-slice panic in `truncate_prompt` inside `crates/sceneworks-core/src/jobs_store.rs`.

`truncate_prompt` did `prompt[..max]` after a byte-length guard (`prompt.len() <= max`), but `max` (80 for image/video/person, 60 for prompt-refine) is a **byte** index. A prompt of arbitrary user text with multi-byte UTF-8 (CJK, emoji, accents) whose byte at `max` fell mid-character panicked with *"byte index is not a char boundary"*.

Because this runs inside `derive_job_title`, which `row_to_job` calls on **every** job row read, a single job with a >80-byte non-ASCII prompt (e.g. 27 three-byte CJK chars) bricked `list_jobs`, `get_job`, `queue_summary`, claim, and sweep for the whole project until the row was deleted out-of-band.

## Fix

Cut at the largest char boundary at or below `max`:

```rust
let boundary = (0..=max).rev().find(|&i| prompt.is_char_boundary(i)).unwrap_or(0);
```

Semantics preserved:
- **Byte-budget intent** (80/60) — the boundary is always `<= max` bytes, matching the original byte-oriented budget (and the byte-oriented word-boundary heuristic `space > (max * 6) / 10`).
- **Word-boundary trim** at the last space — unchanged.
- **Trailing ellipsis** `…` — unchanged.
- Short prompts still return untouched.

The only byte-index slice of user text in the file was this one; no other `prompt[..` / `&s[..n]` hazards found. `cut.truncate(space)` remains safe (`space` from `rfind(' ')` is a char boundary).

## Tests

Adds `derive_job_title_truncate_tests` with four regressions exercising the previously-panicking path through `derive_job_title`:
- long CJK (40× 3-byte chars, byte 80 mid-char) → truncates, no panic
- long emoji (4-byte) mixed run → truncates, no panic
- 60-byte-budget Hangul via `PromptRefine`
- short non-ASCII prompt returned untouched

`cargo test -p sceneworks-core` (452 lib + integration), `cargo clippy -p sceneworks-core --all-targets -- -D warnings`, and `cargo fmt --all --check` are all green.

Epic 11147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)