### PR TITLE
chore(worker): dedup cache-thread scaffolding + hoist SAM3 twin logic (sc-11191)

### DIFF
--- a/crates/sceneworks-worker/src/cache_thread.rs
+++ b/crates/sceneworks-worker/src/cache_thread.rs
@@ -1,0 +1,449 @@
+//! Generic single-resident, dedicated-OS-thread model cache (sc-11191, F-019).
+//!
+//! [`crate::generator_cache`] (image/video `Generator`) and [`crate::refine_model_cache`] (text
+//! `core_llm::TextLlm`) previously re-implemented the SAME scaffolding almost verbatim (~250 lines
+//! each): a `Fingerprint` content-change proxy, a `panic_message` payload formatter, a dedicated
+//! worker thread that owns one resident model keyed by a load spec, an idle-timeout eviction event
+//! loop, evict-on-panic containment, and a `oneshot`-reply job seam. This module hoists all of that
+//! into one generic [`CacheThread<K, M>`] parameterized over the cache key `K`, the resident model
+//! `M`, and a caller-supplied loader closure; the two caches become thin wrappers that supply their
+//! key/model types, their loader, their idle-eviction log, and their user-facing message strings.
+//!
+//! ## Preserved divergence: evict-before-load (do NOT unify away)
+//!
+//! The two caches deliberately differ in ONE behavior, kept here as the [`CacheThread::new`]
+//! `evict_before_load` flag so each retains its CURRENT semantics exactly:
+//!
+//! - **generator cache — `evict_before_load = false`.** On a cold miss it clears the resident entry
+//!   (`self.entry = None`) and then loads; it does NOT free the backend cache before the new load.
+//!   The unified-memory fit-gate / residency policy (epic 10834) runs inside the loader closure to
+//!   size the load, so an explicit pre-load backend trim is not part of its contract.
+//! - **refine cache — `evict_before_load = true`.** The ~16 GB text model frees the prior resident
+//!   model's backend allocation ([`release_backend_cache_after_evict`]) BEFORE the new load
+//!   allocates, so peak memory is one model, not two.
+//!
+//! This is a real, intentional difference (not drift); unifying it would change the memory profile of
+//! one lane. If a future change makes a single policy correct for both, make that an explicit decision
+//! and update both wrappers — do not silently flip the flag here.
+
+use std::path::Path;
+use std::sync::mpsc;
+use std::time::{Duration, SystemTime};
+
+use tokio::sync::oneshot;
+
+use crate::{WorkerError, WorkerResult};
+
+/// A unit of work handed to a cache worker thread: a boxed closure that runs against the resident
+/// [`CacheThread`] on that thread and signals completion through its own captured reply channel. The
+/// closure is `Send` (it crosses the channel) but the resident model `M` never leaves the thread, so
+/// `M` itself may be `!Send` (e.g. a `Box<dyn TextLlm>` holding an `Rc`).
+pub(crate) type CacheJob<K, M> = Box<dyn FnOnce(&mut CacheThread<K, M>) + Send + 'static>;
+
+/// Content-change proxy for a weights/adapter file (or HF snapshot dir) referenced in a cache key
+/// (sc-8841, F-039). A pre-fingerprint key identified weights/adapters by path only, so a file
+/// replaced at the SAME path — a re-imported LoRA, a re-converted checkpoint — was served from the
+/// resident model with the OLD tensors until the idle timeout. Folding `(size, mtime)` into the key
+/// self-heals for ANY overwrite path (in-process re-import/re-convert, out-of-band replacement,
+/// manual swap) without an explicit evict hook that only fires for the code paths that remember it.
+///
+/// We deliberately stat metadata rather than hashing contents: mtime+size is a cheap, good
+/// content-change proxy, and hashing multi-GB weight files on every request would be a severe perf
+/// regression.
+///
+/// For a `Dir` (an HF snapshot) callers fingerprint the DIRECTORY's own metadata. A re-convert lands
+/// via a finalize/rename path that replaces directory entries and bumps the dir's mtime, so a
+/// re-converted snapshot at the same path is a distinct key. `size` for a dir is its own metadata
+/// length (not the recursive content size) — it only needs to move on change, not be meaningful;
+/// mtime carries the signal.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum Fingerprint {
+    /// `metadata()` succeeded: `(len, modified)`. `modified` is `None` on the rare platform/FS that
+    /// does not report an mtime, in which case `len` alone carries the (weaker) signal.
+    Present {
+        size: u64,
+        mtime: Option<SystemTime>,
+    },
+    /// `metadata()` errored (path missing, transient stat failure, permissions). Kept DISTINCT from
+    /// any `Present` value so a stat error forces a cache MISS (rebuild) rather than serving a stale
+    /// entry — the load that follows surfaces the real error. Two `Unavailable`s compare equal
+    /// (`Eq` must stay reflexive), but that only arises when the file is genuinely gone on both the
+    /// cached and the incoming key, in which case the reload fails loudly anyway.
+    Unavailable,
+}
+
+impl Fingerprint {
+    /// Snapshot `(size, mtime)` for `path` once, at key-construction time, so the fingerprint is
+    /// stable across the lookup within a single request (no mtime drift mid-request).
+    pub(crate) fn of(path: &Path) -> Self {
+        match std::fs::metadata(path) {
+            Ok(meta) => Self::Present {
+                size: meta.len(),
+                mtime: meta.modified().ok(),
+            },
+            Err(_) => Self::Unavailable,
+        }
+    }
+}
+
+/// A single-resident model cache. Holds at most one loaded model (`M`) keyed by `K`; a lookup for a
+/// different key is a miss that drops the resident model and loads the new one.
+pub(crate) struct CacheThread<K, M> {
+    entry: Option<Entry<K, M>>,
+    /// See the module docs: `true` frees the backend cache before loading a miss (refine cache),
+    /// `false` does not (generator cache). Kept as a per-cache parameter to preserve each lane's
+    /// current memory behavior exactly.
+    evict_before_load: bool,
+}
+
+struct Entry<K, M> {
+    key: K,
+    model: M,
+}
+
+impl<K, M> CacheThread<K, M>
+where
+    K: Clone + PartialEq,
+{
+    pub(crate) fn new(evict_before_load: bool) -> Self {
+        Self {
+            entry: None,
+            evict_before_load,
+        }
+    }
+
+    /// Drop the resident model so the next job reloads from scratch. Returns the evicted key (for the
+    /// idle-eviction log), or `None` when nothing was resident.
+    pub(crate) fn evict(&mut self) -> Option<K> {
+        self.entry.take().map(|entry| entry.key)
+    }
+
+    /// Load (on a miss) or reuse (on a hit) the model for `key`, then run `run` against it.
+    ///
+    /// A miss clears the resident entry, optionally frees the backend cache first (see
+    /// `evict_before_load`), then invokes the caller's `load` closure — which owns whatever
+    /// per-lane policy the load needs (fit-gate/residency selection for the generator, error-context
+    /// wrapping for either). `entry_missing_msg` is the (should-be-impossible) error surfaced if the
+    /// entry vanished after a successful load.
+    pub(crate) fn with_model<R>(
+        &mut self,
+        key: K,
+        load: impl FnOnce() -> WorkerResult<M>,
+        run: impl FnOnce(&M) -> WorkerResult<R>,
+        entry_missing_msg: &str,
+    ) -> WorkerResult<R> {
+        if self.entry.as_ref().map_or(true, |entry| entry.key != key) {
+            self.entry = None;
+            if self.evict_before_load {
+                release_backend_cache_after_evict();
+            }
+            let model = load()?;
+            self.entry = Some(Entry {
+                key: key.clone(),
+                model,
+            });
+        }
+
+        let Some(entry) = self.entry.as_ref() else {
+            return Err(WorkerError::Engine(entry_missing_msg.to_owned()));
+        };
+        run(&entry.model)
+    }
+
+    /// Whether a model is currently resident. Test/introspection helper.
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.entry.is_none()
+    }
+
+    /// The resident entry's key, if any. Test/introspection helper.
+    #[cfg(test)]
+    pub(crate) fn resident_key(&self) -> Option<&K> {
+        self.entry.as_ref().map(|entry| &entry.key)
+    }
+
+    /// Install a resident entry directly (test seam — production goes through [`Self::with_model`]).
+    #[cfg(test)]
+    pub(crate) fn install(&mut self, key: K, model: M) {
+        self.entry = Some(Entry { key, model });
+    }
+}
+
+/// The event a cache worker's receive step yields.
+enum WorkerEvent<J> {
+    Job(J),
+    IdleTimeout,
+    Disconnected,
+}
+
+/// Block for the next job, or report an idle timeout / disconnect. With `idle_timeout = None` the
+/// worker blocks forever for a job (idle eviction disabled).
+fn recv_job<J>(rx: &mpsc::Receiver<J>, idle_timeout: Option<Duration>) -> WorkerEvent<J> {
+    match idle_timeout {
+        Some(timeout) => match rx.recv_timeout(timeout) {
+            Ok(job) => WorkerEvent::Job(job),
+            Err(mpsc::RecvTimeoutError::Timeout) => WorkerEvent::IdleTimeout,
+            Err(mpsc::RecvTimeoutError::Disconnected) => WorkerEvent::Disconnected,
+        },
+        None => match rx.recv() {
+            Ok(job) => WorkerEvent::Job(job),
+            Err(_) => WorkerEvent::Disconnected,
+        },
+    }
+}
+
+/// The dedicated cache thread's event loop: own a single-resident [`CacheThread`], serve jobs from
+/// `rx`, and evict the resident model after `idle_timeout` of inactivity. `log_idle_evict(key,
+/// idle_seconds)` emits the lane-specific idle-eviction telemetry.
+///
+/// A panic escaping a job is contained (`catch_unwind`) so this one shared thread can never die and
+/// poison every later request (sc-6067); on a contained panic the cache is reset because post-abort
+/// backend state is suspect.
+pub(crate) fn run_cache_worker<K, M>(
+    rx: mpsc::Receiver<CacheJob<K, M>>,
+    idle_timeout: Option<Duration>,
+    evict_before_load: bool,
+    log_idle_evict: impl Fn(&K, u64),
+) where
+    K: Clone + PartialEq,
+{
+    let mut cache = CacheThread::<K, M>::new(evict_before_load);
+    loop {
+        let job = match recv_job(&rx, idle_timeout) {
+            WorkerEvent::Job(job) => job,
+            WorkerEvent::IdleTimeout => {
+                if let Some(key) = cache.evict() {
+                    release_backend_cache_after_evict();
+                    log_idle_evict(&key, idle_timeout.map_or(0, |timeout| timeout.as_secs()));
+                }
+                continue;
+            }
+            WorkerEvent::Disconnected => break,
+        };
+        // Backstop: contain any panic that escapes a job's own guard so this single shared cache
+        // thread can never die and poison every later request (sc-6067). A job normally catches its
+        // own panic, replies with a clean error, and evicts; this catches anything it misses. On a
+        // contained panic the cache is reset because post-abort backend state is suspect.
+        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| job(&mut cache))).is_err()
+            && cache.evict().is_some()
+        {
+            release_backend_cache_after_evict();
+        }
+    }
+}
+
+/// User-facing message strings for [`run_cached`], so each lane keeps its exact wording.
+#[derive(Clone, Copy)]
+pub(crate) struct SeamMessages {
+    /// Surfaced if the resident entry vanished right after a successful load (should be impossible).
+    pub entry_missing: &'static str,
+    /// Prefix for a contained-panic error; the caught payload text is appended as `"{prefix}: {msg}"`.
+    pub panic_reset: &'static str,
+    /// Surfaced when the worker thread's channel is closed (worker gone).
+    pub worker_stopped: &'static str,
+    /// Surfaced when the worker dropped the job's reply channel without answering.
+    pub worker_dropped: &'static str,
+}
+
+/// Run `run` against the cached (or freshly-loaded) model for `key` on the dedicated cache `worker`
+/// thread, and await the result. The model lives on the worker thread — `load` builds it there and
+/// `run` executes there (so it may hold a `!Send` reference) — and only the `R` result crosses back.
+///
+/// A panic from inside the load/run (e.g. an mlx-rs `.unwrap()` on a Metal OOM) is contained: it
+/// fails THIS request with a clean [`WorkerError::Engine`] built from `msgs.panic_reset`, evicts the
+/// resident model (post-abort backend state is suspect), and leaves the shared thread serving.
+pub(crate) async fn run_cached<K, M, R>(
+    worker: &'static mpsc::Sender<CacheJob<K, M>>,
+    key: K,
+    load: impl FnOnce() -> WorkerResult<M> + Send + 'static,
+    run: impl FnOnce(&M) -> WorkerResult<R> + Send + 'static,
+    msgs: SeamMessages,
+) -> WorkerResult<R>
+where
+    K: Clone + PartialEq + Send + 'static,
+    M: 'static,
+    R: Send + 'static,
+{
+    let (reply_tx, reply_rx) = oneshot::channel::<WorkerResult<R>>();
+    let job: CacheJob<K, M> = Box::new(move |cache: &mut CacheThread<K, M>| {
+        // Contain a panic from inside the load/run so it fails THIS job with a clean error instead of
+        // unwinding out of the shared cache thread and stopping every subsequent request (sc-6067).
+        // The cached model is evicted on panic — post-abort backend state is suspect, so the next
+        // job reloads fresh.
+        let result = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            cache.with_model(key, load, run, msgs.entry_missing)
+        })) {
+            Ok(result) => result,
+            Err(panic) => {
+                if cache.evict().is_some() {
+                    release_backend_cache_after_evict();
+                }
+                Err(WorkerError::Engine(format!(
+                    "{}: {}",
+                    msgs.panic_reset,
+                    panic_message(panic.as_ref())
+                )))
+            }
+        };
+        let _ = reply_tx.send(result);
+    });
+    worker
+        .send(job)
+        .map_err(|_| WorkerError::Engine(msgs.worker_stopped.to_owned()))?;
+    reply_rx
+        .await
+        .map_err(|_| WorkerError::Engine(msgs.worker_dropped.to_owned()))?
+}
+
+/// Parse a cache idle-eviction window (seconds) from an env value, falling back to `default_secs`
+/// when absent/blank/unparseable. `0` disables idle eviction (returns `None`); any positive value is
+/// that many seconds.
+pub(crate) fn idle_timeout_from_secs(raw: Option<&str>, default_secs: u64) -> Option<Duration> {
+    let seconds = raw
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(default_secs);
+    (seconds > 0).then(|| Duration::from_secs(seconds))
+}
+
+/// Best-effort human-readable text from a caught panic payload — the `&str`/`String` a `panic!`
+/// produces. mlx-rs `.unwrap()`/`.expect()` panics carry their formatted message as a `String`
+/// (e.g. the `[metal::malloc] Attempting to allocate …` Metal OOM), so this surfaces the real cause.
+pub(crate) fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        (*s).to_owned()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "unknown panic payload".to_owned()
+    }
+}
+
+#[cfg(all(target_os = "macos", not(test)))]
+pub(crate) fn release_backend_cache_after_evict() {
+    mlx_rs::memory::clear_cache();
+}
+
+/// Off-Mac (candle/CUDA) this is intentionally a no-op (epic 10765, sc-10766). candle's CUDA backend
+/// uses cudarc's stream-ordered caching allocator, which exposes no `empty_cache` and does not reclaim
+/// on `Device::synchronize()`: dropping the evicted model already returns its pages to candle's
+/// in-process pool (where the next load reuses them), but there is no supported way to hand those pages
+/// back to the driver — so `nvidia-smi` resident VRAM stays flat across an evict regardless. A real
+/// driver-level trim would need a candle/cudarc fork (tracked as a separate optional spike under epic
+/// 10765), not this seam. The VRAM fit-gate therefore budgets on predicted peak, not resident deltas.
+#[cfg(any(not(target_os = "macos"), test))]
+pub(crate) fn release_backend_cache_after_evict() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The generic evict-before-load flag must gate the pre-load backend trim. We can't observe the
+    // (cfg'd-out under test) backend call, so exercise the ORDERING through the loader closure: a
+    // loader that records whether the resident entry was already cleared when it ran. Both flag
+    // values must clear the resident entry before loading a miss (single-resident); the flag only
+    // toggles the backend trim, which is a no-op under `cfg(test)`.
+    #[test]
+    fn with_model_reloads_on_miss_and_reuses_on_hit() {
+        use std::cell::Cell;
+        let mut cache = CacheThread::<u32, u32>::new(false);
+        let loads = Cell::new(0u32);
+        let run = |cache: &mut CacheThread<u32, u32>, value: u32| {
+            cache
+                .with_model(
+                    value,
+                    || {
+                        loads.set(loads.get() + 1);
+                        Ok(value)
+                    },
+                    |m: &u32| Ok(*m),
+                    "missing",
+                )
+                .unwrap()
+        };
+        assert_eq!(run(&mut cache, 7), 7);
+        assert_eq!(loads.get(), 1, "cold key loads");
+        // Same key → hit, no reload.
+        assert_eq!(run(&mut cache, 7), 7);
+        assert_eq!(loads.get(), 1, "same key reuses the resident model");
+        // Different key → miss, reload.
+        assert_eq!(run(&mut cache, 9), 9);
+        assert_eq!(loads.get(), 2, "a new key reloads");
+        assert_eq!(cache.resident_key(), Some(&9));
+    }
+
+    // The evict-before-load flag is preserved per-cache: only when set does a miss free the backend
+    // cache before the load. `release_backend_cache_after_evict` is a no-op under `cfg(test)`, so we
+    // assert the flag is plumbed through `new` and that a miss still clears the prior entry in both
+    // modes (the flag only adds the trim, never changes the single-resident replacement).
+    #[test]
+    fn evict_before_load_flag_is_per_cache_and_miss_replaces_entry() {
+        for evict_before_load in [false, true] {
+            let mut cache = CacheThread::<u32, u32>::new(evict_before_load);
+            cache.install(1, 100);
+            assert_eq!(cache.resident_key(), Some(&1));
+            // Miss on a new key replaces the resident entry regardless of the flag.
+            let got = cache
+                .with_model(2, || Ok(200u32), |m: &u32| Ok(*m), "missing")
+                .unwrap();
+            assert_eq!(got, 200);
+            assert_eq!(cache.resident_key(), Some(&2));
+        }
+    }
+
+    #[test]
+    fn evict_clears_resident_and_returns_key() {
+        let mut cache = CacheThread::<u32, u32>::new(false);
+        assert!(cache.is_empty());
+        cache.install(5, 50);
+        assert!(!cache.is_empty());
+        assert_eq!(cache.evict(), Some(5));
+        assert!(cache.is_empty());
+        assert_eq!(cache.evict(), None);
+    }
+
+    #[test]
+    fn idle_timeout_defaults_parses_and_disables() {
+        assert_eq!(
+            idle_timeout_from_secs(None, 300),
+            Some(Duration::from_secs(300))
+        );
+        assert_eq!(
+            idle_timeout_from_secs(Some(""), 300),
+            Some(Duration::from_secs(300))
+        );
+        assert_eq!(
+            idle_timeout_from_secs(Some("not-a-number"), 300),
+            Some(Duration::from_secs(300))
+        );
+        assert_eq!(idle_timeout_from_secs(Some("0"), 300), None);
+        assert_eq!(
+            idle_timeout_from_secs(Some("42"), 300),
+            Some(Duration::from_secs(42))
+        );
+    }
+
+    #[test]
+    fn fingerprint_of_reports_present_and_unavailable() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("weights.bin");
+        std::fs::write(&path, b"bytes").expect("write");
+        assert!(matches!(
+            Fingerprint::of(&path),
+            Fingerprint::Present { .. }
+        ));
+        assert_eq!(
+            Fingerprint::of(&dir.path().join("missing")),
+            Fingerprint::Unavailable
+        );
+    }
+
+    #[test]
+    fn panic_message_extracts_str_and_string_payloads() {
+        let s = std::panic::catch_unwind(|| panic!("boom-str")).unwrap_err();
+        assert_eq!(panic_message(s.as_ref()), "boom-str");
+        let s = std::panic::catch_unwind(|| panic!("{}", "boom-string".to_owned())).unwrap_err();
+        assert_eq!(panic_message(s.as_ref()), "boom-string");
+    }
+}

--- a/crates/sceneworks-worker/src/generator_cache.rs
+++ b/crates/sceneworks-worker/src/generator_cache.rs
@@ -1,30 +1,37 @@
 use std::path::{Path, PathBuf};
 use std::sync::{mpsc, OnceLock};
 use std::thread;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use gen_core::{
     AdapterKind, AdapterSpec, Generator, LoadSpec, MoeExpert, Precision, Quant, WeightsSource,
 };
-use tokio::sync::oneshot;
 
-use crate::{WorkerError, WorkerResult};
+use crate::cache_thread::{self, CacheJob, CacheThread, Fingerprint, SeamMessages};
+use crate::WorkerResult;
 
-type GeneratorJob = Box<dyn FnOnce(&mut GeneratorCache) + Send + 'static>;
+/// The generator cache is a single-resident [`CacheThread`] keyed by [`GeneratorCacheKey`], holding a
+/// loaded `Box<dyn Generator>`. The generic scaffolding (dedicated worker thread, idle-timeout
+/// eviction, panic containment, `Fingerprint`, oneshot-reply seam) lives in [`crate::cache_thread`];
+/// this module supplies only the key derivation, the loader, and the message strings (sc-11191, F-019).
+// Referenced only from the candle `with_uncached_generator` and the tests' worker closures (the
+// production seam infers the `CacheThread` type from the job channel), so it reads as dead on the
+// base macOS lib build.
+#[allow(dead_code)]
+type GeneratorCache = CacheThread<GeneratorCacheKey, Box<dyn Generator>>;
+type GeneratorJob = CacheJob<GeneratorCacheKey, Box<dyn Generator>>;
 
 const GENERATOR_CACHE_IDLE_SECONDS_ENV: &str = "SCENEWORKS_GENERATOR_CACHE_IDLE_SECONDS";
 const DEFAULT_GENERATOR_CACHE_IDLE_SECONDS: u64 = 300;
 
+/// The generator cache does NOT free the backend cache before a cold load (unlike the refine cache,
+/// which sets this `true` to bound peak memory to one ~16 GB model). A cold miss here clears the
+/// resident generator and loads, sizing the load via the fit-gate/residency policy in the loader
+/// closure rather than a pre-load backend trim. This divergence is deliberate and documented — see
+/// the [`crate::cache_thread`] module docs; do not silently unify it away.
+const GENERATOR_EVICT_BEFORE_LOAD: bool = false;
+
 static GENERATOR_WORKER: OnceLock<mpsc::Sender<GeneratorJob>> = OnceLock::new();
-
-struct GeneratorCache {
-    entry: Option<GeneratorCacheEntry>,
-}
-
-struct GeneratorCacheEntry {
-    key: GeneratorCacheKey,
-    generator: Box<dyn Generator>,
-}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct GeneratorCacheKey {
@@ -47,53 +54,6 @@ pub(crate) struct GeneratorCacheKey {
 enum CacheWeightsSource {
     Dir(PathBuf, Fingerprint),
     File(PathBuf, Fingerprint),
-}
-
-/// Content-change proxy for a weights/adapter file (or HF snapshot dir) referenced in the cache key
-/// (sc-8841, F-039). The pre-fingerprint key identified weights/adapters by path + scale only, so a
-/// file replaced at the SAME path — a re-imported LoRA, a re-converted checkpoint — was served from
-/// the resident generator with the OLD tensors until the 300 s idle timeout ("my new LoRA does
-/// nothing"). Folding `(size, mtime)` into the key self-heals for ANY overwrite path (in-process
-/// re-import/re-convert, out-of-band replacement, manual swap) without an explicit evict hook that
-/// only fires for the code paths that remember to call it.
-///
-/// We deliberately stat metadata rather than hashing contents: mtime+size is a cheap, good
-/// content-change proxy, and hashing multi-GB weight files on every generation would be a severe
-/// perf regression.
-///
-/// For a `Dir` (an HF snapshot) we fingerprint the DIRECTORY's own metadata. A re-convert lands via
-/// the finalize/rename path (`finalize_converted_dir`), which replaces directory entries and bumps
-/// the dir's mtime, so a re-converted snapshot at the same path is a distinct key. `size` for a dir
-/// is its own metadata length (not the recursive content size) — it only needs to move on change,
-/// not be meaningful; mtime carries the signal.
-#[derive(Clone, Debug, PartialEq, Eq)]
-enum Fingerprint {
-    /// `metadata()` succeeded: `(len, modified)`. `modified` is `None` on the rare platform/FS that
-    /// does not report an mtime, in which case `len` alone carries the (weaker) signal.
-    Present {
-        size: u64,
-        mtime: Option<SystemTime>,
-    },
-    /// `metadata()` errored (path missing, transient stat failure, permissions). Kept DISTINCT from
-    /// any `Present` value so a stat error forces a cache MISS (rebuild) rather than serving a stale
-    /// entry — the load that follows surfaces the real error. Two `Unavailable`s compare equal
-    /// (`Eq` must stay reflexive), but that only arises when the file is genuinely gone on both the
-    /// cached and the incoming key, in which case the reload fails loudly anyway.
-    Unavailable,
-}
-
-impl Fingerprint {
-    /// Snapshot `(size, mtime)` for `path` once, at key-construction time, so the fingerprint is
-    /// stable across the lookup within a single generation (no mtime drift mid-request).
-    fn of(path: &Path) -> Self {
-        match std::fs::metadata(path) {
-            Ok(meta) => Self::Present {
-                size: meta.len(),
-                mtime: meta.modified().ok(),
-            },
-            Err(_) => Self::Unavailable,
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -156,50 +116,6 @@ impl From<&AdapterSpec> for CacheAdapterSpec {
     }
 }
 
-impl GeneratorCache {
-    fn new() -> Self {
-        Self { entry: None }
-    }
-
-    /// Drop the resident generator so the next job reloads from scratch.
-    fn evict(&mut self) -> Option<GeneratorCacheKey> {
-        self.entry.take().map(|entry| entry.key)
-    }
-
-    fn with_generator<R>(
-        &mut self,
-        key: GeneratorCacheKey,
-        spec: LoadSpec,
-        load_error_context: String,
-        run: impl FnOnce(&dyn Generator) -> WorkerResult<R>,
-    ) -> WorkerResult<R> {
-        if self.entry.as_ref().map_or(true, |entry| entry.key != key) {
-            self.entry = None;
-            // Pre-load unified-memory fit-gate + residency selection (epic 10834; sc-10835 Phase 0,
-            // sc-10839 Phase 1): BEFORE gen_core::load allocates, either reject a model that can't fit
-            // this machine's unified memory (a wired overcommit SIGKILLs the worker mid-load rather
-            // than returning a catchable error) OR, for a provider that supports sequential component
-            // residency, select `OffloadPolicy::Sequential` when the resident sum won't fit but the
-            // staged max-single-component will. Cold-load path only (a warm cache hit takes the branch
-            // above and skips it), so an already-resident model is never re-gated.
-            let spec = crate::mlx_fit_gate::apply_residency_policy(spec, &key.engine_id)?;
-            let generator = gen_core::load(&key.engine_id, &spec)
-                .map_err(|error| crate::classify_engine_error(&load_error_context, error))?;
-            self.entry = Some(GeneratorCacheEntry {
-                key: key.clone(),
-                generator,
-            });
-        }
-
-        let Some(entry) = self.entry.as_ref() else {
-            return Err(WorkerError::Engine(
-                "Generator cache entry missing after load.".to_owned(),
-            ));
-        };
-        run(entry.generator.as_ref())
-    }
-}
-
 fn generator_worker() -> &'static mpsc::Sender<GeneratorJob> {
     GENERATOR_WORKER.get_or_init(|| {
         let (tx, rx) = mpsc::channel::<GeneratorJob>();
@@ -214,60 +130,23 @@ fn generator_worker() -> &'static mpsc::Sender<GeneratorJob> {
     })
 }
 
+/// Thin wrapper over the generic [`cache_thread::run_cache_worker`]: no evict-before-load
+/// ([`GENERATOR_EVICT_BEFORE_LOAD`]) and the generator-specific idle-eviction log.
 fn run_generator_cache_worker(rx: mpsc::Receiver<GeneratorJob>, idle_timeout: Option<Duration>) {
-    let mut cache = GeneratorCache::new();
-    loop {
-        let job = match recv_generator_job(&rx, idle_timeout) {
-            GeneratorWorkerEvent::Job(job) => job,
-            GeneratorWorkerEvent::IdleTimeout => {
-                if let Some(key) = cache.evict() {
-                    release_backend_cache_after_evict();
-                    // Documented event (docs/observability.md): expected idle-timeout
-                    // eviction, so info level with the engine + idle window.
-                    tracing::info!(
-                        event = "generator_cache_idle_evicted",
-                        engine = %key.engine_id,
-                        idleSeconds = idle_timeout.map_or(0, |timeout| timeout.as_secs()),
-                    );
-                }
-                continue;
-            }
-            GeneratorWorkerEvent::Disconnected => break,
-        };
-        // Backstop: contain any panic that escapes a job's own guard so this single
-        // shared cache thread can never die and poison every later generation (sc-6067).
-        // A job normally catches its own panic, replies with a clean error, and evicts;
-        // this catches anything it misses. On a contained panic the cache is reset
-        // because post-abort MLX/Metal state is suspect.
-        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| job(&mut cache))).is_err()
-            && cache.evict().is_some()
-        {
-            release_backend_cache_after_evict();
-        }
-    }
-}
-
-enum GeneratorWorkerEvent {
-    Job(GeneratorJob),
-    IdleTimeout,
-    Disconnected,
-}
-
-fn recv_generator_job(
-    rx: &mpsc::Receiver<GeneratorJob>,
-    idle_timeout: Option<Duration>,
-) -> GeneratorWorkerEvent {
-    match idle_timeout {
-        Some(timeout) => match rx.recv_timeout(timeout) {
-            Ok(job) => GeneratorWorkerEvent::Job(job),
-            Err(mpsc::RecvTimeoutError::Timeout) => GeneratorWorkerEvent::IdleTimeout,
-            Err(mpsc::RecvTimeoutError::Disconnected) => GeneratorWorkerEvent::Disconnected,
+    cache_thread::run_cache_worker(
+        rx,
+        idle_timeout,
+        GENERATOR_EVICT_BEFORE_LOAD,
+        |key: &GeneratorCacheKey, idle_seconds| {
+            // Documented event (docs/observability.md): expected idle-timeout eviction, so info
+            // level with the engine + idle window.
+            tracing::info!(
+                event = "generator_cache_idle_evicted",
+                engine = %key.engine_id,
+                idleSeconds = idle_seconds,
+            );
         },
-        None => match rx.recv() {
-            Ok(job) => GeneratorWorkerEvent::Job(job),
-            Err(_) => GeneratorWorkerEvent::Disconnected,
-        },
-    }
+    );
 }
 
 fn generator_cache_idle_timeout_from_env() -> Option<Duration> {
@@ -279,28 +158,8 @@ fn generator_cache_idle_timeout_from_env() -> Option<Duration> {
 }
 
 fn generator_cache_idle_timeout(raw: Option<&str>) -> Option<Duration> {
-    let seconds = raw
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .and_then(|value| value.parse::<u64>().ok())
-        .unwrap_or(DEFAULT_GENERATOR_CACHE_IDLE_SECONDS);
-    (seconds > 0).then(|| Duration::from_secs(seconds))
+    cache_thread::idle_timeout_from_secs(raw, DEFAULT_GENERATOR_CACHE_IDLE_SECONDS)
 }
-
-#[cfg(all(target_os = "macos", not(test)))]
-fn release_backend_cache_after_evict() {
-    mlx_rs::memory::clear_cache();
-}
-
-/// Off-Mac (candle/CUDA) this is intentionally a no-op (epic 10765, sc-10766). candle's CUDA backend
-/// uses cudarc's stream-ordered caching allocator, which exposes no `empty_cache` and does not reclaim
-/// on `Device::synchronize()`: dropping the evicted generator already returns its pages to candle's
-/// in-process pool (where the next load reuses them), but there is no supported way to hand those pages
-/// back to the driver — so `nvidia-smi` resident VRAM stays flat across an evict regardless. A real
-/// driver-level trim would need a candle/cudarc fork (tracked as a separate optional spike under epic
-/// 10765), not this seam. The VRAM fit-gate therefore budgets on predicted peak, not resident deltas.
-#[cfg(any(not(target_os = "macos"), test))]
-fn release_backend_cache_after_evict() {}
 
 /// Apply the user-configured GPU memory ceiling to the MLX runtime (epic 7819, sc-7820).
 ///
@@ -418,18 +277,15 @@ pub(crate) fn sync_gpu_memory_limit(_config_dir: &Path) {}
 #[cfg(any(not(target_os = "macos"), test))]
 pub(crate) fn spawn_gpu_telemetry(_config_dir: PathBuf) {}
 
-/// Best-effort human-readable text from a caught panic payload — the `&str`/`String` a `panic!`
-/// produces. mlx-rs `.unwrap()`/`.expect()` panics carry their formatted message as a `String`
-/// (e.g. the `[metal::malloc] Attempting to allocate …` Metal OOM), so this surfaces the real cause.
-fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
-    if let Some(s) = payload.downcast_ref::<&str>() {
-        (*s).to_owned()
-    } else if let Some(s) = payload.downcast_ref::<String>() {
-        s.clone()
-    } else {
-        "unknown panic payload".to_owned()
-    }
-}
+/// User-facing message strings for the generator cache seam, preserving the exact wording the worker
+/// emitted before the `cache_thread` extraction (sc-11191, F-019).
+const GENERATOR_SEAM_MESSAGES: SeamMessages = SeamMessages {
+    entry_missing: "Generator cache entry missing after load.",
+    panic_reset: "MLX generation panicked and was contained (the engine likely ran out of memory; \
+                  the cached generator was reset)",
+    worker_stopped: "MLX generator cache worker stopped",
+    worker_dropped: "MLX generator cache worker dropped the job result",
+};
 
 pub(crate) async fn with_cached_generator<R>(
     engine_id: &'static str,
@@ -442,35 +298,24 @@ where
 {
     let key = GeneratorCacheKey::from_load_spec(engine_id, &spec);
     let load_error_context = load_error_context.into();
-    let (reply_tx, reply_rx) = oneshot::channel::<WorkerResult<R>>();
-    let job = Box::new(move |cache: &mut GeneratorCache| {
-        // Contain a panic from inside the engine (e.g. mlx-rs `.unwrap()`-ing a Metal allocation
-        // failure) so it fails THIS job with a clean error instead of unwinding out of the shared
-        // cache thread and stopping every subsequent generation (sc-6067). The cached generator is
-        // evicted on panic — post-abort MLX/Metal state is suspect, so the next job reloads fresh.
-        let result = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            cache.with_generator(key, spec, load_error_context, run)
-        })) {
-            Ok(result) => result,
-            Err(panic) => {
-                if cache.evict().is_some() {
-                    release_backend_cache_after_evict();
-                }
-                Err(WorkerError::Engine(format!(
-                    "MLX generation panicked and was contained (the engine likely ran out of \
-                     memory; the cached generator was reset): {}",
-                    panic_message(panic.as_ref())
-                )))
-            }
-        };
-        let _ = reply_tx.send(result);
-    });
-    generator_worker()
-        .send(job)
-        .map_err(|_| WorkerError::Engine("MLX generator cache worker stopped".to_owned()))?;
-    reply_rx.await.map_err(|_| {
-        WorkerError::Engine("MLX generator cache worker dropped the job result".to_owned())
-    })?
+    // The loader owns the generator-specific cold-load policy. Pre-load unified-memory fit-gate +
+    // residency selection (epic 10834; sc-10835 Phase 0, sc-10839 Phase 1): BEFORE gen_core::load
+    // allocates, either reject a model that can't fit this machine's unified memory (a wired
+    // overcommit SIGKILLs the worker mid-load rather than returning a catchable error) OR, for a
+    // provider that supports sequential component residency, select `OffloadPolicy::Sequential` when
+    // the resident sum won't fit but the staged max-single-component will. This runs only on a cold
+    // miss (a warm cache hit never invokes the loader), so an already-resident model is never re-gated.
+    let load = move || {
+        let spec = crate::mlx_fit_gate::apply_residency_policy(spec, engine_id)?;
+        gen_core::load(engine_id, &spec)
+            .map_err(|error| crate::classify_engine_error(&load_error_context, error))
+    };
+    // Adapt the user's `&dyn Generator` run closure to the generic cache's resident
+    // `Box<dyn Generator>`. The `&Box<_>` param is inherent to the seam (the cache stores the boxed
+    // trait object), so silence the borrowed-box lint here rather than boxing/unboxing again.
+    #[allow(clippy::borrowed_box)]
+    let run = move |generator: &Box<dyn Generator>| run(&**generator);
+    cache_thread::run_cached(generator_worker(), key, load, run, GENERATOR_SEAM_MESSAGES).await
 }
 
 /// Run `run` against a freshly-loaded, **uncached** generator on the shared cache thread (epic 10451
@@ -492,14 +337,15 @@ pub(crate) async fn with_uncached_generator<R>(
 where
     R: Send + 'static,
 {
-    let (reply_tx, reply_rx) = oneshot::channel::<WorkerResult<R>>();
-    let job = Box::new(move |cache: &mut GeneratorCache| {
+    use crate::WorkerError;
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel::<WorkerResult<R>>();
+    let job: GeneratorJob = Box::new(move |cache: &mut GeneratorCache| {
         let result = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             // Free the resident cached generator (if any) before loading the fresh one, so the pool has
             // room for the large in-place weights. On CUDA `release_backend_cache_after_evict` is a
             // no-op (cudarc has no empty_cache); the drop returns the tensors' allocation to the pool.
             if cache.evict().is_some() {
-                release_backend_cache_after_evict();
+                cache_thread::release_backend_cache_after_evict();
             }
             let generator = load()?;
             run(generator.as_ref())
@@ -507,10 +353,10 @@ where
             Ok(result) => result,
             Err(panic) => {
                 // Post-panic backend state is suspect; the resident (already-evicted) cache stays empty.
-                release_backend_cache_after_evict();
+                cache_thread::release_backend_cache_after_evict();
                 Err(WorkerError::Engine(format!(
                     "generation panicked and was contained (the engine likely ran out of memory): {}",
-                    panic_message(panic.as_ref())
+                    cache_thread::panic_message(panic.as_ref())
                 )))
             }
         };
@@ -527,6 +373,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::WorkerError;
 
     #[test]
     fn cache_key_includes_adapter_fingerprint() {
@@ -556,6 +403,7 @@ mod tests {
     #[test]
     fn fingerprint_tracks_content_change_and_missing_files() {
         use std::io::Write;
+        use std::time::SystemTime;
 
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("weights.safetensors");
@@ -784,13 +632,15 @@ mod tests {
         GeneratorCacheKey::from_load_spec("sc3724_stub", &spec)
     }
 
-    fn stub_cache_entry() -> GeneratorCacheEntry {
-        GeneratorCacheEntry {
-            key: stub_cache_key(),
-            generator: Box::new(StubGenerator {
+    /// Seed the generic cache with a resident stub generator (the test replacement for directly
+    /// assigning the old `GeneratorCache.entry`, now that the entry lives in `cache_thread`).
+    fn seed_stub_entry(cache: &mut GeneratorCache) {
+        cache.install(
+            stub_cache_key(),
+            Box::new(StubGenerator {
                 descriptor: stub_descriptor(),
             }),
-        }
+        );
     }
 
     #[test]
@@ -822,7 +672,7 @@ mod tests {
         });
         let (seed_tx, seed_rx) = mpsc::channel();
         tx.send(Box::new(move |cache: &mut GeneratorCache| {
-            cache.entry = Some(stub_cache_entry());
+            seed_stub_entry(cache);
             seed_tx.send(()).expect("ack cache seed");
         }))
         .expect("seed cache entry");
@@ -842,9 +692,7 @@ mod tests {
             thread::sleep(Duration::from_millis(50));
             let (reply_tx, reply_rx) = mpsc::channel();
             tx.send(Box::new(move |cache: &mut GeneratorCache| {
-                reply_tx
-                    .send(cache.entry.is_none())
-                    .expect("send cache state");
+                reply_tx.send(cache.is_empty()).expect("send cache state");
             }))
             .expect("check cache state");
             if reply_rx
@@ -871,7 +719,7 @@ mod tests {
         });
         let (seed_tx, seed_rx) = mpsc::channel();
         tx.send(Box::new(move |cache: &mut GeneratorCache| {
-            cache.entry = Some(stub_cache_entry());
+            seed_stub_entry(cache);
             seed_tx.send(()).expect("ack cache seed");
         }))
         .expect("seed cache entry");
@@ -883,9 +731,7 @@ mod tests {
 
         let (reply_tx, reply_rx) = mpsc::channel();
         tx.send(Box::new(move |cache: &mut GeneratorCache| {
-            reply_tx
-                .send(cache.entry.is_some())
-                .expect("send cache state");
+            reply_tx.send(!cache.is_empty()).expect("send cache state");
         }))
         .expect("check cache state");
 

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -62,6 +62,12 @@ mod api_client;
 // (sc-5891). Compiles on all targets; the socket I/O is `cfg(unix)` and inert unless
 // the desktop injects `SCENEWORKS_CRED_IPC_*`, so server/Docker/Windows are unaffected.
 mod credentials_ipc;
+// Generic single-resident, dedicated-thread model cache scaffolding (sc-11191, F-019): the
+// `CacheThread<K, M>` + `Fingerprint` + panic/idle-timeout/oneshot-seam machinery shared verbatim by
+// `generator_cache` and `refine_model_cache`. All-targets like its two consumers; off macOS the
+// production seams are cfg'd out, so allow dead_code there (mirrors the generator_cache precedent).
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+mod cache_thread;
 // Backend-neutral generator load/run cache (epic 3720, sc-3724). Typed entirely against
 // `gen_core::*` (no tensor types leak), so it links on ALL targets — the production load seam
 // (`with_cached_generator`) is reached only from the macOS image/video paths, but the all-targets

--- a/crates/sceneworks-worker/src/person_segment.rs
+++ b/crates/sceneworks-worker/src/person_segment.rs
@@ -30,25 +30,14 @@ use mlx_gen_sam2::{Sam2ModelSize, Sam2VideoPredictor};
 
 use crate::{Settings, WorkerError, WorkerResult};
 
-/// Cancel copy surfaced when a segmentation is interrupted by a user cancel — either by the
-/// engine's per-frame propagate cancel contract (gen-core d8038beb) or by the coarse checks
-/// around the cold weight load (sc-8807). Shared by the SAM2/SAM3 segmenter modules.
-pub(crate) const CANCEL_MESSAGE: &str = "Person segmentation canceled by user.";
-
-/// Per-frame propagate progress callback `(frame_index, total_frames)`, invoked from the blocking
-/// thread after each propagated frame (the gen-core d8038beb video per-step progress contract).
-/// Boxed + `Send` so call sites can move it into `spawn_blocking`.
-pub(crate) type SegmentProgress = Box<dyn FnMut(usize, usize) + Send>;
-
-/// Bail out with [`WorkerError::Canceled`] when the threaded flag has been tripped — the coarse
-/// cancel seam guarding the phases the engine cannot observe (frame decode, the cold multi-GB
-/// weight load/parse, quantize). The engine itself checks the same flag between frames (sc-8807).
-pub(crate) fn check_segment_canceled(cancel: Option<&CancelFlag>) -> WorkerResult<()> {
-    if cancel.is_some_and(CancelFlag::is_cancelled) {
-        return Err(WorkerError::Canceled(CANCEL_MESSAGE.to_owned()));
-    }
-    Ok(())
-}
+// The cancel copy / progress alias / coarse-cancel helper shared by the SAM2/SAM3 segmenter modules
+// are hoisted to `person_segment_sam3_common` (sc-11191, F-018): the off-Mac candle SAM3 twin cannot
+// reach this Mac-only module, so a single home there gives all three modules ONE definition (a tweak
+// in one can no longer silently diverge). Re-exported here so existing `person_segment::…` references
+// (and this module's own SAM2 path) keep resolving unchanged.
+pub(crate) use crate::person_segment_sam3_common::{
+    check_segment_canceled, SegmentProgress, CANCEL_MESSAGE,
+};
 
 /// The production SAM2 size (matches the spike + the `SceneWorks/sam2-mlx` upload).
 const SEG_FILE: &str = "sam2.1_hiera_large.safetensors";

--- a/crates/sceneworks-worker/src/person_segment_sam3.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3.rs
@@ -27,7 +27,6 @@ use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
-use crate::person_segment::{check_segment_canceled, SegmentProgress, CANCEL_MESSAGE};
 use gen_core::CancelFlag;
 use mlx_gen::weights::Weights;
 use mlx_gen_sam3::{
@@ -37,8 +36,9 @@ use mlx_gen_sam3::{
 use mlx_rs::Array;
 
 use crate::person_segment_sam3_common::{
-    mask_centroid_x, mask_to_frame, normalize_chw, select_object, BoxNorm, Sam3FrameOutput,
-    CONCEPT_PROMPT, INPUT_SIZE, MASK_GRID,
+    check_segment_canceled, frame_mask_for_object, mask_to_frame, normalize_chw, paint_order,
+    per_frame_masks, select_object, BoxNorm, Sam3FrameOutput, SegmentProgress, CANCEL_MESSAGE,
+    CONCEPT_PROMPT, INPUT_SIZE,
 };
 use crate::{WorkerError, WorkerResult};
 
@@ -414,29 +414,6 @@ pub(crate) fn segment_track_blocking(
     Ok(masks)
 }
 
-/// Emit the selected object's binary mask on one SAM3 frame, or an empty vec when the object
-/// isn't present (legitimate per-frame absence → orchestrator box-fallback). Guards the
-/// `obj_ids`/`masks` parallel-vec assumption: an id present in `obj_ids` but with no matching
-/// entry in `masks` is a malformed engine output, surfaced as an `Engine` error rather than
-/// indexing OOB (sc-8905, F-103).
-fn frame_mask_for_object(
-    frame: &VideoFrameOutput,
-    selected: i32,
-    width: u32,
-    height: u32,
-) -> WorkerResult<Vec<u8>> {
-    let Some(i) = frame.obj_ids.iter().position(|&o| o == selected) else {
-        return Ok(Vec::new());
-    };
-    let logits = frame.masks.get(i).ok_or_else(|| {
-        WorkerError::Engine(format!(
-            "sam3 frame has obj id {selected} at index {i} but only {} masks",
-            frame.masks.len()
-        ))
-    })?;
-    mask_to_frame(logits, MASK_GRID, width, height)
-}
-
 /// Normalize an `[x1, y1, x2, y2]` pixel box (clamped to the image) to SAM3's `[cx, cy, w, h]`
 /// ∈ [0, 1]. SAM3 squashes the image to a fixed 1008² square (NOT aspect-preserving), so a box's
 /// normalized source coordinates equal its normalized model-input coordinates — no letterbox math.
@@ -763,45 +740,11 @@ pub(crate) fn segment_all_persons_in_memory(
             e => WorkerError::Engine(format!("sam3 propagate: {e}")),
         })?;
 
-    // Paint order: each object's centroid-x in the FIRST frame it appears, ascending (tie-break on
-    // first-seen frame, then object id, so repeated runs agree).
-    use std::collections::BTreeMap;
-    let mut first_seen: BTreeMap<i32, (usize, f64)> = BTreeMap::new();
-    for (f, frame) in outputs.iter().enumerate() {
-        for (oid, logits) in frame.obj_ids.iter().zip(&frame.masks) {
-            if first_seen.contains_key(oid) {
-                continue;
-            }
-            if let Some(cx) = mask_centroid_x(logits, MASK_GRID) {
-                first_seen.insert(*oid, (f, cx));
-            }
-        }
-    }
-    let mut order: Vec<i32> = first_seen.keys().copied().collect();
-    order.sort_by(|a, b| {
-        let (fa, xa) = first_seen[a];
-        let (fb, xb) = first_seen[b];
-        xa.partial_cmp(&xb)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then(fa.cmp(&fb))
-            .then(a.cmp(b))
-    });
-
-    // `zip` already bounds to the shorter of obj_ids/masks, so the parallel-vec assumption is
-    // safe here; `mask_to_frame` now returns an `Engine` error on a malformed (grid-mismatched)
-    // mask instead of the empty-vec sentinel, so propagate rather than silently dropping it
-    // (sc-8905, F-103).
-    let per_frame = outputs
-        .iter()
-        .map(|frame| {
-            frame
-                .obj_ids
-                .iter()
-                .zip(&frame.masks)
-                .map(|(oid, logits)| Ok((*oid, mask_to_frame(logits, MASK_GRID, width, height)?)))
-                .collect::<WorkerResult<Vec<_>>>()
-        })
-        .collect::<WorkerResult<Vec<_>>>()?;
+    // Paint order + per-frame masks are backend-neutral pure logic shared with the candle twin via
+    // `person_segment_sam3_common` (sc-11191, F-018), so the tie-break and mask selection stay
+    // byte-identical on both platforms.
+    let order = paint_order(&outputs);
+    let per_frame = per_frame_masks(&outputs, width, height)?;
 
     Ok(AllPersonMasks {
         order,
@@ -815,8 +758,9 @@ pub(crate) fn segment_all_persons_in_memory(
 mod tests {
     use super::*;
     // The checkpoint filenames now live in the shared module; the real-weights smokes below join them
-    // onto a snapshot dir to build the model/tokenizer paths.
-    use crate::person_segment_sam3_common::{MODEL_FILE, TOKENIZER_FILE};
+    // onto a snapshot dir to build the model/tokenizer paths. `MASK_GRID` sizes the synthetic mask
+    // fixtures (the production paths call it inside the shared `person_segment_sam3_common` helpers).
+    use crate::person_segment_sam3_common::{MASK_GRID, MODEL_FILE, TOKENIZER_FILE};
 
     /// sc-8846 / F-044: the smart-select model cache is keyed by `(model_path, quant_bits)`, so a
     /// re-pinned weight snapshot **or** a `SCENEWORKS_SAM3_QUANT` flip is a cache miss (rebuild),

--- a/crates/sceneworks-worker/src/person_segment_sam3_candle.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3_candle.rs
@@ -27,8 +27,9 @@ use candle_gen_sam3::{Sam3TextConfig, Sam3Tokenizer, Sam3VideoModel, VideoFrameO
 use gen_core::CancelFlag;
 
 use crate::person_segment_sam3_common::{
-    mask_centroid_x, mask_to_frame, normalize_chw, select_object, BoxNorm, Sam3FrameOutput,
-    CONCEPT_PROMPT, INPUT_SIZE, MASK_GRID,
+    check_segment_canceled, frame_mask_for_object, normalize_chw, paint_order, per_frame_masks,
+    select_object, BoxNorm, Sam3FrameOutput, SegmentProgress, CANCEL_MESSAGE, CONCEPT_PROMPT,
+    INPUT_SIZE,
 };
 use crate::{WorkerError, WorkerResult};
 
@@ -48,26 +49,6 @@ impl Sam3FrameOutput for VideoFrameOutput {
     fn masks(&self) -> &[Vec<f32>] {
         &self.masks
     }
-}
-
-/// Cancel copy surfaced when a segmentation is interrupted by a user cancel — the candle sibling
-/// of `person_segment::CANCEL_MESSAGE` (Mac-only, so duplicated like the other shared helpers).
-pub(crate) const CANCEL_MESSAGE: &str = "Person segmentation canceled by user.";
-
-/// Per-propagated-frame progress callback `(frame_index, total_frames)` — the candle sibling of
-/// `person_segment::SegmentProgress` (Mac-only, so duplicated like the other shared helpers).
-pub(crate) type SegmentProgress = Box<dyn FnMut(usize, usize) + Send>;
-
-/// Bail out with [`WorkerError::Canceled`] when the threaded flag has been tripped — the coarse
-/// cancel seam guarding frame decode, the cold multi-GB checkpoint parse, and model build/quantize
-/// (sc-8807). The same flag is also threaded into `Sam3VideoModel::propagate`'s per-frame cancel
-/// contract (sc-8972, the candle sibling of gen-core d8038beb), so a tripped flag stops the clip
-/// between propagated frames too.
-fn check_segment_canceled(cancel: Option<&CancelFlag>) -> WorkerResult<()> {
-    if cancel.is_some_and(CancelFlag::is_cancelled) {
-        return Err(WorkerError::Canceled(CANCEL_MESSAGE.to_owned()));
-    }
-    Ok(())
 }
 
 /// Affine-quantization level for the segmenter, from `SCENEWORKS_SAM3_QUANT`: **dense by default**
@@ -239,29 +220,6 @@ pub(crate) fn segment_track_blocking(
     Ok(masks)
 }
 
-/// Emit the selected object's binary mask on one SAM3 frame, or an empty vec when the object
-/// isn't present (legitimate per-frame absence → orchestrator box-fallback). Guards the
-/// `obj_ids`/`masks` parallel-vec assumption: an id present in `obj_ids` but with no matching
-/// entry in `masks` is a malformed engine output, surfaced as an `Engine` error rather than
-/// indexing OOB (sc-8905, F-103). Kept in sync with the MLX twin.
-fn frame_mask_for_object(
-    frame: &VideoFrameOutput,
-    selected: i32,
-    width: u32,
-    height: u32,
-) -> WorkerResult<Vec<u8>> {
-    let Some(i) = frame.obj_ids.iter().position(|&o| o == selected) else {
-        return Ok(Vec::new());
-    };
-    let logits = frame.masks.get(i).ok_or_else(|| {
-        WorkerError::Engine(format!(
-            "sam3 frame has obj id {selected} at index {i} but only {} masks",
-            frame.masks.len()
-        ))
-    })?;
-    mask_to_frame(logits, MASK_GRID, width, height)
-}
-
 /// Segment + track every "person" across already-decoded RGB `frames` with the off-Mac candle SAM3
 /// text-concept (PCS) video pipeline (sc-6837), returning all objects' per-frame masks + the
 /// left-to-right paint order — the input to [`crate::scail2_masks`]. The candle sibling of
@@ -353,45 +311,11 @@ pub(crate) fn segment_all_persons_in_memory(
             e => WorkerError::Engine(format!("sam3 propagate: {e}")),
         })?;
 
-    // Paint order: each object's centroid-x in the FIRST frame it appears, ascending (tie-break on
-    // first-seen frame, then object id, so repeated runs agree). Shared with the MLX module.
-    use std::collections::BTreeMap;
-    let mut first_seen: BTreeMap<i32, (usize, f64)> = BTreeMap::new();
-    for (f, frame) in outputs.iter().enumerate() {
-        for (oid, logits) in frame.obj_ids.iter().zip(&frame.masks) {
-            if first_seen.contains_key(oid) {
-                continue;
-            }
-            if let Some(cx) = mask_centroid_x(logits, MASK_GRID) {
-                first_seen.insert(*oid, (f, cx));
-            }
-        }
-    }
-    let mut order: Vec<i32> = first_seen.keys().copied().collect();
-    order.sort_by(|a, b| {
-        let (fa, xa) = first_seen[a];
-        let (fb, xb) = first_seen[b];
-        xa.partial_cmp(&xb)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then(fa.cmp(&fb))
-            .then(a.cmp(b))
-    });
-
-    // `zip` already bounds to the shorter of obj_ids/masks; `mask_to_frame` now returns an
-    // `Engine` error on a malformed (grid-mismatched) mask instead of the empty-vec sentinel,
-    // so propagate rather than silently dropping it (sc-8905, F-103). Kept in sync with the MLX
-    // twin.
-    let per_frame = outputs
-        .iter()
-        .map(|frame| {
-            frame
-                .obj_ids
-                .iter()
-                .zip(&frame.masks)
-                .map(|(oid, logits)| Ok((*oid, mask_to_frame(logits, MASK_GRID, width, height)?)))
-                .collect::<WorkerResult<Vec<_>>>()
-        })
-        .collect::<WorkerResult<Vec<_>>>()?;
+    // Paint order + per-frame masks are backend-neutral pure logic shared with the MLX twin via
+    // `person_segment_sam3_common` (sc-11191, F-018), so the tie-break and mask selection stay
+    // byte-identical on both platforms.
+    let order = paint_order(&outputs);
+    let per_frame = per_frame_masks(&outputs, width, height)?;
 
     Ok(AllPersonMasks {
         order,

--- a/crates/sceneworks-worker/src/person_segment_sam3_common.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3_common.rs
@@ -14,8 +14,35 @@
 
 use std::path::{Path, PathBuf};
 
+use gen_core::CancelFlag;
+
 use crate::downloads::{ensure_hf_cached_file, DownloadContext};
-use crate::{Settings, WorkerResult};
+use crate::{Settings, WorkerError, WorkerResult};
+
+/// Cancel copy surfaced when a SAM2/SAM3 person segmentation is interrupted by a user cancel — either
+/// by an engine's per-frame propagate cancel contract (gen-core d8038beb / sc-8972) or by the coarse
+/// checks around the cold weight load (sc-8807). Shared by the SAM2 module ([`crate::person_segment`])
+/// and both SAM3 twins (sc-11191, F-018): the candle twin is off-Mac, so it cannot reach the Mac-only
+/// `person_segment`; hoisting the trio here gives both cfg-exclusive twins ONE definition and stops a
+/// tweak in one silently diverging from the other.
+pub(crate) const CANCEL_MESSAGE: &str = "Person segmentation canceled by user.";
+
+/// Per-propagated-frame progress callback `(frame_index, total_frames)`, invoked from the blocking
+/// thread after each propagated frame (the gen-core d8038beb video per-step progress contract).
+/// Boxed + `Send` so call sites can move it into `spawn_blocking`. Shared by the SAM2/SAM3 modules
+/// (sc-11191, F-018).
+pub(crate) type SegmentProgress = Box<dyn FnMut(usize, usize) + Send>;
+
+/// Bail out with [`WorkerError::Canceled`] when the threaded flag has been tripped — the coarse
+/// cancel seam guarding the phases the engine cannot observe (frame decode, the cold multi-GB weight
+/// load/parse, quantize). The engine itself checks the same flag between frames (sc-8807). Shared by
+/// the SAM2/SAM3 modules (sc-11191, F-018).
+pub(crate) fn check_segment_canceled(cancel: Option<&CancelFlag>) -> WorkerResult<()> {
+    if cancel.is_some_and(CancelFlag::is_cancelled) {
+        return Err(WorkerError::Canceled(CANCEL_MESSAGE.to_owned()));
+    }
+    Ok(())
+}
 
 /// SAM3 checkpoint files (loaded stock from `facebook/sam3`, no conversion).
 pub(crate) const MODEL_FILE: &str = "model.safetensors";
@@ -271,6 +298,88 @@ pub(crate) fn mask_centroid_x(mask_logits: &[f32], grid: usize) -> Option<f64> {
     (n > 0).then(|| sum_x / n as f64)
 }
 
+/// Emit the selected object's binary mask on one SAM3 frame, or an empty vec when the object isn't
+/// present (legitimate per-frame absence → orchestrator box-fallback). Guards the `obj_ids`/`masks`
+/// parallel-vec assumption: an id present in `obj_ids` but with no matching entry in `masks` is a
+/// malformed engine output, surfaced as an `Engine` error rather than indexing OOB (sc-8905, F-103).
+///
+/// Generic over [`Sam3FrameOutput`] so the identical selection/emit runs on either backend's frame
+/// type — the last verbatim duplicate between the two SAM3 twins (sc-11191, F-018).
+pub(crate) fn frame_mask_for_object<F: Sam3FrameOutput>(
+    frame: &F,
+    selected: i32,
+    width: u32,
+    height: u32,
+) -> WorkerResult<Vec<u8>> {
+    let Some(i) = frame.obj_ids().iter().position(|&o| o == selected) else {
+        return Ok(Vec::new());
+    };
+    let logits = frame.masks().get(i).ok_or_else(|| {
+        WorkerError::Engine(format!(
+            "sam3 frame has obj id {selected} at index {i} but only {} masks",
+            frame.masks().len()
+        ))
+    })?;
+    mask_to_frame(logits, MASK_GRID, width, height)
+}
+
+/// Stable left-to-right paint order for the SCAIL-2 painter: each object's centroid-x in the FIRST
+/// frame it appears, ascending (tie-break on first-seen frame, then object id, so repeated runs
+/// agree). Generic over [`Sam3FrameOutput`] so both SAM3 twins share ONE definition — a tie-break
+/// tweak can no longer silently change SCAIL-2 palette assignment on one platform only (sc-11191,
+/// F-018).
+pub(crate) fn paint_order<F: Sam3FrameOutput>(outputs: &[F]) -> Vec<i32> {
+    use std::collections::BTreeMap;
+    let mut first_seen: BTreeMap<i32, (usize, f64)> = BTreeMap::new();
+    for (f, frame) in outputs.iter().enumerate() {
+        for (oid, logits) in frame.obj_ids().iter().zip(frame.masks()) {
+            if first_seen.contains_key(oid) {
+                continue;
+            }
+            if let Some(cx) = mask_centroid_x(logits, MASK_GRID) {
+                first_seen.insert(*oid, (f, cx));
+            }
+        }
+    }
+    let mut order: Vec<i32> = first_seen.keys().copied().collect();
+    order.sort_by(|a, b| {
+        let (fa, xa) = first_seen[a];
+        let (fb, xb) = first_seen[b];
+        xa.partial_cmp(&xb)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(fa.cmp(&fb))
+            .then(a.cmp(b))
+    });
+    order
+}
+
+/// Per-frame `(obj_id, binary row-major `width*height` 0/255 mask)` lists — the body of
+/// [`AllPersonMasks::per_frame`], one inner `Vec` per clip frame.
+pub(crate) type PerFrameMasks = Vec<Vec<(i32, Vec<u8>)>>;
+
+/// Map every SAM3 object present on each frame to its `(obj_id, binary mask)` at `width×height` — the
+/// per-frame body of [`AllPersonMasks::per_frame`]. `zip` bounds to the shorter of obj_ids/masks (so
+/// the parallel-vec assumption is safe here); a malformed (grid-mismatched) mask propagates as an
+/// `Engine` error from [`mask_to_frame`] rather than the empty-vec sentinel (sc-8905, F-103). Generic
+/// over [`Sam3FrameOutput`] so both SAM3 twins share ONE definition (sc-11191, F-018).
+pub(crate) fn per_frame_masks<F: Sam3FrameOutput>(
+    outputs: &[F],
+    width: u32,
+    height: u32,
+) -> WorkerResult<PerFrameMasks> {
+    outputs
+        .iter()
+        .map(|frame| {
+            frame
+                .obj_ids()
+                .iter()
+                .zip(frame.masks())
+                .map(|(oid, logits)| Ok((*oid, mask_to_frame(logits, MASK_GRID, width, height)?)))
+                .collect::<WorkerResult<Vec<_>>>()
+        })
+        .collect::<WorkerResult<Vec<_>>>()
+}
+
 /// Every tracked person's per-frame mask + a stable left-to-right paint order — the input to the
 /// SCAIL-2 color-mask painter (sc-5448). Backend-neutral (pure mask bytes): both SAM3 modules build
 /// this and [`crate::scail2_masks`]'s painters consume it. Unlike the per-backend `segment_track`
@@ -282,7 +391,7 @@ pub(crate) struct AllPersonMasks {
     pub order: Vec<i32>,
     /// `per_frame[f]` = `(obj_id, binary mask row-major width*height, 0/255)` for every object
     /// present on frame `f` (empty masks dropped). Object ids index into [`AllPersonMasks::order`].
-    pub per_frame: Vec<Vec<(i32, Vec<u8>)>>,
+    pub per_frame: PerFrameMasks,
     pub width: u32,
     pub height: u32,
 }
@@ -433,6 +542,114 @@ mod tests {
             matches!(result, Err(crate::WorkerError::Engine(ref m)) if m.contains("logits")),
             "mismatched grid length must be rejected, got {result:?}"
         );
+    }
+
+    /// A `MASK_GRID²` mask with the top-left quadrant foreground, for the shared-helper tests below.
+    fn quadrant_mask(top_left: bool) -> Vec<f32> {
+        let g = MASK_GRID;
+        let mut m = vec![-1.0f32; g * g];
+        let (rows, cols) = if top_left {
+            (0..g / 2, 0..g / 2)
+        } else {
+            (g / 2..g, g / 2..g)
+        };
+        for y in rows {
+            for x in cols.clone() {
+                m[y * g + x] = 1.0;
+            }
+        }
+        m
+    }
+
+    /// sc-11191 / F-018 (was sc-8905 / F-103, per twin): the shared `frame_mask_for_object` guards
+    /// the obj_ids/masks parallel-vec assumption — absent id → empty vec (legitimate box-fallback), a
+    /// present-but-unmatched id → `Engine` error (not an OOB index), a well-formed pair → a binary
+    /// mask at the requested dims. Exercised on the backend-neutral `TestFrame` so it covers the
+    /// single copy both twins now delegate to.
+    #[test]
+    fn frame_mask_for_object_selects_guards_and_binarizes() {
+        // obj id 5 present but `masks` empty → parallel-vec violation → Engine error.
+        let malformed = TestFrame {
+            obj_ids: vec![5],
+            masks: vec![],
+        };
+        assert!(
+            matches!(frame_mask_for_object(&malformed, 5, 8, 8), Err(crate::WorkerError::Engine(ref m)) if m.contains("masks")),
+            "obj id without a mask must error"
+        );
+
+        // Selected object absent → empty vec (box fallback), not an error.
+        let absent = TestFrame {
+            obj_ids: vec![9],
+            masks: vec![quadrant_mask(true)],
+        };
+        assert!(
+            frame_mask_for_object(&absent, 5, 8, 8)
+                .expect("absent is not an error")
+                .is_empty(),
+            "absent object → empty mask"
+        );
+
+        // Well-formed pair → binary mask at width*height.
+        let present = TestFrame {
+            obj_ids: vec![5],
+            masks: vec![quadrant_mask(true)],
+        };
+        let mask = frame_mask_for_object(&present, 5, 8, 8).expect("well-formed");
+        assert_eq!(mask.len(), 64);
+        assert!(mask.iter().all(|&v| v == 0 || v == 255), "binary");
+    }
+
+    /// sc-11191 / F-018: the shared `paint_order` sorts objects by first-seen centroid-x ascending
+    /// (leftmost first), tie-breaking on first-seen frame then object id — the SCAIL-2 palette order.
+    /// A left object must precede a right one regardless of obj-id numbering.
+    #[test]
+    fn paint_order_sorts_left_to_right_by_first_seen_centroid() {
+        // obj 8 sits left, obj 3 sits right — order must be by centroid (8 then 3), NOT by id.
+        let outputs = vec![TestFrame {
+            obj_ids: vec![8, 3],
+            masks: vec![quadrant_mask(true), quadrant_mask(false)],
+        }];
+        assert_eq!(paint_order(&outputs), vec![8, 3]);
+
+        // Empty-mask objects (no centroid) are dropped from the order.
+        let empty = vec![TestFrame {
+            obj_ids: vec![1],
+            masks: vec![vec![-1.0f32; MASK_GRID * MASK_GRID]],
+        }];
+        assert!(paint_order(&empty).is_empty());
+    }
+
+    /// sc-11191 / F-018: the shared `per_frame_masks` maps every present object to `(obj_id, binary
+    /// mask)` per frame, and propagates a malformed-mask `Engine` error rather than dropping it.
+    #[test]
+    fn per_frame_masks_maps_all_objects_and_propagates_errors() {
+        let outputs = vec![
+            TestFrame {
+                obj_ids: vec![2, 4],
+                masks: vec![quadrant_mask(true), quadrant_mask(false)],
+            },
+            TestFrame {
+                obj_ids: vec![2],
+                masks: vec![quadrant_mask(true)],
+            },
+        ];
+        let per_frame = per_frame_masks(&outputs, 8, 8).expect("well-formed");
+        assert_eq!(per_frame.len(), 2);
+        assert_eq!(per_frame[0].len(), 2);
+        assert_eq!(per_frame[0][0].0, 2);
+        assert_eq!(per_frame[0][0].1.len(), 64);
+        assert_eq!(per_frame[1].len(), 1);
+
+        // A grid-mismatched mask surfaces as an Engine error (not a silently dropped frame).
+        let bad = vec![TestFrame {
+            obj_ids: vec![7],
+            masks: vec![vec![1.0f32; 10]],
+        }];
+        assert!(matches!(
+            per_frame_masks(&bad, 8, 8),
+            Err(crate::WorkerError::Engine(_))
+        ));
     }
 
     fn f011_test_settings(data_dir: PathBuf) -> Settings {

--- a/crates/sceneworks-worker/src/refine_model_cache.rs
+++ b/crates/sceneworks-worker/src/refine_model_cache.rs
@@ -17,35 +17,40 @@
 //! (`SCENEWORKS_GENERATOR_CACHE_IDLE_SECONDS`, default 300 s), so the two caches age out together and
 //! a single setting bounds resident model memory across both lanes.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::{mpsc, OnceLock};
 use std::thread;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use gen_core::core_llm::{
     load_for_model_with, Constraint, LoadSpec, ModelRequirements, Quantize, TextLlm,
 };
-use tokio::sync::oneshot;
 
+use crate::cache_thread::{self, CacheJob, CacheThread, Fingerprint, SeamMessages};
 use crate::{WorkerError, WorkerResult};
 
-type RefineJob = Box<dyn FnOnce(&mut RefineModelCache) + Send + 'static>;
+/// The refine cache is a single-resident [`CacheThread`] keyed by [`RefineModelCacheKey`], holding a
+/// loaded `Box<dyn TextLlm>`. The generic scaffolding (dedicated worker thread, idle-timeout
+/// eviction, panic containment, `Fingerprint`, oneshot-reply seam) lives in [`crate::cache_thread`];
+/// this module supplies only the key derivation, the loader, and the message strings (sc-11191, F-019).
+// Referenced only from the tests' worker closures (the production seam infers the `CacheThread` type
+// from the job channel), so it reads as dead on the non-test lib build.
+#[allow(dead_code)]
+type RefineModelCache = CacheThread<RefineModelCacheKey, Box<dyn TextLlm>>;
+type RefineJob = CacheJob<RefineModelCacheKey, Box<dyn TextLlm>>;
 
 /// Reuse the generator cache's idle-eviction knob so both resident-model caches age out on the same
 /// window and one setting bounds memory across the image/video AND text lanes.
 const REFINE_CACHE_IDLE_SECONDS_ENV: &str = "SCENEWORKS_GENERATOR_CACHE_IDLE_SECONDS";
 const DEFAULT_REFINE_CACHE_IDLE_SECONDS: u64 = 300;
 
+/// The refine cache DOES free the backend cache before a cold load (unlike the generator cache): the
+/// prior resident ~16 GB model's backend allocation is released BEFORE the new load allocates, so
+/// peak memory is one model, not two. This is the deliberate divergence from the generator cache —
+/// see the [`crate::cache_thread`] module docs; do not silently unify it away.
+const REFINE_EVICT_BEFORE_LOAD: bool = true;
+
 static REFINE_WORKER: OnceLock<mpsc::Sender<RefineJob>> = OnceLock::new();
-
-struct RefineModelCache {
-    entry: Option<RefineModelCacheEntry>,
-}
-
-struct RefineModelCacheEntry {
-    key: RefineModelCacheKey,
-    model: Box<dyn TextLlm>,
-}
 
 /// Identity of a loaded refine model. Two loads collide (a cache hit) iff they would produce the
 /// same resident model: the same weights source + quantization, resolved against the same selection
@@ -60,40 +65,6 @@ pub(crate) struct RefineModelCacheKey {
     vision: bool,
     video: bool,
     constraints: Vec<Constraint>,
-}
-
-/// Content-change proxy for the weights snapshot dir referenced in the cache key. We stat `(size,
-/// mtime)` rather than hashing multi-GB weights: mtime+size is a cheap, good content-change proxy,
-/// and a re-convert lands via a finalize/rename that bumps the dir's mtime, so a re-converted
-/// snapshot at the same path is a distinct key (same rationale as `generator_cache::Fingerprint`).
-#[derive(Clone, Debug, PartialEq, Eq)]
-enum Fingerprint {
-    /// `metadata()` succeeded: `(len, modified)`. `modified` is `None` on the rare platform/FS that
-    /// reports no mtime, in which case `len` alone carries the weaker signal.
-    Present {
-        size: u64,
-        mtime: Option<SystemTime>,
-    },
-    /// `metadata()` errored (path missing / transient stat failure / permissions). Kept DISTINCT
-    /// from any `Present` value so a stat error forces a MISS (rebuild) rather than serving a stale
-    /// entry — the load that follows surfaces the real error. Two `Unavailable`s compare equal
-    /// (`Eq` stays reflexive), but that only arises when the file is genuinely gone on both keys, in
-    /// which case the reload fails loudly anyway.
-    Unavailable,
-}
-
-impl Fingerprint {
-    /// Snapshot `(size, mtime)` for `path` once at key-construction time so the fingerprint is
-    /// stable across the lookup within a single request (no mtime drift mid-request).
-    fn of(path: &Path) -> Self {
-        match std::fs::metadata(path) {
-            Ok(meta) => Self::Present {
-                size: meta.len(),
-                mtime: meta.modified().ok(),
-            },
-            Err(_) => Self::Unavailable,
-        }
-    }
 }
 
 impl RefineModelCacheKey {
@@ -111,50 +82,6 @@ impl RefineModelCacheKey {
     }
 }
 
-impl RefineModelCache {
-    fn new() -> Self {
-        Self { entry: None }
-    }
-
-    /// Drop the resident model so the next job reloads from scratch. Returns the evicted key for the
-    /// idle-eviction log.
-    fn evict(&mut self) -> Option<RefineModelCacheKey> {
-        self.entry.take().map(|entry| entry.key)
-    }
-
-    /// Load (on a miss) or reuse (on a hit) the model for `key`/`spec`/`reqs`, then run `run` against
-    /// it. A miss first drops the resident model (single-resident: only one refine model in memory at
-    /// a time) so the old ~16 GB weights are freed before the new load allocates.
-    fn with_model<R>(
-        &mut self,
-        key: RefineModelCacheKey,
-        spec: LoadSpec,
-        reqs: ModelRequirements,
-        load_error_context: String,
-        run: impl FnOnce(&dyn TextLlm) -> WorkerResult<R>,
-    ) -> WorkerResult<R> {
-        if self.entry.as_ref().map_or(true, |entry| entry.key != key) {
-            // Free the prior resident model BEFORE loading the new one so peak memory is one model,
-            // not two.
-            self.entry = None;
-            release_backend_cache_after_evict();
-            let model = load_for_model_with(&spec, &reqs)
-                .map_err(|error| WorkerError::Engine(format!("{load_error_context}: {error}")))?;
-            self.entry = Some(RefineModelCacheEntry {
-                key: key.clone(),
-                model,
-            });
-        }
-
-        let Some(entry) = self.entry.as_ref() else {
-            return Err(WorkerError::Engine(
-                "Refine model cache entry missing after load.".to_owned(),
-            ));
-        };
-        run(entry.model.as_ref())
-    }
-}
-
 fn refine_worker() -> &'static mpsc::Sender<RefineJob> {
     REFINE_WORKER.get_or_init(|| {
         let (tx, rx) = mpsc::channel::<RefineJob>();
@@ -169,56 +96,22 @@ fn refine_worker() -> &'static mpsc::Sender<RefineJob> {
     })
 }
 
+/// Thin wrapper over the generic [`cache_thread::run_cache_worker`]: evict-before-load
+/// ([`REFINE_EVICT_BEFORE_LOAD`]) to bound peak memory to one ~16 GB model, plus the refine-specific
+/// idle-eviction log.
 fn run_refine_cache_worker(rx: mpsc::Receiver<RefineJob>, idle_timeout: Option<Duration>) {
-    let mut cache = RefineModelCache::new();
-    loop {
-        let job = match recv_refine_job(&rx, idle_timeout) {
-            RefineWorkerEvent::Job(job) => job,
-            RefineWorkerEvent::IdleTimeout => {
-                if let Some(key) = cache.evict() {
-                    release_backend_cache_after_evict();
-                    tracing::info!(
-                        event = "refine_model_cache_idle_evicted",
-                        source = %key.source.display(),
-                        idleSeconds = idle_timeout.map_or(0, |timeout| timeout.as_secs()),
-                    );
-                }
-                continue;
-            }
-            RefineWorkerEvent::Disconnected => break,
-        };
-        // Backstop: contain any panic that escapes a job's own guard so this single shared cache
-        // thread can never die and poison every later refine (mirrors sc-6067 in generator_cache).
-        // The cache is reset on a contained panic because post-abort MLX/Metal state is suspect.
-        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| job(&mut cache))).is_err()
-            && cache.evict().is_some()
-        {
-            release_backend_cache_after_evict();
-        }
-    }
-}
-
-enum RefineWorkerEvent {
-    Job(RefineJob),
-    IdleTimeout,
-    Disconnected,
-}
-
-fn recv_refine_job(
-    rx: &mpsc::Receiver<RefineJob>,
-    idle_timeout: Option<Duration>,
-) -> RefineWorkerEvent {
-    match idle_timeout {
-        Some(timeout) => match rx.recv_timeout(timeout) {
-            Ok(job) => RefineWorkerEvent::Job(job),
-            Err(mpsc::RecvTimeoutError::Timeout) => RefineWorkerEvent::IdleTimeout,
-            Err(mpsc::RecvTimeoutError::Disconnected) => RefineWorkerEvent::Disconnected,
+    cache_thread::run_cache_worker(
+        rx,
+        idle_timeout,
+        REFINE_EVICT_BEFORE_LOAD,
+        |key: &RefineModelCacheKey, idle_seconds| {
+            tracing::info!(
+                event = "refine_model_cache_idle_evicted",
+                source = %key.source.display(),
+                idleSeconds = idle_seconds,
+            );
         },
-        None => match rx.recv() {
-            Ok(job) => RefineWorkerEvent::Job(job),
-            Err(_) => RefineWorkerEvent::Disconnected,
-        },
-    }
+    );
 }
 
 fn refine_cache_idle_timeout_from_env() -> Option<Duration> {
@@ -226,39 +119,28 @@ fn refine_cache_idle_timeout_from_env() -> Option<Duration> {
 }
 
 fn refine_cache_idle_timeout(raw: Option<&str>) -> Option<Duration> {
-    let seconds = raw
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .and_then(|value| value.parse::<u64>().ok())
-        .unwrap_or(DEFAULT_REFINE_CACHE_IDLE_SECONDS);
-    (seconds > 0).then(|| Duration::from_secs(seconds))
+    cache_thread::idle_timeout_from_secs(raw, DEFAULT_REFINE_CACHE_IDLE_SECONDS)
 }
 
-#[cfg(all(target_os = "macos", not(test)))]
-fn release_backend_cache_after_evict() {
-    mlx_rs::memory::clear_cache();
-}
-
-#[cfg(any(not(target_os = "macos"), test))]
-fn release_backend_cache_after_evict() {}
-
-/// Best-effort human-readable text from a caught panic payload (the `&str`/`String` a `panic!`
-/// produces), so a contained mlx-rs `.unwrap()`/`.expect()` panic surfaces its real cause.
-fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
-    if let Some(s) = payload.downcast_ref::<&str>() {
-        (*s).to_owned()
-    } else if let Some(s) = payload.downcast_ref::<String>() {
-        s.clone()
-    } else {
-        "unknown panic payload".to_owned()
-    }
-}
+/// User-facing message strings for the refine cache seam, preserving the exact wording the worker
+/// emitted before the `cache_thread` extraction (sc-11191, F-019).
+const REFINE_SEAM_MESSAGES: SeamMessages = SeamMessages {
+    entry_missing: "Refine model cache entry missing after load.",
+    panic_reset: "Refine generation panicked and was contained (the engine likely ran out of \
+                  memory; the cached model was reset)",
+    worker_stopped: "Refine model cache worker stopped",
+    worker_dropped: "Refine model cache worker dropped the job result",
+};
 
 /// Run `run` against the cached (or freshly loaded) refine model for `spec`/`reqs`. Mirrors
 /// [`crate::generator_cache::with_cached_generator`]: the model lives on the dedicated cache thread,
 /// `run` executes there (so it may hold a `!Send` reference to the model), and only the `R` result
 /// crosses back. `run` is where the caller drives `model.generate(...)` — streaming tokens through
 /// its own callback and honoring the request's cancel flag.
+///
+/// A cache miss frees the prior resident model's backend allocation BEFORE loading the new one
+/// (evict-before-load, [`REFINE_EVICT_BEFORE_LOAD`]) so peak memory is one ~16 GB model, not two —
+/// the deliberate divergence from the generator cache.
 pub(crate) async fn with_cached_refiner<R>(
     spec: LoadSpec,
     reqs: ModelRequirements,
@@ -270,35 +152,18 @@ where
 {
     let key = RefineModelCacheKey::new(&spec, &reqs);
     let load_error_context = load_error_context.into();
-    let (reply_tx, reply_rx) = oneshot::channel::<WorkerResult<R>>();
-    let job = Box::new(move |cache: &mut RefineModelCache| {
-        // Contain a panic from inside the provider (e.g. mlx-rs `.unwrap()`-ing a Metal allocation
-        // failure) so it fails THIS job with a clean error instead of unwinding out of the shared
-        // cache thread and stopping every subsequent refine. The cached model is evicted on panic —
-        // post-abort MLX/Metal state is suspect, so the next job reloads fresh.
-        let result = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            cache.with_model(key, spec, reqs, load_error_context, run)
-        })) {
-            Ok(result) => result,
-            Err(panic) => {
-                if cache.evict().is_some() {
-                    release_backend_cache_after_evict();
-                }
-                Err(WorkerError::Engine(format!(
-                    "Refine generation panicked and was contained (the engine likely ran out of \
-                     memory; the cached model was reset): {}",
-                    panic_message(panic.as_ref())
-                )))
-            }
-        };
-        let _ = reply_tx.send(result);
-    });
-    refine_worker()
-        .send(job)
-        .map_err(|_| WorkerError::Engine("Refine model cache worker stopped".to_owned()))?;
-    reply_rx.await.map_err(|_| {
-        WorkerError::Engine("Refine model cache worker dropped the job result".to_owned())
-    })?
+    // The loader owns the refine-specific error-context wrapping; evict-before-load happens in the
+    // generic `CacheThread::with_model` before this runs (see `REFINE_EVICT_BEFORE_LOAD`).
+    let load = move || {
+        load_for_model_with(&spec, &reqs)
+            .map_err(|error| WorkerError::Engine(format!("{load_error_context}: {error}")))
+    };
+    // Adapt the user's `&dyn TextLlm` run closure to the generic cache's resident `Box<dyn TextLlm>`.
+    // The `&Box<_>` param is inherent to the seam (the cache stores the boxed trait object), so
+    // silence the borrowed-box lint here rather than boxing/unboxing again.
+    #[allow(clippy::borrowed_box)]
+    let run = move |model: &Box<dyn TextLlm>| run(&**model);
+    cache_thread::run_cached(refine_worker(), key, load, run, REFINE_SEAM_MESSAGES).await
 }
 
 #[cfg(test)]
@@ -382,6 +247,7 @@ mod tests {
     #[test]
     fn cache_key_changes_when_weights_dir_is_replaced_at_same_path() {
         use std::io::Write;
+        use std::time::SystemTime;
 
         let dir = tempfile::tempdir().expect("tempdir");
         let source = dir.path().join("snapshot");
@@ -473,11 +339,14 @@ mod tests {
         }
     }
 
-    fn stub_entry() -> RefineModelCacheEntry {
-        RefineModelCacheEntry {
-            key: RefineModelCacheKey::new(&spec("/models/stub"), &ModelRequirements::default()),
-            model: Box::new(StubLlm),
-        }
+    fn stub_key() -> RefineModelCacheKey {
+        RefineModelCacheKey::new(&spec("/models/stub"), &ModelRequirements::default())
+    }
+
+    /// Seed the generic cache with a resident stub model (the test replacement for directly assigning
+    /// the old `RefineModelCache.entry`, now that the entry lives in `cache_thread`).
+    fn seed_stub_entry(cache: &mut RefineModelCache) {
+        cache.install(stub_key(), Box::new(StubLlm));
     }
 
     #[test]
@@ -488,7 +357,7 @@ mod tests {
         });
         let (seed_tx, seed_rx) = mpsc::channel();
         tx.send(Box::new(move |cache: &mut RefineModelCache| {
-            cache.entry = Some(stub_entry());
+            seed_stub_entry(cache);
             seed_tx.send(()).expect("ack cache seed");
         }))
         .expect("seed cache entry");
@@ -504,9 +373,7 @@ mod tests {
             thread::sleep(Duration::from_millis(50));
             let (reply_tx, reply_rx) = mpsc::channel();
             tx.send(Box::new(move |cache: &mut RefineModelCache| {
-                reply_tx
-                    .send(cache.entry.is_none())
-                    .expect("send cache state");
+                reply_tx.send(cache.is_empty()).expect("send cache state");
             }))
             .expect("check cache state");
             if reply_rx
@@ -533,7 +400,7 @@ mod tests {
         });
         let (seed_tx, seed_rx) = mpsc::channel();
         tx.send(Box::new(move |cache: &mut RefineModelCache| {
-            cache.entry = Some(stub_entry());
+            seed_stub_entry(cache);
             seed_tx.send(()).expect("ack cache seed");
         }))
         .expect("seed cache entry");
@@ -545,9 +412,7 @@ mod tests {
 
         let (reply_tx, reply_rx) = mpsc::channel();
         tx.send(Box::new(move |cache: &mut RefineModelCache| {
-            reply_tx
-                .send(cache.entry.is_some())
-                .expect("send cache state");
+            reply_tx.send(!cache.is_empty()).expect("send cache state");
         }))
         .expect("check cache state");
         assert!(
@@ -566,20 +431,20 @@ mod tests {
     // changes across a miss by tracking a load counter.
     #[test]
     fn with_model_reuses_on_hit_and_reloads_on_miss() {
-        // Drive the cache directly (not through the async worker) so we can count loads. `with_model`
-        // itself calls the real `load_for_model_with`, so instead we assert the reuse policy on the
-        // entry lifecycle: seed an entry, then a matching key must keep it and a differing key must
-        // replace it. We stub the load by pre-seeding and checking `entry` identity via the key.
-        let mut cache = RefineModelCache::new();
-        cache.entry = Some(stub_entry());
-        let seeded_key = cache.entry.as_ref().map(|e| e.key.clone()).unwrap();
+        // Drive the cache directly (not through the async worker) so we can assert the reuse policy on
+        // the entry lifecycle: seed an entry, then a matching key must keep it resident and a differing
+        // key must be a miss. (`with_model` calls the real `load_for_model_with`, so we exercise the
+        // key identity rather than a real load.)
+        let mut cache = RefineModelCache::new(REFINE_EVICT_BEFORE_LOAD);
+        seed_stub_entry(&mut cache);
+        let seeded_key = cache.resident_key().cloned().unwrap();
 
         // Same key → hit: the entry is untouched (same key still resident).
         let hit_key =
             RefineModelCacheKey::new(&spec("/models/stub"), &ModelRequirements::default());
         assert_eq!(seeded_key, hit_key);
         assert!(
-            cache.entry.as_ref().is_some_and(|e| e.key == hit_key),
+            cache.resident_key() == Some(&hit_key),
             "a matching key must keep the resident model"
         );
 


### PR DESCRIPTION
Closes sc-11191 (epic 11147). Behavior-preserving refactor removing two verbatim-duplication clusters flagged in the code review.

## F-019 — Deduplicate the generator/refine cache-thread scaffolding

`generator_cache.rs` and `refine_model_cache.rs` re-implemented the same single-resident, dedicated-OS-thread cache almost verbatim (~250 lines each): a `Fingerprint` content-change proxy, a `panic_message` payload formatter, the worker event loop, idle-timeout eviction, evict-on-panic containment, and the `oneshot`-reply job seam.

- New `cache_thread` module with a generic `CacheThread<K, M>` (parameterized over cache key, resident model, and a caller-supplied loader closure) plus the shared `Fingerprint`, `panic_message`, `idle_timeout_from_secs`, `release_backend_cache_after_evict`, worker loop (`run_cache_worker`), and async seam (`run_cached`).
- Both caches are now thin wrappers supplying only their key derivation, loader, idle-eviction log, and message strings.
- **KNOWN DRIFT preserved, not unified:** the refine cache frees the backend cache *before* loading a miss (to bound peak to one ~16 GB model); the generator cache does not. This is kept EXACTLY as a per-cache `evict_before_load` parameter (`GENERATOR_EVICT_BEFORE_LOAD = false`, `REFINE_EVICT_BEFORE_LOAD = true`) and documented with a do-not-unify note in the `cache_thread` module docs. All user-facing message strings are byte-identical to before.

## F-018 — Hoist the verbatim-duplicated SAM3 twin logic

`person_segment_sam3.rs` (mlx) and `person_segment_sam3_candle.rs` (candle) duplicated three tensor-independent blocks line-for-line — `frame_mask_for_object`, the paint-order computation, and the per-frame `obj_ids×masks → mask_to_frame` mapping — plus the cancel-message / progress-alias / coarse-cancel-helper trio (candle re-declared what `person_segment` owns, since the Mac-only SAM2 module is unreachable off-Mac).

- Added generic `frame_mask_for_object<F: Sam3FrameOutput>`, `paint_order<F>`, and `per_frame_masks<F>` to `person_segment_sam3_common`, and hoisted `CANCEL_MESSAGE` / `SegmentProgress` / `check_segment_canceled` there.
- Both SAM3 twins now delegate; `person_segment` (SAM2) re-exports the trio so a single definition serves all three modules. The tie-break / paint-order / mask-selection results are **byte-identical on both platforms** — a tweak can no longer silently change SCAIL-2 palette or replace-person mask selection on one platform only.

## Testing

- Full existing `sceneworks-worker` suite preserved and green: **770 → 770** existing tests + **9 new** (761 → 770 total lib): `cargo test -p sceneworks-worker` passes (770 passed, 0 failed).
- Added focused unit tests for the extracted helpers: `CacheThread` reuse/reload + the `evict_before_load` flag + idle-timeout parse (6 in `cache_thread`), and `frame_mask_for_object` / `paint_order` / `per_frame_masks` selection/ordering/error-propagation on a small fixture (3 in `_common`).
- Verified on macOS: `cargo build`, `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --all --check`, and `cargo clippy --all-targets --target x86_64-unknown-linux-gnu -- -D warnings` (non-candle) all green.
- The candle SAM3 twin is `backend-candle` + `cfg(not(macos))` gated; `cudarc` needs a CUDA toolkit absent from this Mac, so its edits were verified by inspection (CI's candle-worker / build-windows lanes compile it). Every symbol it references resolves to a shared `_common` item and no removed local is still referenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)