### PR TITLE
feat(core): candle img2img routing for boogu_image base/turbo + pin bump (sc-11786, epic 8588)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -570,7 +570,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-gen",
  "image",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -768,7 +768,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -805,7 +805,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -817,7 +817,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -830,7 +830,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=1be2369b46378edd448c6fdde3a8e5dafc9c4ac0#1be2369b46378edd448c6fdde3a8e5dafc9c4ac0"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3930,6 +3930,47 @@ mod candle_routing_tests {
     }
 
     #[test]
+    fn boogu_base_and_turbo_img2img_route_to_candle() {
+        // sc-11786 (epic 8588): a `boogu_image` / `boogu_image_turbo` job in a non-edit mode with a
+        // `referenceAssetId` is now the REGISTRY img2img path — the candle Base/Turbo generators advertise
+        // `Reference` and VAE-encode it into the reduced-schedule denoise. Branched before the txt2img gate
+        // (which rejects any `referenceAssetId`), disjoint from the `boogu_image_edit` instruction-edit lane.
+        for model in ["boogu_image", "boogu_image_turbo"] {
+            let img2img = json!({
+                "model": model,
+                "referenceAssetId": "asset_1",
+                "advanced": { "strength": 0.6 }
+            });
+            assert!(
+                image_job_is_candle_eligible(&image_generate_job(img2img.clone())),
+                "{model} img2img (referenceAssetId, non-edit) must be candle-eligible (sc-11786)"
+            );
+            // The eligibility predicate: a non-edit reference is img2img; an `edit_image` reference is NOT
+            // (that is the `boogu_image_edit` instruction-edit lane, a different engine id).
+            assert!(boogu_img2img_candle_eligible(&object(json!({
+                "model": model, "referenceAssetId": "asset_1"
+            }))));
+            assert!(!boogu_img2img_candle_eligible(&object(json!({
+                "model": model, "mode": "edit_image", "referenceAssetId": "asset_1"
+            }))));
+            // A blank/absent reference is plain txt2img, not img2img.
+            assert!(!boogu_img2img_candle_eligible(&object(json!({
+                "model": model, "referenceAssetId": "  "
+            }))));
+            assert!(!boogu_img2img_candle_eligible(&object(
+                json!({ "model": model })
+            )));
+        }
+        // Base/Turbo carry NO separate edit lane, so an `edit_image` job on them stays ineligible (the
+        // img2img branch is gated to a non-edit mode; the edit branch is gated to `boogu_image_edit`).
+        for model in ["boogu_image", "boogu_image_turbo"] {
+            assert!(!image_job_is_candle_eligible(&image_edit_job(json!({
+                "model": model, "mode": "edit_image", "sourceAssetId": "asset_1"
+            }))));
+        }
+    }
+
+    #[test]
     fn explicit_quantization_falls_back_to_torch_image_and_video() {
         // sc-5099: a candle provider that advertises NO quant (supported_quants: &[]) must route an
         // explicit `advanced.mlxQuantize > 0` to Python rather than silently running dense. chroma1_hd

--- a/crates/sceneworks-core/src/jobs_store/routing/candle.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/candle.rs
@@ -142,6 +142,20 @@ pub(crate) fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     if model == "boogu_image_edit" && boogu_edit_candle_eligible(&job.payload) {
         return true;
     }
+    // Boogu Base/Turbo img2img (reference-guided latent-init, sc-11786, epic 8588): a `boogu_image` /
+    // `boogu_image_turbo` job in a **non-edit** mode with a `referenceAssetId` is the REGISTRY img2img
+    // path — the candle Base/Turbo generators now advertise `Reference` and their `generate` VAE-encodes
+    // a single reference into the clean init latent + denoises the reduced schedule tail (`pipeline`
+    // `resolve_reference` + `init_time_step` + `render_base`/`render_turbo`, candle-gen sc-11786), and the
+    // worker `generate_candle_stream` resolves the init generically (`model_supports_img2img`, sc-10134).
+    // DISJOINT from the `boogu_image_edit` multi-reference instruction-edit lane above (a different engine
+    // id + the Qwen3-VL vision tower). The txt2img gate below rejects any `referenceAssetId`, so branch it
+    // out here. Mirrors the mlx-gen-boogu img2img (sc-10191) + the Z-Image img2img routing.
+    if matches!(model, "boogu_image" | "boogu_image_turbo")
+        && boogu_img2img_candle_eligible(&job.payload)
+    {
+        return true;
+    }
     // Krea 2 Kontext-style dual-conditioned image-edit (epic 10871 Raw + sc-11640 Turbo): a `krea_2_raw` /
     // `krea_2_turbo` `edit_image` job with a source image is the bespoke candle `KreaEdit` lane
     // (`generate_candle_krea_edit_stream`), NOT txt2img — Raw runs the full-CFG loop, Turbo the CFG-free
@@ -858,6 +872,26 @@ pub(crate) fn boogu_edit_candle_eligible(payload: &Map<String, Value>) -> bool {
                 .any(|v| v.as_str().is_some_and(|s| !s.trim().is_empty()))
         });
     single || plural
+}
+
+/// Boogu Base/Turbo img2img (reference-guided latent-init) candle-routing conditions (sc-11786, epic
+/// 8588). The registered `boogu_image` (Base) and `boogu_image_turbo` candle generators serve registry
+/// img2img: a single `Conditioning::Reference` in a **non-edit** request VAE-encodes to the clean init
+/// latent and denoises the reduced schedule tail (`candle-gen-boogu` `resolve_reference` +
+/// `init_time_step` — `render_base` / `render_turbo`). So a Base/Turbo job in a non-edit mode with a
+/// `referenceAssetId` is candle-eligible; the worker resolves the init generically
+/// (`model_supports_img2img`, sc-10134). Same payload predicate as [`zimage_img2img_candle_eligible`],
+/// gated to the Boogu Base/Turbo ids by the caller. DISJOINT from the `boogu_image_edit` multi-reference
+/// instruction-edit lane (`boogu_edit_candle_eligible`, a different engine id + `edit_image` mode + the
+/// Qwen3-VL vision tower). Mirrors the mlx-gen-boogu img2img (sc-10191).
+pub(crate) fn boogu_img2img_candle_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
+        return false;
+    }
+    payload
+        .get("referenceAssetId")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty())
 }
 
 /// Bernini still-image i2i candle-routing conditions (sc-10996, epic 6562). The candle

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1700,15 +1700,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c4
 # (both parents pin it; `git diff 0cf90d1d..1be2369 -- gen-core/` is EMPTY), so the skew gate stays
 # single-rev with NO mlx-gen move. GPU-validated sm_120 (monotone reference fidelity 15.0/8.4/3.1 at
 # s=0.25/0.6/0.9). ALL candle-gen-* pins move together; backend-candle check --locked green.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1722,7 +1722,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1730,17 +1730,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1750,7 +1750,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1758,21 +1758,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1781,7 +1781,7 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # Candle Bernini still-image companion (sc-10996, epic 6562) — the Windows/CUDA sibling of
 # `mlx-gen-bernini`, built ON candle-gen-wan (the full Qwen2.5-VL/MAR semantic planner driving a
 # Wan2.2-A14B dual-expert renderer, `frames:1` for a single still). Self-registers the full `bernini`
@@ -1793,17 +1793,17 @@ candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # main HEAD, the merged #421 planner-components commit — contains the #419 full generator sc-10995) — its
 # gen-core pin (951227a) MATCHES the worker's mlx pin, so `--features backend-candle --target all`
 # resolves ONE gen-core rev (no skew).
-candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1812,7 +1812,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1845,7 +1845,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1854,12 +1854,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1867,7 +1867,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be23
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1876,7 +1876,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1884,7 +1884,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1898,7 +1898,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1925,7 +1925,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1936,7 +1936,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "1be2369b46378edd448c6fdde3a8e5dafc9c4ac0", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with


### PR DESCRIPTION
Make an off-Mac Boogu **Base/Turbo** img2img job candle-eligible so the "Start from an image" tile (`ui.img2img`, in the catalog since mlx sc-10191) renders instead of enforce-failing `candle_unsupported`. The candle sibling of the mlx-gen-boogu img2img (sc-10191, worker #1263): the candle `boogu_image` / `boogu_image_turbo` generators now serve **registry** img2img (candle-gen [#494](https://github.com/SceneWorks/candle-gen/pull/494), rev `8750b52`), and the worker `generate_candle_stream` already resolves the init generically (`model_supports_img2img`, sc-10134) — so only the router branch + the pin bump are needed off-Mac.

## Router (`sceneworks-core` `routing::candle`)
A `boogu_image | boogu_image_turbo` img2img branch in `image_job_is_candle_eligible` via a new `boogu_img2img_candle_eligible` (non-edit mode + a `referenceAssetId` — the same predicate as `zimage_img2img_candle_eligible`). Branched right after the `boogu_image_edit` instruction-edit branch and **disjoint** from it (a different engine id + `edit_image` mode + the Qwen3-VL vision tower); before the txt2img gate (which rejects any `referenceAssetId`). No catalog change — `ui.img2img: true` was already set for both Base/Turbo when mlx shipped sc-10191.

## Pin
All `candle-gen-*` pins `1be2369b` → `8750b52` (the candle-gen boogu img2img engine). `8750b52` is a direct child of `1be2369b` (main's current pin), re-pinning the **same** gen-core `b8c41526` — the `backend-candle` skew gate resolves ONE gen-core rev (verified via `check-gen-core-skew.sh`), no mlx-gen move. `Cargo.lock` regen'd via cargo; `--locked` green.

## Tests
`boogu_base_and_turbo_img2img_route_to_candle` (eligibility + edit/blank-reference precedence). The full `candle_routing_tests` module stays green (61 pass); `sceneworks-core` clippy clean.

Depends on candle-gen [#494](https://github.com/SceneWorks/candle-gen/pull/494). Relates to sc-10191 (mlx Boogu img2img), sc-10265, sc-10134, epic 8588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)