### PR TITLE
fix(training-studio): clarify Mac-blocked target/network messages

### DIFF
--- a/apps/web/src/screens/training/ConfigureJobPanel.jsx
+++ b/apps/web/src/screens/training/ConfigureJobPanel.jsx
@@ -130,7 +130,7 @@ export function ConfigureJobPanel({
                   return (
                     <option key={target.id} value={target.id} disabled={blocked}>
                       {target.ui?.label ?? target.name}
-                      {blocked ? " — not on Mac (MLX only)" : ""}
+                      {blocked ? " — not on Mac (Cuda only)" : ""}
                     </option>
                   );
                 })}
@@ -315,7 +315,7 @@ export function ConfigureJobPanel({
                       return (
                         <option key={option} value={option} disabled={blocked}>
                           {networkTypeLabel(option)}
-                          {blocked ? " — not on Mac (MLX only)" : ""}
+                          {blocked ? " — not on Mac for Wan targets" : ""}
                         </option>
                       );
                     })}


### PR DESCRIPTION
## Summary

The Training Studio config panel labeled disabled dropdown options with **"not on Mac (MLX only)"**, which is backwards and confusing — MLX *is* the Mac backend, so "MLX only" reads as the opposite of the actual restriction.

Replaced with wording that reflects the real reason each option is blocked:

- **Target** picker → `— not on Mac (Cuda only)` — these targets (e.g. Krea 2 ControlNet) require a CUDA kernel the MLX backend doesn't provide.
- **Network type / LoKr** → `— not on Mac for Wan targets` — the MLX Wan trainer can't merge a Kronecker (LoKr) adapter; LoKr still works on other Mac targets (Z-Image/SDXL/LTX), so "Cuda only" would be inaccurate here.

## Notes

Static string-only change; no logic touched. Verification in-browser would require the specific Mac-gating capability + registry state to surface each disabled state, so the diff is the whole change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)