### PR TITLE
feat(core): candle img2img routing for z_image base (sc-10265, epic 8588)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -4208,6 +4208,45 @@ mod candle_routing_tests {
     }
 
     #[test]
+    fn zimage_base_img2img_routes_to_candle() {
+        // sc-10265 (epic 8588): a `z_image` (base, NOT Turbo) job in a non-edit mode with a
+        // `referenceAssetId` is the REGISTRY img2img path — the base candle engine already serves it
+        // (sc-8646) and the worker resolves the init generically (sc-10134), so only the router branch was
+        // missing. Branched before the txt2img gate that rejects references.
+        let img2img = json!({
+            "model": "z_image",
+            "referenceAssetId": "asset_1",
+            "advanced": { "strength": 0.6 }
+        });
+        assert!(
+            image_job_is_candle_eligible(&image_generate_job(img2img.clone())),
+            "z_image base img2img (referenceAssetId, non-edit) must be candle-eligible"
+        );
+        assert!(zimage_img2img_candle_eligible(&object(img2img)));
+        // NOT the edit lane: `edit_image` is the bespoke `ZimageEdit` stream, not registry img2img.
+        assert!(!zimage_img2img_candle_eligible(&object(json!({
+            "mode": "edit_image",
+            "referenceAssetId": "asset_1"
+        }))));
+        // A pose job stays on the control lane (poses branch first), not img2img.
+        assert!(image_job_is_candle_eligible(&image_generate_job(json!({
+            "model": "z_image",
+            "advanced": { "poses": [{ "keypoints": [] }] }
+        }))));
+        // `z_image_turbo` img2img is NOT yet candle-eligible — its registry descriptor is txt2img-only
+        // (img2img is a bespoke `edit_image` stream); the tile shape (referenceAssetId + advanced.strength,
+        // no `character_image`/referenceStrength → not identity-init) has no candle lane until sc-11783.
+        assert!(
+            !image_job_is_candle_eligible(&image_generate_job(json!({
+                "model": "z_image_turbo",
+                "referenceAssetId": "asset_1",
+                "advanced": { "strength": 0.6 }
+            }))),
+            "z_image_turbo img2img needs the candle engine (sc-11783), not yet eligible"
+        );
+    }
+
+    #[test]
     fn sdxl_advanced_shapes_fall_back_to_torch() {
         // Every conditioning shape the txt2img candle lane can't honor must be ineligible. A LoRA is NOT
         // in this set anymore (sc-10767): the SDXL family advertises inference LoRA on candle, so a plain

--- a/crates/sceneworks-core/src/jobs_store/routing/candle.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/candle.rs
@@ -219,6 +219,17 @@ pub(crate) fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     if model == "z_image" && zimage_control_candle_eligible(&job.payload) {
         return true;
     }
+    // Z-Image base img2img (reference-guided latent-init, sc-10265, epic 8588): `z_image` (base, NOT
+    // Turbo) in a non-edit mode with a `referenceAssetId` is the REGISTRY img2img path — the candle
+    // `z_image` generator's `generate` already VAE-encodes a single `Conditioning::Reference` and denoises
+    // the reduced schedule tail (`base.rs` `resolve_reference` + `init_time_step` + `render_base`, sc-8646),
+    // and the worker `generate_candle_stream` resolves the init generically (`model_supports_img2img`,
+    // sc-10134). The txt2img gate below rejects any `referenceAssetId`, so branch it out (after the pose-
+    // control branch above — a pose job stays on control). `z_image_turbo` is the separate sc-11783 (its
+    // registry descriptor is txt2img-only; its img2img is a bespoke `edit_image` stream).
+    if model == "z_image" && zimage_img2img_candle_eligible(&job.payload) {
+        return true;
+    }
     // FLUX.1-dev strict-control Shakker Union-Pro-2.0 (sc-8412, epic 8236): `flux_dev` + `advanced.poses` is
     // the bespoke candle `Flux1DevControl` lane (`generate_candle_flux1_control_stream`), NOT txt2img — the
     // `image_request_candle_eligible` gate below DEFERS any `advanced.poses` job to torch, and the
@@ -763,6 +774,25 @@ pub(crate) fn krea_edit_candle_eligible(payload: &Map<String, Value>) -> bool {
 /// (Raw img2img is the separate sc-10226). Mirrors the worker's `krea_2_turbo` img2img resolve in
 /// `generate_candle_stream` (the `model_supports_img2img` + `resolve_img2img_init_generic` path).
 pub(crate) fn krea_img2img_candle_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
+        return false;
+    }
+    payload
+        .get("referenceAssetId")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty())
+}
+
+/// Z-Image **base** img2img (reference-guided latent-init) candle-routing conditions (sc-10265, epic
+/// 8588). The registered `z_image` (base) candle generator already serves registry img2img — a single
+/// `Conditioning::Reference` in a non-edit request VAE-encodes to the clean init latent and denoises the
+/// reduced schedule tail (`candle-gen-z-image::base` `resolve_reference` + `init_time_step`, sc-8646). So
+/// a `z_image` job in a non-edit mode with a `referenceAssetId` is candle-eligible; the worker resolves
+/// the init generically (`model_supports_img2img`, sc-10134). Same payload shape as
+/// [`krea_img2img_candle_eligible`], gated to `z_image` by the caller. NOT Turbo (`z_image_turbo`'s
+/// registry descriptor is txt2img-only — its img2img is the bespoke `edit_image` stream; sc-11783) and
+/// NOT the pose-control shape (`advanced.poses`, branched first).
+pub(crate) fn zimage_img2img_candle_eligible(payload: &Map<String, Value>) -> bool {
     if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
         return false;
     }


### PR DESCRIPTION
**Stacked on #1482** (sc-10134) — depends on its generic worker img2img resolve. Rebase onto main once #1482 merges.

Makes an off-Mac `z_image` (base) img2img job candle-eligible so the "Start from an image" tile renders instead of enforce-failing `candle_unsupported`. The candle `z_image` base generator already serves registry img2img (`resolve_reference` + `init_time_step` + `render_base`, sc-8646) and #1482 already resolves the img2img init generically — only the router branch was missing.

## Scope (sc-10265 readiness discovery)
sc-10265's "one de-gate lights up all four" premise doesn't hold off-Mac — the candle engines' readiness is fragmented per-id. Among the `ui.img2img` families, **only `z_image` base is registry-ready**:

| model | candle engine | verdict |
|---|---|---|
| `z_image` (base) | already does registry img2img + advertises `Reference` | ✅ this PR |
| `z_image_turbo` | descriptor txt2img-only; img2img is a bespoke `edit_image` stream | → sc-11783 |
| `sd3_5_large/turbo/medium` | descriptor `conditioning: vec![]` | → sc-11784 |
| `boogu_image` / `_turbo` | `Reference` is the instruction-edit path, not img2img latent-init | → sc-11786 |
| `sana_*` | not built on macOS yet | joins later |
| Ideogram | img2img is `edit_image` (Remix), already routed | n/a |

The worker half of sc-10265 (the generic `model_supports_img2img` resolve) already landed in #1482. The three 🔴 rows are split into candle-gen engine stories mirroring the sc-10134 Krea pattern.

## Verification
Core-only (no worker/candle-gen change). fmt + clippy `-D warnings` clean; core routing tests green (new `zimage_base_img2img_routes_to_candle`, 59 candle-routing tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)