### PR TITLE
fix(image-editor): catalog the Detail tile ControlNet + surface it as required

### DIFF
--- a/apps/web/public/prompt-guides/controlnet-tile-sdxl.md
+++ b/apps/web/public/prompt-guides/controlnet-tile-sdxl.md
@@ -1,0 +1,18 @@
+# SDXL Tile ControlNet (Detail enhance)
+
+The xinsir SDXL tile ControlNet is a small utility dependency SceneWorks uses only for the Image Editor's **Detail** enhancer. **It does not generate images on its own, and there is nothing to prompt.** The Detail tool feeds the working image through this ControlNet on an SDXL/RealVisXL backbone to refine fine texture while keeping the original composition.
+
+## Installation
+
+The native worker (MLX on macOS, candle on Windows/CUDA) resolves this model from the shared Hugging Face cache and does **not** auto-download it. Install it once from the **Models** screen — or use the one-click **Download** button the Image Editor's Detail panel shows when it is missing. It downloads into the shared Hugging Face cache, so every SDXL detail-capable backbone reuses the same copy.
+
+If Detail enhance reports "tile ControlNet weights not found (download xinsir/controlnet-tile-sdxl-1.0)," this is the model to install.
+
+## Practical Notes
+
+There is nothing to prompt here. The two Detail-panel sliders do the work:
+
+- **Detail amount** — how much new fine texture the refine pass invents (higher = more).
+- **Structure lock** — how strongly the tile ControlNet holds the result to the source composition (higher = closer to the original).
+
+apache-2.0 licensed, commercial use OK, ungated. Roughly 2.5 GB on disk.

--- a/apps/web/src/imageJobs.js
+++ b/apps/web/src/imageJobs.js
@@ -22,6 +22,23 @@ export function detailCapableModels(imageModels) {
   return (imageModels ?? []).filter((model) => (model.capabilities ?? []).includes("image_detail"));
 }
 
+// The SDXL tile ControlNet the Detail enhancer requires — every `image_detail` run feeds the working
+// image through it (worker `detail.rs`). It ships as a standalone `type:"utility"` catalog entry, so it
+// is ABSENT from the image-only picker list (`imageModels`): a detail-capable backbone can be installed
+// while this dependency is not, and the job would fail at run time with "tile ControlNet weights not
+// found". Look it up in the FULL catalog so the Detail panel can gate the run + offer a one-click install.
+export const TILE_CONTROLNET_MODEL_ID = "controlnet_tile_sdxl";
+
+export function tileControlNetModel(models) {
+  return (models ?? []).find((model) => model.id === TILE_CONTROLNET_MODEL_ID) ?? null;
+}
+
+// Installed == present with any non-"missing" install state (matches App.jsx's `imageModels` gate).
+export function tileControlNetInstalled(models) {
+  const model = tileControlNetModel(models);
+  return Boolean(model) && model.installState !== "missing";
+}
+
 // The `POST /api/v1/image/jobs` body for a prompt edit (sc-2435). Reuses the existing
 // `mode:"edit_image"` flow: a `sourceAssetId` image is edited to the new `width`×`height`
 // (the worker fits the source per `fitMode`). Pure for unit testing.

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -40,6 +40,9 @@ import {
   buildUpscaleJobBody,
   detailCapableModels,
   editCapableModels,
+  tileControlNetInstalled,
+  tileControlNetModel,
+  TILE_CONTROLNET_MODEL_ID,
   upscaleEngineHasSoftness,
   upscaleFactorsForEngine,
 } from "../imageJobs.js";
@@ -102,6 +105,9 @@ export {
   buildUpscaleJobBody,
   detailCapableModels,
   editCapableModels,
+  tileControlNetInstalled,
+  tileControlNetModel,
+  TILE_CONTROLNET_MODEL_ID,
   upscaleEngineHasSoftness,
   upscaleFactorsForEngine,
 };
@@ -609,6 +615,11 @@ export function ImageEditor() {
     releaseEditorScratchOp,
     registerEditorScratchClaim,
     imageModels,
+    // Full catalog (all types incl. utility) + downloader — the Detail tool's tile ControlNet is a
+    // `type:"utility"` entry, so it is absent from the image-only `imageModels`; we look it up here to
+    // gate the run and offer a one-click install (sc-2437/sc-2438 provisioning gap).
+    models = [],
+    createModelDownloadJob,
     editorLaunch = null,
     clearEditorLaunch,
     macCapabilities = DEFAULT_MAC_CAPABILITIES,
@@ -734,6 +745,22 @@ export function ImageEditor() {
   const [detailModel, setDetailModel] = useState("");
   const [detailStrength, setDetailStrength] = useState(0.55);
   const [detailCnScale, setDetailCnScale] = useState(0.7);
+  // The tile ControlNet is a hard co-requisite of every detail run (worker `detail.rs`), but it ships as
+  // a separate `type:"utility"` catalog artifact — so a detail-capable backbone can be installed while
+  // the ControlNet is not, and the job would fail at run time. Surface it as a required dependency with a
+  // one-click install, mirroring the managed edit-LoRA CTA below. Installed == not "missing" (App.jsx).
+  const tileControlNet = tileControlNetModel(models);
+  const tileControlNetReady = tileControlNetInstalled(models);
+  const [tileControlNetDownloadRequested, setTileControlNetDownloadRequested] = useState(false);
+  // Clear the transient "requested" state once the download lands (installState flips off "missing").
+  useEffect(() => {
+    if (tileControlNetReady) setTileControlNetDownloadRequested(false);
+  }, [tileControlNetReady]);
+  const requestTileControlNetDownload = useCallback(() => {
+    if (!tileControlNet || !createModelDownloadJob) return;
+    setTileControlNetDownloadRequested(true);
+    createModelDownloadJob(tileControlNet);
+  }, [tileControlNet, createModelDownloadJob]);
 
   // Keyboard-shortcut quick reference panel (sc-6111).
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
@@ -2710,8 +2737,38 @@ export function ImageEditor() {
                 <p className="ie-note">Higher keeps the result closer to the source composition.</p>
               </div>
             </div>
+            {/* Tile ControlNet dependency (sc-2437/sc-2438): Detail can't run without it, but it's a
+                separate utility download — surface it as required with a one-click install when missing,
+                and gate the run. Mirrors the managed edit-LoRA CTA in the AI Edit panel. */}
             <div className="ie-section">
-              <button className="ie-btn block primary" disabled={!!aiOp || !detailModel} onClick={runDetail} type="button">
+              <div className="ie-sec-title">Required model</div>
+              {tileControlNetReady ? (
+                <p className="ie-note">✨ {tileControlNet.name ?? "SDXL Tile ControlNet"} is installed and ready.</p>
+              ) : (
+                <>
+                  <p className="ie-note">
+                    The SDXL tile ControlNet (~2.5 GB) is required for Detail enhance and isn’t installed yet.
+                  </p>
+                  <button
+                    className="ie-btn block"
+                    disabled={!tileControlNet || !createModelDownloadJob || tileControlNetDownloadRequested}
+                    onClick={requestTileControlNetDownload}
+                    type="button"
+                  >
+                    {tileControlNetDownloadRequested
+                      ? "Downloading…"
+                      : `Download ${tileControlNet?.name ?? "SDXL Tile ControlNet"}`}
+                  </button>
+                </>
+              )}
+            </div>
+            <div className="ie-section">
+              <button
+                className="ie-btn block primary"
+                disabled={!!aiOp || !detailModel || !tileControlNetReady}
+                onClick={runDetail}
+                type="button"
+              >
                 Enhance detail
               </button>
               <button className="ie-btn block" onClick={() => setTool("move")} type="button">

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -34,6 +34,9 @@ import {
   maskHasContent,
   detailCapableModels,
   buildDetailJobBody,
+  tileControlNetModel,
+  tileControlNetInstalled,
+  TILE_CONTROLNET_MODEL_ID,
   rectToBbox,
   bboxToRect,
   isValidHexColor,
@@ -777,6 +780,32 @@ describe("detail job", () => {
         advanced: { strength: 0.55, cnScale: 0.7 },
       },
     });
+  });
+
+  // The tile ControlNet is a `type:"utility"` dependency the Detail run needs but the image-only
+  // picker never lists — the panel looks it up in the full catalog to gate the run + offer an install.
+  it("finds the tile ControlNet in the full catalog by its utility id", () => {
+    const models = [
+      { id: "realvisxl", type: "image", installState: "installed" },
+      { id: TILE_CONTROLNET_MODEL_ID, type: "utility", installState: "missing" },
+    ];
+    expect(tileControlNetModel(models)?.id).toBe(TILE_CONTROLNET_MODEL_ID);
+    expect(tileControlNetModel([{ id: "realvisxl" }])).toBeNull();
+    expect(tileControlNetModel(undefined)).toBeNull();
+  });
+
+  it("treats the tile ControlNet as ready only when present and not 'missing'", () => {
+    // Absent from the catalog → not ready (so the run is gated, not silently allowed to fail).
+    expect(tileControlNetInstalled([{ id: "realvisxl", installState: "installed" }])).toBe(false);
+    expect(tileControlNetInstalled(undefined)).toBe(false);
+    // Present but not downloaded → not ready.
+    expect(
+      tileControlNetInstalled([{ id: TILE_CONTROLNET_MODEL_ID, installState: "missing" }]),
+    ).toBe(false);
+    // Present and installed → ready.
+    expect(
+      tileControlNetInstalled([{ id: TILE_CONTROLNET_MODEL_ID, installState: "installed" }]),
+    ).toBe(true);
   });
 });
 

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -7194,6 +7194,57 @@
       }
     },
     {
+      // SDXL tile ControlNet — the auxiliary weights the Image Editor Detail enhancer needs
+      // (`JobType::ImageDetail`, sc-2437/sc-2438). The native worker (`image_jobs/detail.rs`) resolves it
+      // by REPO STRING (`TILE_CONTROLNET_REPO = "xinsir/controlnet-tile-sdxl-1.0"`, overridable via
+      // `advanced.tileControlNetRepo`) through `huggingface_snapshot_dir` — which only RESOLVES an
+      // already-cached snapshot, never auto-downloads (the JoyCaption / CLIP seam, epic 3482). Without a
+      // catalog entry Detail dead-ended with "tile ControlNet weights not found (download
+      // xinsir/controlnet-tile-sdxl-1.0)" and there was no UI to install it. Cataloging it as a utility
+      // lets Model Manager pull the snapshot into the HF cache the worker reads, and lets the Detail panel
+      // surface it as a required dependency with a one-click download (mirrors the managed edit-LoRA CTA).
+      // apache-2.0, ungated; stock repo pulled as-is (a plain SDXL ControlNet safetensors — no conversion).
+      // Shared by every SDXL-family `image_detail` backbone (realvisxl / sdxl / …), so it is a single
+      // standalone artifact rather than a per-model co-requisite bolted onto each base's footprint.
+      "id": "controlnet_tile_sdxl",
+      "autoDownload": false,
+      "name": "SDXL Tile ControlNet (Detail enhance)",
+      "family": "controlnet-tile",
+      "type": "utility",
+      "adapter": "controlnet-tile",
+      "capabilities": [],
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "xinsir/controlnet-tile-sdxl-1.0",
+          "files": ["diffusion_pytorch_model.safetensors", "config.json"],
+          "estimatedSizeBytes": 2500000000
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/xinsir/controlnet-tile-sdxl-1.0"
+      },
+      "defaults": {},
+      "limits": {},
+      "loraCompatibility": {
+        "families": [],
+        "types": []
+      },
+      "ui": {
+        "label": "SDXL Tile ControlNet (Detail enhance)",
+        "description": "Optional tile ControlNet weights used only by the Image Editor's Detail enhancer to refine texture on an SDXL/RealVisXL backbone. A small utility dependency shared by every SDXL detail-capable model — not a generation model of its own. apache-2.0, commercial-use OK, ungated.",
+        "recommendedFor": ["image_detail"],
+        "promptGuide": {
+          "title": "SDXL Tile ControlNet (Detail enhance)",
+          "path": "/prompt-guides/controlnet-tile-sdxl.md",
+          "sources": [
+            { "label": "xinsir/controlnet-tile-sdxl-1.0 model card", "url": "https://huggingface.co/xinsir/controlnet-tile-sdxl-1.0" },
+            { "label": "ControlNet paper", "url": "https://arxiv.org/abs/2302.05543" }
+          ]
+        }
+      }
+    },
+    {
       // PiD pixel-diffusion super-resolving decoder — qwenimage latent space (epic 7840, sc-7852).
       // OPTIONAL per-generation replacement for the VAE decoder (request `advanced.usePid`): PiD
       // denoises directly in pixel space and decodes + 4x super-resolves in one 4-step pass. It is tied


### PR DESCRIPTION
## Problem

The Image Editor **Detail** enhancer failed at runtime with:

> tile ControlNet weights not found (download xinsir/controlnet-tile-sdxl-1.0).

The Detail job needs `xinsir/controlnet-tile-sdxl-1.0`, which the worker resolves **by repo string** from the HF cache (`detail.rs`, `TILE_CONTROLNET_REPO`). That path only *resolves* an already-cached snapshot and never downloads (the JoyCaption / CLIP native-utility seam). The repo was **absent from `builtin.models.jsonc`**, so:

1. It was **un-installable** — not listed in Model Manager's Utility Models.
2. The Detail panel **never surfaced it** — it gated only on a detail-capable *backbone* (`image_detail` capability, satisfied by RealVisXL alone), so the ControlNet co-requisite was invisible until the job crashed.

## Fix

- **Catalog it as a `type:"utility"` model** (`controlnet_tile_sdxl`) in `builtin.models.jsonc`, mirroring the `clip_vit_l14` precedent — apache-2.0, ungated, ~2.5 GB — so it appears in Model Manager's Utility Models and is one-click installable. Adds its required prompt-guide.
  - Design choice: a **standalone utility** shared by every SDXL detail backbone, **not** a per-model `coRequisite` — that would force 2.5 GB onto every RealVisXL/SDXL install and couple those models' install-state to a dependency they don't need for t2i/edit/inpaint.
- **Detail panel surfaces it as required** (`ImageEditor.jsx`): a ✨ "installed and ready" note, or a one-click **Download** button when missing, and **gates "Enhance detail" until it's installed** — mirroring the existing managed edit-LoRA CTA in the same file.
- Gating logic extracted to pure, unit-tested helpers (`tileControlNetModel` / `tileControlNetInstalled`) in `imageJobs.js`.

## Verification

- Scaffold check ✅ (manifest + prompt-guide valid)
- ESLint ✅
- Web tests ✅ **87 passed** (85 existing + 2 new for the gating helpers)
- Not driven end-to-end in the browser — the Detail panel needs a Konva working image (out of reach for jsdom) plus the full backend/project/models stack. The wiring reuses a proven in-file pattern and the pure logic is unit-covered.

## Note for reviewers / deploy

A dev rust-api that already seeded a catalog serves the *stale* builtin manifest (`SeedMode::IfMissing`), so the new entry may not appear on an already-running instance until the catalog is re-seeded / the app is freshly launched. Fresh installs and releases pick it up normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)