### PR TITLE
feat(routing): candle Krea 2 Raw CFG img2img lane (Windows/Linux fast-follow) (sc-10226, epic 8588)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -570,7 +570,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-gen",
  "image",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -768,7 +768,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -805,7 +805,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -817,7 +817,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -830,7 +830,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=573aa78bbda3e644da7070bb2183e40424dbb2f3#573aa78bbda3e644da7070bb2183e40424dbb2f3"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -8361,7 +8361,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2757,8 +2757,9 @@
         // generic arm (resolve_img2img_init_generic → Conditioning::Reference) to the engine's Raw CFG
         // entrypoint `generate_base_img2img_with_progress` (mlx-gen #670 / sc-10224), so guidance + the
         // negative prompt are honored. Full 0–1 slider (default 0.5), NOT clamped — usable band is
-        // model-specific. macOS/MLX only for now (the worker generic img2img arm is Mac-gated); the
-        // candle/Windows-Linux twin is sc-10226.
+        // model-specific. Both backends: MLX (sc-10224/10225) and candle/CUDA (sc-10226 —
+        // `krea_2_raw` router branch + engine `render_base_img2img`; the worker generic img2img arm is
+        // cross-platform, gated on this `ui.img2img` flag).
         "img2img": true,
         "img2imgStrength": { "label": "Reference strength", "default": 0.5, "min": 0.0, "max": 1.0, "step": 0.05 },
         // Two-reference Kontext edit (epic 10871 P1.3): the `krea2_identity_edit` edit optionally takes a

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -4277,15 +4277,23 @@ mod candle_routing_tests {
         assert!(!krea_img2img_candle_eligible(&object(
             json!({ "prompt": "an emerald forest" })
         )));
-        // Raw img2img is the separate sc-10226 — the img2img branch is gated to `krea_2_turbo`, so a
-        // `krea_2_raw` reference job has no candle img2img lane yet and defers.
+        // Raw img2img (sc-10226): the undistilled `krea_2_raw` sibling gets its own branch (engine
+        // `render_base_img2img`), so a non-edit `krea_2_raw` reference job is candle-eligible too.
+        let raw_img2img = json!({
+            "model": "krea_2_raw",
+            "referenceAssetId": "asset_1",
+            "advanced": { "strength": 0.55 }
+        });
         assert!(
-            !image_job_is_candle_eligible(&image_generate_job(json!({
-                "model": "krea_2_raw",
-                "referenceAssetId": "asset_1"
-            }))),
-            "krea_2_raw img2img has no candle lane yet (sc-10226)"
+            image_job_is_candle_eligible(&image_generate_job(raw_img2img.clone())),
+            "krea_2_raw img2img (referenceAssetId, non-edit) must be candle-eligible (sc-10226)"
         );
+        assert!(krea_img2img_candle_eligible(&object(raw_img2img)));
+        // An `edit_image` `krea_2_raw` reference is still the Kontext edit surface, not img2img.
+        assert!(!krea_img2img_candle_eligible(&object(json!({
+            "mode": "edit_image",
+            "referenceAssetId": "asset_1"
+        }))));
     }
 
     #[test]

--- a/crates/sceneworks-core/src/jobs_store/routing/candle.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/candle.rs
@@ -315,9 +315,20 @@ pub(crate) fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     // `image_request_candle_eligible` gate below rejects ANY `referenceAssetId`, so an img2img job would
     // otherwise fall to the "conditioned shape on a txt2img candle family" gap. Branch it out AFTER the
     // pose-control lane (a pose job with an identity reference stays on control) and BEFORE the txt2img
-    // gate. Turbo-only: Raw img2img is the separate sc-10226. Mirrors the worker's `krea_2_turbo` img2img
-    // resolve in `generate_candle_stream`.
+    // gate. Mirrors the worker's `krea_2_turbo` img2img resolve in `generate_candle_stream`.
     if model == "krea_2_turbo" && krea_img2img_candle_eligible(&job.payload) {
+        return true;
+    }
+    // Krea 2 Raw img2img (reference-guided latent-init under full CFG, sc-10226, epic 8588): the
+    // undistilled `krea_2_raw` sibling of the Turbo lane above — a non-edit `referenceAssetId` seeds the
+    // engine's `render_base_img2img` (VAE-encode the reference → blend at `sigmas[init_time_step]` → the
+    // two-forward CFG denoise, honoring guidance + a user negative prompt). Same payload predicate as
+    // Turbo (`krea_img2img_candle_eligible`, gated to the id by this caller); `krea_2_raw` is a registered
+    // candle txt2img id, so without diverting first the `image_request_candle_eligible` gate below would
+    // reject the reference and drop it to the "conditioned shape on a txt2img candle family" gap. Behind
+    // the Krea edit lane (`edit_image`, branched earlier) so an edit never reaches here. The worker's
+    // generic `ui.img2img` arm in `generate_candle_stream` resolves the init for Raw exactly as Turbo.
+    if model == "krea_2_raw" && krea_img2img_candle_eligible(&job.payload) {
         return true;
     }
     // PuLID-FLUX face identity (sc-5492, epic 5480): `pulid_flux_dev` is a distinct model id (not a
@@ -815,13 +826,14 @@ pub(crate) fn krea_edit_candle_eligible(payload: &Map<String, Value>) -> bool {
             .is_some_and(|value| !value.trim().is_empty())
 }
 
-/// Krea 2 Turbo img2img (reference-guided latent-init) candle-routing conditions (sc-10134, epic 8588).
-/// The bespoke candle `render_img2img` lane serves a `krea_2_turbo` job in a **non-edit** mode carrying a
-/// `referenceAssetId` — the "Start from an image" tile: the reference is VAE-encoded and blended into the
-/// init latent at `advanced.strength`, then the CFG-free denoise runs from `sigmas[start]`. Distinct from
-/// the Krea **edit** lane (`edit_image` mode + the Kontext dual-conditioning, `krea_edit_candle_eligible`)
-/// and the pose-control lane (`advanced.poses`, branched first). Gated to `krea_2_turbo` by the caller
-/// (Raw img2img is the separate sc-10226). Mirrors the worker's `krea_2_turbo` img2img resolve in
+/// Krea 2 img2img (reference-guided latent-init) candle-routing conditions (sc-10134 Turbo, sc-10226 Raw;
+/// epic 8588). The candle img2img lane serves a `krea_2_turbo` / `krea_2_raw` job in a **non-edit** mode
+/// carrying a `referenceAssetId` — the "Start from an image" tile: the reference is VAE-encoded and blended
+/// into the init latent at `advanced.strength`, then the denoise runs from `sigmas[start]` (CFG-free
+/// `render_img2img` for Turbo, two-forward CFG `render_base_img2img` for Raw). Distinct from the Krea
+/// **edit** lane (`edit_image` mode + the Kontext dual-conditioning, `krea_edit_candle_eligible`) and the
+/// pose-control lane (`advanced.poses`, branched first). Gated to each id by the caller (Turbo + Raw have
+/// separate branches so the precedence comments stay per-id). Mirrors the worker's img2img resolve in
 /// `generate_candle_stream` (the `model_supports_img2img` + `resolve_img2img_init_generic` path).
 pub(crate) fn krea_img2img_candle_eligible(payload: &Map<String, Value>) -> bool {
     if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1737,15 +1737,26 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568
 # literal in image_jobs/krea_control_candle.rs fail to compile until it sets the field (the coordinated-bump
 # situation sc-11761 flagged) — set here in the same commit. ALL candle-gen-* pins move together;
 # backend-candle check --locked green.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+# Bumped candle-gen `573aa78` -> `293f2af` (sc-10226, epic 8588): candle-gen PR #497 adds the Krea 2 **Raw**
+# CFG img2img path — `pipeline::render_base_img2img` (the undistilled two-forward-CFG sibling of the Turbo
+# `render_img2img`, sc-10134): reference VAE-encoded to the clean latent, blended at `sigmas[init_time_step]`,
+# then the dynamic-mu `base_schedule` CFG denoise from the reduced schedule. `raw_descriptor` now KEEPS the
+# single `ConditioningKind::Reference` (was reset empty) so the worker's generic `ui.img2img` arm threads it.
+# Based directly on `573aa78` (this worker's prior pin) per the pin-treadmill playbook — candle-gen-krea
+# source-ONLY (`git diff 573aa78..293f2af -- gen-core/ gen-core-testkit/` is EMPTY), still gen-core `b568fdb`
+# matching this worker's mlx-gen pin, so `--features backend-candle` resolves the SINGLE gen-core rev with NO
+# mlx-gen move. Additive (a Raw txt2img job with no reference is byte-identical). Points at the branch content
+# commit (durable ancestor once #497's merge reconciles onto candle-gen main). ALL candle-gen-* pins move
+# together; backend-candle check --locked green.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1759,7 +1770,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1767,17 +1778,17 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1787,7 +1798,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1795,21 +1806,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1818,7 +1829,7 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # Candle Bernini still-image companion (sc-10996, epic 6562) — the Windows/CUDA sibling of
 # `mlx-gen-bernini`, built ON candle-gen-wan (the full Qwen2.5-VL/MAR semantic planner driving a
 # Wan2.2-A14B dual-expert renderer, `frames:1` for a single still). Self-registers the full `bernini`
@@ -1830,17 +1841,17 @@ candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # main HEAD, the merged #421 planner-components commit — contains the #419 full generator sc-10995) — its
 # gen-core pin (951227a) MATCHES the worker's mlx pin, so `--features backend-candle --target all`
 # resolves ONE gen-core rev (no skew).
-candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1849,7 +1860,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1882,7 +1893,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1891,12 +1902,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1904,7 +1915,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1913,7 +1924,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1921,7 +1932,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1935,7 +1946,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1962,7 +1973,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1973,7 +1984,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "573aa78bbda3e644da7070bb2183e40424dbb2f3", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -4113,13 +4113,14 @@ async fn generate_candle_stream(
     } else {
         Vec::new()
     };
-    // Krea 2 Turbo img2img (reference-guided latent-init, sc-10134, epic 8588): a `ui.img2img` model in a
+    // Generic img2img (reference-guided latent-init, sc-10134, epic 8588): a `ui.img2img` model in a
     // NON-edit mode carrying a `referenceAssetId` resolves to the img2img init `(image, advanced.strength)`,
-    // threaded to `generate_one` as the single `Conditioning::Reference` the candle Krea engine routes to
-    // `render_img2img` (VAE-encode the reference → blend at `sigmas[init_time_step]` → CFG-free denoise).
-    // The candle router (`krea_img2img_candle_eligible`) only lets `krea_2_turbo` reach this lane with a
-    // reference today; the other `ui.img2img` families (SD3.5 / Z-Image / Boogu / Ideogram) follow in
-    // sc-10265. Disjoint from the Ideogram `edit_reference` (edit_image vs text_to_image) and Boogu's
+    // threaded to `generate_one` as the single `Conditioning::Reference` the candle engine routes to its
+    // img2img entrypoint (VAE-encode the reference → blend at `sigmas[init_time_step]` → denoise; CFG-free
+    // for distilled families, two-forward CFG for the base ones like Krea Raw `render_base_img2img`,
+    // sc-10226). Model-agnostic here — the candle router gates which ids reach this lane with a reference
+    // (`krea_2_turbo`/`krea_2_raw`, SD3.5, Z-Image, Boogu, Ideogram all wired). Disjoint from the Ideogram
+    // `edit_reference` (edit_image vs text_to_image) and Boogu's
     // `multi_references` (guarded here so a future overlap never double-drives the single `reference` slot).
     let img2img_reference = if edit_reference.is_none()
         && boogu_refs.is_empty()


### PR DESCRIPTION
## What

Routes **Krea 2 Raw reference-guided img2img** to candle/CUDA — the Windows/Linux fast-follow to the Mac vertical (A5a `sc-10224` mlx-gen + A5b `sc-10225` worker/manifest). Closes the last per-model gap in epic 8588's candle img2img rollout (Krea Turbo, Z-Image base/turbo, SD3.5, Boogu, Ideogram, SANA already shipped).

## Scope (smaller than the story's original framing)

The story (2026-07-07) predates sc-10134, which made the worker's `ui.img2img` arm **generic** off-Mac. So this is **not** net-new worker plumbing — it's an engine path + a router branch + a pin bump:

- **Engine** (candle-gen [#497](https://github.com/SceneWorks/candle-gen/pull/497)): `pipeline::render_base_img2img` — the undistilled two-forward-CFG sibling of the Turbo `render_img2img` (sc-10134). Reference VAE-encoded to the clean latent, blended at `sigmas[init_time_step]`, then the dynamic-mu `base_schedule` CFG denoise from the reduced schedule. `raw_descriptor` now advertises the single `ConditioningKind::Reference`.
- **Router** (`jobs_store/routing/candle.rs`): a `krea_2_raw` img2img branch (reuses `krea_img2img_candle_eligible` — non-edit + `referenceAssetId` — gated to the id by the caller, mirroring the Turbo branch).
- **Pin bump**: all `candle-gen-*` `573aa78` → `293f2af` (#497). candle-gen-krea source-only; gen-core stays `b568fdb` (no mlx-gen move; `--features backend-candle` skew gate single-rev).
- No worker code change — the generic `resolve_img2img_init_generic` arm threads the `Conditioning::Reference` cross-platform; `krea_2_raw` already carries `ui.img2img` (A5b). Only stale comments refreshed (`base.rs`, manifest).

## Test

- `cargo test -p sceneworks-core --lib routing` → 91 passed (incl. `krea_2_turbo_img2img_routes_to_candle` now asserting `krea_2_raw` img2img IS candle-eligible).
- `cargo clippy -p sceneworks-worker --features backend-candle -- -D warnings` → clean with the new pin.
- Real-CUDA engine validation (Raw CFG img2img @ ~52/3.5, monotone reference fidelity) — **in progress on RTX PRO 6000 (sm_120)**; results to follow.

Depends on candle-gen [#497](https://github.com/SceneWorks/candle-gen/pull/497) (pin reconciles to a main superset on its merge).

sc-10226