### PR TITLE
feat(routing): candle Ideogram 4/Turbo generic ui.img2img reference-guided t2i (sc-10261, epic 8588)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3795,11 +3795,51 @@ mod candle_routing_tests {
             assert!(!ideogram_edit_candle_eligible(&object(json!({
                 "model": model, "mode": "edit_image"
             }))));
-            // Pure IP-Adapter reference (Ideogram has no candle IP path) still defers to torch.
+            // The raw txt2img gate still rejects any `referenceAssetId` (it stays txt2img-only). A
+            // text_to_image reference is the `ui.img2img` "Image reference" tile, handled by the bespoke
+            // `ideogram_img2img_candle_eligible` branch in the dispatcher (covered by
+            // `ideogram_img2img_routes_to_candle`), NOT the generic gate.
             assert!(!image_request_candle_eligible(
                 model,
                 &object(json!({ "referenceAssetId": "a" }))
             ));
+        }
+    }
+
+    #[test]
+    fn ideogram_img2img_routes_to_candle() {
+        // sc-10261 (epic 8588): the candle parity of the MLX Ideogram generic img2img arm (sc-10192). An
+        // `ideogram_4` / `ideogram_4_turbo` job in a non-edit mode with a `referenceAssetId` is the
+        // `ui.img2img` "Image reference" tile — a single `Conditioning::Reference` with NO `Mask`, which
+        // the candle `candle-gen-ideogram` pipeline denoises as plain img2img (`resolve_edit` →
+        // `prepare_edit` with `mask = None`). Branched before the txt2img gate (which rejects any
+        // `referenceAssetId`), disjoint from the `edit_image` Remix/inpaint lane. No worker/candle-gen
+        // change — the worker `generate_candle_stream` already resolves the init generically (sc-10134).
+        for model in ["ideogram_4", "ideogram_4_turbo"] {
+            let img2img = json!({
+                "model": model,
+                "referenceAssetId": "asset_1",
+                "advanced": { "strength": 0.6 }
+            });
+            assert!(
+                image_job_is_candle_eligible(&image_generate_job(img2img.clone())),
+                "{model} img2img (referenceAssetId, non-edit) must be candle-eligible (sc-10261)"
+            );
+            // The eligibility predicate: a non-edit reference is img2img; an `edit_image` reference is the
+            // Remix/inpaint edit lane, NOT this img2img arm.
+            assert!(ideogram_img2img_candle_eligible(&object(json!({
+                "model": model, "referenceAssetId": "asset_1"
+            }))));
+            assert!(!ideogram_img2img_candle_eligible(&object(json!({
+                "model": model, "mode": "edit_image", "referenceAssetId": "asset_1"
+            }))));
+            // A blank/absent reference is plain txt2img, not img2img.
+            assert!(!ideogram_img2img_candle_eligible(&object(json!({
+                "model": model, "referenceAssetId": "  "
+            }))));
+            assert!(!ideogram_img2img_candle_eligible(&object(
+                json!({ "model": model })
+            )));
         }
     }
 

--- a/crates/sceneworks-core/src/jobs_store/routing/candle.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/candle.rs
@@ -131,6 +131,21 @@ pub(crate) fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     {
         return true;
     }
+    // Ideogram 4 / Turbo img2img (reference-guided latent-init, sc-10261, epic 8588): an ideogram-family
+    // job in a **non-edit** mode with a `referenceAssetId` is the "Image reference" `ui.img2img` tile —
+    // a single `Conditioning::Reference` with NO `Mask`, which the candle `candle-gen-ideogram` pipeline's
+    // `resolve_edit` denoises as plain img2img (VAE-encode the source → start from the strength-derived
+    // step, no keep-region mask), exactly as the MLX edit path does (sc-10192, worker #1266). DISJOINT
+    // from the Ideogram `edit_image` Remix/inpaint branch above (that arm is `edit_image` + `sourceAssetId`;
+    // this arm is `text_to_image` + `referenceAssetId`), and the txt2img gate below rejects any
+    // `referenceAssetId`, so branch it out here. The worker `generate_candle_stream` already resolves the
+    // init generically (`model_supports_img2img`, sc-10134) — no worker or candle-gen change, just this
+    // router branch. Mirrors the Z-Image / SD3.5 / Boogu img2img routing.
+    if matches!(model, "ideogram_4" | "ideogram_4_turbo")
+        && ideogram_img2img_candle_eligible(&job.payload)
+    {
+        return true;
+    }
     // Boogu instruction edit (sc-7524, epic 6831): a `boogu_image_edit` `edit_image` job with a source
     // image runs the candle `candle-gen-boogu` edit path. Like Ideogram (and unlike the SDXL/FLUX.2/Qwen/
     // Z-Image bespoke streams above), Boogu has no separate edit stream — the SAME registered
@@ -879,6 +894,26 @@ pub(crate) fn ideogram_edit_candle_eligible(payload: &Map<String, Value>) -> boo
     }
     payload
         .get("sourceAssetId")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty())
+}
+
+/// Ideogram 4 / Turbo img2img (reference-guided latent-init) candle-routing conditions (sc-10261, epic
+/// 8588). The registered `ideogram_4` / `ideogram_4_turbo` candle generators serve the `ui.img2img`
+/// "Image reference" tile: a single `Conditioning::Reference` (no `Mask`) in a **non-edit** request is
+/// VAE-encoded to the clean init latent and denoised from the strength-derived step to the schedule tail
+/// (`candle-gen-ideogram` `resolve_edit` → `prepare_edit` with `mask = None`, sc-6598). So an ideogram
+/// job in a non-edit mode with a `referenceAssetId` is candle-eligible; the worker resolves the init
+/// generically (`model_supports_img2img`, sc-10134). Same payload predicate as
+/// [`boogu_img2img_candle_eligible`] / [`sd3_img2img_candle_eligible`], gated to the ideogram ids by the
+/// caller. DISJOINT from the [`ideogram_edit_candle_eligible`] Remix/inpaint lane (that arm is
+/// `edit_image` + `sourceAssetId`). Mirrors the mlx generic img2img arm (sc-10192).
+pub(crate) fn ideogram_img2img_candle_eligible(payload: &Map<String, Value>) -> bool {
+    if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
+        return false;
+    }
+    payload
+        .get("referenceAssetId")
         .and_then(Value::as_str)
         .is_some_and(|value| !value.trim().is_empty())
 }


### PR DESCRIPTION
## What

Candle (Windows/CUDA) worker-lane parity for the Ideogram 4 / Turbo **`ui.img2img` "Image reference" tile** — the last remaining sibling of [sc-10265](https://app.shortcut.com/trefry/story/10265) (which shipped SD3.5 / Z-Image / Boogu and explicitly punted Ideogram here).

An `ideogram_4` / `ideogram_4_turbo` job in a **non-edit** mode carrying a `referenceAssetId` is the plain-t2i "Image reference" tile: a single `Conditioning::Reference` with **no `Mask`**, which the candle `candle-gen-ideogram` pipeline's `resolve_edit` already denoises as plain img2img (VAE-encode the source → start from the strength-derived step, no keep-region mask), exactly as the MLX edit path does ([sc-10192](https://app.shortcut.com/trefry/story/10192), #1266).

**The gap was router-only.** The candle router had ONLY an `edit_image`-gated Ideogram branch (`ideogram_edit_candle_eligible`, the Remix/inpaint lane). A `text_to_image` + `referenceAssetId` job matched no branch and fell through to the txt2img gate — which rejects any `referenceAssetId` — so off-Mac the tile rendered but the strength slider was dropped and Ideogram rendered plain t2i.

## Change

- **`ideogram_img2img_candle_eligible`** (`routing/candle.rs`) + a dispatcher branch, co-located with the Ideogram edit branch and mirroring the Z-Image / SD3.5 / Boogu img2img routing (`mode != "edit_image"` + non-empty `referenceAssetId`).
- **Test** `ideogram_img2img_routes_to_candle`; updated the stale "defers to torch" comment in `ideogram_candle_txt2img_and_edit_route_to_candle`.

**No worker change** — the generic `generate_candle_stream` img2img resolve (`model_supports_img2img` + `resolve_img2img_init_generic`, sc-10134) already threads a non-edit reference into the single `Conditioning::Reference` slot for Ideogram. **No candle-gen change** — engine ready (`resolve_edit` treats Reference-no-Mask as img2img). **No manifest change** — the `ui.img2img` flag is already set on both ids (sc-10192).

## Verification checklist (from sc-10265's per-model list)

- [x] **Engine readiness**: `candle-gen-ideogram` (pinned `f572005`) `pipeline.rs::resolve_edit` denoises a `Conditioning::Reference` with no `Mask` as plain img2img — `prepare_edit` with `mask = None`, denoise from the strength-derived step. Verified in the pinned source.
- [x] **Mode-split preserved**: `edit_image` + `sourceAssetId` → `ideogram_edit_candle_eligible` (Remix/inpaint, mask-capable); `text_to_image` + `referenceAssetId` → the new img2img branch. Disjoint by mode; the two are gated on different payload keys.
- [x] Worker `resolve_ideogram_edit` returns `None` for non-edit mode → the generic `img2img_reference` arm engages.
- [x] `cargo fmt -p sceneworks-core --check` clean; `cargo clippy -p sceneworks-core --lib` clean.
- [x] `cargo test -p sceneworks-core --lib` — 63 candle-routing tests pass (incl. the new one).

**Real-CUDA validation** (attach a reference + sweep strength → reference-guided output; distilled Turbo → eyeball the A0 strength window) is the standard follow-up on an NVIDIA box — the routing + engine are in place.

Relates to [sc-10192](https://app.shortcut.com/trefry/story/10192) (MLX), [sc-10265](https://app.shortcut.com/trefry/story/10265) (consolidation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)