### PR TITLE
fix(sana): re-host sana_1600m base from BF16 checkpoint + correct scheduler doc (sc-11760)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -4120,9 +4120,14 @@
         "model": "${HF_CACHE}/SceneWorks/Sana_1600M_1024px_mlx"
       },
       "defaults": {
-        // diffusers `SanaPipeline` reference defaults: flow-match Euler with a static time-shift of
-        // 3.0, 20 steps, true CFG 4.5 (negative-prompt capable). The shift is the orthogonal
-        // schedulerShift knob (epic 7114) rather than a scheduler choice.
+        // Flow-match Euler, static time-shift 3.0, 20 steps, true CFG 4.5 (negative-prompt capable).
+        // The shift is the orthogonal schedulerShift knob (epic 7114), not a scheduler choice.
+        // IMPORTANT (sc-11760): NVIDIA's shipped `Sana_1600M_1024px_diffusers` pipeline actually
+        // DEFAULTS to `DPMSolverMultistepScheduler` (2nd-order flow), NOT Euler — but that 2nd-order
+        // DPM solver produces a garish / over-saturated / chromatic-aberration artifact on this base
+        // model (clean fox/apple/portrait under Euler render blown + false-color under DPM, same
+        // weights/seed). We deliberately run flow-match Euler. Do NOT "restore" a DPM-Solver default
+        // to "match the reference" — it reintroduces the artifact.
         "resolution": "1024x1024",
         "steps": 20,
         "guidanceScale": 4.5,


### PR DESCRIPTION
## Summary
Fixes the base **SANA-1600M (`sana_1600m`)** bug ([sc-11760](https://app.shortcut.com/trefry/story/11760)): output was "abstract expressionism" — a subject emerging from dense colorful petal/comma blobs, worst on plain backgrounds.

Two findings from the investigation, one real bug + one **misdiagnosis** corrected:

### 1. Blobs = wrong source checkpoint (the real bug — fixed)
The `sana_1600m` mirror (`SceneWorks/Sana_1600M_1024px_mlx`) was converted from `Efficient-Large-Model/Sana_1600M_1024px` — a checkpoint that blobs in **every** faithful implementation (our MLX port, diffusers 0.32/0.39, NVlabs `LiteLA`; matches diffusers #10241). `Sana_1600M_1024px_BF16` is a genuinely different checkpoint that renders clean.

**Fix (data, not code):** re-hosted the transformer for all 3 tiers (q4/q8/bf16) from `_BF16` → HF commit [`ac421696`](https://huggingface.co/SceneWorks/Sana_1600M_1024px_mlx/commit/ac421696dd6eb0b41f446f4c45a53ccc057d82a1). The DC-AE VAE + Gemma-2 TE are shared and unchanged, so only `*/transformer/diffusion_pytorch_model.safetensors` changed. The manifest pins no revision, so this propagates without a manifest edit.

### 2. "Garish / over-saturated / chromatic aberration base-path bug" = NOT a bug (misdiagnosis)
The prior session concluded that even on the good checkpoint the base path was garish (blown highlights, cyan/orange CA), and that this was a base-specific true-CFG defect. **Root cause: the scheduler.** NVIDIA's shipped `Sana_1600M_1024px_diffusers` pipeline actually defaults to `DPMSolverMultistepScheduler` (2nd-order flow) — **not** FlowMatchEuler. Every prior "quality" test ran through that DPM default via `SanaPipeline.from_pretrained(...)` while believing it was Euler.

A/B on the good checkpoint (same weights/seed, g=4.5, 20 steps): **FlowMatchEuler → clean; DPM-Solver → the exact garish/CA artifact.** The SceneWorks product already runs flow-match Euler, so there is no base-path bug to fix.

## Code change in this PR
Only a doc-comment correction in `builtin.models.jsonc` (`sana_1600m.defaults`): the comment previously claimed the diffusers repo "ships a FlowMatchEulerDiscreteScheduler." It ships DPM-Solver. The corrected comment records that we deliberately use Euler and **warns against "restoring" a DPM-Solver default** (which would reintroduce the artifact).

## Verification (native MLX port, v0.7.3 pin, flow-match Euler)
Ran the shipped `mlx-gen-sana` harness on the re-hosted weights, on plain-background prompts (the gate the story required):
- **bf16 / q4 / q8** — apple-on-white product shot + plain-grey studio portrait: all **clean, photorealistic, zero blobs, zero CA**. Final latents healthy (std ~0.74–1.38, no NaN/Inf).
- Same harness on the **old** (bad-checkpoint) mirror = blobs.
- **Sampler-curation check:** the manifest's `heun`/`dpmpp_2m`/`uni_pc` match Euler (clean) — mlx-gen's k-diffusion solvers do **not** reproduce the diffusers flow-DPM catastrophe. `dpmpp_sde` is higher-variance/over-sharpened by design (stochastic, 20 steps) but a coherent, valid image. **No sampler removed.**

## Notes
- Not run locally: `npm run rust:check` — this PR is a comment-only change to a `.jsonc` file (no Rust touched); leaving validation to CI to avoid starving the self-hosted runner.
- Follow-up (separate repo): mlx-gen `pipeline.rs` carries the same false "repo ships FlowMatchEuler" claim — filing a Shortcut story to correct it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)