### PR TITLE
test(rust-api): drain spawned-binary pipes + banner stale planning docs (sc-11239)

### DIFF
--- a/documents/IMAGE_MODEL_RESEARCH.md
+++ b/documents/IMAGE_MODEL_RESEARCH.md
@@ -1,5 +1,7 @@
 # Image Model Research
 
+> **Historical — partially superseded.** The model recommendations here (Z-Image-Turbo, Qwen-Image-Edit) still informed the current app, but the Python/Diffusers worker path this doc describes as the default has been deleted and replaced by native Rust inference engines (MLX on macOS, candle/CUDA on Windows) — there is no Diffusers/Python worker. Kept for historical context — see the [README](../README.md) for the current architecture.
+
 ## Recommendation
 
 Use `z_image_turbo` as the first SceneWorks image-generation target, expose `z_image_edit` as the matching Diffusers image-to-image target, and keep `qwen_image_edit` available behind the same adapter boundary for higher-control edit workflows.

--- a/documents/IMPLEMENTATION_PLAN.md
+++ b/documents/IMPLEMENTATION_PLAN.md
@@ -1,5 +1,7 @@
 # SceneWorks Implementation Plan
 
+> **Historical — superseded.** This plan describes the original local Docker / FastAPI backend + Python-worker architecture, which has since been deleted and replaced by the desktop-native Rust engine (MLX on macOS, candle/CUDA on Windows; Docker is now an optional server that runs the Rust API/workers). Kept for historical context — see the [README](../README.md) for the current architecture.
+
 This document turns the SceneWorks product plan into a practical implementation sequence. It assumes the current goal is to build a local Docker-based AI image/video generation and editing app with a React + Vite frontend, FastAPI backend, Python workers, SQLite metadata, file-backed assets, and model adapters.
 
 ## Guiding Principles

--- a/documents/SCENEWORKS_PLAN.md
+++ b/documents/SCENEWORKS_PLAN.md
@@ -1,5 +1,7 @@
 # SceneWorks Plan
 
+> **Historical — superseded.** This plan frames SceneWorks as a "local Docker-based web app" on a FastAPI + Python-worker stack, which has since been deleted and replaced by the desktop-native Rust engine (MLX on macOS, candle/CUDA on Windows; Docker is now an optional server that runs the Rust API/workers). The product intent still informs the app, but the architecture here is out of date — see the [README](../README.md) for the current architecture.
+
 ## Product Summary
 
 SceneWorks is a local Docker-based AI image and video generation web app for semi-technical AI hobbyists who want ComfyUI-class power without managing node graphs. It is also being designed first for the creator's own workflow.

--- a/tests/rust_api_harness.py
+++ b/tests/rust_api_harness.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import socket
 import subprocess
+import threading
 import time
 
 import httpx
@@ -50,9 +51,93 @@ def safetensors_bytes() -> bytes:
 minimal_safetensors = safetensors_bytes
 
 
+class SpawnedProcess:
+    """A spawned API/worker binary whose pipes can't deadlock the test (F-042).
+
+    The children emit `tracing` output the whole time a test drives them. When a
+    spawn keeps ``stdout``/``stderr`` as ``PIPE`` and nobody reads them until the
+    child exits, the child blocks on ``write`` the moment either OS pipe buffer
+    fills (~64 KB) -- the test then hangs until its deadline and is mis-reported
+    as "job did not reach status" rather than the real cause.
+
+    This wrapper sends ``stdout`` to ``DEVNULL`` (the previous code captured it
+    but never read it) and drains ``stderr`` on a background daemon thread into an
+    in-memory buffer, so the child can always make progress. ``stderr_text()``
+    returns everything captured so far for failure messages, preserving the
+    stderr-on-early-exit debuggability the callers relied on.
+
+    It delegates the small slice of the ``Popen`` surface the tests use
+    (``poll``/``returncode``/``terminate``/``wait``/``kill``) so it drops in for
+    the old ``subprocess.Popen`` handles.
+    """
+
+    def __init__(self, popen: subprocess.Popen) -> None:
+        self._popen = popen
+        self._chunks: list[str] = []
+        self._lock = threading.Lock()
+        self._thread = threading.Thread(
+            target=self._drain, name="spawned-stderr-drain", daemon=True
+        )
+        self._thread.start()
+
+    def _drain(self) -> None:
+        stream = self._popen.stderr
+        if stream is None:
+            return
+        # Iterating a text-mode pipe yields lines until EOF (child exit/close),
+        # so this loop drains continuously and ends on its own.
+        for line in stream:
+            with self._lock:
+                self._chunks.append(line)
+
+    def stderr_text(self) -> str:
+        """Return the child's captured stderr. If the child has already exited,
+        wait briefly for the drain thread to consume the final buffered bytes so
+        the failure message is complete."""
+        if self._popen.poll() is not None:
+            self._thread.join(timeout=5)
+        with self._lock:
+            return "".join(self._chunks)
+
+    # -- Popen delegation (only what the tests touch) ------------------------
+    def poll(self) -> int | None:
+        return self._popen.poll()
+
+    @property
+    def returncode(self) -> int | None:
+        return self._popen.returncode
+
+    def terminate(self) -> None:
+        self._popen.terminate()
+
+    def kill(self) -> None:
+        self._popen.kill()
+
+    def wait(self, timeout: float | None = None) -> int:
+        return self._popen.wait(timeout=timeout)
+
+
+def spawn_process(command, *, cwd, env) -> SpawnedProcess:
+    """Spawn an API/worker binary with non-blocking pipe handling (F-042).
+
+    ``stdout`` is discarded to ``DEVNULL`` (it was captured but never read) and
+    ``stderr`` is drained by a background thread -- neither can fill and block the
+    child, so a chatty binary can no longer hang the test. Returns a
+    :class:`SpawnedProcess` that stands in for the old raw ``Popen`` handle."""
+    popen = subprocess.Popen(
+        command,
+        cwd=cwd,
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return SpawnedProcess(popen)
+
+
 def wait_for_health(
     base_url: str,
-    process: subprocess.Popen,
+    process: SpawnedProcess,
     runtime: str = "rust",
     timeout_seconds: float = 30.0,
 ) -> None:
@@ -62,7 +147,7 @@ def wait_for_health(
     last_error: Exception | None = None
     while time.monotonic() < deadline:
         if process.poll() is not None:
-            stderr = process.stderr.read() if process.stderr else ""
+            stderr = process.stderr_text()
             raise AssertionError(
                 f"{runtime} API exited early with code {process.returncode}: {stderr}"
             )

--- a/tests/test_rust_api_contract_snapshots.py
+++ b/tests/test_rust_api_contract_snapshots.py
@@ -17,7 +17,13 @@ import pytest
 # Shared, corruption-free fixtures (sc-8934 / F-132): the PNG + safetensors
 # builder and the API-spawn helpers used to be copy-pasted (and had drifted)
 # between this file and test_rust_api_worker_smoke.py.
-from rust_api_harness import PNG_1X1, free_port, safetensors_bytes, wait_for_health
+from rust_api_harness import (
+    PNG_1X1,
+    free_port,
+    safetensors_bytes,
+    spawn_process,
+    wait_for_health,
+)
 
 
 pytestmark = pytest.mark.parity
@@ -199,14 +205,7 @@ class ServerApiHarness:
             if rust_binary
             else ["cargo", "run", "-q", "-p", "sceneworks-rust-api"]
         )
-        self.process = subprocess.Popen(
-            command,
-            cwd=ROOT,
-            env=env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
+        self.process = spawn_process(command, cwd=ROOT, env=env)
         wait_for_health(self.base_url, self.process, "rust")
         self.client = httpx.Client(base_url=self.base_url, timeout=10)
 

--- a/tests/test_rust_api_worker_smoke.py
+++ b/tests/test_rust_api_worker_smoke.py
@@ -20,8 +20,10 @@ from conftest import require_tool
 # file and test_rust_api_contract_snapshots.py.
 from rust_api_harness import (
     PNG_1X1,
+    SpawnedProcess,
     free_port,
     minimal_safetensors as _minimal_safetensors,
+    spawn_process,
     wait_for_health,
 )
 
@@ -212,12 +214,12 @@ def _launch_command(binary_env: str, package: str, purpose: str) -> list[str]:
     return ["cargo", "run", "-q", "-p", package]
 
 
-def wait_for_job_status(base_url: str, job_id: str, status: str, process: subprocess.Popen) -> dict:
+def wait_for_job_status(base_url: str, job_id: str, status: str, process: SpawnedProcess) -> dict:
     deadline = time.monotonic() + 30
     last_job: dict | None = None
     while time.monotonic() < deadline:
         if process.poll() is not None:
-            stderr = process.stderr.read() if process.stderr else ""
+            stderr = process.stderr_text()
             raise AssertionError(f"Rust worker exited early with code {process.returncode}: {stderr}")
         response = httpx.get(f"{base_url}/api/v1/jobs/{job_id}", timeout=5)
         response.raise_for_status()
@@ -249,14 +251,7 @@ def rust_api(tmp_path):
             "SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE": "1",
         }
     )
-    process = subprocess.Popen(
-        command,
-        cwd=ROOT,
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+    process = spawn_process(command, cwd=ROOT, env=env)
     try:
         wait_for_health(base_url, process)
         yield base_url
@@ -519,14 +514,7 @@ def test_rust_worker_claims_and_completes_lora_import_against_rust_api_binary(ru
             "SCENEWORKS_HEARTBEAT_SECONDS": "5",
         }
     )
-    worker = subprocess.Popen(
-        worker_command,
-        cwd=ROOT,
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+    worker = spawn_process(worker_command, cwd=ROOT, env=env)
     try:
         created = httpx.post(
             f"{rust_api}/api/v1/loras/import",
@@ -579,14 +567,7 @@ def test_rust_worker_completes_ffmpeg_frame_and_timeline_jobs_against_rust_api_b
             "SCENEWORKS_HEARTBEAT_SECONDS": "5",
         }
     )
-    worker = subprocess.Popen(
-        worker_command,
-        cwd=ROOT,
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+    worker = spawn_process(worker_command, cwd=ROOT, env=env)
     try:
         created_project = httpx.post(f"{rust_api}/api/v1/projects", json={"name": "FFmpeg Smoke"}, timeout=5)
         created_project.raise_for_status()


### PR DESCRIPTION
## Summary

Story **sc-11239** (epic 11147, Chore). Two independent hygiene fixes from the 2026-07-12 review.

### F-042 — Drain spawned-binary stdout/stderr pipes in the pytest harness

The live Rust API/worker tests spawned every binary with `Popen(stdout=PIPE, stderr=PIPE)` and only read the pipes **after** `poll()` reported exit. Nothing drained them while a test drove the child over HTTP, so as soon as a chatty child wrote more than the ~64 KB OS pipe buffer of `tracing` output it blocked on `write` and the test **hung until its deadline**, mis-reported as "job did not reach status" rather than the real cause.

**Fix (drain approach):** a new `SpawnedProcess` wrapper + `spawn_process()` helper in `tests/rust_api_harness.py`:
- **stdout → `DEVNULL`** (the old code captured it via PIPE but never read it — nothing lost).
- **stderr → drained on a background daemon thread** into an in-memory buffer, so the child can always make progress and can never deadlock on a full pipe.
- `stderr_text()` returns everything captured so far for failure messages (joins the drain thread once the child has exited so the message is complete) — **stderr-on-early-exit debuggability is preserved**.
- Delegates the small slice of the `Popen` surface the tests use (`poll`/`returncode`/`terminate`/`wait`/`kill`), so it drops in for the old raw handle.

All spawn sites now route through `spawn_process`:
- `tests/rust_api_harness.py` — the helper itself; `wait_for_health` now reads `stderr_text()`.
- `tests/test_rust_api_worker_smoke.py` — the `rust_api` API fixture + both worker spawns; `wait_for_job_status` now reads `stderr_text()`.
- `tests/test_rust_api_contract_snapshots.py` — `ServerApiHarness`.

### F-043 — Banner the stale planning docs

Verified each candidate against the README's current architecture (desktop-native Rust: MLX on macOS, candle/CUDA on Windows; **no Python, no FastAPI, no Python workers**; Docker is an optional server running the Rust API/workers). Added a one-line `> **Historical — superseded**` banner (pointing at the README) to the docs that describe the **deleted** local Docker / FastAPI + Python-worker stack:

- **`documents/IMPLEMENTATION_PLAN.md`** — explicit FastAPI backend, Python workers, Docker Compose. Bannered.
- **`documents/SCENEWORKS_PLAN.md`** — frames the product as a "local Docker-based web app". Bannered.
- **`documents/IMAGE_MODEL_RESEARCH.md`** — model recommendations still current, but describes a Python/Diffusers worker path as the default. Bannered as **partially superseded** (recommendations stand; the Diffusers/Python path is gone).

**Left untouched:** `documents/V1_RISK_REGISTER.md` — verified genuinely current (living doc, "Last updated 2026-06-18", discusses the Rust backend / native Wan-VACE / SAM2 MLX directly, zero docker/FastAPI/Python-worker references).

## Verification

- **F-042:** the full suite can't run here (no `httpx` installed; needs built Rust binaries), but the drain logic was exercised directly with `httpx` stubbed: a child writing ~800 KB to stdout + ~140 KB to stderr (well past the ~64 KB pipe buffer) exits cleanly with **no deadlock** and its **full stderr (all 20,001 lines, first + last) is captured**; `poll`/`terminate`/`wait`/`returncode` delegation verified on a long-lived child. All three changed test files pass `ast.parse`. No dead imports (`subprocess` still used for `TimeoutExpired`).
- **F-043:** banners are standard markdown blockquotes with a valid `../README.md` relative link; render cleanly.
- No Rust touched — the cargo CI lanes don't exercise this change; local verification + reasoning is the safety net.

sc-11239 · epic 11147

🤖 Generated with [Claude Code](https://claude.com/claude-code)