### PR TITLE
feat(worker): q8/q4 base for the MLX Krea pose-ControlNet lane (sc-11735)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/krea_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control.rs
@@ -13,9 +13,12 @@
 //
 // Registry-backed like the other MLX control lanes (Z-Image / Qwen / Kolors): resolve the base snapshot +
 // the overlay checkpoint into a `LoadSpec`, then `start_cached_gen_stream(krea_2_turbo_control, …)` feeds
-// `Conditioning::Control` per pose. Krea 2 Turbo needs the DENSE `krea/Krea-2-Turbo` snapshot (the
-// composable-forward overlay was trained on the bf16 base), NOT the packed q8 turnkey (`krea-2-turbo-mlx`)
-// the plain `krea_2_turbo` txt2img lane loads — the same base the candle lane uses.
+// `Conditioning::Control` per pose. The base is any complete Krea 2 Turbo snapshot: a legacy dense
+// `krea/Krea-2-Turbo` diffusers repo when separately cached, else the installed `SceneWorks/krea-2-turbo-mlx`
+// tier (q8 default / q4 / bf16) the txt2img lane uses. The dense `krea/Krea-2-Turbo` download entry was
+// retired (sc-9092), so the installed tier is the base a current user actually has; the MLX
+// `Krea2Transformer` packed-detects the tier and runs a true packed forward on the control base (mlx-gen
+// sc-11730 / candle-gen #471, sc-11727) — pose-lock holds on q8/q4 (q8 ~ bf16, q4 mild haze).
 
 /// The engine registry id — matches the mlx-gen `KreaTurboControl` registration and the shared
 /// `STRICT_CONTROL_ENGINES` `krea_2_turbo_control` row (`supported_kinds = {Pose}`). One id, both
@@ -45,17 +48,23 @@ const KREA_CONTROL_OVERLAY_FILE: &str = "control_step5000.safetensors";
 /// `KREA_CONTROL_OVERLAY_REVISION` — a repo re-push can't swap the checkpoint under us). Applied ONLY to
 /// the default repo; a `controlWeights.repo` override keeps `main`.
 const KREA_CONTROL_OVERLAY_REVISION: &str = "cb3a0ac7590f5ec594a4eeb43b95ee1da0b5a0ac";
+/// The `SceneWorks/krea-2-turbo-mlx` turnkey (q8 default / q4 / bf16 self-contained subdirs) — the SAME
+/// base the txt2img lane loads. The pose-control lane falls back here (via the shared [`krea_model_subdir`])
+/// when the legacy dense `krea/Krea-2-Turbo` repo is absent (retired, sc-9092). Mirrors the candle lane's
+/// `KREA_CONTROL_MLX_REPO` (sc-11727).
+const KREA_CONTROL_MLX_REPO: &str = "SceneWorks/krea-2-turbo-mlx";
 
 /// Model ids the MLX Krea strict-pose control route accepts (the deployed base the overlay applies on).
 fn is_krea_control_model(model: &str) -> bool {
     model == "krea_2_turbo"
 }
 
-/// Resolve the Krea 2 Turbo dense snapshot the MLX control provider loads: the
-/// `SCENEWORKS_KREA_CONTROL_BASE` env → an explicit `modelPath` (advanced or manifest) → the HF-cache
-/// snapshot for the manifest `repo` (default = the shared strict-control table's `krea_2_turbo_control`
-/// base repo, `krea/Krea-2-Turbo`). `None` ⇒ not present locally (the job is not MLX-control-runnable).
-/// The MLX twin of the candle `resolve_krea_control_base`.
+/// Resolve the Krea 2 Turbo base the MLX control provider loads: the `SCENEWORKS_KREA_CONTROL_BASE` env →
+/// an explicit `modelPath` (advanced or manifest) → the legacy dense `krea/Krea-2-Turbo` HF-cache snapshot
+/// when separately cached → the installed `SceneWorks/krea-2-turbo-mlx` tier (resolved EXACTLY like the
+/// txt2img lane). `None` ⇒ not present locally (the job is not MLX-control-runnable). The MLX twin of the
+/// candle `resolve_krea_control_base` (sc-11727): un-gates the dense-only assumption so a current user (who
+/// installs the tier, not the retired dense repo) has a base.
 fn resolve_krea_control_base(
     request: &ImageRequest,
     settings: &Settings,
@@ -84,7 +93,23 @@ fn resolve_krea_control_base(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| strict_control_default_repo(KREA_CONTROL_ENGINE_ID));
-    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
+    // Legacy / bring-your-own dense diffusers base (`krea/Krea-2-Turbo`), if separately cached — keeps
+    // existing dense-install behavior byte-identical.
+    if let Some(dense) = huggingface_snapshot_dir(&settings.data_dir, repo) {
+        return Ok(Some(dense));
+    }
+    // The installed `SceneWorks/krea-2-turbo-mlx` tier the user actually has (q8 default / q4 / bf16),
+    // resolved EXACTLY like the txt2img lane (`krea_model_subdir` honours `advanced.mlxQuantize` and falls
+    // back to any downloaded tier). The MLX control lane sets no `spec.quantize`, so the packed tier
+    // auto-detects its quant and the `Krea2Transformer` runs a true packed forward on the base (sc-11727).
+    // Gate on `transformer/` so a partial download surfaces "base not installed" rather than half-loading.
+    if let Some(root) = huggingface_snapshot_dir(&settings.data_dir, KREA_CONTROL_MLX_REPO) {
+        let tier = krea_model_subdir(&root, request);
+        if tier.join("transformer").is_dir() {
+            return Ok(Some(tier));
+        }
+    }
+    Ok(None)
 }
 
 /// True when this is an MLX-eligible Krea 2 strict-pose job: `krea_2_turbo` with a non-empty


### PR DESCRIPTION
The MLX twin of #1475 (candle). Un-gates the macOS Krea pose-ControlNet lane from the retired dense `krea/Krea-2-Turbo` repo.

## Why it was broken
`krea_control.rs::resolve_krea_control_base` (macOS/MLX lane) resolved **only** the dense `krea/Krea-2-Turbo` snapshot. That download entry was retired (sc-9092) in favour of the `SceneWorks/krea-2-turbo-mlx` q8/q4/bf16 tiers the txt2img lane uses — so a current user had no control base and the job failed `PoseControlBaseMissing`, regardless of the (inert) studio quant selector. The "must be dense" assumption was never a numerical requirement.

## How
- `resolve_krea_control_base` now falls back to the installed `krea-2-turbo-mlx` tier via the shared `krea_model_subdir` (honours `advanced.mlxQuantize`, falls back to any downloaded tier), gated on `transformer/`. The legacy dense `krea/Krea-2-Turbo` base stays **preferred when separately cached** — existing dense-install behaviour is byte-identical.
- The MLX control lane sets **no `spec.quantize`**, so a packed tier auto-detects its quant and the `Krea2Transformer` runs a **true packed forward** on the base (real memory savings — better than candle's dequant-to-bf16). q8 ≈ bf16, q4 pose-lock intact (candle-gen #471 GPU-proof).
- Stale "needs the DENSE base, NOT the packed q8 turnkey" comments corrected.

## No engine change needed to ship
The existing `krea_2_turbo_control` engine (mlx-gen, current pin) already loads a **pre-packed** snapshot — only quantize-at-load was ever gated. So this resolver fix alone delivers q8/q4 pose-control on the current engine. The engine-side un-gate (supported_quants advertisement + quantize-at-load path) landed in mlx-gen (sc-11730, PR #710) and rides the separate worker mlx-gen pin bump (deferred with the michaeltrefry→SceneWorks org migration, sc-11738).

## Validation
- `cargo check -p sceneworks-worker` + `cargo clippy -p sceneworks-worker --all-targets -- -D warnings` clean; existing `cargo test -p sceneworks-worker krea_control` green (macOS lane).
- Faithful line-by-line mirror of the merged, GPU-validated #1475 candle resolver (same `huggingface_snapshot_dir` / `krea_model_subdir` / `strict_control_default_repo` helpers).
- **Open:** a real q8/q4 pose render on a Mac with an installed tier + the beta overlay (the true e2e gate) — not yet run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)