### PR TITLE
fix(core): atomic manifest seeding + fail-open list_projects (sc-11198)

### DIFF
--- a/crates/sceneworks-core/src/builtin_manifests.rs
+++ b/crates/sceneworks-core/src/builtin_manifests.rs
@@ -57,8 +57,16 @@ pub enum SeedMode {
 
 /// Write the builtin manifests into `config_dir/manifests` according to `mode`.
 ///
-/// Each file is written atomically (temp + rename) so a crash or partial write
-/// can't leave a truncated manifest that parses to an empty/broken catalog.
+/// Each file is written through [`store_util::atomic_write`], the house
+/// atomic-write primitive: it stages into a uniquely-named temp in the same
+/// directory, `sync_all`s the temp (and best-effort the parent dir) so the bytes
+/// are durable *before* the rename, then renames into place. That closes the two
+/// windows a bare temp+rename left open — a power loss after the rename leaving a
+/// zero-length `builtin.*.jsonc` (sc-8949), and two processes seeding concurrently
+/// colliding on a shared deterministic temp name (sc-1633). A crash therefore
+/// cannot leave a truncated manifest that parses to an empty/broken catalog and
+/// then gets skipped by a later `IfMissing` seeding.
+///
 /// Returns an error — annotated with which manifest failed — if any required
 /// manifest can't be installed, so callers can abort startup rather than serving
 /// an empty catalog.
@@ -72,13 +80,8 @@ pub fn seed_builtin_manifests(config_dir: &Path, mode: SeedMode) -> std::io::Res
         if mode == SeedMode::IfMissing && target.exists() {
             continue;
         }
-        let temp = dir.join(format!("{name}.tmp"));
-        std::fs::write(&temp, contents)
-            .map_err(|error| std::io::Error::new(error.kind(), format!("write {name}: {error}")))?;
-        std::fs::rename(&temp, &target).map_err(|error| {
-            let _ = std::fs::remove_file(&temp);
-            std::io::Error::new(error.kind(), format!("install {name}: {error}"))
-        })?;
+        crate::store_util::atomic_write(&target, contents.as_bytes())
+            .map_err(|error| std::io::Error::other(format!("install {name}: {error}")))?;
     }
     Ok(())
 }
@@ -134,6 +137,33 @@ mod tests {
             std::fs::read_to_string(dir.join("builtin.loras.jsonc")).expect("loras written"),
             embedded("builtin.loras.jsonc")
         );
+    }
+
+    #[test]
+    fn overwrite_repairs_a_truncated_manifest_and_leaves_no_temp() {
+        // Simulate the crash the old temp+rename path could leave behind: a
+        // zero-length `builtin.*.jsonc`. Overwrite seeding must replace it with the
+        // full embedded copy and leave no atomic-write temp files behind.
+        let temp = tempfile::tempdir().expect("temp dir");
+        let dir = temp.path().join("manifests");
+        std::fs::create_dir_all(&dir).expect("create manifests dir");
+        let truncated = dir.join("builtin.models.jsonc");
+        std::fs::write(&truncated, b"").expect("seed zero-length manifest");
+
+        seed_builtin_manifests(temp.path(), SeedMode::Overwrite).expect("seeding succeeds");
+
+        assert_eq!(
+            std::fs::read_to_string(&truncated).expect("read repaired"),
+            embedded("builtin.models.jsonc"),
+            "overwrite repairs the truncated manifest to the full embedded copy"
+        );
+        // atomic_write stages into `*.<token>.tmp` and renames it away; none survive.
+        let leftovers: Vec<_> = std::fs::read_dir(&dir)
+            .expect("read manifests dir")
+            .flatten()
+            .filter(|entry| entry.file_name().to_string_lossy().ends_with(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "no atomic-write temp files remain");
     }
 
     #[test]

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -288,7 +288,19 @@ impl ProjectStore {
             };
             let project_path = PathBuf::from(path);
             if project_path.exists() {
-                projects.push(read_project_summary(&project_path)?);
+                // Fail open per entry: one project whose `project.json` is missing,
+                // unreadable, or short a required field must not take down the whole
+                // listing and leave every healthy project unreachable. Skip the bad
+                // entry with a structured warning and keep the rest.
+                match read_project_summary(&project_path) {
+                    Ok(summary) => projects.push(summary),
+                    Err(error) => tracing::warn!(
+                        event = "list_projects_summary_failed",
+                        project = %project_path.display(),
+                        error = %error,
+                        "skipping project with unreadable project.json"
+                    ),
+                }
             }
         }
         Ok(projects)
@@ -5932,6 +5944,39 @@ mod tests {
                 .id,
             GLOBAL_POSES_PROJECT_ID
         );
+    }
+
+    #[test]
+    fn list_projects_skips_a_corrupt_entry_and_returns_the_healthy_ones() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+
+        let good = store.create_project("Healthy One").expect("first project");
+        let broken = store.create_project("Corrupt One").expect("second project");
+        let also_good = store.create_project("Healthy Two").expect("third project");
+
+        // Corrupt one project's `project.json` after the fact: truncate it to an
+        // object missing every required field (id/name/createdAt) so
+        // `read_project_summary` fails for that entry only.
+        let broken_file = std::path::Path::new(&broken.path).join("project.json");
+        std::fs::write(&broken_file, b"{}").expect("clobber project.json");
+
+        let listed = store.list_projects().expect("list survives a bad entry");
+
+        let ids: Vec<&str> = listed.iter().map(|p| p.id.as_str()).collect();
+        assert!(
+            ids.contains(&good.id.as_str()),
+            "healthy project before the bad entry is still listed"
+        );
+        assert!(
+            ids.contains(&also_good.id.as_str()),
+            "healthy project after the bad entry is still listed"
+        );
+        assert!(
+            !ids.contains(&broken.id.as_str()),
+            "the corrupt entry is skipped, not surfaced"
+        );
+        assert_eq!(listed.len(), 2, "exactly the two healthy projects remain");
     }
 
     #[test]


### PR DESCRIPTION
## sc-11198 — Core store durability (epic 11147)

Two independent core-store durability fixes.

### F-023 — Atomic builtin-manifest seeding
`crates/sceneworks-core/src/builtin_manifests.rs` — `seed_builtin_manifests`

Previously each `builtin.*.jsonc` was staged to a **deterministic** temp name (`{name}.tmp`) and renamed with **no fsync** — the exact two defects `store_util::atomic_write` was hardened against:
- **sc-8949 (rename-before-durable):** a power loss after the rename could leave a zero-length `builtin.*.jsonc`. Under `SeedMode::IfMissing` the truncated file *exists*, so every later seeding skips it and the broken catalog persists.
- **sc-1633 (colliding writers):** two processes seeding concurrently collide on the shared temp name.

Now writes each manifest through `store_util::atomic_write` (unique random temp suffix, `sync_all` before rename, best-effort parent-dir fsync). `SeedMode` semantics are unchanged — only the write mechanism changed. The doc comment was updated to stop overclaiming and to name the sc-8949/sc-1633 windows it now actually closes.

### F-024 — Fail-open `list_projects`
`crates/sceneworks-core/src/project_store.rs:273` (uses `read_project_summary` at ~3475)

`list_projects` propagated `read_project_summary(...)?` per registry entry, so **one** project whose `project.json` is missing/unreadable/short-a-required-field failed the **entire** listing — every healthy project became unreachable. It now matches the store's fail-open convention: a bad entry is skipped with a structured `tracing::warn!` (`event = "list_projects_summary_failed"`, `project = <path>`, `error = …`) and the healthy projects are returned. Successful-entry behavior is byte-identical.

**Double-catch check:** the rust-api handler (`apps/rust-api/src/projects.rs`) does **not** catch this per entry — it forwards `store.list_projects()` as a single `ApiError`. So the core-level fail-open is the only guard; this fix makes the store robust regardless of caller.

### Tests
- `overwrite_repairs_a_truncated_manifest_and_leaves_no_temp` — a pre-existing zero-length manifest (the sc-8949 crash artifact) is repaired to the full embedded copy by `Overwrite`, and no atomic-write temp files remain.
- `list_projects_skips_a_corrupt_entry_and_returns_the_healthy_ones` — three real projects created via the store harness, one's `project.json` clobbered to `{}`; listing returns exactly the two healthy projects and omits the corrupt one.

### Verification
`cargo build -p sceneworks-core`, `cargo test -p sceneworks-core` (454+ pass), `cargo clippy -p sceneworks-core --all-targets -- -D warnings`, `cargo fmt --all --check` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)