### PR TITLE
fix(web): stabilize useJobEvents inputs + retry the access probe (sc-11231)

### DIFF
--- a/apps/web/src/App.auth.test.jsx
+++ b/apps/web/src/App.auth.test.jsx
@@ -420,4 +420,151 @@ describe("SceneWorks app shell", () => {
     });
   });
 
+  // sc-11231 (F-038): a failed mount-time GET /api/v1/access must NOT fail open. The prior
+  // `.finally(() => setAccessResolved(true))` released the gate while `access` stayed
+  // `{ authRequired: false }`, so `authenticated` flipped true with no token: protected data
+  // + the SSE stream fired unauthenticated (a 401 storm on an auth-required deployment), and
+  // the login band — which needs `access.authRequired` — never rendered, recoverable only by
+  // reload. The fix holds the gate closed on failure, surfaces a notice, and retries with
+  // backoff so a transient blip self-heals and a persistent outage shows an error.
+  describe("access-probe failure (sc-11231 F-038)", () => {
+    it("holds the gate closed — no unauthenticated load or SSE — and shows a notice when /access fails", async () => {
+      const requests = [];
+      global.fetch = vi.fn((url, options = {}) => {
+        const path = new URL(url).pathname;
+        requests.push({ path, method: options.method ?? "GET" });
+        if (path.endsWith("/health")) {
+          return Promise.resolve(response({ status: "ok", authRequired: true }));
+        }
+        if (path.endsWith("/access")) {
+          return Promise.resolve(errorResponse(500, "probe exploded"));
+        }
+        if (path.endsWith("/projects")) {
+          return Promise.resolve(response([{ id: "project-default", name: "Default Project" }]));
+        }
+        return Promise.resolve(response([]));
+      });
+
+      root = createRoot(container);
+      await act(async () => {
+        root.render(<App />);
+      });
+      await settle();
+
+      // No fail-open: the failed probe leaves accessResolved false, so `authenticated`
+      // never flips → zero protected loads and zero SSE connections (pre-fix both fired).
+      expect(requests.some((request) => request.path.endsWith("/projects"))).toBe(false);
+      expect(requests.some((request) => request.path.endsWith("/jobs/events/ticket"))).toBe(false);
+      expect(FakeEventSource.instances.length).toBe(0);
+      // And a notice names the unreachable host rather than silently authenticating.
+      const noticeTexts = [...document.body.querySelectorAll(".notice.error")].map((node) => node.textContent);
+      expect(noticeTexts.some((text) => text.includes("access check"))).toBe(true);
+    });
+
+    it("recovers on a backoff retry: a later /access success resolves the gate and clears the notice", async () => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      try {
+        let accessOk = false;
+        global.fetch = vi.fn((url) => {
+          const path = new URL(url).pathname;
+          if (path.endsWith("/health")) {
+            return Promise.resolve(response({ status: "ok", authRequired: true }));
+          }
+          if (path.endsWith("/access")) {
+            return Promise.resolve(accessOk ? response({ authRequired: true }) : errorResponse(500, "probe exploded"));
+          }
+          if (path.endsWith("/projects")) {
+            return Promise.resolve(response([{ id: "project-default", name: "Default Project" }]));
+          }
+          return Promise.resolve(response([]));
+        });
+
+        root = createRoot(container);
+        await act(async () => {
+          root.render(<App />);
+        });
+        await settle();
+
+        // Gate closed: no login band yet (auth requirement still unknown), notice is up.
+        expect(document.body.querySelector("#token")).toBeNull();
+        const failedTexts = [...document.body.querySelectorAll(".notice.error")].map((node) => node.textContent);
+        expect(failedTexts.some((text) => text.includes("access check"))).toBe(true);
+
+        // The first backoff retry fires after 1s; let it succeed (auth required this time).
+        accessOk = true;
+        await act(async () => {
+          vi.advanceTimersByTime(1000);
+        });
+        await settle();
+
+        // Probe resolved auth-required → the login band renders and the notice clears.
+        expect(document.body.querySelector("#token")).not.toBeNull();
+        const remaining = [...document.body.querySelectorAll(".notice.error")].map((node) => node.textContent);
+        expect(remaining.some((text) => text.includes("access check"))).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("leaves the successful probe path unchanged: auth-off resolves, data loads, no notice", async () => {
+      const requests = [];
+      global.fetch = vi.fn((url, options = {}) => {
+        const path = new URL(url).pathname;
+        requests.push({ path, method: options.method ?? "GET" });
+        if (path.endsWith("/health")) {
+          return Promise.resolve(response({ status: "ok", authRequired: false }));
+        }
+        if (path.endsWith("/access")) {
+          return Promise.resolve(response({ authRequired: false }));
+        }
+        if (path.endsWith("/jobs/events/ticket")) {
+          return Promise.resolve(response({ ticket: "stream-ticket" }));
+        }
+        if (path.endsWith("/projects")) {
+          return Promise.resolve(response([{ id: "project-default", name: "Default Project" }]));
+        }
+        return Promise.resolve(response([]));
+      });
+
+      root = createRoot(container);
+      await act(async () => {
+        root.render(<App />);
+      });
+      await settle();
+
+      // A successful probe still releases the gate and loads data with no access-probe notice.
+      expect(requests.some((request) => request.path.endsWith("/projects"))).toBe(true);
+      const noticeTexts = [...document.body.querySelectorAll(".notice.error")].map((node) => node.textContent);
+      expect(noticeTexts.some((text) => text.includes("access check"))).toBe(false);
+    });
+  });
+
+  // sc-11231 (F-037): the live SSE stream reaches hasVisibleLocalFailure through the
+  // subscribe-time closure. After hardening it into a stable useCallback, the failed-job
+  // path must still run (a TDZ from the const-move or a dead closure would crash the handler
+  // and swallow the notice). A failed job that isn't a locally-launched run surfaces a notice.
+  it("routes a failed SSE job through hasVisibleLocalFailure and surfaces a notice (sc-11231 F-037)", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+    expect(FakeEventSource.instances.length).toBe(1);
+
+    const failedJob = {
+      id: "job-remote-fail",
+      type: "image_generate",
+      status: "failed",
+      projectId: "project-default",
+      payload: { prompt: "x" },
+    };
+    await act(async () => {
+      FakeEventSource.instances[0].listeners["job.updated"]({ data: JSON.stringify(failedJob) });
+    });
+    await settle();
+
+    const noticeTexts = [...document.body.querySelectorAll(".notice.error")].map((node) => node.textContent);
+    expect(noticeTexts.some((text) => text.includes("Failed without additional worker detail."))).toBe(true);
+  });
+
 });

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1076,6 +1076,27 @@ export function App() {
     return () => controller.abort();
   }, [activeProject?.id, ready, token]);
 
+  // sc-11231 (F-037): useJobEvents captures whichever callback existed at subscribe time
+  // (its SSE effect deps are only [access.authRequired, ready, token]), so this MUST have a
+  // stable identity — else the live stream keeps calling a stale closure. It reads no props
+  // directly, only the two live refs (kept in sync by the effects above), so an empty-dep
+  // useCallback is both stable and always current — the `stableRefreshData` ref-delegation
+  // pattern used elsewhere in this file, expressed inline here since the whole body is refs.
+  const hasVisibleLocalFailure = useCallback((job) => {
+    const active = activeViewRef.current;
+    const localIds = localGenerationJobIdsRef.current;
+    if (active === "Image" && localIds.image.includes(job.id)) {
+      return true;
+    }
+    if (active === "Video" && localIds.video.includes(job.id)) {
+      return true;
+    }
+    if (active === "Document" && localIds.document.includes(job.id)) {
+      return true;
+    }
+    return active === "Models" && job.type === "model_download";
+  }, []);
+
   // Live job/worker/queue SSE stream, extracted to a hook (sc-9750). The handlers reach
   // back into App state through the identity-stable setters/refs/callbacks passed here;
   // the hook re-subscribes only on [access.authRequired, ready, token] (see useJobEvents).
@@ -1560,21 +1581,6 @@ export function App() {
       [kind]: [job.id, ...current[kind].filter((id) => id !== job.id)].slice(0, localJobStackLimit),
     }));
   }, []);
-
-  function hasVisibleLocalFailure(job) {
-    const active = activeViewRef.current;
-    const localIds = localGenerationJobIdsRef.current;
-    if (active === "Image" && localIds.image.includes(job.id)) {
-      return true;
-    }
-    if (active === "Video" && localIds.video.includes(job.id)) {
-      return true;
-    }
-    if (active === "Document" && localIds.document.includes(job.id)) {
-      return true;
-    }
-    return active === "Models" && job.type === "model_download";
-  }
 
   const sendAssetToImage = useCallback((asset, mode = null) => {
     if (!asset) {

--- a/apps/web/src/hooks/appGateHooks.test.jsx
+++ b/apps/web/src/hooks/appGateHooks.test.jsx
@@ -10,6 +10,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useAccessGate } from "./useAccessGate.js";
 import { useJobEvents } from "./useJobEvents.js";
+import { useTimelines } from "./useTimelines.js";
+import { apiFetch } from "../api.js";
 
 // Controllable apiFetch: each call resolves with whatever the per-path map returns (or
 // rejects when the value is an Error), so a test can drive the /access probe, the
@@ -313,5 +315,96 @@ describe("useJobEvents (sc-9750)", () => {
     act(() => root.unmount());
     root = null;
     expect(source.closed).toBe(true);
+  });
+});
+
+// sc-11231 (F-037): useJobEvents' SSE effect captures enqueueTimelineGenerationApply and
+// hasVisibleLocalFailure at SUBSCRIBE time (deps are only [access.authRequired, ready,
+// token]). If those inputs are plain per-render function declarations, the stream keeps
+// invoking the closure from the subscribe render — a latent stale-closure. These tests
+// pin the useTimelines side of the fix: the exposed enqueue callback is identity-stable
+// AND, because it delegates through a per-commit ref, the callback captured at subscribe
+// time still runs against live state (the fresh token) — exactly what the SSE handler needs.
+describe("useTimelines.enqueueTimelineGenerationApply stability + liveness (sc-11231)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    apiResponders.clear();
+    apiFetch.mockClear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container.remove();
+  });
+
+  function mount() {
+    const activeProject = { id: "p1", name: "P1" };
+    // Stable across renders — mirrors App, where setError is a useState setter (stable).
+    const stable = {
+      activeProject,
+      activeProjectRef: { current: activeProject },
+      setError: () => {},
+      setActiveView: () => {},
+      createVideoJob: async () => null,
+    };
+    let latest = null;
+    function Harness() {
+      const [token, setToken] = useState("t1");
+      const api = useTimelines({
+        token,
+        requestedGpu: "auto",
+        ...stable,
+      });
+      latest = { enqueue: api.enqueueTimelineGenerationApply, setToken };
+      return null;
+    }
+    root = createRoot(container);
+    act(() => root.render(<Harness />));
+    return { get: () => latest };
+  }
+
+  it("keeps a stable enqueue identity that still applies with the live token after a re-render", async () => {
+    // A completed generation whose result carries assets — enough to reach the timeline
+    // GET inside applyCompletedTimelineGeneration, where the live token is threaded.
+    const job = {
+      id: "job-1",
+      projectId: "p1",
+      status: "completed",
+      payload: { advanced: { timelineContext: { timelineId: "tl1" } } },
+      result: { assetIds: ["a1"] },
+    };
+    apiResponders.set("/api/v1/projects/p1/timelines/tl1", { id: "tl1", tracks: [] });
+
+    const { get } = mount();
+    await settle();
+    // Capture the callback at "subscribe time" (as useJobEvents would).
+    const enqueueAtSubscribe = get().enqueue;
+
+    // Token advances on an unrelated re-render (fresh login / rotation).
+    await act(async () => get().setToken("t2"));
+    await settle();
+
+    // Stability: the captured callback is the SAME identity the hook still exposes — so a
+    // stream that subscribed earlier is not holding a dead closure.
+    expect(typeof enqueueAtSubscribe).toBe("function");
+    expect(enqueueAtSubscribe).toBe(get().enqueue);
+
+    // Liveness: invoking the callback captured BEFORE the token changed must still run
+    // against the live token ("t2"), not the stale "t1". Pre-fix (plain fn delegating to a
+    // per-render closure) the subscribe-time callback would have used "t1".
+    await act(async () => {
+      enqueueAtSubscribe(job);
+      await settle();
+    });
+    const timelineGet = apiFetch.mock.calls.find(
+      (call) => call[0] === "/api/v1/projects/p1/timelines/tl1" && (call[2]?.method ?? "GET") === "GET",
+    );
+    expect(timelineGet).toBeTruthy();
+    expect(timelineGet[1]).toBe("t2");
   });
 });

--- a/apps/web/src/hooks/hookStability.test.jsx
+++ b/apps/web/src/hooks/hookStability.test.jsx
@@ -41,9 +41,13 @@ const ACTION_KEYS = {
     "createTrainingDatasetAnalysisJob", "createTrainingDatasetFaceAnalysisJob",
     "smartCropTrainingDataset", "stripExifTrainingDataset", "createTrainingJob",
   ],
+  // sc-11231 (F-037): enqueueTimelineGenerationApply is fed to useJobEvents, whose SSE
+  // effect captures it at subscribe time — so it MUST be identity-stable too, else the
+  // live stream keeps calling a stale closure. It was a plain per-render function
+  // declaration before the fix (new identity every render → this assertion would fail).
   useTimelines: [
     "refreshTimelines", "createTimeline", "saveTimeline", "exportTimeline",
-    "extractTimelineFrame", "queueTimelineVideoJob",
+    "extractTimelineFrame", "queueTimelineVideoJob", "enqueueTimelineGenerationApply",
   ],
 };
 

--- a/apps/web/src/hooks/useAccessGate.js
+++ b/apps/web/src/hooks/useAccessGate.js
@@ -119,14 +119,55 @@ export function useAccessGate({ setError, pushNotice, dismissNoticeKind }) {
   // Probe whether the deployment requires a password, then release `accessResolved`
   // so an authenticated client (or one not requiring auth) can load its data. Mirrors
   // the health fetch's mount timing but owns only the access state (App keeps health).
+  //
+  // sc-11231 (F-038): the gate releases ONLY on a successful probe. The prior code did
+  // `.finally(() => setAccessResolved(true))`, so a single failed GET /api/v1/access
+  // released the gate while `access` stayed `{ authRequired: false }` → `authenticated`
+  // flipped true with no token, protected data + SSE fired unauthenticated, and the login
+  // band (which needs `access.authRequired`) never rendered — on an auth-required remote
+  // deployment that is a 401 storm with no login path, recoverable only by reload (fail
+  // OPEN). Instead we hold the gate closed and retry with exponential backoff — mirroring
+  // the media-ticket mint loop above — so a transient failure self-heals and a persistent
+  // outage surfaces an "access-probe" notice rather than silently authenticating.
   useEffect(() => {
-    apiFetch("/api/v1/access", "")
-      .then(setAccess)
-      .catch((err) => setError(err.message))
-      // Either way the auth state is now as resolved as it'll get; release the gate so
-      // an authenticated client (or one not requiring auth) can load its data.
-      .finally(() => setAccessResolved(true));
-    // Mount-only probe (matches the pre-extraction App effect); setError is stable.
+    let closed = false;
+    let timer = null;
+    let attempt = 0;
+    async function probe() {
+      try {
+        const result = await apiFetch("/api/v1/access", "");
+        if (closed) {
+          return;
+        }
+        setAccess(result);
+        setAccessResolved(true);
+        dismissNoticeKind("access-probe");
+      } catch (err) {
+        if (closed) {
+          return;
+        }
+        // Keep accessResolved false (gate stays closed → no unauthenticated loads), tell
+        // the user why, and schedule a backoff retry so recovery is automatic.
+        setError(err.message);
+        pushNotice(
+          "access-probe",
+          "access check: couldn't reach the host to determine whether a password is required. Retrying in the background.",
+        );
+        const delay = Math.min(30000, 1000 * 2 ** attempt);
+        attempt += 1;
+        timer = window.setTimeout(probe, delay);
+      }
+    }
+    probe();
+    return () => {
+      closed = true;
+      if (timer) {
+        window.clearTimeout(timer);
+      }
+    };
+    // Mount-only probe (matches the pre-extraction App effect); setError, pushNotice, and
+    // dismissNoticeKind are App-owned and identity-stable, so the retry loop captures them
+    // once safely.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/apps/web/src/hooks/useJobEvents.js
+++ b/apps/web/src/hooks/useJobEvents.js
@@ -16,11 +16,16 @@ import {
 // ready, token] dependency array, same cleanup.
 //
 // The handlers reach back into App state through the setters/refs/callbacks passed in.
-// App feeds them identity-stable (useCallback actions, useState setters, and refs), so
-// the effect's deps are exactly the three inputs that must re-subscribe the stream —
-// auth mode, readiness, and the token — mirroring the pre-extraction effect. `access`
-// is read only for `access.authRequired`; the whole object is passed so the dep array
-// (`access.authRequired`) matches the original render-scope reference.
+// Every one of these is fed identity-stable: useState setters (stable by React),
+// useRef handles, and the two callbacks — `hasVisibleLocalFailure` (an empty-dep
+// useCallback reading only refs) and `enqueueTimelineGenerationApply` (a stable
+// ref-delegating useCallback in useTimelines) — which sc-11231 (F-037) hardened after
+// finding them plain per-render declarations that the SSE effect captured stale at
+// subscribe time. Because they are stable, the effect's deps are exactly the three
+// inputs that must re-subscribe the stream — auth mode, readiness, and the token —
+// mirroring the pre-extraction effect. `access` is read only for `access.authRequired`;
+// the whole object is passed so the dep array (`access.authRequired`) matches the
+// original render-scope reference.
 export function useJobEvents({
   access,
   ready,
@@ -206,8 +211,11 @@ export function useJobEvents({
     };
     // Deps deliberately limited to the three inputs that must re-subscribe the stream
     // (auth mode / readiness / token) — mirrors the pre-extraction App effect. The
-    // setters/refs/callbacks are fed identity-stable and read live inside the handlers,
-    // so listing them would only re-open the EventSource on unrelated re-renders.
+    // setters/refs/callbacks are fed identity-stable (see the header note; sc-11231
+    // closed the last two gaps) and read live inside the handlers, so listing them would
+    // only churn the EventSource, never satisfy the stream's actual re-subscribe contract.
+    // The disable stays because exhaustive-deps can't prove that stability statically — it
+    // would still demand ~15 always-stable handles in the array.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [access.authRequired, ready, token]);
 }

--- a/apps/web/src/hooks/useTimelines.js
+++ b/apps/web/src/hooks/useTimelines.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { apiFetch, isAbortError } from "../api.js";
 import { ensureItemVersionFields } from "../timeline.js";
 
@@ -267,11 +267,26 @@ export function useTimelines({
     return { ...timeline, tracks };
   }
 
-  function enqueueTimelineGenerationApply(job) {
-    timelineApplyQueueRef.current = timelineApplyQueueRef.current
-      .then(() => applyCompletedTimelineGeneration(job))
-      .catch((err) => setError(err.message));
-  }
+  // sc-11231 (F-037): useJobEvents' SSE effect captures this at subscribe time (its deps
+  // are only [access.authRequired, ready, token]), so it MUST be identity-stable — a plain
+  // per-render function declaration left the stream calling a stale closure (the same
+  // stale-closure class as the prior F-009 fix). The queue push itself only touches refs,
+  // but applyCompletedTimelineGeneration is recreated every render and closes over the live
+  // `token`, so we publish it into a ref each commit (the `stableRefreshData` ref-delegation
+  // pattern) and expose a stable callback that always runs the freshest body. useLayoutEffect
+  // matches App's ref-publish ordering so the ref holds the newest committed closure.
+  const applyCompletedTimelineGenerationRef = useRef(null);
+  useLayoutEffect(() => {
+    applyCompletedTimelineGenerationRef.current = applyCompletedTimelineGeneration;
+  });
+  const enqueueTimelineGenerationApply = useCallback(
+    (job) => {
+      timelineApplyQueueRef.current = timelineApplyQueueRef.current
+        .then(() => applyCompletedTimelineGenerationRef.current?.(job))
+        .catch((err) => setError(err.message));
+    },
+    [setError],
+  );
 
   async function applyCompletedTimelineGeneration(job) {
     const timelineId = job.payload?.advanced?.timelineContext?.timelineId;


### PR DESCRIPTION
Fixes **sc-11231** (Bug, Medium) under **epic 11147**. Two React bad-pattern fixes at the `useJobEvents` / login-gate seam.

## F-037 — useJobEvents stability contract
`useJobEvents`' SSE effect has deps `[access.authRequired, ready, token]`, so it captures whichever callbacks existed at subscribe time. Two of its inputs violated the "App feeds them identity-stable" doc:

- `hasVisibleLocalFailure` (`App.jsx`) and `enqueueTimelineGenerationApply` (`hooks/useTimelines.js`) were plain function declarations recreated every render — a latent stale-closure (same class as the already-fixed F-009), with no lint/test guard.

Fix (the house `stableRefreshData` ref-delegation pattern):
- `App.jsx` — `hasVisibleLocalFailure` is now an empty-dep `useCallback` reading only the two live refs (`activeViewRef`, `localGenerationJobIdsRef`, kept in sync by existing effects), hoisted above the `useJobEvents` call (a `const` isn't hoisted like the old `function`).
- `hooks/useTimelines.js` — `enqueueTimelineGenerationApply` is now a stable `useCallback` that delegates through a per-commit ref (`applyCompletedTimelineGenerationRef`, published via `useLayoutEffect` to match App's ref-publish ordering), so the subscribe-time closure always runs the freshest body (live `token`).
- Corrected the misleading `useJobEvents` doc comment. Kept the `exhaustive-deps` disable — the rule can't prove the now-genuine stability statically (it would still demand ~15 always-stable handles) — with a corrected explanation.

## F-038 — access probe could fail open
If the mount-time `GET /api/v1/access` failed, `.finally(() => setAccessResolved(true))` released the gate while `access` stayed `{ authRequired: false }` → `authenticated` flipped true with no token, protected data + SSE fired unauthenticated, and the login band (which needs `access.authRequired`) never rendered. On an auth-required remote deployment that is a 401 storm with no login path, recoverable only by reload.

Chosen fix (most robust — retry **and** hold-closed): the gate releases **only** on a successful probe. A failure keeps `accessResolved` false (gate stays closed → no unauthenticated loads/SSE), surfaces an `access-probe` notice, and retries with exponential backoff — mirroring the existing media-ticket mint retry loop in the same file. A transient blip self-heals; a persistent outage shows an error rather than failing open. The successful path is unchanged.

## Tests (vitest)
- `hooks/hookStability.test.jsx` — adds `enqueueTimelineGenerationApply` to the useTimelines identity-stability check.
- `hooks/appGateHooks.test.jsx` — new: the enqueue callback captured at subscribe time is referentially stable AND still applies with the live token after a re-render.
- `App.auth.test.jsx` — new: a failed `/access` probe does not fail open (no `/projects`, no SSE, notice shown); a backoff retry recovers and resolves the gate; the successful probe path is unchanged. Plus a guard that the failed-job SSE path still routes through `hasVisibleLocalFailure` after the refactor.
- All four teeth-tests were verified to FAIL on the pre-fix source.

## Verification
- `npm run test` (web): **1653 passed** / 120 files.
- `npm run lint`: **0 errors**, 48 pre-existing exhaustive-deps warnings (unchanged baseline).
- `npm run build`: ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)