### PR TITLE
feat(worker): candle Krea 2 Turbo img2img lane + router (sc-10134, epic 8588)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -570,7 +570,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-gen",
  "image",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -768,7 +768,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -805,7 +805,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -817,7 +817,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -830,7 +830,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=cb42aa85de3d63c78dd122bc6e2851392a58c4f3#cb42aa85de3d63c78dd122bc6e2851392a58c4f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=fcbd42f392f7571008125ad360d4d997de612a03#fcbd42f392f7571008125ad360d4d997de612a03"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -8361,7 +8361,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -4147,7 +4147,10 @@ mod candle_routing_tests {
                 "{model} Q{bits} tier-select should stay on candle"
             );
         }
-        // Every conditioning shape defers (txt2img + LoRA only).
+        // Every conditioning shape defers AT THE TXT2IMG GATE (txt2img + LoRA only). NB `referenceAssetId`
+        // here tests the low-level `image_request_candle_eligible` gate, which still rejects a raw
+        // reference; the sc-10134 img2img lane is a SEPARATE branch in `image_job_is_candle_eligible` that
+        // claims a `krea_2_turbo` reference BEFORE this gate (see `krea_2_turbo_img2img_routes_to_candle`).
         for case in [
             json!({ "mode": "edit_image", "sourceAssetId": "a" }),
             json!({ "referenceAssetId": "a" }),
@@ -4159,6 +4162,49 @@ mod candle_routing_tests {
                 "{model} conditioning shape must fall back to torch: {case}"
             );
         }
+    }
+
+    #[test]
+    fn krea_2_turbo_img2img_routes_to_candle() {
+        // sc-10134 (epic 8588 slice A): a `krea_2_turbo` job in a NON-edit mode carrying a
+        // `referenceAssetId` is the bespoke candle `render_img2img` lane, branched out in
+        // `image_job_is_candle_eligible` BEFORE the txt2img gate (which still rejects any raw reference —
+        // see `krea_lora_and_quant_stay_on_candle_but_conditioning_defers`). The job-level predicate is
+        // what claims it; the gate keeps deferring the reference shape.
+        let img2img = json!({
+            "model": "krea_2_turbo",
+            "referenceAssetId": "asset_1",
+            "advanced": { "strength": 0.55 }
+        });
+        assert!(
+            image_job_is_candle_eligible(&image_generate_job(img2img.clone())),
+            "krea_2_turbo img2img (referenceAssetId, non-edit) must be candle-eligible"
+        );
+        assert!(krea_img2img_candle_eligible(&object(img2img)));
+        // An explicit `text_to_image` mode is still img2img (the tile may send the mode or omit it).
+        assert!(image_job_is_candle_eligible(&image_generate_job(json!({
+            "model": "krea_2_turbo",
+            "mode": "text_to_image",
+            "referenceAssetId": "asset_1"
+        }))));
+        // NOT the img2img lane: an `edit_image` reference is the Kontext `KreaEdit` surface.
+        assert!(!krea_img2img_candle_eligible(&object(json!({
+            "mode": "edit_image",
+            "referenceAssetId": "asset_1"
+        }))));
+        // A plain txt2img job (no reference) is not img2img — it falls to the generic candle txt2img lane.
+        assert!(!krea_img2img_candle_eligible(&object(
+            json!({ "prompt": "an emerald forest" })
+        )));
+        // Raw img2img is the separate sc-10226 — the img2img branch is gated to `krea_2_turbo`, so a
+        // `krea_2_raw` reference job has no candle img2img lane yet and defers.
+        assert!(
+            !image_job_is_candle_eligible(&image_generate_job(json!({
+                "model": "krea_2_raw",
+                "referenceAssetId": "asset_1"
+            }))),
+            "krea_2_raw img2img has no candle lane yet (sc-10226)"
+        );
     }
 
     #[test]

--- a/crates/sceneworks-core/src/jobs_store/routing/candle.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/candle.rs
@@ -247,6 +247,18 @@ pub(crate) fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     if model == "krea_2_turbo" && krea_control_candle_eligible(&job.payload) {
         return true;
     }
+    // Krea 2 Turbo img2img (reference-guided latent-init, sc-10134, epic 8588): `krea_2_turbo` in a
+    // non-edit mode with a `referenceAssetId` is the bespoke candle `render_img2img` lane (a single
+    // `Conditioning::Reference` seeds the CFG-free denoise from the VAE-encoded reference at
+    // `advanced.strength`) — `krea_2_turbo` is a registered candle txt2img id, and the
+    // `image_request_candle_eligible` gate below rejects ANY `referenceAssetId`, so an img2img job would
+    // otherwise fall to the "conditioned shape on a txt2img candle family" gap. Branch it out AFTER the
+    // pose-control lane (a pose job with an identity reference stays on control) and BEFORE the txt2img
+    // gate. Turbo-only: Raw img2img is the separate sc-10226. Mirrors the worker's `krea_2_turbo` img2img
+    // resolve in `generate_candle_stream`.
+    if model == "krea_2_turbo" && krea_img2img_candle_eligible(&job.payload) {
+        return true;
+    }
     // PuLID-FLUX face identity (sc-5492, epic 5480): `pulid_flux_dev` is a distinct model id (not a
     // candle txt2img id), so the `image_request_candle_eligible` gate below would reject it; the candle
     // `candle-gen-pulid` provider serves it via a bespoke `generate_candle_pulid_stream` lane (the
@@ -740,6 +752,24 @@ pub(crate) fn krea_edit_candle_eligible(payload: &Map<String, Value>) -> bool {
             .get("sourceAssetId")
             .and_then(Value::as_str)
             .is_some_and(|value| !value.trim().is_empty())
+}
+
+/// Krea 2 Turbo img2img (reference-guided latent-init) candle-routing conditions (sc-10134, epic 8588).
+/// The bespoke candle `render_img2img` lane serves a `krea_2_turbo` job in a **non-edit** mode carrying a
+/// `referenceAssetId` — the "Start from an image" tile: the reference is VAE-encoded and blended into the
+/// init latent at `advanced.strength`, then the CFG-free denoise runs from `sigmas[start]`. Distinct from
+/// the Krea **edit** lane (`edit_image` mode + the Kontext dual-conditioning, `krea_edit_candle_eligible`)
+/// and the pose-control lane (`advanced.poses`, branched first). Gated to `krea_2_turbo` by the caller
+/// (Raw img2img is the separate sc-10226). Mirrors the worker's `krea_2_turbo` img2img resolve in
+/// `generate_candle_stream` (the `model_supports_img2img` + `resolve_img2img_init_generic` path).
+pub(crate) fn krea_img2img_candle_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
+        return false;
+    }
+    payload
+        .get("referenceAssetId")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty())
 }
 
 /// Ideogram 4 img2img / Remix + mask inpaint / outpaint edit candle-routing conditions (sc-6598, epic

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1667,15 +1667,23 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c4
 # up to main (candle-gen #425 shared-core AdaptLinear + #426 CI + #427 krea_2_edit Generator registration),
 # all additive candle-provider work with no worker-surface change. ALL mlx-gen-* + candle-gen-* pins move
 # together; backend-candle check --locked green.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+# Bumped candle-gen `cb42aa85` -> `fcbd42f` (sc-10134, epic 8588): candle-gen adds `render_img2img` +
+# reference-conditioning routing to the `krea_2_turbo` generator (reference-guided latent-init — the candle
+# twin of mlx A1 sc-8590), so an off-Mac Krea 2 img2img job renders instead of enforce-failing
+# `candle_unsupported`. Based ON `cb42aa85` (this worker's PRIOR candle-gen pin), so `fcbd42f` re-pins the
+# SAME gen-core `b8c41526` this worker's mlx-gen block already pins — the `--features backend-candle` skew
+# gate resolves ONE gen-core rev with NO mlx-gen move. `git diff cb42aa85..fcbd42f -- gen-core/
+# gen-core-testkit/` is EMPTY (gen-core byte-identical); the range is purely the additive candle-gen-krea
+# img2img engine. ALL candle-gen-* pins move together; backend-candle check --locked green.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1689,7 +1697,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1697,17 +1705,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1717,7 +1725,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1725,21 +1733,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1748,7 +1756,7 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # Candle Bernini still-image companion (sc-10996, epic 6562) — the Windows/CUDA sibling of
 # `mlx-gen-bernini`, built ON candle-gen-wan (the full Qwen2.5-VL/MAR semantic planner driving a
 # Wan2.2-A14B dual-expert renderer, `frames:1` for a single still). Self-registers the full `bernini`
@@ -1760,17 +1768,17 @@ candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # main HEAD, the merged #421 planner-components commit — contains the #419 full generator sc-10995) — its
 # gen-core pin (951227a) MATCHES the worker's mlx pin, so `--features backend-candle --target all`
 # resolves ONE gen-core rev (no skew).
-candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1779,7 +1787,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1812,7 +1820,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1821,12 +1829,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1834,7 +1842,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42a
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1843,7 +1851,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1851,7 +1859,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1865,7 +1873,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1892,7 +1900,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1903,7 +1911,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "cb42aa85de3d63c78dd122bc6e2851392a58c4f3", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "fcbd42f392f7571008125ad360d4d997de612a03", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -2732,7 +2732,15 @@ fn resolve_identity_init(
 /// `generate_turbo_img2img` (sc-10135), whose `preprocess_init_image` LANCZOS-resizes the reference to
 /// the output W×H — so, like Z-Image's [`resolve_identity_init`], the reference is fed raw (the
 /// `edit_image`-only [`should_fit_edit_source`] crop/pad-fit never applies to Krea's t2i-only surface).
-#[cfg(target_os = "macos")]
+///
+/// Available to the candle lane too (sc-10134): the candle `generate_candle_stream` calls this to resolve
+/// the Krea 2 Turbo img2img init off-Mac, feeding the same `(image, strength)` into `generate_one`'s
+/// `reference` → `Conditioning::Reference` → the engine's `render_img2img`. (The broader `ui.img2img`
+/// candle roll-out for SD3.5 / Z-Image / Boogu / Ideogram is sc-10265.)
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 fn resolve_img2img_init_generic(
     request: &ImageRequest,
     settings: &Settings,
@@ -2766,7 +2774,14 @@ fn resolve_img2img_init_generic(
 /// model-specific reference arms (z-image identity-init, FLUX IP-Adapter, Kolors, Ideogram edit) so
 /// those bespoke surfaces keep precedence; the generic arm then catches Krea + SD3.5 + any future
 /// `ui.img2img` model uniformly.
-#[cfg(target_os = "macos")]
+///
+/// Available to the candle lane too (sc-10134): `generate_candle_stream` gates its Krea 2 Turbo img2img
+/// resolve on this same manifest flag off-Mac. (Today the candle router only lets `krea_2_turbo` reach the
+/// candle lane with a reference; the other `ui.img2img` families follow in sc-10265.)
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 fn model_supports_img2img(request: &ImageRequest) -> bool {
     request
         .model_manifest_entry
@@ -4079,6 +4094,23 @@ async fn generate_candle_stream(
     } else {
         Vec::new()
     };
+    // Krea 2 Turbo img2img (reference-guided latent-init, sc-10134, epic 8588): a `ui.img2img` model in a
+    // NON-edit mode carrying a `referenceAssetId` resolves to the img2img init `(image, advanced.strength)`,
+    // threaded to `generate_one` as the single `Conditioning::Reference` the candle Krea engine routes to
+    // `render_img2img` (VAE-encode the reference → blend at `sigmas[init_time_step]` → CFG-free denoise).
+    // The candle router (`krea_img2img_candle_eligible`) only lets `krea_2_turbo` reach this lane with a
+    // reference today; the other `ui.img2img` families (SD3.5 / Z-Image / Boogu / Ideogram) follow in
+    // sc-10265. Disjoint from the Ideogram `edit_reference` (edit_image vs text_to_image) and Boogu's
+    // `multi_references` (guarded here so a future overlap never double-drives the single `reference` slot).
+    let img2img_reference = if edit_reference.is_none()
+        && boogu_refs.is_empty()
+        && request.mode != "edit_image"
+        && model_supports_img2img(request)
+    {
+        resolve_img2img_init_generic(request, settings, project_path)?
+    } else {
+        None
+    };
     let (width, height) = (request.width, request.height);
     // Per-payload sampler / scheduler / schedule-shift, mirroring the MLX `generate_stream` lane (the
     // 1753 front-half advanced carrier — epic 7114 P5, sc-7127). RealVisXL Lightning (sc-7176) forces the
@@ -4298,7 +4330,10 @@ async fn generate_candle_stream(
                         steps,
                         guidance,
                         negative_prompt.clone(),
-                        edit_reference.as_ref(),
+                        // Ideogram edit source (edit_image) OR the Krea 2 Turbo img2img init (sc-10134) —
+                        // mutually exclusive by mode/family; whichever resolved seeds the single
+                        // `Conditioning::Reference` slot.
+                        edit_reference.as_ref().or(img2img_reference.as_ref()),
                         &boogu_refs,
                         edit_mask.as_ref(),
                         true_cfg,

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -4972,6 +4972,39 @@ fn candle_image_route_gates_on_flag_then_pose_reject_then_txt2img() {
     assert_eq!(resolve_candle_image_route(&unknown, &settings), None);
 }
 
+// sc-10134 (epic 8588): a `krea_2_turbo` job in a NON-edit mode carrying a `referenceAssetId` (the img2img
+// "Start from an image" tile) routes to the generic candle txt2img lane — NOT the Krea edit lane
+// (`edit_image`-only, `krea_edit_candle_mode`) nor the pose-control lane (needs `advanced.poses`).
+// `generate_candle_stream` then resolves the img2img init `(image, advanced.strength)` and feeds it as the
+// single `Conditioning::Reference` the candle Krea engine routes to `render_img2img`. This locks the ROUTE
+// decision; the resolve + render are exercised by the candle-gen engine tests + the CUDA smoke.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn candle_image_route_sends_krea_img2img_to_txt2img() {
+    let mut settings = Settings::from_env();
+    settings.backend_candle_enabled = true;
+
+    // krea_2_turbo + a reference, no poses, non-edit mode → the generic candle txt2img lane (the img2img
+    // init is resolved inside `generate_candle_stream`, not a distinct route).
+    let krea_img2img = request(json!({
+        "projectId": "p", "model": "krea_2_turbo", "count": 1,
+        "referenceAssetId": "asset_1",
+        "advanced": { "strength": 0.5 }
+    }));
+    assert_eq!(
+        resolve_candle_image_route(&krea_img2img, &settings),
+        Some(CandleImageRoute::CandleTxt2Img),
+    );
+
+    // Plain krea_2_turbo txt2img (no reference) routes to the same generic lane — the img2img resolve just
+    // no-ops without a reference.
+    let krea_t2i = request(json!({ "projectId": "p", "model": "krea_2_turbo", "count": 1 }));
+    assert_eq!(
+        resolve_candle_image_route(&krea_t2i, &settings),
+        Some(CandleImageRoute::CandleTxt2Img),
+    );
+}
+
 // sc-11171 (F-008): a strict-pose job on a WIRED candle pose family (e.g. `z_image_turbo`) whose control
 // base snapshot is NOT installed must route to the loud `PoseControlBaseMissing` reject, NOT fall through
 // to the plain candle txt2img lane (which would silently render an unconditioned image and drop the


### PR DESCRIPTION
Fixes the off-Mac error a user hit generating a **Krea 2 image2image**:
> `candle_unsupported: conditioned shape on a txt2img candle family (krea_2_turbo) … [epic 5480]`

Krea 2 Turbo img2img ("Start from an image") was MLX-only. The web tile sends a `krea_2_turbo` **text_to_image** job with a top-level `referenceAssetId` + `advanced.strength`, but the candle txt2img gate rejects any reference, so it fell to the `conditioned shape on a txt2img candle family` gap. This wires the reference through the candle lane to the new candle-gen `render_img2img` engine.

## Changes
**Router** (`sceneworks-core::routing::candle`): `krea_img2img_candle_eligible` + a `krea_2_turbo` img2img branch in `image_job_is_candle_eligible` — a non-edit `krea_2_turbo` job with a `referenceAssetId`, branched AFTER pose-control and BEFORE the txt2img gate. Turbo-only (Raw img2img = separate sc-10226).

**Worker** (`generate_candle_stream`): de-gate `resolve_img2img_init_generic` + `model_supports_img2img` off `#[cfg(macos)]` (candle-inclusive cfg, matching `load_reference_image`); resolve the img2img init `(image, advanced.strength)` for a `ui.img2img` model in a non-edit mode and feed it to `generate_one` as the single `Conditioning::Reference` the engine routes to `render_img2img`. Routes to `CandleTxt2Img` (krea_edit is `edit_image`-only; krea_control needs poses).

**Pin**: all candle-gen-* pins `cb42aa85 → fcbd42f` ([SceneWorks/candle-gen#484](https://github.com/SceneWorks/candle-gen/pull/484), the engine). fcbd42f is a child of the prior pin, re-pinning the SAME gen-core `b8c41526` the mlx-gen block pins — the backend-candle skew gate resolves ONE gen-core rev (verified), no mlx-gen move.

## Verification (off-Mac, `--features backend-candle`)
- fmt + clippy `-D warnings` clean; **577 worker lib tests pass**, core routing tests pass.
- New tests: core `krea_2_turbo_img2img_routes_to_candle`, worker `candle_image_route_sends_krea_img2img_to_txt2img`.
- gen-core skew gate: single rev `b8c4152`; `cargo metadata --locked` green.
- **Engine GPU-validated** on sm_120 (Krea-2-Turbo bf16) in #484: coherent + monotone reference fidelity (MAE→ref 47.1 → 25.5 → 11.2 as strength 0.35 → 0.6 → 0.85).

Depends on SceneWorks/candle-gen#484 (pinned by commit; merge order-independent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)