### PR TITLE
chore(catalog): rename Krea 2 Turbo edit hint scene/person → image 1/image 2 (sc-11816)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2546,13 +2546,14 @@
         "img2img": true,
         "img2imgStrength": { "label": "Reference strength", "default": 0.5, "min": 0.0, "max": 1.0, "step": 0.05 },
         // Two-reference Kontext edit (sc-11640, mirrors Krea 2 Raw): the `krea2_identity_edit` edit
-        // optionally takes a SECOND source — scene = image 1 (the required Source image), person = image 2
-        // (optional) — in a FIXED order. Presence of this object makes the Studio render the optional
-        // person slot in Edit mode; the worker + engine (`krea_2_turbo_edit` MultiReference) cap at two and
-        // preserve order. Ignored outside `edit_image` (t2i/img2img).
+        // optionally takes a SECOND source — any two images, image 1 (the required Source image) + image 2
+        // (optional) — in a FIXED order (swapping degrades results per the LoRA authors; the instruction
+        // describes how to combine them). Presence of this object makes the Studio render the optional
+        // second-image slot in Edit mode; the worker + engine (`krea_2_turbo_edit` MultiReference) cap at
+        // two and preserve order. Ignored outside `edit_image` (t2i/img2img).
         "editReferences": {
-          "secondaryLabel": "Person image",
-          "secondaryHint": "Optional — a person to place into the scene. Fixed order: the Source image is the scene (image 1), this is the person (image 2)."
+          "secondaryLabel": "Image 2 (optional)",
+          "secondaryHint": "Optional — a second image to combine with Image 1. Order is fixed (Image 1, then Image 2); describe in your instruction how to combine them (e.g. place the subject from Image 2 into Image 1)."
         },
         "label": "Krea 2 Turbo",
         "description": "Krea 2 Turbo — Krea AI's from-scratch foundation image model, distilled to a fast few-step (~8), CFG-free variant: a 28-block single-stream rectified-flow DiT with a Qwen3-VL-4B text encoder, native MLX (Apple Silicon). Strong photorealism up to 2048². Pre-quantized Q8 (~20.5 GB download, default). Krea 2 Community License (non-commercial). Needs a 48 GB-class Mac. Candle (Windows/Linux) adds an INT8-ConvRot tier (online-rotation int8 DiT), an sm_89-exclusive visibility feature: A/B @1024²/8-step — bf16 ~8.8 s (reference, coherent) · Q4-packed ~9.8 s (PSNR 22.7 dB vs bf16, coherent) · INT8-ConvRot (coherent, PSNR 34.4 dB vs bf16 — visibly closer to full precision than Q4). Requires an RTX 40xx / RTX PRO Blackwell (sm_89+) GPU; hidden on Mac and pre-Ada cards.",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2553,7 +2553,7 @@
         // two and preserve order. Ignored outside `edit_image` (t2i/img2img).
         "editReferences": {
           "secondaryLabel": "Image 2 (optional)",
-          "secondaryHint": "Optional — a second image to combine with Image 1. Order is fixed (Image 1, then Image 2); describe in your instruction how to combine them (e.g. place the subject from Image 2 into Image 1)."
+          "secondaryHint": "Optional — a second image combined with Image 1 in a fixed order (Image 1, then Image 2). In your instruction, refer to each subject by position (\"the person in image 1 / image 2\") or by description (\"the woman in the green jacket\") — either works."
         },
         "label": "Krea 2 Turbo",
         "description": "Krea 2 Turbo — Krea AI's from-scratch foundation image model, distilled to a fast few-step (~8), CFG-free variant: a 28-block single-stream rectified-flow DiT with a Qwen3-VL-4B text encoder, native MLX (Apple Silicon). Strong photorealism up to 2048². Pre-quantized Q8 (~20.5 GB download, default). Krea 2 Community License (non-commercial). Needs a 48 GB-class Mac. Candle (Windows/Linux) adds an INT8-ConvRot tier (online-rotation int8 DiT), an sm_89-exclusive visibility feature: A/B @1024²/8-step — bf16 ~8.8 s (reference, coherent) · Q4-packed ~9.8 s (PSNR 22.7 dB vs bf16, coherent) · INT8-ConvRot (coherent, PSNR 34.4 dB vs bf16 — visibly closer to full precision than Q4). Requires an RTX 40xx / RTX PRO Blackwell (sm_89+) GPU; hidden on Mac and pre-Ada cards.",
@@ -2751,7 +2751,7 @@
         // Ignored outside `edit_image` (t2i/img2img).
         "editReferences": {
           "secondaryLabel": "Image 2 (optional)",
-          "secondaryHint": "Optional — a second image to combine with Image 1. Order is fixed (Image 1, then Image 2); describe in your instruction how to combine them (e.g. place the subject from Image 2 into Image 1)."
+          "secondaryHint": "Optional — a second image combined with Image 1 in a fixed order (Image 1, then Image 2). In your instruction, refer to each subject by position (\"the person in image 1 / image 2\") or by description (\"the woman in the green jacket\") — either works."
         },
         "label": "Krea 2 Raw",
         "description": "Krea 2 Raw — Krea AI's undistilled 12B single-stream rectified-flow DiT with a Qwen3-VL-4B text encoder, native MLX (Apple Silicon). The full-fidelity, TRUE classifier-free-guidance counterpart to the fast CFG-free Krea 2 Turbo: run ~52 steps with a real guidance scale (~3.5) and an optional negative prompt for the highest quality and the most control. Pre-quantized Q8 (~20.5 GB download, default); the dense bf16 tier doubles as the Krea 2 LoRA training base. Krea 2 Community License (non-commercial). Runs on Apple Silicon (MLX) and Windows/Linux NVIDIA GPUs (candle/CUDA, sc-9994); needs a 48 GB-class Mac or a ~32 GB-class CUDA GPU.",


### PR DESCRIPTION
## What

Fixes the last straggler of the sc-11797 rename. The Krea 2 **Turbo** edit second-image slot still showed the "scene/person" misnomer in the UI:

> **Person image** — "Optional — a person to place into the scene. Fixed order: the Source image is the scene (image 1), this is the person (image 2)."

sc-11797's scope covered the worker + candle-gen engine and assumed the UI was already correct, but it **missed `config/manifests/builtin.models.jsonc`**. The `krea_2_raw` `editReferences` block had already been corrected; `krea_2_turbo` was left behind, so the two Krea edit surfaces were inconsistent.

## Change

Mirror the already-correct `krea_2_raw` wording into the `krea_2_turbo` block — `secondaryLabel` → `"Image 2 (optional)"`, the neutral "combine with Image 1" hint, and the adjacent comment — keeping the Turbo-specific bits (`sc-11640`, `krea_2_turbo_edit`). The two blocks are now identical wording.

No behavior change — the fixed image-1-then-image-2 trained order is preserved. Other manifest `scene`/`person` hits (multi-person scenes, person replacement, scene-flexible resemblance) are legitimate and untouched.

## Verification

- `node scripts/check-scaffold.mjs` → **green**; manifest JSONC parses.
- No `scene (image …`/`person (image …`/`Person image`/`place into the scene` left in the manifest.
- Turbo and Raw edit slots now render identical neutral wording.

Reported by @michaeltrefry1818 (Turbo edit still showing the old hint). Relates to sc-11797.

🤖 Generated with [Claude Code](https://claude.com/claude-code)