### PR TITLE
chore(worker): rename Krea 2 edit reference slots scene/person → image 1/image 2 (sc-11797)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -570,7 +570,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-gen",
  "image",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -768,7 +768,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -805,7 +805,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -817,7 +817,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -830,7 +830,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=0cf90d1d8c59f1a5731610680e3ed03320b72e34#0cf90d1d8c59f1a5731610680e3ed03320b72e34"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=4c102a69bd217404db288fea8c495b638248f747#4c102a69bd217404db288fea8c495b638248f747"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1683,15 +1683,24 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c4
 # additive candle-gen-krea only and gen-core is BYTE-IDENTICAL across `921cf99..0cf90d1d` — the skew gate
 # stays single-rev with NO mlx-gen move. candle-gen-ONLY; ALL candle-gen-* pins move together;
 # backend-candle check --locked green.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+# Bumped candle-gen `0cf90d1d` -> `4c102a6` (sc-11797): candle-gen #487 renames the Krea 2 edit
+# two-reference slots from the misnomer "scene = image 1, person = image 2" to the neutral "image 1
+# (required) + image 2 (optional), either can be a person" across `candle-gen-krea` (comment/doc/error-
+# string only; the fixed image-1-then-image-2 trained order is untouched). `4c102a6` is #487's content
+# commit, based directly on `0cf90d1d` (this worker's prior pin), so `git diff 0cf90d1d..4c102a6 --
+# gen-core/ gen-core-testkit/` is EMPTY — gen-core is BYTE-IDENTICAL and the `--features backend-candle`
+# skew gate stays single-rev with NO mlx-gen move. Points at the branch content commit (durable ancestor
+# once #487's merge lands on candle-gen main). candle-gen-ONLY; ALL candle-gen-* pins move together;
+# backend-candle check --locked green.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1705,7 +1714,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1713,17 +1722,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1733,7 +1742,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1741,21 +1750,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1764,7 +1773,7 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # Candle Bernini still-image companion (sc-10996, epic 6562) — the Windows/CUDA sibling of
 # `mlx-gen-bernini`, built ON candle-gen-wan (the full Qwen2.5-VL/MAR semantic planner driving a
 # Wan2.2-A14B dual-expert renderer, `frames:1` for a single still). Self-registers the full `bernini`
@@ -1776,17 +1785,17 @@ candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # main HEAD, the merged #421 planner-components commit — contains the #419 full generator sc-10995) — its
 # gen-core pin (951227a) MATCHES the worker's mlx pin, so `--features backend-candle --target all`
 # resolves ONE gen-core rev (no skew).
-candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1795,7 +1804,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1828,7 +1837,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1837,12 +1846,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1850,7 +1859,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1859,7 +1868,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1867,7 +1876,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1881,7 +1890,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1908,7 +1917,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1919,7 +1928,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "0cf90d1d8c59f1a5731610680e3ed03320b72e34", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "4c102a69bd217404db288fea8c495b638248f747", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/krea_edit.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_edit.rs
@@ -5,10 +5,11 @@
 // (the Raw pipeline routed to `generate_edit_with_progress`: each source rides as
 // in-context VAE tokens at a distinct RoPE frame AND grounds the Qwen3-VL vision
 // tower). Conditions on one source (`Conditioning::Reference`) or two in FIXED order
-// — scene = image 1, person = image 2 (`Conditioning::MultiReference`, epic 10871
-// P1.3). One output per requested count, each an edit of the same source(s) under the
-// instruction prompt. Krea is MLX-only, so this is the only Krea edit path (the candle
-// mirror is a separate slice, P1.2/P2.2 + the sc-11085 seam registration). Mirrors
+// — image 1 (required) + image 2 (optional) (`Conditioning::MultiReference`, epic 10871
+// P1.3); either image can be a person. One output per requested count, each an edit of
+// the same source(s) under the instruction prompt. Krea is MLX-only, so this is the only
+// Krea edit path (the candle mirror is a separate slice, P1.2/P2.2 + the sc-11085 seam
+// registration). Mirrors
 // `generate_flux2_edit_stream`'s blocking-thread + streamed-events shape and reuses
 // `consume_gen_events`.
 // ---------------------------------------------------------------------------
@@ -26,8 +27,9 @@ fn krea_edit_engine_id(model: &str) -> &'static str {
     }
 }
 
-/// The most source images a Krea edit conditions on (epic 10871 P1.3): scene = image 1, person =
-/// image 2, a FIXED order (swapping degrades identity per the LoRA authors). Mirrors the engine cap
+/// The most source images a Krea edit conditions on (epic 10871 P1.3): image 1 (required) + image 2
+/// (optional), a FIXED order (swapping degrades identity per the LoRA authors); either can be a
+/// person. Mirrors the engine cap
 /// (`mlx-gen-krea` / `candle-gen-krea` `MAX_EDIT_REFERENCES`); the worker rejects a longer list up
 /// front so the error is clear rather than surfacing from the engine seam.
 const KREA_MAX_EDIT_REFERENCES: usize = 2;
@@ -139,7 +141,7 @@ fn krea_edit_generate_one(
 /// Real Krea 2 edit generation: load the `krea_2_edit` generator once, then one output per requested
 /// count, each an edit of the shared source(s) under the instruction prompt. Mirrors
 /// [`generate_flux2_edit_stream`]'s blocking-thread + streamed-events shape and reuses
-/// [`consume_gen_events`]; differs in the required edit LoRA (R5) and the scene+person edit
+/// [`consume_gen_events`]; differs in the required edit LoRA (R5) and the two-reference edit
 /// conditioning (one `Reference` or a two-source `MultiReference`, epic 10871 P1.3).
 async fn generate_krea_edit_stream(
     api: &ApiClient,
@@ -177,7 +179,7 @@ async fn generate_krea_edit_stream(
     let adapter_label = model.adapter_label();
 
     // Resolve the source image(s) on the async side (decode → Send Image moved into the worker thread).
-    // Krea edit conditions on scene = image 1, person = image 2 (fixed order, epic 10871 P1.3): the
+    // Krea edit conditions on image 1 (required) + image 2 (optional) (fixed order, epic 10871 P1.3): the
     // multi-image picker sends the plural `referenceAssetIds`, and a single Image-Edit `sourceAssetId`
     // is the one-source case (both via `edit_reference_ids`). Capped at [`KREA_MAX_EDIT_REFERENCES`] —
     // `build_edit_conditioning` then emits a single `Reference` (1) or a `MultiReference` (2), which the
@@ -190,7 +192,7 @@ async fn generate_krea_edit_stream(
     }
     if reference_ids.len() > KREA_MAX_EDIT_REFERENCES {
         return Err(WorkerError::InvalidPayload(format!(
-            "Krea 2 edit takes at most {KREA_MAX_EDIT_REFERENCES} images (scene, then person)."
+            "Krea 2 edit takes at most {KREA_MAX_EDIT_REFERENCES} images (image 1, then image 2)."
         )));
     }
     let mut sources = Vec::with_capacity(reference_ids.len());

--- a/crates/sceneworks-worker/src/image_jobs/krea_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_edit_candle.rs
@@ -18,7 +18,8 @@
 // Both Krea image variants edit: **Raw** on the full-CFG loop (epic 10871) and **Turbo** on the CFG-free
 // distilled few-step loop (`render_edit(distilled = true)`, sc-11640 — the fast-path); the same
 // `krea2_identity_edit` LoRA drives both (family match, no base gating). One or two references in fixed
-// order — scene = image 1, person = image 2 ([`KREA_EDIT_CANDLE_MAX_REFERENCES`]).
+// order — image 1 (required) + image 2 (optional), either can be a person
+// ([`KREA_EDIT_CANDLE_MAX_REFERENCES`]).
 
 /// Krea edit denoise steps default — Raw undistilled, full-CFG (mirrors `candle_gen_krea` `RAW_STEPS`).
 const KREA_EDIT_CANDLE_DEFAULT_STEPS: u32 = 52;
@@ -30,7 +31,8 @@ const KREA_EDIT_CANDLE_DEFAULT_GUIDANCE: f32 = 3.5;
 /// The adapter/engine id recorded on candle Krea edit assets + telemetry (distinct from the `candle_krea`
 /// txt2img lane — the edit is a separate surface with the required edit LoRA).
 const KREA_EDIT_CANDLE_ENGINE: &str = "candle_krea_edit";
-/// Reference cap — the edit LoRA's fixed-order contract: scene = image 1, person = image 2. Swapping the
+/// Reference cap — the edit LoRA's fixed-order contract: image 1 (required) + image 2 (optional), either
+/// can be a person. Swapping the
 /// order degrades results (the LoRA authors' note); more than two is off-contract.
 const KREA_EDIT_CANDLE_MAX_REFERENCES: usize = 2;
 
@@ -52,7 +54,7 @@ fn krea_edit_candle_has_lora(request: &ImageRequest) -> bool {
     request.loras.iter().any(krea_edit_candle_lora_role)
 }
 
-/// Reference asset ids for a Krea edit, in fixed order (scene = image 1, person = image 2), capped at
+/// Reference asset ids for a Krea edit, in fixed order (image 1 (required) + image 2 (optional)), capped at
 /// [`KREA_EDIT_CANDLE_MAX_REFERENCES`]. The multi-image picker sends the plural `referenceAssetIds`; with
 /// no plural list it falls back to the single Image-Edit `sourceAssetId`. Mirrors
 /// `flux2_edit_candle_reference_ids` (capped to the Krea 1..=2 contract).
@@ -274,7 +276,7 @@ async fn generate_candle_krea_edit_stream(
                     return Ok(None);
                 }
                 // One image per streamed item: `render_edit` batches on `count`, so pass `count = 1` and
-                // the item's seed. The scene/person references are passed directly (not via
+                // the item's seed. The image 1 / image 2 references are passed directly (not via
                 // `conditioning`) in fixed order.
                 let req = gen_core::GenerationRequest {
                     prompt,


### PR DESCRIPTION
## What

Renames the Krea 2 image-edit two-reference slots from the misnomer **"scene = image 1, person = image 2"** to the neutral, correct **image 1 (required) + image 2 (optional)** across the worker, and bumps the candle-gen pin to carry the matching engine-side rename.

Either image can be a person — established during sc-11689 GPU validation (the LoRA's real two-ref use is two subject crops composited into a shared scene, not "empty scene + person"). The web UI (`ImageStudio.jsx`) was already corrected; this propagates the same wording to the worker + engine. The **priority fix is a user-facing error string** (`krea_edit.rs`) that still said "(scene, then person)".

## Scope — rename only, NO behavior change

The fixed order (image 1 = first RoPE frame, image 2 = second) is a real, trained contract and is **preserved**. No logic changes, no reordering.

**Commit 1 — worker rename** (`c18df19d`)
- `crates/sceneworks-worker/src/image_jobs/krea_edit.rs` (MLX/macOS lane): the user-facing over-limit error string `"...(scene, then person)."` → `"...(image 1, then image 2)."`, plus four stale comments.
- `crates/sceneworks-worker/src/image_jobs/krea_edit_candle.rs` (candle/CUDA lane): four stale comments.

**Commit 2 — candle-gen pin bump** (`2d02f070`)
- Bumps all `candle-gen-*` pins `0cf90d1d` → `4c102a6` to pick up [candle-gen #487](https://github.com/SceneWorks/candle-gen/pull/487), the engine-side twin of this rename (comment/doc/error-string only across `candle-gen-krea`). `4c102a6` is based directly on `0cf90d1d`, so gen-core is byte-identical (no `--features backend-candle` skew); lock regenerated via cargo, `--locked` resolves green.

## Verification

- `rg -n "scene.*person|person.*scene" crates/sceneworks-worker/src/image_jobs/krea_edit*.rs` → nothing.
- The remaining `scene`/`person` hits in those files are the corrected "either can be a person" wording.
- `cargo tree -p sceneworks-worker --features backend-candle --locked` resolves green; `git diff Cargo.lock` is rev-only (single candle-gen rev, no unrelated bumps).
- candle-gen #487: `cargo test -p candle-gen-krea --lib` → 120 passed/0 failed (incl. the over-cap error test whose `contains("scene")/contains("person")` assertion moved to `contains("image 1")/contains("image 2")` in lockstep); fmt clean, CI green.

## Notes

- The UI is intentionally untouched (already correct).
- The docs (`MULTI_MODEL_REFERENCE_CONDITIONING.md`, `prompt-guides/krea-2.md`) do not carry the slot misnomer — their `scene` usages are prompt-composition guidance.
- **Merge order:** candle-gen #487 should land first so `4c102a6` is an ancestor of candle-gen main; it's a pushed content commit and already resolves, so this PR builds against it either way.

Story: sc-11797

🤖 Generated with [Claude Code](https://claude.com/claude-code)