### PR TITLE
fix(worker): MLX router loud-rejects strict-pose on any wired control family w/ missing base (sc-11814, epic 8459)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -679,17 +679,30 @@ pub(crate) async fn run_image_generate_job(
                 )
                 .await?;
             }
-            ImageRoute::KreaPoseControlBaseMissing => {
-                // A `krea_2_turbo` strict-pose job whose control base (the `SceneWorks/krea-2-turbo-mlx`
-                // turnkey) isn't installed. Refuse loudly rather than silently rendering an unconditioned
-                // image via the plain MLX lane and dropping the poses (sc-11796) — the MLX twin of the
-                // candle `PoseControlBaseMissing` reject.
+            ImageRoute::PoseControlBaseMissing => {
+                // A strict-pose job on a WIRED MLX pose family (`WIRED_MLX_POSE_FAMILIES`) whose control
+                // base/overlay snapshot is NOT installed (its `…_control_available` weight-gate failed, so
+                // it fell through). Refuse loudly rather than silently rendering an unconditioned image via
+                // the plain MLX lane and dropping the poses (sc-11796 for krea, generalized to every wired
+                // family in sc-11814) — the MLX twin of the candle `PoseControlBaseMissing` reject.
                 return Err(WorkerError::InvalidPayload(format!(
-                    "strict pose (advanced.poses) requested for model '{}', but its Krea 2 Turbo control \
-                     base (SceneWorks/krea-2-turbo-mlx) is not installed — refusing rather than silently \
-                     generating an unconditioned image; install a Krea 2 Turbo tier to enable strict-pose \
-                     generation",
+                    "strict pose (advanced.poses) requested for model '{}', but its control base snapshot \
+                     is not installed — refusing rather than silently generating an unconditioned image; \
+                     install the control base model to enable strict-pose generation",
                     request.model
+                )));
+            }
+            ImageRoute::PoseReject => {
+                // No-silent-T2I (sc-5968): a strict-pose job on an MLX model with NO pose-control lane
+                // (e.g. a plain `sdxl` pose job with no reference — SDXL identity-pose ships via InstantID /
+                // IP-Adapter) that `mlx_available` would otherwise render as plain txt2img, dropping the
+                // poses. Refuse loudly — the MLX twin of the candle `PoseReject` reject.
+                return Err(WorkerError::InvalidPayload(format!(
+                    "strict pose (advanced.poses) is not supported for model '{}' on the MLX backend — \
+                     refusing rather than silently generating an unconditioned image (wired MLX pose \
+                     families: {}; SDXL identity-pose runs via InstantID)",
+                    request.model,
+                    WIRED_MLX_POSE_FAMILIES.join(", ")
                 )));
             }
             ImageRoute::Mlx => {

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -94,13 +94,47 @@ enum ImageRoute {
     SdxlAdvanced,
     SensenovaEdit,
     Bernini,
-    /// A `krea_2_turbo` strict-pose job whose control base (the `SceneWorks/krea-2-turbo-mlx` turnkey)
-    /// isn't installed, so `krea_control_available` failed. Reject loudly instead of falling through to
-    /// `Mlx` (plain txt2img) and silently dropping the poses (sc-11796) — the MLX twin of the candle
-    /// `CandleImageRoute::PoseControlBaseMissing`.
-    KreaPoseControlBaseMissing,
+    /// A strict-pose job on a WIRED MLX pose family (one with a `…_control_available` lane, i.e. a
+    /// [`WIRED_MLX_POSE_FAMILIES`] id) whose control base/overlay is NOT installed — its
+    /// `…_control_available` gate failed, so it reached the fall-through. Reject loudly instead of
+    /// falling through to `Mlx` (plain txt2img) and silently dropping the poses (sc-11796 generalized to
+    /// every wired family, sc-11814) — the MLX twin of the candle `CandleImageRoute::PoseControlBaseMissing`.
+    PoseControlBaseMissing,
+    /// A strict-pose job on an MLX model with NO pose-control lane (e.g. a plain `sdxl` pose job with no
+    /// reference — SDXL identity-pose ships via InstantID / IP-Adapter) that `mlx_available` would
+    /// otherwise render as plain txt2img, dropping the poses. Reject loudly (sc-5968) — the MLX twin of
+    /// the candle `CandleImageRoute::PoseReject`.
+    PoseReject,
     Mlx,
 }
+
+/// Image model ids the MLX router HAS a bespoke strict-pose control lane for — each is claimed by an
+/// `… _control_available` arm in [`resolve_image_route`] BEFORE the generic `mlx_available` txt2img arm,
+/// but only when its control base/overlay resolves locally. This is the SINGLE source for the
+/// fall-through reject: a wired family that reached the fall-through means its control base is absent
+/// (its lane's local weight-gate failed) → [`ImageRoute::PoseControlBaseMissing`], never silent txt2img.
+/// The MLX twin of [`WIRED_CANDLE_POSE_FAMILIES`] (sc-11171/F-008), and the SAME id set — every candle
+/// wired family has a matching MLX control lane:
+///   - `z_image_turbo` → `zimage_control_available` (Turbo Fun-Controlnet-Union)
+///   - `z_image`       → `zimage_base_control_available` (base full-CFG Fun-Controlnet-Union, sc-8251)
+///   - `qwen_image`    → `qwen_control_available` (2512 Fun-Controlnet-Union)
+///   - `kolors`        → `kolors_control_available` (Kolors ControlNet; also needs a reference)
+///   - `krea_2_turbo`  → `krea_control_available` (trained control-branch overlay, sc-8465)
+///   - `flux_dev`      → `flux1_dev_control_available` (Shakker Union-Pro-2.0)
+///   - `flux2_dev`     → `flux2_dev_control_available` (Fun-Controlnet-Union)
+///
+/// Distinct from a non-wired MLX pose family (e.g. `sdxl`), which reaches the sc-5968
+/// [`ImageRoute::PoseReject`] instead. (sc-11814.)
+#[cfg(target_os = "macos")]
+const WIRED_MLX_POSE_FAMILIES: &[&str] = &[
+    "z_image_turbo",
+    "z_image",
+    "qwen_image",
+    "kolors",
+    "krea_2_turbo",
+    "flux_dev",
+    "flux2_dev",
+];
 
 #[cfg(target_os = "macos")]
 fn resolve_image_route(request: &ImageRequest, settings: &Settings) -> Option<ImageRoute> {
@@ -153,18 +187,30 @@ fn resolve_image_route(request: &ImageRequest, settings: &Settings) -> Option<Im
         // `mlx_available` would match it), but the generic `generate_stream` leaves `frames`/
         // `video_mode` unset, which the engine treats as a multi-frame video request.
         Some(ImageRoute::Bernini)
-    } else if is_krea_control_model(&request.model)
-        && request.mode != "edit_image"
+    } else if request.mode != "edit_image"
         && !pose_entries(request).is_empty()
+        && (WIRED_MLX_POSE_FAMILIES.contains(&request.model.as_str())
+            || mlx_available(request, settings))
     {
-        // A `krea_2_turbo` strict-pose job that fell past `krea_control_available` above means its control
-        // base (the `SceneWorks/krea-2-turbo-mlx` turnkey) isn't installed. Reject loudly BEFORE the
-        // generic `mlx_available` arm — `krea_2_turbo` is in MODEL_TABLE, so `mlx_available` would match it
-        // and render plain txt2img, silently dropping the poses (the reported sc-11796 bug). The MLX twin
-        // of the candle `CandleImageRoute::PoseControlBaseMissing` reject (base.rs, sc-11171/F-008).
-        // NOTE: only krea is guarded here; full candle-parity reject across every wired MLX pose family
-        // (qwen/kolors/z-image/flux) is tracked separately.
-        Some(ImageRoute::KreaPoseControlBaseMissing)
+        // A strict-pose job that fell past every `…_control_available` lane above (and the edit / identity /
+        // bernini lanes) must be REJECTED, not silently rendered as plain txt2img with the poses dropped —
+        // the MLX twin of the candle fall-through reject (base.rs, sc-11171/F-008 + sc-5968). Two sub-cases,
+        // distinguished by whether the family has a wired MLX pose lane at all:
+        //  - WIRED MLX pose family (`WIRED_MLX_POSE_FAMILIES`): its control lane exists but the base/overlay
+        //    snapshot is absent (the lane's `…_control_available` weight-gate failed) → `PoseControlBaseMissing`.
+        //    Fires regardless of whether the plain base weights resolve, because the control gate can fail while
+        //    `mlx_available` succeeds — for `krea_2_turbo` the control base (`resolve_krea_control_base`) diverges
+        //    from the txt2img base (the reported sc-11796 silent-drop), and for `kolors` the lane additionally
+        //    needs a `referenceAssetId`. Generalizes the sc-11796 krea-only reject to every wired family (sc-11814).
+        //  - A non-wired MLX pose family that `mlx_available` would render as plain txt2img (e.g. a plain `sdxl`
+        //    pose job with no reference — SDXL identity-pose ships via InstantID / IP-Adapter, claimed above) →
+        //    the sc-5968 no-silent-T2I `PoseReject`.
+        // Checked BEFORE the generic `mlx_available` arm.
+        if WIRED_MLX_POSE_FAMILIES.contains(&request.model.as_str()) {
+            Some(ImageRoute::PoseControlBaseMissing)
+        } else {
+            Some(ImageRoute::PoseReject)
+        }
     } else if mlx_available(request, settings) {
         Some(ImageRoute::Mlx)
     } else {
@@ -194,12 +240,14 @@ impl ImageRoute {
             // PuLID-FLUX is one identity image per seed (no angle/pose grouping) — like the base
             // MLX + SDXL-advanced + Bernini paths, the effective count is the requested count. Krea
             // edit (epic 10871) is likewise plain per-image: `count` edits of the one source. The
-            // pose-control-base-missing reject errors before generation, so its count is inert.
+            // pose reject arms (`PoseControlBaseMissing` / `PoseReject`) error before generation, so
+            // their count is inert.
             ImageRoute::PulidFlux
             | ImageRoute::SdxlAdvanced
             | ImageRoute::Bernini
             | ImageRoute::KreaEdit
-            | ImageRoute::KreaPoseControlBaseMissing
+            | ImageRoute::PoseControlBaseMissing
+            | ImageRoute::PoseReject
             | ImageRoute::Mlx => request.count,
         }
     }

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -4936,6 +4936,136 @@ fn image_route_count_follows_dispatch_order() {
     assert_eq!(route.image_count(&zimage_base_t2i, &settings), 4);
 }
 
+// sc-11814: a strict-pose job on any WIRED MLX pose family (`WIRED_MLX_POSE_FAMILIES`) whose control
+// base/overlay is NOT installed must route to the loud `PoseControlBaseMissing` reject, NOT fall through
+// to the plain MLX txt2img lane (`ImageRoute::Mlx`), which would silently render an unconditioned image
+// and drop the poses. Generalizes the sc-11796 krea-only reject to every wired family — the MLX twin of
+// the candle `candle_image_route_rejects_wired_pose_when_control_base_absent` (sc-11171/F-008).
+#[cfg(target_os = "macos")]
+#[test]
+fn image_route_rejects_wired_pose_when_control_base_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    // Isolate the HF hub cache to the empty tempdir so the control base is genuinely absent regardless of
+    // the machine's real cache (the weight resolvers read the global HF cache in preference to `data_dir`).
+    let _hf = HfHubCacheGuard::isolate_to(dir.path());
+    let mut settings = Settings::from_env();
+    // Empty data_dir + isolated HF cache + no `modelPath` → every `…_control_available` weight-gate (and
+    // `mlx_available`) resolves nothing, so each wired-family pose job falls through to the reject arm.
+    settings.data_dir = dir.path().to_path_buf();
+
+    for model in WIRED_MLX_POSE_FAMILIES {
+        // A `referenceAssetId` is present so the `kolors` lane (which additionally requires a reference)
+        // is proven to reject on the ABSENT BASE, not the missing reference; it is inert for the others.
+        let pose = request(json!({
+            "projectId": "p", "model": model, "count": 1,
+            "referenceAssetId": "ref",
+            "advanced": { "poses": [{ "id": "a" }] }
+        }));
+        let route = resolve_image_route(&pose, &settings);
+        assert_eq!(
+            route,
+            Some(ImageRoute::PoseControlBaseMissing),
+            "wired pose family {model:?} with an absent control base must loudly reject",
+        );
+        assert_ne!(
+            route,
+            Some(ImageRoute::Mlx),
+            "wired pose family {model:?} with an absent control base must NOT silently render plain txt2img",
+        );
+
+        // The SAME family WITHOUT poses still resolves to the generic MLX txt2img lane when base weights
+        // are present — the reject is scoped to the strict-pose shape, not the model id. `modelPath`
+        // satisfies `resolve_weights_dir` (an empty tempdir dir, as in `image_route_count_...`).
+        let t2i = request(json!({
+            "projectId": "p", "model": model, "count": 1,
+            "advanced": { "modelPath": dir.path().to_string_lossy() }
+        }));
+        // `krea_2_turbo`/`kolors` base t2i route through their own arms; assert only that a non-pose job is
+        // never a pose-reject route (the invariant under test), whatever concrete lane claims it.
+        let t2i_route = resolve_image_route(&t2i, &settings);
+        assert_ne!(t2i_route, Some(ImageRoute::PoseControlBaseMissing));
+        assert_ne!(t2i_route, Some(ImageRoute::PoseReject));
+    }
+}
+
+// sc-11814: a wired MLX pose family with its base PRESENT still routes to its bespoke control lane — the
+// reject arm must not shadow a legitimately-claimable job. `modelPath` (an empty tempdir) satisfies the
+// generic `resolve_weights_dir` gate the zimage/qwen/kolors/flux lanes share. (`krea_2_turbo`'s custom
+// `resolve_krea_control_base` is covered by its dedicated sc-11853 test.)
+#[cfg(target_os = "macos")]
+#[test]
+fn image_route_wired_pose_with_base_present_routes_to_control_lane() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut settings = Settings::from_env();
+    settings.data_dir = dir.path().to_path_buf();
+    let model_path = dir.path().to_string_lossy().to_string();
+
+    // (model id, expected control lane) — every resolve_weights_dir-gated wired family. `kolors`
+    // additionally needs a reference to reach its lane.
+    let cases = [
+        ("z_image_turbo", ImageRoute::ZImageControl, false),
+        ("z_image", ImageRoute::ZImageBaseControl, false),
+        ("qwen_image", ImageRoute::QwenControl, false),
+        ("kolors", ImageRoute::KolorsControl, true),
+        ("flux_dev", ImageRoute::Flux1DevControl, false),
+        ("flux2_dev", ImageRoute::Flux2DevControl, false),
+    ];
+    for (model, expected, needs_ref) in cases {
+        let mut payload = json!({
+            "projectId": "p", "model": model, "count": 1,
+            "advanced": { "modelPath": model_path.clone(), "poses": [{ "id": "a" }] }
+        });
+        if needs_ref {
+            payload["referenceAssetId"] = json!("ref");
+        }
+        let route = resolve_image_route(&request(payload), &settings);
+        assert_eq!(
+            route,
+            Some(expected),
+            "wired pose family {model:?} with its base present must route to its control lane, not the reject",
+        );
+    }
+}
+
+// sc-11814 (sc-5968 parity): a strict-pose job on an MLX model with NO pose-control lane (a plain `sdxl`
+// pose job with no reference → no `sdxl` advanced sub-mode) that `mlx_available` would otherwise render as
+// plain txt2img must route to the loud `PoseReject` — the MLX twin of the candle `PoseReject`. `sdxl` is a
+// MODEL_TABLE id, so `mlx_available` matches it; without the reject arm the poses silently drop.
+#[cfg(target_os = "macos")]
+#[test]
+fn image_route_rejects_pose_on_unwired_mlx_family() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut settings = Settings::from_env();
+    settings.data_dir = dir.path().to_path_buf();
+    let model_path = dir.path().to_string_lossy().to_string();
+
+    // Plain `sdxl` pose job, base weights present (`modelPath`), no reference → no sub-mode → `PoseReject`,
+    // never `Mlx`.
+    let sdxl_pose = request(json!({
+        "projectId": "p", "model": "sdxl", "count": 1,
+        "advanced": { "modelPath": model_path.clone(), "poses": [{ "id": "a" }] }
+    }));
+    let route = resolve_image_route(&sdxl_pose, &settings);
+    assert_eq!(route, Some(ImageRoute::PoseReject));
+    assert_ne!(
+        route,
+        Some(ImageRoute::Mlx),
+        "an unwired MLX pose family must NOT silently render plain txt2img",
+    );
+    // `sdxl` is not a wired family, so it is the sc-5968 no-lane reject, not the missing-base variant.
+    assert_ne!(route, Some(ImageRoute::PoseControlBaseMissing));
+
+    // Guard: the same `sdxl` job WITHOUT poses is unaffected — it routes to the generic MLX txt2img lane.
+    let sdxl_t2i = request(json!({
+        "projectId": "p", "model": "sdxl", "count": 1,
+        "advanced": { "modelPath": model_path }
+    }));
+    assert_eq!(
+        resolve_image_route(&sdxl_t2i, &settings),
+        Some(ImageRoute::Mlx)
+    );
+}
+
 // sc-8828 (F-026): `resolve_candle_image_route` is the extracted candle dispatch decision — the
 // `else if settings.backend_candle_enabled && <predicate>` ladder pulled out of `run_image_generate_job`
 // into a table (the candle sibling of `resolve_image_route`/`ImageRoute`). Locks the flag gate + the


### PR DESCRIPTION
## Summary
Generalizes the sc-11796 krea-only MLX pose reject to **every** wired MLX control family, mirroring the candle `WIRED_CANDLE_POSE_FAMILIES` reject (sc-11171 / F-008). A strict-pose job on a wired family whose control base isn't installed now loud-rejects instead of silently falling through to `ImageRoute::Mlx` (plain txt2img, poses dropped). Adds the candle sc-5968-parity `PoseReject` for MLX models with no control lane at all.

Story: [sc-11814](https://app.shortcut.com/trefry/story/11814) · Relates: sc-11796 (krea-only MLX reject this generalizes), candle sc-11171 / F-008.

## Changes (`crates/sceneworks-worker/src/image_jobs/`)
- **`base.rs`** — add `WIRED_MLX_POSE_FAMILIES` (`z_image_turbo, z_image, qwen_image, kolors, krea_2_turbo, flux_dev, flux2_dev`), the **same** id set as `WIRED_CANDLE_POSE_FAMILIES`, each verified 1:1 to an MLX `…_control_available` lane. Fold the enum variant `KreaPoseControlBaseMissing` → general `ImageRoute::PoseControlBaseMissing`; add `ImageRoute::PoseReject`. Replace the krea-only reject arm in `resolve_image_route` with a wired-family-driven arm in the **same** ladder slot (after every control/edit/identity/bernini lane, before `mlx_available`), so it never shadows a legitimately-claimable route.
- **`image_jobs.rs`** — generalize the reject handler message (drops the krea-specific wording); add the `PoseReject` handler (enumerates the wired families).

## Model-id → MLX control-lane mapping (verified)
`z_image_turbo`→`zimage_control_available`, `z_image`→`zimage_base_control_available`, `qwen_image`→`qwen_control_available`, `kolors`→`kolors_control_available` (also needs a reference), `krea_2_turbo`→`krea_control_available`, `flux_dev`→`flux1_dev_control_available`, `flux2_dev`→`flux2_dev_control_available`.

## Notes on scope
- The genuine silent-drop bugs were **krea** (its `resolve_krea_control_base` diverges from the txt2img `resolve_weights_dir`) and **kolors** (its control gate additionally requires a `referenceAssetId`; a poses-but-no-reference job with base weights present fell through to `Mlx`). For `qwen_image`/`z_image`/`flux_dev`/`flux2_dev` the control gate shares `resolve_weights_dir` with `mlx_available`, so a missing base already errored loudly via `mlx_weights_gap` — the generalized arm is candle-parity + a clearer pose-specific message there (harmless, never spurious).
- **`PoseReject` is needed on MLX**: `sdxl` is a MODEL_TABLE id, so `mlx_available("sdxl")` is true; a plain `sdxl` pose job with no reference gets no advanced sub-mode and silently dropped poses. SDXL identity-pose still ships via InstantID / IP-Adapter (claimed earlier in the ladder).

## Tests (3 new, macos-gated, `tests.rs`)
- `image_route_rejects_wired_pose_when_control_base_absent` — all 7 wired families with an absent base → `PoseControlBaseMissing`, never `Mlx`; same family without poses unaffected.
- `image_route_wired_pose_with_base_present_routes_to_control_lane` — the 6 `resolve_weights_dir`-gated families with base present still route to their control lane.
- `image_route_rejects_pose_on_unwired_mlx_family` — plain `sdxl` pose (weights present, no reference) → `PoseReject`; non-pose `sdxl` → `Mlx`.

## Validation
`npm run rust:check` green (fmt + clippy `-D warnings` + test + build). Full `image_jobs` suite: 148 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)