### PR TITLE
feat(core): candle img2img routing for SD3.5 large/turbo/medium (sc-11784, epic 8588)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -570,7 +570,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-gen",
  "image",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -768,7 +768,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -805,7 +805,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -817,7 +817,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -830,7 +830,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -8361,7 +8361,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -4312,6 +4312,37 @@ mod candle_routing_tests {
     }
 
     #[test]
+    fn sd3_img2img_routes_to_candle() {
+        // sc-11784 (epic 8588): each SD3.5 variant in a non-edit mode with a `referenceAssetId` is the
+        // REGISTRY img2img path — the candle `candle-gen-sd3` generators advertise `Reference` and
+        // VAE-encode it into the reduced denoise tail (real CFG for Large/Medium, distilled for Turbo).
+        // Branched before the txt2img gate that rejects references. Candle/CUDA parity of MLX sc-10189.
+        for model in ["sd3_5_large", "sd3_5_large_turbo", "sd3_5_medium"] {
+            let img2img = json!({
+                "model": model,
+                "referenceAssetId": "asset_1",
+                "advanced": { "strength": 0.6 }
+            });
+            assert!(
+                image_job_is_candle_eligible(&image_generate_job(img2img.clone())),
+                "{model} img2img (referenceAssetId, non-edit) must be candle-eligible (sc-11784)"
+            );
+            assert!(is_sd3_family_candle_model(model));
+            assert!(sd3_img2img_candle_eligible(&object(img2img)));
+            // A plain txt2img (no reference) still rides the generic candle gate — not the img2img branch.
+            assert!(!sd3_img2img_candle_eligible(&object(
+                json!({ "model": model })
+            )));
+            // The `edit_image` shape is NOT registry img2img (SD3.5 has no candle edit lane).
+            assert!(!sd3_img2img_candle_eligible(&object(json!({
+                "model": model,
+                "mode": "edit_image",
+                "referenceAssetId": "asset_1"
+            }))));
+        }
+    }
+
+    #[test]
     fn sdxl_advanced_shapes_fall_back_to_torch() {
         // Every conditioning shape the txt2img candle lane can't honor must be ineligible. A LoRA is NOT
         // in this set anymore (sc-10767): the SDXL family advertises inference LoRA on candle, so a plain

--- a/crates/sceneworks-core/src/jobs_store/routing/candle.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/candle.rs
@@ -253,6 +253,18 @@ pub(crate) fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     if model == "z_image_turbo" && zimage_img2img_candle_eligible(&job.payload) {
         return true;
     }
+    // SD3.5 img2img (reference-guided latent-init, sc-11784, epic 8588): `sd3_5_large` / `sd3_5_large_turbo`
+    // / `sd3_5_medium` in a non-edit mode with a `referenceAssetId` is now the REGISTRY img2img path — the
+    // candle SD3.5 generators advertise `Reference` and their `generate` VAE-encodes a single
+    // `Conditioning::Reference` and denoises the reduced schedule tail (real CFG for Large/Medium, the
+    // CFG-free distilled loop for Turbo — `candle-gen-sd3` `resolve_reference` + `init_time_step` + `render`,
+    // candle-gen #493). The candle/CUDA parity of the MLX `denoise_img2img_cfg` lane (sc-10189). SD3.5 has no
+    // candle identity / edit / control lane, so the only reference shape is img2img — branch it out before
+    // the txt2img gate below (which rejects any `referenceAssetId`). The worker resolves the init generically
+    // (`model_supports_img2img`, sc-10134).
+    if is_sd3_family_candle_model(model) && sd3_img2img_candle_eligible(&job.payload) {
+        return true;
+    }
     // FLUX.1-dev strict-control Shakker Union-Pro-2.0 (sc-8412, epic 8236): `flux_dev` + `advanced.poses` is
     // the bespoke candle `Flux1DevControl` lane (`generate_candle_flux1_control_stream`), NOT txt2img — the
     // `image_request_candle_eligible` gate below DEFERS any `advanced.poses` job to torch, and the
@@ -817,6 +829,32 @@ pub(crate) fn krea_img2img_candle_eligible(payload: &Map<String, Value>) -> bool
 /// identity-init (`character_image` + `referenceStrength`), the `edit_image` masked-edit, or the
 /// pose-control (`advanced.poses`) shapes — all branched first.
 pub(crate) fn zimage_img2img_candle_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
+        return false;
+    }
+    payload
+        .get("referenceAssetId")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty())
+}
+
+/// The three registered candle SD3.5 txt2img ids (`candle-gen-sd3`): Large (CFG), Large Turbo
+/// (distilled), Medium (MMDiT-X CFG). Shared by the SD3.5 img2img branch (sc-11784) so the id set has
+/// one home; each also rides the generic txt2img gate below (all three are in `CANDLE_ROUTED_MODELS`).
+pub(crate) fn is_sd3_family_candle_model(model: &str) -> bool {
+    matches!(model, "sd3_5_large" | "sd3_5_large_turbo" | "sd3_5_medium")
+}
+
+/// SD3.5 img2img (reference-guided latent-init) candle-routing conditions (sc-11784, epic 8588). The
+/// registered `sd3_5_*` candle generators serve registry img2img — a single `Conditioning::Reference`
+/// in a non-edit request VAE-encodes to the clean init latent and denoises the reduced schedule tail
+/// (`candle-gen-sd3` `resolve_reference` + `init_time_step` + `render`, candle-gen #493; real CFG for
+/// Large/Medium, the distilled loop for Turbo). So an SD3.5 job in a non-edit mode with a
+/// `referenceAssetId` is candle-eligible; the worker resolves the init generically
+/// (`model_supports_img2img`, sc-10134). Same payload shape as [`zimage_img2img_candle_eligible`], gated
+/// to the SD3.5 ids by the caller. SD3.5 has no candle identity / `edit_image` / pose-control lane, so
+/// the only reference shape on these ids is img2img — no earlier branch to keep precedence behind.
+pub(crate) fn sd3_img2img_candle_eligible(payload: &Map<String, Value>) -> bool {
     if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
         return false;
     }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1713,15 +1713,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c4
 # (`decode()` is byte-identical when `force_tile = false`, the default for every existing caller). Points at
 # the branch content commit (durable ancestor once #492's merge lands on candle-gen main). ALL candle-gen-*
 # pins move together; backend-candle check --locked green.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1735,7 +1735,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1743,17 +1743,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1763,7 +1763,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1771,21 +1771,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1794,7 +1794,7 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "3
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # Candle Bernini still-image companion (sc-10996, epic 6562) — the Windows/CUDA sibling of
 # `mlx-gen-bernini`, built ON candle-gen-wan (the full Qwen2.5-VL/MAR semantic planner driving a
 # Wan2.2-A14B dual-expert renderer, `frames:1` for a single still). Self-registers the full `bernini`
@@ -1806,17 +1806,17 @@ candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # main HEAD, the merged #421 planner-components commit — contains the #419 full generator sc-10995) — its
 # gen-core pin (951227a) MATCHES the worker's mlx pin, so `--features backend-candle --target all`
 # resolves ONE gen-core rev (no skew).
-candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1825,7 +1825,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1858,7 +1858,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1867,12 +1867,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1880,7 +1880,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f8
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1889,7 +1889,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1897,7 +1897,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1911,7 +1911,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1938,7 +1938,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1949,7 +1949,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with


### PR DESCRIPTION
Makes off-Mac SD3.5 img2img jobs candle-eligible so the "Start from an image" tile renders instead of enforce-failing `candle_unsupported`. The downstream worker half of sc-11784, paired with the candle-gen engine PR [SceneWorks/candle-gen#493](https://github.com/SceneWorks/candle-gen/pull/493).

## What
- **Router** (`sceneworks-core::routing::candle`) — `is_sd3_family_candle_model` + `sd3_img2img_candle_eligible`, and an SD3.5 img2img branch in `image_job_is_candle_eligible` (before the txt2img gate that rejects any `referenceAssetId`). Each of `sd3_5_large` / `sd3_5_large_turbo` / `sd3_5_medium` in a non-edit mode with a `referenceAssetId` now routes to the candle registry img2img path.
- **Pin bump** — all candle-gen-* pins `1be2369b` → `f17b5d1` (the SD3.5 img2img engine, candle-gen #493). `f17b5d1` is a direct child of the prior pin, re-pinning the **same** gen-core `b8c41526` → the backend-candle skew gate resolves ONE gen-core rev (verified); `--locked` green.

## Why this is router-only
The candle SD3.5 generators now advertise `ConditioningKind::Reference` and VAE-encode it into the reduced denoise tail (candle-gen #493). The worker `generate_candle_stream` already resolves the img2img init generically off-Mac (`model_supports_img2img` reads the `ui.img2img` manifest flag, true for all three SD3.5 ids — sc-10134/#1482). So — exactly like the z_image base (sc-10265/#1487) and Turbo (sc-11783/#1491) slices — only the router branch + pin bump are needed. Candle/CUDA parity of the MLX `denoise_img2img_cfg` lane (sc-10189).

## Tests
- `sd3_img2img_routes_to_candle` — all three variants eligible with a reference; plain txt2img + `edit_image` shapes excluded.
- Core routing tests green; fmt + clippy clean.

⚠️ Merge after candle-gen #493 (the pin points at that branch commit; flip to the merged candle-gen `main` rev once it lands if desired).

Relates to sc-10265, sc-10189, sc-10134, epic 8588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)