### PR TITLE
perf(sceneworks-core): reduce SQLite connection churn + training_store busy_timeout (sc-11202)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -228,7 +228,20 @@ impl From<serde_json::Error> for JobsStoreError {
 #[derive(Debug)]
 pub struct JobsStore {
     db_path: PathBuf,
-    lock: Mutex<()>,
+    /// Serializes writers AND owns the process's single long-lived write
+    /// connection (sc-11202 / F-025). Every mutating method takes this mutex and
+    /// reuses the connection inside it, so the hot claim/heartbeat/progress path
+    /// no longer pays a fresh `Connection::open` + `create_dir_all` + WAL/
+    /// busy_timeout/foreign_keys pragma round-trip per call. The connection is
+    /// created lazily on first write (so `new` stays infallible) and its
+    /// WAL/busy_timeout/foreign_keys pragmas are established exactly once when it
+    /// opens. The mutex still serializes writers exactly as before, and because
+    /// the connection lives entirely behind it, it is never touched by two
+    /// threads at once. Read-only methods still open their own short-lived
+    /// connection off the mutex and rely on WAL reader isolation (see
+    /// `list_jobs`); the separate worker PROCESS keeps its own connection, so
+    /// cross-process access and WAL semantics are unchanged.
+    lock: Mutex<Option<Connection>>,
 }
 
 #[derive(Debug, Clone)]
@@ -346,7 +359,7 @@ impl JobsStore {
     pub fn new(db_path: impl Into<PathBuf>) -> Self {
         Self {
             db_path: db_path.into(),
-            lock: Mutex::new(()),
+            lock: Mutex::new(None),
         }
     }
 
@@ -355,8 +368,8 @@ impl JobsStore {
     }
 
     pub fn initialize(&self) -> JobsStoreResult<()> {
-        let _guard = self.lock.lock();
-        let mut connection = self.connect()?;
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         transaction.execute_batch(
             "
@@ -469,8 +482,8 @@ impl JobsStore {
     }
 
     pub fn mark_interrupted_on_startup(&self) -> JobsStoreResult<Vec<JobSnapshot>> {
-        let _guard = self.lock.lock();
-        let mut connection = self.connect()?;
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let interrupted = self.list_jobs_by_status_on_connection(&transaction, ACTIVE_STATUSES)?;
         // A `pending_caption` job (sc-9120) is owned by an API-side background task, not a worker,
@@ -533,8 +546,8 @@ impl JobsStore {
     }
 
     pub fn create_job(&self, request: CreateJob) -> JobsStoreResult<JobSnapshot> {
-        let _guard = self.lock.lock();
-        let mut connection = self.connect()?;
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let job = self.create_job_on_connection(&transaction, request, None)?;
         transaction.commit()?;
@@ -550,8 +563,8 @@ impl JobsStore {
         id: String,
         request: CreateJob,
     ) -> JobsStoreResult<JobSnapshot> {
-        let _guard = self.lock.lock();
-        let mut connection = self.connect()?;
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let job = self.create_job_on_connection(&transaction, request, Some(id))?;
         transaction.commit()?;
@@ -580,8 +593,8 @@ impl JobsStore {
         job_id: &str,
         new_payload: Option<Map<String, Value>>,
     ) -> JobsStoreResult<PendingCaptionPromotion> {
-        let _guard = self.lock.lock();
-        let mut connection = self.connect()?;
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let now = utc_now();
         let affected = match new_payload {
@@ -632,7 +645,7 @@ impl JobsStore {
         prompt: &str,
         aspect_ratio: &str,
     ) -> JobsStoreResult<Option<JobSnapshot>> {
-        let connection = self.connect()?;
+        let connection = self.open_connection()?;
         let mut statement = connection.prepare(&format!(
             "
             select * from jobs
@@ -665,7 +678,7 @@ impl JobsStore {
         // pure read never mutates and never needs it, so keeping it here would
         // pointlessly stall list/get/summary traffic behind every claim or
         // progress update. All mutating methods still hold the mutex.
-        let connection = self.connect()?;
+        let connection = self.open_connection()?;
         let limit = limit.clamp(1, 500);
         let mut conditions: Vec<&str> = Vec::new();
         let mut bindings: Vec<Box<dyn ToSql>> = Vec::new();
@@ -693,7 +706,7 @@ impl JobsStore {
     pub fn get_job(&self, job_id: &str) -> JobsStoreResult<JobSnapshot> {
         // Read-only single-SELECT: no write mutex, relies on WAL reader isolation
         // (sc-8950 / F-148 — see list_jobs for the full rationale).
-        let connection = self.connect()?;
+        let connection = self.open_connection()?;
         self.get_job_on_connection(&connection, job_id)
     }
 
@@ -707,8 +720,8 @@ impl JobsStore {
         job_id: &str,
         metrics: &GenerationMetrics,
     ) -> JobsStoreResult<()> {
-        let _guard = self.lock.lock();
-        let connection = self.connect()?;
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
         let now = utc_now();
         let loras_json = optional_dumps(metrics.loras.as_ref())?;
         connection.execute(
@@ -792,7 +805,7 @@ impl JobsStore {
         &self,
         job_id: &str,
     ) -> JobsStoreResult<Option<GenerationMetrics>> {
-        let connection = self.connect()?;
+        let connection = self.open_connection()?;
         let metrics = connection
             .query_row(
                 "select * from generation_metrics where job_id = ?1",
@@ -813,7 +826,7 @@ impl JobsStore {
         quant_label: Option<&str>,
         limit: u32,
     ) -> JobsStoreResult<Vec<GenerationMetricsRow>> {
-        let connection = self.connect()?;
+        let connection = self.open_connection()?;
         let limit = limit.clamp(1, 5000);
         let mut conditions: Vec<&str> = Vec::new();
         let mut bindings: Vec<Box<dyn ToSql>> = Vec::new();
@@ -853,8 +866,8 @@ impl JobsStore {
     }
 
     pub fn cancel_job(&self, job_id: &str) -> JobsStoreResult<JobSnapshot> {
-        let _guard = self.lock.lock();
-        let mut connection = self.connect()?;
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let job = self.get_job_on_connection(&transaction, job_id)?;
         if is_terminal_status(job.status.as_str()) {
@@ -902,8 +915,8 @@ impl JobsStore {
     }
 
     pub fn retry_job(&self, job_id: &str, request: RetryJob) -> JobsStoreResult<JobSnapshot> {
-        let _guard = self.lock.lock();
-        let mut connection = self.connect()?;
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let job = self.get_job_on_connection(&transaction, job_id)?;
         if job.attempts >= MAX_JOB_ATTEMPTS {
@@ -940,8 +953,8 @@ impl JobsStore {
         job_id: &str,
         request: DuplicateJob,
     ) -> JobsStoreResult<JobSnapshot> {
-        let _guard = self.lock.lock();
-        let mut connection = self.connect()?;
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let job = self.get_job_on_connection(&transaction, job_id)?;
         let mut payload = job.payload;
@@ -968,8 +981,8 @@ impl JobsStore {
     }
 
     pub fn register_worker(&self, request: RegisterWorker) -> JobsStoreResult<WorkerSnapshot> {
-        let _guard = self.lock.lock();
-        let mut connection = self.connect()?;
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let now = utc_now();
         transaction.execute(
@@ -1003,8 +1016,8 @@ impl JobsStore {
     }
 
     pub fn heartbeat_worker(&self, request: WorkerHeartbeat) -> JobsStoreResult<WorkerSnapshot> {
-        let _guard = self.lock.lock();
-        let mut connection = self.connect()?;
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let worker = self.get_worker_on_connection(&transaction, &request.worker_id)?;
         let now = utc_now();
@@ -1081,8 +1094,8 @@ impl JobsStore {
         &self,
         timeout_seconds: u64,
     ) -> JobsStoreResult<StaleSweep> {
-        let _guard = self.lock.lock();
-        let mut connection = self.connect()?;
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let now = now_unix_seconds();
         let timeout = i64::try_from(timeout_seconds.max(1)).unwrap_or(i64::MAX);
@@ -1177,8 +1190,8 @@ impl JobsStore {
         signal: Option<i32>,
         exit_code: Option<i32>,
     ) -> JobsStoreResult<Option<JobSnapshot>> {
-        let _guard = self.lock.lock();
-        let mut connection = self.connect()?;
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let now = utc_now();
         let worker_ids = [worker_id.to_owned()];
@@ -1253,8 +1266,8 @@ impl JobsStore {
         if !mlx_required {
             return Ok(Vec::new());
         }
-        let _guard = self.lock.lock();
-        let mut connection = self.connect()?;
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let now = now_unix_seconds();
         let grace = i64::try_from(grace_seconds.max(1)).unwrap_or(i64::MAX);
@@ -1348,8 +1361,8 @@ impl JobsStore {
         if !mlx_required || !enforce {
             return Ok(Vec::new());
         }
-        let _guard = self.lock.lock();
-        let mut connection = self.connect()?;
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let mut statement = transaction
             .prepare("select * from jobs where status = 'queued' order by created_at asc")?;
@@ -1405,8 +1418,8 @@ impl JobsStore {
         if !candle_required {
             return Ok(Vec::new());
         }
-        let _guard = self.lock.lock();
-        let mut connection = self.connect()?;
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let now = now_unix_seconds();
         let grace = i64::try_from(grace_seconds.max(1)).unwrap_or(i64::MAX);
@@ -1501,8 +1514,8 @@ impl JobsStore {
         if !candle_required || !enforce {
             return Ok(Vec::new());
         }
-        let _guard = self.lock.lock();
-        let mut connection = self.connect()?;
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let mut statement = transaction
             .prepare("select * from jobs where status = 'queued' order by created_at asc")?;
@@ -1551,8 +1564,8 @@ impl JobsStore {
         worker_id: &str,
         mlx_required: bool,
     ) -> JobsStoreResult<(Option<JobSnapshot>, Option<RouteDecision>)> {
-        let _guard = self.lock.lock();
-        let mut connection = self.connect()?;
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
         // BEGIN IMMEDIATE: take the write lock up front. The claim reads the worker, the
         // active-gpu-job guard and the full queued set before deciding, then writes. A
         // DEFERRED transaction holds only a read lock through those reads and tries to
@@ -1675,8 +1688,8 @@ impl JobsStore {
             return Err(JobsStoreError::InvalidNumber("peakGpuLoadPct".to_owned()));
         }
 
-        let _guard = self.lock.lock();
-        let mut connection = self.connect()?;
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         // Guard against zombie-worker writes (sc-4172): a worker that went
         // silent long enough for the stale sweep to mark its job `interrupted`
@@ -1779,7 +1792,7 @@ impl JobsStore {
     pub fn list_workers(&self) -> JobsStoreResult<Vec<WorkerSnapshot>> {
         // Read-only single-SELECT: no write mutex, relies on WAL reader isolation
         // (sc-8950 / F-148 — see list_jobs for the full rationale).
-        let connection = self.connect()?;
+        let connection = self.open_connection()?;
         let mut statement = connection.prepare("select * from workers order by gpu_id, id")?;
         let workers = collect_workers(statement.query_map([], row_to_worker)?)?;
         Ok(workers)
@@ -1788,7 +1801,7 @@ impl JobsStore {
     pub fn get_worker(&self, worker_id: &str) -> JobsStoreResult<WorkerSnapshot> {
         // Read-only single-SELECT: no write mutex, relies on WAL reader isolation
         // (sc-8950 / F-148 — see list_jobs for the full rationale).
-        let connection = self.connect()?;
+        let connection = self.open_connection()?;
         self.get_worker_on_connection(&connection, worker_id)
     }
 
@@ -1803,7 +1816,7 @@ impl JobsStore {
         // first to dodge a self-deadlock on the non-reentrant mutex; dropping the
         // mutex removes that hazard entirely.)
         let workers = self.list_workers()?;
-        let connection = self.connect()?;
+        let connection = self.open_connection()?;
 
         // Per-status counts over the WHOLE table — never a capped/newest-N sample.
         // Filtering an already-capped list silently undercounts once a project
@@ -1845,7 +1858,25 @@ impl JobsStore {
         })
     }
 
-    fn connect(&self) -> JobsStoreResult<Connection> {
+    /// Borrow the store's single long-lived write connection, lazily opening it
+    /// on first use (sc-11202 / F-025). The caller must already hold the write
+    /// mutex (`guard` is its contents), so the returned `&mut Connection` is only
+    /// ever reachable by one thread at a time. The WAL/busy_timeout/foreign_keys
+    /// pragmas are established once, when the connection first opens; subsequent
+    /// writes skip the per-op `Connection::open` + pragma round-trip entirely.
+    fn write_connection<'a>(
+        &self,
+        guard: &'a mut Option<Connection>,
+    ) -> JobsStoreResult<&'a mut Connection> {
+        if guard.is_none() {
+            *guard = Some(self.open_connection()?);
+        }
+        Ok(guard
+            .as_mut()
+            .expect("write connection was just initialized"))
+    }
+
+    fn open_connection(&self) -> JobsStoreResult<Connection> {
         if let Some(parent) = self.db_path.parent() {
             fs::create_dir_all(parent)?;
         }
@@ -6550,5 +6581,81 @@ mod mlx_routing_tests {
         assert!(video_mode_is_mlx_eligible("wan_2_2", "replace_person"));
         // Unknown modes are never eligible.
         assert!(!video_mode_is_mlx_eligible("ltx_2_3", "nonsense"));
+    }
+}
+
+#[cfg(test)]
+mod connection_pool_tests {
+    //! sc-11202 / F-025: the store keeps ONE long-lived write connection behind
+    //! its write mutex instead of opening a fresh one per op. These pin that the
+    //! long-lived connection still establishes WAL + busy_timeout + foreign_keys
+    //! exactly once, so the concurrency contract the per-op opener guaranteed is
+    //! unchanged.
+    use super::*;
+
+    /// The long-lived write connection carries the same three pragmas every
+    /// opener set before the refactor: a 5s `busy_timeout` (so a concurrent
+    /// worker+API writer waits on the lock instead of failing instantly),
+    /// `foreign_keys=on`, and WAL journal mode.
+    #[test]
+    fn long_lived_write_connection_has_wal_busy_timeout_and_foreign_keys() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = JobsStore::new(dir.path().join("jobs.db"));
+        store.initialize().expect("store initializes");
+
+        let mut guard = store.lock.lock();
+        let connection = store
+            .write_connection(&mut guard)
+            .expect("long-lived write connection");
+
+        let busy_timeout: i64 = connection
+            .pragma_query_value(None, "busy_timeout", |row| row.get(0))
+            .expect("busy_timeout pragma reads");
+        assert_eq!(busy_timeout, 5000, "5s busy_timeout established");
+
+        let foreign_keys: i64 = connection
+            .pragma_query_value(None, "foreign_keys", |row| row.get(0))
+            .expect("foreign_keys pragma reads");
+        assert_eq!(foreign_keys, 1, "foreign_keys enforcement on");
+
+        let journal_mode: String = connection
+            .pragma_query_value(None, "journal_mode", |row| row.get(0))
+            .expect("journal_mode pragma reads");
+        assert_eq!(journal_mode, "wal", "WAL journal mode established");
+    }
+
+    /// The write connection is opened once and REUSED across ops: a connection-
+    /// scoped `TEMP` table created on it survives into a later `write_connection`
+    /// call. A fresh `Connection::open` per op (the pre-refactor churn) would not
+    /// carry the temp table, so this fails if the long-lived connection is ever
+    /// re-created behind the mutex.
+    #[test]
+    fn write_connection_is_reused_across_calls() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = JobsStore::new(dir.path().join("jobs.db"));
+        store.initialize().expect("store initializes");
+
+        {
+            let mut guard = store.lock.lock();
+            let connection = store.write_connection(&mut guard).expect("write conn");
+            connection
+                .execute_batch("create temp table reuse_probe(x integer)")
+                .expect("temp table created on the long-lived connection");
+        }
+
+        let mut guard = store.lock.lock();
+        let connection = store.write_connection(&mut guard).expect("write conn");
+        let exists: i64 = connection
+            .query_row(
+                "select count(*) from sqlite_temp_master \
+                 where type = 'table' and name = 'reuse_probe'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("temp probe query");
+        assert_eq!(
+            exists, 1,
+            "the connection-scoped temp table persists → same long-lived connection reused"
+        );
     }
 }

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -3535,6 +3535,21 @@ fn connect_project_db(project_path: &Path) -> ProjectStoreResult<Connection> {
     Ok(connection)
 }
 
+/// Open `project.db` with the shared `busy_timeout` AND run the version-gated
+/// migrations, then hand back the ready connection. This is the house helper
+/// external store modules (e.g. `training_store`) should use instead of a raw
+/// `Connection::open(project_path.join("project.db"))`, which sets no
+/// `busy_timeout` (so concurrent worker+API access hits an immediate
+/// `SQLITE_BUSY` instead of waiting) and can miss migrations (sc-11202 / F-026).
+/// `apply_project_migrations` is `PRAGMA user_version`-gated, so the DDL only
+/// runs when the schema is actually behind — cheap on the common already-migrated
+/// path.
+pub(crate) fn connect_project_db_migrated(project_path: &Path) -> ProjectStoreResult<Connection> {
+    let connection = connect_project_db(project_path)?;
+    apply_project_migrations(&connection)?;
+    Ok(connection)
+}
+
 /// Assemble the on-disk asset sidecar from the worker-reported flat facts. Rust
 /// is the single owner of this envelope schema now (story 1656): the worker
 /// ships values (paths, dimensions, seed, recipe inputs) and Rust builds the

--- a/crates/sceneworks-core/src/training_store.rs
+++ b/crates/sceneworks-core/src/training_store.rs
@@ -9,7 +9,7 @@ use crate::dataset_quality::{
     caption_hash, CachedTier0Scalars, DatasetEmbeddings, DatasetFaceRecords, QualityAck,
     QualityCheck,
 };
-use crate::project_store::{apply_project_migrations, ProjectStoreError, ProjectStoreResult};
+use crate::project_store::{connect_project_db_migrated, ProjectStoreError, ProjectStoreResult};
 use crate::store_util::{
     atomic_write, ensure_column, is_safe_id, is_safe_relative_path, parse_string_enum, random_hex,
     read_json, relative_string, write_json,
@@ -1266,7 +1266,7 @@ fn resolve_asset_source(
     if !is_safe_id(asset_id) {
         return Err(ProjectStoreError::BadRequest("Invalid asset ID".to_owned()));
     }
-    let connection = Connection::open(project_path.join("project.db"))?;
+    let connection = connect_project_db_migrated(project_path)?;
     let (file_path, sidecar_path): (String, Option<String>) = connection
         .query_row(
             "select file_path, sidecar_path from assets where id = ?1",
@@ -1371,10 +1371,11 @@ fn ensure_dataset_project(project_id: &str, dataset: &TrainingDataset) -> Projec
 }
 
 pub fn ensure_training_dataset_table(project_path: &Path) -> ProjectStoreResult<()> {
-    let connection = Connection::open(project_path.join("project.db"))?;
-    // Route through the version-gated comprehensive migration so the training
-    // path stops replaying DDL on every call (the table is created either way).
-    apply_project_migrations(&connection)
+    // Route through the shared helper: it applies the version-gated comprehensive
+    // migration (so the training path stops replaying DDL on every call — the
+    // table is created either way) AND sets the same busy_timeout as every other
+    // opener (sc-11202 / F-026).
+    connect_project_db_migrated(project_path).map(|_| ())
 }
 
 pub fn apply_training_dataset_migrations(connection: &Connection) -> ProjectStoreResult<()> {
@@ -1406,7 +1407,7 @@ fn list_dataset_summaries_from_index(
     project_path: &Path,
     project_id: &str,
 ) -> ProjectStoreResult<Vec<TrainingDatasetSummary>> {
-    let connection = Connection::open(project_path.join("project.db"))?;
+    let connection = connect_project_db_migrated(project_path)?;
     let mut statement = connection.prepare(
         "
         select id, project_id, name, modality, status, version, item_count, created_at, updated_at, file_path, character_id
@@ -1480,7 +1481,7 @@ fn index_dataset(
 ) -> ProjectStoreResult<()> {
     ensure_training_dataset_table(project_path)?;
     let rel_path = relative_string(project_path, manifest_path)?;
-    let connection = Connection::open(project_path.join("project.db"))?;
+    let connection = connect_project_db_migrated(project_path)?;
     connection.execute(
         "
         insert or replace into training_datasets (
@@ -1506,7 +1507,7 @@ fn index_dataset(
 
 fn remove_dataset_index(project_path: &Path, dataset_id: &str) -> ProjectStoreResult<()> {
     ensure_training_dataset_table(project_path)?;
-    let connection = Connection::open(project_path.join("project.db"))?;
+    let connection = connect_project_db_migrated(project_path)?;
     connection.execute(
         "delete from training_datasets where id = ?1",
         params![dataset_id],
@@ -2262,5 +2263,44 @@ mod tests {
 
         // Metadata write: the dataset version is untouched (the pixels didn't change).
         assert_eq!(store.get_dataset("proj", "ds_test").unwrap().version, 1);
+    }
+
+    /// sc-11202 / F-026: the training path's project.db openers were raw
+    /// `Connection::open` with no `busy_timeout` (so concurrent worker+API access
+    /// got an immediate `SQLITE_BUSY` instead of waiting) and `resolve_asset_source`
+    /// skipped migrations. They now route through the shared
+    /// `connect_project_db_migrated` helper. This pins that a connection from that
+    /// helper carries the same 5s `busy_timeout` every other opener sets AND that
+    /// migrations ran (the `training_datasets` table exists), so the training path
+    /// no longer differs from the rest of the store.
+    #[test]
+    fn training_path_connection_has_busy_timeout_and_runs_migrations() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let project_path = dir.path();
+
+        let connection = connect_project_db_migrated(project_path).expect("project.db opens");
+
+        let busy_timeout: i64 = connection
+            .pragma_query_value(None, "busy_timeout", |row| row.get(0))
+            .expect("busy_timeout pragma reads");
+        assert_eq!(
+            busy_timeout, 5000,
+            "training-path project.db connections get the shared 5s busy_timeout"
+        );
+
+        // Migrations ran: the comprehensive migration creates `training_datasets`,
+        // which the old raw-open `resolve_asset_source` path never guaranteed.
+        let table_count: i64 = connection
+            .query_row(
+                "select count(*) from sqlite_master \
+                 where type = 'table' and name = 'training_datasets'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("schema probe query");
+        assert_eq!(
+            table_count, 1,
+            "connect_project_db_migrated applied the project migrations"
+        );
     }
 }

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -6034,3 +6034,111 @@ fn mlx_worker_refuses_anima_edit_image_jobs() {
         "an Anima edit_image job must not be claimed by the mlx worker"
     );
 }
+
+/// sc-11202 / F-025 — the store now keeps ONE long-lived write connection behind
+/// its mutex instead of opening a fresh one per op. This drives many sequential
+/// claim → heartbeat → progress round-trips through that single connection and
+/// asserts every op stays correct (jobs claimed once, progressed, and completed;
+/// the worker returns to idle). It also confirms WAL is established on the shared
+/// db file (a fresh reader sees `journal_mode = wal`), proving the long-lived
+/// connection preserves the concurrency contract the per-op opener guaranteed.
+#[test]
+fn long_lived_connection_survives_many_sequential_ops() {
+    let path = temp_db("long-lived-sequential");
+    let store = JobsStore::new(path.clone());
+    store.initialize().expect("store initializes");
+    register_image_worker(&store);
+
+    const OPS: usize = 40;
+    for i in 0..OPS {
+        let job = store
+            .create_job(image_job(object(json!({ "prompt": format!("seq-{i}") }))))
+            .expect("job creates");
+
+        let claimed = store
+            .claim_next_job("worker-1")
+            .expect("claim ok")
+            .expect("worker claims the queued job");
+        assert_eq!(
+            claimed.id, job.id,
+            "op {i}: the just-created job is claimed"
+        );
+
+        // Heartbeat mid-run (a hot-path write on the long-lived connection).
+        store
+            .heartbeat_worker(WorkerHeartbeat {
+                worker_id: "worker-1".to_owned(),
+                status: WorkerStatus::Busy,
+                current_job_id: Some(job.id.clone()),
+                loaded_models: Vec::new(),
+                utilization: None,
+            })
+            .expect("heartbeat ok");
+
+        // A running progress update, then terminal completion.
+        let running = store
+            .update_job_progress(
+                &job.id,
+                ProgressUpdate {
+                    status: JobStatus::Running,
+                    stage: ProgressStage::Running,
+                    progress: 0.5,
+                    message: "halfway".to_owned(),
+                    error: None,
+                    result: None,
+                    eta_seconds: None,
+                    peak_gpu_memory_pct: None,
+                    peak_gpu_load_pct: None,
+                    backend: None,
+                    worker_id: Some("worker-1".to_owned()),
+                },
+            )
+            .expect("running progress ok");
+        assert_eq!(running.status, JobStatus::Running, "op {i}: job is running");
+
+        let done = store
+            .update_job_progress(
+                &job.id,
+                ProgressUpdate {
+                    status: JobStatus::Completed,
+                    stage: ProgressStage::Completed,
+                    progress: 1.0,
+                    message: "done".to_owned(),
+                    error: None,
+                    result: None,
+                    eta_seconds: None,
+                    peak_gpu_memory_pct: None,
+                    peak_gpu_load_pct: None,
+                    backend: None,
+                    worker_id: Some("worker-1".to_owned()),
+                },
+            )
+            .expect("completion ok");
+        assert_eq!(done.status, JobStatus::Completed, "op {i}: job completed");
+    }
+
+    // Every job ran exactly once and finished: no queued/running leftovers, and
+    // the worker is idle again.
+    let summary = store.queue_summary().expect("queue summary");
+    assert!(
+        summary.active_jobs.is_empty(),
+        "no active jobs remain after {OPS} sequential round-trips: {:?}",
+        summary.active_jobs
+    );
+    let worker = store.get_worker("worker-1").expect("worker read");
+    assert_eq!(worker.status, WorkerStatus::Idle, "worker idle at the end");
+    assert!(
+        worker.current_job_id.is_none(),
+        "worker holds no job at the end"
+    );
+
+    // WAL is established on the shared db file — a fresh independent reader sees it.
+    let reader = Connection::open(&path).expect("reader opens");
+    let journal_mode: String = reader
+        .pragma_query_value(None, "journal_mode", |row| row.get(0))
+        .expect("journal_mode reads");
+    assert_eq!(
+        journal_mode, "wal",
+        "WAL journal mode persisted on the db file"
+    );
+}


### PR DESCRIPTION
## Summary

Two SQLite hygiene fixes on the shared `sceneworks-core` stores. **sc-11202**, epic **11147**. Both sub-tasks preserve the existing concurrency model (mutex-serialized writers, WAL reader isolation for reads, separate worker-process access).

### Sub-task 1 — F-026 (carried from the 2026-07-01 review): `training_store` project.db `busy_timeout` + migrations

`training_store.rs` had five raw `Connection::open(project_path.join("project.db"))` openers with **no `busy_timeout`** (so under concurrent worker+API access they hit an immediate `SQLITE_BUSY` instead of waiting), and `resolve_asset_source` additionally **skipped migrations**.

All five (`resolve_asset_source`, `ensure_training_dataset_table`, `list_dataset_summaries_from_index`, `index_dataset`, `remove_dataset_index`) now route through a new shared house helper, `connect_project_db_migrated` in `project_store.rs`, which:
- sets the **same 5s `busy_timeout`** every other opener uses (via the existing `connect_project_db`), and
- runs the `PRAGMA user_version`-gated `apply_project_migrations` (cheap on the already-migrated path), so the training path stops differing from the rest of the store.

### Sub-task 2 — F-025 (efficiency): drop per-op connection churn on the hot jobs path

Every `jobs_store` op opened a **fresh** connection: `create_dir_all` + `Connection::open` + a WAL write-locking pragma round-trip + `busy_timeout` + `foreign_keys`. Claims/heartbeats/progress paid this repeatedly.

`JobsStore` now keeps **ONE long-lived write connection behind its existing write mutex** (`lock: Mutex<Option<Connection>>`), created lazily on first write so `new` stays infallible. Per-op open/pragma churn is gone from the write path.

**Concurrency correctness preserved:**
- WAL + `busy_timeout` + `foreign_keys` are still established, **once**, when the long-lived connection first opens.
- The existing mutex still serializes writers; the connection lives entirely behind it, so it is never touched by two threads at once.
- Read-only methods (`list_jobs`/`get_job`/`list_workers`/`get_worker`/`queue_summary`/…) still open their own short-lived connection **off** the mutex and rely on WAL reader isolation — unchanged.
- The separate **worker process** keeps its own connection, so cross-process access and WAL semantics are unchanged.
- Migrations (`initialize`) run on the long-lived connection under the lock.

**`project_store` / `character_store` left per-op (intentional):** their connections are keyed **per `project.db`** (many projects → many DB files), so a single long-lived connection doesn't map cleanly; a path-keyed pool would add eviction/lifetime/cross-process-staleness risk for no clear win. Their existing `busy_timeout` openers are unchanged.

## Tests
- `long_lived_write_connection_has_wal_busy_timeout_and_foreign_keys` — pins all three pragmas on the shared write connection.
- `write_connection_is_reused_across_calls` — a connection-scoped `TEMP` table persists across ops → proves reuse (not per-op reopen).
- `long_lived_connection_survives_many_sequential_ops` — 40 sequential claim→heartbeat→progress round-trips stay correct (jobs claimed once, completed, worker returns idle) with WAL persisted on the db file.
- `training_path_connection_has_busy_timeout_and_runs_migrations` — F-026 pragma + migration assertion.
- Existing `concurrent_claims_never_lock_and_stay_exactly_once` and `reads_proceed_while_a_writer_holds_the_write_lock` continue to pass (concurrency contract intact).

## Checks
- macOS: `cargo build/test -p sceneworks-core` green (461 lib + integration tests pass), `clippy --all-targets -D warnings` clean, `fmt --all --check` clean.
- Linux parity lane: `cargo clippy -p sceneworks-core --all-targets --target x86_64-unknown-linux-gnu -D warnings` clean. (Linux *test-binary linking* isn't runnable from this macOS host — no Linux cross-linker — but clippy type-checks all target/test code; CI's Linux runner links & runs it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)