### PR TITLE
feat(worker): Krea pose-ControlNet explicit-quant + user-LoRA pin bump, loud-reject + q8 smoke (sc-11796)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -570,7 +570,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-gen",
  "image",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -768,7 +768,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -805,7 +805,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -817,7 +817,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -830,7 +830,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=c077d7247bbecabe1623c675d92e92d2731530ee#c077d7247bbecabe1623c675d92e92d2731530ee"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -3690,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3704,7 +3704,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "image",
  "inventory",
@@ -3717,7 +3717,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "image",
  "inventory",
@@ -3731,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "image",
  "inventory",
@@ -3745,7 +3745,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3759,7 +3759,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3770,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3779,7 +3779,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3788,7 +3788,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3802,7 +3802,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3815,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3828,7 +3828,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3840,7 +3840,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3850,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "image",
  "inventory",
@@ -3863,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "image",
  "inventory",
@@ -3878,7 +3878,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "image",
  "inventory",
@@ -3892,7 +3892,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "image",
  "inventory",
@@ -3904,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3915,7 +3915,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3927,7 +3927,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3939,7 +3939,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3948,7 +3948,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3957,7 +3957,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3967,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3979,7 +3979,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "image",
  "inventory",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "image",
  "inventory",
@@ -4008,7 +4008,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4019,7 +4019,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4031,7 +4031,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4042,7 +4042,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "image",
  "inventory",
@@ -4056,7 +4056,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "image",
  "inventory",
@@ -5890,7 +5890,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b8c415261a9fc6a2409a8ffc989881f0e6a3c99b#b8c415261a9fc6a2409a8ffc989881f0e6a3c99b"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
 dependencies = [
  "core-llm",
  "inventory",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -534,7 +534,17 @@ sceneworks-core = { path = "../sceneworks-core" }
 # reports exactly one). NOTE: this bump FIXES a live bug — on 6a10ae1, every Anima LoRA/LoKr failed at
 # model load, because the worker defaults spec.quantize to Some(Q8) for every MLX model and mlx-gen-anima
 # rejected quant+adapter together. See test `anima_default_tier_with_adapter_builds_loadable_spec`.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+# Bumped mlx-gen + gen-core `b8c4152` -> `b568fdb` (sc-11796, epic 8459): pick up the Krea pose-ControlNet
+# packed-base + user-LoRA surface (sc-11730 #710 explicit-quant/packed forward, sc-11720 additive
+# user-LoRAs on the control lane). The base-resolution fix itself already landed on b8c4152 (sc-11727
+# #1476); this bump layers the explicit-quant `LoadSpec` threading + wires the newer provider. gen-core is
+# NOT byte-identical: `git diff b8c4152..b568fdb -- gen-core/` is three files, PURELY ADDITIVE (sc-11126) —
+# `Capabilities.supports_sequential_offload: bool` (default false), `Progress::Loading(LoadPhase)` + the
+# `LoadPhase` export; the only compile-affecting change is the new `Capabilities` field. The candle-gen pin
+# block below moves `c077d724` -> `f572005c` IN LOCKSTEP (candle-gen main adopted the contract via sc-11794
+# + re-pins its OWN gen-core -> b568fdb) so `--features backend-candle` resolves the SINGLE gen-core rev
+# b568fdb. mlx-rs (38e1cc1) + mlx-llm (7041411f) UNCHANGED across the range — MLX does not rebuild.
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -904,7 +914,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # lockstep to f2ec6e3 (candle-gen #428, which re-pins gen-core to THIS 592419c) and the skew gate resolves
 # ONE gen-core rev on BOTH lanes. Real-weight A/B (byte-identical): turbo 22.4->18.1, raw 22.0->18.1, edit
 # 25.7->20.2 (Q8), control 42.8->35.5 GiB (bf16). Adds the 4 krea ids to SEQUENTIAL_CAPABLE_ENGINES below.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -920,23 +930,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -944,7 +954,7 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
 # mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
 # mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
@@ -952,7 +962,7 @@ mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c4152
 # conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
 # DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
 # generator-cache load path drives.
-mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # Anima 2B anime t2i provider (native MLX, CircleStone Labs Non-Commercial License v1.2; epic 10512,
 # sc-10523). Same git rev as mlx-gen so MLX builds once. Self-registers `anima_base` / `anima_aesthetic`
 # / `anima_turbo` (Cosmos-Predict2 DiT + Qwen3-0.6B T5-query-token adapter conditioner + Qwen-Image VAE)
@@ -961,59 +971,59 @@ mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415
 # scheduler (sc-10519) and strong prompt-weighting on the T5 query tokens (sc-10566). Carries the
 # install-time q4/q8/bf16 converter the model_jobs.rs Anima path drives (sc-10517). Pinned to merged
 # mlx-gen main 6a10ae1 (PR #680), which carries both the Anima crate and gen-core's is_hidden_file.
-mlx-gen-anima = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-anima = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -1022,19 +1032,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -1043,7 +1053,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c41
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -1051,7 +1061,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -1062,7 +1072,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c4
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -1073,7 +1083,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c41
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -1095,7 +1105,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -1106,7 +1116,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -1138,7 +1148,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c415261a9fc6a2409a8ffc989881f0e6a3c99b" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1713,15 +1723,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b8c4
 # (`decode()` is byte-identical when `force_tile = false`, the default for every existing caller). Points at
 # the branch content commit (durable ancestor once #492's merge lands on candle-gen main). ALL candle-gen-*
 # pins move together; backend-candle check --locked green.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1735,7 +1745,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1743,17 +1753,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1763,7 +1773,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1771,21 +1781,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1794,7 +1804,7 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # Candle Bernini still-image companion (sc-10996, epic 6562) — the Windows/CUDA sibling of
 # `mlx-gen-bernini`, built ON candle-gen-wan (the full Qwen2.5-VL/MAR semantic planner driving a
 # Wan2.2-A14B dual-expert renderer, `frames:1` for a single still). Self-registers the full `bernini`
@@ -1806,17 +1816,17 @@ candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # main HEAD, the merged #421 planner-components commit — contains the #419 full generator sc-10995) — its
 # gen-core pin (951227a) MATCHES the worker's mlx pin, so `--features backend-candle --target all`
 # resolves ONE gen-core rev (no skew).
-candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1825,7 +1835,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1858,7 +1868,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1867,12 +1877,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1880,7 +1890,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1889,7 +1899,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1897,7 +1907,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1911,7 +1921,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1938,7 +1948,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1949,7 +1959,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "c077d7247bbecabe1623c675d92e92d2731530ee", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -672,6 +672,19 @@ pub(crate) async fn run_image_generate_job(
                 )
                 .await?;
             }
+            ImageRoute::KreaPoseControlBaseMissing => {
+                // A `krea_2_turbo` strict-pose job whose control base (the `SceneWorks/krea-2-turbo-mlx`
+                // turnkey) isn't installed. Refuse loudly rather than silently rendering an unconditioned
+                // image via the plain MLX lane and dropping the poses (sc-11796) — the MLX twin of the
+                // candle `PoseControlBaseMissing` reject.
+                return Err(WorkerError::InvalidPayload(format!(
+                    "strict pose (advanced.poses) requested for model '{}', but its Krea 2 Turbo control \
+                     base (SceneWorks/krea-2-turbo-mlx) is not installed — refusing rather than silently \
+                     generating an unconditioned image; install a Krea 2 Turbo tier to enable strict-pose \
+                     generation",
+                    request.model
+                )));
+            }
             ImageRoute::Mlx => {
                 generate_stream(
                     api,

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -94,6 +94,11 @@ enum ImageRoute {
     SdxlAdvanced,
     SensenovaEdit,
     Bernini,
+    /// A `krea_2_turbo` strict-pose job whose control base (the `SceneWorks/krea-2-turbo-mlx` turnkey)
+    /// isn't installed, so `krea_control_available` failed. Reject loudly instead of falling through to
+    /// `Mlx` (plain txt2img) and silently dropping the poses (sc-11796) — the MLX twin of the candle
+    /// `CandleImageRoute::PoseControlBaseMissing`.
+    KreaPoseControlBaseMissing,
     Mlx,
 }
 
@@ -148,6 +153,18 @@ fn resolve_image_route(request: &ImageRequest, settings: &Settings) -> Option<Im
         // `mlx_available` would match it), but the generic `generate_stream` leaves `frames`/
         // `video_mode` unset, which the engine treats as a multi-frame video request.
         Some(ImageRoute::Bernini)
+    } else if is_krea_control_model(&request.model)
+        && request.mode != "edit_image"
+        && !pose_entries(request).is_empty()
+    {
+        // A `krea_2_turbo` strict-pose job that fell past `krea_control_available` above means its control
+        // base (the `SceneWorks/krea-2-turbo-mlx` turnkey) isn't installed. Reject loudly BEFORE the
+        // generic `mlx_available` arm — `krea_2_turbo` is in MODEL_TABLE, so `mlx_available` would match it
+        // and render plain txt2img, silently dropping the poses (the reported sc-11796 bug). The MLX twin
+        // of the candle `CandleImageRoute::PoseControlBaseMissing` reject (base.rs, sc-11171/F-008).
+        // NOTE: only krea is guarded here; full candle-parity reject across every wired MLX pose family
+        // (qwen/kolors/z-image/flux) is tracked separately.
+        Some(ImageRoute::KreaPoseControlBaseMissing)
     } else if mlx_available(request, settings) {
         Some(ImageRoute::Mlx)
     } else {
@@ -176,11 +193,13 @@ impl ImageRoute {
             },
             // PuLID-FLUX is one identity image per seed (no angle/pose grouping) — like the base
             // MLX + SDXL-advanced + Bernini paths, the effective count is the requested count. Krea
-            // edit (epic 10871) is likewise plain per-image: `count` edits of the one source.
+            // edit (epic 10871) is likewise plain per-image: `count` edits of the one source. The
+            // pose-control-base-missing reject errors before generation, so its count is inert.
             ImageRoute::PulidFlux
             | ImageRoute::SdxlAdvanced
             | ImageRoute::Bernini
             | ImageRoute::KreaEdit
+            | ImageRoute::KreaPoseControlBaseMissing
             | ImageRoute::Mlx => request.count,
         }
     }

--- a/crates/sceneworks-worker/src/image_jobs/krea_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control.rs
@@ -260,10 +260,23 @@ fn krea_control_raw_settings(
     raw
 }
 
-/// Load the MLX Krea pose-control generator: the dense base snapshot + the control overlay. Krea control
-/// is CFG-free dense bf16 — no quant, no adapters (the candle-lane parity), no identity img2img-init.
-fn krea_control_spec(weights_dir: PathBuf, control_weights: PathBuf) -> LoadSpec {
-    LoadSpec::new(WeightsSource::Dir(weights_dir)).with_control(WeightsSource::File(control_weights))
+/// Load the MLX Krea pose-control generator: the base tier subdir + the control overlay. The base runs at
+/// the `mlxQuantize`-selected tier (mlx-gen sc-11730): a pre-packed q4/q8 tier subdir loads packed and the
+/// matching `quant` is a no-op (`load_time_quant_bits` detects already-packed), while a dense bf16 subdir
+/// with `quant` set quantizes the base DiT/TE at load. Activation precision stays bf16 (the control
+/// provider requires it; weight packing is orthogonal) and the pose overlay stays bf16. CFG-free, no
+/// adapters yet (user-LoRA-on-control, mlx-gen sc-11720, is a follow-up), no identity img2img-init.
+fn krea_control_spec(
+    weights_dir: PathBuf,
+    control_weights: PathBuf,
+    quant: Option<Quant>,
+) -> LoadSpec {
+    let mut spec = LoadSpec::new(WeightsSource::Dir(weights_dir))
+        .with_control(WeightsSource::File(control_weights));
+    if let Some(quant) = quant {
+        spec = spec.with_quant(quant);
+    }
+    spec
 }
 
 /// Generate one strict-pose image: the pre-built `conditioning` (the required pose `Control`) drives the
@@ -379,8 +392,10 @@ async fn generate_krea_control_stream(
     let prompt = request.prompt.clone();
     let (width, height) = (request.width, request.height);
     let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
-    // Dense bf16, no adapters — the control overlay rides the frozen base (parity with the candle lane).
-    let spec = krea_control_spec(weights_dir, control_weights);
+    // The base runs at the `mlxQuantize`-selected tier (sc-11730); the pose overlay rides it bf16. No
+    // adapters on this lane yet (user-LoRA-on-control, mlx-gen sc-11720, is a follow-up).
+    let (quant, _quant_bits) = resolve_quant(request);
+    let spec = krea_control_spec(weights_dir, control_weights, quant);
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
         KREA_CONTROL_ENGINE_ID,

--- a/crates/sceneworks-worker/src/image_jobs/stream.rs
+++ b/crates/sceneworks-worker/src/image_jobs/stream.rs
@@ -38,6 +38,10 @@ fn send_gen_progress(tx: &tokio::sync::mpsc::Sender<GenEvent>, index: usize, pro
             total,
         },
         Progress::Decoding => GenEvent::Decoding { index },
+        // Sequential-residency in-`generate` component-load signal (gen-core sc-11126). The image gallery
+        // doesn't surface a load phase yet, so ignore it — identical to pre-bump behavior, when the variant
+        // didn't exist. Surfacing it as a UI status is the F-179 follow-up.
+        Progress::Loading(_) => return,
     };
     let _ = tx.blocking_send(event);
 }

--- a/crates/sceneworks-worker/src/image_jobs/strict_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/strict_control.rs
@@ -101,11 +101,13 @@ const STRICT_CONTROL_ENGINES: &[StrictControlEngine] = &[
         // control-branch overlay on the frozen Turbo base — a from-scratch pose ControlNet, not a
         // Fun-Union VACE engine, so it has no canny/depth conditioning (those are Phase-C follow-ups).
         // Listed here so the candle lane routes through `run_candle_strict_control` and a
-        // `controlMode = canny | depth` request is REJECTED (not silently rendered as pose). Off-Mac
-        // candle-only; the candle lane resolves its overlay from env / `advanced.controlWeights` (no
-        // hosted default repo yet — B4/sc-10165 + sc-8466), so `repo` here is informational.
+        // `controlMode = canny | depth` request is REJECTED (not silently rendered as pose). `repo` here
+        // is INFORMATIONAL for Krea: neither lane resolves its base from this row. The MLX lane
+        // (`krea_control.rs`) loads the packed `SceneWorks/krea-2-turbo-mlx` turnkey tier subdir (sc-11796);
+        // the candle lane keeps its own dense `krea/Krea-2-Turbo` const; both resolve the overlay from
+        // env / `advanced.controlWeights` / the hosted beta (sc-8466).
         engine_id: "krea_2_turbo_control",
-        repo: "krea/Krea-2-Turbo",
+        repo: "SceneWorks/krea-2-turbo-mlx",
         supported_kinds: &[ControlKind::Pose],
     },
 ];

--- a/crates/sceneworks-worker/src/krea_control_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/krea_control_mlx_smoke.rs
@@ -1,0 +1,210 @@
+//! Local real-weight MLX smoke for the Krea 2 Turbo pose-ControlNet worker lane on a **packed Q8 base**
+//! (sc-11796). `#[ignore]`d — run by hand on an Apple-Silicon Mac with the `SceneWorks/krea-2-turbo-mlx`
+//! turnkey + the `SceneWorks/krea2-pose-controlnet-beta` overlay cached. It drives the real native-MLX
+//! `krea_2_turbo_control` engine via `gen_core::load("krea_2_turbo_control")` with the EXACT `LoadSpec`
+//! the worker's `krea_control_spec` builds after sc-11796: a `Dir` pointed at the packed **q8** turnkey
+//! tier subdir (`krea_model_subdir`'s default) + the pose overlay as the required `Control` checkpoint +
+//! `with_quant(Q8)`. This proves two things the old dense-only lane could not. First, the control branch
+//! loads + renders on a PACKED q8 base (mlx-gen sc-11730's true packed forward), not just the dense bf16
+//! tree the phantom `krea/Krea-2-Turbo` repo used to demand. Second, the pose actually STEERS the output —
+//! the same pose skeleton at `control_scale = 0.6` must differ meaningfully from `control_scale = 0.0`
+//! (base passthrough); if pose selection were being silently dropped (the reported sc-11796 bug), the two
+//! renders would be identical.
+//!
+//! Same force-link anchor idiom as the sibling smokes: `use mlx_gen_krea as _;` in `image_jobs.rs` keeps
+//! the `krea_2_turbo_control` `inventory::submit!` from being GC'd so `gen_core::load` resolves it.
+//!
+//! Setup — with the turnkey + overlay already in the HF cache, no env is needed (auto-discovered). The
+//! pose defaults to a repo skeleton PNG (`poses/dance_01.png`), already an OpenPose render.
+//! ```text
+//! # optional: KREA_CTRL_POSE=/path/to/skeleton.png KREA_CTRL_STEPS=8 KREA_CTRL_SIZE=512
+//! #           KREA_CTRL_SCALE=0.6 KREA_CTRL_SEED=1234 KREA_CTRL_OUT_DIR=/tmp/krea_control_smoke
+//! cargo test -p sceneworks-worker krea_control_q8_mlx_smoke -- --ignored --nocapture
+//! ```
+
+use std::path::PathBuf;
+
+use gen_core::{
+    CancelFlag, Conditioning, ControlKind, GenerationOutput, GenerationRequest, Image, LoadSpec,
+    Quant, WeightsSource,
+};
+
+use super::smoke_support::{env_or, image_std, DEGENERATE_STD_FLOOR_DEFAULT};
+
+/// Auto-discover the cached `SceneWorks/krea-2-turbo-mlx` q8 tier subdir (the packed transformer root the
+/// worker's `krea_model_subdir` resolves by default). `None` if the turnkey q8 tier hasn't been pulled.
+fn cached_q8_dir() -> Option<PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+    let snapshots = PathBuf::from(home)
+        .join(".cache/huggingface/hub/models--SceneWorks--krea-2-turbo-mlx/snapshots");
+    std::fs::read_dir(&snapshots)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .find_map(|e| {
+            let q8 = e.path().join("q8");
+            q8.join("transformer/diffusion_pytorch_model.safetensors")
+                .is_file()
+                .then_some(q8)
+        })
+}
+
+/// Auto-discover the cached `SceneWorks/krea2-pose-controlnet-beta` overlay checkpoint.
+fn cached_overlay() -> Option<PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+    let snapshots = PathBuf::from(home)
+        .join(".cache/huggingface/hub/models--SceneWorks--krea2-pose-controlnet-beta/snapshots");
+    std::fs::read_dir(&snapshots)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .find_map(|e| {
+            let f = e.path().join("control_step5000.safetensors");
+            f.is_file().then_some(f)
+        })
+}
+
+/// Load an RGB skeleton PNG into a gen_core `Image`.
+fn load_rgb(path: &std::path::Path) -> Image {
+    let img = image::open(path)
+        .unwrap_or_else(|e| panic!("open pose skeleton {}: {e}", path.display()))
+        .to_rgb8();
+    let (width, height) = img.dimensions();
+    Image {
+        width,
+        height,
+        pixels: img.into_raw(),
+    }
+}
+
+/// Mean absolute per-byte delta between two same-size RGB buffers (the pose-steer metric).
+fn mean_abs_delta(a: &Image, b: &Image) -> f64 {
+    assert_eq!(
+        a.pixels.len(),
+        b.pixels.len(),
+        "compared images differ in size"
+    );
+    let sum: u64 = a
+        .pixels
+        .iter()
+        .zip(&b.pixels)
+        .map(|(&x, &y)| (x as i16 - y as i16).unsigned_abs() as u64)
+        .sum();
+    sum as f64 / a.pixels.len() as f64
+}
+
+fn render_pose(
+    generator: &dyn gen_core::Generator,
+    prompt: &str,
+    size: u32,
+    steps: u32,
+    seed: u64,
+    skeleton: &Image,
+    scale: f32,
+) -> Image {
+    let request = GenerationRequest {
+        prompt: prompt.to_owned(),
+        width: size,
+        height: size,
+        count: 1,
+        seed: Some(seed),
+        steps: Some(steps),
+        // Krea Turbo is CFG-free (distilled) — no guidance, one forward per step.
+        guidance: None,
+        conditioning: vec![Conditioning::Control {
+            image: skeleton.clone(),
+            kind: ControlKind::Pose,
+            scale: Some(scale),
+        }],
+        cancel: CancelFlag::new(),
+        ..Default::default()
+    };
+    match generator
+        .generate(&request, &mut |_| {})
+        .unwrap_or_else(|e| panic!("krea_2_turbo_control generate at scale {scale}: {e}"))
+    {
+        GenerationOutput::Images(mut images) => images.pop().expect("one image"),
+        other => panic!("expected Images output, got {other:?}"),
+    }
+}
+
+#[test]
+#[ignore = "real-weight MLX smoke; needs the SceneWorks/krea-2-turbo-mlx q8 turnkey + krea2-pose-controlnet-beta overlay cached on an Apple-Silicon Mac"]
+fn krea_control_q8_mlx_smoke() {
+    let q8_dir = cached_q8_dir().unwrap_or_else(|| {
+        panic!("no cached SceneWorks/krea-2-turbo-mlx q8 turnkey found — download the Krea 2 Turbo q8 tier")
+    });
+    let overlay = cached_overlay()
+        .unwrap_or_else(|| panic!("no cached SceneWorks/krea2-pose-controlnet-beta overlay found"));
+    let pose_path = PathBuf::from(env_or(
+        "KREA_CTRL_POSE",
+        "/Users/michael/Repos/SceneWorks/poses/dance_01.png",
+    ));
+    let out_dir = PathBuf::from(env_or("KREA_CTRL_OUT_DIR", "/tmp/krea_control_smoke"));
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+    let steps: u32 = env_or("KREA_CTRL_STEPS", "8")
+        .parse()
+        .expect("KREA_CTRL_STEPS");
+    let size: u32 = env_or("KREA_CTRL_SIZE", "512")
+        .parse()
+        .expect("KREA_CTRL_SIZE");
+    let scale: f32 = env_or("KREA_CTRL_SCALE", "0.6")
+        .parse()
+        .expect("KREA_CTRL_SCALE");
+    let seed: u64 = env_or("KREA_CTRL_SEED", "1234")
+        .parse()
+        .expect("KREA_CTRL_SEED");
+    let prompt = env_or(
+        "KREA_CTRL_PROMPT",
+        "a full-body studio photo of a person, plain grey background, sharp focus",
+    );
+
+    let skeleton = load_rgb(&pose_path);
+
+    // The EXACT seam `krea_control_spec` builds after sc-11796: the packed q8 tier subdir as the base
+    // `Dir` + the pose overlay as the required control checkpoint + `with_quant(Q8)` (the resolved tier's
+    // packed bits, a no-op match for the pre-packed subdir). Proves the control branch runs a true packed
+    // forward on the q8 base the plain txt2img lane already installs.
+    println!(
+        "[smoke] loading krea_2_turbo_control (packed Q8) base {} overlay {}",
+        q8_dir.display(),
+        overlay.display()
+    );
+    let spec = LoadSpec::new(WeightsSource::Dir(q8_dir))
+        .with_control(WeightsSource::File(overlay))
+        .with_quant(Quant::Q8);
+    let generator =
+        gen_core::load("krea_2_turbo_control", &spec).expect("load krea_2_turbo_control generator");
+
+    // A/B on the SAME pose/prompt/seed: pose-locked (scale) vs base passthrough (0.0). Only the control
+    // residual differs, so a meaningful delta proves the pose actually steers the render.
+    let locked = render_pose(&*generator, &prompt, size, steps, seed, &skeleton, scale);
+    let passthrough = render_pose(&*generator, &prompt, size, steps, seed, &skeleton, 0.0);
+
+    for (label, img) in [("scale", &locked), ("base", &passthrough)] {
+        image::RgbImage::from_raw(img.width, img.height, img.pixels.clone())
+            .expect("rgb")
+            .save(out_dir.join(format!("krea_control_q8_{label}.png")))
+            .expect("save render");
+    }
+
+    let locked_std = image_std(&locked);
+    let base_std = image_std(&passthrough);
+    let steer = mean_abs_delta(&locked, &passthrough);
+    println!(
+        "[smoke] q8 pose-lock std {locked_std:.2} / base std {base_std:.2} / steer(meanAbsΔ) {steer:.2} -> {}",
+        out_dir.display()
+    );
+
+    assert_eq!((locked.width, locked.height), (size, size));
+    assert!(
+        locked_std > DEGENERATE_STD_FLOOR_DEFAULT && base_std > DEGENERATE_STD_FLOOR_DEFAULT,
+        "a render looks degenerate (pose-lock std {locked_std:.2}, base std {base_std:.2})"
+    );
+    // The core sc-11796 assertion: the pose STEERS the output on the packed q8 base. If pose selection
+    // were being dropped (silent t2i), the two renders would be identical (steer ~= 0).
+    assert!(
+        steer > 1.0,
+        "pose did not steer the packed-q8 render vs base passthrough (meanAbsΔ {steer:.2}) — the pose \
+         was effectively ignored"
+    );
+    println!("[smoke] DONE: krea_2_turbo_control renders pose-locked on a PACKED Q8 base");
+}

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -250,6 +250,12 @@ mod zimage_pid_gpu_smoke;
 // the worker-lane validation (the crate links + drives the engine), not just the mlx-gen-krea crate.
 #[cfg(all(test, target_os = "macos"))]
 mod krea_turbo_mlx_smoke;
+// Real-weight MLX smoke for the Krea 2 Turbo pose-ControlNet worker lane on a PACKED Q8 base (sc-11796).
+// Test-only + macOS-only; drives `gen_core::load("krea_2_turbo_control")` with the exact packed-q8
+// `LoadSpec` `krea_control_spec` builds and asserts the pose steers the render vs a base passthrough —
+// the worker-lane proof that pose control is honored on the installed quant tier (not silently dropped).
+#[cfg(all(test, target_os = "macos"))]
+mod krea_control_mlx_smoke;
 // Real-weight MLX smoke for the FLUX.1-dev strict-control worker lane (sc-8244; engine E2 sc-8239).
 // Test-only + macOS-only; drives `gen_core::load("flux1_dev_control")` (Dir base + Shakker control
 // overlay) per control mode (pose/canny/depth) and asserts a control-vs-control-free steer — the

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -4423,6 +4423,8 @@ async fn generate_video(
                             }
                         }
                         Progress::Decoding => phase_timer.mark_decoding(Instant::now()),
+                        // Sequential-residency component-load boundary (gen-core sc-11126) — no phase mark.
+                        Progress::Loading(_) => {}
                     }
                     let (fraction, message) = match progress {
                         Progress::Step { current, total } => (
@@ -4430,6 +4432,9 @@ async fn generate_video(
                             format!("Generating frames — step {current}/{total}."),
                         ),
                         Progress::Decoding => (0.58, "Decoding frames.".to_owned()),
+                        // A Sequential-residency component (text encoder / renderer) is (re)loading before
+                        // denoise starts; surface a stable pre-generation status without regressing the bar.
+                        Progress::Loading(_) => (0.22, "Loading model components.".to_owned()),
                     };
                     update_job(
                         api,
@@ -13465,6 +13470,8 @@ mod tests {
                 // Peak so far = the DiT-denoise peak (the VAE decode is the *next* stage).
                 dit_peak_bytes.get_or_insert(mlx_rs::memory::get_peak_memory());
             }
+            // Sequential-residency component-load boundary (gen-core sc-11126) — not a step/decode marker.
+            Progress::Loading(_) => {}
         };
         let decoded =
             run_video_generation(input, &cancel, &mut on_progress).expect("5B generation");


### PR DESCRIPTION
## Summary
Completes the macOS Krea 2 Turbo pose-ControlNet lane on top of the base-resolution fix that landed separately (**#1476 / sc-11727** — repoints `resolve_krea_control_base` from the phantom dense `krea/Krea-2-Turbo` to the installed `krea-2-turbo-mlx` tier). Main took the minimal route (no pin bump, no explicit quant, no loud-reject); this PR layers the remaining hardening.

## What's here
- **Pin bump** mlx-gen + gen-core `b8c4152` → `b568fdb` (sc-11730 explicit-quant / true packed forward + sc-11720 additive user-LoRAs on the control lane), candle-gen `c077d724` → `f572005c` **in lockstep** (candle-gen adopted the additive gen-core contract via sc-11794). A single `sceneworks-gen-core` (b568fdb) resolves on both lanes — `check-gen-core-skew.sh` green incl. `--features backend-candle`. `mlx-rs`/`mlx-llm` unchanged, so **MLX does not rebuild**; the gen-core delta is purely additive (`Capabilities.supports_sequential_offload`, `Progress::Loading(LoadPhase)`).
- **Explicit quant** threaded into `krea_control_spec` (`resolve_quant` → `with_quant`): a pre-packed q4/q8 tier is a no-op match; a dense bf16 subdir + `mlxQuantize` quantizes the base at load.
- **`ImageRoute::KreaPoseControlBaseMissing`** loud-reject — a krea pose job with no installed base now errors instead of silently falling through to plain t2i (the MLX twin of the candle `PoseControlBaseMissing`). Generalization to all wired MLX pose families tracked in **sc-11814**.
- **`Progress::Loading`** handled in the worker's exhaustive `match` sites (`image_jobs/stream.rs`, `video_jobs.rs`) — required by the bump.
- **Real-weight smoke** `krea_control_q8_mlx_smoke` (`#[ignore]`d): drives the exact packed-q8 `LoadSpec` through `gen_core::load("krea_2_turbo_control")` and asserts the pose steers the render vs a base passthrough.

## Validation (on-device, this Mac)
- `krea_control_q8_mlx_smoke` on the packed **Q8** base: pose-locked, **steer meanAbsΔ 25.86** vs scale-0 base passthrough, both renders non-degenerate. Visually, the pose-locked render follows the skeleton (hands clasped at chest) while the base has arms at the sides.
- `npm run rust:check` green; `cargo fmt --check` + `cargo clippy --all-targets -D warnings` clean; gen-core skew single-rev on both lanes.

## Related
- mlx-gen: sc-11730 (packed base un-gate), sc-11720 (user-LoRA on control)
- candle-gen: sc-11794 (gen-core contract adoption / lockstep)
- Follow-up: sc-11814 (generalize the loud-reject to all MLX pose families); user-LoRA-on-control worker wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)