### PR TITLE
fix(desktop): recover first-run when the workspace folder rejects writes (#1435, sc-11855)

### DIFF
--- a/apps/rust-api/src/error.rs
+++ b/apps/rust-api/src/error.rs
@@ -103,6 +103,14 @@ impl From<ProjectStoreError> for ApiError {
                 status: StatusCode::NOT_FOUND,
                 detail,
             },
+            // A non-writable workspace folder is an environment problem, not a bad
+            // request — 507 keeps the actionable, path-naming detail intact and out
+            // of the 4xx validation bucket, while still logging server-side for
+            // diagnosis (issue #1435 / sc-11855).
+            ProjectStoreError::StorageNotWritable(detail) => Self {
+                status: StatusCode::INSUFFICIENT_STORAGE,
+                detail,
+            },
             other => Self::internal(other.to_string()),
         }
     }

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -816,6 +816,33 @@ fn warn_on_startup_err(label: &str, path: &FsPath, result: std::io::Result<()>) 
     }
 }
 
+/// issue #1435 / sc-11855: `create_dir_all` on an existing-but-non-writable data
+/// dir returns `Ok`, so the startup dir checks above pass even when the workspace
+/// folder silently rejects the in-place writes a `project.db` needs — the failure
+/// only surfaces later as an opaque `SQLITE_READONLY` on the first project
+/// creation. Run the SAME faithful rollback-mode probe project creation uses,
+/// against the projects tree, and log the resolved path + result so the condition
+/// is diagnosable from `api.log` without reproducing it. Purely diagnostic —
+/// never fails startup (the app must still boot so the user can reach Settings and
+/// repoint the workspace folder).
+fn probe_data_dir_writable(data_dir: &FsPath) {
+    let projects = data_dir.join("projects");
+    match sceneworks_core::project_store::probe_storage_writable(&projects) {
+        Ok(()) => tracing::info!(
+            event = "startup_data_dir_writable",
+            path = %projects.display(),
+            "workspace projects folder is writable"
+        ),
+        Err(error) => tracing::warn!(
+            event = "startup_data_dir_not_writable",
+            path = %projects.display(),
+            error = %error,
+            "workspace projects folder is NOT writable — creating a project will fail; \
+             the user must pick a different workspace folder or fix this folder's permissions"
+        ),
+    }
+}
+
 /// Log (but never fail on) a stale-upload sweep error. sc-8882 (F-080): a failed sweep
 /// silently leaves leaked multi-GB upload temps unreclaimed; a warning makes that
 /// diagnosable without aborting startup.
@@ -848,6 +875,9 @@ pub(crate) fn create_app_with_state(
         &settings.data_dir,
         std::fs::create_dir_all(&settings.data_dir),
     );
+    // create_dir_all above is a no-op (and returns Ok) for an existing but
+    // non-writable data dir, so probe the projects tree for real (sc-11855 C).
+    probe_data_dir_writable(&settings.data_dir);
     warn_on_startup_err(
         "config_dir",
         &settings.config_dir,

--- a/apps/web/src/App.shell.test.jsx
+++ b/apps/web/src/App.shell.test.jsx
@@ -234,6 +234,10 @@ describe("SceneWorks app shell", () => {
 
     expect(props.onCreateProject).toHaveBeenCalledWith("Doomed Project");
     expect(props.onComplete).not.toHaveBeenCalled();
+    // issue #1435 / sc-11855: the wizard overlays the whole app (incl. Settings),
+    // so a failed create must surface in-wizard recovery guidance rather than
+    // silently leaving the user stuck on the model screen.
+    expect(container.textContent).toContain("different workspace folder");
   });
 
   it("renders the app navigation against mocked API calls", async () => {

--- a/apps/web/src/screens/SetupWizard.jsx
+++ b/apps/web/src/screens/SetupWizard.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { Logo } from "../components/Logo.jsx";
 import { terminalStatuses } from "../constants.js";
+import { isDesktop, tauriInvoke } from "../runtime.js";
 
 // The curated "getting started" set is catalog-driven: a model is recommended when
 // its manifest entry carries `recommended: true` (config/manifests/builtin.models.jsonc).
@@ -49,6 +50,12 @@ export function SetupWizard({ models, jobs, onDownloadModel, onCreateProject, on
   const [started, setStarted] = useState(() => new Set());
   const [projectName, setProjectName] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  // When the first project can't be created — almost always because the chosen
+  // workspace folder rejects writes (issue #1435 / sc-11855) — the wizard is the
+  // ONLY surface the user can see (it overlays the whole app, including Settings),
+  // so it must offer its own recovery: repoint the workspace folder + restart.
+  const [createFailed, setCreateFailed] = useState(false);
+  const [workspaceNotice, setWorkspaceNotice] = useState("");
   const initializedRef = useRef(false);
 
   // The catalog may arrive a tick after mount; seed the recommended selection
@@ -110,13 +117,37 @@ export function SetupWizard({ models, jobs, onDownloadModel, onCreateProject, on
       return;
     }
     setSubmitting(true);
+    setCreateFailed(false);
     try {
       const created = await onCreateProject(trimmed);
       if (created) {
         await onComplete();
+      } else {
+        // onCreateProject returns null on failure (the exact error is shown in the
+        // app-level banner). Reveal the in-wizard recovery so the user isn't stuck.
+        setCreateFailed(true);
       }
     } finally {
       setSubmitting(false);
+    }
+  }
+
+  // Repoint the workspace folder from inside the wizard. Mirrors the Settings
+  // data-directory control: pick a folder, persist it, then apply on restart
+  // (the data dir is bound when the API sidecar spawns, so it can't move live).
+  async function changeWorkspaceFolder() {
+    setWorkspaceNotice("");
+    try {
+      const picked = await tauriInvoke("choose_data_dir");
+      if (!picked) {
+        return;
+      }
+      await tauriInvoke("set_data_dir", { path: picked });
+      setWorkspaceNotice(
+        `Workspace folder set to ${picked}. Quit and reopen SceneWorks to apply, then finish setup.`,
+      );
+    } catch (error) {
+      setWorkspaceNotice(String(error?.message ?? error));
     }
   }
 
@@ -217,6 +248,25 @@ export function SetupWizard({ models, jobs, onDownloadModel, onCreateProject, on
                 {submitting ? "Setting up…" : "Finish setup"}
               </button>
             </form>
+            {createFailed ? (
+              <div className="setup-wizard-recovery" role="alert">
+                <p>
+                  SceneWorks couldn&apos;t create the project in your current workspace folder — this
+                  is almost always a permissions problem with that location. Choose a different
+                  workspace folder, then restart to finish setup.
+                </p>
+                {isDesktop ? (
+                  <button
+                    className="setup-wizard-secondary"
+                    onClick={changeWorkspaceFolder}
+                    type="button"
+                  >
+                    Change workspace folder…
+                  </button>
+                ) : null}
+                {workspaceNotice ? <p className="setup-wizard-notice">{workspaceNotice}</p> : null}
+              </div>
+            ) : null}
             <button className="setup-wizard-back" onClick={() => setStep("models")} type="button">
               ← Back to models
             </button>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -10725,6 +10725,30 @@ details[open] > summary.lora-scope-group-heading::before,
   font-size: 0.85rem;
 }
 
+/* Recovery block shown when the first project can't be created because the
+   workspace folder rejects writes (issue #1435 / sc-11855). */
+.setup-wizard-recovery {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 4px;
+  padding: 12px 14px;
+  border: 1px solid color-mix(in oklch, var(--danger) 35%, var(--border));
+  background: var(--danger-soft);
+  border-radius: 10px;
+  text-align: left;
+  font-size: 0.85rem;
+}
+
+.setup-wizard-recovery p {
+  margin: 0;
+  color: var(--text);
+}
+
+.setup-wizard-notice {
+  color: var(--text-muted);
+}
+
 /* Settings screen (sc-1350) */
 .settings-screen {
   display: flex;

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -95,6 +95,13 @@ pub enum ProjectStoreError {
     Json(serde_json::Error),
     BadRequest(String),
     NotFound(String),
+    /// The workspace storage location rejected the writes a project needs — the
+    /// raw SQLite/IO error ("attempt to write a readonly database", permission
+    /// denied) is opaque, so this carries an actionable, path-naming message
+    /// instead (issue #1435 / sc-11855). Surfaced when the projects tree can be
+    /// read/created but not modified in place (e.g. a macOS inherited ACL or an
+    /// endpoint-security/backup agent that blocks in-place file rewrites).
+    StorageNotWritable(String),
 }
 
 impl std::fmt::Display for ProjectStoreError {
@@ -105,6 +112,7 @@ impl std::fmt::Display for ProjectStoreError {
             Self::Json(error) => write!(formatter, "{error}"),
             Self::BadRequest(detail) => write!(formatter, "{detail}"),
             Self::NotFound(detail) => write!(formatter, "{detail}"),
+            Self::StorageNotWritable(detail) => write!(formatter, "{detail}"),
         }
     }
 }
@@ -321,6 +329,17 @@ impl ProjectStore {
 
         let _guard = self.lock.lock();
         self.ensure_data_dirs()?;
+        // Fail fast with an actionable error if the workspace folder rejects writes,
+        // rather than surfacing an opaque SQLITE_READONLY from deep in provisioning
+        // after a half-built project dir already exists (issue #1435 / sc-11855).
+        if let Err(error) = probe_storage_writable(&self.projects_dir()) {
+            if is_write_denied(&error) {
+                return Err(ProjectStoreError::StorageNotWritable(
+                    storage_not_writable_message(&self.projects_dir()),
+                ));
+            }
+            return Err(error);
+        }
         let project_id = format!("project_{}", random_hex(16)?);
         let slug = slugify(name, "project", None);
         let mut project_path = self.projects_dir().join(format!("{slug}.sceneworks"));
@@ -348,7 +367,21 @@ impl ProjectStore {
             fs::create_dir_all(project_path.join(folder))?;
         }
         write_project_file(&self.app_version, project_path, project_id, name)?;
-        apply_project_migrations(&connect_project_db(project_path)?)?;
+        // Backstop for the create_project preflight (and the only guard on the
+        // lazily-provisioned global pose/keypoint projects): translate a write
+        // denial on the project.db migration into the actionable, path-naming
+        // error instead of a raw SQLITE_READONLY (issue #1435 / sc-11855).
+        if let Err(error) =
+            connect_project_db(project_path).and_then(|conn| apply_project_migrations(&conn))
+        {
+            return Err(if is_write_denied(&error) {
+                ProjectStoreError::StorageNotWritable(storage_not_writable_message(
+                    project_path.parent().unwrap_or(project_path),
+                ))
+            } else {
+                error
+            });
+        }
 
         let mut registry = self
             .load_registry()?
@@ -3533,6 +3566,66 @@ fn connect_project_db(project_path: &Path) -> ProjectStoreResult<Connection> {
     let connection = Connection::open(project_path.join("project.db"))?;
     connection.busy_timeout(Duration::from_millis(5000))?;
     Ok(connection)
+}
+
+/// True when `error` means the storage location rejected a write (as opposed to a
+/// logic/validation error). Covers SQLite `SQLITE_READONLY` ("attempt to write a
+/// readonly database"), `SQLITE_CANTOPEN` (read-only directory), `SQLITE_PERM`,
+/// and IO `PermissionDenied`/`ReadOnlyFilesystem` — the whole family a
+/// non-writable workspace folder produces (issue #1435 / sc-11855).
+fn is_write_denied(error: &ProjectStoreError) -> bool {
+    match error {
+        ProjectStoreError::Sqlite(rusqlite::Error::SqliteFailure(err, _)) => matches!(
+            err.code,
+            rusqlite::ErrorCode::ReadOnly
+                | rusqlite::ErrorCode::CannotOpen
+                | rusqlite::ErrorCode::PermissionDenied
+        ),
+        ProjectStoreError::Io(err) => matches!(
+            err.kind(),
+            std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::ReadOnlyFilesystem
+        ),
+        _ => false,
+    }
+}
+
+/// Actionable, path-naming message for a non-writable workspace folder. Replaces
+/// the opaque raw SQLite/IO text the user would otherwise see (issue #1435).
+fn storage_not_writable_message(dir: &Path) -> String {
+    format!(
+        "SceneWorks can't write to your workspace folder ({}). This is almost always a \
+         permissions problem with that location — pick a different workspace folder in \
+         Settings, or fix the folder's permissions, then try again.",
+        dir.display()
+    )
+}
+
+/// Exercise the exact write path a `project.db` needs, so a non-writable
+/// workspace folder fails fast with an actionable error instead of surfacing an
+/// opaque `SQLITE_READONLY` from deep in project provisioning (issue #1435 /
+/// sc-11855). A plain "can I create a file here" check is NOT enough: a granular
+/// write denial (a macOS inherited ACL, or an endpoint-security/backup agent) can
+/// permit creating and appending to files while blocking the in-place rewrites a
+/// rollback-journal SQLite db performs — which is exactly why the WAL-mode
+/// `jobs.db` keeps working while `project.db` writes are refused. So we open a
+/// throwaway rollback-mode db in `dir`, write to it, and clean up.
+///
+/// Public so the rust-api startup path can run the same faithful probe against
+/// the projects tree and log the result for diagnosis (sc-11855 fix C).
+pub fn probe_storage_writable(dir: &Path) -> ProjectStoreResult<()> {
+    fs::create_dir_all(dir)?;
+    let probe = dir.join(format!(".sceneworks-write-test-{}.db", random_hex(8)?));
+    let outcome = (|| -> rusqlite::Result<()> {
+        let connection = Connection::open(&probe)?;
+        connection.execute_batch("create table t (x); insert into t values (1); drop table t;")
+    })();
+    // Best-effort cleanup of the probe db and any rollback-journal sidecar,
+    // regardless of outcome — never mask the real error with a cleanup failure.
+    let _ = fs::remove_file(&probe);
+    let mut journal = probe.clone().into_os_string();
+    journal.push("-journal");
+    let _ = fs::remove_file(PathBuf::from(journal));
+    outcome.map_err(ProjectStoreError::from)
 }
 
 /// Open `project.db` with the shared `busy_timeout` AND run the version-gated
@@ -7239,5 +7332,38 @@ mod tests {
             .and_then(Value::as_array)
             .expect("looks array");
         assert_eq!(looks.len(), threads * per_thread);
+    }
+
+    /// issue #1435 / sc-11855: a workspace folder that rejects writes must fail
+    /// with the actionable `StorageNotWritable` error (naming the folder), not a
+    /// raw `SQLITE_READONLY`/`unable to open database file` that the UI shows
+    /// verbatim. A read-only `projects` dir is the portable stand-in for the
+    /// user's granular write denial.
+    #[cfg(unix)]
+    #[test]
+    fn create_project_on_unwritable_projects_dir_reports_storage_not_writable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp.path().join("data"), "test-app");
+        let projects = store.projects_dir();
+        std::fs::create_dir_all(&projects).expect("seed projects dir");
+        std::fs::set_permissions(&projects, std::fs::Permissions::from_mode(0o555))
+            .expect("lock projects dir read-only");
+
+        let result = store.create_project("Test");
+
+        // Restore perms so the tempdir teardown can remove the tree.
+        let _ = std::fs::set_permissions(&projects, std::fs::Permissions::from_mode(0o755));
+
+        match result {
+            Err(ProjectStoreError::StorageNotWritable(detail)) => {
+                assert!(
+                    detail.contains("workspace folder") && detail.contains("Settings"),
+                    "message should be actionable and name the workspace folder: {detail}"
+                );
+            }
+            other => panic!("expected StorageNotWritable, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
Fixes the first-run brick reported in #1435 (Mac Studio, macOS Tahoe 26.5.2, 0.7.3). Shortcut: sc-11855.

## What happened
On first run the app showed only the "Download starter models" screen for every nav item, and creating a workspace showed a red banner: **"attempt to write a readonly database"**.

Both symptoms are **one** cause. Creating the first workspace → `POST /api/v1/projects` → opens `<data_dir>/projects/<name>.sceneworks/project.db` and runs migrations. That write fails, so the setup wizard's "Finish" (which only completes `if (created)`) never fires and `setupCompleted` stays false. The wizard renders **instead of** the whole main content area — including `SettingsScreen`, the only place to change the workspace folder — so the failure blocks its own remedy. Hard brick.

## Why the DB write was refused
Reproduced the SQLite mechanism:
- read-only **directory** → `unable to open database file` (a *different* error)
- read-only **file** / denied in-place write → **`attempt to write a readonly database (8)`** (exactly this)

So the folder was writable enough to *create* `project.db`; *modifying* it was denied — a file-level write denial, consistent with a fresh install. The screenshot's "Ready · Queue 16" shows `jobs.db` writing fine on the same tree; `jobs.db` runs in **WAL** mode (appends to a `-wal` sidecar) while `project.db` runs in **rollback-journal** mode (rewrites the main file in place), which is why one slips through and the other doesn't. Leading hypothesis for the environment: a macOS inherited ACL or an endpoint-security/backup agent that permits create/append but blocks in-place rewrites. (Confirming the reporter's exact cause needs their `api.log` + `ls -le@`; this PR makes the app self-recover regardless.)

## Changes
- **A — escape hatch (web):** `SetupWizard` surfaces a failed create inline and offers **"Change workspace folder…"** (`choose_data_dir` + `set_data_dir`, apply on restart), mirroring the Settings data-dir control — so an unwritable data dir is recoverable without reaching Settings.
- **B — actionable error (core/api):** a preflight (and a provisioning backstop) that exercises the **real rollback-mode write path** and returns `ProjectStoreError::StorageNotWritable` — an actionable, path-naming message mapped to **507** — instead of a raw `SQLITE_READONLY`. A plain "is the directory writable" check would pass under a granular ACL and miss this, so the probe opens a throwaway rollback-mode SQLite db and writes to it.
- **C — diagnosability (api):** at startup, probe the projects tree for writability and log the resolved path + result (`create_dir_all` returns `Ok` for an existing-but-unwritable dir, so the prior check couldn't catch it).

## Tests
- New `sceneworks-core` unit test: `create_project` on an unwritable projects dir → `StorageNotWritable` (not a raw SQLite error).
- Extended the wizard shell test to assert the in-wizard recovery guidance appears on a failed create.
- `cargo check` (workspace), `clippy --all-targets` + `fmt --check` clean on both edited crates; `vitest` shell suite green.

## Verification note
This first-run path is gated to the desktop shell, so it isn't exercisable in the plain web preview — covered by the component/unit tests above instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)