### PR TITLE
feat(catalog): trim Recommended image models to Krea 2 Turbo, SDXL, Z-Image-Turbo

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1067,7 +1067,6 @@
     },
     {
       "id": "sensenova_u1_8b",
-      "recommended": true,
       "name": "SenseNova-U1 8B",
       "family": "sensenova-u1",
       "type": "image",
@@ -2052,11 +2051,8 @@
     },
     {
       "id": "boogu_image",
-      // Recommended (sc-6616): render quality validated real-weight in S5 (sc-6402). autoDownload:false
-      // because the Q8 turnkey is ~23 GB/variant — surfaced in the Models Recommended section +
-      // SetupWizard (with its size) so users discover it, but they opt in rather than the wizard
-      // auto-pulling it on first run (mirrors ltx_2_3 / prompt_refine_anubis_8b).
-      "recommended": true,
+      // Available (render quality validated real-weight in S5, sc-6402), but no longer in the curated
+      // Recommended set. autoDownload:false because the Q8 turnkey is ~23 GB/variant — users opt in.
       "autoDownload": false,
       "name": "Boogu Image",
       "family": "boogu",
@@ -2173,9 +2169,8 @@
     },
     {
       "id": "boogu_image_turbo",
-      // Recommended (sc-6616): the fast few-step variant (S5-validated); same autoDownload:false opt-in
-      // as Base. Edit is intentionally NOT recommended (a specialized mode, only shown in the Edit tab).
-      "recommended": true,
+      // Available: the fast few-step variant (S5-validated); same autoDownload:false opt-in as Base.
+      // No longer in the curated Recommended set. Edit stays Edit-tab-only.
       "autoDownload": false,
       "name": "Boogu Image Turbo",
       "family": "boogu",
@@ -2359,6 +2354,11 @@
       // Same gen_core engine code (the `krea_2_turbo` descriptor / KreaPipeline::generate_turbo); loads
       // the packed Q8 (default) / Q4 turnkey subdir. Krea 2 Community License (non-commercial OK; the
       // re-host carries the license + "Krea" name prefix + attribution — sc-7573).
+      // Recommended but opt-in: it's one of the three curated getting-started image models (badged in the
+      // Setup Wizard / Models Recommended section), yet autoDownload:false leaves it badged-but-unchecked
+      // because the q8 default is ~20.6 GB — unlike the auto-pulled z_image_turbo / sdxl, the user opts in
+      // rather than the wizard pulling it on first run (mirrors ltx_2_3 / prompt_refine_anubis_8b).
+      "recommended": true,
       "autoDownload": false,
       "name": "Krea 2 Turbo",
       "family": "krea_2",
@@ -3818,11 +3818,9 @@
     },
     {
       "id": "sd3_5_large_turbo",
-      // Recommended (the fast default per epic 7841): the few-step distilled flagship — discoverable
-      // in the Models Recommended section. autoDownload:false because it is a gated, large turnkey
-      // (mirrors the Boogu / krea_2 opt-in pattern) — users acknowledge the license + opt in rather
-      // than the wizard auto-pulling it.
-      "recommended": true,
+      // Available: the few-step distilled flagship, but no longer in the curated Recommended set.
+      // autoDownload:false because it is a gated, large turnkey (mirrors the Boogu / krea_2 opt-in
+      // pattern) — users acknowledge the license + opt in rather than the wizard auto-pulling it.
       "autoDownload": false,
       "name": "Stable Diffusion 3.5 Large Turbo",
       "family": "sd3",
@@ -5151,7 +5149,6 @@
     },
     {
       "id": "instantid_realvisxl",
-      "recommended": true,
       "name": "InstantID (RealVisXL)",
       "family": "sdxl",
       "type": "image",


### PR DESCRIPTION
## Summary

Curates the **Recommended** image-model set down to three getting-started models: **Krea 2 Turbo**, **SDXL**, and **Z-Image-Turbo**. Everything else stays fully available/selectable — it's just dropped from the curated Recommended set surfaced in the Setup Wizard, the Models page Recommended section, and per-Studio availability gates.

### Dropped from Recommended (still available)
- SenseNova-U1 8B
- Boogu Image
- Boogu Image Turbo
- Stable Diffusion 3.5 Large Turbo
- InstantID (RealVisXL)

### Added to Recommended
- **Krea 2 Turbo** — kept `autoDownload: false` (badged-but-unchecked opt-in) because its q8 default is ~20.6 GB.

### First-run auto-download footprint
Auto-download = `recommended && autoDownload !== false`. After this change the image auto-download set stays lean — **~8.7 GB**: Z-Image-Turbo (5.9), SDXL (2.7), plus the Real-ESRGAN utility (0.1). Krea/LTX/Anubis/Qwen3-VL remain opt-in.

### Notes
- Video/utility recommendations (LTX-2.3, Real-ESRGAN, Prompt Refiner, Vision Captioner) are untouched.
- Stale `Recommended (...)` comments on the dropped entries were reworded to reflect available-but-not-recommended status; the SD3.5 cross-reference to the `krea_2` opt-in pattern is preserved (Krea is still an opt-in example).
- Config-only change; JSONC parses clean and no test asserts the manifest's recommended set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)