### PR TITLE
fix(web): share one job-request builder between ImageStudio single-submit and batch (sc-11219)

### DIFF
--- a/apps/web/src/imageJobRequest.js
+++ b/apps/web/src/imageJobRequest.js
@@ -1,0 +1,200 @@
+import { buildImageJobAdvanced } from "./imageJobAdvanced.js";
+import { effectiveFitMode } from "./components/FitModeControl.jsx";
+import { upscaleEngineHasSoftness } from "./upscaleEngines.js";
+
+// sc-11219 (F-031): single pure builder for the Image Studio job request, shared by both the
+// single "Generate" submit and the batch run. It used to be duplicated — `submit()` held the
+// canonical ~105-line createImageJob payload and `buildBatchJobRequest` was a hand-copied
+// near-twin that had DRIFTED: the batch copy dropped the top-level `referenceAssetId` img2img
+// branch and omitted `pidTarget` + the `supportsImg2img`/`img2imgReferenceAssetId`/
+// `img2imgStrength` trio from `advanced`. So a batch on an img2img-capable model (Krea 2 Turbo)
+// silently ignored the reference image and a PiD "2K" batch rendered at the 4K default. Extracting
+// one builder makes the two paths byte-identical for the same visible settings; the ONLY intended
+// difference is the per-item prompt / structured-caption / per-prompt-resolution override, which
+// each caller resolves and passes in (promptToSend / submitIntent / sendStructured / submitCaption
+// / submitBackend / resolutionOverride).
+//
+// This is the single-submit payload verbatim (the correct reference), parameterized only by those
+// overrides. Every omit-when-default and mode gate is preserved; `advanced` is delegated to the
+// already-pure buildImageJobAdvanced so its guards stay in one place.
+export function buildImageJobRequest(state) {
+  const {
+    // Prompt / resolution overrides — the one legitimate single-vs-batch difference.
+    promptToSend,
+    submitIntent,
+    sendStructured,
+    submitCaption,
+    submitBackend,
+    // A per-prompt [WxH] directive (sc-10063) overrides the studio resolution for a batch job.
+    resolutionOverride,
+    resolution,
+    // Shared studio settings (identical for both paths).
+    mode,
+    negativePrompt,
+    model,
+    count,
+    seed,
+    posePayload,
+    width,
+    height,
+    recipePresetId,
+    characterId,
+    characterLookId,
+    multiReference,
+    editSecondPair,
+    sourceAssetId,
+    controlPreprocessSourceId,
+    referenceAssetIds,
+    fitMode,
+    editInpaintCapable,
+    referenceAssetId,
+    supportsImg2img,
+    img2imgReferenceAssetId,
+    loras,
+    upscaleEnabled,
+    upscaleFactor,
+    upscaleEngine,
+    upscaleSoftness,
+    // Advanced knobs (delegated to buildImageJobAdvanced).
+    sampler,
+    scheduler,
+    schedulerShift,
+    stepsOverride,
+    guidanceOverride,
+    guidanceMethod,
+    flashAttn,
+    promptEnhance,
+    enhancePrompt,
+    precisionToggle,
+    bf16Precision,
+    showTierPicker,
+    quantTier,
+    showPidToggle,
+    usePid,
+    pidTarget,
+    hideReferenceStrength,
+    ipAdapterScale,
+    identityStructure,
+    controlnetScale,
+    variationStrength,
+    trueCfgScale,
+    img2imgStrength,
+    viewAngles,
+    viewAngle,
+    faceRestore,
+    controlActive,
+    activeControlMode,
+    controlPassthroughId,
+    effectiveControlScale,
+    controlOverlayId,
+  } = state;
+
+  return {
+    mode,
+    prompt: promptToSend,
+    negativePrompt,
+    model,
+    count: posePayload.length ? 1 : count,
+    seed: seed === "" ? null : Number(seed),
+    // A per-prompt [WxH] directive (sc-10063) overrides the studio resolution for this job.
+    width: resolutionOverride?.width ?? width,
+    height: resolutionOverride?.height ?? height,
+    recipePresetId,
+    characterId: mode === "character_image" ? characterId || null : null,
+    characterLookId: mode === "character_image" ? characterLookId || null : null,
+    // edit_image: a single source image, except for a multi-reference model (sc-6211,
+    // FLUX.2-dev) whose source picker is replaced by the multi-image reference picker below.
+    // text_to_image strict-control (sc-8245): canny/depth in preprocess (derive) mode send the
+    // uploaded control image here as the source the worker auto-derives the map FROM
+    // (strict_control.rs `resolve_control_source`). Passthrough mode uses `advanced.controlImage`.
+    sourceAssetId:
+      mode === "edit_image" && !multiReference
+        ? // A two-reference edit sends the ordered [image1, image2] pair as referenceAssetIds instead
+          // (epic 10871 P1.3), so the single sourceAssetId is dropped when a second image is chosen.
+          editSecondPair
+          ? null
+          : sourceAssetId || null
+        : controlPreprocessSourceId,
+    // Multi-reference edit (sc-6211): the plural reference set the FLUX.2-dev edit conditions on.
+    // Only sent in edit_image mode for a multiReference model; the worker routes a non-empty list
+    // to Conditioning::MultiReference (one image ⇒ a normal single-reference edit). The Krea
+    // two-reference edit (epic 10871 P1.3) reuses this channel with the ordered [image1, image2] pair.
+    referenceAssetIds:
+      mode === "edit_image" && multiReference && referenceAssetIds.length
+        ? referenceAssetIds
+        : (editSecondPair ?? undefined),
+    // Fit mode applies to edits only; coerced so a stale "outpaint" never reaches a
+    // non-inpaint model (epic 2551). Omitted for non-edit modes (worker default crop).
+    fitMode: mode === "edit_image" ? effectiveFitMode(fitMode, editInpaintCapable) : undefined,
+    // character_image: the IP-Adapter identity reference. Otherwise, on an img2img-capable model
+    // (Krea 2 Turbo, sc-8593), the reference picked in the "Start from an image" panel — sent so the
+    // worker's krea arm routes it to img2img latent-init (advanced.strength below).
+    referenceAssetId:
+      mode === "character_image"
+        ? referenceAssetId || null
+        : supportsImg2img
+          ? img2imgReferenceAssetId || null
+          : null,
+    loras,
+    ...(upscaleEnabled
+      ? {
+          upscale: {
+            enabled: true,
+            factor: upscaleFactor,
+            engine: upscaleEngine,
+            // SeedVR2-only detail/softness knob (sc-4815); omitted for engines that ignore it.
+            ...(upscaleEngineHasSoftness(upscaleEngine) ? { softness: upscaleSoftness } : {}),
+          },
+        }
+      : {}),
+    // advanced payload (sc-8854, F-052): assembled by the pure buildImageJobAdvanced
+    // builder. Every omit-when-default rule (which keeps saved recipes byte-identical)
+    // lives in imageJobAdvanced.js and is covered by imageJobAdvanced.test.js.
+    advanced: buildImageJobAdvanced({
+      resolution: resolutionOverride
+        ? `${resolutionOverride.width}x${resolutionOverride.height}`
+        : resolution,
+      sendStructured,
+      submitIntent,
+      submitCaption,
+      submitBackend,
+      sampler,
+      scheduler,
+      schedulerShift,
+      stepsOverride,
+      guidanceOverride,
+      guidanceMethod,
+      flashAttn,
+      promptEnhance,
+      enhancePrompt,
+      precisionToggle,
+      bf16Precision,
+      showTierPicker,
+      quantTier,
+      showPidToggle,
+      usePid,
+      pidTarget,
+      mode,
+      referenceAssetId,
+      hideReferenceStrength,
+      ipAdapterScale,
+      // img2img (sc-8593): emit advanced.strength when an img2img-capable model has a reference.
+      supportsImg2img,
+      img2imgReferenceAssetId,
+      img2imgStrength,
+      identityStructure,
+      controlnetScale,
+      variationStrength,
+      trueCfgScale,
+      viewAngles,
+      viewAngle,
+      posePayload,
+      faceRestore,
+      controlActive,
+      activeControlMode,
+      controlPassthroughId,
+      effectiveControlScale,
+      controlOverlayId,
+    }),
+  };
+}

--- a/apps/web/src/imageJobRequest.test.js
+++ b/apps/web/src/imageJobRequest.test.js
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+
+import { buildImageJobRequest } from "./imageJobRequest.js";
+
+// sc-11219 (F-031): the batch job-request builder used to be a hand-copied twin of the single
+// Generate payload that had DRIFTED — the batch copy dropped the top-level `referenceAssetId`
+// img2img branch and omitted `pidTarget` + the `supportsImg2img`/`img2imgReferenceAssetId`/
+// `img2imgStrength` trio from `advanced`. So a batch on an img2img-capable model (Krea 2 Turbo)
+// silently ignored the reference image and a PiD "2K" batch rendered at the 4K default. Both paths
+// now go through buildImageJobRequest; these tests pin that a batch-style call (with the per-item
+// prompt / caption / [WxH] override) produces the same img2img + PiD payload as single Generate.
+
+// A studio state for an img2img-capable text-to-image model with a "Start from an image"
+// reference picked and the PiD decoder set to the 2K tier — exactly the settings the drifted
+// batch copy used to silently discard.
+function img2imgPidState(overrides = {}) {
+  return {
+    // Prompt / resolution overrides (the one legitimate single-vs-batch difference).
+    promptToSend: "a fox",
+    submitIntent: "a fox",
+    sendStructured: false,
+    submitCaption: null,
+    submitBackend: null,
+    resolutionOverride: null,
+    resolution: "1024x1024",
+    // Shared studio settings.
+    mode: "text_to_image",
+    negativePrompt: "",
+    model: "krea-2-turbo",
+    count: 1,
+    seed: "",
+    posePayload: [],
+    width: 1024,
+    height: 1024,
+    recipePresetId: null,
+    characterId: null,
+    characterLookId: null,
+    multiReference: false,
+    editSecondPair: null,
+    sourceAssetId: null,
+    controlPreprocessSourceId: null,
+    referenceAssetIds: [],
+    fitMode: "crop",
+    editInpaintCapable: false,
+    referenceAssetId: null,
+    // The img2img trio: an img2img-capable model with a reference chosen in the shared panel.
+    supportsImg2img: true,
+    img2imgReferenceAssetId: "start-image-asset",
+    img2imgStrength: 0.42,
+    loras: [],
+    upscaleEnabled: false,
+    upscaleFactor: 2,
+    upscaleEngine: "realesrgan",
+    upscaleSoftness: 0.5,
+    // Advanced knobs — everything default except the PiD 2K tier.
+    sampler: "default",
+    scheduler: "default",
+    schedulerShift: "",
+    stepsOverride: "",
+    guidanceOverride: "",
+    guidanceMethod: "cfg",
+    flashAttn: true,
+    promptEnhance: false,
+    enhancePrompt: false,
+    precisionToggle: false,
+    bf16Precision: false,
+    showTierPicker: false,
+    quantTier: "default",
+    showPidToggle: true,
+    usePid: true,
+    pidTarget: "2k",
+    hideReferenceStrength: false,
+    ipAdapterScale: 0.8,
+    identityStructure: false,
+    controlnetScale: 0.5,
+    variationStrength: false,
+    trueCfgScale: 4,
+    viewAngles: false,
+    viewAngle: "",
+    faceRestore: false,
+    controlActive: false,
+    activeControlMode: null,
+    controlPassthroughId: null,
+    effectiveControlScale: 0.7,
+    controlOverlayId: null,
+    ...overrides,
+  };
+}
+
+describe("buildImageJobRequest", () => {
+  it("routes the img2img reference to the top-level referenceAssetId on an img2img model", () => {
+    // The branch the drifted batch copy dropped (it hardcoded character-only referenceAssetId).
+    const request = buildImageJobRequest(img2imgPidState());
+    expect(request.referenceAssetId).toBe("start-image-asset");
+  });
+
+  it("emits advanced.strength for the img2img trio (dropped by the drifted batch copy)", () => {
+    const request = buildImageJobRequest(img2imgPidState());
+    expect(request.advanced.strength).toBe(0.42);
+  });
+
+  it("emits advanced.pidTarget:'2k' when the PiD 2K tier is selected (dropped by the batch copy)", () => {
+    const request = buildImageJobRequest(img2imgPidState());
+    expect(request.advanced.usePid).toBe(true);
+    expect(request.advanced.pidTarget).toBe("2k");
+  });
+
+  it("produces an identical img2img + PiD payload for a batch-style call as for single Generate", () => {
+    // Single Generate: no per-prompt resolution override.
+    const single = buildImageJobRequest(img2imgPidState());
+    // Batch: a per-prompt prompt + [WxH] directive rides `overrides`, everything else identical.
+    const batch = buildImageJobRequest(
+      img2imgPidState({
+        promptToSend: "a fox in the snow",
+        submitIntent: "a fox in the snow",
+        resolutionOverride: { width: 1280, height: 720 },
+      }),
+    );
+
+    // The img2img/PiD-relevant fields the drift affected must match single exactly.
+    expect(batch.referenceAssetId).toBe(single.referenceAssetId);
+    expect(batch.advanced.strength).toBe(single.advanced.strength);
+    expect(batch.advanced.usePid).toBe(single.advanced.usePid);
+    expect(batch.advanced.pidTarget).toBe(single.advanced.pidTarget);
+
+    // The ONLY intended differences are the prompt + the per-prompt resolution.
+    expect(batch.prompt).toBe("a fox in the snow");
+    expect(batch.width).toBe(1280);
+    expect(batch.height).toBe(720);
+    expect(batch.advanced.resolution).toBe("1280x720");
+
+    // Everything else is byte-identical to single Generate.
+    const stripVariant = (req) => {
+      const { prompt: _p, width: _w, height: _h, advanced, ...rest } = req;
+      const { resolution: _r, ...advRest } = advanced;
+      return { ...rest, advanced: advRest };
+    };
+    expect(stripVariant(batch)).toEqual(stripVariant(single));
+  });
+
+  it("keeps the top-level referenceAssetId as the character reference in character_image mode", () => {
+    // Regression guard: the img2img branch must not steal the character-reference slot.
+    const request = buildImageJobRequest(
+      img2imgPidState({
+        mode: "character_image",
+        referenceAssetId: "character-ref",
+        supportsImg2img: false,
+        img2imgReferenceAssetId: null,
+      }),
+    );
+    expect(request.referenceAssetId).toBe("character-ref");
+    expect(request.advanced).not.toHaveProperty("strength");
+  });
+});

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -42,7 +42,7 @@ import {
   serializeCaption,
   validateCaption,
 } from "../ideogramCaption.js";
-import { buildImageJobAdvanced } from "../imageJobAdvanced.js";
+import { buildImageJobRequest } from "../imageJobRequest.js";
 import { usePoseLibrary, useUserPoseLoader } from "../poseLibrary.js";
 
 const PROMPT_SUGGESTION_POOL = [
@@ -1764,166 +1764,69 @@ export function ImageStudio() {
         }
         setSubmitError("");
       }
-      const job = await createImageJob({
-        mode,
-        prompt: promptToSend,
-        negativePrompt,
-        model,
-        count: posePayload.length ? 1 : count,
-        seed: seed === "" ? null : Number(seed),
-        width,
-        height,
-        recipePresetId: selectedPreset?.id ?? null,
-        characterId: mode === "character_image" ? characterId || null : null,
-        characterLookId: mode === "character_image" ? characterLookId || null : null,
-        // edit_image: a single source image, except for a multi-reference model (sc-6211,
-        // FLUX.2-dev) whose source picker is replaced by the multi-image reference picker below.
-        // text_to_image strict-control (sc-8245): canny/depth in preprocess (derive) mode send the
-        // uploaded control image here as the source the worker auto-derives the map FROM
-        // (strict_control.rs `resolve_control_source`). Passthrough mode uses `advanced.controlImage`.
-        sourceAssetId:
-          mode === "edit_image" && !multiReference
-            ? // A two-reference edit sends the ordered [image1, image2] pair as referenceAssetIds instead
-              // (epic 10871 P1.3), so the single sourceAssetId is dropped when a second image is chosen.
-              editSecondPair
-              ? null
-              : sourceAssetId || null
-            : controlPreprocessSourceId,
-        // Multi-reference edit (sc-6211): the plural reference set the FLUX.2-dev edit conditions on.
-        // Only sent in edit_image mode for a multiReference model; the worker routes a non-empty list
-        // to Conditioning::MultiReference (one image ⇒ a normal single-reference edit). The Krea
-        // two-reference edit (epic 10871 P1.3) reuses this channel with the ordered [image1, image2] pair.
-        referenceAssetIds:
-          mode === "edit_image" && multiReference && referenceAssetIds.length
-            ? referenceAssetIds
-            : (editSecondPair ?? undefined),
-        // Fit mode applies to edits only; coerced so a stale "outpaint" never reaches a
-        // non-inpaint model (epic 2551). Omitted for non-edit modes (worker default crop).
-        fitMode: mode === "edit_image" ? effectiveFitMode(fitMode, editInpaintCapable) : undefined,
-        // character_image: the IP-Adapter identity reference. Otherwise, on an img2img-capable model
-        // (Krea 2 Turbo, sc-8593), the reference picked in the "Start from an image" panel — sent so the
-        // worker's krea arm routes it to img2img latent-init (advanced.strength below).
-        referenceAssetId:
-          mode === "character_image"
-            ? referenceAssetId || null
-            : supportsImg2img
-              ? img2imgReferenceAssetId || null
-              : null,
-        loras: buildLorasPayload(),
-        ...(upscaleEnabled
-          ? {
-              upscale: {
-                enabled: true,
-                factor: upscaleFactor,
-                engine: upscaleEngine,
-                // SeedVR2-only detail/softness knob (sc-4815); omitted for engines that ignore it.
-                ...(upscaleEngineHasSoftness(upscaleEngine) ? { softness: upscaleSoftness } : {}),
-              },
-            }
-          : {}),
-        // advanced payload (sc-8854, F-052): assembled by the pure buildImageJobAdvanced
-        // builder so this async submit() stays focused on prompt resolution + the API
-        // call. Every omit-when-default rule (which keeps saved recipes byte-identical)
-        // lives in imageJobAdvanced.js and is covered by imageJobAdvanced.test.js.
-        advanced: buildImageJobAdvanced({
-          resolution,
-          sendStructured,
+      // sc-11219 (F-031): the single Generate payload is built by the shared buildJobRequest so
+      // it stays byte-identical to a batch run with the same visible settings. The only per-call
+      // difference is the resolved prompt / structured-caption override threaded in here.
+      const job = await createImageJob(
+        buildJobRequest({
+          promptToSend,
           submitIntent,
+          sendStructured,
           submitCaption,
           submitBackend,
-          sampler,
-          scheduler,
-          schedulerShift,
-          stepsOverride,
-          guidanceOverride,
-          guidanceMethod,
-          flashAttn,
-          promptEnhance,
-          enhancePrompt,
-          precisionToggle,
-          bf16Precision,
-          showTierPicker,
-          quantTier,
-          showPidToggle,
-          usePid,
-          pidTarget,
-          mode,
-          referenceAssetId,
-          hideReferenceStrength,
-          ipAdapterScale,
-          // img2img (sc-8593): emit advanced.strength when an img2img-capable model has a reference.
-          supportsImg2img,
-          img2imgReferenceAssetId,
-          img2imgStrength,
-          identityStructure,
-          controlnetScale,
-          variationStrength,
-          trueCfgScale,
-          viewAngles,
-          viewAngle,
-          posePayload,
-          faceRestore,
-          controlActive,
-          activeControlMode,
-          controlPassthroughId,
-          effectiveControlScale,
-          controlOverlayId,
         }),
-      });
+      );
       onLocalJobCreated?.(job);
     } finally {
       setSubmitting(false);
     }
   }
 
-  // One image-job request for a single resolved batch prompt. Reuses the current studio
-  // settings (model, loras, upscale, reference/source per mode, pose-library + strict-control
-  // conditioning, and the whole advanced knob set via the tested buildImageJobAdvanced).
-  // `count` multiplies within each job UNLESS poses are selected, in which case each job
-  // emits one image per pose (images = jobs × posePayload.length). For a structured-caption
-  // model (sc-9980) the caller passes the per-prompt auto-expanded caption via `opts`.
-  const buildBatchJobRequest = (resolvedPrompt, opts = {}) => ({
-    mode,
-    prompt: opts.promptToSend ?? resolvedPrompt,
-    negativePrompt,
-    model,
-    count: posePayload.length ? 1 : count,
-    seed: seed === "" ? null : Number(seed),
-    // A per-prompt [WxH] directive (sc-10063) overrides the studio resolution for this job.
-    width: opts.resolution?.width ?? width,
-    height: opts.resolution?.height ?? height,
-    recipePresetId: selectedPreset?.id ?? null,
-    characterId: mode === "character_image" ? characterId || null : null,
-    characterLookId: mode === "character_image" ? characterLookId || null : null,
-    sourceAssetId:
-      mode === "edit_image" && !multiReference
-        ? editSecondPair
-          ? null
-          : sourceAssetId || null
-        : controlPreprocessSourceId,
-    referenceAssetIds:
-      mode === "edit_image" && multiReference && referenceAssetIds.length
-        ? referenceAssetIds
-        : (editSecondPair ?? undefined),
-    fitMode: mode === "edit_image" ? effectiveFitMode(fitMode, editInpaintCapable) : undefined,
-    referenceAssetId: mode === "character_image" ? referenceAssetId || null : null,
-    loras: buildLorasPayload(),
-    ...(upscaleEnabled
-      ? {
-          upscale: {
-            enabled: true,
-            factor: upscaleFactor,
-            engine: upscaleEngine,
-            ...(upscaleEngineHasSoftness(upscaleEngine) ? { softness: upscaleSoftness } : {}),
-          },
-        }
-      : {}),
-    advanced: buildImageJobAdvanced({
-      resolution: opts.resolution ? `${opts.resolution.width}x${opts.resolution.height}` : resolution,
-      sendStructured: opts.sendStructured ?? false,
-      submitIntent: resolvedPrompt,
-      submitCaption: opts.submitCaption ?? caption,
-      submitBackend: opts.submitBackend ?? magicPromptBackend,
+  // sc-11219 (F-031): the single shared image-job-request builder used by BOTH single Generate
+  // (submit) and the batch run. It resolves the current studio state into the args the pure
+  // buildImageJobRequest assembles, so the two paths emit a byte-identical payload for the same
+  // visible settings. The ONLY intended difference is the per-item prompt / structured-caption /
+  // per-prompt-resolution override passed in `overrides` (promptToSend / submitIntent /
+  // sendStructured / submitCaption / submitBackend / resolutionOverride). This replaced a
+  // hand-copied batch twin that had drifted (dropped the img2img reference + pidTarget/img2img
+  // advanced knobs), silently ignoring an img2img reference and PiD "2K" tier on batch runs.
+  const buildJobRequest = (overrides = {}) =>
+    buildImageJobRequest({
+      // Overrides — the one legitimate single-vs-batch difference.
+      promptToSend: overrides.promptToSend,
+      submitIntent: overrides.submitIntent,
+      sendStructured: overrides.sendStructured ?? false,
+      submitCaption: overrides.submitCaption,
+      submitBackend: overrides.submitBackend,
+      resolutionOverride: overrides.resolutionOverride ?? null,
+      // Shared studio settings (identical for both paths).
+      resolution,
+      mode,
+      negativePrompt,
+      model,
+      count,
+      seed,
+      posePayload,
+      width,
+      height,
+      recipePresetId: selectedPreset?.id ?? null,
+      characterId,
+      characterLookId,
+      multiReference,
+      editSecondPair,
+      sourceAssetId,
+      controlPreprocessSourceId,
+      referenceAssetIds,
+      fitMode,
+      editInpaintCapable,
+      referenceAssetId,
+      supportsImg2img,
+      img2imgReferenceAssetId,
+      loras: buildLorasPayload(),
+      upscaleEnabled,
+      upscaleFactor,
+      upscaleEngine,
+      upscaleSoftness,
       sampler,
       scheduler,
       schedulerShift,
@@ -1939,25 +1842,39 @@ export function ImageStudio() {
       quantTier,
       showPidToggle,
       usePid,
-      mode,
-      referenceAssetId,
+      pidTarget,
       hideReferenceStrength,
       ipAdapterScale,
       identityStructure,
       controlnetScale,
       variationStrength,
       trueCfgScale,
+      img2imgStrength,
       viewAngles,
       viewAngle,
-      posePayload,
       faceRestore,
       controlActive,
       activeControlMode,
       controlPassthroughId,
       effectiveControlScale,
       controlOverlayId,
-    }),
-  });
+    });
+
+  // One image-job request for a single resolved batch prompt. Thin adapter over the shared
+  // buildJobRequest: resolves the per-prompt override defaults (structured-caption payload and a
+  // per-prompt [WxH] directive, sc-10063) against studio state, then delegates. `count`
+  // multiplies within each job UNLESS poses are selected, in which case each job emits one image
+  // per pose (images = jobs × posePayload.length). For a structured-caption model (sc-9980) the
+  // caller passes the per-prompt auto-expanded caption via `opts`.
+  const buildBatchJobRequest = (resolvedPrompt, opts = {}) =>
+    buildJobRequest({
+      promptToSend: opts.promptToSend ?? resolvedPrompt,
+      submitIntent: resolvedPrompt,
+      sendStructured: opts.sendStructured ?? false,
+      submitCaption: opts.submitCaption ?? caption,
+      submitBackend: opts.submitBackend ?? magicPromptBackend,
+      resolutionOverride: opts.resolution ?? null,
+    });
 
   // Fan out one image job per resolved prompt (mirrors the asset batch, sc-6112): each
   // posts independently so the worker runs them serially with its between-image cache


### PR DESCRIPTION
## sc-11219 (F-031, Medium) — Epic 11147

### Problem
`buildBatchJobRequest` in `ImageStudio.jsx` was a ~75-line hand-copy of `submit()`'s `createImageJob` payload and had **drifted** from the correct single-Generate reference. Concretely, the batch copy:

| Field | Single Generate (correct) | Batch (drifted) |
|---|---|---|
| top-level `referenceAssetId` | `character_image` → char ref; **else `supportsImg2img` → `img2imgReferenceAssetId`**; else null | `character_image` → char ref; **else null** (img2img branch dropped) |
| `advanced.pidTarget` | emitted (`"2k"` when PiD 2K picked) | **missing** |
| `advanced.supportsImg2img` / `img2imgReferenceAssetId` / `img2imgStrength` | passed → `advanced.strength` emitted | **missing** (no `advanced.strength`) |

**Impact:** a batch run on an img2img-capable model (Krea 2 Turbo) with a "Start from an image" reference silently ignored it, and a batch with PiD "2K" rendered at the slower 4K default. Batch output differed from single Generate with identical visible settings.

### Fix
- New **`apps/web/src/imageJobRequest.js`** — one pure `buildImageJobRequest(state)` that produces the full, correct payload (the single-submit reference verbatim), delegating `advanced` to the already-pure `buildImageJobAdvanced`. It is parameterized only by the prompt/caption/resolution overrides.
- **`ImageStudio.jsx`** — one component closure `buildJobRequest(overrides)` feeds studio state into the pure builder. Both `submit()` (single Generate) and `buildBatchJobRequest` (now a thin adapter) delegate to it. The **only** intended single-vs-batch difference is the per-item prompt / structured-caption / per-prompt `[WxH]` resolution override, threaded via `overrides`. Single-submit behavior is unchanged (it is the correct reference).

Result: batch payloads are byte-identical to single Generate for the same visible settings, except the intended prompt/caption/resolution override — img2img reference honored, `pidTarget` honored.

### Tests
- New **`apps/web/src/imageJobRequest.test.js`** (5 tests): pins the previously-dropped fields (top-level img2img `referenceAssetId`, `advanced.strength`, `advanced.pidTarget`), asserts a batch-style call yields an **identical** img2img+PiD payload to single Generate (equal except the prompt/resolution override), and guards the `character_image` reference slot against the img2img branch.
- Full web suite green: **lint 0 errors** (pre-existing exhaustive-deps warnings only), **vitest 1647 passing / 120 files**, **vite build** succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)