### PR TITLE
perf(web): virtualize Library asset grid + Logs screen (sc-11224)

### DIFF
--- a/apps/web/src/components/AssetGrid.test.jsx
+++ b/apps/web/src/components/AssetGrid.test.jsx
@@ -8,6 +8,17 @@ const assets = [
   { id: "b", type: "image", displayName: "two.png", file: { path: "assets/two.png", mimeType: "image/png" }, projectId: "p1" },
 ];
 
+// A video asset with a server-advertised poster — the grid must paint the poster
+// <img>, never a full <video controls preload="metadata"> (sc-11224 / F-032).
+const videoAsset = {
+  id: "v",
+  type: "video",
+  displayName: "clip.mp4",
+  file: { path: "assets/clip.mp4", mimeType: "video/mp4" },
+  projectId: "p1",
+  posterUrl: "/api/v1/projects/p1/files/assets/clip.poster.jpg",
+};
+
 describe("AssetGrid multi-select (sc-6112)", () => {
   let container;
   let root;
@@ -67,6 +78,54 @@ describe("AssetGrid multi-select (sc-6112)", () => {
     // The tile body still drives single-select (the detail flow is unchanged).
     await act(async () => tiles()[0].click());
     expect(setSelectedAssetId).toHaveBeenCalledWith("a");
+  });
+
+  it("renders poster thumbnails, not full <video>/full-res media, in grid tiles (sc-11224 F-032)", async () => {
+    const setSelectedAssetId = vi.fn();
+    await act(() => {
+      root.render(
+        <AssetGrid assets={[videoAsset, ...assets]} onPreview={vi.fn()} selectedAsset={null} setSelectedAssetId={setSelectedAssetId} />,
+      );
+    });
+    // No full <video> element is mounted for the video tile — the poster <img> is used
+    // instead (pre-fix the grid rendered a <video controls preload="metadata">).
+    expect(container.querySelectorAll("video")).toHaveLength(0);
+    // Every tile (1 video poster + 2 image thumbs) paints an <img> thumbnail.
+    expect(container.querySelectorAll(".asset-tile img")).toHaveLength(3);
+    // Clicking the video tile still drives single-select — interactions are preserved.
+    await act(async () => tiles()[0].click());
+    expect(setSelectedAssetId).toHaveBeenCalledWith("v");
+  });
+
+  it("applies the content-visibility windowing class to single-select grid cells (sc-11224 F-032)", async () => {
+    await act(() => {
+      root.render(<AssetGrid assets={assets} onPreview={vi.fn()} selectedAsset={null} setSelectedAssetId={vi.fn()} />);
+    });
+    // In single-select the tile button IS the grid cell, so it carries the class.
+    expect(container.querySelectorAll(".asset-tile.asset-tile-windowed")).toHaveLength(assets.length);
+  });
+
+  it("windows multi-select cells at the wrap (not the inner button) and still toggles (sc-11224 F-032)", async () => {
+    const onToggleSelect = vi.fn();
+    await act(() => {
+      root.render(
+        <AssetGrid
+          assets={assets}
+          onPreview={vi.fn()}
+          selectedAsset={null}
+          setSelectedAssetId={vi.fn()}
+          selectedIds={new Set()}
+          onToggleSelect={onToggleSelect}
+        />,
+      );
+    });
+    // The grid cell is the wrap in multi-select, so IT carries the windowing class;
+    // the inner button must NOT (avoids nesting two content-visibility containers).
+    expect(container.querySelectorAll(".asset-tile-wrap.asset-tile-windowed")).toHaveLength(assets.length);
+    expect(container.querySelectorAll(".asset-tile.asset-tile-windowed")).toHaveLength(0);
+    // Checkbox toggling is unaffected.
+    await act(async () => checks()[0].click());
+    expect(onToggleSelect).toHaveBeenCalledWith("a");
   });
 
   it("suppresses the native context menu on a Library grid thumbnail cell (sc-8731) without breaking selection", async () => {

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -3,7 +3,7 @@ import { isAbortError } from "../api.js";
 import { assetMatchesCharacter } from "../characterMembership.js";
 import { saveAssetAs, revealAsset } from "../assetActions.js";
 import { isDesktop, isPageFullscreen, setViewerFullscreen } from "../runtime.js";
-import { AssetMedia, assetCanRenderAsVideo, assetUrl, suppressThumbnailContextMenu } from "./assetMedia.jsx";
+import { AssetMedia, AssetThumbnail, assetCanRenderAsVideo, assetUrl, suppressThumbnailContextMenu } from "./assetMedia.jsx";
 import { DocumentView } from "./DocumentView.jsx";
 import { Icon } from "./Icons.jsx";
 import { LikenessBadge } from "./LikenessBadge.jsx";
@@ -290,6 +290,16 @@ function CharacterAssetLinker({ asset, characters = [], onMoveToCharacter }) {
 // checkbox (a sibling of the tile button, so no interactive element nests inside the
 // button) toggling membership in `selectedIds`. The tile-body click still drives the
 // single-select detail flow unchanged, so the default Library behavior is preserved.
+//
+// Perf (sc-11224 / F-032): grid tiles render `AssetThumbnail` (the poster/JPEG path),
+// NOT the full-resolution `AssetMedia`, so a few-hundred-asset project no longer decodes
+// hundreds of originals or mounts a `<video preload="metadata">` per clip on every visit.
+// Each grid cell also carries the `asset-tile-windowed` class, which applies
+// `content-visibility: auto` (styles.css) so off-screen tiles skip layout/paint/decode
+// until scrolled near — a dependency-free windowing (react-window is not a dep). Clicking
+// a tile still opens the full asset via the detail/preview flow; the thumbnail only
+// changes what the grid paints, not what selection/open resolve to. Applies to every grid
+// that shares this component (Library, Pose Library, character-asset views).
 export function AssetGrid({ assets, onPreview, selectedAsset, setSelectedAssetId, selectedIds = null, onToggleSelect = null }) {
   if (!assets.length) {
     return <div className="empty-panel">No assets in this view</div>;
@@ -299,15 +309,20 @@ export function AssetGrid({ assets, onPreview, selectedAsset, setSelectedAssetId
   return (
     <div className="asset-grid">
       {assets.map((asset) => {
+        // In single-select mode the button IS the grid cell, so it carries the
+        // windowing class; in multi-select the wrap is the cell (below).
+        const tileClasses = ["asset-tile"];
+        if (selectedAsset?.id === asset.id) tileClasses.push("active");
+        if (!multi) tileClasses.push("asset-tile-windowed");
         const tile = (
           <button
-            className={selectedAsset?.id === asset.id ? "asset-tile active" : "asset-tile"}
+            className={tileClasses.join(" ")}
             onClick={() => setSelectedAssetId(asset.id)}
             onContextMenu={suppressThumbnailContextMenu}
             onDoubleClick={() => onPreview(asset)}
             type="button"
           >
-            <AssetMedia asset={asset} />
+            <AssetThumbnail asset={asset} />
             <strong>{asset.displayName}</strong>
             {Array.isArray(asset.tags) && asset.tags.length ? (
               <div className="asset-tile-tags">
@@ -323,8 +338,10 @@ export function AssetGrid({ assets, onPreview, selectedAsset, setSelectedAssetId
         if (!multi) {
           return React.cloneElement(tile, { key: asset.id });
         }
+        const wrapClasses = ["asset-tile-wrap", "asset-tile-windowed"];
+        if (selectedIds?.has(asset.id)) wrapClasses.push("selected");
         return (
-          <div className={selectedIds?.has(asset.id) ? "asset-tile-wrap selected" : "asset-tile-wrap"} key={asset.id}>
+          <div className={wrapClasses.join(" ")} key={asset.id}>
             <label className="asset-tile-check">
               <input
                 aria-label={`Select ${asset.displayName}`}

--- a/apps/web/src/screens/LogsScreen.jsx
+++ b/apps/web/src/screens/LogsScreen.jsx
@@ -29,6 +29,19 @@ const POLL_MS = 2000;
 // no shared constant across the HTTP/FFI boundary, so this is pinned by comment.
 const SESSION_LOG_CAPACITY = 5000; // == sceneworks-core session_log DEFAULT_CAPACITY
 const MAX_ROWS = SESSION_LOG_CAPACITY;
+// Render-window cap (sc-11224 / F-033). The in-memory snapshot mirrors the whole
+// 5,000-entry server buffer so search stays complete, but mounting all 5,000 as DOM
+// rows — and re-rendering them every 2s poll — is the actual cost. The viewer is a
+// live tail: newest rows matter, so we render only the last LOG_RENDER_WINDOW rows of
+// the (already search-filtered) list. Search still runs over the ENTIRE snapshot
+// (visibleEntries below); windowing only bounds how many *matches* we paint, always
+// the newest — which is what auto-scroll-to-bottom shows anyway.
+const LOG_RENDER_WINDOW = 400;
+// Poll backoff (sc-11224 / F-033). A healthy poll keeps the 2s cadence; consecutive
+// failures back off exponentially up to a cap so a dead API (e.g. remote-auth mode
+// with an unreachable host) isn't hammered every 2s forever. Mirrors the media-ticket
+// / access-probe backoff loop in hooks/useAccessGate.js. Reset to POLL_MS on success.
+const POLL_BACKOFF_MAX_MS = 30000;
 // The full snapshot is already in memory, so text search filters client-side
 // over the held `entries` instead of refetching. We still debounce the term
 // before it drives the (cheap, in-memory) filter to keep typing snappy on large
@@ -97,9 +110,11 @@ export function LogsScreen() {
     }
   }, [token, source, level]);
 
-  // Incremental tail: append only entries newer than the last seq we hold.
+  // Incremental tail: append only entries newer than the last seq we hold. Returns
+  // `true` when the tick is healthy (a successful fetch, or a paused no-op) and
+  // `false` when the fetch failed, so the scheduler below can back off (sc-11224).
   const poll = useCallback(async () => {
-    if (pausedRef.current) return;
+    if (pausedRef.current) return true;
     try {
       // Incremental: afterSeq means the server only returns rows newer than the
       // ones we hold, so this is a small delta each tick — raising the cap to the
@@ -111,15 +126,20 @@ export function LogsScreen() {
         source,
         level,
       });
-      if (!rows.length) return;
+      if (!rows.length) {
+        setError("");
+        return true;
+      }
       lastSeqRef.current = rows[rows.length - 1].seq;
       setEntries((prev) => {
         const merged = prev.concat(rows);
         return merged.length > MAX_ROWS ? merged.slice(merged.length - MAX_ROWS) : merged;
       });
       setError("");
+      return true;
     } catch (err) {
       setError(String(err?.message ?? err));
+      return false;
     }
   }, [token, source, level]);
 
@@ -150,9 +170,44 @@ export function LogsScreen() {
     });
   }, [entries, debouncedSearch]);
 
+  // Windowed render tail (sc-11224 / F-033): `visibleEntries` already ran the search
+  // over the ENTIRE snapshot, so every match is accounted for; we only paint the last
+  // LOG_RENDER_WINDOW of them. The live tail auto-scrolls to the newest row, so the
+  // window is exactly what the user sees. `hiddenCount` surfaces how many older
+  // (matching) rows are scrolled out of the rendered window.
+  const renderedEntries =
+    visibleEntries.length > LOG_RENDER_WINDOW ? visibleEntries.slice(-LOG_RENDER_WINDOW) : visibleEntries;
+  const hiddenCount = visibleEntries.length - renderedEntries.length;
+
+  // Self-scheduling poll with failure backoff (sc-11224 / F-033). Replaces a fixed
+  // setInterval that fired every 2s regardless of outcome — a dead API in remote-auth
+  // mode was hammered forever. A healthy tick re-arms at POLL_MS; consecutive failures
+  // grow the delay exponentially up to POLL_BACKOFF_MAX_MS and reset on the next
+  // success. Mirrors the media-ticket / access-probe backoff in useAccessGate.js.
   useEffect(() => {
-    const id = setInterval(poll, POLL_MS);
-    return () => clearInterval(id);
+    let closed = false;
+    let timer = null;
+    let attempt = 0;
+    const schedule = (ms) => {
+      timer = setTimeout(run, ms);
+    };
+    async function run() {
+      const ok = await poll();
+      if (closed) return;
+      if (ok) {
+        attempt = 0;
+        schedule(POLL_MS);
+      } else {
+        const delay = Math.min(POLL_BACKOFF_MAX_MS, POLL_MS * 2 ** attempt);
+        attempt += 1;
+        schedule(delay);
+      }
+    }
+    schedule(POLL_MS);
+    return () => {
+      closed = true;
+      if (timer) clearTimeout(timer);
+    };
   }, [poll]);
 
   // Auto-scroll to newest unless the user paused (or scrolled up).
@@ -233,7 +288,12 @@ export function LogsScreen() {
         {visibleEntries.length === 0 && !error ? (
           <p className="logs-empty">No log entries yet for this session.</p>
         ) : null}
-        {visibleEntries.map((entry) => {
+        {hiddenCount > 0 ? (
+          <p className="logs-windowed" role="status">
+            Showing the latest {renderedEntries.length.toLocaleString()} of {visibleEntries.length.toLocaleString()} entries.
+          </p>
+        ) : null}
+        {renderedEntries.map((entry) => {
           const eventName = entry.event?.event;
           const highlighted = eventName && HIGHLIGHT_EVENTS.has(eventName);
           const isOpen = expanded === entry.seq;

--- a/apps/web/src/screens/LogsScreen.test.jsx
+++ b/apps/web/src/screens/LogsScreen.test.jsx
@@ -167,12 +167,17 @@ describe("LogsScreen", () => {
     }
   });
 
-  it("does not re-arm the 2s poll on every keystroke (sc-8849)", async () => {
+  it("does not re-arm the 2s poll on every keystroke (sc-8849, sc-11224)", async () => {
     vi.useFakeTimers();
-    const setInterval = vi.spyOn(globalThis, "setInterval");
+    // The poll is now a self-scheduling setTimeout(run, POLL_MS) loop with backoff
+    // (sc-11224), so a poll re-arm is a setTimeout call at the 2000ms cadence. The
+    // 250ms search debounce also uses setTimeout, so we count only the POLL_MS timers
+    // to isolate poll re-arms from debounce timers.
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const pollArms = () => setTimeoutSpy.mock.calls.filter((call) => call[1] === 2000).length;
     try {
       await render();
-      const intervalsAfterLoad = setInterval.mock.calls.length;
+      const armsAfterLoad = pollArms();
       const input = container.querySelector("input.logs-search");
 
       for (const value of ["c", "ca", "can", "cand"]) {
@@ -182,10 +187,11 @@ describe("LogsScreen", () => {
         vi.advanceTimersByTime(300);
       });
 
-      // The poll interval must not be recreated as the search term changes.
-      expect(setInterval.mock.calls.length).toBe(intervalsAfterLoad);
+      // The poll loop must not be re-scheduled as the search term changes — only
+      // source/level filter changes (which refetch) may reset the poll.
+      expect(pollArms()).toBe(armsAfterLoad);
     } finally {
-      setInterval.mockRestore();
+      setTimeoutSpy.mockRestore();
       vi.useRealTimers();
     }
   });
@@ -227,8 +233,13 @@ describe("LogsScreen", () => {
           logRows.push(row(seq, "api", "info", message, { event: "tick" }));
         }
         await render();
-        // Snapshot fetched all rows, so the deep row is actually held in memory.
-        expect(container.querySelectorAll(".logs-row").length).toBe(ROW_COUNT);
+        // The snapshot fetched ALL rows (held in memory for search), but the render
+        // is now windowed to the newest LOG_RENDER_WINDOW (400) rows (sc-11224), so
+        // the DOM shows fewer than the full buffer — yet the deep needle is still
+        // searchable because the filter runs over the whole in-memory snapshot.
+        const beforeSearchRows = container.querySelectorAll(".logs-row").length;
+        expect(beforeSearchRows).toBe(400);
+        expect(beforeSearchRows).toBeLessThan(ROW_COUNT);
 
         const input = container.querySelector("input.logs-search");
         await typeSearch(input, "needle_deep_in_buffer");
@@ -264,6 +275,104 @@ describe("LogsScreen", () => {
       });
       expect(container.querySelectorAll(".logs-row").length).toBe(3);
     } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("windows the rendered tail to the newest rows while search still spans the whole buffer (sc-11224)", async () => {
+    vi.useFakeTimers();
+    try {
+      // A buffer larger than the render window, with a UNIQUE marker on an OLD row
+      // (seq 10) that lives far outside the newest-400 render window.
+      const ROW_COUNT = 900;
+      const OLD_MARKER_SEQ = 10;
+      logRows = [];
+      for (let seq = 0; seq < ROW_COUNT; seq += 1) {
+        const message = seq === OLD_MARKER_SEQ ? "old_unique_marker alpha" : "routine tick";
+        logRows.push(row(seq, "api", "info", message, { event: "tick" }));
+      }
+      await render();
+
+      // Only the newest LOG_RENDER_WINDOW (400) rows are painted, though all 900 are held.
+      const painted = container.querySelectorAll(".logs-row").length;
+      expect(painted).toBe(400);
+      expect(painted).toBeLessThan(ROW_COUNT);
+      // A windowed-count notice tells the user older rows are scrolled out.
+      expect(container.textContent).toContain("Showing the latest");
+
+      // Search runs over the ENTIRE in-memory snapshot: the old, un-painted row is found.
+      const input = container.querySelector("input.logs-search");
+      await typeSearch(input, "old_unique_marker");
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+      const rows = container.querySelectorAll(".logs-row");
+      expect(rows.length).toBe(1);
+      expect(rows[0].textContent).toContain("old_unique_marker");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("backs off the poll after consecutive failures and resets to 2s cadence on success (sc-11224)", async () => {
+    vi.useFakeTimers();
+    try {
+      // Snapshot loads fine; every incremental (afterSeq) poll fails.
+      apiFetch.mockImplementation(async (path) => {
+        if (path.includes("afterSeq=")) throw new Error("network down");
+        return logRows;
+      });
+      await render();
+      const pollCalls = () => apiFetch.mock.calls.filter((call) => call[0].includes("afterSeq=")).length;
+      expect(pollCalls()).toBe(0);
+
+      // First poll fires at the 2s cadence and fails; the error is surfaced.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+      expect(pollCalls()).toBe(1);
+      expect(container.textContent).toContain("network down");
+
+      // Second failure re-arms at 2s (2000 * 2^0).
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+      expect(pollCalls()).toBe(2);
+
+      // Now backed off to 4s: a fixed 2s interval would fire again at +2s, but the
+      // backoff holds it — no new poll until +4s.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+      expect(pollCalls()).toBe(2); // still 2 — proof the poll backed off past 2s
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+      expect(pollCalls()).toBe(3); // fired at +4s
+
+      // Recover: polls succeed again. The pending arm after 3 failures is 8s.
+      apiFetch.mockImplementation(async (path) => (path.includes("afterSeq=") ? [] : logRows));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(8000);
+      });
+      const afterRecover = pollCalls();
+      expect(afterRecover).toBeGreaterThanOrEqual(4);
+      // Cadence reset to 2s: the next poll fires within 2s, not the backed-off 16s.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+      expect(pollCalls()).toBe(afterRecover + 1);
+      // A successful poll clears the error banner.
+      expect(container.textContent).not.toContain("network down");
+    } finally {
+      // Restore the factory-equivalent implementation so later tests are unaffected.
+      apiFetch.mockImplementation(async (path) => {
+        if (path.includes("afterSeq=")) return [];
+        if (path.includes("source=mlx-worker")) {
+          return logRows.filter((r) => r.source === "mlx-worker");
+        }
+        return logRows;
+      });
       vi.useRealTimers();
     }
   });

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4334,6 +4334,18 @@ input.dataset-name-input.boxed:focus {
   border-color: var(--border-strong);
 }
 
+/* Grid windowing (sc-11224 / F-032): skip layout/paint/thumbnail-decode for grid
+   cells scrolled off-screen. `content-visibility: auto` lets the browser leave an
+   off-screen tile un-rendered until it nears the viewport; `contain-intrinsic-size`
+   reserves its box (≈ the .asset-tile min-height plus its label) so the scrollbar and
+   scroll offset stay stable while tiles are skipped. Dependency-free (no react-window).
+   Applied to the grid cell — the .asset-tile button in single-select, the
+   .asset-tile-wrap in multi-select. */
+.asset-tile-windowed {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 240px;
+}
+
 .asset-tile.active {
   border-color: var(--accent);
   box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 22%, transparent);


### PR DESCRIPTION
## sc-11224 — Virtualize the Library asset grid and the Logs screen
Epic **11147**. Type: Chore (efficiency). Two findings from the full-codebase review.

### F-032 — Thumbnail + window the shared `AssetGrid`
`AssetGrid` (`apps/web/src/components/assetPanels.jsx`) is shared by the Library grid, the Pose Library category grids, and character-asset views. It previously mapped every visible asset to the full `AssetMedia`: image tiles loaded full-resolution originals and video tiles each mounted a `<video controls preload="metadata">`, with no windowing — so a few-hundred-asset project decoded hundreds of originals and opened a metadata connection per video on every visit.

- **Poster thumbnails:** tiles now render `AssetThumbnail` (the poster/JPEG path) instead of `AssetMedia`. Video tiles paint the poster `<img>` — no `<video>` element per clip.
- **Windowing (dependency-free):** each grid cell carries an `asset-tile-windowed` class applying `content-visibility: auto` + `contain-intrinsic-size: auto 240px` (`styles.css`), so off-screen tiles skip layout/paint/thumbnail-decode until scrolled near. `react-window` is **not** a dependency (checked `apps/web/package.json`); `content-visibility` was preferred over adding a heavy new dep. The class lands on the `.asset-tile` button in single-select and on the `.asset-tile-wrap` in multi-select — the grid cell in each case (never both, to avoid nesting two content-visibility containers).
- **Interactions preserved:** single-select click, double-click → full preview, context-menu suppression, and multi-select checkbox toggling are unchanged. Clicking a tile still opens the full asset via the existing detail/preview flow.
- **Server thumbnail-size param:** not added. There is no downscaled-image endpoint and adding one is not low-risk; the existing poster + content-visibility windowing already address the decode/connection cost. Noted here rather than silently dropped.

### F-033 — Virtualize the Logs tail + back off the poll on failure
`apps/web/src/screens/LogsScreen.jsx` mirrored the whole 5,000-entry buffer and rendered **all** rows as DOM (re-rendered per 2s poll), and `setInterval(poll, 2000)` kept firing at full rate even when every request failed — a dead API in remote-auth mode was hammered every 2s forever.

- **Windowed tail:** the full snapshot stays in memory (search still runs over **all** entries), but only the newest `LOG_RENDER_WINDOW` (400) search-matches are rendered as DOM, with a "Showing the latest N of M entries" notice when older matches are windowed out. Live-tail auto-scroll shows exactly this window. Search over the whole buffer is preserved — a needle on an old, un-painted row is still found.
- **Poll backoff:** the fixed `setInterval` is replaced by a self-scheduling `setTimeout` loop. Healthy ticks keep the 2s cadence; consecutive failures back off exponentially (`POLL_MS * 2 ** attempt`) up to a 30s cap and reset on the next success. Mirrors the media-ticket / access-probe backoff in `hooks/useAccessGate.js`.

### Tests
- **AssetGrid** (`AssetGrid.test.jsx`): poster `<img>` (no `<video>`) in tiles + interactions still fire; windowing class applied to the correct cell in single- and multi-select. The no-`<video>` assertion would fail pre-fix.
- **LogsScreen** (`LogsScreen.test.jsx`): windowed tail renders only the 400-row slice while search still matches an old row across the full buffer; poll backs off after consecutive failures and resets to 2s cadence on success; existing sc-8849 poll/keystroke test updated to the new setTimeout mechanism.
- Full web suite green (**1658** passing), `npm run lint` 0 errors (48 pre-existing warnings, none in changed files), `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)