### PR TITLE
fix(mcp): re-enable /mcp DNS-rebinding defense + cap generate_image payload (sc-11236)

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -940,7 +940,20 @@ pub(crate) fn create_app_with_state(
     // port) carrying the access token, so there is no second engine/DB path.
     // Blocking-job wait policy comes from Settings (sc-10277: SCENEWORKS_MCP_JOB_*
     // env knobs), clamped to the invariants the poll loop needs.
-    let mcp_service = sceneworks_mcp::streamable_http_service_with(
+    // F-040 (sc-11236): restore the transport's Host-header (DNS-rebinding)
+    // defense. `/mcp` rides `access_control`, but that gate performs NO
+    // Host/Origin validation, so in the loopback/loopback-trust/no-token desktop
+    // posture a malicious page could DNS-rebind a browser onto `/mcp`. Derive the
+    // allowed Host set from the SAME bind config that decides where the API
+    // listens: loopback is always allowed; a concrete interface host adds itself;
+    // a wildcard LAN bind honors `SCENEWORKS_MCP_ALLOWED_HOSTS` (and otherwise
+    // disables the check, relying on the mandatory LAN access token).
+    let mcp_allowed_hosts = sceneworks_mcp::mcp_allowed_hosts(
+        &state.settings.host,
+        state.settings.port,
+        &state.settings.mcp_allowed_hosts_extra,
+    );
+    let mcp_service = sceneworks_mcp::streamable_http_service_with_hosts(
         sceneworks_mcp::ApiClientConfig {
             base_url: state.settings.mcp_api_url.clone(),
             access_token: Some(state.settings.access_token.clone()),
@@ -949,6 +962,7 @@ pub(crate) fn create_app_with_state(
             state.settings.mcp_job_poll_interval,
             state.settings.mcp_job_timeout,
         ),
+        mcp_allowed_hosts,
     );
 
     let router = Router::new()

--- a/apps/rust-api/src/server.rs
+++ b/apps/rust-api/src/server.rs
@@ -118,6 +118,16 @@ pub struct Settings {
     /// `SCENEWORKS_EXTERNAL_MODEL_ROOTS`; empty (feature off) by default and always empty
     /// on macOS — see `sceneworks_core::external_roots`.
     pub external_model_roots: Vec<PathBuf>,
+    /// F-040 (sc-11236) — operator-declared extra Host-header authorities the
+    /// `/mcp` DNS-rebinding defense accepts, on top of the always-allowed loopback
+    /// set. Read from `SCENEWORKS_MCP_ALLOWED_HOSTS` (comma-separated `host` or
+    /// `host:port` entries). Only needed for the wildcard LAN bind
+    /// (`SCENEWORKS_API_HOST=0.0.0.0`), whose reachable interface addresses can't
+    /// be enumerated: set it to the machine's LAN hostname/IP(s) to keep the
+    /// Host check ON for remote clients. Empty by default; irrelevant for a
+    /// loopback bind (loopback is always allowed) — see
+    /// [`sceneworks_mcp::mcp_allowed_hosts`].
+    pub mcp_allowed_hosts_extra: Vec<String>,
 }
 
 impl Settings {
@@ -189,6 +199,13 @@ impl Settings {
                 sceneworks_mcp::JobWaitConfig::default().timeout,
             ),
             external_model_roots: sceneworks_core::external_roots::external_model_roots_from_env(),
+            // F-040: extra Host authorities for the /mcp DNS-rebinding allow-list.
+            mcp_allowed_hosts_extra: env_string("SCENEWORKS_MCP_ALLOWED_HOSTS", "")
+                .split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+                .collect(),
         }
     }
 

--- a/apps/rust-api/src/tests.rs
+++ b/apps/rust-api/src/tests.rs
@@ -370,6 +370,7 @@ fn test_settings(temp_dir: &tempfile::TempDir) -> Settings {
         mcp_job_poll_interval: sceneworks_mcp::JobWaitConfig::default().poll_interval,
         mcp_job_timeout: sceneworks_mcp::JobWaitConfig::default().timeout,
         external_model_roots: Vec::new(),
+        mcp_allowed_hosts_extra: Vec::new(),
     }
 }
 

--- a/crates/sceneworks-mcp/src/lib.rs
+++ b/crates/sceneworks-mcp/src/lib.rs
@@ -31,11 +31,11 @@ pub type McpHttpService = StreamableHttpService<SceneWorksMcp, LocalSessionManag
 /// spins up a fresh [`SceneWorksMcp`] (sharing the one [`ApiClient`]) per MCP
 /// session.
 ///
-/// rmcp's own `allowed_hosts` (DNS-rebinding) check is disabled deliberately:
-/// its loopback-only default would 403 the supported LAN deployment
-/// (`SCENEWORKS_API_HOST=0.0.0.0` + access token), and the real access control
-/// for `/mcp` is the surrounding `access_control` middleware — identical to
-/// every `/api/v1` route (sc-10233 acceptance).
+/// Defaults to the loopback-only DNS-rebinding [`allowed_hosts`](mcp_allowed_hosts)
+/// posture (`localhost`/`127.0.0.1`/`::1`). Production wires
+/// [`streamable_http_service_with_hosts`] with the set derived from the API's
+/// bind config; the loopback default here keeps in-crate tests (which dial
+/// `127.0.0.1`) working with the defense ON.
 pub fn streamable_http_service(config: ApiClientConfig) -> McpHttpService {
     streamable_http_service_with(config, JobWaitConfig::default())
 }
@@ -47,10 +47,182 @@ pub fn streamable_http_service_with(
     config: ApiClientConfig,
     job_wait: JobWaitConfig,
 ) -> McpHttpService {
+    streamable_http_service_with_hosts(config, job_wait, loopback_allowed_hosts())
+}
+
+/// The full constructor: also takes the [`allowed_hosts`](mcp_allowed_hosts)
+/// list for the transport's Host-header (DNS-rebinding) validation.
+///
+/// **F-040 (sc-11236).** `/mcp` is mounted inside the API's axum router and, in
+/// the default desktop posture (loopback bind, `SCENEWORKS_TRUST_LOOPBACK`, no
+/// token), the surrounding `access_control` middleware performs NO Host/Origin
+/// validation — so a malicious web page could use DNS rebinding to reach `/mcp`
+/// from the victim's browser and drive job submission / ticketed file reads. rmcp
+/// re-validates the `Host` header against this list and 403s a mismatch (the
+/// canonical DNS-rebinding defense). An **empty** list disables the check
+/// (rmcp's allow-all): used only for the wildcard LAN bind, where the interface
+/// address can't be enumerated and a token already gates every request — see
+/// [`mcp_allowed_hosts`].
+pub fn streamable_http_service_with_hosts(
+    config: ApiClientConfig,
+    job_wait: JobWaitConfig,
+    allowed_hosts: Vec<String>,
+) -> McpHttpService {
     let api = ApiClient::new(config);
+    let transport_config = if allowed_hosts.is_empty() {
+        // Empty ⇒ allow any Host (rmcp semantics). Only reached for the wildcard
+        // LAN bind with no operator override; the access token is the control there.
+        StreamableHttpServerConfig::default().disable_allowed_hosts()
+    } else {
+        StreamableHttpServerConfig::default().with_allowed_hosts(allowed_hosts)
+    };
     StreamableHttpService::new(
         move || Ok(SceneWorksMcp::new(api.clone()).with_job_wait(job_wait.clone())),
         Arc::new(LocalSessionManager::default()),
-        StreamableHttpServerConfig::default().disable_allowed_hosts(),
+        transport_config,
     )
+}
+
+/// The loopback host set always accepted for `/mcp`: `localhost`, `127.0.0.1`,
+/// `::1`. Bare host entries (no port) match ANY port, so the desktop's
+/// OS-assigned dynamic loopback port is covered.
+pub fn loopback_allowed_hosts() -> Vec<String> {
+    vec![
+        "localhost".to_owned(),
+        "127.0.0.1".to_owned(),
+        "::1".to_owned(),
+    ]
+}
+
+/// Derive the `/mcp` Host-header allow-list (F-040, sc-11236) from the API's bind
+/// configuration — the SAME `SCENEWORKS_API_HOST`/`SCENEWORKS_API_PORT` that
+/// decide where the API listens.
+///
+/// - **Loopback / default desktop** (`host` is a loopback name/IP): the returned
+///   set is [`loopback_allowed_hosts`] plus any `extra` operator entries. This
+///   restores the DNS-rebinding defense for the posture the finding names — a
+///   rebinding page sending `Host: attacker.example` is 403'd, while the local UI
+///   and worker (`127.0.0.1`/`localhost`, any port) pass.
+/// - **Concrete non-loopback interface** (e.g. `SCENEWORKS_API_HOST=192.168.4.97`):
+///   loopback set + that host, both bare and `host:port`, + `extra`. Legit LAN
+///   clients dialing that address pass; other Hosts are rejected.
+/// - **Wildcard LAN bind** (`0.0.0.0` / `::`, i.e. the desktop's remote-access
+///   mode): the reachable interface addresses cannot be enumerated from a
+///   wildcard, so the operator declares them via `extra`
+///   (`SCENEWORKS_MCP_ALLOWED_HOSTS`). When `extra` is set the returned set is
+///   loopback + extra (defense ON). When `extra` is empty this returns an
+///   **empty** vec, which the constructor treats as "disable Host validation" so
+///   legitimate LAN clients are never locked out — safe because remote mode
+///   ALWAYS binds with an access token, and a browser doing DNS rebinding is a
+///   remote (non-loopback) peer that cannot present that token.
+///
+/// `port` is included on the concrete-host entry; loopback and `extra` entries
+/// are passed through verbatim. Result is de-duplicated preserving order.
+pub fn mcp_allowed_hosts(host: &str, port: u16, extra: &[String]) -> Vec<String> {
+    let host = host.trim();
+    let is_wildcard = host.is_empty() || host == "0.0.0.0" || host == "::" || host == "[::]";
+    let is_loopback = host == "127.0.0.1"
+        || host == "::1"
+        || host == "[::1]"
+        || host.eq_ignore_ascii_case("localhost");
+
+    let extra: Vec<String> = extra
+        .iter()
+        .map(|entry| entry.trim().to_owned())
+        .filter(|entry| !entry.is_empty())
+        .collect();
+
+    // Wildcard LAN bind with no operator override: cannot enumerate reachable
+    // hosts, so disable the Host check (token-gated) rather than 403 real clients.
+    if is_wildcard && extra.is_empty() {
+        return Vec::new();
+    }
+
+    let mut hosts = loopback_allowed_hosts();
+    if !is_wildcard && !is_loopback {
+        // A concrete interface address the operator bound to: allow it (any port
+        // and the specific `host:port`), so a client dialing it directly passes.
+        hosts.push(host.to_owned());
+        hosts.push(format!("{host}:{port}"));
+    }
+    hosts.extend(extra);
+    // Order-preserving de-dup (an `extra` entry may repeat a loopback name).
+    let mut seen = std::collections::HashSet::new();
+    hosts.retain(|entry| seen.insert(entry.clone()));
+    hosts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mcp_allowed_hosts;
+
+    const LOOPBACK: [&str; 3] = ["localhost", "127.0.0.1", "::1"];
+
+    #[test]
+    fn loopback_bind_is_loopback_only() {
+        for host in ["127.0.0.1", "::1", "localhost", "LocalHost"] {
+            let allowed = mcp_allowed_hosts(host, 0, &[]);
+            assert_eq!(allowed, LOOPBACK, "loopback bind {host} → loopback-only");
+        }
+    }
+
+    #[test]
+    fn wildcard_bind_without_extra_disables_check() {
+        for host in ["0.0.0.0", "::", "[::]", ""] {
+            assert!(
+                mcp_allowed_hosts(host, 8000, &[]).is_empty(),
+                "wildcard bind {host} with no override disables the check"
+            );
+        }
+    }
+
+    #[test]
+    fn wildcard_bind_with_extra_enforces_loopback_plus_extra() {
+        let allowed = mcp_allowed_hosts("0.0.0.0", 8000, &["scenebox.local:8000".to_owned()]);
+        assert_eq!(
+            allowed,
+            ["localhost", "127.0.0.1", "::1", "scenebox.local:8000"],
+            "operator override re-enables the check with the LAN host allowed"
+        );
+    }
+
+    #[test]
+    fn concrete_interface_host_is_added_with_and_without_port() {
+        let allowed = mcp_allowed_hosts("192.168.4.97", 8000, &[]);
+        assert_eq!(
+            allowed,
+            [
+                "localhost",
+                "127.0.0.1",
+                "::1",
+                "192.168.4.97",
+                "192.168.4.97:8000"
+            ],
+        );
+    }
+
+    #[test]
+    fn extra_entries_are_trimmed_and_deduped_against_loopback() {
+        let allowed = mcp_allowed_hosts(
+            "192.168.4.97",
+            8000,
+            &[
+                " localhost ".to_owned(),
+                "".to_owned(),
+                "box.lan".to_owned(),
+            ],
+        );
+        // `localhost` already present (trimmed) → not duplicated; empty dropped.
+        assert_eq!(
+            allowed,
+            [
+                "localhost",
+                "127.0.0.1",
+                "::1",
+                "192.168.4.97",
+                "192.168.4.97:8000",
+                "box.lan"
+            ],
+        );
+    }
 }

--- a/crates/sceneworks-mcp/src/server.rs
+++ b/crates/sceneworks-mcp/src/server.rs
@@ -48,6 +48,21 @@ use crate::api_client::{ApiClient, ApiClientError};
 /// server-side; only a sustained failure streak surfaces as an error.
 const MAX_CONSECUTIVE_POLL_ERRORS: u32 = 5;
 
+/// F-041 (sc-11236) — inline-payload caps for `generate_image`. The tool
+/// base64-inlines every produced image into the JSON-RPC tool result. base64
+/// inflates the bytes by ~33% and the encoded response is held twice in memory,
+/// so a large batch (`count` up to 8, caller-chosen dimensions up to 2048²) can
+/// balloon to tens of MB — enough to exceed an MCP client's message-size limit or
+/// blow the model's context window. When a single image exceeds
+/// [`MAX_INLINE_IMAGE_BYTES`] OR the running total exceeds
+/// [`MAX_INLINE_TOTAL_BYTES`], `generate_image` returns the exact same
+/// ticketed-download-link shape as `get_job_result` (resource links + a JSON
+/// summary, no inline bytes) instead of inlining. Thresholds are on the RAW
+/// (pre-base64) byte count and picked conservatively: a typical 1–2 image job of a
+/// few-MP PNG still inlines; only genuinely heavy batches spill to links.
+const MAX_INLINE_IMAGE_BYTES: usize = 4 * 1024 * 1024;
+const MAX_INLINE_TOTAL_BYTES: usize = 10 * 1024 * 1024;
+
 /// How the blocking job tools (generate_image) wait for a terminal JobSnapshot:
 /// poll `GET /api/v1/jobs/:id` every `poll_interval` until terminal, and give up
 /// with a clear tool error after `timeout` so a stuck job can never hang the MCP
@@ -303,6 +318,7 @@ impl SceneWorksMcp {
         &self,
         Parameters(args): Parameters<GenerateImageArgs>,
         ctx: RequestContext<RoleServer>,
+        extensions: Extensions,
     ) -> Result<CallToolResult, ErrorData> {
         let body =
             image_job_body(&args).map_err(|message| ErrorData::invalid_params(message, None))?;
@@ -431,6 +447,7 @@ impl SceneWorksMcp {
 
         let mut blocks = Vec::with_capacity(assets.len() + 1);
         let mut summary_assets = Vec::with_capacity(assets.len());
+        let mut total_bytes = 0usize;
         for asset in assets {
             let Some(media_path) = asset_media_path(asset) else {
                 continue;
@@ -448,6 +465,18 @@ impl SceneWorksMcp {
                 asset.pointer("/file/mimeType").and_then(Value::as_str),
                 header_mime.as_deref(),
             );
+            // F-041 (sc-11236): an over-cap result must not be inlined — the
+            // base64 JSON-RPC payload (held twice in memory) would exceed MCP
+            // client message limits / the model context. Above EITHER the
+            // per-image or running-total cap, switch the WHOLE response to the
+            // get_job_result ticketed-link shape (bytes downloaded so far are
+            // simply dropped). The ticket links reach the same media without
+            // inlining, so no result is lost.
+            total_bytes = total_bytes.saturating_add(bytes.len());
+            if bytes.len() > MAX_INLINE_IMAGE_BYTES || total_bytes > MAX_INLINE_TOTAL_BYTES {
+                let link_base = self.request_link_base(&extensions);
+                return self.job_result_links(&job_id, &job, link_base).await;
+            }
             summary_assets.push(json!({
                 "id": asset.get("id").cloned().unwrap_or(Value::Null),
                 "path": &media_path,
@@ -565,6 +594,38 @@ impl SceneWorksMcp {
             }
         }
 
+        let link_base = self.request_link_base(&extensions);
+        self.job_result_links(job_id, &job, link_base).await
+    }
+
+    /// Absolute URL base for ticketed media links (sc-10290). `/mcp` and
+    /// `/api/v1` are the SAME axum app, so the host the client used to reach
+    /// `/mcp` is exactly the host that serves the media — derive it from the
+    /// incoming request so the URL is reachable by THIS client regardless of how
+    /// `SCENEWORKS_API_URL` is configured (e.g. a loopback-default desktop
+    /// answering a LAN client). Falls back to the configured API base when the
+    /// request parts / Host aren't available. The Host is only reflected back to
+    /// the caller that supplied it (never stored / shown to other users), and
+    /// `/mcp` is already gated by access_control, so reflecting it is safe.
+    fn request_link_base(&self, extensions: &Extensions) -> String {
+        extensions
+            .get::<http::request::Parts>()
+            .and_then(|parts| request_base_url(&parts.headers, &parts.uri))
+            .unwrap_or_else(|| self.api.base_url().to_owned())
+    }
+
+    /// Build the ticketed-download-link result for a COMPLETED `job`: mint one
+    /// sliding multi-use media ticket and emit one `resource_link` block per
+    /// result asset plus a JSON summary, with `link_base` as the absolute URL
+    /// base. This is the response shape `get_job_result` returns, and the
+    /// oversize-payload fallback `generate_image` uses (F-041, sc-11236) instead
+    /// of inlining tens of MB of base64.
+    async fn job_result_links(
+        &self,
+        job_id: &str,
+        job: &Value,
+        link_base: String,
+    ) -> Result<CallToolResult, ErrorData> {
         let Some(project_id) = job
             .get("projectId")
             .and_then(Value::as_str)
@@ -611,20 +672,6 @@ impl SceneWorksMcp {
             ));
         };
         let expires_in_seconds = ticket_response.get("expiresInSeconds").cloned();
-
-        // Absolute URL base for the ticket links (sc-10290). `/mcp` and `/api/v1`
-        // are the SAME axum app, so the host the client used to reach `/mcp` is
-        // exactly the host that serves the media — derive it from the incoming
-        // request so the URL is reachable by THIS client regardless of how
-        // `SCENEWORKS_API_URL` is configured (e.g. a loopback-default desktop
-        // answering a LAN client). Falls back to the configured API base when the
-        // request parts / Host aren't available. The Host is only reflected back to
-        // the caller that supplied it (never stored / shown to other users), and
-        // `/mcp` is already gated by access_control, so reflecting it is safe.
-        let link_base = extensions
-            .get::<http::request::Parts>()
-            .and_then(|parts| request_base_url(&parts.headers, &parts.uri))
-            .unwrap_or_else(|| self.api.base_url().to_owned());
 
         let mut blocks = Vec::with_capacity(assets.len() + 1);
         let mut summary_assets = Vec::with_capacity(assets.len());

--- a/crates/sceneworks-mcp/tests/dns_rebinding_host.rs
+++ b/crates/sceneworks-mcp/tests/dns_rebinding_host.rs
@@ -1,0 +1,138 @@
+//! F-040 (sc-11236): the `/mcp` streamable-HTTP transport must re-validate the
+//! `Host` header (DNS-rebinding defense). `/mcp` rides the API's `access_control`
+//! middleware, but that gate performs NO Host/Origin validation — so in the
+//! loopback / loopback-trust / no-token desktop posture a malicious web page could
+//! DNS-rebind a victim's browser onto `/mcp`. These tests drive the mounted
+//! service with raw HTTP/1.1 requests carrying spoofed / legitimate Host headers
+//! and assert the transport 403s a disallowed Host while accepting the loopback
+//! (and, in remote mode, the configured LAN) host.
+
+use axum::Router;
+use sceneworks_mcp::{mcp_allowed_hosts, streamable_http_service_with_hosts, ApiClientConfig};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+/// Mount the MCP service (with `allowed_hosts`) at `/mcp` behind a live listener,
+/// returning its `host:port` authority. The API base URL is never dialed here (no
+/// tool is called), so a placeholder is fine.
+async fn serve_mcp(allowed_hosts: Vec<String>) -> String {
+    let service = streamable_http_service_with_hosts(
+        ApiClientConfig {
+            base_url: "http://127.0.0.1:0".to_owned(),
+            access_token: None,
+        },
+        sceneworks_mcp::JobWaitConfig::default(),
+        allowed_hosts,
+    );
+    let router = Router::new().nest_service("/mcp", service);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind mcp listener");
+    let addr = listener.local_addr().expect("mcp addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+    addr.to_string()
+}
+
+/// Send a raw `GET /mcp` with an explicit `Host` header (raw TCP so the Host is
+/// exactly what we choose — a client library would derive it from the URL) and
+/// return the HTTP status code. The DNS-rebinding check runs before method
+/// dispatch, so a GET is enough to exercise it without a full MCP handshake.
+async fn get_mcp_status(authority: &str, host_header: &str) -> u16 {
+    let mut stream = TcpStream::connect(authority)
+        .await
+        .expect("connect to mcp listener");
+    let request = format!(
+        "GET /mcp HTTP/1.1\r\nHost: {host_header}\r\nAccept: text/event-stream\r\nConnection: close\r\n\r\n"
+    );
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .expect("write request");
+    let mut buf = Vec::new();
+    stream.read_to_end(&mut buf).await.expect("read response");
+    let response = String::from_utf8_lossy(&buf);
+    let status_line = response.lines().next().expect("status line");
+    status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|code| code.parse().ok())
+        .unwrap_or_else(|| panic!("no status code in response: {status_line:?}"))
+}
+
+#[tokio::test]
+async fn loopback_bind_rejects_spoofed_host_but_accepts_loopback() {
+    // Default desktop posture: loopback bind → loopback-only allow-list.
+    let allowed = mcp_allowed_hosts("127.0.0.1", 0, &[]);
+    let authority = serve_mcp(allowed).await;
+    let port = authority.rsplit(':').next().unwrap();
+
+    // A DNS-rebinding page reaches 127.0.0.1 but sends an attacker Host → 403.
+    assert_eq!(
+        get_mcp_status(&authority, "attacker.example").await,
+        403,
+        "a disallowed Host must be rejected (DNS-rebinding defense)"
+    );
+
+    // The legitimate local UI / MCP client dials 127.0.0.1 or localhost → allowed
+    // (bare loopback entries match any port, incl. the OS-assigned desktop port).
+    for host in [format!("127.0.0.1:{port}"), format!("localhost:{port}")] {
+        assert_ne!(
+            get_mcp_status(&authority, &host).await,
+            403,
+            "loopback Host {host} must be accepted"
+        );
+    }
+}
+
+#[tokio::test]
+async fn remote_bind_accepts_configured_lan_host_and_rejects_others() {
+    // LAN remote posture: wildcard bind (0.0.0.0) + operator-declared LAN host via
+    // SCENEWORKS_MCP_ALLOWED_HOSTS. The defense stays ON with the LAN host allowed.
+    let allowed = mcp_allowed_hosts("0.0.0.0", 8000, &["scenebox.local:8000".to_owned()]);
+    let authority = serve_mcp(allowed).await;
+    let port = authority.rsplit(':').next().unwrap();
+
+    // The declared LAN authority passes; loopback still passes.
+    assert_ne!(
+        get_mcp_status(&authority, "scenebox.local:8000").await,
+        403,
+        "the configured LAN Host must be accepted in remote mode"
+    );
+    assert_ne!(
+        get_mcp_status(&authority, &format!("127.0.0.1:{port}")).await,
+        403,
+        "loopback stays allowed in remote mode"
+    );
+
+    // A different host — or the right host on the wrong port — is rejected.
+    assert_eq!(
+        get_mcp_status(&authority, "attacker.example").await,
+        403,
+        "an unrelated Host must be rejected even in remote mode"
+    );
+    assert_eq!(
+        get_mcp_status(&authority, "scenebox.local:9999").await,
+        403,
+        "the LAN host on a non-configured port must be rejected"
+    );
+}
+
+#[tokio::test]
+async fn wildcard_bind_without_operator_hosts_disables_check() {
+    // Wildcard bind with no override: the reachable interface IPs can't be
+    // enumerated, so the Host check is disabled (empty allow-list ⇒ allow all) to
+    // avoid locking out LAN clients — the mandatory LAN access token is the control
+    // there. This documents/guards that deliberate fallback.
+    assert!(
+        mcp_allowed_hosts("0.0.0.0", 8000, &[]).is_empty(),
+        "wildcard bind without operator hosts yields an empty (disabled) allow-list"
+    );
+    let authority = serve_mcp(mcp_allowed_hosts("0.0.0.0", 8000, &[])).await;
+    assert_ne!(
+        get_mcp_status(&authority, "anything.example").await,
+        403,
+        "with the check disabled, any Host is accepted (token-gated deployment)"
+    );
+}

--- a/crates/sceneworks-mcp/tests/generate_image_tool.rs
+++ b/crates/sceneworks-mcp/tests/generate_image_tool.rs
@@ -31,6 +31,12 @@ const PNG_BYTES: &[u8] = b"fake-png-payload-0001";
 const JPG_BYTES: &[u8] = b"fake-jpeg-payload-0002";
 const PNG_PATH: &str = "assets/images/genset_1/img_0001.png";
 const JPG_PATH: &str = "assets/images/genset_1/img_0002.jpg";
+// F-041 (sc-11236): an asset that exceeds the per-image inline cap (4 MiB), so
+// generate_image must fall back to the ticketed-link response shape instead of
+// base64-inlining it.
+const LARGE_PATH: &str = "assets/images/genset_1/img_large.png";
+const LARGE_IMAGE_LEN: usize = 5 * 1024 * 1024;
+const TICKET: &str = "tkt-abc123";
 
 /// Scripted `/api/v1` job pipeline: the submit returns a queued JobSnapshot,
 /// then each `GET /jobs/:id` poll steps through `snapshots` (the last repeats,
@@ -116,16 +122,22 @@ fn stub_api_router(state: StubState) -> Router {
             "/api/v1/projects/:project_id/files/*relative_path",
             get(
                 |Path((_project_id, relative_path)): Path<(String, String)>| async move {
-                    let (bytes, mime) = match relative_path.as_str() {
-                        PNG_PATH => (PNG_BYTES, "image/png"),
-                        JPG_PATH => (JPG_BYTES, "image/jpeg"),
+                    let (bytes, mime): (Vec<u8>, &str) = match relative_path.as_str() {
+                        PNG_PATH => (PNG_BYTES.to_vec(), "image/png"),
+                        JPG_PATH => (JPG_BYTES.to_vec(), "image/jpeg"),
+                        LARGE_PATH => (vec![0x42u8; LARGE_IMAGE_LEN], "image/png"),
                         _ => return Err(StatusCode::NOT_FOUND),
                     };
                     let mut headers = HeaderMap::new();
                     headers.insert(header::CONTENT_TYPE, mime.parse().unwrap());
-                    Ok((headers, bytes.to_vec()))
+                    Ok((headers, bytes))
                 },
             ),
+        )
+        // F-041: the oversize-payload fallback mints a media ticket for its links.
+        .route(
+            "/api/v1/files/ticket",
+            post(|| async { Json(json!({ "ticket": TICKET, "expiresInSeconds": 600 })) }),
         )
         .with_state(state)
 }
@@ -718,6 +730,76 @@ async fn invalid_mode_is_rejected_before_submitting_a_job() {
         harness.submitted.lock().unwrap().is_empty(),
         "no job may be submitted for an invalid mode"
     );
+
+    let _ = harness.client.cancel().await;
+}
+
+/// F-041 (sc-11236): an over-cap result (one 5 MiB image, above the 4 MiB
+/// per-image inline cap) must NOT be base64-inlined — the tool falls back to the
+/// `get_job_result` ticketed-link shape (resource links + a JSON summary carrying
+/// ticketed URLs, zero inline image bytes).
+#[tokio::test]
+async fn oversize_result_falls_back_to_ticketed_links() {
+    let harness = harness(vec![
+        snapshot("running", 0.5, "generating", json!({})),
+        snapshot(
+            "completed",
+            1.0,
+            "completed",
+            json!({ "result": { "assets": [image_asset("asset_big", LARGE_PATH, "image/png")] } }),
+        ),
+    ])
+    .await;
+
+    let result = harness
+        .client
+        .call_tool(
+            CallToolRequestParams::new("generate_image").with_arguments(generate_args(json!({}))),
+        )
+        .await
+        .expect("generate_image succeeds");
+    assert_ne!(result.is_error, Some(true), "unexpected error: {result:?}");
+
+    // Zero inline image blocks: the oversize payload spilled to links.
+    assert!(
+        !result
+            .content
+            .iter()
+            .any(|block| block.as_image().is_some()),
+        "an over-cap result must not inline base64 image bytes: {result:?}"
+    );
+
+    // Exactly one ticketed resource link for the asset.
+    let links: Vec<_> = result
+        .content
+        .iter()
+        .filter_map(|block| block.as_resource_link())
+        .collect();
+    assert_eq!(links.len(), 1, "one ticketed link: {result:?}");
+    assert!(
+        links[0].uri.contains("/api/v1/projects/p1/files/")
+            && links[0].uri.contains(&format!("?ticket={TICKET}")),
+        "link is the ticketed media URL: {}",
+        links[0].uri
+    );
+
+    // The JSON summary is the get_job_result shape (completed status + ticketed url).
+    let summary: Value = serde_json::from_str(
+        &result
+            .content
+            .iter()
+            .rev()
+            .find_map(|block| block.as_text())
+            .expect("summary text block")
+            .text,
+    )
+    .expect("summary is JSON");
+    assert_eq!(summary["jobId"], "job-1");
+    assert_eq!(summary["status"], "completed");
+    assert_eq!(summary["assets"][0]["id"], "asset_big");
+    assert!(summary["assets"][0]["url"]
+        .as_str()
+        .is_some_and(|url| url.contains(&format!("?ticket={TICKET}"))));
 
     let _ = harness.client.cancel().await;
 }


### PR DESCRIPTION
## Summary

MCP hardening for **sc-11236** (epic **11147**) — two findings from the 2026-07-12 code review.

### F-040 (security) — restore the Host/Origin (DNS-rebinding) defense on `/mcp`

**auth.rs finding (confirmed):** `access_control` in `apps/rust-api/src/auth.rs` performs **no** Host/Origin validation — only token, loopback-trust, media-ticket, and brute-force-throttle checks. So in the default desktop posture (loopback bind, `SCENEWORKS_TRUST_LOOPBACK`, no token) the tokenless/loopback-trust path is genuinely unprotected against DNS rebinding: a malicious web page can rebind a victim's browser onto `127.0.0.1` and reach `/mcp` (the browser connects as a loopback peer → trusted, no token needed), driving job submission / ticketed file reads. This is the real gap the transport's `disable_allowed_hosts()` opened.

**Fix:** replace `disable_allowed_hosts()` with an allow-list derived from the **same** bind config that decides where the API listens (`sceneworks_mcp::mcp_allowed_hosts`, `crates/sceneworks-mcp/src/lib.rs`), wired at the mount in `apps/rust-api/src/lib.rs`:

- **Loopback / default desktop** → loopback-only (`localhost`/`127.0.0.1`/`::1`), bare entries so the OS-assigned dynamic port matches. A rebinding page's `Host: attacker.example` is 403'd; the local UI/worker pass.
- **Concrete interface host** (e.g. `SCENEWORKS_API_HOST=192.168.4.97`) → loopback + that host (bare and `host:port`).
- **Wildcard LAN bind** (`0.0.0.0`, the desktop's remote-access mode) → reachable IPs can't be enumerated, so the operator declares them via `SCENEWORKS_MCP_ALLOWED_HOSTS`; when set the defense stays ON (loopback + declared), when unset the check is disabled — safe because remote mode **always** binds with an access token and a rebinding browser is a remote (non-loopback) peer that can't present it. This keeps legit LAN clients from being locked out.

Both legit loopback and token/LAN access keep working (the existing live-listener round-trip tests still pass with the defense on).

### F-041 (efficiency) — cap generate_image's inline base64 payload

`generate_image` base64-inlined **every** result asset with no cap; `count` up to 8 at caller-chosen dimensions could return tens of MB (held twice in memory), exceeding MCP client message limits / the model context. Now, above **4 MiB/image** or **10 MiB total** (`MAX_INLINE_IMAGE_BYTES` / `MAX_INLINE_TOTAL_BYTES`, `crates/sceneworks-mcp/src/server.rs`) the tool returns the existing `get_job_result` **ticketed-link** shape instead of inlining — via a shared `job_result_links` helper extracted from `get_job_result`, so there's no new response shape.

## Tests

- `crates/sceneworks-mcp/src/lib.rs` — `mcp_allowed_hosts` unit tests (loopback-only, wildcard-disables, wildcard+extra enforces, concrete host, trim/dedup).
- `crates/sceneworks-mcp/tests/dns_rebinding_host.rs` — raw-HTTP integration: spoofed `Host` → 403; loopback and configured LAN host → accepted; LAN host on wrong port → 403; wildcard-without-override → check disabled.
- `crates/sceneworks-mcp/tests/generate_image_tool.rs` — oversize (5 MiB) result falls back to ticketed links (zero inline image blocks); small results still inline (existing happy-path).

macOS: `cargo build`/`test -p sceneworks-mcp` green (35 unit + all integration), `cargo test -p sceneworks-rust-api mcp` green, `clippy -p sceneworks-mcp` + `-p sceneworks-rust-api --all-targets -D warnings` clean, `fmt --all --check` clean. Contract lane: `clippy -p sceneworks-mcp --all-targets --target x86_64-unknown-linux-gnu -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)