### PR TITLE
fix(worker): confine Krea controlWeights.path + finish MLX HF revision pinning (sc-11168)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/instantid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/instantid.rs
@@ -52,6 +52,18 @@ const INSTANTID_ANGLE_CONTROLNET_SCALE: f32 = 0.65;
 const INSTANTID_OPENPOSE_REPO: &str = "xinsir/controlnet-openpose-sdxl-1.0";
 /// Pinned revision for the xinsir OpenPose-SDXL ControlNet (sc-9879, F-077 follow-up).
 const INSTANTID_OPENPOSE_REVISION: &str = "23f966cd5cfdd3f7729c903e243d87152162d2b7";
+/// Pinned commit revisions for the MLX PuLID-FLUX download repos (sc-11168, F-007 — completes the sc-9879
+/// rollout on the MLX lane). The MLX PuLID route (`pulid.rs`) fetches its adapter + EVA/BiSeNet bundle
+/// through `ensure_instantid_file`, so those repos route through `instantid_revision` below and were
+/// falling back to the mutable `main` branch — the candle twin (`pulid_candle.rs`) already pins them, so
+/// the MLX side was the last unpinned lane. Pin each to its exact commit for defense-in-depth. The repo
+/// NAMES are the macOS-only `pulid.rs` `PULID_ADAPTER_REPO` / `PULID_MLX_REPO` consts; they are matched
+/// here as string literals because `instantid.rs` also compiles on the candle lane where those macOS-only
+/// consts do not exist (a macOS test ties the literals back to the consts). These shas MUST equal the
+/// candle `PULID_CANDLE_ADAPTER_REVISION` / `PULID_CANDLE_MLX_REVISION` (same repos). PuLID's third repo
+/// (SCRFD / ArcFace) IS `SceneWorks/instantid-mlx`, already pinned above by `INSTANTID_MLX_REVISION`.
+const PULID_ADAPTER_REVISION: &str = "492b1451255dc9d9bc3c857259690b5f8b998d4a";
+const PULID_MLX_REVISION: &str = "78ef91f977eae16d66fb191caf003154b7a0a0b8";
 /// Torch-parity default OpenPose lock (`instantid_adapter.py::_openpose_scale`, default 0.7).
 const INSTANTID_OPENPOSE_SCALE: f32 = 0.7;
 /// The face-restore re-render side (the engine's production crop size, sc-3380).
@@ -358,6 +370,11 @@ fn instantid_revision(repo: &str) -> &'static str {
         INSTANTID_MLX_REPO => INSTANTID_MLX_REVISION,
         INSTANTID_CONTROLNET_REPO => INSTANTID_CONTROLNET_REVISION,
         INSTANTID_OPENPOSE_REPO => INSTANTID_OPENPOSE_REVISION,
+        // The MLX PuLID lane (`pulid.rs`) fetches its adapter + EVA/BiSeNet bundle through
+        // `ensure_instantid_file`, so pin those two repos here too (sc-11168 / F-007). Matched as string
+        // literals because `pulid.rs`'s `PULID_ADAPTER_REPO` / `PULID_MLX_REPO` consts are macOS-only.
+        "guozinan/PuLID" => PULID_ADAPTER_REVISION,
+        "SceneWorks/pulid-flux-mlx" => PULID_MLX_REVISION,
         _ => "main",
     }
 }

--- a/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
@@ -14,10 +14,12 @@
 /// The Kolors IP-Adapter-Plus repo (CLIP ViT-L/14-336 `image_encoder/` + the `image_proj` Resampler +
 /// `ip_adapter.*` K/V). Same repo the MLX path uses (`kolors.rs` `KOLORS_IP_ADAPTER_REPO`).
 const KOLORS_IPADAPTER_REPO: &str = "Kwai-Kolors/Kolors-IP-Adapter-Plus";
-/// The repo revision carrying the **safetensors** (`refs/pr/4`): the repo's `main` ships only `.bin`
-/// (a torch pickle candle can't read); PR-4 adds `ip_adapter_plus_general.safetensors` +
-/// `image_encoder/model.safetensors`. The torch/MLX download flow uses this same rev.
-const KOLORS_IPADAPTER_REVISION: &str = "refs/pr/4";
+/// The repo revision carrying the **safetensors**: the repo's `main` ships only `.bin` (a torch pickle
+/// candle can't read); PR-4 adds `ip_adapter_plus_general.safetensors` + `image_encoder/model.safetensors`.
+/// Pinned to the exact commit at the tip of `refs/pr/4` rather than the mutable `refs/pr/4` ref itself
+/// (sc-11168 / F-007 — completes the sc-9879 rollout): a force-push to the PR could otherwise swap the
+/// adapter/encoder weights we load. The `hf` CLI still verifies each file's own hash on download.
+const KOLORS_IPADAPTER_REVISION: &str = "5c72aa86cd8d9d23ff406d293c5473820e09e1d9";
 /// The IP-Adapter-Plus bundle file (root of the snapshot).
 const KOLORS_IPADAPTER_BUNDLE: &str = "ip_adapter_plus_general.safetensors";
 /// The CLIP ViT-L/14-336 image-encoder files inside the repo (config + weights).

--- a/crates/sceneworks-worker/src/image_jobs/krea_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control.rs
@@ -128,6 +128,36 @@ fn krea_control_overlay_repo_file(request: &ImageRequest) -> WorkerResult<(Strin
     ))
 }
 
+/// Confine a payload-supplied `advanced.controlWeights.path` to an app-managed root (sc-11168 / F-006).
+/// The API writes this key for a studio-trained / registered LOCAL overlay (B4/sc-10165), but the value
+/// arrives untrusted across the LAN boundary (epic 4484), so — like every other on-disk model input — it
+/// must resolve under the app data dir / HF hub cache (or a declared external root) via the house
+/// `normalize_app_managed_model_path`; without this a crafted job could point the loader at any file on
+/// disk (an arbitrary-file-read primitive). Returns `Ok(None)` when the payload carries no path, `Ok(Some)`
+/// for a confined path (whether or not it exists — the caller checks `is_file`), and the same
+/// `InvalidPayload` rejection as the sibling lanes for an out-of-root path. Mirrors the candle twin.
+fn krea_control_payload_overlay_path(
+    settings: &Settings,
+    request: &ImageRequest,
+) -> WorkerResult<Option<PathBuf>> {
+    let Some(path) = request
+        .advanced
+        .get("controlWeights")
+        .and_then(Value::as_object)
+        .and_then(|cw| cw.get("path"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(None);
+    };
+    Ok(Some(crate::paths::normalize_app_managed_model_path(
+        settings,
+        path,
+        "Krea control overlay",
+    )?))
+}
+
 /// Resolve the MLX control-branch overlay the `KreaTurboControl` provider loads, downloading on first use.
 /// Order (most specific wins): the `SCENEWORKS_CONTROLNET_KREA` env → an `advanced.controlWeights.path`
 /// (a studio-trained / registered LOCAL overlay the API resolved, B4/sc-10165) → an
@@ -145,16 +175,7 @@ async fn ensure_krea_control_weights(
             return Ok(p);
         }
     }
-    if let Some(path) = request
-        .advanced
-        .get("controlWeights")
-        .and_then(Value::as_object)
-        .and_then(|cw| cw.get("path"))
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        let p = PathBuf::from(path);
+    if let Some(p) = krea_control_payload_overlay_path(settings, request)? {
         if p.is_file() {
             return Ok(p);
         }

--- a/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
@@ -137,6 +137,36 @@ fn krea_control_overlay_repo_file(request: &ImageRequest) -> WorkerResult<(Strin
     ))
 }
 
+/// Confine a payload-supplied `advanced.controlWeights.path` to an app-managed root (sc-11168 / F-006).
+/// The API writes this key for a studio-trained / registered LOCAL overlay (B4/sc-10165), but the value
+/// arrives untrusted across the LAN boundary (epic 4484), so — like every other on-disk model input — it
+/// must resolve under the app data dir / HF hub cache (or a declared external root) via the house
+/// `normalize_app_managed_model_path`; without this a crafted job could point the loader at any file on
+/// disk (an arbitrary-file-read primitive). Returns `Ok(None)` when the payload carries no path, `Ok(Some)`
+/// for a confined path (whether or not it exists — the caller checks `is_file`), and the same
+/// `InvalidPayload` rejection as the sibling lanes for an out-of-root path. Mirrors the MLX twin.
+fn krea_control_payload_overlay_path(
+    settings: &Settings,
+    request: &ImageRequest,
+) -> WorkerResult<Option<PathBuf>> {
+    let Some(path) = request
+        .advanced
+        .get("controlWeights")
+        .and_then(Value::as_object)
+        .and_then(|cw| cw.get("path"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(None);
+    };
+    Ok(Some(crate::paths::normalize_app_managed_model_path(
+        settings,
+        path,
+        "Krea control overlay",
+    )?))
+}
+
 /// Resolve the control-branch overlay checkpoint the `Krea2Control` provider loads, downloading on first
 /// use. Order (most specific wins): the `SCENEWORKS_CONTROLNET_KREA` env (validation / bring-your-own) → an
 /// `advanced.controlWeights.path` (a studio-trained or registered LOCAL overlay the API resolved,
@@ -158,17 +188,9 @@ async fn ensure_krea_control_weights(
         }
     }
     // 2. A LOCAL overlay path the API resolved from a studio-trained / registered overlay selection
-    //    (B4/sc-10165 `resolve_control_overlay_selection` writes `advanced.controlWeights.path`).
-    if let Some(path) = request
-        .advanced
-        .get("controlWeights")
-        .and_then(Value::as_object)
-        .and_then(|cw| cw.get("path"))
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        let p = PathBuf::from(path);
+    //    (B4/sc-10165 `resolve_control_overlay_selection` writes `advanced.controlWeights.path`),
+    //    confined to an app-managed root (sc-11168 / F-006).
+    if let Some(p) = krea_control_payload_overlay_path(settings, request)? {
         if p.is_file() {
             return Ok(p);
         }

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -3721,6 +3721,57 @@ fn mlx_control_weight_filenames_reject_traversal() {
     assert!(resolve_qwen_control_weights(&plain, &settings).is_ok());
 }
 
+/// sc-11168 / F-006: the Krea strict-pose lanes accept a payload-supplied `advanced.controlWeights.path`
+/// (a studio-trained / registered LOCAL overlay the API resolved) and load it directly. That untrusted
+/// value must be confined to an app-managed root, or a crafted job turns the overlay loader into an
+/// arbitrary-file read across the LAN boundary (epic 4484). Exercise the confinement helper on whichever
+/// twin the current build compiles (MLX on macOS / candle off-Mac — both define the same-named helper):
+/// an out-of-root path is rejected with the house `InvalidPayload`, a path under the data dir resolves,
+/// and an absent key yields `None`. Mirrors `app_managed_helpers_resolve_symlinks_before_root_check`.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[test]
+fn krea_control_payload_overlay_path_confines_to_app_root() {
+    let data = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let mut settings = Settings::from_env();
+    settings.data_dir = data.path().to_path_buf();
+    settings.external_model_roots = Vec::new();
+
+    // No `controlWeights.path` in the payload → nothing to confine.
+    let none = request(json!({ "projectId": "p" }));
+    assert!(krea_control_payload_overlay_path(&settings, &none)
+        .expect("an absent overlay path is Ok(None)")
+        .is_none());
+
+    // An out-of-root absolute path (the arbitrary-file-read primitive) is rejected.
+    let escape_file = outside.path().join("evil.safetensors");
+    std::fs::write(&escape_file, b"x").unwrap();
+    let escape = request(json!({
+        "projectId": "p",
+        "advanced": { "controlWeights": { "path": escape_file.display().to_string() } }
+    }));
+    let err = krea_control_payload_overlay_path(&settings, &escape)
+        .expect_err("an out-of-root overlay path is rejected");
+    assert!(err.to_string().contains("app-managed"), "{err}");
+
+    // A path under the app data dir resolves (canonicalized) and is loadable.
+    let managed = settings.data_dir.join("models").join("overlay.safetensors");
+    std::fs::create_dir_all(managed.parent().unwrap()).unwrap();
+    std::fs::write(&managed, b"weights").unwrap();
+    let ok = request(json!({
+        "projectId": "p",
+        "advanced": { "controlWeights": { "path": managed.display().to_string() } }
+    }));
+    let resolved = krea_control_payload_overlay_path(&settings, &ok)
+        .expect("a managed overlay path is Ok")
+        .expect("a present key yields Some");
+    assert_eq!(resolved, managed.canonicalize().unwrap());
+    assert!(resolved.is_file());
+}
+
 #[cfg(target_os = "macos")]
 #[test]
 fn flux2_control_raw_settings_records_control_recipe() {
@@ -8748,6 +8799,26 @@ fn instantid_revisions_are_pinned_commits_not_main() {
         INSTANTID_CONTROLNET_REVISION,
     );
     assert_pinned_revision("INSTANTID_OPENPOSE_REVISION", INSTANTID_OPENPOSE_REVISION);
+    // sc-11168 / F-007: the MLX PuLID lane (`pulid.rs`) fetches its adapter + EVA/BiSeNet bundle repos
+    // through `ensure_instantid_file` → `instantid_revision`, so those two repos must be pinned here too
+    // (they were falling back to `main`; the candle twin already pins them).
+    assert_pinned_revision("PULID_ADAPTER_REVISION", PULID_ADAPTER_REVISION);
+    assert_pinned_revision("PULID_MLX_REVISION", PULID_MLX_REVISION);
+    assert_eq!(instantid_revision("guozinan/PuLID"), PULID_ADAPTER_REVISION);
+    assert_eq!(
+        instantid_revision("SceneWorks/pulid-flux-mlx"),
+        PULID_MLX_REVISION
+    );
+    // Tie the literal repo names matched in `instantid_revision` back to `pulid.rs`'s consts (macOS-only,
+    // so a rename of either const can't silently desync the pin from the repo it guards).
+    #[cfg(target_os = "macos")]
+    {
+        assert_eq!(
+            instantid_revision(PULID_ADAPTER_REPO),
+            PULID_ADAPTER_REVISION
+        );
+        assert_eq!(instantid_revision(PULID_MLX_REPO), PULID_MLX_REVISION);
+    }
     // `instantid_revision` returns the pin for a known repo and falls back to `main` otherwise.
     assert_eq!(
         instantid_revision(INSTANTID_MLX_REPO),
@@ -8764,6 +8835,12 @@ fn mlx_control_and_distill_revisions_are_pinned_commits_not_main() {
     assert_pinned_revision("FLUX1_CONTROL_REVISION", FLUX1_CONTROL_REVISION);
     assert_pinned_revision("FLUX2_CONTROL_REVISION", FLUX2_CONTROL_REVISION);
     assert_pinned_revision("QWEN_LIGHTNING_LORA_REVISION", QWEN_LIGHTNING_LORA_REVISION);
+    // sc-11168 / F-007: the default MLX Krea pose-control overlay repo is a fixed, non-overridable const,
+    // so its pin must be a fixed commit rather than the mutable `main` branch.
+    assert_pinned_revision(
+        "KREA_CONTROL_OVERLAY_REVISION",
+        KREA_CONTROL_OVERLAY_REVISION,
+    );
 }
 
 /// The candle-only strict-control pins (qwen / kolors / zimage / flux1 / flux2 control branches). These
@@ -8782,6 +8859,13 @@ fn candle_control_revisions_are_pinned_commits_not_main() {
     assert_pinned_revision(
         "FLUX2_CONTROL_CANDLE_REVISION",
         FLUX2_CONTROL_CANDLE_REVISION,
+    );
+    // sc-11168 / F-007: the default candle Krea pose-control overlay repo is a fixed, non-overridable
+    // const, so its pin must be a fixed commit rather than the mutable `main` branch (twin of the MLX
+    // `KREA_CONTROL_OVERLAY_REVISION` assert on the macOS lane).
+    assert_pinned_revision(
+        "KREA_CONTROL_OVERLAY_REVISION",
+        KREA_CONTROL_OVERLAY_REVISION,
     );
 }
 
@@ -8819,6 +8903,19 @@ fn candle_ipadapter_and_pulid_revisions_are_pinned_commits_not_main() {
         PULID_CANDLE_FACE_REVISION
     );
     assert_eq!(pulid_candle_revision("some/override-repo"), "main");
+    // sc-11168 / F-007: the candle Kolors IP-Adapter-Plus fetch carried the mutable `refs/pr/4` ref;
+    // it is now pinned to the exact commit at that PR's tip (a force-push can't swap the weights).
+    assert_pinned_revision("KOLORS_IPADAPTER_REVISION", KOLORS_IPADAPTER_REVISION);
+    // sc-11168 / F-007: the MLX PuLID pins (in `instantid.rs`) fetch the SAME repos as these candle pins,
+    // so a bump to one lane without the other must fail loudly (twin-drift guard).
+    assert_eq!(
+        PULID_ADAPTER_REVISION, PULID_CANDLE_ADAPTER_REVISION,
+        "MLX + candle PuLID adapter (guozinan/PuLID) pins must agree"
+    );
+    assert_eq!(
+        PULID_MLX_REVISION, PULID_CANDLE_MLX_REVISION,
+        "MLX + candle PuLID EVA/BiSeNet bundle (SceneWorks/pulid-flux-mlx) pins must agree"
+    );
 }
 
 /// The candle-only Krea 2 ConvRot bf16-base pin (`base.rs`, sc-9300 tier). Fetches the fixed

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -2942,6 +2942,19 @@ const WAN_TI2V_5B_REPO: &str = "SceneWorks/wan2.2-ti2v-5b-mlx";
 #[cfg(target_os = "macos")]
 const WAN_TI2V_5B_REVISION: &str = "bb1b055249614cf9d7cf4373fbdbc184b77dee88";
 
+/// Pinned commit revision for the A14B Lightning distill-LoRA repo `lightx2v/Wan2.2-Lightning` (sc-11168 /
+/// F-007 — completes the sc-9879 rollout). Both the MLX (`ensure_wan_lightning_present`) and candle
+/// (`candle_ensure_wan_lightning_present`) self-heal fetches were pulling the mutable `main` branch, so an
+/// upstream re-push (or a compromised token) could silently swap the high/low distill weights we load.
+/// Pin the exact commit for defense-in-depth (the `hf` CLI still verifies each file's own hash on
+/// download). Shared by BOTH lanes so the twins agree. Gated to the lanes that actually fetch it (macOS
+/// MLX or the candle build) so a Linux-non-candle build doesn't flag it dead.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+const WAN_LIGHTNING_REVISION: &str = "18bccf8884ec0a078eed79785eb4ef13ea16ce1e";
+
 /// The files that make an **A14B** (dual-expert MoE) Wan tier subdir COMPLETE: both experts + the T5
 /// encoder + VAE + tokenizer + `config.json`.
 #[cfg(target_os = "macos")]
@@ -3166,7 +3179,13 @@ async fn ensure_wan_lightning_present(
         format!("{subdir}/low_noise_model.safetensors"),
     ];
     let result = crate::model_jobs::download_model_with_hf_cli(
-        api, settings, job, REPO, "main", &files, &scratch,
+        api,
+        settings,
+        job,
+        REPO,
+        WAN_LIGHTNING_REVISION,
+        &files,
+        &scratch,
     )
     .await;
     let _ = tokio::fs::remove_dir_all(&scratch).await;
@@ -5017,7 +5036,13 @@ async fn candle_ensure_wan_lightning_present(
         format!("{subdir}/low_noise_model.safetensors"),
     ];
     let result = crate::model_jobs::download_model_with_hf_cli(
-        api, settings, job, REPO, "main", &files, &scratch,
+        api,
+        settings,
+        job,
+        REPO,
+        WAN_LIGHTNING_REVISION,
+        &files,
+        &scratch,
     )
     .await;
     let _ = tokio::fs::remove_dir_all(&scratch).await;
@@ -10046,6 +10071,35 @@ mod tests {
             SEEDVR2_REPO,
             crate::upscale_jobs::SEEDVR2_REPO,
             "video and image SeedVR2 must reference the same upstream mirror repo"
+        );
+    }
+
+    /// sc-11168 / F-007 (completes the sc-9879 rollout on the video lanes): both the MLX
+    /// (`ensure_wan_lightning_present`) and candle (`candle_ensure_wan_lightning_present`) A14B Lightning
+    /// self-heal fetches pull the FIXED `lightx2v/Wan2.2-Lightning` distill pair from the SHARED
+    /// `WAN_LIGHTNING_REVISION` const, so it must pin an exact commit rather than the mutable `main`
+    /// branch — an upstream re-push would otherwise silently swap the high/low distill weights we load.
+    /// Lock the pin to a real 40-hex lowercase commit id (mirrors the SeedVR2 format test above).
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn wan_lightning_revision_is_pinned_commit_not_main() {
+        assert_ne!(
+            WAN_LIGHTNING_REVISION, "main",
+            "Wan Lightning distill pair must pin a fixed revision"
+        );
+        assert_eq!(
+            WAN_LIGHTNING_REVISION.len(),
+            40,
+            "a pinned HF revision is a 40-char commit sha"
+        );
+        assert!(
+            WAN_LIGHTNING_REVISION
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+            "the pinned revision must be lowercase hex"
         );
     }
 


### PR DESCRIPTION
## sc-11168 — Confine controlWeights.path + complete MLX HF revision pinning

Bug (security). Epic 11147 (MLX↔candle twin-drift). Two fixes that bring the MLX lanes up to the same lock-down posture as their candle twins.

### F-006 — Confine payload-supplied `controlWeights.path` in BOTH Krea control lanes
`krea_control.rs` (MLX) and `krea_control_candle.rs` (candle) both accepted an untrusted absolute `advanced.controlWeights.path` from the job payload and loaded it directly (`PathBuf::from(path); if p.is_file() { return Ok(p) }`) with **no confinement**, while every sibling payload-path input is confined — a crafted job could point the overlay loader at any file on disk (arbitrary-file-read across the LAN boundary, epic 4484).

Fix: route the value through the house `normalize_app_managed_model_path` (same `InvalidPayload` rejection the sibling lanes use), extracted into a shared `krea_control_payload_overlay_path` helper in **each** twin. A confined-but-absent path still falls through to the hosted overlay; an out-of-root path is rejected.

- MLX: `crates/sceneworks-worker/src/image_jobs/krea_control.rs` (`krea_control_payload_overlay_path` → used by `ensure_krea_control_weights`)
- candle: `crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs` (twin helper, same name/body)

### F-007 — Complete the sc-9879 HF revision-pinning rollout on the MLX lanes
The candle twins already pin exact commits; the MLX twins still fetched mutable `main`/PR refs. Each pin is the exact commit the ref resolves to today (`git ls-remote`), reusing the candle twin's sha where the repo is shared:

| Repo | Pinned sha | Site |
|---|---|---|
| `guozinan/PuLID` | `492b1451255dc9d9bc3c857259690b5f8b998d4a` | added to MLX `instantid_revision` (PuLID lane routes through it) — reuses candle `PULID_CANDLE_ADAPTER_REVISION` |
| `SceneWorks/pulid-flux-mlx` | `78ef91f977eae16d66fb191caf003154b7a0a0b8` | added to MLX `instantid_revision` — reuses candle `PULID_CANDLE_MLX_REVISION` |
| `lightx2v/Wan2.2-Lightning` | `18bccf8884ec0a078eed79785eb4ef13ea16ce1e` | new shared `WAN_LIGHTNING_REVISION`, used on **both** video lanes (`video_jobs.rs` MLX + candle) |
| `Kwai-Kolors/Kolors-IP-Adapter-Plus` | `5c72aa86cd8d9d23ff406d293c5473820e09e1d9` | `kolors_ipadapter.rs` — was mutable `refs/pr/4`, pinned to that PR's current tip commit |
| `SceneWorks/krea2-pose-controlnet-beta` | `cb3a0ac7590f5ec594a4eeb43b95ee1da0b5a0ac` | already pinned in both twins on `main`; now guarded by a pin-format test |

PuLID's third repo (`SceneWorks/instantid-mlx`, SCRFD/ArcFace) was already pinned via `INSTANTID_MLX_REVISION`.

### Tests
- `krea_control_payload_overlay_path_confines_to_app_root` — rejects an out-of-root path, accepts a data-dir path, `None` for an absent key; runs on whichever twin the build compiles.
- Extended the sc-9879 revision-pin tests: MLX PuLID pins + `instantid_revision` mapping, `WAN_LIGHTNING_REVISION`, `KOLORS_IPADAPTER_REVISION`, `KREA_CONTROL_OVERLAY_REVISION` (both lanes), and a MLX↔candle PuLID sha-agreement twin-drift guard.
- `cargo fmt --all --check`, `cargo clippy -p sceneworks-worker --all-targets -D warnings`, `cargo test -p sceneworks-worker` all green (745 passed, 157 ignored real-weight). Candle-gated code verified by inspection (it cannot compile on macOS; the twin helper is byte-identical to the compiling MLX helper).

Refs sc-11168, epic 11147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)