### PR TITLE
fix(worker): supervisor survives spawn/wait errors + Windows graceful shutdown (sc-11184)

### DIFF
--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -676,7 +676,16 @@ async fn wait_for_parent_stdin_close() {
                     Err(_) => break,
                 }
             }
-            let _ = signal.send(true);
+            // `send_replace` (NOT `send`) so the latch is updated UNCONDITIONALLY even
+            // when `receiver_count() == 0`: `send` returns `Err` WITHOUT storing the value
+            // if no receiver is currently subscribed, and receivers only exist while a
+            // `wait_for_parent_stdin_close` future is being polled. In the synchronous gap
+            // between the poll-phase `select!` and the run_job `select!` no receiver is
+            // subscribed, so an EOF landing in that window would be lost forever and every
+            // later waiter would block on `changed()` indefinitely (the reader is
+            // single-shot and has exited). `send_replace` latches `true` regardless, so the
+            // next `subscribe()`'s `borrow_and_update()` observes it immediately (sc-11184).
+            let _ = signal.send_replace(true);
         });
         tx
     });

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -618,7 +618,79 @@ async fn shutdown_signal() {
     }
     #[cfg(not(unix))]
     {
-        let _ = tokio::signal::ctrl_c().await;
+        // Windows has no per-child SIGTERM, so a supervised child ALSO treats stdin-EOF
+        // as a graceful-shutdown request: the supervisor holds the write end of the
+        // child's piped stdin and closing it (see `supervisor::terminate_child`)
+        // delivers EOF here — the Windows analogue of the unix SIGTERM path (sc-11184 /
+        // F-014). This trips the same sc-8845 graceful-cancel wind-down, so an in-flight
+        // job posts a terminal `Canceled` instead of dying mid-GPU-write. The top-level
+        // supervisor process is NOT a child (its stdin is the real console, not a
+        // supervisor-held pipe), so it keeps Ctrl-C only; gate the stdin path to child
+        // workers via the `SCENEWORKS_WORKER_CHILD` marker the supervisor sets.
+        if std::env::var_os("SCENEWORKS_WORKER_CHILD").is_some() {
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {}
+                _ = wait_for_parent_stdin_close() => {}
+            }
+        } else {
+            let _ = tokio::signal::ctrl_c().await;
+        }
+    }
+}
+
+/// Resolve once the supervisor closes the write end of this child's stdin pipe
+/// (sc-11184 / F-014) — the Windows graceful-shutdown signal, standing in for the unix
+/// SIGTERM the supervisor cannot deliver per-child on Windows.
+///
+/// `shutdown_signal()` is awaited on every worker-loop turn, so opening a fresh reader
+/// per call would risk parking a blocking thread on each turn. Instead a SINGLE
+/// background reader is started once (guarded by a `OnceLock`) and its EOF result is
+/// fanned out over a `watch` channel; every caller just subscribes. The channel latches
+/// `true` on close and stays there, so a caller that subscribes AFTER the pipe already
+/// closed still returns immediately. The reader drains stdin on std's blocking handle
+/// inside `spawn_blocking` (rather than `tokio::io::stdin`, which needs the `io-std`
+/// feature this crate does not enable).
+#[cfg(not(unix))]
+async fn wait_for_parent_stdin_close() {
+    use std::sync::OnceLock;
+    use tokio::sync::watch;
+
+    static CLOSED: OnceLock<watch::Sender<bool>> = OnceLock::new();
+    let sender = CLOSED.get_or_init(|| {
+        let (tx, _rx) = watch::channel(false);
+        let signal = tx.clone();
+        // One dedicated blocking reader for the whole process, so repeated turns never
+        // each park a fresh thread. Detached: dropping the JoinHandle lets it run on.
+        tokio::task::spawn_blocking(move || {
+            use std::io::Read;
+            let mut stdin = std::io::stdin();
+            let mut scratch = [0_u8; 64];
+            loop {
+                match stdin.read(&mut scratch) {
+                    // EOF: the supervisor dropped the write end → graceful shutdown.
+                    Ok(0) => break,
+                    // A worker child consumes stdin for nothing else, so discard any
+                    // stray bytes; only closure is meaningful.
+                    Ok(_) => continue,
+                    // Treat a read error as closure too, so shutdown never hangs on it.
+                    Err(_) => break,
+                }
+            }
+            let _ = signal.send(true);
+        });
+        tx
+    });
+
+    let mut receiver = sender.subscribe();
+    if *receiver.borrow_and_update() {
+        return;
+    }
+    // Wait until the reader latches `true`. `changed()` cannot error from a dropped
+    // sender: the `OnceLock` holds it for the process lifetime.
+    while receiver.changed().await.is_ok() {
+        if *receiver.borrow() {
+            return;
+        }
     }
 }
 

--- a/crates/sceneworks-worker/src/supervisor.rs
+++ b/crates/sceneworks-worker/src/supervisor.rs
@@ -140,7 +140,26 @@ where
         if child.next_restart_at.is_some() {
             continue;
         }
-        if let Some(status) = child.process.try_wait()? {
+        // A transient `try_wait` failure must NOT tear the whole supervisor down and
+        // orphan the still-running healthy siblings — log it and revisit this child on
+        // the next 1 s tick, exactly as a not-yet-exited child would be (sc-11184 /
+        // F-013).
+        let status = match child.process.try_wait() {
+            Ok(status) => status,
+            Err(error) => {
+                emit_event_value(
+                    Level::ERROR,
+                    json!({
+                        "event": "worker_wait_failed",
+                        "workerId": worker_id,
+                        "gpuId": child.spec.gpu_id,
+                        "error": error.to_string(),
+                    }),
+                );
+                continue;
+            }
+        };
+        if let Some(status) = status {
             // A child that ran healthily for a while before exiting starts its
             // backoff fresh, so rare widely-spaced crashes don't ratchet the delay
             // up to the cap forever (sc-4282 / F-MLXW-20).
@@ -198,9 +217,35 @@ where
         let Some(child) = children.get_mut(&worker_id) else {
             continue;
         };
-        child.process = spawner(settings, &child.spec)?;
-        child.spawned_at = now;
-        child.next_restart_at = None;
+        match spawner(settings, &child.spec) {
+            Ok(process) => {
+                child.process = process;
+                child.spawned_at = now;
+                child.next_restart_at = None;
+            }
+            Err(error) => {
+                // A failed respawn (an AV-locked exe mid-update, momentary resource
+                // exhaustion) is treated like another crash: log it, re-arm the backoff
+                // with a fresh deadline, and try again on a later tick — rather than
+                // propagating the error out of the supervision loop, which would kill
+                // the whole supervisor and orphan the healthy siblings still running
+                // (sc-11184 / F-013). Advancing the attempt keeps the backoff climbing
+                // so a persistently unspawnable child doesn't hot-loop the exec.
+                child.restart_attempt = child.restart_attempt.saturating_add(1);
+                let delay = retry_delay(settings.poll_seconds, child.restart_attempt);
+                child.next_restart_at = Some(now + Duration::from_secs(delay));
+                emit_event_value(
+                    Level::ERROR,
+                    json!({
+                        "event": "worker_respawn_failed",
+                        "workerId": worker_id,
+                        "gpuId": child.spec.gpu_id,
+                        "restartInSeconds": delay,
+                        "error": error.to_string(),
+                    }),
+                );
+            }
+        }
     }
     Ok(())
 }
@@ -252,6 +297,20 @@ pub(crate) async fn terminate_child(child: &mut Child) {
             return;
         }
     }
+    // Windows graceful signal (sc-11184 / F-014): the child was spawned with a
+    // supervisor-held stdin pipe (see `start_child_worker`), so dropping the write end
+    // here delivers EOF to the child. Its `shutdown_signal()` selects on that EOF and
+    // trips the sc-8845 graceful-cancel machinery, letting an in-flight job post its
+    // terminal `Canceled` during the grace window in `stop_children` before we escalate
+    // to `start_kill()` — the Windows analogue of the unix SIGTERM→wait→SIGKILL ladder.
+    // Falls through to `start_kill()` if the pipe is absent (never piped / already
+    // taken), so a child with no graceful channel is still stopped.
+    #[cfg(not(unix))]
+    {
+        if child.stdin.take().is_some() {
+            return;
+        }
+    }
     let _ = child.start_kill();
 }
 
@@ -267,6 +326,15 @@ pub(crate) fn start_child_worker(_settings: &Settings, spec: &WorkerSpec) -> Wor
     );
     let mut command = Command::new(executable);
     command.envs(child_environment(spec));
+    // Windows graceful-shutdown channel (sc-11184 / F-014). Windows has no per-child
+    // SIGTERM, so give the child a supervisor-held stdin pipe: closing the write end in
+    // `terminate_child` delivers EOF, which the child's `shutdown_signal()` selects on
+    // to begin the sc-8845 graceful wind-down instead of being killed mid-GPU-write.
+    // Unix is unchanged — the child keeps inherited stdin and SIGTERM is its signal.
+    #[cfg(not(unix))]
+    {
+        command.stdin(std::process::Stdio::piped());
+    }
     command.spawn().map_err(Into::into)
 }
 

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -70,7 +70,8 @@ use super::model_jobs::{
 use super::supervisor::terminating_signal;
 use super::supervisor::{
     auto_worker_specs, child_died_abnormally, child_environment, restart_exited_children_at,
-    restart_exited_children_with_spawner, utility_worker_specs, SupervisedChild, WorkerSpec,
+    restart_exited_children_with_spawner, stop_children, utility_worker_specs, SupervisedChild,
+    WorkerSpec,
 };
 use super::{
     allow_pattern_matches, bounded_tail, cancel_requested_peek, cleanup_uploaded_import_source,

--- a/crates/sceneworks-worker/src/tests/cancel_and_heartbeat.rs
+++ b/crates/sceneworks-worker/src/tests/cancel_and_heartbeat.rs
@@ -964,3 +964,61 @@ async fn keepalive_cancels_the_job_even_when_the_task_cannot_observe_the_flag() 
     );
 }
 
+/// sc-11184 (F-014) — the Windows stdin-close latch must survive a zero-receiver window.
+///
+/// `wait_for_parent_stdin_close` (the `#[cfg(not(unix))]` graceful-shutdown signal) fans a single
+/// stdin-EOF over a `tokio::sync::watch` channel whose `Sender` lives in a process-lifetime
+/// `OnceLock`; receivers exist ONLY while a caller is polling the wait future. Between the poll-phase
+/// `select!` and the run_job `select!` `receiver_count()` is 0, and the dedicated reader is
+/// single-shot (it breaks on EOF, latches once, exits). The reader originally used
+/// `watch::Sender::send`, which returns `Err` WITHOUT storing the value when there is no receiver —
+/// so an EOF landing in that window was lost forever and every later waiter blocked on `changed()`
+/// indefinitely, defeating F-014's graceful shutdown. The fix trips the latch with `send_replace`,
+/// which stores the value unconditionally.
+///
+/// This asserts the semantics directly (the reader task itself is `#[cfg(not(unix))]` and can't be
+/// driven on the macOS/Linux test host): construct the channel EXACTLY as the reader does, drop the
+/// initial receiver so `receiver_count() == 0`, trip via `send_replace`, THEN subscribe (mirroring
+/// `sender.subscribe()` in the wait fn) and assert the fresh receiver observes `true` immediately via
+/// `borrow_and_update()` (the wait fn's entry-borrow), so its wait future is ready with no `changed()`
+/// await. It also documents that plain `send` would have failed this scenario.
+#[tokio::test]
+async fn stdin_close_latch_retained_across_zero_receiver_window() {
+    use tokio::sync::watch;
+
+    // Same construction the reader uses: initial `_rx` is dropped, so no receiver is subscribed.
+    let (tx, rx) = watch::channel(false);
+    drop(rx);
+    assert_eq!(
+        tx.receiver_count(),
+        0,
+        "precondition: the zero-receiver window (initial rx dropped, no waiter polling)"
+    );
+
+    // Regression guard: the OLD `send` drops the value in this window (returns Err, latch stays
+    // false) — this is exactly the missed-wakeup the fix removes.
+    assert!(
+        tx.send(true).is_err(),
+        "watch::Sender::send returns Err with zero receivers — proves the pre-fix bug"
+    );
+    assert!(
+        !*tx.borrow(),
+        "and `send` left the latched value UNCHANGED (false) — the lost graceful-shutdown request"
+    );
+
+    // The fix: `send_replace` stores the value unconditionally, even with zero receivers.
+    tx.send_replace(true);
+    assert!(
+        *tx.borrow(),
+        "send_replace latches `true` regardless of receiver_count"
+    );
+
+    // A waiter that subscribes AFTER the trip (the run_job select!'s fresh `subscribe()`) must see
+    // the latched value immediately via the entry-borrow, never blocking on `changed()`.
+    let mut receiver = tx.subscribe();
+    assert!(
+        *receiver.borrow_and_update(),
+        "a receiver created after the trip observes shutdown immediately (entry-borrow), not a hang"
+    );
+}
+

--- a/crates/sceneworks-worker/src/tests/supervisor_lifecycle.rs
+++ b/crates/sceneworks-worker/src/tests/supervisor_lifecycle.rs
@@ -220,6 +220,160 @@ async fn supervisor_backoff_on_one_child_does_not_stall_another() {
     }
 }
 
+/// sc-11184 / F-013: a transient respawn failure must NOT tear the supervisor down.
+/// A spawner that errors once (an AV-locked exe mid-update, momentary resource
+/// exhaustion) is handled like another crash — the tick returns `Ok`, the child's
+/// backoff is re-armed with a fresh deadline, and a later tick respawns it — instead
+/// of propagating the error out of the supervision loop and orphaning the healthy
+/// siblings that are still running.
+#[tokio::test]
+async fn supervisor_survives_a_transient_respawn_failure_and_retries() {
+    let settings = test_settings("http://127.0.0.1".to_owned(), None);
+    let spec = WorkerSpec {
+        worker_id: "worker-gpu-auto-0".to_owned(),
+        gpu_id: "0".to_owned(),
+    };
+    let mut exited = spawn_exit_child();
+    for _ in 0..20 {
+        if exited.try_wait().expect("child status checks").is_some() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    let mut children = HashMap::from([(
+        spec.worker_id.clone(),
+        SupervisedChild {
+            spec,
+            process: exited,
+            restart_attempt: 0,
+            spawned_at: std::time::Instant::now(),
+            next_restart_at: None,
+        },
+    )]);
+
+    let attempts = std::cell::Cell::new(0_u32);
+    let mut spawner = |_settings: &_, _spec: &WorkerSpec| {
+        let attempt = attempts.get() + 1;
+        attempts.set(attempt);
+        if attempt == 1 {
+            // The first respawn attempt fails transiently.
+            Err(WorkerError::Io(std::io::Error::other(
+                "simulated transient spawn failure",
+            )))
+        } else {
+            Ok(spawn_sleep_child())
+        }
+    };
+
+    // Detection tick: reap the exit and stamp a backoff deadline (no spawn yet).
+    let t0 = std::time::Instant::now();
+    restart_exited_children_at(&settings, &mut children, &mut spawner, t0)
+        .await
+        .expect("exit detection never errors");
+    assert_eq!(attempts.get(), 0, "detection tick does not spawn");
+    assert_eq!(children["worker-gpu-auto-0"].restart_attempt, 1);
+
+    // First restart tick (past the backoff): the spawner fails once. The tick must
+    // still return Ok, and the child must be re-armed with a fresh, later deadline —
+    // NOT dropped and NOT propagated as an error out of the loop.
+    restart_exited_children_at(
+        &settings,
+        &mut children,
+        &mut spawner,
+        t0 + Duration::from_secs(10),
+    )
+    .await
+    .expect("a transient respawn failure does NOT propagate out of the tick");
+    assert_eq!(attempts.get(), 1, "the spawner was attempted exactly once");
+    {
+        let child = &children["worker-gpu-auto-0"];
+        let deadline = child
+            .next_restart_at
+            .expect("the failed respawn re-arms the backoff instead of dropping the child");
+        assert!(
+            deadline > t0 + Duration::from_secs(10),
+            "the re-armed deadline is in the future so the retry backs off"
+        );
+        assert_eq!(
+            child.restart_attempt, 2,
+            "a failed respawn advances the backoff attempt like a crash"
+        );
+    }
+
+    // Second restart tick (past the re-armed deadline): the spawner now succeeds and
+    // the child comes back — proving the supervisor kept going and eventually recovered.
+    restart_exited_children_at(
+        &settings,
+        &mut children,
+        &mut spawner,
+        t0 + Duration::from_secs(60),
+    )
+    .await
+    .expect("the retried respawn succeeds");
+    assert_eq!(attempts.get(), 2, "the child was respawned on the retry");
+    let child = children
+        .get_mut("worker-gpu-auto-0")
+        .expect("respawned child stays tracked");
+    assert!(
+        child.next_restart_at.is_none(),
+        "a successful respawn clears the backoff deadline"
+    );
+    assert!(child
+        .process
+        .try_wait()
+        .expect("child status checks")
+        .is_none());
+    let _ = child.process.start_kill();
+    let _ = child.process.wait().await;
+}
+
+/// sc-11184 / F-014: the supervisor's shutdown ladder (`terminate_child` → grace
+/// wait → `start_kill`) stops every supervised child and clears the map. This
+/// exercises the same terminate-then-escalate path the Windows stdin-close graceful
+/// signal plugs into: on unix the SIGTERM reaps the sleeper within the grace window;
+/// on Windows the child that ignores the stdin-close is escalated to `start_kill`
+/// after the grace deadline — either way the map ends empty.
+#[tokio::test]
+async fn stop_children_terminates_and_clears_every_child() {
+    let settings = test_settings("http://127.0.0.1".to_owned(), None);
+    let mut children = HashMap::from([
+        (
+            "worker-gpu-auto-0".to_owned(),
+            SupervisedChild {
+                spec: WorkerSpec {
+                    worker_id: "worker-gpu-auto-0".to_owned(),
+                    gpu_id: "0".to_owned(),
+                },
+                process: spawn_sleep_child(),
+                restart_attempt: 0,
+                spawned_at: std::time::Instant::now(),
+                next_restart_at: None,
+            },
+        ),
+        (
+            "worker-gpu-auto-1".to_owned(),
+            SupervisedChild {
+                spec: WorkerSpec {
+                    worker_id: "worker-gpu-auto-1".to_owned(),
+                    gpu_id: "1".to_owned(),
+                },
+                process: spawn_sleep_child(),
+                restart_attempt: 0,
+                spawned_at: std::time::Instant::now(),
+                next_restart_at: None,
+            },
+        ),
+    ]);
+
+    stop_children(&settings, &mut children).await;
+
+    assert!(
+        children.is_empty(),
+        "every supervised child is stopped and untracked after a graceful stop"
+    );
+}
+
 /// sc-4282 / F-MLXW-20: a child that ran healthily past the reset threshold
 /// before exiting starts its restart backoff fresh, rather than carrying a
 /// counter that has saturated upward over many widely-spaced crashes.


### PR DESCRIPTION
Epic 11147 / sc-11184 — worker supervisor robustness. Two independent fixes in `crates/sceneworks-worker/src/supervisor.rs` (+ the child-side signal in `lib.rs`).

## F-013 — one child's spawn/try_wait error no longer tears down the whole supervisor

Before, `restart_exited_children_at` did `try_wait()?` (pass 1) and `spawner(...)?` (pass 2), and `supervise_children` `?`'d the tick out of its loop. A single transient respawn failure (an AV-locked exe during an update, momentary resource exhaustion) or a `try_wait` error terminated the supervisor while healthy siblings kept running — orphaning them.

Now:
- **Pass 1 (detect):** a `try_wait()` error is logged (`worker_wait_failed`) and the child is skipped, revisited on the next 1 s tick — never propagated.
- **Pass 2 (respawn):** a failed respawn is treated like another crash — logged (`worker_respawn_failed`), the backoff is re-armed with a fresh `next_restart_at` deadline, the attempt is advanced (so a persistently unspawnable child keeps backing off instead of hot-looping the exec), and it retries on a later tick. Never propagated.

The supervise loop can no longer exit on one child's transient error. Existing healthy-child behavior and backoff semantics (`sc-8899` per-child deadlines, `sc-4282` healthy-uptime reset) are preserved.

## F-014 — Windows supervised children now get a graceful shutdown signal

On unix the supervisor sends SIGTERM, which the child's `shutdown_signal()` selects on to trip the `sc-8845` graceful-cancel machinery (cancel flag → wind-down → terminal `Canceled`). On Windows `terminate_child` fell straight to `start_kill()`, so the grace window was moot and a supervisor-driven stop killed a child mid-GPU-write — the job dangled until the 90 s sweep marked it generic `interrupted`.

**Mechanism chosen: stdin-close.** The worker child consumes stdin for nothing else, so this needs **zero winapi** — the whole path is portable `tokio`/`std`, which is why it can be type-checked off-Windows (see Verification). A named event would have required unsafe Windows syscalls for no added robustness here.

**Both ends implemented:**
- **Supervisor (send):** `start_child_worker` spawns Windows children with a piped stdin (`Stdio::piped()`); `terminate_child` drops the write end (`child.stdin.take()`) to deliver EOF, then falls through to `start_kill()` only if there is no pipe. `stop_children`'s existing grace window then escalates to `start_kill()` **only after the deadline** — mirroring the unix SIGTERM → wait → SIGKILL ladder. **Unix path unchanged.**
- **Child (select):** `shutdown_signal()` on non-unix additionally selects on stdin-EOF via `wait_for_parent_stdin_close()`, gated to child workers by the `SCENEWORKS_WORKER_CHILD` marker (the top-level supervisor process keeps Ctrl-C only — its stdin is the real console, not a supervisor-held pipe). A single `OnceLock`-guarded blocking reader (`spawn_blocking` on std stdin, so no `io-std` tokio feature is needed) latches a `watch` channel that stays `true`, so the per-turn `shutdown_signal()` awaits are cheap and never leak blocking threads, and a caller that subscribes after the close still returns immediately.

## Tests
- `supervisor_survives_a_transient_respawn_failure_and_retries` — a spawner stub that errors once: the detection tick stamps the backoff, the failing restart tick returns `Ok` (not propagated) and re-arms a later deadline with the attempt advanced, and a subsequent tick respawns the child. Proves the supervisor keeps going and recovers.
- `stop_children_terminates_and_clears_every_child` — exercises the `terminate_child` → grace → `start_kill` ladder that the Windows stdin-close signal plugs into; the map ends empty on both platforms.

## Verification
- macOS: `cargo build`, `cargo test -p sceneworks-worker` (755 passed / 157 ignored real-weight), `cargo clippy --all-targets -D warnings`, `cargo fmt --all --check` — all green.
- unix/shared path: `cargo clippy --all-targets --target x86_64-unknown-linux-gnu -D warnings` — green.
- The `#[cfg(not(unix))]` Windows code can't compile on macOS (a transitive C dep, `onig_sys`, blocks `--target x86_64-pc-windows-msvc` on a macOS host — a native-build limitation, not the Rust). It is pure `tokio`/`std` (no winapi), so it was **type-checked under the crate's real tokio features** by temporarily forcing it to compile on the host (`cfg(all())`), which passed, then reverted. The **`build-windows` CI lane** compiles the real cfg'd path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)