### PR TITLE
feat(worker): Krea pose-ControlNet tiled VAE decode rung to kill the end-of-render VRAM spike (sc-11744)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -570,7 +570,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-gen",
  "image",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -768,7 +768,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -805,7 +805,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -817,7 +817,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -830,7 +830,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=8750b52#8750b529cb7da9561d203e30468b965b1ac38af8"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=324f89606da51704613459e25cd0c0b71fc4c9ac#324f89606da51704613459e25cd0c0b71fc4c9ac"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -8361,7 +8361,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2523,15 +2523,25 @@
         // free VRAM and, only when constrained, engages the cheapest sufficient rung. @1024²/8-step/scale 0.6
         // on an RTX PRO 6000 (Blackwell sm_120).
         "control": {
-          // Overall render peak (GB) by BASE tier, bf16 control branch, NO rungs engaged. q4 MEASURED 30.9
-          // (sc-11744 GPU timeline, the VAE-decode spike); bf16 MEASURED 46.2 (sc-11743, dense base + bf16
-          // branch); q8 ESTIMATED ~35.5 (between the two) pending measurement.
+          // Overall render peak (GB) by BASE tier, bf16 control branch, NO rungs engaged (monolithic VAE
+          // decode). q4 MEASURED 30.9 (sc-11744 GPU timeline, the VAE-decode spike); bf16 MEASURED 46.2
+          // (sc-11743, dense base + bf16 branch); q8 ESTIMATED ~35.5 (between the two) pending measurement.
           "peakGbByTier": { "q4": 30.9, "q8": 35.5, "bf16": 46.2 },
+          // CHEAPEST rung (sc-11744, candle-gen #492): the peak reduction (GB) from forcing the seam-free
+          // tiled VAE decode (`Krea2ControlRequest.tile_vae_decode`) — a SPEED cost, no quality cost. The
+          // fit-gate engages it BEFORE branch-quant. GPU-MEASURED on an RTX PRO 6000 (Blackwell sm_120),
+          // 1024²/8-step: the monolithic decode peaks at +6.7 GiB over the tiled tail (40.2 → 33.4 GiB
+          // whole-render), at a decode cost of +0.14 s (0.56 → 0.71 s, +26%). Seam-free: the tiled render
+          // is bit-near-identical to monolithic (mean |Δ| 0.05/255, no tile-boundary spike). Keyed to the
+          // q4 BASE tier, where the ~30.9 GB decode spike IS the render peak; 6.7 brings it to ~24.2 GB,
+          // essentially the denoise steady floor. Higher tiers omit it (their denoise steady-state, not the
+          // decode, is the peak — tiling there recovers little, so branch-quant is the operative rung).
+          "decodeTileSaveGb": { "q4": 6.7 },
           // Last-resort rung: the peak reduction (GB) from quantizing the control branch bf16 → q8/q4
           // (candle-gen #483, sc-11743), MEASURED (dense base holds the rest fixed to isolate the branch):
           // q8 −8.4 (near-lossless), q4 −10.2 (pose-locked; non-pose details drift). The gate prefers q8
-          // before q4. Cheaper rungs (VAE-decode tiling sc-11744, activation chunking / res-cap sc-11745)
-          // engage BEFORE this once their candle-gen mechanism ships; their deltas land with those stories.
+          // before q4, and composes it with the tiling rung above. The activation-chunking / res-cap rung
+          // (sc-11745) slots between tiling and branch-quant once its candle-gen mechanism ships.
           "branchQuantSaveGb": { "q8": 8.4, "q4": 10.2 },
           "measured": false
         }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1700,15 +1700,28 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c4
 # (both parents pin it; `git diff 0cf90d1d..1be2369 -- gen-core/` is EMPTY), so the skew gate stays
 # single-rev with NO mlx-gen move. GPU-validated sm_120 (monotone reference fidelity 15.0/8.4/3.1 at
 # s=0.25/0.6/0.9). ALL candle-gen-* pins move together; backend-candle check --locked green.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+# Bumped candle-gen `8750b52` -> `324f896` (sc-11744, epic 8459): candle-gen PR #492 adds the pose-control
+# fit-ladder's cheapest VRAM rung — `QwenVae::decode_with(latents, force_tile)` + the
+# `Krea2ControlRequest.tile_vae_decode` toggle the sc-11754 fit-gate flips to force the seam-free tiled VAE
+# tail below the im2col threshold, capping the ~30.9 GB end-of-render decode spike that OOMs a constrained
+# card at 1024². `324f896` RECONCILES the diverged pin treadmill: it is #492's content commit (the VAE-tiling
+# change + an example-constructor fix) cherry-picked ON TOP of `8750b52` (the sc-11786 boogu img2img pin main
+# carried, itself a disjoint sibling off `1be2369` — candle-gen-boogu vs candle-gen-krea/-qwen-image), so
+# `324f896` carries BOTH boogu img2img AND the Krea VAE-decode tiling. Both parents pin gen-core `b8c41526`
+# (`git diff 8750b52..324f896 -- gen-core/ gen-core-testkit/` is EMPTY), so the `--features backend-candle`
+# skew gate stays single-rev with NO mlx-gen move. Additive candle-gen-krea/candle-gen-qwen-image only
+# (`decode()` is byte-identical when `force_tile = false`, the default for every existing caller). Points at
+# the branch content commit (durable ancestor once #492's merge lands on candle-gen main). ALL candle-gen-*
+# pins move together; backend-candle check --locked green.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1722,7 +1735,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1730,17 +1743,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1750,7 +1763,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1758,21 +1771,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1781,7 +1794,7 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # Candle Bernini still-image companion (sc-10996, epic 6562) — the Windows/CUDA sibling of
 # `mlx-gen-bernini`, built ON candle-gen-wan (the full Qwen2.5-VL/MAR semantic planner driving a
 # Wan2.2-A14B dual-expert renderer, `frames:1` for a single still). Self-registers the full `bernini`
@@ -1793,17 +1806,17 @@ candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # main HEAD, the merged #421 planner-components commit — contains the #419 full generator sc-10995) — its
 # gen-core pin (951227a) MATCHES the worker's mlx pin, so `--features backend-candle --target all`
 # resolves ONE gen-core rev (no skew).
-candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1812,7 +1825,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1845,7 +1858,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1854,12 +1867,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1867,7 +1880,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1876,7 +1889,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1884,7 +1897,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1898,7 +1911,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1925,7 +1938,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1936,7 +1949,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "8750b52", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "324f89606da51704613459e25cd0c0b71fc4c9ac", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
@@ -305,6 +305,10 @@ struct KreaStrictControl {
     /// peak wouldn't otherwise fit the (possibly emulated) card. Folds the ~6.6 GB dense branch onto the
     /// GPU packed (dequant-on-forward) so it never lands dense in VRAM.
     branch_quant: Option<gen_core::Quant>,
+    /// Force the seam-free tiled VAE decode (sc-11744) — the fit ladder's cheapest rung, engaged only
+    /// when the predicted decode-phase peak exceeds free VRAM. `false` (the big-card default) is the
+    /// monolithic full-speed decode. A *speed* cost, no quality cost.
+    tile_vae_decode: bool,
     prompt: String,
     width: u32,
     height: u32,
@@ -363,6 +367,7 @@ impl CandleStrictControl for KreaStrictControl {
             steps: self.steps as usize,
             control_scale: self.control_scale,
             seed,
+            tile_vae_decode: self.tile_vae_decode,
             cancel: cancel.clone(),
         };
         model.generate(&req, control, on_progress).map_err(|error| {
@@ -432,27 +437,34 @@ async fn generate_candle_krea_control_stream(
         crate::gpu::nvidia_vram_budget_gb(&settings.gpu_id).await,
         crate::vram_gate::cuda_vram_cap_gb(),
     );
-    let branch_quant = match crate::krea_control_fit::fit_ladder(
+    let (tile_vae_decode, branch_quant) = match crate::krea_control_fit::fit_ladder(
         crate::krea_control_fit::predicted_control_peak_gb(&request.model_manifest_entry, tier),
         budget,
+        crate::krea_control_fit::decode_tile_save_gb(&request.model_manifest_entry, tier),
         crate::krea_control_fit::branch_quant_save_gb(&request.model_manifest_entry, "q8"),
         crate::krea_control_fit::branch_quant_save_gb(&request.model_manifest_entry, "q4"),
     ) {
-        // Big-card fast path (or no signal): keep the bf16 branch.
+        // Big-card fast path (or no signal): monolithic full-speed decode, bf16 branch.
         crate::krea_control_fit::KreaControlFit::Unknown
-        | crate::krea_control_fit::KreaControlFit::Fits { branch_quant: None } => None,
-        // Constrained card: the fit ladder engaged the branch-quant rung to fit.
+        | crate::krea_control_fit::KreaControlFit::Fits {
+            tile_vae_decode: false,
+            branch_quant: None,
+        } => (false, None),
+        // Constrained card: the fit ladder engaged the cheapest sufficient set of rungs to fit — the
+        // seam-free tiled VAE decode (sc-11744, a speed cost) and/or the last-resort branch quant.
         crate::krea_control_fit::KreaControlFit::Fits {
-            branch_quant: Some(quant),
+            tile_vae_decode: tile,
+            branch_quant: quant,
         } => {
             tracing::info!(
                 model = %request.model,
                 tier,
+                tile_vae_decode = tile,
                 branch_quant = ?quant,
-                "Krea control VRAM fit ladder: predicted peak exceeds free VRAM — quantizing the \
-                 control branch (last-resort rung) to fit"
+                "Krea control VRAM fit ladder: predicted peak exceeds free VRAM — engaging rungs \
+                 (VAE-decode tiling and/or control-branch quant) to fit"
             );
-            Some(quant)
+            (tile, quant)
         }
         // Won't fit even at the last rung ⇒ reject before the reactive CUDA OOM.
         crate::krea_control_fit::KreaControlFit::TooBig {
@@ -461,8 +473,9 @@ async fn generate_candle_krea_control_stream(
         } => {
             return Err(WorkerError::InvalidPayload(format!(
                 "Krea 2 pose-ControlNet at the {tier} base tier needs ~{needed} GB of VRAM (with \
-                 headroom, control branch quantized to q4) but GPU {gpu} has ~{available} GB \
-                 available. Lower the output resolution or run on a card with more VRAM.",
+                 headroom, tiled VAE decode + control branch quantized to q4) but GPU {gpu} has \
+                 ~{available} GB available. Lower the output resolution or run on a card with more \
+                 VRAM.",
                 needed = needed_gb.round() as i64,
                 available = available_gb.round() as i64,
                 gpu = settings.gpu_id,
@@ -475,6 +488,7 @@ async fn generate_candle_krea_control_stream(
         control,
         adapters,
         branch_quant,
+        tile_vae_decode,
         prompt: request.prompt.clone(),
         width: request.width,
         height: request.height,

--- a/crates/sceneworks-worker/src/krea_control_fit.rs
+++ b/crates/sceneworks-worker/src/krea_control_fit.rs
@@ -14,17 +14,21 @@
 //! stopping as soon as the predicted peak ≤ budget:
 //!  1. **packed base** — default, ~free (candle-gen #480, shipped). Always on; the peak below already
 //!     reflects it.
-//!  2. **VAE-decode tiling** (sc-11744) — engage when the decode-phase spike is the overflow.
+//!  2. **VAE-decode tiling** (sc-11744, candle-gen #492) — force the seam-free tiled VAE tail (a *speed*
+//!     cost, no quality cost) to cap the end-of-render decode spike. Engaged first, when the measured
+//!     `decodeTileSaveGb` is enough to fit; also stays on underneath the quant rungs (it is cheaper than
+//!     quant and every bit helps).
 //!  3. **activation chunking / resolution cap** (sc-11745) — engage when the denoise steady state is the
-//!     overflow.
+//!     overflow. Still pending its candle-gen mechanism (`WIRED_ACTIVATION_CHUNKING = false`); slots in
+//!     here between tiling and branch-quant when it lands.
 //!  4. **control-branch quant** (sc-11743, candle-gen #483) — bf16 → q8 → q4. A *quality cost* (the
-//!     residual is precision-sensitive, RMS-clamped at τ), so it is the **last-resort rung**.
+//!     residual is precision-sensitive, RMS-clamped at τ), so it is the **last-resort rung**. Composes
+//!     with tiling (both reduce the decode-dominated peak).
 //!
-//! Rungs 2–3 need their own candle-gen mechanism, which ships with sc-11744 / sc-11745; until then they
-//! are declared but **not yet engageable** (`WIRED_CHEAPER_RUNGS = false`) — the ladder skips straight to
-//! the branch-quant rung and, if even q4 won't fit, rejects-before-OOM noting the pending cheaper rungs.
-//! When those stories land they slot in AHEAD of branch-quant here (a localized change), so a constrained
-//! card prefers the cheaper rungs and keeps a bf16 branch more often.
+//! Rung 3 needs its own candle-gen mechanism (sc-11745); until then it is declared but **not yet
+//! engageable** — the ladder walks packed → tiling → branch-quant and, if even (tiling + q4) won't fit,
+//! rejects-before-OOM noting the pending activation-chunking rung. `decodeTileSaveGb` absent for a tier
+//! (unmeasured) ⇒ the tiling rung is skipped for that tier exactly like an unmeasured branch-quant save.
 //!
 //! Everything here is pure and unit-tested; the live `nvidia-smi` reading lives in [`crate::gpu`] and the
 //! wiring is in `generate_candle_krea_control_stream` (image_jobs/krea_control_candle.rs).
@@ -38,11 +42,12 @@ use serde_json::Value;
 /// slack + activation spikes not captured by the steady peak.
 const HEADROOM_GB: f64 = 2.0;
 
-/// Whether the cheaper-than-branch-quant rungs (VAE-decode tiling sc-11744, activation chunking /
-/// resolution cap sc-11745) are wired yet. `false` until those stories ship their candle-gen mechanism +
-/// the `Krea2ControlRequest` toggles they engage; the ladder then inserts them AHEAD of the branch-quant
-/// rung. Flipping this (and threading the toggles) is those stories' one-line hook into this gate.
-const WIRED_CHEAPER_RUNGS: bool = false;
+/// Whether the activation-chunking / resolution-cap rung (sc-11745) is wired yet. `false` until that
+/// story ships its candle-gen mechanism + the `Krea2ControlRequest` toggle it engages; the ladder then
+/// inserts it between the VAE-tiling rung (sc-11744, already wired below) and the branch-quant rung.
+/// Flipping this (and threading the toggle) is sc-11745's one-line hook into this gate. (The VAE-tiling
+/// rung is now live — gated instead by the presence of the measured `decodeTileSaveGb`.)
+const WIRED_ACTIVATION_CHUNKING: bool = false;
 
 /// The outcome of walking the Krea control fit ladder. `Unknown` = no signal (no `candle.control` block,
 /// or a non-NVIDIA host) ⇒ never block, run the bf16 branch — exactly like [`crate::vram_gate::FitDecision::Unknown`].
@@ -50,10 +55,17 @@ const WIRED_CHEAPER_RUNGS: bool = false;
 pub(crate) enum KreaControlFit {
     /// No measured control peak or no live budget ⇒ don't gate; load the default bf16 branch.
     Unknown,
-    /// The predicted peak fits (possibly after engaging branch quant). `branch_quant = None` is the
-    /// big-card fast path (bf16 branch, zero quality penalty); `Some(Q8)`/`Some(Q4)` is the last-resort
-    /// rung the gate engaged to fit a constrained card.
-    Fits { branch_quant: Option<Quant> },
+    /// The predicted peak fits after engaging the minimal sufficient set of rungs. The big-card fast
+    /// path is `{ tile_vae_decode: false, branch_quant: None }` (monolithic full-speed decode, bf16
+    /// branch, zero penalty). `tile_vae_decode = true` is the cheapest rung (sc-11744 — a *speed* cost
+    /// only, seam-free); `branch_quant = Some(Q8)`/`Some(Q4)` is the last-resort *quality* rung, engaged
+    /// only after tiling was insufficient.
+    Fits {
+        /// Force the seam-free tiled VAE decode (sc-11744) to cap the end-of-render decode spike. The
+        /// worker threads this into `Krea2ControlRequest::tile_vae_decode`.
+        tile_vae_decode: bool,
+        branch_quant: Option<Quant>,
+    },
     /// Won't fit even at the last rung (q4 branch). Reject-before-OOM with an actionable message rather
     /// than a reactive CUDA OOM mid-render. `needed_gb` is the best-case (q4-branch) predicted peak.
     TooBig { needed_gb: f64, available_gb: f64 },
@@ -89,16 +101,35 @@ pub(crate) fn branch_quant_save_gb(manifest_entry: &JsonObject, quant: &str) -> 
         .and_then(json_f64)
 }
 
-/// Walk the fit ladder: given the bf16-branch predicted peak, the (capped) live budget, and the measured
-/// branch-quant savings, engage the minimal sufficient set of rungs and return the [`KreaControlFit`].
+/// Measured peak reduction (GB) from forcing the seam-free tiled VAE decode for BASE tier `tier_key`
+/// (sc-11744, candle-gen #492): `candle.control.decodeTileSaveGb[tier_key]` — the monolithic whole-render
+/// peak minus the tiled one (the decode spike capped toward the denoise steady state). `None` when
+/// unmeasured for that tier ⇒ the VAE-tiling rung is unavailable there and the ladder walks straight to
+/// branch-quant. Tier-keyed like [`predicted_control_peak_gb`] because whether the decode spike *is* the
+/// global peak (and thus how much tiling recovers) depends on the tier's denoise-steady floor.
+pub(crate) fn decode_tile_save_gb(manifest_entry: &JsonObject, tier_key: &str) -> Option<f64> {
+    manifest_entry
+        .get("candle")?
+        .get("control")?
+        .get("decodeTileSaveGb")
+        .and_then(|saves| saves.get(tier_key))
+        .and_then(json_f64)
+}
+
+/// Walk the fit ladder: given the bf16-branch predicted peak, the (capped) live budget, the measured
+/// VAE-decode tiling saving, and the measured branch-quant savings, engage the minimal sufficient set of
+/// rungs in increasing (Δcost) order and return the [`KreaControlFit`].
 ///
-/// Today the only wired rung is branch-quant (bf16 → q8 → q4, the LAST resort), so the walk is: if the
-/// bf16 peak fits, load bf16 (big-card fast path, no penalty); else prefer q8 (near-lossless), then q4
-/// (pose-locked, non-pose drift); else reject. The cheaper rungs (sc-11744/45) engage AHEAD of q8 once
-/// [`WIRED_CHEAPER_RUNGS`] flips. Missing peak or budget ⇒ [`KreaControlFit::Unknown`] (never block).
+/// Walk: if the monolithic peak fits, run untiled at the bf16 branch (big-card fast path, no penalty);
+/// else force the seam-free tiled decode (sc-11744 — a *speed* cost only); else — keeping tiling on —
+/// quantize the control branch, preferring q8 (near-lossless) then q4 (pose-locked, non-pose drift);
+/// else reject-before-OOM. The activation-chunking rung (sc-11745) slots between tiling and branch-quant
+/// once [`WIRED_ACTIVATION_CHUNKING`] flips. An unmeasured saving skips that rung. Missing peak or budget
+/// ⇒ [`KreaControlFit::Unknown`] (never block).
 pub(crate) fn fit_ladder(
     peak_bf16_branch_gb: Option<f64>,
     budget: Option<crate::vram_gate::VramBudget>,
+    decode_tile_save_gb: Option<f64>,
     q8_save_gb: Option<f64>,
     q4_save_gb: Option<f64>,
 ) -> KreaControlFit {
@@ -108,33 +139,54 @@ pub(crate) fn fit_ladder(
     let free = budget.free_gb;
     let fits = |needed: f64| free + f64::EPSILON >= needed;
 
-    // (Cheaper rungs — VAE-decode tiling, activation chunking / res-cap — engage here, ahead of
-    //  branch-quant, once sc-11744 / sc-11745 wire their candle-gen toggles; see WIRED_CHEAPER_RUNGS.)
-    let _ = WIRED_CHEAPER_RUNGS;
+    // (The activation-chunking / res-cap rung, sc-11745, engages here — between tiling and branch-quant —
+    //  once it wires its candle-gen toggle; see WIRED_ACTIVATION_CHUNKING.)
+    let _ = WIRED_ACTIVATION_CHUNKING;
 
-    // Big-card fast path: the bf16 branch already fits — no rung engages, zero quality penalty.
+    // Rung 1 (packed base, always on) — big-card fast path: the monolithic bf16-branch peak already fits,
+    // so nothing engages: full-speed decode, zero quality penalty.
     if fits(peak) {
-        return KreaControlFit::Fits { branch_quant: None };
+        return KreaControlFit::Fits {
+            tile_vae_decode: false,
+            branch_quant: None,
+        };
     }
-    // Last-resort rung: quantize the control branch. Prefer q8 (effectively free quality) before q4
-    // (visible non-pose drift). Each save is measured (sc-11743); an unmeasured save skips that option.
-    if let Some(save) = q8_save_gb {
-        if fits(peak - save) {
+    // Rung 2 (VAE-decode tiling, sc-11744) — cheapest: a *speed* cost, no quality loss (seam-free). An
+    // unmeasured tier saving (None) leaves this rung unavailable, degenerating to the old quant-only walk.
+    if let Some(tile_save) = decode_tile_save_gb {
+        if fits(peak - tile_save) {
             return KreaControlFit::Fits {
+                tile_vae_decode: true,
+                branch_quant: None,
+            };
+        }
+    }
+    // Past here tiling alone was insufficient, so keep it on beneath the quant rungs (it is cheaper than
+    // quant and every GB helps); if it was unmeasured, `tile_on` stays false and the peak is unreduced.
+    let tile_on = decode_tile_save_gb.is_some();
+    let peak_after_tile = peak - decode_tile_save_gb.unwrap_or(0.0);
+
+    // Rung 4 (control-branch quant, sc-11743) — last resort, a *quality* cost. Prefer q8 (effectively
+    // free quality) before q4 (visible non-pose drift). Each save is measured; an unmeasured save skips.
+    if let Some(save) = q8_save_gb {
+        if fits(peak_after_tile - save) {
+            return KreaControlFit::Fits {
+                tile_vae_decode: tile_on,
                 branch_quant: Some(Quant::Q8),
             };
         }
     }
     if let Some(save) = q4_save_gb {
-        if fits(peak - save) {
+        if fits(peak_after_tile - save) {
             return KreaControlFit::Fits {
+                tile_vae_decode: tile_on,
                 branch_quant: Some(Quant::Q4),
             };
         }
     }
-    // Won't fit even at q4 (the cheaper sc-11744/45 rungs would add more headroom once shipped). Report
-    // the best-case (q4-branch) peak so the reject message is honest about what still overflows.
-    let best_case = q4_save_gb.or(q8_save_gb).map_or(peak, |save| peak - save);
+    // Won't fit even at (tiling + q4). Report the best-case peak (tiling on + the deepest branch quant) so
+    // the reject message is honest about what still overflows (the sc-11745 rung would add more headroom).
+    let best_case = peak_after_tile - q4_save_gb.or(q8_save_gb).unwrap_or(0.0);
     KreaControlFit::TooBig {
         needed_gb: best_case,
         available_gb: free,
@@ -166,11 +218,23 @@ mod tests {
                 "control": {
                     // q4 measured (sc-11744), bf16 measured (sc-11743), q8 estimated.
                     "peakGbByTier": { "q4": 30.9, "q8": 35.5, "bf16": 46.2 },
+                    // VAE-decode tiling saving (sc-11744); measured only for the constrained q4 tier here
+                    // (the decode spike is the peak there). Illustrative test value, not the shipped one.
+                    "decodeTileSaveGb": { "q4": 6.9 },
                     // measured sc-11743 (dense base isolates the branch).
                     "branchQuantSaveGb": { "q8": 8.4, "q4": 10.2 }
                 }
             }
         }))
+    }
+
+    /// Read the q4 rung savings the ladder tests exercise (tiling + both branch quants).
+    fn q4_saves(m: &JsonObject) -> (Option<f64>, Option<f64>, Option<f64>) {
+        (
+            decode_tile_save_gb(m, "q4"),
+            branch_quant_save_gb(m, "q8"),
+            branch_quant_save_gb(m, "q4"),
+        )
     }
 
     #[test]
@@ -202,6 +266,16 @@ mod tests {
         assert_eq!(branch_quant_save_gb(&obj(json!({})), "q8"), None);
     }
 
+    #[test]
+    fn decode_tile_save_reads_the_measured_delta() {
+        let m = krea_manifest();
+        assert_eq!(decode_tile_save_gb(&m, "q4"), Some(6.9));
+        // Unmeasured for a tier ⇒ None (the tiling rung is unavailable there).
+        assert_eq!(decode_tile_save_gb(&m, "bf16"), None);
+        // No control block / no candle block ⇒ None.
+        assert_eq!(decode_tile_save_gb(&obj(json!({})), "q4"), None);
+    }
+
     fn budget(free: f64) -> VramBudget {
         VramBudget {
             free_gb: free,
@@ -209,16 +283,71 @@ mod tests {
         }
     }
 
+    /// The big-card fast path: untiled monolithic decode, bf16 branch, no rung engaged.
+    fn fits_untiled_bf16() -> KreaControlFit {
+        KreaControlFit::Fits {
+            tile_vae_decode: false,
+            branch_quant: None,
+        }
+    }
+
     #[test]
     fn big_card_keeps_the_bf16_branch_with_no_penalty() {
         let m = krea_manifest();
         let peak = predicted_control_peak_gb(&m, "q4");
-        let q8 = branch_quant_save_gb(&m, "q8");
-        let q4 = branch_quant_save_gb(&m, "q4");
-        // 96 GB card: the bf16 branch fits outright — nothing engages.
+        let (tile, q8, q4) = q4_saves(&m);
+        // 96 GB card: the monolithic peak fits outright — nothing engages (no tiling, no quant).
         assert_eq!(
-            fit_ladder(peak, Some(budget(90.0)), q8, q4),
-            KreaControlFit::Fits { branch_quant: None }
+            fit_ladder(peak, Some(budget(90.0)), tile, q8, q4),
+            fits_untiled_bf16()
+        );
+    }
+
+    #[test]
+    fn vae_tiling_is_the_cheapest_rung_and_keeps_the_bf16_branch() {
+        let m = krea_manifest();
+        // q4 base: monolithic peak 30.9 + 2 = 32.9; tiling saves 6.9 ⇒ tiled peak 26.0.
+        let peak = predicted_control_peak_gb(&m, "q4");
+        let (tile, q8, q4) = q4_saves(&m);
+        // 26 GB card: monolithic (32.9) won't fit, but the tiled decode (26.0) does ⇒ tile on, bf16 branch
+        // kept (no quality penalty). Without sc-11744 this card would have dropped to a q8 branch.
+        assert_eq!(
+            fit_ladder(peak, Some(budget(26.0)), tile, q8, q4),
+            KreaControlFit::Fits {
+                tile_vae_decode: true,
+                branch_quant: None,
+            }
+        );
+    }
+
+    #[test]
+    fn tiling_composes_with_branch_quant_when_still_constrained() {
+        let m = krea_manifest();
+        let peak = predicted_control_peak_gb(&m, "q4"); // 32.9; tiled 26.0
+        let (tile, q8, q4) = q4_saves(&m);
+        // 24 GB card: tiled peak 26.0 > 24; tiling stays on and q8 engages (26.0 − 8.4 = 17.6 ≤ 24) ⇒
+        // tiling + q8 (near-lossless) instead of the old tiling-less q4-branch drop.
+        assert_eq!(
+            fit_ladder(peak, Some(budget(24.0)), tile, q8, q4),
+            KreaControlFit::Fits {
+                tile_vae_decode: true,
+                branch_quant: Some(Quant::Q8),
+            }
+        );
+        // 16 GB card: tiling + q8 (17.6) > 16; tiling + q4 (26.0 − 10.2 = 15.8 ≤ 16) fits ⇒ the deepest
+        // rung. Without the tiling rung this card OOM-rejected (q4-alone peak 22.7 > 16).
+        assert_eq!(
+            fit_ladder(peak, Some(budget(16.0)), tile, q8, q4),
+            KreaControlFit::Fits {
+                tile_vae_decode: true,
+                branch_quant: Some(Quant::Q4),
+            }
+        );
+        // 15 GB card: even tiling + q4 (15.8) won't fit ⇒ reject-before-OOM at the best-case peak.
+        assert_too_big(
+            fit_ladder(peak, Some(budget(15.0)), tile, q8, q4),
+            15.8,
+            15.0,
         );
     }
 
@@ -240,75 +369,71 @@ mod tests {
     }
 
     #[test]
-    fn constrained_card_prefers_q8_then_q4() {
+    fn pure_quant_walk_when_the_tier_has_no_tiling_measurement() {
         let m = krea_manifest();
-        // Use the bf16 BASE tier so the peak (46.2 + 2 = 48.2) exercises both branch-quant rungs.
+        // The bf16 BASE tier carries no `decodeTileSaveGb` (the decode spike is not its peak), so the
+        // tiling rung is unavailable and the walk degenerates to the old quant-only ladder. Peak 48.2.
         let peak = predicted_control_peak_gb(&m, "bf16");
+        let tile = decode_tile_save_gb(&m, "bf16"); // None
         let q8 = branch_quant_save_gb(&m, "q8"); // 8.4
         let q4 = branch_quant_save_gb(&m, "q4"); // 10.2
 
-        // 48.2 fits ⇒ bf16 branch.
+        // 48.2 fits ⇒ untiled bf16 branch.
         assert_eq!(
-            fit_ladder(peak, Some(budget(49.0)), q8, q4),
-            KreaControlFit::Fits { branch_quant: None }
+            fit_ladder(peak, Some(budget(49.0)), tile, q8, q4),
+            fits_untiled_bf16()
         );
-        // 48.2 > 41, 48.2 − 8.4 = 39.8 ≤ 41 ⇒ q8 (preferred, near-lossless).
+        // 48.2 > 41, 48.2 − 8.4 = 39.8 ≤ 41 ⇒ q8 (preferred, near-lossless), tiling unavailable.
         assert_eq!(
-            fit_ladder(peak, Some(budget(41.0)), q8, q4),
+            fit_ladder(peak, Some(budget(41.0)), tile, q8, q4),
             KreaControlFit::Fits {
-                branch_quant: Some(Quant::Q8)
+                tile_vae_decode: false,
+                branch_quant: Some(Quant::Q8),
             }
         );
         // 39.8 > 39, 48.2 − 10.2 = 38.0 ≤ 39 ⇒ q4 (last resort).
         assert_eq!(
-            fit_ladder(peak, Some(budget(39.0)), q8, q4),
+            fit_ladder(peak, Some(budget(39.0)), tile, q8, q4),
             KreaControlFit::Fits {
-                branch_quant: Some(Quant::Q4)
+                tile_vae_decode: false,
+                branch_quant: Some(Quant::Q4),
             }
         );
         // Even q4 (~38.0) won't fit a 30 GB budget ⇒ reject, reporting the best-case peak.
-        assert_too_big(fit_ladder(peak, Some(budget(30.0)), q8, q4), 38.0, 30.0);
-    }
-
-    #[test]
-    fn q4_base_tier_fits_a_24gb_card_at_q4_branch() {
-        let m = krea_manifest();
-        // The common small-card install: q4 base. Peak 30.9 + 2 = 32.9.
-        let peak = predicted_control_peak_gb(&m, "q4");
-        let q8 = branch_quant_save_gb(&m, "q8");
-        let q4 = branch_quant_save_gb(&m, "q4");
-        // 32.9 > 24; 32.9 − 8.4 = 24.5 > 24; 32.9 − 10.2 = 22.7 ≤ 24 ⇒ q4 branch fits the 24 GB card.
-        assert_eq!(
-            fit_ladder(peak, Some(budget(24.0)), q8, q4),
-            KreaControlFit::Fits {
-                branch_quant: Some(Quant::Q4)
-            }
+        assert_too_big(
+            fit_ladder(peak, Some(budget(30.0)), tile, q8, q4),
+            38.0,
+            30.0,
         );
-        // A 16 GB card can't fit even q4 (~22.7) ⇒ reject (the sc-11744/45 rungs would add headroom).
-        assert_too_big(fit_ladder(peak, Some(budget(16.0)), q8, q4), 22.7, 16.0);
     }
 
     #[test]
     fn missing_signal_never_blocks() {
         let m = krea_manifest();
         let peak = predicted_control_peak_gb(&m, "q4");
-        let q8 = branch_quant_save_gb(&m, "q8");
-        let q4 = branch_quant_save_gb(&m, "q4");
+        let (tile, q8, q4) = q4_saves(&m);
         // No live budget ⇒ Unknown (never block).
-        assert_eq!(fit_ladder(peak, None, q8, q4), KreaControlFit::Unknown);
+        assert_eq!(
+            fit_ladder(peak, None, tile, q8, q4),
+            KreaControlFit::Unknown
+        );
         // No measured peak ⇒ Unknown.
         assert_eq!(
-            fit_ladder(None, Some(budget(8.0)), q8, q4),
+            fit_ladder(None, Some(budget(8.0)), tile, q8, q4),
             KreaControlFit::Unknown
         );
     }
 
     #[test]
-    fn unmeasured_branch_quant_can_only_reject() {
+    fn unmeasured_rungs_can_only_reject_at_the_raw_peak() {
         let m = krea_manifest();
         let peak = predicted_control_peak_gb(&m, "q4"); // 32.9
-                                                        // No branch-quant savings measured ⇒ the only rung is unavailable, so a too-small card rejects
-                                                        // reporting the bf16 peak itself (no rung to subtract).
-        assert_too_big(fit_ladder(peak, Some(budget(20.0)), None, None), 32.9, 20.0);
+                                                        // No tiling save and no branch-quant savings measured ⇒ no rung is available, so a too-small card
+                                                        // rejects reporting the raw peak itself (nothing to subtract).
+        assert_too_big(
+            fit_ladder(peak, Some(budget(20.0)), None, None, None),
+            32.9,
+            20.0,
+        );
     }
 }

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -542,19 +542,22 @@ fn flux2_candle_blocks_drive_the_fit_gate_and_reject() {
     );
 }
 
-/// sc-11754 (epic 8459 → epic 10765): the Krea 2 Turbo `candle.control` block drives the pose-ControlNet
-/// VRAM fit LADDER end-to-end against the SHIPPED manifest bytes. The control-lane sibling of
-/// `flux2_candle_blocks_drive_the_fit_gate_and_reject`: guards the DATA half — dropping the `control` block
-/// makes `predicted_control_peak_gb` return `None` → the control fit-gate goes INERT (bf16 branch always,
-/// the pre-sc-11754 behavior). Exercises the same `SCENEWORKS_CUDA_VRAM_CAP_GB` small-card emulation via
-/// `apply_vram_cap`, asserting the whole ladder: big card → bf16 branch (no penalty), 24 GB → q4 branch
-/// (the last-resort rung), 16 GB → reject-before-OOM. The branch-quant deltas are the sc-11743 measured
-/// values; a manifest edit that drifts them fails here.
+/// sc-11754 + sc-11744 (epic 8459 → epic 10765): the Krea 2 Turbo `candle.control` block drives the
+/// pose-ControlNet VRAM fit LADDER end-to-end against the SHIPPED manifest bytes. The control-lane sibling
+/// of `flux2_candle_blocks_drive_the_fit_gate_and_reject`: guards the DATA half — dropping the `control`
+/// block makes `predicted_control_peak_gb` return `None` → the control fit-gate goes INERT (bf16 branch
+/// always, the pre-sc-11754 behavior). Exercises the `SCENEWORKS_CUDA_VRAM_CAP_GB` small-card emulation via
+/// `apply_vram_cap` across the cost-ordered rungs: big card → untiled bf16 branch (no penalty); the
+/// VAE-tiling rung (sc-11744) engaging first (a bf16 branch kept where it would otherwise quantize); then
+/// tiling composing with branch-quant; then reject-before-OOM. Expectations are expressed relative to the
+/// SHIPPED deltas (a manifest edit that drifts `decodeTileSaveGb` / `branchQuantSaveGb` fails here) rather
+/// than hard-coded arithmetic.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 #[test]
 fn krea_control_candle_block_drives_the_fit_ladder() {
     use crate::krea_control_fit::{
-        branch_quant_save_gb, fit_ladder, predicted_control_peak_gb, KreaControlFit,
+        branch_quant_save_gb, decode_tile_save_gb, fit_ladder, predicted_control_peak_gb,
+        KreaControlFit,
     };
     use crate::vram_gate::apply_vram_cap;
     use gen_core::Quant;
@@ -576,45 +579,79 @@ fn krea_control_candle_block_drives_the_fit_ladder() {
     assert_eq!(q8, Some(8.4));
     assert_eq!(q4, Some(10.2));
 
-    // The common small-card install: q4 BASE tier. Peak 30.9 (measured sc-11744) + 2 headroom = 32.9.
+    // The common small-card install: q4 BASE tier. Peak 30.9 (measured sc-11744) + 2 headroom = 32.9,
+    // and the shipped VAE-decode tiling saving (sc-11744) that caps the decode spike.
     let q4_peak = predicted_control_peak_gb(entry, "q4");
-    assert!((q4_peak.expect("q4 control peak") - 32.9).abs() < 1e-6);
+    let peak = q4_peak.expect("q4 control peak");
+    assert!((peak - 32.9).abs() < 1e-6);
+    let tile = decode_tile_save_gb(entry, "q4");
+    let tile_save = tile.expect("q4 decodeTileSaveGb shipped (the sc-11744 tiling rung)");
+    assert!(tile_save > 0.0, "tiling must recover VRAM, got {tile_save}");
+    let tiled_peak = peak - tile_save;
 
-    // 96 GB card: the bf16 branch fits outright — nothing engages, zero speed/quality penalty.
+    // 96 GB card: the monolithic peak fits outright — nothing engages, untiled full-speed bf16 branch.
     assert_eq!(
-        fit_ladder(q4_peak, apply_vram_cap(None, Some(96.0)), q8, q4),
+        fit_ladder(q4_peak, apply_vram_cap(None, Some(96.0)), tile, q8, q4),
         KreaControlFit::Fits {
-            branch_quant: None
+            tile_vae_decode: false,
+            branch_quant: None,
         }
     );
-    // Emulate a 24 GB card: 32.9 > 24; q8 → 24.5 > 24; q4 → 22.7 ≤ 24 ⇒ q4 branch (last-resort rung).
+    // A card that fits the TILED peak but not the monolithic one ⇒ the cheapest rung: tiling on, bf16
+    // branch kept (no quality penalty). This is sc-11744's win — a card that used to drop to a q8 branch.
     assert_eq!(
-        fit_ladder(q4_peak, apply_vram_cap(None, Some(24.0)), q8, q4),
+        fit_ladder(q4_peak, apply_vram_cap(None, Some(tiled_peak)), tile, q8, q4),
         KreaControlFit::Fits {
-            branch_quant: Some(Quant::Q4)
+            tile_vae_decode: true,
+            branch_quant: None,
         }
     );
-    // Emulate a 16 GB card: even q4 (22.7) won't fit ⇒ reject-before-OOM (the sc-11744/45 rungs would add
-    // the remaining headroom once shipped).
-    match fit_ladder(q4_peak, apply_vram_cap(None, Some(16.0)), q8, q4) {
-        KreaControlFit::TooBig {
-            needed_gb,
-            available_gb,
-        } => {
-            assert!((needed_gb - 22.7).abs() < 1e-6, "best-case q4 peak, got {needed_gb}");
-            assert!((available_gb - 16.0).abs() < 1e-6);
+    // Just below the tiled peak: tiling stays on and q8 composes (tiled_peak − 8.4 fits) ⇒ tiling + q8,
+    // near-lossless — where the old ladder had already spent q4 or rejected.
+    assert_eq!(
+        fit_ladder(q4_peak, apply_vram_cap(None, Some(tiled_peak - 0.5)), tile, q8, q4),
+        KreaControlFit::Fits {
+            tile_vae_decode: true,
+            branch_quant: Some(Quant::Q8),
         }
-        other => panic!("16 GB → reject, got {other:?}"),
+    );
+    // A card between (tiling + q8) and (tiling + q4): tiling + q4 (tiled_peak − 10.2) fits where the old
+    // q4-only ladder (peak − 10.2) rejected — a real capability gain from stacking tiling under quant.
+    assert_eq!(
+        fit_ladder(q4_peak, apply_vram_cap(None, Some(tiled_peak - 8.9)), tile, q8, q4),
+        KreaControlFit::Fits {
+            tile_vae_decode: true,
+            branch_quant: Some(Quant::Q4),
+        }
+    );
+    // A card below even (tiling + q4) ⇒ reject-before-OOM at the best-case peak (tiled + q4 branch).
+    match fit_ladder(q4_peak, apply_vram_cap(None, Some(tiled_peak - 11.0)), tile, q8, q4) {
+        KreaControlFit::TooBig { needed_gb, .. } => {
+            assert!(
+                (needed_gb - (tiled_peak - 10.2)).abs() < 1e-6,
+                "best-case (tiled + q4) peak, got {needed_gb}"
+            );
+        }
+        other => panic!("below tiling+q4 → reject, got {other:?}"),
     }
 
-    // The bf16 BASE tier (peak 46.2 measured sc-11743 + 2 = 48.2) exercises the q8 rung: a 41 GB card
-    // takes q8 (48.2 − 8.4 = 39.8 ≤ 41), the near-lossless preference before q4.
+    // The bf16 BASE tier (peak 46.2 measured sc-11743 + 2 = 48.2) carries NO tiling saving (its denoise
+    // steady-state, not the decode, is the peak), so the walk is pure quant: a 41 GB card takes q8
+    // (48.2 − 8.4 = 39.8 ≤ 41), the near-lossless preference before q4.
     let bf16_peak = predicted_control_peak_gb(entry, "bf16");
     assert!((bf16_peak.expect("bf16 control peak") - 48.2).abs() < 1e-6);
+    assert_eq!(decode_tile_save_gb(entry, "bf16"), None);
     assert_eq!(
-        fit_ladder(bf16_peak, apply_vram_cap(None, Some(41.0)), q8, q4),
+        fit_ladder(
+            bf16_peak,
+            apply_vram_cap(None, Some(41.0)),
+            decode_tile_save_gb(entry, "bf16"),
+            q8,
+            q4
+        ),
         KreaControlFit::Fits {
-            branch_quant: Some(Quant::Q8)
+            tile_vae_decode: false,
+            branch_quant: Some(Quant::Q8),
         }
     );
 }
@@ -630,48 +667,57 @@ fn krea_control_candle_block_drives_the_fit_ladder() {
 #[ignore]
 async fn krea_control_live_ladder_on_a_real_card() {
     use crate::krea_control_fit::{
-        branch_quant_save_gb, fit_ladder, predicted_control_peak_gb, KreaControlFit,
+        branch_quant_save_gb, decode_tile_save_gb, fit_ladder, predicted_control_peak_gb,
+        KreaControlFit,
     };
     use crate::vram_gate::apply_vram_cap;
-    use gen_core::Quant;
 
     let krea = builtin_model_entry("krea_2_turbo");
     let entry = krea.as_object().expect("krea_2_turbo entry object");
+    let tile = decode_tile_save_gb(entry, "q4");
     let q8 = branch_quant_save_gb(entry, "q8");
     let q4 = branch_quant_save_gb(entry, "q4");
     // The common small-card install: q4 base tier.
     let peak = predicted_control_peak_gb(entry, "q4");
+    let tiled_peak = peak.unwrap() - tile.expect("q4 decodeTileSaveGb shipped");
 
     let real = crate::gpu::nvidia_vram_budget_gb("0")
         .await
         .expect("GPU 0 should report a live VRAM budget on a CUDA box");
     eprintln!("live CUDA budget GPU0: {real:?}");
 
-    // Uncapped real 96 GB card → bf16 branch, no rung engages.
+    // Uncapped real 96 GB card → untiled monolithic decode, bf16 branch, no rung engages.
     assert_eq!(
-        fit_ladder(peak, apply_vram_cap(Some(real), None), q8, q4),
+        fit_ladder(peak, apply_vram_cap(Some(real), None), tile, q8, q4),
         KreaControlFit::Fits {
-            branch_quant: None
+            tile_vae_decode: false,
+            branch_quant: None,
         },
-        "uncapped 96 GB card keeps the bf16 branch"
+        "uncapped 96 GB card keeps the untiled bf16 branch"
     );
-    // Emulate a 24 GB card off the REAL reading (free := min(real_free, 24)) → q4 branch (last-resort rung).
+    // Cap just at the tiled peak (off the REAL reading) → the cheapest rung engages: tiling on, bf16
+    // branch kept (no quality penalty).
     assert_eq!(
-        fit_ladder(peak, apply_vram_cap(Some(real), Some(24.0)), q8, q4),
+        fit_ladder(peak, apply_vram_cap(Some(real), Some(tiled_peak)), tile, q8, q4),
         KreaControlFit::Fits {
-            branch_quant: Some(Quant::Q4)
+            tile_vae_decode: true,
+            branch_quant: None,
         },
-        "SCENEWORKS_CUDA_VRAM_CAP_GB=24 → q4 branch fits"
+        "cap at the tiled peak → VAE tiling keeps the bf16 branch"
     );
-    // Emulate a 16 GB card → reject-before-OOM.
-    assert!(
-        matches!(
-            fit_ladder(peak, apply_vram_cap(Some(real), Some(16.0)), q8, q4),
-            KreaControlFit::TooBig { .. }
-        ),
-        "SCENEWORKS_CUDA_VRAM_CAP_GB=16 → reject-before-OOM"
+    // Cap between (tiling + q8) and (tiling + q4) off the REAL reading → tiling composes with q4 to fit
+    // where the old tiling-less ladder rejected-before-OOM.
+    assert_eq!(
+        fit_ladder(peak, apply_vram_cap(Some(real), Some(tiled_peak - 8.9)), tile, q8, q4),
+        KreaControlFit::Fits {
+            tile_vae_decode: true,
+            branch_quant: Some(gen_core::Quant::Q4),
+        },
+        "cap below tiling+q8 → tiling + q4 fits"
     );
-    eprintln!("krea control fit ladder on a real card: 96→bf16, 24→q4 branch, 16→reject ✓");
+    eprintln!(
+        "krea control fit ladder on a real card: 96→untiled bf16, tiled-peak→tiling, deep→tiling+q4 ✓"
+    );
 }
 
 /// epic 10765 sc-11019: the Qwen-Image-Edit `candle` blocks drive the EDIT fit-gate (qwen_edit_candle.rs,

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -243,14 +243,19 @@
                     "description": "Overall control-lane render peak VRAM (GB) at 1024²/8-step, keyed by BASE quant tier, with a bf16 control branch and NO fit-ladder rungs engaged. The peak is the end-of-render VAE-decode spike (sc-11744). The fit-gate compares this + headroom against free VRAM.",
                     "additionalProperties": { "type": "number" }
                   },
+                  "decodeTileSaveGb": {
+                    "type": "object",
+                    "description": "Measured peak reduction (GB) from the CHEAPEST rung — forcing the seam-free tiled VAE decode (sc-11744, candle-gen #492; Krea2ControlRequest.tile_vae_decode), keyed by BASE quant tier. A SPEED cost, no quality cost. The fit-gate subtracts this from peakGbByTier and engages it BEFORE branch-quant. Measured only for the tier(s) where the end-of-render decode spike IS the render peak (q4); omitted where the denoise steady-state dominates and tiling recovers little.",
+                    "additionalProperties": { "type": "number" }
+                  },
                   "branchQuantSaveGb": {
                     "type": "object",
-                    "description": "Measured peak reduction (GB) from the last-resort rung — quantizing the control branch bf16 → q8/q4 (candle-gen #483, sc-11743), keyed by target quant (q8 / q4). The fit-gate subtracts this from peakGbByTier to decide whether the branch-quant rung makes the lane fit, preferring q8 (near-lossless) before q4 (pose-locked; non-pose drift).",
+                    "description": "Measured peak reduction (GB) from the last-resort rung — quantizing the control branch bf16 → q8/q4 (candle-gen #483, sc-11743), keyed by target quant (q8 / q4). The fit-gate subtracts this (composed with decodeTileSaveGb) from peakGbByTier to decide whether the branch-quant rung makes the lane fit, preferring q8 (near-lossless) before q4 (pose-locked; non-pose drift).",
                     "additionalProperties": { "type": "number" }
                   },
                   "measured": {
                     "type": "boolean",
-                    "description": "true when peakGbByTier / branchQuantSaveGb were MEASURED on a real GPU; false when partially ESTIMATED (e.g. an interpolated q8 base peak) pending measurement."
+                    "description": "true when peakGbByTier / decodeTileSaveGb / branchQuantSaveGb were MEASURED on a real GPU; false when partially ESTIMATED (e.g. an interpolated q8 base peak) pending measurement."
                   }
                 }
               },


### PR DESCRIPTION
## What

The peak VRAM of a Krea pose-ControlNet render is the **final VAE decode**, not the denoise loop. At 1024²/q4 the denoise steady-state is ~24 GB but the last-step *monolithic* decode spikes to ~30.9 GB, OOMing a constrained card even when the loop itself would fit. This adds the Krea control VRAM fit-ladder's **cheapest rung** — force the seam-free tiled VAE decode to cap that spike — engaged ahead of the last-resort branch-quant (sc-11743).

Follow-up to sc-11727 (packed-base forward) / sc-11754 (the fit ladder). Part of the "Krea control on a 16/24 GB card" effort.

## Changes

- **candle-gen `1be2369 → 6f41696`** (PR SceneWorks/candle-gen#492), cherry-picked onto the prior pin so `git diff 1be2369..6f41696 -- gen-core/` is EMPTY — gen-core stays byte-identical `b8c41526`, the `--features backend-candle` skew gate resolves a SINGLE gen-core rev, no mlx-gen move. Adds `QwenVae::decode_with(latents, force_tile)` + `Krea2ControlRequest::tile_vae_decode`; `decode()` is **byte-identical** when `force_tile = false`, so every existing caller is unchanged.
- **`krea_control_fit`**: `KreaControlFit::Fits` now carries `tile_vae_decode` alongside `branch_quant`. The ladder walks **packed → VAE tiling (speed cost, no quality) → branch-quant (quality, last resort)**, composing tiling *under* the quant rungs. `decodeTileSaveGb` gates the tiling rung per tier; the activation-chunking rung (sc-11745) still slots between tiling and branch-quant when it lands (`WIRED_ACTIVATION_CHUNKING = false`).
- **Wiring**: `tile_vae_decode` threaded from the fit decision into `KreaStrictControl` → `Krea2ControlRequest`. **Default OFF** (untiled, full-speed) on a card with headroom.
- **Manifest + schema**: `candle.control.decodeTileSaveGb`.

## GPU validation (RTX PRO 6000, Blackwell sm_120, 1024²/8-step)

| decode | peak VRAM | decode time |
|---|---|---|
| monolithic (default) | 40.2 GiB | 0.56 s |
| tiled (rung engaged)  | 33.4 GiB | 0.71 s |

**Δsaving 6.7 GiB · Δcost +0.14 s (+26%)**, measured via the `KREA_TILE_VAE=0/1` A/B on the control-infer example. **Seam-free**: the tiled render is bit-near-identical to monolithic (mean |Δ| 0.05/255, max 26/255 on 0.13% of pixels, **no tile-boundary spike**) and fully coherent. The q4 saving (6.7) brings the 30.9 GB peak to ~24.2 GB — essentially the denoise floor. A 16 GB card that previously reject-OOM'd now fits (tiling + q4).

## Tests

`cargo clippy -p sceneworks-worker --features backend-candle --locked -- -D warnings` clean; `cargo test -p sceneworks-worker --lib --features backend-candle --locked krea_control` green (11 passed) — the manifest-driven ladder test asserts the cost-ordered rungs against the SHIPPED `decodeTileSaveGb`.

Relates to sc-11727, sc-11743, sc-11754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)