### PR TITLE
Harden worker weight-load: Real-ESRGAN output shape + loud env pins (sc-11175)

### DIFF
--- a/crates/sceneworks-worker/src/person_jobs.rs
+++ b/crates/sceneworks-worker/src/person_jobs.rs
@@ -965,22 +965,28 @@ pub(crate) fn detect_people_blocking(
 /// Resolve already-present detector weights (the MLX safetensors on macOS / the ONNX export
 /// off-Mac, per `DET_FILE`): explicit env pin (`SCENEWORKS_PERSON_DETECTOR_WEIGHTS`), then the
 /// app cache `<data_dir>/cache/person-detect/`, then the model dir
-/// `<data_dir>/models/person-detect/`. Returns `None` when nothing is staged (then
+/// `<data_dir>/models/person-detect/`. Returns `Ok(None)` when nothing is staged (then
 /// `ensure_detector_weights` downloads it).
-pub(crate) fn resolve_detector_weights(settings: &Settings) -> Option<PathBuf> {
-    if let Ok(pinned) = std::env::var("SCENEWORKS_PERSON_DETECTOR_WEIGHTS") {
-        let path = PathBuf::from(pinned);
-        if path.exists() {
-            return Some(path);
-        }
+///
+/// A set-but-missing `SCENEWORKS_PERSON_DETECTOR_WEIGHTS` is an operator error: it fails
+/// loudly (`InvalidPayload`) via [`crate::util::resolve_env_file_pin`] instead of silently
+/// falling through to the cache/HF download and loading different weights than the operator
+/// asked for (sc-11175/F-011, mirroring the sc-8911 upscaler pin).
+pub(crate) fn resolve_detector_weights(settings: &Settings) -> WorkerResult<Option<PathBuf>> {
+    if let Some(path) = crate::util::resolve_env_file_pin(
+        "SCENEWORKS_PERSON_DETECTOR_WEIGHTS",
+        std::env::var_os("SCENEWORKS_PERSON_DETECTOR_WEIGHTS"),
+        "the local person-detector weights (MLX safetensors / ONNX export)",
+    )? {
+        return Ok(Some(path));
     }
     for sub in ["cache/person-detect", "models/person-detect"] {
         let candidate = settings.data_dir.join(sub).join(DET_FILE);
         if candidate.exists() {
-            return Some(candidate);
+            return Ok(Some(candidate));
         }
     }
-    None
+    Ok(None)
 }
 
 /// Resolve the detector weights (MLX safetensors on macOS / ONNX export off-Mac, per
@@ -990,7 +996,7 @@ pub(crate) async fn ensure_detector_weights(
     settings: &Settings,
     context: &DownloadContext<'_>,
 ) -> WorkerResult<PathBuf> {
-    if let Some(path) = resolve_detector_weights(settings) {
+    if let Some(path) = resolve_detector_weights(settings)? {
         return Ok(path);
     }
     let target = settings

--- a/crates/sceneworks-worker/src/person_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/person_jobs/tests.rs
@@ -711,3 +711,65 @@ fn person_detect_candle_real_weights_finds_person() {
     assert!(b["width"].as_f64().unwrap() > 0.0 && b["height"].as_f64().unwrap() > 0.0);
     assert_eq!(top["maskState"], "missing");
 }
+
+fn f011_test_settings(data_dir: PathBuf) -> Settings {
+    Settings {
+        api_url: "http://127.0.0.1:0".to_owned(),
+        access_token: None,
+        data_dir,
+        config_dir: PathBuf::from("config"),
+        worker_id: "test-worker".to_owned(),
+        gpu_id: "cpu".to_owned(),
+        is_child_worker: true,
+        poll_seconds: 1,
+        heartbeat_seconds: 5,
+        shutdown_timeout_seconds: 1,
+        huggingface_base_url: "http://127.0.0.1:0".to_owned(),
+        huggingface_token: None,
+        credentials: Vec::new(),
+        max_lora_url_bytes: 8u64 * 1024 * 1024 * 1024,
+        max_model_url_bytes: 256u64 * 1024 * 1024 * 1024,
+        allow_private_lora_urls: true,
+        utility_workers: 1,
+        backend_mlx_enabled: true,
+        backend_candle_enabled: false,
+        gpu_memory_limit_bytes: 0,
+        external_model_roots: Vec::new(),
+    }
+}
+
+/// sc-11175/F-011: a set-but-missing `SCENEWORKS_PERSON_DETECTOR_WEIGHTS` pin must fail
+/// loudly (`InvalidPayload`) via `resolve_env_file_pin` instead of silently falling through
+/// to the cache/HF download; an unset pin (with nothing staged) falls through to `Ok(None)`.
+/// `RUST_TEST_THREADS=1` is forced workspace-wide, so the env mutation is serial.
+#[test]
+fn resolve_detector_weights_env_pin_missing_errors_and_unset_falls_through() {
+    let key = "SCENEWORKS_PERSON_DETECTOR_WEIGHTS";
+    let dir = tempfile::tempdir().expect("tempdir");
+    let settings = f011_test_settings(dir.path().to_path_buf());
+    let prior = std::env::var_os(key);
+
+    // Set but missing → loud InvalidPayload naming the key.
+    std::env::set_var(
+        key,
+        "/nonexistent/person-detector/does-not-exist.safetensors",
+    );
+    let missing = resolve_detector_weights(&settings);
+    assert!(
+        matches!(missing, Err(WorkerError::InvalidPayload(ref m)) if m.contains(key) && m.contains("does not exist")),
+        "a set-but-missing detector pin must error loudly, got {missing:?}"
+    );
+
+    // Unset + nothing staged in the temp data_dir → fall through.
+    std::env::remove_var(key);
+    let unset = resolve_detector_weights(&settings);
+    assert!(
+        matches!(unset, Ok(None)),
+        "an unset detector pin must fall through to Ok(None), got {unset:?}"
+    );
+
+    match prior {
+        Some(value) => std::env::set_var(key, value),
+        None => std::env::remove_var(key),
+    }
+}

--- a/crates/sceneworks-worker/src/person_segment.rs
+++ b/crates/sceneworks-worker/src/person_segment.rs
@@ -79,22 +79,28 @@ pub(crate) type BoxNorm = (f64, f64, f64, f64);
 
 /// Resolve already-present SAM2 weights: an explicit env pin
 /// (`SCENEWORKS_SAM2_WEIGHTS`), then the app cache `<data_dir>/cache/person-segment/`,
-/// then the model dir `<data_dir>/models/person-segment/`. Returns `None` when nothing
+/// then the model dir `<data_dir>/models/person-segment/`. Returns `Ok(None)` when nothing
 /// is staged (then `ensure_segmenter_weights` downloads it).
-pub(crate) fn resolve_segmenter_weights(settings: &Settings) -> Option<PathBuf> {
-    if let Ok(pinned) = std::env::var("SCENEWORKS_SAM2_WEIGHTS") {
-        let path = PathBuf::from(pinned);
-        if path.exists() {
-            return Some(path);
-        }
+///
+/// A set-but-missing `SCENEWORKS_SAM2_WEIGHTS` is an operator error: it fails loudly
+/// (`InvalidPayload`) via [`crate::util::resolve_env_file_pin`] instead of silently falling
+/// through to the cache/HF download and loading different weights than the operator asked
+/// for (sc-11175/F-011, mirroring the sc-8911 upscaler pin).
+pub(crate) fn resolve_segmenter_weights(settings: &Settings) -> WorkerResult<Option<PathBuf>> {
+    if let Some(path) = crate::util::resolve_env_file_pin(
+        "SCENEWORKS_SAM2_WEIGHTS",
+        std::env::var_os("SCENEWORKS_SAM2_WEIGHTS"),
+        "the local SAM2 segmenter weights",
+    )? {
+        return Ok(Some(path));
     }
     for sub in ["cache/person-segment", "models/person-segment"] {
         let candidate = settings.data_dir.join(sub).join(SEG_FILE);
         if candidate.exists() {
-            return Some(candidate);
+            return Ok(Some(candidate));
         }
     }
-    None
+    Ok(None)
 }
 
 /// Resolve the SAM2 weights, downloading them from HuggingFace on first use (into the
@@ -103,7 +109,7 @@ pub(crate) async fn ensure_segmenter_weights(
     settings: &Settings,
     context: &DownloadContext<'_>,
 ) -> WorkerResult<PathBuf> {
-    if let Some(path) = resolve_segmenter_weights(settings) {
+    if let Some(path) = resolve_segmenter_weights(settings)? {
         return Ok(path);
     }
     let target = settings
@@ -472,5 +478,62 @@ mod tests {
         // A box over the left half of the block → ~half the foreground inside.
         let half = mask_box_coverage(&pixels, (0.0, 0.0, 0.4, 1.0), w, h);
         assert!((half - 0.5).abs() < 1e-9, "half coverage was {half}");
+    }
+
+    fn f011_test_settings(data_dir: PathBuf) -> Settings {
+        Settings {
+            api_url: "http://127.0.0.1:0".to_owned(),
+            access_token: None,
+            data_dir,
+            config_dir: PathBuf::from("config"),
+            worker_id: "test-worker".to_owned(),
+            gpu_id: "cpu".to_owned(),
+            is_child_worker: true,
+            poll_seconds: 1,
+            heartbeat_seconds: 5,
+            shutdown_timeout_seconds: 1,
+            huggingface_base_url: "http://127.0.0.1:0".to_owned(),
+            huggingface_token: None,
+            credentials: Vec::new(),
+            max_lora_url_bytes: 8u64 * 1024 * 1024 * 1024,
+            max_model_url_bytes: 256u64 * 1024 * 1024 * 1024,
+            allow_private_lora_urls: true,
+            utility_workers: 1,
+            backend_mlx_enabled: true,
+            backend_candle_enabled: false,
+            gpu_memory_limit_bytes: 0,
+            external_model_roots: Vec::new(),
+        }
+    }
+
+    /// sc-11175/F-011: a set-but-missing `SCENEWORKS_SAM2_WEIGHTS` pin must fail loudly
+    /// (`InvalidPayload`) via `resolve_env_file_pin` instead of silently falling through to
+    /// the cache/HF download; an unset pin (with nothing staged) falls through to `Ok(None)`.
+    /// `RUST_TEST_THREADS=1` is forced workspace-wide, so the env mutation is serial.
+    #[test]
+    fn resolve_segmenter_weights_env_pin_missing_errors_and_unset_falls_through() {
+        let key = "SCENEWORKS_SAM2_WEIGHTS";
+        let dir = tempfile::tempdir().expect("tempdir");
+        let settings = f011_test_settings(dir.path().to_path_buf());
+        let prior = std::env::var_os(key);
+
+        std::env::set_var(key, "/nonexistent/sam2/does-not-exist.safetensors");
+        let missing = resolve_segmenter_weights(&settings);
+        assert!(
+            matches!(missing, Err(WorkerError::InvalidPayload(ref m)) if m.contains(key) && m.contains("does not exist")),
+            "a set-but-missing SAM2 pin must error loudly, got {missing:?}"
+        );
+
+        std::env::remove_var(key);
+        let unset = resolve_segmenter_weights(&settings);
+        assert!(
+            matches!(unset, Ok(None)),
+            "an unset SAM2 pin must fall through to Ok(None), got {unset:?}"
+        );
+
+        match prior {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
     }
 }

--- a/crates/sceneworks-worker/src/person_segment_sam3_common.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3_common.rs
@@ -63,31 +63,48 @@ pub(crate) trait Sam3FrameOutput {
 /// Resolve already-present SAM3 weights: an explicit env pin (`SCENEWORKS_SAM3_WEIGHTS`, a dir or
 /// the `model.safetensors` inside it), then the app cache `<data_dir>/cache/person-segment-sam3/`,
 /// then the model dir `<data_dir>/models/person-segment-sam3/`. Both `model.safetensors` and
-/// `tokenizer.json` must be present. Returns `(model_path, tokenizer_path)` or `None` (then
-/// [`ensure_segmenter_weights`] downloads them).
-pub(crate) fn resolve_segmenter_weights(settings: &Settings) -> Option<(PathBuf, PathBuf)> {
+/// `tokenizer.json` must be present. Returns `Ok(Some((model_path, tokenizer_path)))` or `Ok(None)`
+/// (then [`ensure_segmenter_weights`] downloads them).
+///
+/// A set-but-missing `SCENEWORKS_SAM3_WEIGHTS` is an operator error: it fails loudly
+/// (`InvalidPayload`) instead of silently falling through to the cache/HF download and loading
+/// different weights than the operator asked for (sc-11175/F-011, mirroring the sc-8911 upscaler
+/// pin). [`crate::util::resolve_env_file_pin`] errors if the pinned path itself is absent; an
+/// incomplete pinned dir (missing either file of the pair) is likewise a loud error, not a
+/// silent fall-through.
+pub(crate) fn resolve_segmenter_weights(
+    settings: &Settings,
+) -> WorkerResult<Option<(PathBuf, PathBuf)>> {
     let pair_in = |dir: &Path| -> Option<(PathBuf, PathBuf)> {
         let model = dir.join(MODEL_FILE);
         let tokenizer = dir.join(TOKENIZER_FILE);
         (model.exists() && tokenizer.exists()).then_some((model, tokenizer))
     };
-    if let Ok(pinned) = std::env::var("SCENEWORKS_SAM3_WEIGHTS") {
-        let p = PathBuf::from(pinned);
-        let dir = if p.is_file() {
-            p.parent().map(Path::to_path_buf).unwrap_or(p)
+    if let Some(pinned) = crate::util::resolve_env_file_pin(
+        "SCENEWORKS_SAM3_WEIGHTS",
+        std::env::var_os("SCENEWORKS_SAM3_WEIGHTS"),
+        "a local facebook/sam3 snapshot dir (or its model.safetensors)",
+    )? {
+        let dir = if pinned.is_file() {
+            pinned.parent().map(Path::to_path_buf).unwrap_or(pinned)
         } else {
-            p
+            pinned
         };
-        if let Some(pair) = pair_in(&dir) {
-            return Some(pair);
-        }
+        return pair_in(&dir).map(Some).ok_or_else(|| {
+            crate::WorkerError::InvalidPayload(format!(
+                "SCENEWORKS_SAM3_WEIGHTS is set to {} but that directory is missing {MODEL_FILE} \
+                 and/or {TOKENIZER_FILE}. Point it at a complete facebook/sam3 snapshot dir, or \
+                 unset it to download on first use.",
+                dir.display()
+            ))
+        });
     }
     for sub in ["cache/person-segment-sam3", "models/person-segment-sam3"] {
         if let Some(pair) = pair_in(&settings.data_dir.join(sub)) {
-            return Some(pair);
+            return Ok(Some(pair));
         }
     }
-    None
+    Ok(None)
 }
 
 /// Resolve the SAM3 weights, downloading `model.safetensors` + `tokenizer.json` from HuggingFace
@@ -96,7 +113,7 @@ pub(crate) async fn ensure_segmenter_weights(
     settings: &Settings,
     context: &DownloadContext<'_>,
 ) -> WorkerResult<(PathBuf, PathBuf)> {
-    if let Some(pair) = resolve_segmenter_weights(settings) {
+    if let Some(pair) = resolve_segmenter_weights(settings)? {
         return Ok(pair);
     }
     let dir = settings.data_dir.join("cache").join("person-segment-sam3");
@@ -416,5 +433,76 @@ mod tests {
             matches!(result, Err(crate::WorkerError::Engine(ref m)) if m.contains("logits")),
             "mismatched grid length must be rejected, got {result:?}"
         );
+    }
+
+    fn f011_test_settings(data_dir: PathBuf) -> Settings {
+        Settings {
+            api_url: "http://127.0.0.1:0".to_owned(),
+            access_token: None,
+            data_dir,
+            config_dir: PathBuf::from("config"),
+            worker_id: "test-worker".to_owned(),
+            gpu_id: "cpu".to_owned(),
+            is_child_worker: true,
+            poll_seconds: 1,
+            heartbeat_seconds: 5,
+            shutdown_timeout_seconds: 1,
+            huggingface_base_url: "http://127.0.0.1:0".to_owned(),
+            huggingface_token: None,
+            credentials: Vec::new(),
+            max_lora_url_bytes: 8u64 * 1024 * 1024 * 1024,
+            max_model_url_bytes: 256u64 * 1024 * 1024 * 1024,
+            allow_private_lora_urls: true,
+            utility_workers: 1,
+            backend_mlx_enabled: true,
+            backend_candle_enabled: false,
+            gpu_memory_limit_bytes: 0,
+            external_model_roots: Vec::new(),
+        }
+    }
+
+    /// sc-11175/F-011: `SCENEWORKS_SAM3_WEIGHTS` (a dir or its `model.safetensors`) must fail
+    /// loudly when set-but-missing OR set to an incomplete dir (missing either file of the
+    /// `{model.safetensors, tokenizer.json}` pair), instead of silently falling through to the
+    /// cache/HF download. An unset pin (nothing staged) falls through to `Ok(None)`.
+    /// `RUST_TEST_THREADS=1` is forced workspace-wide, so the env mutation is serial.
+    #[test]
+    fn resolve_segmenter_weights_env_pin_missing_and_incomplete_error_unset_falls_through() {
+        let key = "SCENEWORKS_SAM3_WEIGHTS";
+        let dir = tempfile::tempdir().expect("tempdir");
+        let settings = f011_test_settings(dir.path().to_path_buf());
+        let prior = std::env::var_os(key);
+
+        // (a) pinned path does not exist at all → loud, via resolve_env_file_pin.
+        std::env::set_var(key, dir.path().join("nonexistent-sam3-dir"));
+        let missing = resolve_segmenter_weights(&settings);
+        assert!(
+            matches!(missing, Err(crate::WorkerError::InvalidPayload(ref m)) if m.contains(key) && m.contains("does not exist")),
+            "a set-but-missing SAM3 pin must error loudly, got {missing:?}"
+        );
+
+        // (b) pinned dir exists but is missing tokenizer.json → still loud (the pair check).
+        let incomplete = dir.path().join("sam3-incomplete");
+        std::fs::create_dir_all(&incomplete).expect("mk dir");
+        std::fs::write(incomplete.join(MODEL_FILE), b"weights").expect("write model");
+        std::env::set_var(key, &incomplete);
+        let partial = resolve_segmenter_weights(&settings);
+        assert!(
+            matches!(partial, Err(crate::WorkerError::InvalidPayload(ref m)) if m.contains(key) && m.contains(TOKENIZER_FILE)),
+            "an incomplete SAM3 pin dir must error loudly, got {partial:?}"
+        );
+
+        // (c) unset + nothing staged → fall through.
+        std::env::remove_var(key);
+        let unset = resolve_segmenter_weights(&settings);
+        assert!(
+            matches!(unset, Ok(None)),
+            "an unset SAM3 pin must fall through to Ok(None), got {unset:?}"
+        );
+
+        match prior {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
     }
 }

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -44,6 +44,7 @@ use std::sync::{Mutex, OnceLock};
 
 use crate::downloads::{ensure_hf_cached_file, DownloadContext};
 use crate::generator_cache::with_cached_generator;
+use crate::util::resolve_env_file_pin;
 use gen_core::{
     CancelFlag, Conditioning, GenerationOutput, GenerationRequest, Image as GenImage, LoadSpec,
     WeightsSource,
@@ -324,7 +325,10 @@ impl Upscaler {
                 Tensor::from_array((vec![1i64, 3, ch as i64, cw as i64], data)).map_err(ort_err)?;
             let outputs = self.session.run(ort::inputs![tensor]).map_err(ort_err)?;
             let (oshape, odata) = outputs[0].try_extract_tensor::<f32>().map_err(ort_err)?;
-            let (och, ocw) = (oshape[2] as usize, oshape[3] as usize);
+            // Validate the reported output shape/length against the `(1, 3, ch*factor,
+            // cw*factor)` contract before indexing `odata` (sc-11175/F-010) so a mis-scaled
+            // pinned export can't slice out of bounds and panic inside `spawn_blocking`.
+            let (och, ocw) = validate_upscale_output(oshape, odata.len(), cw, ch, factor)?;
 
             // inner (unpadded) region within the upscaled crop → destination
             let ix0 = (tl.x0 - cx0) * factor;
@@ -346,6 +350,54 @@ impl Upscaler {
         RgbImage::from_raw(ow as u32, oh as u32, output)
             .ok_or_else(|| WorkerError::InvalidPayload("upscale buffer size mismatch".to_owned()))
     }
+}
+
+/// Validate the Real-ESRGAN ONNX output shape/length before indexing `odata` (sc-11175/F-010).
+///
+/// The generic `SCENEWORKS_REALESRGAN_ONNX` pin serves both the x2 and x4 exports, so an
+/// operator can pin an x2 export and run a 4× job (or any mismatched export). The output
+/// dims would then be half (or otherwise not `input × factor`) the assumed size and the
+/// `odata[c * och * ocw + sy * ocw + sx]` reads below would slice out of bounds → panic
+/// inside `spawn_blocking`, killing the job as a join error and poisoning the `UPSCALERS`
+/// lock for every subsequent job. Validate the `(1, 3, ch·factor, cw·factor)` contract and
+/// return a `WorkerError::Engine` with expected-vs-actual dims instead — mirroring the
+/// sc-8904/F-102 sibling decode-path guards in `person_jobs::decode` / `pose_jobs`.
+///
+/// `cw`/`ch` are the (even-padded) per-tile model *input* width/height; a valid export
+/// returns `(1, 3, ch·factor, cw·factor)`. Returns the validated `(och, ocw)`.
+fn validate_upscale_output(
+    oshape: &[i64],
+    odata_len: usize,
+    cw: usize,
+    ch: usize,
+    factor: usize,
+) -> WorkerResult<(usize, usize)> {
+    if oshape.len() != 4 {
+        return Err(WorkerError::Engine(format!(
+            "real-esrgan output rank {} != 4 (expected (1, 3, H·factor, W·factor)); is the \
+             pinned SCENEWORKS_REALESRGAN_ONNX export the right model?",
+            oshape.len()
+        )));
+    }
+    let och = oshape[2].max(0) as usize;
+    let ocw = oshape[3].max(0) as usize;
+    let exp_h = ch.saturating_mul(factor);
+    let exp_w = cw.saturating_mul(factor);
+    if och != exp_h || ocw != exp_w {
+        return Err(WorkerError::Engine(format!(
+            "real-esrgan output dims {och}×{ocw} != expected {exp_h}×{exp_w} \
+             (input {ch}×{cw} × factor {factor}); is the pinned SCENEWORKS_REALESRGAN_ONNX \
+             export the wrong scale (e.g. an x2 export run as a {factor}× job)?"
+        )));
+    }
+    let needed = 3usize.saturating_mul(och).saturating_mul(ocw);
+    if odata_len < needed {
+        return Err(WorkerError::Engine(format!(
+            "real-esrgan output has {odata_len} values but the (3 × {och} × {ocw}) contract \
+             needs {needed}"
+        )));
+    }
+    Ok((och, ocw))
 }
 
 /// Blocking upscale: load+cache the factor's session (amortising the CoreML/CUDA graph
@@ -383,29 +435,6 @@ fn upscale_blocking(
 // ---------------------------------------------------------------------------
 // ONNX weight provisioning (download-on-first-use, mirrors Python resolution order)
 // ---------------------------------------------------------------------------
-
-/// Resolve an explicit env-pinned weight *file* (sc-8911). Unset → `Ok(None)` (fall
-/// through to cache/download). Set + existing → `Ok(Some(path))`. Set but missing → an
-/// `InvalidPayload` error so a typo fails loudly instead of silently loading whatever the
-/// download resolves. `what` names the expected file in the error. Takes the raw value
-/// explicitly so it's unit-testable without mutating the process environment.
-fn resolve_env_file_pin(
-    key: &str,
-    value: Option<std::ffi::OsString>,
-    what: &str,
-) -> WorkerResult<Option<PathBuf>> {
-    let Some(value) = value else {
-        return Ok(None);
-    };
-    let path = PathBuf::from(&value);
-    if path.exists() {
-        return Ok(Some(path));
-    }
-    Err(WorkerError::InvalidPayload(format!(
-        "{key} is set to {} but that path does not exist. Point it at {what}, or unset it to download on first use.",
-        path.display()
-    )))
-}
 
 /// Resolve the `SCENEWORKS_SEEDVR2_CHECKPOINT` dir pin (sc-8911). Unset → `Ok(None)`. Set
 /// and holding both checkpoint files → `Ok(Some(dir))`. Set but incomplete → an

--- a/crates/sceneworks-worker/src/upscale_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs/tests.rs
@@ -731,3 +731,43 @@ fn dataset_repoint_body_maps_records_with_a_null_asset_id() {
         "dataset fix re-points to bytes, not a minted child asset"
     );
 }
+
+/// sc-11175/F-010: the Real-ESRGAN ONNX output shape/length must be validated against the
+/// `(1, 3, ch·factor, cw·factor)` contract before `odata` is indexed. A mis-scaled pinned
+/// export (e.g. an x2 export run as a 4× job) must produce a `WorkerError::Engine` with
+/// expected-vs-actual dims — NOT an out-of-bounds slice panic inside `spawn_blocking` (which
+/// would kill the job as a join error and poison the `UPSCALERS` lock). Mirrors the
+/// sc-8904/F-102 sibling decode-path guards in `person_jobs`/`pose_jobs`.
+#[test]
+fn validate_upscale_output_rejects_mismatched_shapes() {
+    // Input tile: 8×8, factor 4 → a valid export returns (1, 3, 32, 32) with 3·32·32 values.
+    let (cw, ch, factor) = (8usize, 8usize, 4usize);
+    let good_len = 3 * 32 * 32;
+
+    // Happy path: exact contract → Ok((32, 32)).
+    let ok = validate_upscale_output(&[1, 3, 32, 32], good_len, cw, ch, factor)
+        .expect("valid (1,3,32,32) output must pass");
+    assert_eq!(ok, (32, 32));
+
+    // Rank != 4 → Engine (would have panicked on `oshape[2]`/`oshape[3]`).
+    let rank = validate_upscale_output(&[1, 3, 32], good_len, cw, ch, factor);
+    assert!(
+        matches!(rank, Err(WorkerError::Engine(ref m)) if m.contains("rank") && m.contains("!= 4")),
+        "rank<4 must be an Engine error, got {rank:?}"
+    );
+
+    // Dims not input·factor (an x2 export: 16×16 instead of 32×32) → Engine with expected-vs-actual.
+    let scale = validate_upscale_output(&[1, 3, 16, 16], 3 * 16 * 16, cw, ch, factor);
+    assert!(
+        matches!(scale, Err(WorkerError::Engine(ref m))
+            if m.contains("16×16") && m.contains("32×32") && m.contains("factor 4")),
+        "a half-scale export must be an Engine error naming expected vs actual, got {scale:?}"
+    );
+
+    // Right dims but a short `odata` buffer → Engine (would have sliced OOB on `odata[…]`).
+    let short = validate_upscale_output(&[1, 3, 32, 32], good_len - 1, cw, ch, factor);
+    assert!(
+        matches!(short, Err(WorkerError::Engine(ref m)) if m.contains("needs") && m.contains(&good_len.to_string())),
+        "a short output buffer must be an Engine error, got {short:?}"
+    );
+}

--- a/crates/sceneworks-worker/src/util.rs
+++ b/crates/sceneworks-worker/src/util.rs
@@ -121,3 +121,31 @@ pub(crate) async fn with_hf_auth(
         None => request,
     }
 }
+
+/// Resolve an explicit env-pinned weight *file* (sc-8911, sc-11175/F-011). Unset →
+/// `Ok(None)` (fall through to cache/download). Set + existing → `Ok(Some(path))`. Set but
+/// missing → an `InvalidPayload` error so a typo fails loudly instead of silently loading
+/// whatever the download resolves. `what` names the expected file in the error. Takes the
+/// raw value explicitly so it's unit-testable without mutating the process environment.
+///
+/// This is the worker-wide house helper the loud-env-pin fixes route through: the
+/// upscaler (`SCENEWORKS_REALESRGAN_*_ONNX`, sc-8911), the person detector
+/// (`SCENEWORKS_PERSON_DETECTOR_WEIGHTS`), and SAM2/SAM3
+/// (`SCENEWORKS_SAM2_WEIGHTS`/`SCENEWORKS_SAM3_WEIGHTS`, sc-11175/F-011).
+pub(crate) fn resolve_env_file_pin(
+    key: &str,
+    value: Option<std::ffi::OsString>,
+    what: &str,
+) -> WorkerResult<Option<PathBuf>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let path = PathBuf::from(&value);
+    if path.exists() {
+        return Ok(Some(path));
+    }
+    Err(WorkerError::InvalidPayload(format!(
+        "{key} is set to {} but that path does not exist. Point it at {what}, or unset it to download on first use.",
+        path.display()
+    )))
+}

--- a/crates/sceneworks-worker/src/util.rs
+++ b/crates/sceneworks-worker/src/util.rs
@@ -132,6 +132,15 @@ pub(crate) async fn with_hf_auth(
 /// upscaler (`SCENEWORKS_REALESRGAN_*_ONNX`, sc-8911), the person detector
 /// (`SCENEWORKS_PERSON_DETECTOR_WEIGHTS`), and SAM2/SAM3
 /// (`SCENEWORKS_SAM2_WEIGHTS`/`SCENEWORKS_SAM3_WEIGHTS`, sc-11175/F-011).
+///
+/// Gated to the union of its callers' cfgs (upscaler / person detector / SAM2 / SAM3),
+/// all of which compile only on macOS OR the off-Mac candle lane. On the Linux `parity`
+/// lane (non-macOS, default features) none of those callers compile, so leaving this
+/// helper ungated makes it dead code under `-D warnings` (sc-11175, Linux parity fix).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(crate) fn resolve_env_file_pin(
     key: &str,
     value: Option<std::ffi::OsString>,


### PR DESCRIPTION
## Summary

Story **sc-11175** (epic **11147** — sweep the stragglers that missed an existing house pattern). Two sub-tasks, both fully implemented.

### F-010 — Validate the Real-ESRGAN ONNX output shape before indexing
`Upscaler::upscale` (`crates/sceneworks-worker/src/upscale_jobs.rs`) read `oshape[2]`/`oshape[3]` with no rank check and indexed `odata[…]` with no length/scale validation — every sibling decode path was hardened under sc-8904/F-102, but the upscaler was missed. The generic `SCENEWORKS_REALESRGAN_ONNX` pin serves both x2 and x4, so pinning an x2 export and running a 4x job makes the output dims half the assumed size → out-of-bounds slice → panic inside `spawn_blocking` (the job dies as a join error and the `UPSCALERS` lock is poisoned for every later job).

New `validate_upscale_output` runs after `try_extract_tensor` and enforces the `(1, 3, ch·factor, cw·factor)` contract: `oshape.len() == 4`, `och == ch*factor && ocw == cw*factor`, `odata.len() >= 3*och*ocw`. On any mismatch it returns `WorkerError::Engine` with expected-vs-actual dims — mirroring the sc-8904/F-102 sibling guards in `person_jobs::decode` / `pose_jobs`.

### F-011 — Make the person-detect/SAM weight env pins fail loudly when set-but-missing
`SCENEWORKS_PERSON_DETECTOR_WEIGHTS`, `SCENEWORKS_SAM2_WEIGHTS`, and `SCENEWORKS_SAM3_WEIGHTS` silently fell through to the cache/HF download when the pinned path didn't exist. sc-8911 already fixed this for DWPose/Real-ESRGAN/SeedVR2 via `resolve_env_file_pin`, but these three kept the old behavior.

The `resolve_env_file_pin` helper is hoisted from `upscale_jobs` into `util` (`pub(crate)`) as the worker-wide house helper, and all three pins now route through it:
- `person_jobs::resolve_detector_weights` → `SCENEWORKS_PERSON_DETECTOR_WEIGHTS`
- `person_segment::resolve_segmenter_weights` → `SCENEWORKS_SAM2_WEIGHTS`
- `person_segment_sam3_common::resolve_segmenter_weights` → `SCENEWORKS_SAM3_WEIGHTS` (a dir or its `model.safetensors`; also errors loudly on a pinned dir missing `model.safetensors`/`tokenizer.json`)

Each function now returns `WorkerResult<Option<…>>`: **set + missing → `InvalidPayload`**, **unset → `Ok(None)`** fall-through. Their `ensure_*` callers propagate with `?`.

## Tests
- `validate_upscale_output_rejects_mismatched_shapes` — rank≠4 / half-scale dims / short `odata` → `Engine` (expected-vs-actual), valid `(1,3,32,32)` → `Ok`.
- `resolve_detector_weights_env_pin_missing_errors_and_unset_falls_through` (SAM/detector), `resolve_segmenter_weights_env_pin_missing_errors_and_unset_falls_through` (SAM2), and `resolve_segmenter_weights_env_pin_missing_and_incomplete_error_unset_falls_through` (SAM3, also asserts the incomplete-dir loud error).
- `cargo test -p sceneworks-worker` (750 passed / 157 ignored), `cargo clippy -p sceneworks-worker --all-targets -- -D warnings`, and `cargo fmt --all --check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)