### PR TITLE
feat(worker): wire Krea control activation-chunking rung into the fit-gate ladder (sc-11842, epic 8459)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -570,7 +570,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-gen",
  "image",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -768,7 +768,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -805,7 +805,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -817,7 +817,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -830,7 +830,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=f572005c5cf009e6f025568b6acf6b2e075b9940#f572005c5cf009e6f025568b6acf6b2e075b9940"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -8361,7 +8361,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2537,11 +2537,19 @@
           // essentially the denoise steady floor. Higher tiers omit it (their denoise steady-state, not the
           // decode, is the peak — tiling there recovers little, so branch-quant is the operative rung).
           "decodeTileSaveGb": { "q4": 6.7 },
+          // MIDDLE rung (sc-11745, candle-gen #496): the peak reduction (GB) from engaging sc-6217-style
+          // query-row attention chunking on the composable base stack + control branch
+          // (`Krea2ControlPaths.chunk_attention`) — a SPEED cost, no quality cost (the chunked forward is
+          // byte-identical to the unchunked one). Bounds the DENOISE-phase activation peak, so it slots
+          // between VAE-decode tiling (decode-phase) and the last-resort branch quant. GPU-MEASURED on an
+          // RTX PRO 6000 (Blackwell sm_120), dense bf16 base, 1024²/8-step: the ~11 GB-of-activations denoise
+          // steady-state peak drops −2.43 GiB, at a cost of +2.6 s (~+6%). A SCALAR (not tier-keyed): the
+          // activation peak is bf16 regardless of the base weight tier, so the saving is tier-independent.
+          "chunkAttnSaveGb": 2.43,
           // Last-resort rung: the peak reduction (GB) from quantizing the control branch bf16 → q8/q4
           // (candle-gen #483, sc-11743), MEASURED (dense base holds the rest fixed to isolate the branch):
           // q8 −8.4 (near-lossless), q4 −10.2 (pose-locked; non-pose details drift). The gate prefers q8
-          // before q4, and composes it with the tiling rung above. The activation-chunking / res-cap rung
-          // (sc-11745) slots between tiling and branch-quant once its candle-gen mechanism ships.
+          // before q4, and composes it with the two cheaper (speed-only) rungs above — tiling then chunking.
           "branchQuantSaveGb": { "q8": 8.4, "q4": 10.2 },
           "measured": false
         }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1723,15 +1723,29 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568
 # (`decode()` is byte-identical when `force_tile = false`, the default for every existing caller). Points at
 # the branch content commit (durable ancestor once #492's merge lands on candle-gen main). ALL candle-gen-*
 # pins move together; backend-candle check --locked green.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+# Bumped candle-gen `f572005c` -> `573aa78` (sc-11842, epic 8459): candle-gen PR #496 adds the pose-control
+# fit-ladder's activation-chunking rung — the `Krea2ControlPaths.chunk_attention: bool` load-time toggle
+# (the twin of #483's `branch_quant`) that engages sc-6217-style query-row attention chunking on the
+# composable base stack + control branch, bounding the ~11 GB 1024² denoise activation peak (measured
+# −2.43 GiB, +~6% cost, byte-identical output — the chunked forward is numerically identical). The
+# sc-11754 fit-gate flips it on ahead of the last-resort branch-quant rung. `573aa78` is candle-gen main
+# HEAD (the #496 merge); `f572005c` is its 2-commit ancestor (`git compare` behind_by 0), so this is a
+# clean forward bump. candle-gen main already pins its OWN gen-core at `b568fdb` (unchanged across
+# `f572005c..573aa78` — #496 is candle-gen-krea source-only, `git diff -- gen-core/ gen-core-testkit/`
+# EMPTY), matching this worker's mlx-gen pin, so `--features backend-candle` still resolves the SINGLE
+# gen-core rev b568fdb. Adding the new `chunk_attention` field makes the existing `Krea2ControlPaths { … }`
+# literal in image_jobs/krea_control_candle.rs fail to compile until it sets the field (the coordinated-bump
+# situation sc-11761 flagged) — set here in the same commit. ALL candle-gen-* pins move together;
+# backend-candle check --locked green.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1745,7 +1759,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1753,17 +1767,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1773,7 +1787,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1781,21 +1795,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1804,7 +1818,7 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # Candle Bernini still-image companion (sc-10996, epic 6562) — the Windows/CUDA sibling of
 # `mlx-gen-bernini`, built ON candle-gen-wan (the full Qwen2.5-VL/MAR semantic planner driving a
 # Wan2.2-A14B dual-expert renderer, `frames:1` for a single still). Self-registers the full `bernini`
@@ -1816,17 +1830,17 @@ candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # main HEAD, the merged #421 planner-components commit — contains the #419 full generator sc-10995) — its
 # gen-core pin (951227a) MATCHES the worker's mlx pin, so `--features backend-candle --target all`
 # resolves ONE gen-core rev (no skew).
-candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1835,7 +1849,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1868,7 +1882,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1877,12 +1891,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1890,7 +1904,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f5720
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1899,7 +1913,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1907,7 +1921,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1921,7 +1935,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1948,7 +1962,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1959,7 +1973,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "f572005c5cf009e6f025568b6acf6b2e075b9940", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
@@ -309,6 +309,11 @@ struct KreaStrictControl {
     /// when the predicted decode-phase peak exceeds free VRAM. `false` (the big-card default) is the
     /// monolithic full-speed decode. A *speed* cost, no quality cost.
     tile_vae_decode: bool,
+    /// Engage sc-6217-style query-row attention chunking on the composable base stack + control branch
+    /// (sc-11745, candle-gen #496) — the fit ladder's rung between VAE-decode tiling and branch quant,
+    /// engaged only when the predicted denoise-phase activation peak exceeds free VRAM. `false` (the
+    /// big-card default) is the unchunked full-speed forward. A *speed* cost (~+6%), byte-identical output.
+    chunk_attention: bool,
     prompt: String,
     width: u32,
     height: u32,
@@ -346,6 +351,9 @@ impl CandleStrictControl for KreaStrictControl {
             adapters: self.adapters.clone(),
             // bf16 by default; the fit ladder (sc-11754) sets q8/q4 only to fit a constrained card.
             branch_quant: self.branch_quant,
+            // Unchunked (full speed) by default; the fit ladder (sc-11745) forces query-row attention
+            // chunking only to bound the denoise activation peak on a constrained card — byte-identical.
+            chunk_attention: self.chunk_attention,
         };
         candle_gen_krea::Krea2Control::load(&paths).map_err(|error| {
             WorkerError::Engine(format!("Krea 2 strict-pose control load failed: {error}"))
@@ -437,34 +445,39 @@ async fn generate_candle_krea_control_stream(
         crate::gpu::nvidia_vram_budget_gb(&settings.gpu_id).await,
         crate::vram_gate::cuda_vram_cap_gb(),
     );
-    let (tile_vae_decode, branch_quant) = match crate::krea_control_fit::fit_ladder(
+    let (tile_vae_decode, chunk_attention, branch_quant) = match crate::krea_control_fit::fit_ladder(
         crate::krea_control_fit::predicted_control_peak_gb(&request.model_manifest_entry, tier),
         budget,
         crate::krea_control_fit::decode_tile_save_gb(&request.model_manifest_entry, tier),
+        crate::krea_control_fit::chunk_attn_save_gb(&request.model_manifest_entry),
         crate::krea_control_fit::branch_quant_save_gb(&request.model_manifest_entry, "q8"),
         crate::krea_control_fit::branch_quant_save_gb(&request.model_manifest_entry, "q4"),
     ) {
-        // Big-card fast path (or no signal): monolithic full-speed decode, bf16 branch.
+        // Big-card fast path (or no signal): monolithic full-speed decode, unchunked attention, bf16 branch.
         crate::krea_control_fit::KreaControlFit::Unknown
         | crate::krea_control_fit::KreaControlFit::Fits {
             tile_vae_decode: false,
+            chunk_attention: false,
             branch_quant: None,
-        } => (false, None),
+        } => (false, false, None),
         // Constrained card: the fit ladder engaged the cheapest sufficient set of rungs to fit — the
-        // seam-free tiled VAE decode (sc-11744, a speed cost) and/or the last-resort branch quant.
+        // seam-free tiled VAE decode (sc-11744) and/or query-row attention chunking (sc-11745), both
+        // speed-only, and/or the last-resort branch quant (sc-11743, a quality cost).
         crate::krea_control_fit::KreaControlFit::Fits {
             tile_vae_decode: tile,
+            chunk_attention: chunk,
             branch_quant: quant,
         } => {
             tracing::info!(
                 model = %request.model,
                 tier,
                 tile_vae_decode = tile,
+                chunk_attention = chunk,
                 branch_quant = ?quant,
                 "Krea control VRAM fit ladder: predicted peak exceeds free VRAM — engaging rungs \
-                 (VAE-decode tiling and/or control-branch quant) to fit"
+                 (VAE-decode tiling, attention chunking, and/or control-branch quant) to fit"
             );
-            (tile, quant)
+            (tile, chunk, quant)
         }
         // Won't fit even at the last rung ⇒ reject before the reactive CUDA OOM.
         crate::krea_control_fit::KreaControlFit::TooBig {
@@ -473,9 +486,9 @@ async fn generate_candle_krea_control_stream(
         } => {
             return Err(WorkerError::InvalidPayload(format!(
                 "Krea 2 pose-ControlNet at the {tier} base tier needs ~{needed} GB of VRAM (with \
-                 headroom, tiled VAE decode + control branch quantized to q4) but GPU {gpu} has \
-                 ~{available} GB available. Lower the output resolution or run on a card with more \
-                 VRAM.",
+                 headroom, tiled VAE decode + attention chunking + control branch quantized to q4) but \
+                 GPU {gpu} has ~{available} GB available. Lower the output resolution or run on a card \
+                 with more VRAM.",
                 needed = needed_gb.round() as i64,
                 available = available_gb.round() as i64,
                 gpu = settings.gpu_id,
@@ -489,6 +502,7 @@ async fn generate_candle_krea_control_stream(
         adapters,
         branch_quant,
         tile_vae_decode,
+        chunk_attention,
         prompt: request.prompt.clone(),
         width: request.width,
         height: request.height,

--- a/crates/sceneworks-worker/src/krea_control_fit.rs
+++ b/crates/sceneworks-worker/src/krea_control_fit.rs
@@ -18,17 +18,17 @@
 //!     cost, no quality cost) to cap the end-of-render decode spike. Engaged first, when the measured
 //!     `decodeTileSaveGb` is enough to fit; also stays on underneath the quant rungs (it is cheaper than
 //!     quant and every bit helps).
-//!  3. **activation chunking / resolution cap** (sc-11745) — engage when the denoise steady state is the
-//!     overflow. Still pending its candle-gen mechanism (`WIRED_ACTIVATION_CHUNKING = false`); slots in
-//!     here between tiling and branch-quant when it lands.
+//!  3. **activation chunking** (sc-11745, candle-gen #496) — engage sc-6217-style query-row attention
+//!     chunking on the composable base stack + control branch when the denoise steady state is the
+//!     overflow. A *speed* cost (~+6%) with byte-identical output; slots between tiling and branch-quant.
+//!     Gated by the presence of the measured scalar `chunkAttnSaveGb`.
 //!  4. **control-branch quant** (sc-11743, candle-gen #483) — bf16 → q8 → q4. A *quality cost* (the
 //!     residual is precision-sensitive, RMS-clamped at τ), so it is the **last-resort rung**. Composes
-//!     with tiling (both reduce the decode-dominated peak).
+//!     with the cheaper rungs (all reduce the co-resident peak).
 //!
-//! Rung 3 needs its own candle-gen mechanism (sc-11745); until then it is declared but **not yet
-//! engageable** — the ladder walks packed → tiling → branch-quant and, if even (tiling + q4) won't fit,
-//! rejects-before-OOM noting the pending activation-chunking rung. `decodeTileSaveGb` absent for a tier
-//! (unmeasured) ⇒ the tiling rung is skipped for that tier exactly like an unmeasured branch-quant save.
+//! `decodeTileSaveGb` / `chunkAttnSaveGb` absent (unmeasured) ⇒ that rung is skipped exactly like an
+//! unmeasured branch-quant save — the ladder walks the rungs it *can* measure and, if even
+//! (tiling + chunking + q4) won't fit, rejects-before-OOM at the honest best-case peak.
 //!
 //! Everything here is pure and unit-tested; the live `nvidia-smi` reading lives in [`crate::gpu`] and the
 //! wiring is in `generate_candle_krea_control_stream` (image_jobs/krea_control_candle.rs).
@@ -42,13 +42,6 @@ use serde_json::Value;
 /// slack + activation spikes not captured by the steady peak.
 const HEADROOM_GB: f64 = 2.0;
 
-/// Whether the activation-chunking / resolution-cap rung (sc-11745) is wired yet. `false` until that
-/// story ships its candle-gen mechanism + the `Krea2ControlRequest` toggle it engages; the ladder then
-/// inserts it between the VAE-tiling rung (sc-11744, already wired below) and the branch-quant rung.
-/// Flipping this (and threading the toggle) is sc-11745's one-line hook into this gate. (The VAE-tiling
-/// rung is now live — gated instead by the presence of the measured `decodeTileSaveGb`.)
-const WIRED_ACTIVATION_CHUNKING: bool = false;
-
 /// The outcome of walking the Krea control fit ladder. `Unknown` = no signal (no `candle.control` block,
 /// or a non-NVIDIA host) ⇒ never block, run the bf16 branch — exactly like [`crate::vram_gate::FitDecision::Unknown`].
 #[derive(Clone, Debug, PartialEq)]
@@ -56,14 +49,18 @@ pub(crate) enum KreaControlFit {
     /// No measured control peak or no live budget ⇒ don't gate; load the default bf16 branch.
     Unknown,
     /// The predicted peak fits after engaging the minimal sufficient set of rungs. The big-card fast
-    /// path is `{ tile_vae_decode: false, branch_quant: None }` (monolithic full-speed decode, bf16
-    /// branch, zero penalty). `tile_vae_decode = true` is the cheapest rung (sc-11744 — a *speed* cost
-    /// only, seam-free); `branch_quant = Some(Q8)`/`Some(Q4)` is the last-resort *quality* rung, engaged
-    /// only after tiling was insufficient.
+    /// path is `{ tile_vae_decode: false, chunk_attention: false, branch_quant: None }` (monolithic
+    /// full-speed decode, unchunked attention, bf16 branch, zero penalty). `tile_vae_decode = true` is the
+    /// cheapest rung (sc-11744 — a *speed* cost only, seam-free); `chunk_attention = true` is the next rung
+    /// (sc-11745 — a *speed* cost only, byte-identical output); `branch_quant = Some(Q8)`/`Some(Q4)` is the
+    /// last-resort *quality* rung, engaged only after both cheaper rungs were insufficient.
     Fits {
         /// Force the seam-free tiled VAE decode (sc-11744) to cap the end-of-render decode spike. The
         /// worker threads this into `Krea2ControlRequest::tile_vae_decode`.
         tile_vae_decode: bool,
+        /// Engage sc-6217-style query-row attention chunking (sc-11745) to bound the denoise activation
+        /// peak. The worker threads this into `Krea2ControlPaths::chunk_attention` (a load-time toggle).
+        chunk_attention: bool,
         branch_quant: Option<Quant>,
     },
     /// Won't fit even at the last rung (q4 branch). Reject-before-OOM with an actionable message rather
@@ -116,20 +113,38 @@ pub(crate) fn decode_tile_save_gb(manifest_entry: &JsonObject, tier_key: &str) -
         .and_then(json_f64)
 }
 
+/// Measured peak reduction (GB) from engaging sc-6217-style query-row attention chunking on the composable
+/// base stack + control branch (sc-11745, candle-gen #496): `candle.control.chunkAttnSaveGb`. Bounds the
+/// DENOISE-phase activation peak — a *speed* cost (~+6%) with byte-identical output (the chunked forward is
+/// numerically identical to the unchunked one, the sc-6217 query-row-independence invariant). Unlike the
+/// tier-keyed [`decode_tile_save_gb`]/[`predicted_control_peak_gb`], this is a SCALAR: the denoise activation
+/// peak is bf16 regardless of the base weight tier, so the saving is tier-independent. `None` when unmeasured
+/// ⇒ the chunking rung is unavailable and the ladder walks tiling → branch-quant. Published measured (RTX PRO
+/// 6000, dense bf16 base, 1024²/8-step): −2.43 GiB.
+pub(crate) fn chunk_attn_save_gb(manifest_entry: &JsonObject) -> Option<f64> {
+    manifest_entry
+        .get("candle")?
+        .get("control")?
+        .get("chunkAttnSaveGb")
+        .and_then(json_f64)
+}
+
 /// Walk the fit ladder: given the bf16-branch predicted peak, the (capped) live budget, the measured
-/// VAE-decode tiling saving, and the measured branch-quant savings, engage the minimal sufficient set of
-/// rungs in increasing (Δcost) order and return the [`KreaControlFit`].
+/// VAE-decode tiling saving, the measured activation-chunking saving, and the measured branch-quant
+/// savings, engage the minimal sufficient set of rungs in increasing (Δcost) order and return the
+/// [`KreaControlFit`].
 ///
-/// Walk: if the monolithic peak fits, run untiled at the bf16 branch (big-card fast path, no penalty);
-/// else force the seam-free tiled decode (sc-11744 — a *speed* cost only); else — keeping tiling on —
-/// quantize the control branch, preferring q8 (near-lossless) then q4 (pose-locked, non-pose drift);
-/// else reject-before-OOM. The activation-chunking rung (sc-11745) slots between tiling and branch-quant
-/// once [`WIRED_ACTIVATION_CHUNKING`] flips. An unmeasured saving skips that rung. Missing peak or budget
-/// ⇒ [`KreaControlFit::Unknown`] (never block).
+/// Walk: if the monolithic peak fits, run untiled/unchunked at the bf16 branch (big-card fast path, no
+/// penalty); else force the seam-free tiled decode (sc-11744 — a *speed* cost only); else — keeping tiling
+/// on — engage query-row attention chunking (sc-11745 — a *speed* cost only, byte-identical); else —
+/// keeping both speed rungs on — quantize the control branch, preferring q8 (near-lossless) then q4
+/// (pose-locked, non-pose drift); else reject-before-OOM. Any unmeasured saving (`None`) skips its rung.
+/// Missing peak or budget ⇒ [`KreaControlFit::Unknown`] (never block).
 pub(crate) fn fit_ladder(
     peak_bf16_branch_gb: Option<f64>,
     budget: Option<crate::vram_gate::VramBudget>,
     decode_tile_save_gb: Option<f64>,
+    chunk_attn_save_gb: Option<f64>,
     q8_save_gb: Option<f64>,
     q4_save_gb: Option<f64>,
 ) -> KreaControlFit {
@@ -139,54 +154,71 @@ pub(crate) fn fit_ladder(
     let free = budget.free_gb;
     let fits = |needed: f64| free + f64::EPSILON >= needed;
 
-    // (The activation-chunking / res-cap rung, sc-11745, engages here — between tiling and branch-quant —
-    //  once it wires its candle-gen toggle; see WIRED_ACTIVATION_CHUNKING.)
-    let _ = WIRED_ACTIVATION_CHUNKING;
-
     // Rung 1 (packed base, always on) — big-card fast path: the monolithic bf16-branch peak already fits,
-    // so nothing engages: full-speed decode, zero quality penalty.
+    // so nothing engages: full-speed decode, unchunked attention, zero quality penalty.
     if fits(peak) {
         return KreaControlFit::Fits {
             tile_vae_decode: false,
+            chunk_attention: false,
             branch_quant: None,
         };
     }
     // Rung 2 (VAE-decode tiling, sc-11744) — cheapest: a *speed* cost, no quality loss (seam-free). An
-    // unmeasured tier saving (None) leaves this rung unavailable, degenerating to the old quant-only walk.
+    // unmeasured tier saving (None) leaves this rung unavailable, degenerating toward the quant-only walk.
     if let Some(tile_save) = decode_tile_save_gb {
         if fits(peak - tile_save) {
             return KreaControlFit::Fits {
                 tile_vae_decode: true,
+                chunk_attention: false,
                 branch_quant: None,
             };
         }
     }
-    // Past here tiling alone was insufficient, so keep it on beneath the quant rungs (it is cheaper than
-    // quant and every GB helps); if it was unmeasured, `tile_on` stays false and the peak is unreduced.
+    // Past here tiling alone was insufficient, so keep it on beneath the deeper rungs (it is cheaper than
+    // chunking or quant and every GB helps); if it was unmeasured, `tile_on` stays false / the peak unreduced.
     let tile_on = decode_tile_save_gb.is_some();
     let peak_after_tile = peak - decode_tile_save_gb.unwrap_or(0.0);
+
+    // Rung 3 (activation chunking, sc-11745, candle-gen #496) — a *speed* cost (~+6%), byte-identical output
+    // (the chunked forward is numerically identical). Cheaper than the quality-costing branch quant, so it is
+    // engaged BEFORE it. An unmeasured saving (None) leaves this rung unavailable.
+    if let Some(chunk_save) = chunk_attn_save_gb {
+        if fits(peak_after_tile - chunk_save) {
+            return KreaControlFit::Fits {
+                tile_vae_decode: tile_on,
+                chunk_attention: true,
+                branch_quant: None,
+            };
+        }
+    }
+    // Chunking alone was insufficient too, so keep it on beneath the quant rungs (byte-identical, cheaper
+    // than quant); if it was unmeasured, `chunk_on` stays false and the peak is unreduced by it.
+    let chunk_on = chunk_attn_save_gb.is_some();
+    let peak_after_chunk = peak_after_tile - chunk_attn_save_gb.unwrap_or(0.0);
 
     // Rung 4 (control-branch quant, sc-11743) — last resort, a *quality* cost. Prefer q8 (effectively
     // free quality) before q4 (visible non-pose drift). Each save is measured; an unmeasured save skips.
     if let Some(save) = q8_save_gb {
-        if fits(peak_after_tile - save) {
+        if fits(peak_after_chunk - save) {
             return KreaControlFit::Fits {
                 tile_vae_decode: tile_on,
+                chunk_attention: chunk_on,
                 branch_quant: Some(Quant::Q8),
             };
         }
     }
     if let Some(save) = q4_save_gb {
-        if fits(peak_after_tile - save) {
+        if fits(peak_after_chunk - save) {
             return KreaControlFit::Fits {
                 tile_vae_decode: tile_on,
+                chunk_attention: chunk_on,
                 branch_quant: Some(Quant::Q4),
             };
         }
     }
-    // Won't fit even at (tiling + q4). Report the best-case peak (tiling on + the deepest branch quant) so
-    // the reject message is honest about what still overflows (the sc-11745 rung would add more headroom).
-    let best_case = peak_after_tile - q4_save_gb.or(q8_save_gb).unwrap_or(0.0);
+    // Won't fit even at (tiling + chunking + q4). Report the best-case peak (every cheaper rung on + the
+    // deepest branch quant) so the reject message is honest about what still overflows.
+    let best_case = peak_after_chunk - q4_save_gb.or(q8_save_gb).unwrap_or(0.0);
     KreaControlFit::TooBig {
         needed_gb: best_case,
         available_gb: free,
@@ -228,10 +260,28 @@ mod tests {
         }))
     }
 
-    /// Read the q4 rung savings the ladder tests exercise (tiling + both branch quants).
-    fn q4_saves(m: &JsonObject) -> (Option<f64>, Option<f64>, Option<f64>) {
+    /// [`krea_manifest`] plus a measured scalar `chunkAttnSaveGb` (sc-11745, candle-gen #496) — exercises
+    /// the activation-chunking rung between VAE-decode tiling and branch-quant. `2.43` mirrors the shipped
+    /// measured Δ (RTX PRO 6000, dense bf16 base, 1024²/8-step).
+    fn krea_manifest_with_chunking() -> JsonObject {
+        let mut m = krea_manifest();
+        m.get_mut("candle")
+            .and_then(Value::as_object_mut)
+            .and_then(|candle| candle.get_mut("control"))
+            .and_then(Value::as_object_mut)
+            .expect("control block")
+            .insert("chunkAttnSaveGb".to_owned(), json!(2.43));
+        m
+    }
+
+    /// Read the q4-tier rung savings the ladder tests exercise: (tiling, chunking, q8-branch, q4-branch).
+    /// [`krea_manifest`] measures no chunking (the scalar `chunkAttnSaveGb` is absent), so `chunk` is None
+    /// here — the existing tests stay a tiling→quant regression walk; the activation-chunking rung has its
+    /// own chunk-enabled manifest + tests below ([`chunking_is_the_rung_before_branch_quant`]).
+    fn q4_saves(m: &JsonObject) -> (Option<f64>, Option<f64>, Option<f64>, Option<f64>) {
         (
             decode_tile_save_gb(m, "q4"),
+            chunk_attn_save_gb(m),
             branch_quant_save_gb(m, "q8"),
             branch_quant_save_gb(m, "q4"),
         )
@@ -287,6 +337,7 @@ mod tests {
     fn fits_untiled_bf16() -> KreaControlFit {
         KreaControlFit::Fits {
             tile_vae_decode: false,
+            chunk_attention: false,
             branch_quant: None,
         }
     }
@@ -295,10 +346,10 @@ mod tests {
     fn big_card_keeps_the_bf16_branch_with_no_penalty() {
         let m = krea_manifest();
         let peak = predicted_control_peak_gb(&m, "q4");
-        let (tile, q8, q4) = q4_saves(&m);
+        let (tile, chunk, q8, q4) = q4_saves(&m);
         // 96 GB card: the monolithic peak fits outright — nothing engages (no tiling, no quant).
         assert_eq!(
-            fit_ladder(peak, Some(budget(90.0)), tile, q8, q4),
+            fit_ladder(peak, Some(budget(90.0)), tile, chunk, q8, q4),
             fits_untiled_bf16()
         );
     }
@@ -308,13 +359,14 @@ mod tests {
         let m = krea_manifest();
         // q4 base: monolithic peak 30.9 + 2 = 32.9; tiling saves 6.9 ⇒ tiled peak 26.0.
         let peak = predicted_control_peak_gb(&m, "q4");
-        let (tile, q8, q4) = q4_saves(&m);
+        let (tile, chunk, q8, q4) = q4_saves(&m);
         // 26 GB card: monolithic (32.9) won't fit, but the tiled decode (26.0) does ⇒ tile on, bf16 branch
         // kept (no quality penalty). Without sc-11744 this card would have dropped to a q8 branch.
         assert_eq!(
-            fit_ladder(peak, Some(budget(26.0)), tile, q8, q4),
+            fit_ladder(peak, Some(budget(26.0)), tile, chunk, q8, q4),
             KreaControlFit::Fits {
                 tile_vae_decode: true,
+                chunk_attention: false,
                 branch_quant: None,
             }
         );
@@ -324,28 +376,30 @@ mod tests {
     fn tiling_composes_with_branch_quant_when_still_constrained() {
         let m = krea_manifest();
         let peak = predicted_control_peak_gb(&m, "q4"); // 32.9; tiled 26.0
-        let (tile, q8, q4) = q4_saves(&m);
+        let (tile, chunk, q8, q4) = q4_saves(&m);
         // 24 GB card: tiled peak 26.0 > 24; tiling stays on and q8 engages (26.0 − 8.4 = 17.6 ≤ 24) ⇒
         // tiling + q8 (near-lossless) instead of the old tiling-less q4-branch drop.
         assert_eq!(
-            fit_ladder(peak, Some(budget(24.0)), tile, q8, q4),
+            fit_ladder(peak, Some(budget(24.0)), tile, chunk, q8, q4),
             KreaControlFit::Fits {
                 tile_vae_decode: true,
+                chunk_attention: false,
                 branch_quant: Some(Quant::Q8),
             }
         );
         // 16 GB card: tiling + q8 (17.6) > 16; tiling + q4 (26.0 − 10.2 = 15.8 ≤ 16) fits ⇒ the deepest
         // rung. Without the tiling rung this card OOM-rejected (q4-alone peak 22.7 > 16).
         assert_eq!(
-            fit_ladder(peak, Some(budget(16.0)), tile, q8, q4),
+            fit_ladder(peak, Some(budget(16.0)), tile, chunk, q8, q4),
             KreaControlFit::Fits {
                 tile_vae_decode: true,
+                chunk_attention: false,
                 branch_quant: Some(Quant::Q4),
             }
         );
         // 15 GB card: even tiling + q4 (15.8) won't fit ⇒ reject-before-OOM at the best-case peak.
         assert_too_big(
-            fit_ladder(peak, Some(budget(15.0)), tile, q8, q4),
+            fit_ladder(peak, Some(budget(15.0)), tile, chunk, q8, q4),
             15.8,
             15.0,
         );
@@ -375,33 +429,36 @@ mod tests {
         // tiling rung is unavailable and the walk degenerates to the old quant-only ladder. Peak 48.2.
         let peak = predicted_control_peak_gb(&m, "bf16");
         let tile = decode_tile_save_gb(&m, "bf16"); // None
+        let chunk = chunk_attn_save_gb(&m); // None (base manifest measures no chunking)
         let q8 = branch_quant_save_gb(&m, "q8"); // 8.4
         let q4 = branch_quant_save_gb(&m, "q4"); // 10.2
 
         // 48.2 fits ⇒ untiled bf16 branch.
         assert_eq!(
-            fit_ladder(peak, Some(budget(49.0)), tile, q8, q4),
+            fit_ladder(peak, Some(budget(49.0)), tile, chunk, q8, q4),
             fits_untiled_bf16()
         );
         // 48.2 > 41, 48.2 − 8.4 = 39.8 ≤ 41 ⇒ q8 (preferred, near-lossless), tiling unavailable.
         assert_eq!(
-            fit_ladder(peak, Some(budget(41.0)), tile, q8, q4),
+            fit_ladder(peak, Some(budget(41.0)), tile, chunk, q8, q4),
             KreaControlFit::Fits {
                 tile_vae_decode: false,
+                chunk_attention: false,
                 branch_quant: Some(Quant::Q8),
             }
         );
         // 39.8 > 39, 48.2 − 10.2 = 38.0 ≤ 39 ⇒ q4 (last resort).
         assert_eq!(
-            fit_ladder(peak, Some(budget(39.0)), tile, q8, q4),
+            fit_ladder(peak, Some(budget(39.0)), tile, chunk, q8, q4),
             KreaControlFit::Fits {
                 tile_vae_decode: false,
+                chunk_attention: false,
                 branch_quant: Some(Quant::Q4),
             }
         );
         // Even q4 (~38.0) won't fit a 30 GB budget ⇒ reject, reporting the best-case peak.
         assert_too_big(
-            fit_ladder(peak, Some(budget(30.0)), tile, q8, q4),
+            fit_ladder(peak, Some(budget(30.0)), tile, chunk, q8, q4),
             38.0,
             30.0,
         );
@@ -411,15 +468,15 @@ mod tests {
     fn missing_signal_never_blocks() {
         let m = krea_manifest();
         let peak = predicted_control_peak_gb(&m, "q4");
-        let (tile, q8, q4) = q4_saves(&m);
+        let (tile, chunk, q8, q4) = q4_saves(&m);
         // No live budget ⇒ Unknown (never block).
         assert_eq!(
-            fit_ladder(peak, None, tile, q8, q4),
+            fit_ladder(peak, None, tile, chunk, q8, q4),
             KreaControlFit::Unknown
         );
         // No measured peak ⇒ Unknown.
         assert_eq!(
-            fit_ladder(None, Some(budget(8.0)), tile, q8, q4),
+            fit_ladder(None, Some(budget(8.0)), tile, chunk, q8, q4),
             KreaControlFit::Unknown
         );
     }
@@ -431,9 +488,89 @@ mod tests {
                                                         // No tiling save and no branch-quant savings measured ⇒ no rung is available, so a too-small card
                                                         // rejects reporting the raw peak itself (nothing to subtract).
         assert_too_big(
-            fit_ladder(peak, Some(budget(20.0)), None, None, None),
+            fit_ladder(peak, Some(budget(20.0)), None, None, None, None),
             32.9,
             20.0,
+        );
+    }
+
+    #[test]
+    fn chunk_attn_save_reads_the_measured_scalar() {
+        // Present (chunk-enabled manifest) ⇒ the measured scalar; tier-independent (no tier arg).
+        assert_eq!(
+            chunk_attn_save_gb(&krea_manifest_with_chunking()),
+            Some(2.43)
+        );
+        // Absent in the base manifest ⇒ None (the chunking rung is unavailable).
+        assert_eq!(chunk_attn_save_gb(&krea_manifest()), None);
+        // No control block / no candle block ⇒ None.
+        assert_eq!(chunk_attn_save_gb(&obj(json!({}))), None);
+    }
+
+    #[test]
+    fn chunking_is_the_rung_before_branch_quant() {
+        let m = krea_manifest_with_chunking();
+        // q4 base: monolithic peak 32.9; tiled 26.0; tiled + chunked 26.0 − 2.43 = 23.57.
+        let peak = predicted_control_peak_gb(&m, "q4");
+        let (tile, chunk, q8, q4) = q4_saves(&m); // chunk now Some(2.43)
+
+        // 24 GB card: tiling alone (26.0) > 24, but tiling + chunking (23.57 ≤ 24) fits ⇒ the bf16 branch is
+        // KEPT (both cheaper rungs are speed-only, byte-identical). Without sc-11745 this dropped to q8.
+        assert_eq!(
+            fit_ladder(peak, Some(budget(24.0)), tile, chunk, q8, q4),
+            KreaControlFit::Fits {
+                tile_vae_decode: true,
+                chunk_attention: true,
+                branch_quant: None,
+            }
+        );
+        // 16 GB card: tiling + chunking (23.57) > 16; both stay on beneath q8 (23.57 − 8.4 = 15.17 ≤ 16) ⇒
+        // tiling + chunking + q8 (near-lossless) — a shallower branch quant than the chunk-less walk needed
+        // (which reached q4 at 16 GB, see tiling_composes_with_branch_quant_when_still_constrained).
+        assert_eq!(
+            fit_ladder(peak, Some(budget(16.0)), tile, chunk, q8, q4),
+            KreaControlFit::Fits {
+                tile_vae_decode: true,
+                chunk_attention: true,
+                branch_quant: Some(Quant::Q8),
+            }
+        );
+        // 14 GB card: q8 (15.17) > 14; q4 (23.57 − 10.2 = 13.37 ≤ 14) fits ⇒ every cheaper rung on + q4.
+        assert_eq!(
+            fit_ladder(peak, Some(budget(14.0)), tile, chunk, q8, q4),
+            KreaControlFit::Fits {
+                tile_vae_decode: true,
+                chunk_attention: true,
+                branch_quant: Some(Quant::Q4),
+            }
+        );
+        // 13 GB card: even (tiling + chunking + q4) = 13.37 won't fit ⇒ reject at the best-case peak.
+        assert_too_big(
+            fit_ladder(peak, Some(budget(13.0)), tile, chunk, q8, q4),
+            13.37,
+            13.0,
+        );
+    }
+
+    #[test]
+    fn chunking_engages_without_tiling_when_the_tier_has_no_tiling_measurement() {
+        let m = krea_manifest_with_chunking();
+        // The bf16 base tier carries no `decodeTileSaveGb` (the decode spike isn't its peak), but the SCALAR
+        // chunk saving applies to every tier. Peak 48.2; chunked (tiling unavailable) 48.2 − 2.43 = 45.77.
+        let peak = predicted_control_peak_gb(&m, "bf16");
+        let tile = decode_tile_save_gb(&m, "bf16"); // None
+        let chunk = chunk_attn_save_gb(&m); // Some(2.43)
+        let q8 = branch_quant_save_gb(&m, "q8");
+        let q4 = branch_quant_save_gb(&m, "q4");
+        // 46 GB card: monolithic (48.2) > 46; tiling unavailable; chunking alone (45.77 ≤ 46) fits ⇒ chunk
+        // on, tiling off, bf16 branch kept — the denoise-peak rung standing in for the absent decode rung.
+        assert_eq!(
+            fit_ladder(peak, Some(budget(46.0)), tile, chunk, q8, q4),
+            KreaControlFit::Fits {
+                tile_vae_decode: false,
+                chunk_attention: true,
+                branch_quant: None,
+            }
         );
     }
 }

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -556,8 +556,8 @@ fn flux2_candle_blocks_drive_the_fit_gate_and_reject() {
 #[test]
 fn krea_control_candle_block_drives_the_fit_ladder() {
     use crate::krea_control_fit::{
-        branch_quant_save_gb, decode_tile_save_gb, fit_ladder, predicted_control_peak_gb,
-        KreaControlFit,
+        branch_quant_save_gb, chunk_attn_save_gb, decode_tile_save_gb, fit_ladder,
+        predicted_control_peak_gb, KreaControlFit,
     };
     use crate::vram_gate::apply_vram_cap;
     use gen_core::Quant;
@@ -579,6 +579,12 @@ fn krea_control_candle_block_drives_the_fit_ladder() {
     assert_eq!(q8, Some(8.4));
     assert_eq!(q4, Some(10.2));
 
+    // Shipped MEASURED activation-chunking delta (sc-11745): the denoise-peak rung between tiling and
+    // branch-quant — a SCALAR (tier-independent), speed-only, byte-identical output.
+    let chunk = chunk_attn_save_gb(entry);
+    let chunk_save = chunk.expect("chunkAttnSaveGb shipped (the sc-11745 chunking rung)");
+    assert!(chunk_save > 0.0, "chunking must recover VRAM, got {chunk_save}");
+
     // The common small-card install: q4 BASE tier. Peak 30.9 (measured sc-11744) + 2 headroom = 32.9,
     // and the shipped VAE-decode tiling saving (sc-11744) that caps the decode spike.
     let q4_peak = predicted_control_peak_gb(entry, "q4");
@@ -587,57 +593,72 @@ fn krea_control_candle_block_drives_the_fit_ladder() {
     let tile = decode_tile_save_gb(entry, "q4");
     let tile_save = tile.expect("q4 decodeTileSaveGb shipped (the sc-11744 tiling rung)");
     assert!(tile_save > 0.0, "tiling must recover VRAM, got {tile_save}");
-    let tiled_peak = peak - tile_save;
+    let tiled_peak = peak - tile_save; // tiling only (bf16 branch, cheapest rung)
+    let chunked_peak = tiled_peak - chunk_save; // + chunking (both speed-only, bf16 branch kept)
 
     // 96 GB card: the monolithic peak fits outright — nothing engages, untiled full-speed bf16 branch.
     assert_eq!(
-        fit_ladder(q4_peak, apply_vram_cap(None, Some(96.0)), tile, q8, q4),
+        fit_ladder(q4_peak, apply_vram_cap(None, Some(96.0)), tile, chunk, q8, q4),
         KreaControlFit::Fits {
             tile_vae_decode: false,
+            chunk_attention: false,
             branch_quant: None,
         }
     );
     // A card that fits the TILED peak but not the monolithic one ⇒ the cheapest rung: tiling on, bf16
     // branch kept (no quality penalty). This is sc-11744's win — a card that used to drop to a q8 branch.
     assert_eq!(
-        fit_ladder(q4_peak, apply_vram_cap(None, Some(tiled_peak)), tile, q8, q4),
+        fit_ladder(q4_peak, apply_vram_cap(None, Some(tiled_peak)), tile, chunk, q8, q4),
         KreaControlFit::Fits {
             tile_vae_decode: true,
+            chunk_attention: false,
             branch_quant: None,
         }
     );
-    // Just below the tiled peak: tiling stays on and q8 composes (tiled_peak − 8.4 fits) ⇒ tiling + q8,
-    // near-lossless — where the old ladder had already spent q4 or rejected.
+    // Just below the tiled peak: tiling alone no longer fits, but the next speed-only rung (chunking) does
+    // (chunked_peak fits) ⇒ tiling + chunking, STILL a bf16 branch — sc-11745's win over dropping to q8.
     assert_eq!(
-        fit_ladder(q4_peak, apply_vram_cap(None, Some(tiled_peak - 0.5)), tile, q8, q4),
+        fit_ladder(q4_peak, apply_vram_cap(None, Some(tiled_peak - 0.5)), tile, chunk, q8, q4),
         KreaControlFit::Fits {
             tile_vae_decode: true,
+            chunk_attention: true,
+            branch_quant: None,
+        }
+    );
+    // Just below the chunked peak: both speed rungs stay on and q8 composes (chunked_peak − 8.4 fits) ⇒
+    // tiling + chunking + q8, near-lossless — a shallower quant than the chunk-less ladder would have taken.
+    assert_eq!(
+        fit_ladder(q4_peak, apply_vram_cap(None, Some(chunked_peak - 0.5)), tile, chunk, q8, q4),
+        KreaControlFit::Fits {
+            tile_vae_decode: true,
+            chunk_attention: true,
             branch_quant: Some(Quant::Q8),
         }
     );
-    // A card between (tiling + q8) and (tiling + q4): tiling + q4 (tiled_peak − 10.2) fits where the old
-    // q4-only ladder (peak − 10.2) rejected — a real capability gain from stacking tiling under quant.
+    // A card between (…+q8) and (…+q4): tiling + chunking + q4 (chunked_peak − 10.2) fits ⇒ the deepest rung.
     assert_eq!(
-        fit_ladder(q4_peak, apply_vram_cap(None, Some(tiled_peak - 8.9)), tile, q8, q4),
+        fit_ladder(q4_peak, apply_vram_cap(None, Some(chunked_peak - 8.9)), tile, chunk, q8, q4),
         KreaControlFit::Fits {
             tile_vae_decode: true,
+            chunk_attention: true,
             branch_quant: Some(Quant::Q4),
         }
     );
-    // A card below even (tiling + q4) ⇒ reject-before-OOM at the best-case peak (tiled + q4 branch).
-    match fit_ladder(q4_peak, apply_vram_cap(None, Some(tiled_peak - 11.0)), tile, q8, q4) {
+    // A card below even (tiling + chunking + q4) ⇒ reject-before-OOM at the best-case peak.
+    match fit_ladder(q4_peak, apply_vram_cap(None, Some(chunked_peak - 11.0)), tile, chunk, q8, q4) {
         KreaControlFit::TooBig { needed_gb, .. } => {
             assert!(
-                (needed_gb - (tiled_peak - 10.2)).abs() < 1e-6,
-                "best-case (tiled + q4) peak, got {needed_gb}"
+                (needed_gb - (chunked_peak - 10.2)).abs() < 1e-6,
+                "best-case (tiling + chunking + q4) peak, got {needed_gb}"
             );
         }
-        other => panic!("below tiling+q4 → reject, got {other:?}"),
+        other => panic!("below tiling+chunking+q4 → reject, got {other:?}"),
     }
 
     // The bf16 BASE tier (peak 46.2 measured sc-11743 + 2 = 48.2) carries NO tiling saving (its denoise
-    // steady-state, not the decode, is the peak), so the walk is pure quant: a 41 GB card takes q8
-    // (48.2 − 8.4 = 39.8 ≤ 41), the near-lossless preference before q4.
+    // steady-state, not the decode, is the peak), but the SCALAR chunking rung applies to every tier: a
+    // 41 GB card engages chunking (speed-only) then q8 (48.2 − chunk_save − 8.4 ≤ 41), the near-lossless
+    // preference before q4 — a shallower quant than the chunk-less walk (which took bare q8 at 39.8).
     let bf16_peak = predicted_control_peak_gb(entry, "bf16");
     assert!((bf16_peak.expect("bf16 control peak") - 48.2).abs() < 1e-6);
     assert_eq!(decode_tile_save_gb(entry, "bf16"), None);
@@ -646,11 +667,13 @@ fn krea_control_candle_block_drives_the_fit_ladder() {
             bf16_peak,
             apply_vram_cap(None, Some(41.0)),
             decode_tile_save_gb(entry, "bf16"),
+            chunk,
             q8,
             q4
         ),
         KreaControlFit::Fits {
             tile_vae_decode: false,
+            chunk_attention: true,
             branch_quant: Some(Quant::Q8),
         }
     );
@@ -667,30 +690,33 @@ fn krea_control_candle_block_drives_the_fit_ladder() {
 #[ignore]
 async fn krea_control_live_ladder_on_a_real_card() {
     use crate::krea_control_fit::{
-        branch_quant_save_gb, decode_tile_save_gb, fit_ladder, predicted_control_peak_gb,
-        KreaControlFit,
+        branch_quant_save_gb, chunk_attn_save_gb, decode_tile_save_gb, fit_ladder,
+        predicted_control_peak_gb, KreaControlFit,
     };
     use crate::vram_gate::apply_vram_cap;
 
     let krea = builtin_model_entry("krea_2_turbo");
     let entry = krea.as_object().expect("krea_2_turbo entry object");
     let tile = decode_tile_save_gb(entry, "q4");
+    let chunk = chunk_attn_save_gb(entry);
     let q8 = branch_quant_save_gb(entry, "q8");
     let q4 = branch_quant_save_gb(entry, "q4");
     // The common small-card install: q4 base tier.
     let peak = predicted_control_peak_gb(entry, "q4");
     let tiled_peak = peak.unwrap() - tile.expect("q4 decodeTileSaveGb shipped");
+    let chunked_peak = tiled_peak - chunk.expect("chunkAttnSaveGb shipped");
 
     let real = crate::gpu::nvidia_vram_budget_gb("0")
         .await
         .expect("GPU 0 should report a live VRAM budget on a CUDA box");
     eprintln!("live CUDA budget GPU0: {real:?}");
 
-    // Uncapped real 96 GB card → untiled monolithic decode, bf16 branch, no rung engages.
+    // Uncapped real 96 GB card → untiled monolithic decode, unchunked, bf16 branch, no rung engages.
     assert_eq!(
-        fit_ladder(peak, apply_vram_cap(Some(real), None), tile, q8, q4),
+        fit_ladder(peak, apply_vram_cap(Some(real), None), tile, chunk, q8, q4),
         KreaControlFit::Fits {
             tile_vae_decode: false,
+            chunk_attention: false,
             branch_quant: None,
         },
         "uncapped 96 GB card keeps the untiled bf16 branch"
@@ -698,25 +724,28 @@ async fn krea_control_live_ladder_on_a_real_card() {
     // Cap just at the tiled peak (off the REAL reading) → the cheapest rung engages: tiling on, bf16
     // branch kept (no quality penalty).
     assert_eq!(
-        fit_ladder(peak, apply_vram_cap(Some(real), Some(tiled_peak)), tile, q8, q4),
+        fit_ladder(peak, apply_vram_cap(Some(real), Some(tiled_peak)), tile, chunk, q8, q4),
         KreaControlFit::Fits {
             tile_vae_decode: true,
+            chunk_attention: false,
             branch_quant: None,
         },
         "cap at the tiled peak → VAE tiling keeps the bf16 branch"
     );
-    // Cap between (tiling + q8) and (tiling + q4) off the REAL reading → tiling composes with q4 to fit
-    // where the old tiling-less ladder rejected-before-OOM.
+    // Cap below (tiling + chunking + q8) off the REAL reading → all three cheaper rungs on + q4 to fit,
+    // where the old tiling-only ladder rejected-before-OOM.
     assert_eq!(
-        fit_ladder(peak, apply_vram_cap(Some(real), Some(tiled_peak - 8.9)), tile, q8, q4),
+        fit_ladder(peak, apply_vram_cap(Some(real), Some(chunked_peak - 8.9)), tile, chunk, q8, q4),
         KreaControlFit::Fits {
             tile_vae_decode: true,
+            chunk_attention: true,
             branch_quant: Some(gen_core::Quant::Q4),
         },
-        "cap below tiling+q8 → tiling + q4 fits"
+        "cap below tiling+chunking+q8 → tiling + chunking + q4 fits"
     );
     eprintln!(
-        "krea control fit ladder on a real card: 96→untiled bf16, tiled-peak→tiling, deep→tiling+q4 ✓"
+        "krea control fit ladder on a real card: 96→untiled bf16, tiled-peak→tiling, \
+         below-chunk-peak→tiling+chunking, deep→+q4 ✓"
     );
 }
 

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -248,14 +248,19 @@
                     "description": "Measured peak reduction (GB) from the CHEAPEST rung — forcing the seam-free tiled VAE decode (sc-11744, candle-gen #492; Krea2ControlRequest.tile_vae_decode), keyed by BASE quant tier. A SPEED cost, no quality cost. The fit-gate subtracts this from peakGbByTier and engages it BEFORE branch-quant. Measured only for the tier(s) where the end-of-render decode spike IS the render peak (q4); omitted where the denoise steady-state dominates and tiling recovers little.",
                     "additionalProperties": { "type": "number" }
                   },
+                  "chunkAttnSaveGb": {
+                    "type": "number",
+                    "description": "Measured peak reduction (GB) from the MIDDLE rung — engaging sc-6217-style query-row attention chunking on the composable base stack + control branch (sc-11745, candle-gen #496; Krea2ControlPaths.chunk_attention). A SPEED cost, no quality cost (the chunked forward is byte-identical). Bounds the DENOISE-phase activation peak, so the fit-gate engages it between decodeTileSaveGb (decode-phase) and the last-resort branch quant. A SCALAR (not tier-keyed): the activation peak is bf16 regardless of the base weight tier.",
+                    "minimum": 0
+                  },
                   "branchQuantSaveGb": {
                     "type": "object",
-                    "description": "Measured peak reduction (GB) from the last-resort rung — quantizing the control branch bf16 → q8/q4 (candle-gen #483, sc-11743), keyed by target quant (q8 / q4). The fit-gate subtracts this (composed with decodeTileSaveGb) from peakGbByTier to decide whether the branch-quant rung makes the lane fit, preferring q8 (near-lossless) before q4 (pose-locked; non-pose drift).",
+                    "description": "Measured peak reduction (GB) from the last-resort rung — quantizing the control branch bf16 → q8/q4 (candle-gen #483, sc-11743), keyed by target quant (q8 / q4). The fit-gate subtracts this (composed with the cheaper decodeTileSaveGb + chunkAttnSaveGb rungs) from peakGbByTier to decide whether the branch-quant rung makes the lane fit, preferring q8 (near-lossless) before q4 (pose-locked; non-pose drift).",
                     "additionalProperties": { "type": "number" }
                   },
                   "measured": {
                     "type": "boolean",
-                    "description": "true when peakGbByTier / decodeTileSaveGb / branchQuantSaveGb were MEASURED on a real GPU; false when partially ESTIMATED (e.g. an interpolated q8 base peak) pending measurement."
+                    "description": "true when peakGbByTier / decodeTileSaveGb / chunkAttnSaveGb / branchQuantSaveGb were MEASURED on a real GPU; false when partially ESTIMATED (e.g. an interpolated q8 base peak) pending measurement."
                   }
                 }
               },


### PR DESCRIPTION
Follow-up to [sc-11745](https://app.shortcut.com/trefry/story/11745) (candle-gen #496, merged): the candle activation-chunking lever existed but wasn't engaged by the worker fit-gate. This wires it in as the ladder's **middle rung**, between VAE-decode tiling and the last-resort branch quant.

Story: [sc-11842](https://app.shortcut.com/trefry/story/11842)

## What changed

**1. candle-gen pin bump** `f572005c` → `573aa78` (candle-gen main HEAD, the #496 merge; `f572005c` is its 2-commit ancestor — a clean forward move, `behind_by 0`). #496 is candle-gen-krea **source-only**: candle-gen still pins gen-core `b568fdb` (matching this worker's mlx-gen pin), so `--features backend-candle` stays **single-rev** (`check-gen-core-skew.sh`: exactly one). The new `Krea2ControlPaths.chunk_attention` field made the existing construction fail to compile until set (the coordinated-bump situation sc-11761 flagged) — set here in the same commit.

**2. Ladder wiring** — added the chunking rung to `krea_control_fit::fit_ladder` between VAE-decode tiling (sc-11744, decode-phase peak) and branch quant (sc-11743, quality cost). Chunking is speed-only and byte-identical, so it engages **before** branch quant and stays on **beneath** it. New `KreaControlFit::Fits { chunk_attention }` field + `chunk_attn_save_gb()` manifest reader (a **scalar**, not tier-keyed: the bf16 denoise activation peak is tier-independent). Removed the obsolete `WIRED_ACTIVATION_CHUNKING` gate. Threaded `chunk_attention` through `KreaStrictControl` → `Krea2ControlPaths` at the same site that sets `branch_quant`.

**3. Manifest data** — published the measured delta to `candle.control`: `chunkAttnSaveGb = 2.43` (RTX PRO 6000, dense bf16 base, 1024²/8-step: −2.43 GiB denoise steady-state, +2.6 s / ~+6%) + schema property. The gate orders the ladder from data, not guesses.

## Effect on a constrained card

The additive model is physically sound: tiling collapses the q4 decode spike to the denoise floor, then chunking reduces that floor. A card that used to drop the control branch to **q8 now keeps bf16** (tiling + chunking, both speed-only); one that dropped to **q4 now takes q8** — only falling to q8/q4 branch when still over budget after both cheaper rungs.

## Validation

- **14 tests pass** (`cargo test -p sceneworks-worker --lib --features backend-candle krea_control`): 3 new chunking-rung tests + the rewritten `krea_control_candle_block_drives_the_fit_ladder` integration test, which exercises the exact cap-below-tiled → tiling+chunking (bf16 kept) → +q8 → +q4 → reject progression against the **shipped** manifest deltas (this is the deterministic form of the story's cap=24/16 validation).
- backend-candle **clippy** + **fmt** green; **gen-core skew** single-rev (`b568fdb`).
- Live ladder reading on GPU 0 confirmed the plumbing: 31 GB free (a resident sidecar held ~65 GB) → the ladder correctly engaged tiling and kept the bf16 branch. The `#[ignore]` live test's *uncapped* assertion assumes an idle 96 GB card, so it needs GPU 0 idle to run fully green.

Relates sc-11745, sc-11744, sc-11743, sc-11754 (the coordinator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)