### PR TITLE
fix(worker): keep .safetensors extension for HF-cache adapter symlinks (sc-11649)

### DIFF
--- a/crates/sceneworks-worker/src/paths.rs
+++ b/crates/sceneworks-worker/src/paths.rs
@@ -238,7 +238,43 @@ pub(crate) fn normalize_app_managed_lora_path(
     }
     let normalized = normalize_absolute_path(path)?;
     let resolved = normalize_existing_or_absolute(&normalized)?;
-    ensure_path_under(resolved, &roots, "LoRA path")
+    let confined = ensure_path_under(resolved, &roots, "LoRA path")?;
+    Ok(loadable_confined_lora_path(&normalized, confined))
+}
+
+/// Return a *loadable* form of a confined adapter path (sc-11649). mlx-rs's safetensors
+/// loader dispatches on the file **extension**: it rejects any path whose final component is
+/// not literally `*.safetensors` with `IoError::UnsupportedFormat` ("Unsupported file
+/// format"). The Hugging Face hub cache stores each file as an extensionless `blobs/<sha>`
+/// object with a `snapshots/…/<name>.safetensors` **symlink** pointing at it, so
+/// canonicalizing an HF-cached adapter — which the confinement above does, to resolve
+/// symlink escapes — strips the `.safetensors` extension. The engine's adapter load then
+/// dies with "Unsupported file format". This bit every Krea 2 **edit**, whose required
+/// `krea2_identity_edit` LoRA is HF-cached (its `installedPath` points straight at the
+/// snapshot symlink), so no edit could load once a second adapter (or, in fact, any) rode
+/// along — the identity LoRA itself never loaded.
+///
+/// When the confined canonical path has lost the `.safetensors` extension but the
+/// pre-canonical path kept it, and both resolve to the **same on-disk file**, hand back the
+/// extension-bearing path. The confinement decision already ran on the canonical target and
+/// the same-file check guarantees we load exactly that vetted blob, so this cannot widen the
+/// confined set (a symlink escape still resolves outside the roots and was already rejected).
+/// The `.safetensors` directory case is unaffected: [`resolve_adapter_in_dir`] joins the
+/// declared filename onto the confined dir, keeping the extension.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn loadable_confined_lora_path(precanonical: &Path, confined: PathBuf) -> PathBuf {
+    let is_safetensors = |path: &Path| {
+        path.extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("safetensors"))
+    };
+    if is_safetensors(&confined) || !is_safetensors(precanonical) {
+        return confined;
+    }
+    match (precanonical.canonicalize(), confined.canonicalize()) {
+        (Ok(pre), Ok(conf)) if pre == conf => precanonical.to_path_buf(),
+        _ => confined,
+    }
 }
 
 pub(crate) fn normalize_existing_or_absolute(path: &Path) -> WorkerResult<PathBuf> {

--- a/crates/sceneworks-worker/src/tests/media_and_paths.rs
+++ b/crates/sceneworks-worker/src/tests/media_and_paths.rs
@@ -252,6 +252,53 @@ fn lora_paths_resolve_symlinks_before_root_check() {
     assert!(error.to_string().contains("LoRA path must be inside"));
 }
 
+/// sc-11649: the Hugging Face hub cache stores each file as an extensionless
+/// `blobs/<sha>` object with a `snapshots/…/<name>.safetensors` **symlink** pointing at
+/// it. Confining an HF-cached adapter canonicalizes that symlink to the blob, which has no
+/// `.safetensors` extension — and mlx-rs's safetensors loader rejects an extensionless path
+/// with "Unsupported file format", so every Krea 2 edit (whose required
+/// `krea2_identity_edit` LoRA is HF-cached, its `installedPath` pointing straight at the
+/// snapshot symlink) failed to load. The confinement must therefore return a path that both
+/// resolves to the confined blob AND keeps the `.safetensors` extension the loader needs.
+#[cfg(unix)]
+#[test]
+fn lora_paths_keep_safetensors_extension_for_hf_blob_symlink() {
+    let temp = tempdir().expect("tempdir creates");
+    let data_dir = temp.path().join("data");
+    // Mimic the HF hub layout under a managed root: an extensionless `blobs/<sha>` object
+    // with a `snapshots/<rev>/<name>.safetensors` symlink pointing at it.
+    let repo = data_dir
+        .join("loras")
+        .join("models--acme--krea2-identity-edit");
+    let blobs = repo.join("blobs");
+    let snapshot = repo.join("snapshots").join("deadbeef");
+    std::fs::create_dir_all(&blobs).expect("blobs dir creates");
+    std::fs::create_dir_all(&snapshot).expect("snapshot dir creates");
+    let blob = blobs.join("78b403a45024d51c24b618046ec1176c346416951f8f4c6c707d1b337ae1d40f");
+    std::fs::write(&blob, b"adapter").expect("blob writes");
+    let link = snapshot.join("krea2_identity_edit_v1_1_r128.safetensors");
+    std::os::unix::fs::symlink(&blob, &link).expect("snapshot symlink creates");
+
+    let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+    settings.data_dir = data_dir;
+
+    // The adapter resolves (its canonical target is confined) AND the returned path keeps the
+    // `.safetensors` extension mlx-rs demands — not the extensionless canonical blob.
+    let resolved = super::normalize_app_managed_lora_path(&settings, &link)
+        .expect("HF-cached adapter is accepted");
+    assert_eq!(
+        resolved.extension().and_then(|extension| extension.to_str()),
+        Some("safetensors"),
+        "confined adapter path must keep the .safetensors extension (got {})",
+        resolved.display()
+    );
+    assert_eq!(
+        resolved.canonicalize().expect("resolved path canonicalizes"),
+        blob.canonicalize().expect("blob canonicalizes"),
+        "the extension-preserving path must still name the confined blob"
+    );
+}
+
 /// epic 10451 / sc-10452: an operator-configured external root (a ComfyUI `models/`
 /// tree) is readable for adapters, in place — no copy into `<data>/loras`. The same
 /// path is rejected when no root is configured, which is the default and therefore


### PR DESCRIPTION
## Summary

Fixes [sc-11649](https://app.shortcut.com/trefry/story/11649): a Krea 2 edit died at load with `krea_2_edit load failed: backend op failed: Unsupported file format`.

**Root cause (NOT the LoKr-classification gap the report suspected).** The auto-applied, required `krea2_identity_edit` LoRA lives in the Hugging Face hub cache as a `snapshots/<rev>/<name>.safetensors` **symlink** pointing at an extensionless `blobs/<sha>` object. `normalize_app_managed_lora_path` canonicalizes the adapter path (to resolve symlink escapes) before handing it to the engine, stripping the `.safetensors` extension. mlx-rs's safetensors loader (`SafeTensors::load_device`) rejects any path whose extension isn't literally `safetensors` with `IoError::UnsupportedFormat` → "Unsupported file format", so the identity LoRA never loaded.

The "stacking an extra LoRA breaks it" framing was a red herring: the same session loaded the user's Realism Engine **LoKr** fine on `krea_2_turbo` t2i (adapterCount:1) — user LoRAs live in `<data>/loras` as real files whose extension survives canonicalization. Krea edit had in fact **never** loaded on the repro machine (zero successful `krea_2_edit` loads in `mlx-worker.log`), because it always auto-applies the HF-cached identity LoRA.

## Fix

`crates/sceneworks-worker/src/paths.rs` — still confine on the canonical target (security posture unchanged) but return an **extension-preserving** path via a new `loadable_confined_lora_path`: when canonicalization dropped the `.safetensors` extension, the pre-canonical path kept it, and both resolve to the **same on-disk file**, hand back the extension-bearing path. Confinement still runs on the canonical target and the same-file check means we load exactly the vetted blob, so this cannot widen the confined set.

- Shared `resolve_adapters` path → covers the **MLX** and **candle** edit lanes and the **video** LoRA lane.
- Directory case unaffected (`resolve_adapter_in_dir` joins the declared filename onto the confined dir, keeping the extension).
- No engine change / no gen-core pin bump.

## Verification

- New regression test `lora_paths_keep_safetensors_extension_for_hf_blob_symlink` — reproduces the blob/snapshot-symlink layout; **fails pre-fix** (returns the extensionless blob), **passes post-fix**.
- End-to-end proof against the **real** identity-edit file via the exact engine loader `mlx_gen::weights::Weights::from_file`: canonical blob → "Unsupported file format" (exact production error); snapshot symlink → loads 512 tensors.
- 746 worker unit tests pass; `cargo fmt` clean; `clippy --all-targets -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)