### PR TITLE
fix(worker): stop leaking control-dataset work dir (sc-11186)

### DIFF
--- a/crates/sceneworks-worker/src/control_training_jobs.rs
+++ b/crates/sceneworks-worker/src/control_training_jobs.rs
@@ -51,6 +51,47 @@ mod imp {
     /// (Dataset Doctor runs the richer quality pass).
     const PERSON_GATE_MIN_CONF: f32 = 0.25;
 
+    /// RAII guard for the job-scoped rendered-control-dataset work dir (sc-11186, F-015). The rendered
+    /// dataset under `cache/control-datasets/<job.id>` is a full letterboxed copy of the training corpus
+    /// — a `.target.png` + `.pose.png` pair per image, easily GBs — and it is consumed only by the
+    /// training executor that runs to completion inside [`run_control_training_job`]. Nothing else in
+    /// the repo sweeps that tree, so before this guard every `control_training` run leaked the whole
+    /// rendered corpus onto disk (success, failure, AND cancel), silently growing the app data dir.
+    /// `Drop` removes the tree on EVERY exit path (success, prep/train error, deferred cancel, panic
+    /// unwind), so no early return can skip cleanup. Best-effort: a removal failure is logged, never
+    /// fatal (a cleanup error must not fail an otherwise-complete job). `Drop` can't be async, so it
+    /// uses the sync `std::fs` API. The dir is keyed by `job.id`, so this only ever removes the current
+    /// job's own tree — never a concurrent sibling worker's active dataset.
+    struct WorkDirGuard {
+        path: std::path::PathBuf,
+    }
+
+    impl WorkDirGuard {
+        fn new(path: std::path::PathBuf) -> Self {
+            Self { path }
+        }
+    }
+
+    impl Drop for WorkDirGuard {
+        fn drop(&mut self) {
+            match std::fs::remove_dir_all(&self.path) {
+                Ok(()) => {}
+                // A missing dir is a benign NotFound (nothing was rendered before an early bail) —
+                // silently ignore it. Anything else is a real cleanup failure worth surfacing, but the
+                // job's outcome is already decided, so we only warn.
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    tracing::warn!(
+                        event = "control_dataset_cleanup_failed",
+                        work_dir = %self.path.display(),
+                        %error,
+                        "failed to remove the rendered control-dataset work dir; it may leak on disk"
+                    );
+                }
+            }
+        }
+    }
+
     /// Run a `control_training` job: render conditions, then train the control branch.
     pub(crate) async fn run_control_training_job(
         api: &ApiClient,
@@ -158,13 +199,17 @@ mod imp {
         let input_count = inputs.len();
 
         // The rendered control dataset lands in an app-managed cache dir keyed by job id, so it is
-        // confined (the executor re-resolves item paths under this root) and cleaned with the cache.
+        // confined (the executor re-resolves item paths under this root).
         let work_dir = settings
             .data_dir
             .join("cache")
             .join("control-datasets")
             .join(&job.id);
         tokio::fs::create_dir_all(&work_dir).await?;
+        // Guard the job-scoped tree so it is removed on EVERY exit path below — success, prep/train
+        // error, deferred cancel, or panic (sc-11186, F-015). Nothing else sweeps
+        // `cache/control-datasets/<job.id>`, so without this the rendered corpus leaked on disk.
+        let _work_dir_guard = WorkDirGuard::new(work_dir.clone());
 
         update_job(
             api,
@@ -399,7 +444,53 @@ mod imp {
 
     #[cfg(test)]
     mod tests {
-        use super::{control_kind_from_label, ControlKind};
+        use super::{control_kind_from_label, ControlKind, WorkDirGuard};
+
+        /// A unique temp path per test (process id + line) so parallel/leftover runs don't collide.
+        fn unique_temp(tag: &str, line: u32) -> std::path::PathBuf {
+            std::env::temp_dir().join(format!(
+                "sw_control_work_{tag}_{}_{line}",
+                std::process::id()
+            ))
+        }
+
+        #[test]
+        fn work_dir_guard_removes_populated_tree_on_drop() {
+            // A rendered control dataset is a nested tree of PNG pairs + a manifest — the guard must
+            // remove the WHOLE subtree, not just the top dir, on drop (sc-11186, F-015).
+            let root = unique_temp("drop", line!());
+            let nested = root.join("images");
+            std::fs::create_dir_all(&nested).expect("create nested work dir");
+            std::fs::write(nested.join("0001.target.png"), b"target").expect("write target");
+            std::fs::write(nested.join("0001.pose.png"), b"pose").expect("write pose");
+            std::fs::write(root.join("manifest.jsonl"), b"{}\n").expect("write manifest");
+            assert!(root.exists(), "precondition: work dir exists before drop");
+
+            {
+                let _guard = WorkDirGuard::new(root.clone());
+                // Still present inside the guarded scope — cleanup happens on drop, not construction.
+                assert!(root.exists(), "guard construction must not remove the dir");
+            }
+
+            assert!(
+                !root.exists(),
+                "guard Drop must remove the entire rendered-dataset tree"
+            );
+        }
+
+        #[test]
+        fn work_dir_guard_drop_on_missing_dir_is_a_noop() {
+            // An early bail before anything is rendered leaves no dir; Drop must treat the resulting
+            // NotFound as benign (best-effort cleanup) and NOT panic.
+            let root = unique_temp("missing", line!());
+            assert!(!root.exists(), "precondition: dir was never created");
+            // Would panic here if Drop unwrapped the io::Error instead of tolerating NotFound.
+            drop(WorkDirGuard::new(root.clone()));
+            assert!(
+                !root.exists(),
+                "a missing dir stays absent, no side effects"
+            );
+        }
 
         #[test]
         fn control_kind_label_maps_studio_types_and_defaults_to_pose() {


### PR DESCRIPTION
## What

Closes the leaked control-dataset work directory (sc-11186, F-015, Medium — epic 11147).

The rendered control dataset is written to `data/cache/control-datasets/<job.id>` — a full letterboxed copy of the training corpus (a `.target.png` + `.pose.png` pair per image, easily GBs). The old comment claimed it was "cleaned with the cache," but **no sweeper or `remove_dir_all` for that tree existed anywhere in the repo**. It was never deleted on success, failure, or cancel, so every `control_training` run permanently leaked the rendered corpus and silently grew the app data dir.

## Fix

Add a `WorkDirGuard` RAII guard (in `crates/sceneworks-worker/src/control_training_jobs.rs`), constructed immediately after `create_dir_all(&work_dir)`. Its `Drop` runs `std::fs::remove_dir_all` and therefore removes the tree on **every** exit path of `run_control_training_job`:

- success (guard drops after `run_training_execution` returns),
- prep/train error (`?` early returns),
- deferred cancel (the terminal `Canceled` return),
- panic unwind.

Design notes:
- Modeled on the existing `ScratchDir` RAII pattern in `video_jobs.rs`.
- Keyed by `job.id`, so it only ever removes the current job's own tree — never a concurrent sibling worker's active dataset (per the story's "don't delete a concurrent active job's dir" constraint).
- Best-effort cleanup: a benign `NotFound` (nothing rendered before an early bail) is ignored; any other removal failure is logged via `tracing::warn!` and **never fails the job**.
- `Drop` can't be async, so it uses the sync `std::fs` API (matching `ScratchDir`).

### Startup sweep — deliberately deferred (follow-up)
The story allowed *optionally* adding a startup sweep of `cache/control-datasets/*` for the residual crash/SIGKILL case (where `Drop` can't run). I did **not** add it: multiple worker processes share one `data_dir`, and a blind startup sweep could delete a sibling worker's in-progress dir. Safe ownership determination would require querying the API for active jobs — non-trivial and outside this fix's low-risk scope. The per-job guard is the required fix and closes the leak for all normal exit paths (including graceful cancel/shutdown, which trip cancel and let the job return so `Drop` runs). Filing the crash-recovery sweep as a follow-up is noted below.

## Tests

- `work_dir_guard_removes_populated_tree_on_drop` — creates a nested tree (`images/*.png` + `manifest.jsonl`), asserts it survives guard construction and is fully gone after the guard drops.
- `work_dir_guard_drop_on_missing_dir_is_a_noop` — asserts `Drop` on a never-created dir tolerates `NotFound` and doesn't panic.

Verification: `cargo build -p sceneworks-worker` ✅, `cargo test -p sceneworks-worker` ✅ (758 passed, 0 failed), `cargo clippy -p sceneworks-worker --all-targets -- -D warnings` ✅, `cargo fmt --all --check` ✅.

Refs sc-11186, epic 11147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)