### PR TITLE
feat(worker): surface SANA-Sprint on the candle backend + dual-pin lockstep (sc-11781, epic 8485)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -570,7 +570,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-gen",
  "image",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -763,7 +763,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -778,7 +778,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -795,7 +795,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -815,7 +815,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -827,7 +827,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -840,7 +840,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -864,7 +864,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=a71772f0952f5c25f0a445a97960d9e60d9e95df#a71772f0952f5c25f0a445a97960d9e60d9e95df"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -4254,23 +4254,30 @@
       // (SceneWorks/gemma-2-2b-it, reused — NOT duplicated) + 32× DC-AE (f32) decoder as base SANA. The
       // distillation is CFG-FREE: a guidance scalar is folded into the trunk via a guidance-embedding
       // (no negative-prompt second pass) and sampled by the SCM (continuous-time consistency / trigflow)
-      // sampler, so it runs in ~2 steps. Native MLX only (mlx-gen-sana, no torch/candle backend) →
-      // macOnly. `adapter` is the asset stamp (mirrors mlx_<family>). Worker routing through
-      // engines::MODEL_TABLE / the gen_core registry + the MLX_ROUTED_MODELS gate (jobs_store.rs) lands in
-      // this story (sc-8490 Phase B).
+      // sampler, so it runs in ~2 steps. Runs on MLX (macOS) AND the candle off-Mac lane (Windows/Linux
+      // CUDA): the candle Sprint port sc-11781 (candle-gen #498, `candle-gen-sana`'s Sprint pipeline +
+      // adapter) is catalog-routed off-Mac, so `macOnly: false` — availability is driven by the routing
+      // tables (`MLX_ROUTED_MODELS` / `CANDLE_ROUTED_MODELS`), not this flag. `adapter` is the asset stamp
+      // (mirrors mlx_<family>).
       //
       // NVIDIA non-commercial: SANA-Sprint is distributed under the NVIDIA Open Model License / NSCLv1
-      // (research & evaluation, non-commercial). The re-hosted `SceneWorks/Sana_Sprint_1.6B_1024px_mlx`
-      // mirror carries the upstream LICENSE + NOTICE + attribution (the Krea/Ideogram re-host precedent —
-      // OK to ship gated-with-notice). SceneWorks's overall non-commercial posture covers this;
-      // generations are for non-commercial use only.
+      // (research & evaluation, non-commercial). On macOS the re-hosted `SceneWorks/Sana_Sprint_1.6B_1024px_mlx`
+      // mirror carries the upstream LICENSE + NOTICE + attribution (the Krea/Ideogram re-host precedent).
+      // Off-Mac the candle lane pulls the ORIGINAL public NVIDIA repo
+      // `Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers` (un-gated — `gated: false` on HF), which
+      // ships the upstream LICENSE.txt (the NVIDIA Open Model License) alongside the weights; the bundled
+      // gemma-2-2b-it text encoder remains under the Gemma Terms of Use. `candle-gen-sana`'s NOTICE documents
+      // the same. SceneWorks's overall non-commercial posture covers this; generations are for
+      // non-commercial / research use only.
       "autoDownload": false,
       "name": "SANA-Sprint 1.6B",
       "family": "sana",
       "type": "image",
       "adapter": "mlx_sana",
       "capabilities": ["text_to_image"],
-      "macOnly": true,
+      "macOnly": false,
+      "nonCommercial": true,
+      "gated": false,
       "downloads": [
         // SceneWorks pre-built MLX quant-matrix turnkey (sc-8490/sc-8513, epic 8506): per-tier subdirs
         // (q4/ default, q8/, bf16/), each a complete `SanaPipeline::new_sprint`-loadable tree —
@@ -4307,6 +4314,25 @@
           "platforms": ["macos"],
           "estimatedSizeBytes": 9715818241,
           "footprint": { "diskSizeBytes": 9715818241, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          // Candle off-Mac dense (sc-11781, epic 8485): the ORIGINAL public NVIDIA Sprint diffusers repo,
+          // pulled WHOLE (empty `files` list = the whole-repo HF snapshot, per the model-download
+          // convention). The `candle-gen-sana` Sprint pipeline (`from_diffusers_snapshot` with the Sprint
+          // config) reads the diffusers-layout tree (`transformer/` Sprint Linear-DiT + guidance embedder +
+          // `vae/` 32× DC-AE f32 + `text_encoder/` gemma-2-2b-it CHI encoder + `tokenizer/`) directly and
+          // `resolve_component_files` tolerates the repo's fp16/fp32 + single/sharded duplication, so NO
+          // curated allow-list is needed — the whole snapshot loads dense bf16 (there is no packed q4/q8
+          // tier off-Mac; the worker resolves this repo's snapshot ROOT, never a tier subdir). CFG-free
+          // 1–4 step SCM/TrigFlow. Un-gated on HF (`gated: false`); ships the upstream NVIDIA Open Model
+          // License LICENSE.txt. Size is the whole-repo on-disk footprint (single-precision — unlike the
+          // base repo the Sprint diffusers tree ships no fp16/fp32 duplication, so it is the smaller ~9.7GB).
+          "provider": "huggingface",
+          "repo": "Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers",
+          "files": [],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 9736976627,
+          "footprint": { "diskSizeBytes": 9736976627, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3661,13 +3661,15 @@ mod candle_routing_tests {
 
     #[test]
     fn non_candle_families_and_variants_are_never_candle_eligible() {
-        // The still-unwired weight/shape variants of wired families (edit ids) plus the MLX-only
-        // SANA-Sprint distill all stay on the Python torch worker. (chroma / kolors / sensenova ARE
-        // candle-routed now — sc-5484 / sc-5576 — for txt2img; the FLUX.2-klein `_kv` / `_true_v2` weight
-        // variants are too — sc-7459 — see the dedicated test below. `bernini_image` is now candle-routed
-        // off-Mac too — sc-10996. Base `sana_1600m` is candle-routed off-Mac too — sc-11780 — see
-        // `sana_candle_txt2img_routes_to_candle` below; only the Sprint distill stays MLX-only.)
-        for model in ["sana_sprint_1600m", "z_image_edit", "qwen_image_edit"] {
+        // The still-unwired weight/shape variants of wired families (edit ids) plus a genuinely
+        // txt2img-torch-only image id (`pulid_flux_dev` — its only candle lane is the bespoke
+        // character-reference path, so a PLAIN txt2img prompt has no candle route) all stay on the Python
+        // torch worker. (chroma / kolors / sensenova ARE candle-routed now — sc-5484 / sc-5576 — for
+        // txt2img; the FLUX.2-klein `_kv` / `_true_v2` weight variants are too — sc-7459 — see the
+        // dedicated test below. `bernini_image` is now candle-routed off-Mac too — sc-10996. Base
+        // `sana_1600m` AND the Sprint distill `sana_sprint_1600m` are candle-routed off-Mac too —
+        // sc-11780 / sc-11781 — see `sana_candle_txt2img_routes_to_candle` below.)
+        for model in ["pulid_flux_dev", "z_image_edit", "qwen_image_edit"] {
             assert!(
                 !image_request_candle_eligible(model, &object(json!({ "prompt": "p" }))),
                 "{model} must fall back to the Python worker"
@@ -3679,33 +3681,29 @@ mod candle_routing_tests {
     fn sana_candle_txt2img_routes_to_candle() {
         // sc-11780 (epic 8485): base `sana_1600m` plain txt2img rides the candle lane (the
         // `candle-gen-sana` provider, candle-gen #495 — the whole `Efficient-Large-Model/
-        // Sana_1600M_1024px_diffusers` snapshot). Pure txt2img: any conditioning / LoRA / quant shape
-        // still defers to the Python torch worker (the candle base path advertises neither adapters nor
-        // quant). SANA-Sprint stays MLX-only.
-        assert!(
-            image_request_candle_eligible("sana_1600m", &object(json!({ "prompt": "a red fox" }))),
-            "base sana_1600m plain txt2img must be candle-eligible (sc-11780)"
-        );
-        for payload in [
-            json!({ "prompt": "p", "mode": "edit_image", "sourceAssetId": "a" }),
-            json!({ "prompt": "p", "referenceAssetId": "a" }),
-            json!({ "prompt": "p", "maskAssetId": "a" }),
-            json!({ "prompt": "p", "loras": [{ "path": "x", "weight": 0.8 }] }),
-            json!({ "prompt": "p", "advanced": { "mlxQuantize": 4 } }),
-        ] {
+        // Sana_1600M_1024px_diffusers` snapshot). sc-11781: the CFG-free SANA-Sprint distill
+        // `sana_sprint_1600m` rides it too (the `candle-gen-sana` Sprint pipeline, candle-gen #498 — the
+        // whole `Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers` snapshot). Pure txt2img on BOTH:
+        // any conditioning / LoRA / quant shape still defers to the Python torch worker (neither candle
+        // base path advertises adapters or quant — the Sprint adapter rejects all three).
+        for model in ["sana_1600m", "sana_sprint_1600m"] {
             assert!(
-                !image_request_candle_eligible("sana_1600m", &object(payload.clone())),
-                "sana_1600m conditioning/adapter/quant shape must fall back to torch: {payload}"
+                image_request_candle_eligible(model, &object(json!({ "prompt": "a red fox" }))),
+                "{model} plain txt2img must be candle-eligible (sc-11780 / sc-11781)"
             );
+            for payload in [
+                json!({ "prompt": "p", "mode": "edit_image", "sourceAssetId": "a" }),
+                json!({ "prompt": "p", "referenceAssetId": "a" }),
+                json!({ "prompt": "p", "maskAssetId": "a" }),
+                json!({ "prompt": "p", "loras": [{ "path": "x", "weight": 0.8 }] }),
+                json!({ "prompt": "p", "advanced": { "mlxQuantize": 4 } }),
+            ] {
+                assert!(
+                    !image_request_candle_eligible(model, &object(payload.clone())),
+                    "{model} conditioning/adapter/quant shape must fall back to torch: {payload}"
+                );
+            }
         }
-        // SANA-Sprint has no candle provider — even plain txt2img stays on MLX/torch.
-        assert!(
-            !image_request_candle_eligible(
-                "sana_sprint_1600m",
-                &object(json!({ "prompt": "a red fox" }))
-            ),
-            "sana_sprint_1600m stays MLX-only (no candle provider)"
-        );
     }
 
     #[test]
@@ -4479,8 +4477,12 @@ mod candle_routing_tests {
             "bernini_image",
             // sc-11780 (epic 8485): base `sana_1600m` plain txt2img rides the candle lane now (the
             // `candle-gen-sana` provider, candle-gen #495). Pure txt2img — its conditioning/adapter/quant
-            // refusal is asserted just below. (SANA-Sprint stays MLX-only, candle_routed=false.)
+            // refusal is asserted just below.
             "sana_1600m",
+            // sc-11781 (epic 8485): the CFG-free SANA-Sprint distill `sana_sprint_1600m` rides the candle
+            // lane too (the `candle-gen-sana` Sprint pipeline, candle-gen #498). Pure txt2img (1–4 step
+            // SCM/TrigFlow) — the Sprint adapter rejects quant / LoRA / control, so those defer to torch.
+            "sana_sprint_1600m",
         ] {
             assert!(
                 worker_supports_job(
@@ -4490,13 +4492,13 @@ mod candle_routing_tests {
                 "candle worker should claim {model} plain txt2img"
             );
         }
-        // Refuses a family with no candle provider (`sana_sprint_1600m` — the CFG-free SANA-Sprint distill
-        // is MLX-only, candle_routed=false), an adapter shape on the txt2img-only SANA base (candle SANA
-        // advertises neither quant nor LoRA — sc-11780), and a conditioning shape on a wired family — all
-        // defer to torch.
+        // Refuses a genuinely txt2img-torch-only image id (`pulid_flux_dev` — its only candle lane is the
+        // bespoke character-reference path, so a PLAIN txt2img prompt has no candle route, candle_routed=
+        // false), an adapter shape on the txt2img-only SANA base (candle SANA advertises neither quant nor
+        // LoRA — sc-11780/sc-11781), and a conditioning shape on a wired family — all defer to torch.
         assert!(!worker_supports_job(
             &candle,
-            &image_generate_job(json!({ "model": "sana_sprint_1600m", "prompt": "p" }))
+            &image_generate_job(json!({ "model": "pulid_flux_dev", "prompt": "p" }))
         ));
         assert!(
             !worker_supports_job(

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -692,10 +692,17 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
     // (Windows/CUDA + Linux, candle-gen #495 — loads the whole `Efficient-Large-Model/
     // Sana_1600M_1024px_diffusers` HF snapshot dense), so `candle_routed = true`. Pure txt2img; NOT
     // `candle_quant` / `candle_lora`: the candle base path advertises neither (dense bf16, no adapter
-    // fold) — an `mlxQuantize` or LoRA request defers to torch off-Mac. SANA-Sprint stays MLX-only
-    // (the CFG-free SCM/Sprint distill is not ported on the candle side).
+    // fold) — an `mlxQuantize` or LoRA request defers to torch off-Mac.
     ModelCaps::new("sana_1600m", true, true, false, false, false),
-    ModelCaps::new("sana_sprint_1600m", true, false, false, false, false),
+    // SANA-Sprint 1.6B (epic 8485 / sc-8490 MLX; sc-11781 candle): NVIDIA's few-step CFG-FREE distill of
+    // SANA — the SAME 1.6B Linear-DiT trunk with a guidance embedder, sampled by the SCM/TrigFlow
+    // continuous-time consistency loop in 1–4 steps. Both backends wired — `mlx-gen-sana` (macOS,
+    // MLX-packed q4/q8/bf16 turnkey) + `candle-gen-sana`'s Sprint pipeline (Windows/CUDA + Linux,
+    // candle-gen #498 — loads the whole `Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers` HF
+    // snapshot dense), so `candle_routed = true`. Pure txt2img; NOT `candle_quant` / `candle_lora`: the
+    // candle Sprint path advertises neither (the adapter rejects quant / LoRA / control) — an `mlxQuantize`
+    // or LoRA request defers to torch off-Mac.
+    ModelCaps::new("sana_sprint_1600m", true, true, false, false, false),
     // Anima base / aesthetic / turbo (epic 10512): anime txt2img on BOTH backends — native-MLX (macOS,
     // install-time Q4/Q8 quant) and the candle off-Mac lane (sc-10676), which sc-10625 GPU-validated on
     // real CUDA (candle-gen #380). `candle_routed = true`; `candle_lora = true` because the candle engine
@@ -1056,8 +1063,11 @@ mod tests {
         "sd3_5_medium",
         // sc-11780 (epic 8485): the candle SANA 1600M provider (candle-gen #495) joins the routed set —
         // true-CFG txt2img on the whole `Efficient-Large-Model/Sana_1600M_1024px_diffusers` snapshot.
-        // SANA-Sprint stays MLX-only (the CFG-free distill is not ported on candle).
         "sana_1600m",
+        // sc-11781 (epic 8485): the candle SANA-Sprint provider (candle-gen #498) joins the routed set too —
+        // CFG-free 1–4 step SCM/TrigFlow txt2img on the whole `Efficient-Large-Model/
+        // Sana_Sprint_1.6B_1024px_diffusers` snapshot.
+        "sana_sprint_1600m",
         "anima_base",
         "anima_aesthetic",
         "anima_turbo",

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -2611,19 +2611,22 @@ fn candle_supported_rejects_unsupported_strict_pose() {
 
 #[test]
 fn candle_supported_flags_a_torch_only_image_model() {
-    // `sana_sprint_1600m` (the CFG-free SANA-Sprint distill) is MLX-only — it has no candle provider and
-    // is not in CANDLE_ROUTED_MODELS — so the candle/CUDA oracle must flag it as an unsupported image
-    // model off-Mac. (`bernini_image` used to be the example here but is now candle-routed — sc-10996,
-    // epic 6562; the base `sana_1600m` was the example next but is now candle-routed too — sc-11780,
-    // epic 8485. SANA-Sprint stays the still-torch-only representative.)
+    // `pulid_flux_dev` is txt2img-torch-only off-Mac: its ONLY candle lane is the bespoke
+    // character-reference path (`pulid_flux_candle_eligible`, which needs character_image + a
+    // referenceAssetId), so a PLAIN txt2img prompt has no candle route and it is not in
+    // CANDLE_ROUTED_MODELS — the candle/CUDA oracle must flag it as an unsupported image model off-Mac.
+    // (`bernini_image` used to be the example here but is now candle-routed — sc-10996, epic 6562; the
+    // base `sana_1600m` was the example next but is now candle-routed too — sc-11780, epic 8485; then
+    // `sana_sprint_1600m`, but the CFG-free SANA-Sprint distill is candle-routed too now — sc-11781,
+    // epic 8485. PuLID-FLUX's reference-less txt2img shape is the still-torch-only representative.)
     let store = store("candle-oracle-torch-model");
     let job = job_of(
         &store,
         JobType::ImageGenerate,
-        json!({ "model": "sana_sprint_1600m", "prompt": "p" }),
+        json!({ "model": "pulid_flux_dev", "prompt": "p" }),
     );
     let reason = candle_supported(&job).unwrap_err();
-    assert_eq!(reason.model.as_deref(), Some("sana_sprint_1600m"));
+    assert_eq!(reason.model.as_deref(), Some("pulid_flux_dev"));
     assert!(reason
         .candle_error_message()
         .starts_with("candle_unsupported:"));

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1752,15 +1752,22 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568
 # mlx-gen move. Additive (a Raw txt2img job with no reference is byte-identical). Points at the branch content
 # commit (durable ancestor once #497's merge reconciles onto candle-gen main). ALL candle-gen-* pins move
 # together; backend-candle check --locked green.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+# Bumped candle-gen `293f2af` -> `a71772f` (sc-11781, epic 8485): candle-gen PR #498 (candle-gen main tip)
+# adds the SANA-**Sprint** pipeline + gen-core adapter to `candle-gen-sana` — the CFG-free 1–4 step SCM/
+# TrigFlow distill self-registering the `sana_sprint_1600m` id (the base `sana_1600m` pipeline is unchanged).
+# candle-gen-sana source-ONLY (`git diff 293f2af..a71772f -- gen-core/ gen-core-testkit/` is EMPTY), still
+# gen-core `b568fdb` matching this worker's mlx-gen pin, so `--features backend-candle` resolves the SINGLE
+# gen-core rev with NO mlx-gen move. Purely additive (the base SANA lane is byte-identical). ALL candle-gen-*
+# pins move together; backend-candle check --locked green.
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1774,7 +1781,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1782,28 +1789,31 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
-# Candle SANA 1600M provider (sc-11780, epic 8485) — Windows/CUDA + Linux sibling of mlx-gen-sana
-# (candle-gen #495, PART 4a). Self-registers ONE T2I id: `sana_1600m` (NVIDIA's 1.6B Linear-DiT +
-# 32x DC-AE f32 autoencoder + the shared gemma-2-2b-it CHI caption encoder reused from candle-gen-pid).
-# True-CFG flow-match (20 steps / guidance 4.5). Loads the WHOLE `Efficient-Large-Model/
-# Sana_1600M_1024px_diffusers` HF snapshot (diffusers layout: transformer/ + vae/ + text_encoder/) —
-# NOT the MLX-packed turnkey — via `resolve_weights_dir`'s candle-sana branch. No LoRA / quant on the
-# candle base path (descriptor advertises neither). Force-linked in `image_jobs.rs`
-# (`use candle_gen_sana as _;`). Same git rev as every candle-gen provider above (one candle build,
-# single gen-core pin) — 293f2af pins gen-core b568fdbf, IDENTICAL to the worker's mlx-gen pin, so
-# `--features backend-candle --target all` still resolves a SINGLE gen-core rev (the skew gate stays green).
-candle-gen-sana = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
+# Candle SANA 1600M provider (sc-11780 base / sc-11781 Sprint, epic 8485) — Windows/CUDA + Linux sibling
+# of mlx-gen-sana. Self-registers TWO T2I ids: `sana_1600m` (candle-gen #495 PART 4a — NVIDIA's 1.6B
+# Linear-DiT + 32x DC-AE f32 autoencoder + the shared gemma-2-2b-it CHI caption encoder reused from
+# candle-gen-pid; true-CFG flow-match 20 steps / guidance 4.5) AND `sana_sprint_1600m` (candle-gen #498
+# PART 5a — the SAME trunk with a guidance embedder, distilled CFG-FREE for 1–4 step SCM/TrigFlow
+# sampling). Each loads the WHOLE diffusers snapshot (`Efficient-Large-Model/Sana_1600M_1024px_diffusers`
+# for base / `Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers` for Sprint — diffusers layout:
+# transformer/ + vae/ + text_encoder/) — NOT the MLX-packed turnkey — via `resolve_weights_dir`'s
+# candle-sana branch. No LoRA / quant / control on either candle base path (the descriptors advertise
+# none — those shapes defer to torch). Force-linked in `image_jobs.rs` (`use candle_gen_sana as _;`).
+# Same git rev as every candle-gen provider above (one candle build, single gen-core pin) — a71772f pins
+# gen-core b568fdbf, IDENTICAL to the worker's mlx-gen pin, so `--features backend-candle --target all`
+# still resolves a SINGLE gen-core rev (the skew gate stays green).
+candle-gen-sana = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1813,7 +1823,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1821,21 +1831,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1844,7 +1854,7 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # Candle Bernini still-image companion (sc-10996, epic 6562) — the Windows/CUDA sibling of
 # `mlx-gen-bernini`, built ON candle-gen-wan (the full Qwen2.5-VL/MAR semantic planner driving a
 # Wan2.2-A14B dual-expert renderer, `frames:1` for a single still). Self-registers the full `bernini`
@@ -1856,17 +1866,17 @@ candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # main HEAD, the merged #421 planner-components commit — contains the #419 full generator sc-10995) — its
 # gen-core pin (951227a) MATCHES the worker's mlx pin, so `--features backend-candle --target all`
 # resolves ONE gen-core rev (no skew).
-candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1875,7 +1885,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1908,7 +1918,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1917,12 +1927,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1930,7 +1940,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1939,7 +1949,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1947,7 +1957,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1961,7 +1971,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1988,7 +1998,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1999,7 +2009,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "a71772f0952f5c25f0a445a97960d9e60d9e95df", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -601,6 +601,17 @@ const IDEOGRAM_BF16_REPO: &str = "SceneWorks/ideogram-4";
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const SANA_CANDLE_DIFFUSERS_REPO: &str = "Efficient-Large-Model/Sana_1600M_1024px_diffusers";
 
+/// The whole-repo `Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers` HF snapshot the candle
+/// SANA-Sprint lane loads (sc-11781, epic 8485). The `candle-gen-sana` Sprint pipeline reads the same
+/// diffusers-layout tree (`transformer/` Sprint Linear-DiT + guidance embedder + `vae/` + `text_encoder/`)
+/// as base SANA, so the off-Mac lane resolves this repo's snapshot root — NOT the MLX-packed
+/// `SceneWorks/Sana_Sprint_1.6B_1024px_mlx` turnkey (the `MODEL_TABLE` `default_repo`, which the macOS/MLX
+/// path loads) and NOT a `q4/q8/bf16` tier subdir. Matches the manifest's windows/linux whole-repo
+/// download entry.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const SANA_SPRINT_CANDLE_DIFFUSERS_REPO: &str =
+    "Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers";
+
 /// Resolve the weights snapshot directory: an explicit `modelPath` dir wins, else the
 /// HuggingFace cache snapshot for the model repo. `None` when the model is not a known
 /// engine family or its snapshot is absent. Available on the candle lane too (sc-5501): the
@@ -717,6 +728,20 @@ pub(crate) fn resolve_weights_dir(
         return Ok(huggingface_snapshot_dir(
             &settings.data_dir,
             SANA_CANDLE_DIFFUSERS_REPO,
+        ));
+    }
+    // SANA-Sprint 1.6B off-Mac (candle, sc-11781, epic 8485): identical treatment to base SANA above —
+    // the `candle-gen-sana` Sprint pipeline loads the WHOLE `Efficient-Large-Model/
+    // Sana_Sprint_1.6B_1024px_diffusers` HF snapshot (same diffusers layout: `transformer/` + `vae/` +
+    // `text_encoder/`), NOT the MLX-packed turnkey and NOT a `q4/q8/bf16` tier subdir. Resolve the
+    // diffusers repo's snapshot ROOT directly, BYPASSING the `STANDARD_TIER_MODELS` descent below
+    // (`sana_sprint_1600m` is registered there for the MLX turnkey, which would otherwise append a
+    // nonexistent `q4/`). macOS never compiles this branch (it keeps the MLX turnkey path).
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    if request.model == "sana_sprint_1600m" {
+        return Ok(huggingface_snapshot_dir(
+            &settings.data_dir,
+            SANA_SPRINT_CANDLE_DIFFUSERS_REPO,
         ));
     }
     // Catalog-wide quant-matrix models (sc-8513, epic 8506) ship as SceneWorks pre-quantized
@@ -3957,9 +3982,17 @@ fn is_candle_engine(model: &str) -> bool {
             // Sana_1600M_1024px_diffusers` diffusers snapshot (transformer/ + vae/ + text_encoder/) via the
             // candle-sana branch in `resolve_weights_dir` — NOT the MLX-packed turnkey, NOT a tier subdir.
             // Pure txt2img (20 steps / guidance 4.5 + negative prompt); no edit/reference/control/LoRA/quant
-            // candle path (those defer to torch via `image_request_candle_eligible`). SANA-Sprint stays
-            // MLX-only (the CFG-free distill is not ported on candle).
+            // candle path (those defer to torch via `image_request_candle_eligible`).
             | "sana_1600m"
+            // SANA-Sprint 1.6B (sc-11781, epic 8485): NVIDIA's CFG-free few-step distill of SANA rides the
+            // generic candle lane too (the `candle-gen-sana` Sprint pipeline, candle-gen #498 — the off-Mac
+            // sibling of `mlx-gen-sana`'s Sprint id). `generate_candle_stream` resolves the whole
+            // `Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers` diffusers snapshot (transformer/ +
+            // vae/ + text_encoder/) via the candle-sana branch in `resolve_weights_dir` — NOT the MLX-packed
+            // turnkey, NOT a tier subdir. Pure txt2img, CFG-free 1–4 step SCM/TrigFlow (guidance embedded,
+            // no negative-prompt second pass); no edit/reference/control/LoRA/quant candle path (the Sprint
+            // adapter rejects those — they defer to torch via `image_request_candle_eligible`).
+            | "sana_sprint_1600m"
             // Anima 2B base / aesthetic / turbo (sc-10676, epic 10512): the candle port (sc-10525,
             // GPU-validated sc-10625) rides the generic candle txt2img lane off-Mac. `generate_candle_\
             // stream` dense-loads bf16 from the raw `circlestone-labs/Anima` split_files/ tree (no
@@ -4000,8 +4033,9 @@ fn candle_adapter_label(model: &str) -> &'static str {
         "krea_2_turbo" | "krea_2_raw" => "candle_krea",
         // Stable Diffusion 3.5 (sc-7880): Large / Large Turbo / Medium share the candle SD3.5 engine.
         "sd3_5_large" | "sd3_5_large_turbo" | "sd3_5_medium" => "candle_sd3",
-        // SANA 1600M (sc-11780): the off-Mac sibling of the `mlx_sana` label.
-        "sana_1600m" => "candle_sana",
+        // SANA 1600M + SANA-Sprint (sc-11780 / sc-11781): both share the candle SANA engine (the off-Mac
+        // sibling of the `mlx_sana` label).
+        "sana_1600m" | "sana_sprint_1600m" => "candle_sana",
         // Anima 2B (sc-10676): base / aesthetic / turbo share the candle Anima engine (the off-Mac
         // sibling of the `mlx_anima` label).
         "anima_base" | "anima_aesthetic" | "anima_turbo" => "candle_anima",

--- a/crates/sceneworks-worker/src/sana_candle_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/sana_candle_gpu_smoke.rs
@@ -1,8 +1,8 @@
 //! Local real-weight GPU smoke for the candle **SANA 1600M** worker lane (epic 8485, sc-11780 — the
-//! hardware-gated acceptance for the candle half). `#[ignore]`d — run by hand on the RTX PRO 6000
-//! (Blackwell sm_120). It drives the ACTUAL worker weight-resolution + `gen_core::load("sana_1600m")` +
-//! render — the exact runtime seam `generate_candle_stream` uses (minus the API/job plumbing) once the
-//! router routes SANA to candle off-Mac.
+//! hardware-gated acceptance for the candle half) + the **SANA-Sprint** sibling (sc-11781). `#[ignore]`d —
+//! run by hand on the RTX PRO 6000 (Blackwell sm_120). Each drives the ACTUAL worker weight-resolution +
+//! `gen_core::load(<id>)` + render — the exact runtime seam `generate_candle_stream` uses (minus the
+//! API/job plumbing) once the router routes SANA / SANA-Sprint to candle off-Mac.
 //!
 //! This is the "the candle SANA lane has actually been RUN on real CUDA" evidence that backs flipping
 //! `macOnly: false` / `candle_routed = true`: the candle-gen-sana port (candle-gen #495) landed
@@ -23,6 +23,9 @@
 //! # optional: SANA_STEPS=20  SANA_GUIDANCE=4.5  SANA_SEED=42  SANA_PROMPT="..."  SANA_NEG="..."
 //! cargo test -p sceneworks-worker --no-default-features --features backend-candle --release \
 //!   sana_worker_lane_gpu_smoke -- --ignored --nocapture
+//! # SANA-Sprint (CFG-free, 1–4 step; optional SANA_SPRINT_STEPS=2 SANA_SPRINT_GUIDANCE=4.5):
+//! cargo test -p sceneworks-worker --no-default-features --features backend-candle --release \
+//!   sana_sprint_worker_lane_gpu_smoke -- --ignored --nocapture
 //! ```
 
 use std::path::PathBuf;
@@ -163,6 +166,150 @@ fn sana_worker_lane_gpu_smoke() {
     );
     println!(
         "[worker-smoke] DONE: sana_1600m candle true-CFG render coherent at {steps} steps (eyeball {})",
+        png.display()
+    );
+}
+
+/// sc-11781 worker-lane E2E: the SANA-**Sprint** sibling of `sana_worker_lane_gpu_smoke`. Drives the
+/// ACTUAL worker weight-resolution + dense-load + render for the candle SANA-Sprint lane on real CUDA.
+/// Calls the WORKER's [`crate::image_jobs::resolve_weights_dir`] the way `generate_candle_stream` does,
+/// asserts it resolves the whole `Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers` diffusers
+/// snapshot ROOT off-Mac (the candle-sana branch — NOT the MLX turnkey, NOT a tier subdir), then loads
+/// DENSE and renders a coherent image. Sprint is CFG-FREE (guidance embedded, no negative-prompt second
+/// pass) and runs in the 1–4 step SCM/TrigFlow band — this smoke drives a 2-step render.
+#[test]
+#[ignore = "real-weight worker-lane GPU smoke; needs the Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers \
+            snapshot in the HF cache (HF_HUB_CACHE/HF_HOME) + a CUDA device (cap=120)"]
+fn sana_sprint_worker_lane_gpu_smoke() {
+    use crate::image_jobs::resolve_weights_dir;
+    use crate::settings::Settings;
+    use sceneworks_core::image_request::ImageRequest;
+    use serde_json::json;
+
+    let out_dir = PathBuf::from(env_or("SANA_OUT_DIR", "/tmp/sana_smoke"));
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+    let settings = Settings::from_env();
+
+    // Sprint operating band is 1–4 steps; default the smoke to 2. Guidance is the embedded CFG-free
+    // scalar (NOT a true-CFG second pass), so there is no negative prompt.
+    let steps: u32 = env_or("SANA_SPRINT_STEPS", "2")
+        .parse()
+        .expect("SANA_SPRINT_STEPS");
+    let guidance: f32 = env_or("SANA_SPRINT_GUIDANCE", "4.5")
+        .parse()
+        .expect("SANA_SPRINT_GUIDANCE");
+    let seed: u64 = env_or("SANA_SEED", "42").parse().expect("SANA_SEED");
+    let w: u32 = env_or("SANA_W", "1024").parse().expect("SANA_W");
+    let h: u32 = env_or("SANA_H", "1024").parse().expect("SANA_H");
+    let prompt = env_or(
+        "SANA_PROMPT",
+        "a photorealistic red fox sitting in a sunlit autumn forest, sharp focus, detailed fur, \
+         golden hour lighting",
+    );
+
+    // A minimal job payload — resolve_weights_dir keys off `model` (+ absent modelPath), the exact shape
+    // the router hands `generate_candle_stream`. No `mlxQuantize`: the candle Sprint path is dense.
+    let payload =
+        json!({ "model": "sana_sprint_1600m", "prompt": prompt, "width": w, "height": h });
+    let request = ImageRequest::from_payload(payload.as_object().unwrap());
+
+    // THE worker resolver (the sc-11781 change): off-Mac SANA-Sprint → the whole diffusers snapshot ROOT,
+    // never the MLX turnkey and never a tier subdir.
+    let dir = resolve_weights_dir(&request, &settings)
+        .expect("resolve_weights_dir")
+        .unwrap_or_else(|| {
+            panic!(
+                "sana_sprint_1600m: Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers snapshot \
+                 not in the HF cache — set HF_HUB_CACHE/HF_HOME"
+            )
+        });
+    assert!(
+        dir.join("transformer").is_dir()
+            && dir.join("vae").is_dir()
+            && dir.join("text_encoder").is_dir(),
+        "sana_sprint_1600m: worker must resolve the whole diffusers snapshot root (transformer/ + vae/ \
+         + text_encoder/), got {}",
+        dir.display()
+    );
+    assert!(
+        !dir.ends_with("q4") && !dir.ends_with("q8") && !dir.ends_with("bf16"),
+        "sana_sprint_1600m candle must NOT descend into a tier subdir, got {}",
+        dir.display()
+    );
+    println!(
+        "[worker-smoke] sana_sprint_1600m: resolve_weights_dir -> {}",
+        dir.display()
+    );
+
+    // DENSE load (no quant) — the candle Sprint path advertises no packed tier off-Mac.
+    let spec = LoadSpec::new(WeightsSource::Dir(dir));
+    let generator = gen_core::load("sana_sprint_1600m", &spec)
+        .unwrap_or_else(|e| panic!("load sana_sprint_1600m: {e}"));
+    assert_eq!(
+        generator.descriptor().backend,
+        "candle",
+        "sana_sprint_1600m must resolve the candle generator off-Mac"
+    );
+
+    // CFG-free: no negative prompt (the guidance scalar is a trunk embedding).
+    let req = GenerationRequest {
+        prompt: prompt.clone(),
+        negative_prompt: None,
+        width: w,
+        height: h,
+        count: 1,
+        seed: Some(seed),
+        steps: Some(steps),
+        guidance: Some(guidance),
+        ..Default::default()
+    };
+    println!(
+        "[worker-smoke] sana_sprint_1600m: rendering {w}x{h} @ {steps} steps (CFG-free), guidance \
+         {guidance}, seed {seed} ..."
+    );
+    let started = std::time::Instant::now();
+    let mut last = String::new();
+    let output = generator
+        .generate(&req, &mut |p| {
+            let s = format!("{p:?}");
+            if s != last {
+                println!("[progress] {s}");
+                last = s;
+            }
+        })
+        .unwrap_or_else(|e| panic!("sana_sprint_1600m generate: {e}"));
+    let elapsed = started.elapsed();
+    let image = match output {
+        GenerationOutput::Images(mut images) => images.pop().expect("engine returned no image"),
+        other => panic!("expected Images output, got {other:?}"),
+    };
+
+    let mean = image_mean(&image);
+    let std = image_std(&image);
+    let png = out_dir.join(format!("sana_sprint_1600m_candle_{w}x{h}_{steps}step.png"));
+    save_png(&image, &png);
+    println!(
+        "[worker-smoke] sana_sprint_1600m: {}x{} mean {:.2} std {:.2} in {:.1}s -> {}",
+        image.width,
+        image.height,
+        mean,
+        std,
+        elapsed.as_secs_f32(),
+        png.display()
+    );
+    assert_eq!((image.width, image.height), (w, h));
+    assert!(
+        mean.is_finite() && std.is_finite(),
+        "sana_sprint_1600m render produced non-finite stats (mean {mean}, std {std}) — NaN in the pipeline"
+    );
+    assert!(
+        std > DEGENERATE_STD_FLOOR_DEFAULT,
+        "sana_sprint_1600m render looks degenerate (std {std:.2}) — possible NaN / all-black decode \
+         (check CUDA_COMPUTE_CAP=120)"
+    );
+    println!(
+        "[worker-smoke] DONE: sana_sprint_1600m candle CFG-free render coherent at {steps} steps \
+         (eyeball {})",
         png.display()
     );
 }


### PR DESCRIPTION
PART 5b (SceneWorks worker half) of **sc-11781**. Adds the CFG-free **SANA-Sprint 1.6B** sibling to the candle off-Mac lane, next to the base SANA lane shipped by sc-11780 (#1499).

## Merged dependency (5a)
candle-gen **#498** (merged `a71772f0952f5c25f0a445a97960d9e60d9e95df`): the SANA-Sprint pipeline + gen-core adapter added to `candle-gen-sana` — the CFG-free 1–4 step SCM/TrigFlow distill self-registering the `sana_sprint_1600m` id (base `sana_1600m` pipeline unchanged).

## Dual-pin lockstep
- Bumped ALL candle-gen* pins `293f2afc` → `a71772f` (git deps can't hold two revs of one source).
- candle-gen@`a71772f` pins gen-core `b568fdbf` — IDENTICAL to the worker's mlx-gen pin, so **gen-core/mlx-gen stay `b568fdbf`** (no move). candle-gen-sana source-only vs `293f2afc` (gen-core/testkit diff EMPTY), purely additive.
- `Cargo.lock` regenerated via `cargo metadata --features backend-candle`: exactly **ONE candle-gen rev** (`a71772f`) + **ONE gen-core rev** (`b568fdbf`); `--locked` green; `check-gen-core-skew.sh` single-rev green.

## builtin.models
- `sana_sprint_1600m`: `macOnly: false` + `nonCommercial: true` + `gated: false` + new windows/linux whole-repo download `Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers` (empty `files` list = whole HF snapshot; un-gated; ~9.7GB single-precision — size verified against HF, corrected from the base repo's 25.8GB fp16/fp32 estimate). NVIDIA Open Model License NOTICE carried in the entry (the NC guard derives its family tokens from it). macOS MLX turnkey downloads + all existing gates untouched.

## Routing (mirrors base sana_1600m)
- ModelCaps `candle_routed = true` (pure txt2img, CFG-free 1–4 step; NOT `candle_quant`/`candle_lora` — the 5a adapter rejects quant/LoRA/control).
- Added to `is_candle_engine` + `candle_adapter_label` (reuse `"candle_sana"`, shared with base) + the `resolve_weights_dir` candle diffusers-root branch (Sprint diffusers snapshot ROOT — NOT the MLX turnkey, NOT a q4/q8/bf16 tier subdir). The existing `use candle_gen_sana as _;` force-link covers BOTH ids (same crate).

## Torch-only test re-point (anti-CI-treadmill)
sc-11780 (#1499) had re-pointed two default-build routing tests at `sana_sprint_1600m` as their "still-torch-only image model" representative (Sprint had no candle lane then). This slice makes Sprint candle-routed, so those would fail again. Substituted **`pulid_flux_dev`** — a genuinely txt2img-torch-only image id (its only candle lane is the bespoke character-reference path, so a PLAIN txt2img prompt has no candle route and it is not in `CANDLE_ROUTED_MODELS`). Updated `candle_supported_flags_a_torch_only_image_model` (tests/jobs_store.rs), `candle_worker_claims_txt2img_but_refuses_unsupported_shapes` + `non_candle_families_and_variants_are_never_candle_eligible` (src/jobs_store.rs); expanded `sana_candle_txt2img_routes_to_candle` to assert Sprint is candle-eligible too. Every invariant preserved (candle claims txt2img, refuses genuinely-torch-only models / unsupported shapes) — no assertion weakened or deleted.

## Verification
- `cargo test -p sceneworks-core` (DEFAULT build) — **0 failed** (all binaries incl. tests/jobs_store.rs).
- `cargo test -p sceneworks-worker` (DEFAULT build) — **0 failed**.
- `cargo test -p sceneworks-worker --lib --features backend-candle` (BuildTools 14.44, `CUDA_COMPUTE_CAP=120`) — **590 passed / 0 failed**.
- `npm run rust:check:neither` (Linux no-candle clippy) — green; `cargo fmt --check` (touched packages) — green; `check-scaffold` + `check-no-nc-weights` — green.

## GPU validation (acceptance)
RTX PRO 6000 Blackwell (sm_120), `CUDA_COMPUTE_CAP=120`, `--release`, `sana_sprint_worker_lane_gpu_smoke`:
- **Routing:** the WORKER's `resolve_weights_dir("sana_sprint_1600m")` resolved the whole `Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers` diffusers snapshot ROOT (transformer/ + vae/ + text_encoder/) — NOT the MLX turnkey, NOT a tier subdir; `gen_core::load("sana_sprint_1600m")` resolved the **candle** generator.
- **Output:** finite, non-degenerate **1024×1024** image, **2-step CFG-free** (guidance 4.5 embedded, no negative prompt); mean **63.76**, std **58.49**; **57.4s** (includes dense weight load); 1.5MB PNG. `test result: ok. 1 passed`.
- Model is ~9.7GB dense resident off-Mac (3.2GB Sprint transformer + 5.2GB gemma-2-2b-it TE + 1.2GB DC-AE VAE); dense bf16, no packed tier off-Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)