### PR TITLE
feat(web): Krea 2 edit identity-LoRA strength slider (sc-11798)

### DIFF
--- a/apps/web/src/imageJobs.js
+++ b/apps/web/src/imageJobs.js
@@ -39,6 +39,7 @@ export function buildEditJobBody({
   fitMode = "crop",
   loras = null,
   editLora = null,
+  editLoraWeight = null,
   guidanceScale = null,
 }) {
   // Guidance override (sc-10275): only sent when the user set a finite value —
@@ -75,9 +76,15 @@ export function buildEditJobBody({
   // and deduped by id so a manual selection that already carries it isn't doubled. `editLora` is the
   // raw catalog entry (its `conditioningRole` must round-trip via serializeLora, or the worker's edit
   // lane rejects the run); it's null for edit models that need no such LoRA (Qwen-Image-Edit, FLUX.2).
+  // `editLoraWeight` (sc-11798) is the user's Identity-strength override; when finite it overrides the
+  // manifest `defaultWeight` on the serialized entry (else serializeLora falls back to that default).
   const loraList = Array.isArray(loras) ? [...loras] : [];
   if (editLora && !loraList.some((lora) => lora.id === editLora.id)) {
-    loraList.push(serializeLora(editLora));
+    const override =
+      editLoraWeight == null || !Number.isFinite(Number(editLoraWeight))
+        ? undefined
+        : { weight: Number(editLoraWeight) };
+    loraList.push(serializeLora(editLora, override));
   }
   if (loraList.length) body.loras = loraList;
   // Inpaint mask (sc-2436): only sent for inpaint-capable models with a painted

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -1905,6 +1905,8 @@ export function ImageEditor() {
           // The boxes-layout edit runs the same edit model, so it also needs the managed
           // image-edit LoRA when the model requires one (Krea R5) — sc-11069.
           editLora: managedEditLoraId ? editLora : null,
+          // Identity strength (sc-11798): the user's edit-LoRA weight override, or the default.
+          editLoraWeight: managedEditLoraId ? editLoraSelection.weightFor(editLora) : null,
         }),
     });
   }
@@ -2140,6 +2142,8 @@ export function ImageEditor() {
           // Auto-apply the model's managed image-edit LoRA (R5) when installed — deduped inside
           // buildEditJobBody, so a run needs no manual picking (epic 10871, sc-11069).
           editLora: managedEditLoraId ? editLora : null,
+          // Identity strength (sc-11798): the user's edit-LoRA weight override, or the default.
+          editLoraWeight: managedEditLoraId ? editLoraSelection.weightFor(editLora) : null,
           guidanceScale: editGuidance,
         }),
     });
@@ -2970,6 +2974,28 @@ export function ImageEditor() {
           editLoraInstalled ? (
             <div className="ie-section">
               <p className="ie-note">✨ {editLora.name} is applied automatically for editing.</p>
+              {/* Identity strength (sc-11798): the managed edit LoRA is hidden from the manual
+                  picker, so expose its apply weight here — threaded into buildEditJobBody's
+                  editLoraWeight → the payload edit-LoRA `weight`. Higher = stronger conditioning. */}
+              <div className="lora-slot-weight edit-lora-strength">
+                <label>
+                  <span>Identity strength</span>
+                  <span className="lora-slot-weight-value">
+                    {editLoraSelection.weightFor(editLora).toFixed(2)}
+                  </span>
+                </label>
+                <input
+                  aria-label={`${editLora.name} identity strength`}
+                  max="2"
+                  min="0"
+                  onChange={(event) =>
+                    editLoraSelection.setWeight(editLora.id, Number(event.target.value))
+                  }
+                  step="0.05"
+                  type="range"
+                  value={editLoraSelection.weightFor(editLora)}
+                />
+              </div>
             </div>
           ) : (
             <div className="ie-section">

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -1072,6 +1072,12 @@ describe("AI prompt edit", () => {
       editLora,
     });
     expect(alreadyPresent.loras.filter((l) => l.id === "krea2_identity_edit")).toHaveLength(1);
+
+    // Identity strength (sc-11798): a finite editLoraWeight overrides the manifest default on the
+    // auto-applied entry; absent/non-finite falls back to the LoRA's defaultWeight (1.0 here).
+    expect(buildEditJobBody({ ...base, editLora }).loras[0].weight).toBe(1);
+    expect(buildEditJobBody({ ...base, editLora, editLoraWeight: 1.35 }).loras[0].weight).toBe(1.35);
+    expect(buildEditJobBody({ ...base, editLora, editLoraWeight: null }).loras[0].weight).toBe(1);
   });
 
   it("sends advanced.guidanceScale only for a finite override (sc-10275)", () => {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -2517,9 +2517,32 @@ export function ImageStudio() {
                     (the base can't edit without it, R5). Inert for edit models that need none. */}
                 {editLora ? (
                   editLoraInstalled ? (
-                    <p className="field-hint" role="status">
-                      <Icon.Sparkle size={13} /> {editLora.name} is applied automatically for editing.
-                    </p>
+                    <>
+                      <p className="field-hint" role="status">
+                        <Icon.Sparkle size={13} /> {editLora.name} is applied automatically for editing.
+                      </p>
+                      {/* Identity strength (sc-11798): the managed edit LoRA is hidden from the manual
+                          picker, so expose its apply weight here. `effectiveLoraWeight`/`setLoraWeight`
+                          already back the value, and `buildLorasPayload` serializes it into the edit
+                          LoRA's payload `weight` — higher = stronger identity/edit conditioning. */}
+                      <div className="lora-slot-weight edit-lora-strength">
+                        <label>
+                          <span>Identity strength</span>
+                          <span className="lora-slot-weight-value">
+                            {effectiveLoraWeight(editLora).toFixed(2)}
+                          </span>
+                        </label>
+                        <input
+                          aria-label={`${editLora.name} identity strength`}
+                          max="2"
+                          min="0"
+                          onChange={(event) => setLoraWeight(editLora.id, Number(event.target.value))}
+                          step="0.05"
+                          type="range"
+                          value={effectiveLoraWeight(editLora)}
+                        />
+                      </div>
+                    </>
                   ) : (
                     <div className="inline-warning edit-lora-download">
                       <span>

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -649,6 +649,10 @@ describe("ImageStudio Krea image edit LoRA (epic 10871)", () => {
     const editEntry = payload.loras.find((l) => l.id === "krea2_identity_edit");
     expect(editEntry).toBeTruthy();
     expect(editEntry.conditioningRole).toBe("image_edit");
+    // Identity strength (sc-11798): with no slider interaction the payload carries the manifest
+    // default weight, and the Identity strength control renders for the managed edit LoRA.
+    expect(editEntry.weight).toBe(1);
+    expect(container.textContent).toContain("Identity strength");
     // Deduped — auto-applied exactly once.
     expect(payload.loras.filter((l) => l.id === "krea2_identity_edit")).toHaveLength(1);
   });

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6747,6 +6747,12 @@ details[open] > summary.lora-scope-group-heading::before,
   gap: 6px;
 }
 
+/* Identity-strength slider for the managed Krea edit LoRA (sc-11798): sits under the
+   "applied automatically" note in both edit surfaces; reuses the LoRA weight-slider styling. */
+.edit-lora-strength {
+  margin-top: 8px;
+}
+
 .lora-slot-weight > label {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## What

Surfaces the Krea 2 **Identity Edit** LoRA's apply weight as an **"Identity strength"** slider in both edit surfaces (Image Studio + canvas Image Editor). Previously the managed edit LoRA (`krea2_identity_edit`) was auto-applied and hidden from the manual LoRA picker, so it always ran at the manifest `defaultWeight` (**1.0**) with no way to adjust it.

The per-LoRA `weight` plumbing already existed end-to-end — worker `resolve_adapters` → `AdapterSpec` scale → additive residual on the DiT. This PR only exposes the knob; **no worker or engine change**.

## Changes

- **ImageStudio.jsx** — render an Identity strength slider (0–2, step 0.05) under the "applied automatically" note, bound to the existing `effectiveLoraWeight` / `setLoraWeight`. `buildLorasPayload` already serialized `effectiveLoraWeight(editLora)`, so nothing else changed.
- **imageJobs.js** — add an `editLoraWeight` param to `buildEditJobBody`; the managed LoRA was previously appended with **no** weight override. Finite value overrides the manifest default; absent/non-finite falls back to `serializeLora`'s default.
- **ImageEditor.jsx** — thread `editLoraSelection.weightFor(editLora)` into both `buildEditJobBody` call sites and render the same slider (via `weightFor`/`setWeight`).
- **styles.css** — small spacing rule; the slider reuses the existing `.lora-slot-weight` styling.

## Scope

Single **global** identity strength. Per-image (image 1 vs image 2) strength is out of scope and architecturally impossible via the LoRA scale — it's one scalar over the entire DiT forward. Naming intentionally stays *image 1 / image 2* (the "scene/person" cleanup is tracked separately in sc-11797).

## Tests

- `buildEditJobBody`: weight override rides through; absent/`null` falls back to the LoRA default.
- ImageStudio: full-mount test asserts the payload carries the default `1.0` and the "Identity strength" control renders.
- Full web suite **1658 passed**, `npm run lint` **0 errors**, `npm run build` green.

Story: sc-11798 (epic 10871). Related: sc-11797 (naming), sc-11069 (managed edit LoRA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)