### PR TITLE
feat(worker): Krea pose-ControlNet VRAM fit ladder — route the control lane through vram_gate (sc-11754)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -570,7 +570,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-gen",
  "image",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -768,7 +768,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -805,7 +805,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -817,7 +817,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -830,7 +830,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a264811bb5bb587a54995e31908085623429eef8#a264811bb5bb587a54995e31908085623429eef8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -8361,7 +8361,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2515,7 +2515,26 @@
         // path as q4/q8/bf16 (the third of the three ConvRot gates; the candle lane + sm_89 compute-cap
         // are the worker's `int8_convrot` capability).
         "vramGbByTier": { "q4": 26.4, "q8": 31.0, "bf16": 44.0, "int8-convrot": 31.0 },
-        "measured": false
+        "measured": false,
+        // Pose-ControlNet lane VRAM fit ladder (sc-11754, epic 8459 → epic 10765). The control lane loads
+        // the base at the installed tier PLUS the trained ~6.6 GB bf16 control branch, so its render peak
+        // (the end-of-render VAE-decode spike, sc-11744) EXCEEDS the txt2img `vramGbByTier` above — it needs
+        // its own numbers. The worker's Krea control fit-gate (`krea_control_fit`) reads these vs live/capped
+        // free VRAM and, only when constrained, engages the cheapest sufficient rung. @1024²/8-step/scale 0.6
+        // on an RTX PRO 6000 (Blackwell sm_120).
+        "control": {
+          // Overall render peak (GB) by BASE tier, bf16 control branch, NO rungs engaged. q4 MEASURED 30.9
+          // (sc-11744 GPU timeline, the VAE-decode spike); bf16 MEASURED 46.2 (sc-11743, dense base + bf16
+          // branch); q8 ESTIMATED ~35.5 (between the two) pending measurement.
+          "peakGbByTier": { "q4": 30.9, "q8": 35.5, "bf16": 46.2 },
+          // Last-resort rung: the peak reduction (GB) from quantizing the control branch bf16 → q8/q4
+          // (candle-gen #483, sc-11743), MEASURED (dense base holds the rest fixed to isolate the branch):
+          // q8 −8.4 (near-lossless), q4 −10.2 (pose-locked; non-pose details drift). The gate prefers q8
+          // before q4. Cheaper rungs (VAE-decode tiling sc-11744, activation chunking / res-cap sc-11745)
+          // engage BEFORE this once their candle-gen mechanism ships; their deltas land with those stories.
+          "branchQuantSaveGb": { "q8": 8.4, "q4": 10.2 },
+          "measured": false
+        }
       },
       "licenseUrl": "https://www.krea.ai/krea-2-licensing",
       "ui": {

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1667,15 +1667,22 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c4
 # up to main (candle-gen #425 shared-core AdaptLinear + #426 CI + #427 krea_2_edit Generator registration),
 # all additive candle-provider work with no worker-surface change. ALL mlx-gen-* + candle-gen-* pins move
 # together; backend-candle check --locked green.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+# Bumped candle-gen `cb42aa8` -> `a264811` (sc-11743 / sc-11754, epic 8459): candle-gen #483 adds the
+# pose-control branch-quant mechanism — `ControlBranch::from_checkpoint_quantized` + a new
+# `Krea2ControlPaths.branch_quant: Option<Quant>` field the sc-11754 fit-gate sets (bf16 default; q8/q4 the
+# last-resort rung on the Krea control VRAM fit ladder). #483 is a single commit ON TOP of the #480 base
+# (`cb42aa8`, the packed-forward pin #1477 already resolves), so gen-core is BYTE-IDENTICAL — the skew gate
+# stays single-rev with NO mlx-gen move. candle-gen-ONLY; ALL candle-gen-* pins move together;
+# backend-candle check --locked green.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1689,7 +1696,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1697,17 +1704,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1717,7 +1724,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1725,21 +1732,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1748,7 +1755,7 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # Candle Bernini still-image companion (sc-10996, epic 6562) — the Windows/CUDA sibling of
 # `mlx-gen-bernini`, built ON candle-gen-wan (the full Qwen2.5-VL/MAR semantic planner driving a
 # Wan2.2-A14B dual-expert renderer, `frames:1` for a single still). Self-registers the full `bernini`
@@ -1760,17 +1767,17 @@ candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # main HEAD, the merged #421 planner-components commit — contains the #419 full generator sc-10995) — its
 # gen-core pin (951227a) MATCHES the worker's mlx pin, so `--features backend-candle --target all`
 # resolves ONE gen-core rev (no skew).
-candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1779,7 +1786,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1812,7 +1819,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1821,12 +1828,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1834,7 +1841,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42a
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1843,7 +1850,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1851,7 +1858,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1865,7 +1872,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1892,7 +1899,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1903,7 +1910,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a264811bb5bb587a54995e31908085623429eef8", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
@@ -300,6 +300,11 @@ struct KreaStrictControl {
     /// User LoRA/LoKr adapters applied additively to the frozen base DiT (sc-11721) — a character/style
     /// adapter reshapes the subject while the control branch keeps the pose lock. Empty ⇒ stock control.
     adapters: Vec<AdapterSpec>,
+    /// Control-branch quant the VRAM fit ladder selected (sc-11754, candle-gen #483). `None` (bf16) is the
+    /// big-card default; `Some(Q8)`/`Some(Q4)` is the last-resort rung engaged only when the predicted
+    /// peak wouldn't otherwise fit the (possibly emulated) card. Folds the ~6.6 GB dense branch onto the
+    /// GPU packed (dequant-on-forward) so it never lands dense in VRAM.
+    branch_quant: Option<gen_core::Quant>,
     prompt: String,
     width: u32,
     height: u32,
@@ -335,6 +340,8 @@ impl CandleStrictControl for KreaStrictControl {
             root: self.base.clone(),
             control: self.control.clone(),
             adapters: self.adapters.clone(),
+            // bf16 by default; the fit ladder (sc-11754) sets q8/q4 only to fit a constrained card.
+            branch_quant: self.branch_quant,
         };
         candle_gen_krea::Krea2Control::load(&paths).map_err(|error| {
             WorkerError::Engine(format!("Krea 2 strict-pose control load failed: {error}"))
@@ -409,10 +416,65 @@ async fn generate_candle_krea_control_stream(
     let raw_settings =
         krea_control_candle_raw_settings(request, &repo, steps, control_scale, pose_count);
 
+    // VRAM fit ladder (sc-11754, epic 8459 → epic 10765). The control lane is diverted around the base.rs
+    // `generate_candle_stream` fit-gate, so it gets its own here: predict the control-lane peak (base tier
+    // + the ~6.6 GB bf16 control branch + activations + the end-of-render VAE-decode spike) and compare it
+    // against the live/capped free VRAM. On a big card the bf16 branch fits — nothing engages, zero speed/
+    // quality penalty. On a constrained card (or one emulated via `SCENEWORKS_CUDA_VRAM_CAP_GB`) the ladder
+    // engages the last-resort branch-quant rung (q8 near-lossless, then q4 pose-locked) until it fits, else
+    // rejects-before-OOM. The cheaper rungs (VAE-decode tiling sc-11744, activation chunking / res-cap
+    // sc-11745) slot in ahead of branch-quant here once their candle-gen mechanism lands. NB: this lane uses
+    // the UNcached `start_gen_stream` (it doesn't evict the single-slot generator cache), so budget against
+    // raw live free VRAM — the cache's pages are NOT reclaimable by this load, unlike the base.rs gate.
+    let tier =
+        crate::vram_gate::requested_tier_key(&request.advanced, &request.model_manifest_entry);
+    let budget = crate::vram_gate::apply_vram_cap(
+        crate::gpu::nvidia_vram_budget_gb(&settings.gpu_id).await,
+        crate::vram_gate::cuda_vram_cap_gb(),
+    );
+    let branch_quant = match crate::krea_control_fit::fit_ladder(
+        crate::krea_control_fit::predicted_control_peak_gb(&request.model_manifest_entry, tier),
+        budget,
+        crate::krea_control_fit::branch_quant_save_gb(&request.model_manifest_entry, "q8"),
+        crate::krea_control_fit::branch_quant_save_gb(&request.model_manifest_entry, "q4"),
+    ) {
+        // Big-card fast path (or no signal): keep the bf16 branch.
+        crate::krea_control_fit::KreaControlFit::Unknown
+        | crate::krea_control_fit::KreaControlFit::Fits { branch_quant: None } => None,
+        // Constrained card: the fit ladder engaged the branch-quant rung to fit.
+        crate::krea_control_fit::KreaControlFit::Fits {
+            branch_quant: Some(quant),
+        } => {
+            tracing::info!(
+                model = %request.model,
+                tier,
+                branch_quant = ?quant,
+                "Krea control VRAM fit ladder: predicted peak exceeds free VRAM — quantizing the \
+                 control branch (last-resort rung) to fit"
+            );
+            Some(quant)
+        }
+        // Won't fit even at the last rung ⇒ reject before the reactive CUDA OOM.
+        crate::krea_control_fit::KreaControlFit::TooBig {
+            needed_gb,
+            available_gb,
+        } => {
+            return Err(WorkerError::InvalidPayload(format!(
+                "Krea 2 pose-ControlNet at the {tier} base tier needs ~{needed} GB of VRAM (with \
+                 headroom, control branch quantized to q4) but GPU {gpu} has ~{available} GB \
+                 available. Lower the output resolution or run on a card with more VRAM.",
+                needed = needed_gb.round() as i64,
+                available = available_gb.round() as i64,
+                gpu = settings.gpu_id,
+            )));
+        }
+    };
+
     let provider = KreaStrictControl {
         base,
         control,
         adapters,
+        branch_quant,
         prompt: request.prompt.clone(),
         width: request.width,
         height: request.height,

--- a/crates/sceneworks-worker/src/krea_control_fit.rs
+++ b/crates/sceneworks-worker/src/krea_control_fit.rs
@@ -1,0 +1,314 @@
+//! Krea pose-ControlNet VRAM fit ladder (sc-11754, epic 8459 → epic 10765).
+//!
+//! The Krea control lane is diverted around the base.rs `generate_candle_stream` fit-gate ([`crate::vram_gate`]):
+//! it loads through the bespoke `Krea2Control` provider, not the shared txt2img path, so the epic-10765
+//! admission check never sees it. This module is its dedicated fit-gate — the SAME live/capped budget
+//! ([`crate::gpu::nvidia_vram_budget_gb`] + `SCENEWORKS_CUDA_VRAM_CAP_GB`) vs a control-lane-specific
+//! predicted peak, walked down a **cheapest-cost-first rung ladder** so the memory optimizations engage
+//! only when VRAM is actually constrained: on a 96 GB card nothing engages (bf16 branch, zero penalty);
+//! on a 24/16 GB card the minimum set engages to fit.
+//!
+//! ## The ladder
+//! The control lane's peak is the base tier + the ~6.6 GB bf16 control branch + activations + the
+//! end-of-render VAE-decode spike. When that peak won't fit, rungs engage in increasing (Δcost) order,
+//! stopping as soon as the predicted peak ≤ budget:
+//!  1. **packed base** — default, ~free (candle-gen #480, shipped). Always on; the peak below already
+//!     reflects it.
+//!  2. **VAE-decode tiling** (sc-11744) — engage when the decode-phase spike is the overflow.
+//!  3. **activation chunking / resolution cap** (sc-11745) — engage when the denoise steady state is the
+//!     overflow.
+//!  4. **control-branch quant** (sc-11743, candle-gen #483) — bf16 → q8 → q4. A *quality cost* (the
+//!     residual is precision-sensitive, RMS-clamped at τ), so it is the **last-resort rung**.
+//!
+//! Rungs 2–3 need their own candle-gen mechanism, which ships with sc-11744 / sc-11745; until then they
+//! are declared but **not yet engageable** (`WIRED_CHEAPER_RUNGS = false`) — the ladder skips straight to
+//! the branch-quant rung and, if even q4 won't fit, rejects-before-OOM noting the pending cheaper rungs.
+//! When those stories land they slot in AHEAD of branch-quant here (a localized change), so a constrained
+//! card prefers the cheaper rungs and keeps a bf16 branch more often.
+//!
+//! Everything here is pure and unit-tested; the live `nvidia-smi` reading lives in [`crate::gpu`] and the
+//! wiring is in `generate_candle_krea_control_stream` (image_jobs/krea_control_candle.rs).
+
+use super::*;
+use gen_core::Quant;
+use serde_json::Value;
+
+/// Fixed transient/runtime headroom (GB) added on top of the MEASURED control-lane peak
+/// (`candle.control.peakGbByTier`), mirroring [`crate::vram_gate`]'s `HEADROOM_GB` — covers allocator
+/// slack + activation spikes not captured by the steady peak.
+const HEADROOM_GB: f64 = 2.0;
+
+/// Whether the cheaper-than-branch-quant rungs (VAE-decode tiling sc-11744, activation chunking /
+/// resolution cap sc-11745) are wired yet. `false` until those stories ship their candle-gen mechanism +
+/// the `Krea2ControlRequest` toggles they engage; the ladder then inserts them AHEAD of the branch-quant
+/// rung. Flipping this (and threading the toggles) is those stories' one-line hook into this gate.
+const WIRED_CHEAPER_RUNGS: bool = false;
+
+/// The outcome of walking the Krea control fit ladder. `Unknown` = no signal (no `candle.control` block,
+/// or a non-NVIDIA host) ⇒ never block, run the bf16 branch — exactly like [`crate::vram_gate::FitDecision::Unknown`].
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum KreaControlFit {
+    /// No measured control peak or no live budget ⇒ don't gate; load the default bf16 branch.
+    Unknown,
+    /// The predicted peak fits (possibly after engaging branch quant). `branch_quant = None` is the
+    /// big-card fast path (bf16 branch, zero quality penalty); `Some(Q8)`/`Some(Q4)` is the last-resort
+    /// rung the gate engaged to fit a constrained card.
+    Fits { branch_quant: Option<Quant> },
+    /// Won't fit even at the last rung (q4 branch). Reject-before-OOM with an actionable message rather
+    /// than a reactive CUDA OOM mid-render. `needed_gb` is the best-case (q4-branch) predicted peak.
+    TooBig { needed_gb: f64, available_gb: f64 },
+}
+
+/// Predicted control-lane peak VRAM (GB) for `tier_key` (the BASE tier — `bf16`/`q8`/`q4`), with a bf16
+/// control branch and no rungs engaged: `candle.control.peakGbByTier[tier_key]` + [`HEADROOM_GB`], else
+/// `None` (unmeasured ⇒ the gate no-ops). The control peak exceeds the txt2img `candle.vramGbByTier`
+/// because the ~6.6 GB control branch is co-resident.
+pub(crate) fn predicted_control_peak_gb(
+    manifest_entry: &JsonObject,
+    tier_key: &str,
+) -> Option<f64> {
+    manifest_entry
+        .get("candle")?
+        .get("control")?
+        .get("peakGbByTier")
+        .and_then(|tiers| tiers.get(tier_key))
+        .and_then(json_f64)
+        .map(|gb| gb + HEADROOM_GB)
+}
+
+/// Measured peak reduction (GB) from quantizing the control branch bf16 → `quant` (`"q8"`/`"q4"`):
+/// `candle.control.branchQuantSaveGb[quant]`. `None` when unmeasured (the branch-quant rung is then
+/// unavailable and the gate can only reject). Published measured (sc-11743, candle-gen #483): q8 −8.4,
+/// q4 −10.2 GiB.
+pub(crate) fn branch_quant_save_gb(manifest_entry: &JsonObject, quant: &str) -> Option<f64> {
+    manifest_entry
+        .get("candle")?
+        .get("control")?
+        .get("branchQuantSaveGb")
+        .and_then(|saves| saves.get(quant))
+        .and_then(json_f64)
+}
+
+/// Walk the fit ladder: given the bf16-branch predicted peak, the (capped) live budget, and the measured
+/// branch-quant savings, engage the minimal sufficient set of rungs and return the [`KreaControlFit`].
+///
+/// Today the only wired rung is branch-quant (bf16 → q8 → q4, the LAST resort), so the walk is: if the
+/// bf16 peak fits, load bf16 (big-card fast path, no penalty); else prefer q8 (near-lossless), then q4
+/// (pose-locked, non-pose drift); else reject. The cheaper rungs (sc-11744/45) engage AHEAD of q8 once
+/// [`WIRED_CHEAPER_RUNGS`] flips. Missing peak or budget ⇒ [`KreaControlFit::Unknown`] (never block).
+pub(crate) fn fit_ladder(
+    peak_bf16_branch_gb: Option<f64>,
+    budget: Option<crate::vram_gate::VramBudget>,
+    q8_save_gb: Option<f64>,
+    q4_save_gb: Option<f64>,
+) -> KreaControlFit {
+    let (Some(peak), Some(budget)) = (peak_bf16_branch_gb, budget) else {
+        return KreaControlFit::Unknown;
+    };
+    let free = budget.free_gb;
+    let fits = |needed: f64| free + f64::EPSILON >= needed;
+
+    // (Cheaper rungs — VAE-decode tiling, activation chunking / res-cap — engage here, ahead of
+    //  branch-quant, once sc-11744 / sc-11745 wire their candle-gen toggles; see WIRED_CHEAPER_RUNGS.)
+    let _ = WIRED_CHEAPER_RUNGS;
+
+    // Big-card fast path: the bf16 branch already fits — no rung engages, zero quality penalty.
+    if fits(peak) {
+        return KreaControlFit::Fits { branch_quant: None };
+    }
+    // Last-resort rung: quantize the control branch. Prefer q8 (effectively free quality) before q4
+    // (visible non-pose drift). Each save is measured (sc-11743); an unmeasured save skips that option.
+    if let Some(save) = q8_save_gb {
+        if fits(peak - save) {
+            return KreaControlFit::Fits {
+                branch_quant: Some(Quant::Q8),
+            };
+        }
+    }
+    if let Some(save) = q4_save_gb {
+        if fits(peak - save) {
+            return KreaControlFit::Fits {
+                branch_quant: Some(Quant::Q4),
+            };
+        }
+    }
+    // Won't fit even at q4 (the cheaper sc-11744/45 rungs would add more headroom once shipped). Report
+    // the best-case (q4-branch) peak so the reject message is honest about what still overflows.
+    let best_case = q4_save_gb.or(q8_save_gb).map_or(peak, |save| peak - save);
+    KreaControlFit::TooBig {
+        needed_gb: best_case,
+        available_gb: free,
+    }
+}
+
+/// Parse a JSON float from either a number or a numeric string (mirrors [`crate::vram_gate`]'s helper).
+fn json_f64(value: &Value) -> Option<f64> {
+    value
+        .as_f64()
+        .or_else(|| value.as_str().and_then(|text| text.trim().parse().ok()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vram_gate::VramBudget;
+    use serde_json::json;
+
+    fn obj(value: Value) -> JsonObject {
+        value.as_object().expect("object literal").clone()
+    }
+
+    fn krea_manifest() -> JsonObject {
+        obj(json!({
+            "candle": {
+                "minMemoryGb": 32,
+                "vramGbByTier": { "q4": 26.4, "q8": 31.0, "bf16": 44.0 },
+                "control": {
+                    // q4 measured (sc-11744), bf16 measured (sc-11743), q8 estimated.
+                    "peakGbByTier": { "q4": 30.9, "q8": 35.5, "bf16": 46.2 },
+                    // measured sc-11743 (dense base isolates the branch).
+                    "branchQuantSaveGb": { "q8": 8.4, "q4": 10.2 }
+                }
+            }
+        }))
+    }
+
+    #[test]
+    fn predicted_control_peak_reads_the_tier_plus_headroom() {
+        let m = krea_manifest();
+        assert_eq!(
+            predicted_control_peak_gb(&m, "q4"),
+            Some(30.9 + HEADROOM_GB)
+        );
+        assert_eq!(
+            predicted_control_peak_gb(&m, "bf16"),
+            Some(46.2 + HEADROOM_GB)
+        );
+        // Tier absent from peakGbByTier ⇒ None (gate no-ops for that tier).
+        assert_eq!(predicted_control_peak_gb(&m, "int8-convrot"), None);
+        // No control block ⇒ None (unmeasured control lane).
+        let no_control = obj(json!({ "candle": { "vramGbByTier": { "q4": 26.4 } } }));
+        assert_eq!(predicted_control_peak_gb(&no_control, "q4"), None);
+        // No candle block ⇒ None.
+        assert_eq!(predicted_control_peak_gb(&obj(json!({})), "q4"), None);
+    }
+
+    #[test]
+    fn branch_quant_save_reads_the_measured_deltas() {
+        let m = krea_manifest();
+        assert_eq!(branch_quant_save_gb(&m, "q8"), Some(8.4));
+        assert_eq!(branch_quant_save_gb(&m, "q4"), Some(10.2));
+        assert_eq!(branch_quant_save_gb(&m, "q2"), None);
+        assert_eq!(branch_quant_save_gb(&obj(json!({})), "q8"), None);
+    }
+
+    fn budget(free: f64) -> VramBudget {
+        VramBudget {
+            free_gb: free,
+            total_gb: free,
+        }
+    }
+
+    #[test]
+    fn big_card_keeps_the_bf16_branch_with_no_penalty() {
+        let m = krea_manifest();
+        let peak = predicted_control_peak_gb(&m, "q4");
+        let q8 = branch_quant_save_gb(&m, "q8");
+        let q4 = branch_quant_save_gb(&m, "q4");
+        // 96 GB card: the bf16 branch fits outright — nothing engages.
+        assert_eq!(
+            fit_ladder(peak, Some(budget(90.0)), q8, q4),
+            KreaControlFit::Fits { branch_quant: None }
+        );
+    }
+
+    /// Assert a [`KreaControlFit::TooBig`] whose `needed_gb` is ~`expected` (float-tolerant).
+    fn assert_too_big(fit: KreaControlFit, expected_needed: f64, expected_free: f64) {
+        match fit {
+            KreaControlFit::TooBig {
+                needed_gb,
+                available_gb,
+            } => {
+                assert!(
+                    (needed_gb - expected_needed).abs() < 1e-6,
+                    "needed_gb {needed_gb} ≉ {expected_needed}"
+                );
+                assert!((available_gb - expected_free).abs() < 1e-6);
+            }
+            other => panic!("expected TooBig, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn constrained_card_prefers_q8_then_q4() {
+        let m = krea_manifest();
+        // Use the bf16 BASE tier so the peak (46.2 + 2 = 48.2) exercises both branch-quant rungs.
+        let peak = predicted_control_peak_gb(&m, "bf16");
+        let q8 = branch_quant_save_gb(&m, "q8"); // 8.4
+        let q4 = branch_quant_save_gb(&m, "q4"); // 10.2
+
+        // 48.2 fits ⇒ bf16 branch.
+        assert_eq!(
+            fit_ladder(peak, Some(budget(49.0)), q8, q4),
+            KreaControlFit::Fits { branch_quant: None }
+        );
+        // 48.2 > 41, 48.2 − 8.4 = 39.8 ≤ 41 ⇒ q8 (preferred, near-lossless).
+        assert_eq!(
+            fit_ladder(peak, Some(budget(41.0)), q8, q4),
+            KreaControlFit::Fits {
+                branch_quant: Some(Quant::Q8)
+            }
+        );
+        // 39.8 > 39, 48.2 − 10.2 = 38.0 ≤ 39 ⇒ q4 (last resort).
+        assert_eq!(
+            fit_ladder(peak, Some(budget(39.0)), q8, q4),
+            KreaControlFit::Fits {
+                branch_quant: Some(Quant::Q4)
+            }
+        );
+        // Even q4 (~38.0) won't fit a 30 GB budget ⇒ reject, reporting the best-case peak.
+        assert_too_big(fit_ladder(peak, Some(budget(30.0)), q8, q4), 38.0, 30.0);
+    }
+
+    #[test]
+    fn q4_base_tier_fits_a_24gb_card_at_q4_branch() {
+        let m = krea_manifest();
+        // The common small-card install: q4 base. Peak 30.9 + 2 = 32.9.
+        let peak = predicted_control_peak_gb(&m, "q4");
+        let q8 = branch_quant_save_gb(&m, "q8");
+        let q4 = branch_quant_save_gb(&m, "q4");
+        // 32.9 > 24; 32.9 − 8.4 = 24.5 > 24; 32.9 − 10.2 = 22.7 ≤ 24 ⇒ q4 branch fits the 24 GB card.
+        assert_eq!(
+            fit_ladder(peak, Some(budget(24.0)), q8, q4),
+            KreaControlFit::Fits {
+                branch_quant: Some(Quant::Q4)
+            }
+        );
+        // A 16 GB card can't fit even q4 (~22.7) ⇒ reject (the sc-11744/45 rungs would add headroom).
+        assert_too_big(fit_ladder(peak, Some(budget(16.0)), q8, q4), 22.7, 16.0);
+    }
+
+    #[test]
+    fn missing_signal_never_blocks() {
+        let m = krea_manifest();
+        let peak = predicted_control_peak_gb(&m, "q4");
+        let q8 = branch_quant_save_gb(&m, "q8");
+        let q4 = branch_quant_save_gb(&m, "q4");
+        // No live budget ⇒ Unknown (never block).
+        assert_eq!(fit_ladder(peak, None, q8, q4), KreaControlFit::Unknown);
+        // No measured peak ⇒ Unknown.
+        assert_eq!(
+            fit_ladder(None, Some(budget(8.0)), q8, q4),
+            KreaControlFit::Unknown
+        );
+    }
+
+    #[test]
+    fn unmeasured_branch_quant_can_only_reject() {
+        let m = krea_manifest();
+        let peak = predicted_control_peak_gb(&m, "q4"); // 32.9
+                                                        // No branch-quant savings measured ⇒ the only rung is unavailable, so a too-small card rejects
+                                                        // reporting the bf16 peak itself (no rung to subtract).
+        assert_too_big(fit_ladder(peak, Some(budget(20.0)), None, None), 32.9, 20.0);
+    }
+}

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -110,6 +110,12 @@ mod job_metrics;
 mod supervisor;
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 mod vram_gate;
+// Krea pose-ControlNet VRAM fit ladder (sc-11754, epic 8459 → epic 10765). The dedicated fit-gate for the
+// control lane, which is diverted around the base.rs `generate_candle_stream` gate. Same candle cfg as
+// `vram_gate` (its only consumer, krea_control_candle.rs, is under that cfg) so its pub(crate) helpers
+// aren't dead code under `-D warnings` on the non-candle / macOS builds.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+mod krea_control_fit;
 use supervisor::*;
 mod model_jobs;
 use model_jobs::*;

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -542,6 +542,138 @@ fn flux2_candle_blocks_drive_the_fit_gate_and_reject() {
     );
 }
 
+/// sc-11754 (epic 8459 → epic 10765): the Krea 2 Turbo `candle.control` block drives the pose-ControlNet
+/// VRAM fit LADDER end-to-end against the SHIPPED manifest bytes. The control-lane sibling of
+/// `flux2_candle_blocks_drive_the_fit_gate_and_reject`: guards the DATA half — dropping the `control` block
+/// makes `predicted_control_peak_gb` return `None` → the control fit-gate goes INERT (bf16 branch always,
+/// the pre-sc-11754 behavior). Exercises the same `SCENEWORKS_CUDA_VRAM_CAP_GB` small-card emulation via
+/// `apply_vram_cap`, asserting the whole ladder: big card → bf16 branch (no penalty), 24 GB → q4 branch
+/// (the last-resort rung), 16 GB → reject-before-OOM. The branch-quant deltas are the sc-11743 measured
+/// values; a manifest edit that drifts them fails here.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn krea_control_candle_block_drives_the_fit_ladder() {
+    use crate::krea_control_fit::{
+        branch_quant_save_gb, fit_ladder, predicted_control_peak_gb, KreaControlFit,
+    };
+    use crate::vram_gate::apply_vram_cap;
+    use gen_core::Quant;
+
+    let krea = builtin_model_entry("krea_2_turbo");
+    let entry = krea.as_object().expect("krea_2_turbo entry object");
+    let candle = entry
+        .get("candle")
+        .and_then(Value::as_object)
+        .expect("krea_2_turbo candle block");
+    assert!(
+        candle.get("control").and_then(Value::as_object).is_some(),
+        "krea_2_turbo candle.control block present (absent ⇒ control fit-gate inert → always bf16 branch)"
+    );
+
+    // Shipped MEASURED branch-quant deltas (sc-11743): q8 −8.4 (near-lossless), q4 −10.2 (pose-locked).
+    let q8 = branch_quant_save_gb(entry, "q8");
+    let q4 = branch_quant_save_gb(entry, "q4");
+    assert_eq!(q8, Some(8.4));
+    assert_eq!(q4, Some(10.2));
+
+    // The common small-card install: q4 BASE tier. Peak 30.9 (measured sc-11744) + 2 headroom = 32.9.
+    let q4_peak = predicted_control_peak_gb(entry, "q4");
+    assert!((q4_peak.expect("q4 control peak") - 32.9).abs() < 1e-6);
+
+    // 96 GB card: the bf16 branch fits outright — nothing engages, zero speed/quality penalty.
+    assert_eq!(
+        fit_ladder(q4_peak, apply_vram_cap(None, Some(96.0)), q8, q4),
+        KreaControlFit::Fits {
+            branch_quant: None
+        }
+    );
+    // Emulate a 24 GB card: 32.9 > 24; q8 → 24.5 > 24; q4 → 22.7 ≤ 24 ⇒ q4 branch (last-resort rung).
+    assert_eq!(
+        fit_ladder(q4_peak, apply_vram_cap(None, Some(24.0)), q8, q4),
+        KreaControlFit::Fits {
+            branch_quant: Some(Quant::Q4)
+        }
+    );
+    // Emulate a 16 GB card: even q4 (22.7) won't fit ⇒ reject-before-OOM (the sc-11744/45 rungs would add
+    // the remaining headroom once shipped).
+    match fit_ladder(q4_peak, apply_vram_cap(None, Some(16.0)), q8, q4) {
+        KreaControlFit::TooBig {
+            needed_gb,
+            available_gb,
+        } => {
+            assert!((needed_gb - 22.7).abs() < 1e-6, "best-case q4 peak, got {needed_gb}");
+            assert!((available_gb - 16.0).abs() < 1e-6);
+        }
+        other => panic!("16 GB → reject, got {other:?}"),
+    }
+
+    // The bf16 BASE tier (peak 46.2 measured sc-11743 + 2 = 48.2) exercises the q8 rung: a 41 GB card
+    // takes q8 (48.2 − 8.4 = 39.8 ≤ 41), the near-lossless preference before q4.
+    let bf16_peak = predicted_control_peak_gb(entry, "bf16");
+    assert!((bf16_peak.expect("bf16 control peak") - 48.2).abs() < 1e-6);
+    assert_eq!(
+        fit_ladder(bf16_peak, apply_vram_cap(None, Some(41.0)), q8, q4),
+        KreaControlFit::Fits {
+            branch_quant: Some(Quant::Q8)
+        }
+    );
+}
+
+/// Live real-hardware validation (sc-11754): the REAL `nvidia-smi` VRAM reading on GPU 0 + the cap →
+/// predict → ladder chain against the SHIPPED krea_2_turbo control block — the one piece the pure/data
+/// tests can't cover (they use a synthetic budget). Mirrors `vram_gate`'s
+/// `live_cuda_budget_drives_a_real_fit_decision`. Ignored by default (needs a CUDA GPU); run on the 96 GB
+/// box with `cargo test -p sceneworks-worker --lib --features backend-candle -- --ignored --nocapture
+/// krea_control_live`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[tokio::test]
+#[ignore]
+async fn krea_control_live_ladder_on_a_real_card() {
+    use crate::krea_control_fit::{
+        branch_quant_save_gb, fit_ladder, predicted_control_peak_gb, KreaControlFit,
+    };
+    use crate::vram_gate::apply_vram_cap;
+    use gen_core::Quant;
+
+    let krea = builtin_model_entry("krea_2_turbo");
+    let entry = krea.as_object().expect("krea_2_turbo entry object");
+    let q8 = branch_quant_save_gb(entry, "q8");
+    let q4 = branch_quant_save_gb(entry, "q4");
+    // The common small-card install: q4 base tier.
+    let peak = predicted_control_peak_gb(entry, "q4");
+
+    let real = crate::gpu::nvidia_vram_budget_gb("0")
+        .await
+        .expect("GPU 0 should report a live VRAM budget on a CUDA box");
+    eprintln!("live CUDA budget GPU0: {real:?}");
+
+    // Uncapped real 96 GB card → bf16 branch, no rung engages.
+    assert_eq!(
+        fit_ladder(peak, apply_vram_cap(Some(real), None), q8, q4),
+        KreaControlFit::Fits {
+            branch_quant: None
+        },
+        "uncapped 96 GB card keeps the bf16 branch"
+    );
+    // Emulate a 24 GB card off the REAL reading (free := min(real_free, 24)) → q4 branch (last-resort rung).
+    assert_eq!(
+        fit_ladder(peak, apply_vram_cap(Some(real), Some(24.0)), q8, q4),
+        KreaControlFit::Fits {
+            branch_quant: Some(Quant::Q4)
+        },
+        "SCENEWORKS_CUDA_VRAM_CAP_GB=24 → q4 branch fits"
+    );
+    // Emulate a 16 GB card → reject-before-OOM.
+    assert!(
+        matches!(
+            fit_ladder(peak, apply_vram_cap(Some(real), Some(16.0)), q8, q4),
+            KreaControlFit::TooBig { .. }
+        ),
+        "SCENEWORKS_CUDA_VRAM_CAP_GB=16 → reject-before-OOM"
+    );
+    eprintln!("krea control fit ladder on a real card: 96→bf16, 24→q4 branch, 16→reject ✓");
+}
+
 /// epic 10765 sc-11019: the Qwen-Image-Edit `candle` blocks drive the EDIT fit-gate (qwen_edit_candle.rs,
 /// sc-10968) end-to-end against the SHIPPED manifest bytes — resident-fits → sequential-offload →
 /// reject-before-OOM. The edit sibling of `flux2_candle_blocks_drive_the_fit_gate_and_reject`: guards the

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -234,6 +234,26 @@
                 "type": "boolean",
                 "description": "true when minMemoryGb / vramGbByTier were MEASURED on a real GPU (sc-9094); false when ESTIMATED (scaled from weight size + a measured sibling) pending a real measurement. An estimated entry is tracked for a follow-up measurement."
               },
+              "control": {
+                "type": "object",
+                "description": "Pose-ControlNet lane VRAM fit ladder numbers (sc-11754, epic 8459 → epic 10765), keyed by BASE quant tier. Present only for a model with a bespoke trained control branch (Krea 2 Turbo). The control lane loads the base at the installed tier PLUS the ~6.6 GB bf16 control branch, so its render peak exceeds the txt2img vramGbByTier and needs its own numbers; the worker's krea_control_fit gate reads these vs live/capped free VRAM and engages the cheapest sufficient rung only when constrained.",
+                "properties": {
+                  "peakGbByTier": {
+                    "type": "object",
+                    "description": "Overall control-lane render peak VRAM (GB) at 1024²/8-step, keyed by BASE quant tier, with a bf16 control branch and NO fit-ladder rungs engaged. The peak is the end-of-render VAE-decode spike (sc-11744). The fit-gate compares this + headroom against free VRAM.",
+                    "additionalProperties": { "type": "number" }
+                  },
+                  "branchQuantSaveGb": {
+                    "type": "object",
+                    "description": "Measured peak reduction (GB) from the last-resort rung — quantizing the control branch bf16 → q8/q4 (candle-gen #483, sc-11743), keyed by target quant (q8 / q4). The fit-gate subtracts this from peakGbByTier to decide whether the branch-quant rung makes the lane fit, preferring q8 (near-lossless) before q4 (pose-locked; non-pose drift).",
+                    "additionalProperties": { "type": "number" }
+                  },
+                  "measured": {
+                    "type": "boolean",
+                    "description": "true when peakGbByTier / branchQuantSaveGb were MEASURED on a real GPU; false when partially ESTIMATED (e.g. an interpolated q8 base peak) pending measurement."
+                  }
+                }
+              },
               "limits": {
                 "$ref": "#/$defs/samplerLimits",
                 "description": "Per-backend candle/CUDA capability override, read by samplerOptionsFromModel(model, \"candle\"). The top-level limits.samplers/schedulers describe the default lane; this narrows/broadens them for the candle path."


### PR DESCRIPTION
## What

Coordinator for the Krea small-card work (sc-11743/44/45). The Krea pose-ControlNet lane loads through the bespoke `Krea2Control` provider, **diverted around** the base.rs `generate_candle_stream` fit-gate ([`vram_gate`](crates/sceneworks-worker/src/vram_gate.rs), epic 10765) — so the admission check never saw it. This gives it its own fit-gate + a **cheapest-cost-first rung ladder** so the memory optimizations engage **only when VRAM is actually constrained**:

| card (real / emulated) | decision | penalty |
|---|---|---|
| 96 GB | bf16 branch, no rung | none |
| 24 GB | last-resort **branch-quant** rung → q4 | non-pose drift |
| 16 GB | reject-before-OOM | (cheaper rungs pending) |

On a big card `fit_ladder` returns `Fits { branch_quant: None }` → the resident fast path, zero speed/quality penalty. On a constrained card it engages the minimal sufficient rung (q8 near-lossless preferred, then q4), and if even q4 won't fit it rejects-before-OOM instead of a reactive CUDA OOM mid-render.

## How

- **`krea_control_fit`** (new, pure + unit-tested) — predicts the control-lane peak from the manifest `candle.control` block (base tier + the ~6.6 GB bf16 control branch + activations + the end-of-render VAE-decode spike) and walks the ladder, returning the `branch_quant` decision or a reject.
- **Wiring** in `generate_candle_krea_control_stream` — reads the raw live/capped budget (this lane uses the **uncached** `start_gen_stream`, so the generator-cache pages are *not* reclaimable by this load, unlike base.rs), computes the plan, sets `Krea2ControlPaths.branch_quant`, rejects-before-OOM otherwise.
- **Manifest** `krea_2_turbo.candle.control`: `peakGbByTier` (q4 30.9 / bf16 46.2 **measured**, q8 ~35.5 est) + `branchQuantSaveGb` (q8 −8.4, q4 −10.2 **measured**, sc-11743) + schema.
- **candle-gen pin** `cb42aa8` → `a264811` (#483) for the branch-quant mechanism (`ControlBranch::from_checkpoint_quantized` + the new `Krea2ControlPaths.branch_quant` field). #483 is a single commit on the #480 base, so gen-core is byte-identical — the skew gate stays single-rev.

## Rung ladder & story boundaries

Branch-quant (sc-11743, #483) is the only rung whose mechanism ships today, so it's the sole engageable rung and — per its design — the **last resort**. The cheaper rungs slot in **ahead** of it here once their candle-gen mechanism lands (a localized change guarded by `WIRED_CHEAPER_RUNGS`):

1. packed base — default, ~free (candle-gen #480, shipped)
2. **VAE-decode tiling** — sc-11744 (To Do)
3. **activation chunking / resolution cap** — sc-11745 (To Do)
4. **control-branch quant** (bf16→q8→q4) — sc-11743 (mechanism merged) ✅ wired here

Until 2–3 land, a 16 GB card rejects (the reject message says so); a 24 GB card fits at q4.

## Validation

- `clippy --lib --all-targets -D warnings` clean; `fmt` clean; scaffold + manifest-schema check pass.
- 9 worker lib tests green: 7 `krea_control_fit` unit tests + 1 manifest-data test (`krea_control_candle_block_drives_the_fit_ladder`, guards the shipped numbers) + 1 **live GPU** test.
- **GPU-validated on the 96 GB box** (`krea_control_live_ladder_on_a_real_card`, off the real `nvidia-smi` reading — free 45.3 / total 95.6 GB): `SCENEWORKS_CUDA_VRAM_CAP_GB` 96 → bf16 branch, 24 → q4 branch, 16 → reject. The q4-branch render itself is the GPU-proven #483 mechanism (sc-11743).

Ties epic 8459 → epic 10765. Coordinates sc-11743/44/45; relates sc-11727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)