### PR TITLE
feat(worker): enable q8/q4 base for the Krea pose-ControlNet lane (sc-11727)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -570,7 +570,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-gen",
  "image",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -768,7 +768,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -805,7 +805,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -817,7 +817,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -830,7 +830,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=3bd8b5a7da787afa25ec0def9fab8d5d2ff25249#3bd8b5a7da787afa25ec0def9fab8d5d2ff25249"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b#0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -8361,7 +8361,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1667,15 +1667,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c4
 # up to main (candle-gen #425 shared-core AdaptLinear + #426 CI + #427 krea_2_edit Generator registration),
 # all additive candle-provider work with no worker-surface change. ALL mlx-gen-* + candle-gen-* pins move
 # together; backend-candle check --locked green.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1689,7 +1689,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1697,17 +1697,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1717,7 +1717,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1725,21 +1725,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1748,7 +1748,7 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # Candle Bernini still-image companion (sc-10996, epic 6562) — the Windows/CUDA sibling of
 # `mlx-gen-bernini`, built ON candle-gen-wan (the full Qwen2.5-VL/MAR semantic planner driving a
 # Wan2.2-A14B dual-expert renderer, `frames:1` for a single still). Self-registers the full `bernini`
@@ -1760,17 +1760,17 @@ candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # main HEAD, the merged #421 planner-components commit — contains the #419 full generator sc-10995) — its
 # gen-core pin (951227a) MATCHES the worker's mlx pin, so `--features backend-candle --target all`
 # resolves ONE gen-core rev (no skew).
-candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1779,7 +1779,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1812,7 +1812,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1821,12 +1821,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1834,7 +1834,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1843,7 +1843,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1851,7 +1851,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1865,7 +1865,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1892,7 +1892,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1903,7 +1903,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3bd8b5a7da787afa25ec0def9fab8d5d2ff25249", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0bb56647c60f192d2b59a12e0ffc2acdfbfa0f3b", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
@@ -11,15 +11,26 @@
 // the `image_jobs` module, so it shares that module's imports (`parse_poses`/`pose_entries`/`Settings`/
 // `WorkerResult`/`huggingface_snapshot_dir`/`start_gen_stream`/… all in scope unqualified).
 //
-// Krea 2 Turbo needs the DENSE diffusers snapshot (`transformer/ text_encoder/ vae/ tokenizer/`), NOT the
-// packed q8 turnkey the registered `krea_2_turbo` txt2img generator loads: the control branch is a
-// composable-forward overlay (`KreaTrainDit`), and it was trained against the bf16 base. Base + branch +
-// TE + VAE are dense on a single 96 GB card.
+// The base is any complete Krea 2 Turbo diffusers snapshot (`transformer/ text_encoder/ vae/ tokenizer/`):
+// the legacy dense `krea/Krea-2-Turbo`, OR — the common case now that the dense download is retired — the
+// installed `SceneWorks/krea-2-turbo-mlx` tier the txt2img lane uses (q8 default / q4 / bf16). The control
+// branch is a composable-forward overlay (`KreaTrainDit`) trained against the bf16 base; the packed q4/q8
+// tiers are key-compatible and load via candle-gen's dequant-on-load (composable DiT reconstructs the dense
+// grid from the packed triple — candle-gen #471, sc-11727), so q8 renders ≈ bf16 and q4 stays pose-locked.
+// Peak VRAM ≈ dense (dequant-to-bf16 in VRAM), well within a single 96 GB card.
 
-/// The dense Krea 2 Turbo diffusers repo when the manifest omits `repo`. Distinct from the packed q8
-/// turnkey (`SceneWorks/krea-2-turbo-mlx`) the txt2img lane uses — the control provider loads the dense
-/// bf16 composable base the overlay applies on.
+/// The dense Krea 2 Turbo diffusers repo when the manifest omits `repo` — a bring-your-own / legacy base
+/// (the manifest download entry was retired in favor of the `SceneWorks/krea-2-turbo-mlx` tiers, sc-9092).
+/// The control provider loads the dense bf16 composable base the overlay trained on; the packed mlx tiers
+/// below are key-compatible (the bf16 tier mirrors this tree) and load via candle-gen's dequant-on-load.
 const KREA_CONTROL_BASE_REPO: &str = "krea/Krea-2-Turbo";
+/// The `SceneWorks/krea-2-turbo-mlx` turnkey (q8 default / q4 / bf16 self-contained subdirs) — the SAME
+/// base the txt2img `krea_2_turbo` lane installs and loads. Now that the dense `krea/Krea-2-Turbo` download
+/// is retired, this is what a user actually has on disk, so the control base resolves the installed tier
+/// here (via the shared [`krea_model_subdir`]) when the legacy dense repo is absent. candle-gen packed-
+/// detects the tier and the composable control DiT dequantizes it on load (candle-gen #471, sc-11727):
+/// q8 renders ≈ bf16, q4 stays pose-locked (mild haze) — GPU-proven.
+const KREA_CONTROL_MLX_REPO: &str = "SceneWorks/krea-2-turbo-mlx";
 /// Pose ControlNet conditioning-scale default (candle-gen `Krea2Control::DEFAULT_CONTROL_SCALE`). The S0
 /// spike found the usable band ~0.5–0.85 for the distilled CFG-free base; ship a comfortable mid.
 const KREA_CONTROL_DEFAULT_SCALE: f32 = candle_gen_krea::DEFAULT_CONTROL_SCALE;
@@ -92,7 +103,24 @@ fn resolve_krea_control_base(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or(KREA_CONTROL_BASE_REPO);
-    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
+    // Legacy / bring-your-own dense diffusers base (`krea/Krea-2-Turbo`), if separately cached — keeps
+    // existing dense-install behavior byte-identical.
+    if let Some(dense) = huggingface_snapshot_dir(&settings.data_dir, repo) {
+        return Ok(Some(dense));
+    }
+    // The installed `SceneWorks/krea-2-turbo-mlx` tier the user actually has (q8 default / q4 / bf16),
+    // resolved EXACTLY like the txt2img lane (`krea_model_subdir` honours `advanced.mlxQuantize` and falls
+    // back to any downloaded tier — so a q4-only or q8-only install resolves). candle-gen `from_dir`
+    // packed-detects the tier; the composable control DiT dequantizes the packed base on load (candle-gen
+    // #471, sc-11727). Gate on `transformer/` so a partial download surfaces "base not installed" rather
+    // than half-loading.
+    if let Some(root) = huggingface_snapshot_dir(&settings.data_dir, KREA_CONTROL_MLX_REPO) {
+        let tier = krea_model_subdir(&root, request);
+        if tier.join("transformer").is_dir() {
+            return Ok(Some(tier));
+        }
+    }
+    Ok(None)
 }
 
 /// True when this is a candle-eligible Krea 2 strict-pose job: `krea_2_turbo` with a non-empty


### PR DESCRIPTION
## What

Lets the Krea 2 Turbo **pose-ControlNet** lane run against the **installed `SceneWorks/krea-2-turbo-mlx` q8/q4/bf16 tier**, not just a dense `krea/Krea-2-Turbo` diffusers repo.

## Why it was broken

The dense `krea/Krea-2-Turbo` download entry was **retired** (sc-9092) — users install the `krea-2-turbo-mlx` q8/q4/bf16 tiers the txt2img lane uses. But `resolve_krea_control_base` still *required* the dense repo, so a user on the current manifest had no base for control: the job failed with `PoseControlBaseMissing` ("control base snapshot not installed"), regardless of the (inert) studio quant selector. The "must be dense" assumption was never a numerical requirement — see candle-gen #471.

## How

- `resolve_krea_control_base` now falls back to the installed `krea-2-turbo-mlx` tier via the shared `krea_model_subdir` (honours `advanced.mlxQuantize`, falls back to any downloaded tier), gated on `transformer/`. The legacy dense `krea/Krea-2-Turbo` base is still **preferred when separately cached** — existing dense-install behavior is byte-identical.
- candle-gen `from_dir` packed-detects the tier; the composable control DiT dequantizes the packed base on load (candle-gen #471). Composes with the sc-11721/#1472 additive user-LoRA surface on the same lane (both land here after rebase).
- **Pin-bump:** all 28 `candle-gen-*` deps `3bd8b5a → 0bb56647` — candle-gen main now carrying **both** the #470 additive-adapter surface AND the #471 dequant-on-load fix. Lock regenerated via `cargo update`.

## Validation

- **GPU-proven** (candle-gen #471) on RTX PRO 6000 against these exact tiers: **q8 visually indistinguishable from bf16; q4 pose-locked, coherent, mild background haze** (expected 4-bit).
- backend-candle (14.44 / `CUDA_COMPUTE_CAP=120`, `--locked`): `build` + `clippy --lib -D warnings` + `test --lib krea_control` all green. The real-weights branch-train test stays GPU/data-gated (ignored).

## Caveat / scope

Dequant-to-bf16 happens **in VRAM**, so peak VRAM ≈ dense — this removes the **disk/download** barrier for a q8/q4-only user, not inference VRAM. A true VRAM-saving packed-forward is a larger follow-up (sc-11727). The studio quant-selector semantics for this combo (honor vs. hide) is the remaining UI decision.

Depends on candle-gen #471 (merged). Relates to sc-8464, sc-8466, sc-11721.

🤖 Generated with [Claude Code](https://claude.com/claude-code)