### PR TITLE
fix(worker): reject candle strict-pose when control base absent + correct expectedCount (sc-11171)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -409,17 +409,17 @@ pub(crate) async fn run_image_generate_job(
         &request,
         route.map_or(request.count, |route| route.image_count(&request, settings)) * upscale_mult,
     );
-    // Windows/CUDA candle lane: an InstantID angle/pose set produces N images (the active angle
-    // collection's length, or the pose count), not `request.count` — bake the real total into the plan
-    // so the generation set + streamed `expectedCount` match (sc-5491, mirroring the macOS route's
-    // `image_count`). Any other candle job stays `request.count`.
+    // Windows/CUDA candle lane: resolve the candle dispatch branch once and bake THAT branch's real
+    // total into the plan, exactly as the macOS arm does with `resolve_image_route`. An InstantID
+    // angle/pose set produces N images (the active angle collection's length, or the pose count) and
+    // every strict-pose control lane produces one image per pose (`pose_entries().len()`), not
+    // `request.count` — so the generation set + streamed `expectedCount` match what lands in the gallery
+    // (sc-5491 InstantID; sc-11171 F-009 strict-pose). `resolve_candle_image_route` returns `None` when
+    // candle is disabled, so any other job (or a disabled backend) keeps `request.count`.
     #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
     let plan = {
-        let count = if settings.backend_candle_enabled && instantid_available(&request, settings) {
-            instantid_image_count(&request, settings)
-        } else {
-            request.count
-        };
+        let count = resolve_candle_image_route(&request, settings)
+            .map_or(request.count, |route| route.image_count(&request, settings));
         ImagePlan::with_count(&request, count * upscale_mult)
     };
     #[cfg(all(
@@ -1007,14 +1007,27 @@ pub(crate) async fn run_image_generate_job(
                 // sdxl) must be REJECTED with a clear error, not silently rendered as plain txt2img (poses
                 // dropped) and not bounced to torch. The candle worker CLAIMS these (jobs_store
                 // `image_job_candle_pose_reject`) precisely to fail them loudly here. SDXL identity-pose
-                // ships via InstantID; the wired candle pose families are qwen_image / kolors /
-                // z_image_turbo / z_image / flux2_dev / flux_dev.
+                // ships via InstantID; the wired candle pose families are `WIRED_CANDLE_POSE_FAMILIES`.
                 CandleImageRoute::PoseReject => {
                     return Err(WorkerError::InvalidPayload(format!(
                         "strict pose (advanced.poses) is not supported for model '{}' on the candle backend — \
                          refusing rather than silently generating an unconditioned image (wired candle pose \
-                         families: qwen_image, kolors, z_image_turbo, z_image, flux2_dev, flux_dev, \
-                         krea_2_turbo; SDXL identity-pose runs via InstantID)",
+                         families: {}; SDXL identity-pose runs via InstantID)",
+                        request.model,
+                        WIRED_CANDLE_POSE_FAMILIES.join(", ")
+                    )));
+                }
+                // No-silent-T2I (sc-11171, F-008): a strict-pose job on a WIRED candle pose family whose
+                // control base snapshot is NOT installed (the family's `…_control_available` weight-gate
+                // failed, so it fell through to here). The scheduler routed it to candle weight-blind
+                // (`zimage_control_candle_eligible` & siblings check only the payload), so REFUSE loudly
+                // rather than silently rendering plain txt2img and dropping the poses.
+                CandleImageRoute::PoseControlBaseMissing => {
+                    return Err(WorkerError::InvalidPayload(format!(
+                        "strict pose (advanced.poses) requested for model '{}' on the candle backend, but \
+                         its control base snapshot is not installed — refusing rather than silently \
+                         generating an unconditioned image; install the control base model to enable \
+                         strict-pose generation",
                         request.model
                     )));
                 }

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -233,6 +233,12 @@ enum CandleImageRoute {
     KreaControl,
     /// A strict-pose job on a candle model with NO pose lane → reject loudly, never silent T2I (sc-5968).
     PoseReject,
+    /// A strict-pose job on a WIRED candle pose family (one with a `…_control_available` lane) whose
+    /// control base snapshot is NOT installed — the lane's local weight-gate failed, so the job reached
+    /// the fall-through arm. Reject loudly ("control base snapshot not installed") rather than silently
+    /// rendering plain txt2img and dropping the poses (sc-11171, F-008). Distinct from `PoseReject`,
+    /// which is a family that has no candle pose lane at all.
+    PoseControlBaseMissing,
     /// An in-place ComfyUI Z-Image base model (`external_base_*`) → `generate_candle_zimage_comfyui_stream`
     /// (epic 10451 Phase 2, sc-10668). Not an `is_candle_engine` id — routed off the forwarded row.
     ZimageComfyui,
@@ -251,6 +257,52 @@ enum CandleImageRoute {
     Bernini,
     /// A plain candle txt2img engine id → `generate_candle_stream`.
     CandleTxt2Img,
+}
+
+/// Candle-routed image model ids that HAVE a bespoke worker strict-pose control lane — each is claimed
+/// by an `else if …_control_available(…)` arm in [`resolve_candle_image_route`] BEFORE the generic
+/// txt2img arm, but only when its control base snapshot resolves locally. This is the SINGLE source for
+/// (a) the fall-through reject branch below (a wired family reaching the fall-through means its control
+/// base is absent → [`CandleImageRoute::PoseControlBaseMissing`], never silent txt2img) and (b) the
+/// reject error message that enumerates the wired families — previously hand-duplicated across the
+/// `resolve_candle_image_route` `matches!` guard, the handler comment, and the reject error string, which
+/// had already drifted (the handler comment omitted `krea_2_turbo`). (sc-11171, F-008.)
+///
+/// NOTE: deliberately DISTINCT from the router's `model_has_candle_pose_lane` (sceneworks-core), which
+/// omits `krea_2_turbo` so the co-resident torch worker declines krea pose jobs and candle reliably wins
+/// them — do not conflate the two lists.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const WIRED_CANDLE_POSE_FAMILIES: &[&str] = &[
+    "qwen_image",
+    "kolors",
+    "z_image_turbo",
+    "z_image",
+    "flux2_dev",
+    "flux_dev",
+    "krea_2_turbo",
+];
+
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+impl CandleImageRoute {
+    /// The real image total this candle route produces, baked into the plan's `expectedCount` so the
+    /// streamed gallery total matches what actually lands (sc-11171, F-009 — the candle sibling of the
+    /// macOS `ImageRoute::image_count`). The strict-pose control lanes each render one image per pose
+    /// (`pose_entries().len()`), InstantID renders its active angle/pose collection, every other lane
+    /// renders the requested `count`.
+    fn image_count(self, request: &ImageRequest, settings: &Settings) -> u32 {
+        match self {
+            CandleImageRoute::QwenControl
+            | CandleImageRoute::KolorsControl
+            | CandleImageRoute::ZimageControl
+            | CandleImageRoute::Flux2Control
+            | CandleImageRoute::Flux1Control
+            | CandleImageRoute::KreaControl => pose_entries(request).len() as u32,
+            CandleImageRoute::InstantId => instantid_image_count(request, settings),
+            // Every other lane (plain txt2img, the edit/reference/identity/comfyui/bernini lanes, and the
+            // pose-reject arms — which error before generation) produces the requested count.
+            _ => request.count,
+        }
+    }
 }
 
 /// Run the candle image dispatch predicate ladder ONCE and return the [`CandleImageRoute`] (or `None`
@@ -332,22 +384,23 @@ fn resolve_candle_image_route(
         // `ImageRoute::Bernini` weight-gates instead only because it must fall through to `mlx_available`).
         Some(CandleImageRoute::Bernini)
     } else if is_candle_engine(&request.model)
-        && !matches!(
-            request.model.as_str(),
-            "qwen_image"
-                | "kolors"
-                | "z_image_turbo"
-                | "z_image"
-                | "flux2_dev"
-                | "flux_dev"
-                | "krea_2_turbo"
-        )
         && request.mode != "edit_image"
         && !pose_entries(request).is_empty()
     {
-        // No-silent-T2I (sc-5968): a strict-pose job on a candle model with NO pose lane (e.g. sdxl) must
-        // be REJECTED, not silently rendered as plain txt2img. Checked BEFORE the txt2img arm below.
-        Some(CandleImageRoute::PoseReject)
+        // A strict-pose candle job that reached here was NOT claimed by any `…_control_available` lane
+        // above, so it must be REJECTED, not silently rendered as plain txt2img (poses dropped). Two
+        // sub-cases, distinguished by whether the family has a wired candle pose lane at all:
+        //  - WIRED pose family (`WIRED_CANDLE_POSE_FAMILIES`): the lane exists but its control base
+        //    snapshot is absent (the lane's local weight-gate failed) → `PoseControlBaseMissing`
+        //    ("control base snapshot not installed"). Previously this family was excluded from the reject
+        //    entirely and fell through to `CandleTxt2Img`, silently dropping the poses (sc-11171, F-008).
+        //  - No candle pose lane (e.g. sdxl) → the sc-5968 no-silent-T2I `PoseReject`.
+        // Checked BEFORE the txt2img arm below.
+        if WIRED_CANDLE_POSE_FAMILIES.contains(&request.model.as_str()) {
+            Some(CandleImageRoute::PoseControlBaseMissing)
+        } else {
+            Some(CandleImageRoute::PoseReject)
+        }
     } else if is_candle_engine(&request.model) {
         Some(CandleImageRoute::CandleTxt2Img)
     } else {

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -4725,6 +4725,96 @@ fn candle_image_route_gates_on_flag_then_pose_reject_then_txt2img() {
     assert_eq!(resolve_candle_image_route(&unknown, &settings), None);
 }
 
+// sc-11171 (F-008): a strict-pose job on a WIRED candle pose family (e.g. `z_image_turbo`) whose control
+// base snapshot is NOT installed must route to the loud `PoseControlBaseMissing` reject, NOT fall through
+// to the plain candle txt2img lane (which would silently render an unconditioned image and drop the
+// poses). The scheduler routes it to candle weight-blind (`zimage_control_candle_eligible` checks only the
+// payload, "minus the local weight-resolve check"), and `image_job_candle_pose_reject` does not catch it
+// (`model_has_candle_pose_lane("z_image_turbo")` is true), so the worker is the last line of defense.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn candle_image_route_rejects_wired_pose_when_control_base_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut settings = Settings::from_env();
+    // A tempdir data_dir holds no HF snapshot, so `resolve_zimage_control_base` yields `None` → the
+    // Z-Image control lane's weight-gate (`zimage_control_available`) fails and the job falls through.
+    settings.data_dir = dir.path().to_path_buf();
+    settings.backend_candle_enabled = true;
+
+    // z_image_turbo + poses, control base absent → the loud missing-base reject, never plain txt2img.
+    let zimage_pose = request(json!({
+        "projectId": "p", "model": "z_image_turbo", "count": 1,
+        "advanced": { "poses": [{ "id": "a" }] }
+    }));
+    let route = resolve_candle_image_route(&zimage_pose, &settings);
+    assert_eq!(route, Some(CandleImageRoute::PoseControlBaseMissing));
+    assert_ne!(
+        route,
+        Some(CandleImageRoute::CandleTxt2Img),
+        "a wired pose family with an absent control base must NOT silently render plain txt2img",
+    );
+
+    // The same family without poses still routes to the generic candle txt2img lane — the reject is
+    // scoped to the strict-pose shape, not the model id.
+    let zimage_t2i = request(json!({ "projectId": "p", "model": "z_image_turbo", "count": 1 }));
+    assert_eq!(
+        resolve_candle_image_route(&zimage_t2i, &settings),
+        Some(CandleImageRoute::CandleTxt2Img),
+    );
+
+    // A non-wired candle family with poses (e.g. sdxl, which has no candle pose lane at all) still hits
+    // the sc-5968 `PoseReject`, not the missing-base variant.
+    let sdxl_pose = request(json!({
+        "projectId": "p", "model": "sdxl", "count": 1,
+        "advanced": { "poses": [{ "id": "a" }] }
+    }));
+    assert_eq!(
+        resolve_candle_image_route(&sdxl_pose, &settings),
+        Some(CandleImageRoute::PoseReject),
+    );
+}
+
+// sc-11171 (F-009): the candle plan bakes the resolved route's real image total into `expectedCount`
+// (via `CandleImageRoute::image_count`), mirroring the macOS `ImageRoute::image_count`. A strict-pose
+// control route renders one image per pose (`pose_entries().len()`), NOT `request.count`, so a pose set
+// whose length differs from the requested count must report the pose count — otherwise the gallery
+// streams against the wrong total (stuck placeholders).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn candle_strict_pose_route_image_count_is_pose_set_length() {
+    let settings = Settings::from_env();
+    // 4 images requested, but 3 poses → the strict-pose lane renders 3 (one per pose).
+    let zimage_pose = request(json!({
+        "projectId": "p", "model": "z_image_turbo", "count": 4,
+        "advanced": { "poses": [{ "id": "a" }, { "id": "b" }, { "id": "c" }] }
+    }));
+    assert_eq!(pose_entries(&zimage_pose).len(), 3);
+    assert_ne!(
+        zimage_pose.count, 3,
+        "guard: request.count must differ from the pose count to prove the fix",
+    );
+    assert_eq!(
+        CandleImageRoute::ZimageControl.image_count(&zimage_pose, &settings),
+        3,
+        "a strict-pose route's plan total is the pose-set length, not request.count",
+    );
+    // Every other strict-pose control lane counts the same way.
+    for route in [
+        CandleImageRoute::QwenControl,
+        CandleImageRoute::KolorsControl,
+        CandleImageRoute::Flux2Control,
+        CandleImageRoute::Flux1Control,
+        CandleImageRoute::KreaControl,
+    ] {
+        assert_eq!(route.image_count(&zimage_pose, &settings), 3);
+    }
+    // A plain txt2img route keeps the requested count.
+    assert_eq!(
+        CandleImageRoute::CandleTxt2Img.image_count(&zimage_pose, &settings),
+        zimage_pose.count,
+    );
+}
+
 // sc-10996 (epic 6562): `bernini_image` t2i / i2i route to the dedicated candle Bernini lane
 // (`CandleImageRoute::Bernini` → `generate_candle_bernini_image_stream`), NOT the generic txt2img arm
 // (the engine is `Modality::Video`, so `bernini_image` is not an `is_candle_engine` id). Routed on the


### PR DESCRIPTION
## Summary

Twin-drift fix (epic 11147, MLX↔candle): make the candle image lane match macOS behavior for strict-pose jobs. Two sub-tasks, both in `crates/sceneworks-worker`.

### F-008 — no silent txt2img fallthrough for wired pose families

**Reachability (confirmed).** The scheduler routes a wired-family pose job (e.g. `z_image_turbo` + poses) to the candle worker **weight-blind**: `zimage_control_candle_eligible`/siblings in `sceneworks-core/.../routing/candle.rs` check only the payload ("minus the local weight-resolve check"), and `image_job_candle_pose_reject` does **not** catch it because `model_has_candle_pose_lane("z_image_turbo")` is `true`. In the worker, `resolve_candle_image_route`'s control lane weight-gates on the **dense upstream** snapshot (`resolve_zimage_control_base` etc.), which differs from the packed **turnkey** the txt2img lane resolves. With only the turnkey installed the control gate fails, the family was excluded from the `PoseReject` arm, and the job landed in `CandleTxt2Img` — plain txt2img, poses **silently dropped**. The fall-through is genuinely reachable; the worker is the last line of defense.

**Fix.** A wired pose family reaching the fall-through now routes to the new `CandleImageRoute::PoseControlBaseMissing`, which errors (`WorkerError::InvalidPayload` — the house style, matching `mlx_weights_gap`) with "control base snapshot is not installed", instead of rendering. A family with no candle pose lane at all (e.g. `sdxl`) still hits the existing sc-5968 `PoseReject`.
- `crates/sceneworks-worker/src/image_jobs/base.rs` — new enum variant + reworked reject arm (`base.rs:386-408`).
- `crates/sceneworks-worker/src/image_jobs.rs` — new `PoseControlBaseMissing` handler (`image_jobs.rs:1025-1033`).

**Const unification.** The wired-family list was hand-duplicated across the `resolve_candle_image_route` `matches!` guard, the `PoseReject` error message, and the handler comment (already **drifted** — the comment omitted `krea_2_turbo`). All three now derive from one `WIRED_CANDLE_POSE_FAMILIES` const (`base.rs`), used for the fall-through branch and the error message (`.join(", ")`).
- **Deliberately left untouched:** the router's `model_has_candle_pose_lane` (sceneworks-core) is a *distinct* list — it omits `krea_2_turbo` so the co-resident torch worker declines krea pose jobs (`worker_supports_job` at `jobs_store.rs:2948`) and candle reliably wins them. Folding it into the shared const would flip that claim/decline routing, so it stays separate (documented in the const's doc-comment).

### F-009 — candle plan `expectedCount` from the strict-pose set

macOS bakes the route's real total (`ImageRoute::image_count` → `pose_entries().len()` for strict-pose). The candle plan special-cased only InstantID and otherwise reported `request.count`, while every strict-pose control lane renders `pose_entries().len()` images (`candle_strict_control.rs` drives `poses`, passes `pose_count` to `consume_gen_events`). A pose job with pose-count ≠ requested count streamed against the wrong total (stuck gallery placeholders).

**Fix.** Added `CandleImageRoute::image_count` (candle sibling of macOS `ImageRoute::image_count`) and bake the resolved route's real total into the plan, mirroring the macOS `resolve_image_route` arm.
- `crates/sceneworks-worker/src/image_jobs/base.rs` — `impl CandleImageRoute { fn image_count }`.
- `crates/sceneworks-worker/src/image_jobs.rs:412-424` — plan count via `resolve_candle_image_route(...).map_or(request.count, |r| r.image_count(...))`.

## Tests (candle-gated, `#[cfg(all(not(target_os="macos"), feature="backend-candle"))]`)

- `candle_image_route_rejects_wired_pose_when_control_base_absent` — `z_image_turbo` + poses with a tempdir data_dir (control base absent) → `PoseControlBaseMissing`, **not** `CandleTxt2Img`; plain t2i still → `CandleTxt2Img`; `sdxl` + poses → `PoseReject`.
- `candle_strict_pose_route_image_count_is_pose_set_length` — 4 requested / 3 poses: every strict-pose control route's `image_count` == 3 (≠ `request.count`); `CandleTxt2Img` == `request.count`.

## Verification

- macOS: `cargo build`, `cargo test -p sceneworks-worker --lib` (745 pass), `cargo clippy -p sceneworks-worker --all-targets -- -D warnings`, `cargo fmt --all --check` — all green.
- The candle-gated code + the two new tests **cannot compile on macOS** (`not(target_os="macos")` cfg; the feature build needs CUDA/`cudarc`, unavailable here). Verified by careful inspection; the CI **candle-worker** + **build-windows** lanes compile it.

Refs sc-11171, epic 11147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)