### PR TITLE
feat: Krea "Text style" control (text_style_gain) — worker + manifest + web (sc-11878)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -570,7 +570,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-gen",
  "image",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -763,7 +763,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -778,7 +778,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -795,7 +795,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -815,7 +815,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -827,7 +827,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -840,7 +840,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -864,7 +864,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=293f2afcf22c0b986e3d5ef6589ed5c6639890fc#293f2afcf22c0b986e3d5ef6589ed5c6639890fc"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3714,7 +3714,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "image",
  "inventory",
@@ -3727,7 +3727,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "image",
  "inventory",
@@ -3741,7 +3741,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "image",
  "inventory",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3769,7 +3769,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3780,7 +3780,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3789,7 +3789,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3798,7 +3798,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3850,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3860,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "image",
  "inventory",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "image",
  "inventory",
@@ -3888,7 +3888,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "image",
  "inventory",
@@ -3902,7 +3902,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "image",
  "inventory",
@@ -3914,7 +3914,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3925,7 +3925,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3949,7 +3949,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3967,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3977,7 +3977,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3989,7 +3989,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "image",
  "inventory",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "image",
  "inventory",
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4029,7 +4029,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4041,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4052,7 +4052,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "image",
  "inventory",
@@ -4066,7 +4066,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "image",
  "inventory",
@@ -4397,7 +4397,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5900,7 +5900,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7#b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=4679195ed94b0f82324f5040c2ada5d0c8088c0e#4679195ed94b0f82324f5040c2ada5d0c8088c0e"
 dependencies = [
  "core-llm",
  "inventory",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -570,7 +570,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-gen",
  "image",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -763,7 +763,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -778,7 +778,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -795,7 +795,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -815,7 +815,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -827,7 +827,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -840,7 +840,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -864,7 +864,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=5ca3ab4a62704412a56fd9da70810ac461c38d54#5ca3ab4a62704412a56fd9da70810ac461c38d54"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=7a16611a707f940d56fc0ec599a31904f2c369bf#7a16611a707f940d56fc0ec599a31904f2c369bf"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",

--- a/apps/web/src/imageJobAdvanced.js
+++ b/apps/web/src/imageJobAdvanced.js
@@ -56,6 +56,9 @@ export function buildImageJobAdvanced(state) {
     supportsImg2img,
     img2imgReferenceAssetId,
     img2imgStrength,
+    // Krea "text style" tap-reweight gain (sc-11878).
+    supportsTextStyle,
+    textStyleGain,
     viewAngles,
     viewAngle,
     // Pose library.
@@ -180,6 +183,14 @@ export function buildImageJobAdvanced(state) {
     // worker owns the band semantics (the usable window is model-specific — A0/sc-8589).
     ...(supportsImg2img && img2imgReferenceAssetId
       ? { strength: img2imgStrength }
+      : {}),
+    // Krea "text style" tap-reweight gain (sc-11878): emit advanced.textStyleGain only when the model
+    // declares the control AND it's off the 1.0 no-op default — keeps existing recipes byte-identical.
+    // The worker clamps to [0.25, 1.75]; candle-gen-krea reweights the Qwen3-VL taps (Krea-only).
+    ...(supportsTextStyle &&
+    Number.isFinite(Number(textStyleGain)) &&
+    Number(textStyleGain) !== 1
+      ? { textStyleGain: Number(textStyleGain) }
       : {}),
     // View angle (InstantID) — only when a specific angle is chosen and no pose is
     // selected (a library pose drives the whole body, superseding the head angle).

--- a/apps/web/src/imageJobAdvanced.test.js
+++ b/apps/web/src/imageJobAdvanced.test.js
@@ -50,6 +50,8 @@ function offState(overrides = {}) {
     supportsImg2img: false,
     img2imgReferenceAssetId: null,
     img2imgStrength: 0.5,
+    supportsTextStyle: false,
+    textStyleGain: 1.0,
     ...overrides,
   };
 }
@@ -88,6 +90,21 @@ describe("buildImageJobAdvanced", () => {
         offState({ supportsImg2img: true, img2imgReferenceAssetId: "ref-1", img2imgStrength: 0.4 }),
       ).strength,
     ).toBe(0.4);
+  });
+
+  it("emits advanced.textStyleGain only for a Krea model off the 1.0 default (sc-11878)", () => {
+    // No text-style support → omitted even off-default.
+    expect(
+      buildImageJobAdvanced(offState({ textStyleGain: 1.5 })),
+    ).not.toHaveProperty("textStyleGain");
+    // Supported but at the 1.0 no-op default → omitted (recipes stay byte-identical).
+    expect(
+      buildImageJobAdvanced(offState({ supportsTextStyle: true, textStyleGain: 1.0 })),
+    ).not.toHaveProperty("textStyleGain");
+    // Supported + off-default → rides advanced.
+    expect(
+      buildImageJobAdvanced(offState({ supportsTextStyle: true, textStyleGain: 1.5 })).textStyleGain,
+    ).toBe(1.5);
   });
 
   it("omits guidanceMethod for the engine no-op 'cfg' and rides a non-default method", () => {

--- a/apps/web/src/imageJobRequest.js
+++ b/apps/web/src/imageJobRequest.js
@@ -79,6 +79,8 @@ export function buildImageJobRequest(state) {
     variationStrength,
     trueCfgScale,
     img2imgStrength,
+    supportsTextStyle,
+    textStyleGain,
     viewAngles,
     viewAngle,
     faceRestore,
@@ -182,6 +184,9 @@ export function buildImageJobRequest(state) {
       supportsImg2img,
       img2imgReferenceAssetId,
       img2imgStrength,
+      // Krea "text style" tap-reweight gain (sc-11878).
+      supportsTextStyle,
+      textStyleGain,
       identityStructure,
       controlnetScale,
       variationStrength,

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -533,6 +533,10 @@ export function ImageStudio() {
   // band is model-specific, so no clamp beyond the slider's 0–1).
   const [img2imgReferenceAssetId, setImg2imgReferenceAssetId] = useState("");
   const [img2imgStrength, setImg2imgStrength] = useState(saved.img2imgStrength ?? 0.5);
+  // Krea "text style" tap-reweight gain (sc-11878): the ui.textStyleGain slider (Krea/Qwen-family).
+  // 1.0 = no-op; >1 warmer/richer (early Qwen3-VL taps), <1 late-biased. Resets to the model default on
+  // model change like the other tuning knobs; emitted to advanced.textStyleGain only when off default.
+  const [textStyleGain, setTextStyleGain] = useState(saved.textStyleGain ?? 1.0);
   const [controlnetScale, setControlnetScale] = useState(saved.controlnetScale ?? 0.8);
   // Variation knob for backbones whose CFG is decoupled from IP-Adapter:
   // FLUX (true_cfg_scale alongside ipAdapterScale) and Qwen-Image-Edit (true_cfg_scale
@@ -820,6 +824,11 @@ export function ImageStudio() {
   // `ui.img2imgStrength` optionally overrides the slider label/range.
   const supportsImg2img = Boolean(selectedModel?.ui?.img2img);
   const img2imgStrengthConfig = selectedModel?.ui?.img2imgStrength ?? null;
+  // Krea "text style" control (sc-11878): the `ui.textStyleGain` slider descriptor. Presence gates the
+  // control — only Krea (Qwen-Image-family) declares it, so the slider (and advanced.textStyleGain) are
+  // Krea-only. Absent ⇒ no slider, no payload key.
+  const textStyleGainConfig = selectedModel?.ui?.textStyleGain ?? null;
+  const supportsTextStyle = Boolean(textStyleGainConfig);
   // Whether the edit model can outpaint (generate the padded border) — only models that
   // accept an inpaint mask (image_inpaint, SDXL family). Gates the Outpaint fit option.
   const editInpaintCapable = (selectedModel?.capabilities ?? []).includes("image_inpaint");
@@ -995,6 +1004,8 @@ export function ImageStudio() {
     const nextModes = supportedControlModes(imageModels.find((item) => item.id === model));
     setControlMode((current) => (nextModes.includes(current) ? current : nextModes[0] ?? "pose"));
     setControlScale(typeof ui.controlScale?.default === "number" ? ui.controlScale.default : null);
+    // Krea text-style gain: snap to the new model's declared default (1.0 = no-op when undeclared).
+    setTextStyleGain(typeof ui.textStyleGain?.default === "number" ? ui.textStyleGain.default : 1.0);
     setControlImageAssetId("");
     setControlImagePassthrough(false);
     // Clear a stale overlay pick so an id trained for a different backbone can't leak into a submit
@@ -1591,6 +1602,7 @@ export function ImageStudio() {
       ["guidanceMethod", setGuidanceMethod],
       ["ipAdapterScale", setIpAdapterScale],
       ["img2imgStrength", setImg2imgStrength],
+      ["textStyleGain", setTextStyleGain],
       ["controlnetScale", setControlnetScale],
       ["trueCfgScale", setTrueCfgScale],
       ["viewAngle", setViewAngle],
@@ -1850,6 +1862,8 @@ export function ImageStudio() {
       variationStrength,
       trueCfgScale,
       img2imgStrength,
+      supportsTextStyle,
+      textStyleGain,
       viewAngles,
       viewAngle,
       faceRestore,
@@ -2921,6 +2935,20 @@ export function ImageStudio() {
                   value={guidanceOverride}
                 />
               </label>
+              {supportsTextStyle ? (
+                <label className="text-style-gain">
+                  {textStyleGainConfig?.label ?? "Text style"}
+                  <input
+                    max={textStyleGainConfig?.max ?? 1.75}
+                    min={textStyleGainConfig?.min ?? 0.25}
+                    onChange={(event) => setTextStyleGain(Number(event.target.value))}
+                    step={textStyleGainConfig?.step ?? 0.05}
+                    type="range"
+                    value={textStyleGain}
+                  />
+                  <span>{Number(textStyleGain).toFixed(2)}</span>
+                </label>
+              ) : null}
               {showGuidanceMethodPicker ? (
                 <label>
                   Guidance method

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2563,6 +2563,13 @@
         // Full 0–1 slider (default 0.5), NOT clamped — usable band is model-specific (A0/sc-8589 ~0.35–0.65).
         "img2img": true,
         "img2imgStrength": { "label": "Reference strength", "default": 0.5, "min": 0.0, "max": 1.0, "step": 0.05 },
+        // "Text style" — Krea Qwen3-VL tap reweight (sc-11878, impl of the sc-8596 spike). Presence of this
+        // slider is the gate: only Krea (Qwen-Image-family) declares it, so the worker sets
+        // `GenerationRequest.text_style_gain` (candle-gen-krea `tap_gain_weights`) only for these models.
+        // A single scalar > 1 emphasizes the early (low-level) Qwen3-VL taps for a warmer/richer look; < 1
+        // biases the late (semantic) taps; 1.0 (default) is a byte-exact no-op. NOT reference/identity
+        // transfer — a stylistic nudge distinct from `img2imgStrength`. GPU-validated safe over [0.25, 1.75].
+        "textStyleGain": { "label": "Text style", "default": 1.0, "min": 0.25, "max": 1.75, "step": 0.05 },
         // Two-reference Kontext edit (sc-11640, mirrors Krea 2 Raw): the `krea2_identity_edit` edit
         // optionally takes a SECOND source — any two images, image 1 (the required Source image) + image 2
         // (optional) — in a FIXED order (swapping degrades results per the LoRA authors; the instruction
@@ -2762,6 +2769,11 @@
         // cross-platform, gated on this `ui.img2img` flag).
         "img2img": true,
         "img2imgStrength": { "label": "Reference strength", "default": 0.5, "min": 0.0, "max": 1.0, "step": 0.05 },
+        // "Text style" — Krea Qwen3-VL tap reweight (sc-11878, impl of the sc-8596 spike). Same control as
+        // Turbo; on Raw it reweights the POSITIVE context of the TRUE-CFG denoise (the CFG-negative is left
+        // untouched, so the knob steers only the conditional prediction). > 1 warmer/richer, < 1 late-biased,
+        // 1.0 (default) no-op. GPU-validated safe over [0.25, 1.75]; Krea/Qwen-Image-family only.
+        "textStyleGain": { "label": "Text style", "default": 1.0, "min": 0.25, "max": 1.75, "step": 0.05 },
         // Two-reference Kontext edit (epic 10871 P1.3): the `krea2_identity_edit` edit optionally takes a
         // SECOND source — any two images, image 1 (the required Source image) + image 2 (optional) — in a
         // FIXED order (swapping degrades results per the LoRA authors; the instruction describes how to

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -1752,15 +1752,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679
 # mlx-gen move. Additive (a Raw txt2img job with no reference is byte-identical). Points at the branch content
 # commit (durable ancestor once #497's merge reconciles onto candle-gen main). ALL candle-gen-* pins move
 # together; backend-candle check --locked green.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1774,7 +1774,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1782,7 +1782,7 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle SANA 1600M provider (sc-11780, epic 8485) — Windows/CUDA + Linux sibling of mlx-gen-sana
 # (candle-gen #495, PART 4a). Self-registers ONE T2I id: `sana_1600m` (NVIDIA's 1.6B Linear-DiT +
 # 32x DC-AE f32 autoencoder + the shared gemma-2-2b-it CHI caption encoder reused from candle-gen-pid).
@@ -1793,17 +1793,17 @@ candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5
 # (`use candle_gen_sana as _;`). Same git rev as every candle-gen provider above (one candle build,
 # single gen-core pin) — 293f2af pins gen-core b568fdbf, IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev (the skew gate stays green).
-candle-gen-sana = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-sana = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1813,7 +1813,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1821,21 +1821,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1844,7 +1844,7 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle Bernini still-image companion (sc-10996, epic 6562) — the Windows/CUDA sibling of
 # `mlx-gen-bernini`, built ON candle-gen-wan (the full Qwen2.5-VL/MAR semantic planner driving a
 # Wan2.2-A14B dual-expert renderer, `frames:1` for a single still). Self-registers the full `bernini`
@@ -1856,17 +1856,17 @@ candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # main HEAD, the merged #421 planner-components commit — contains the #419 full generator sc-10995) — its
 # gen-core pin (951227a) MATCHES the worker's mlx pin, so `--features backend-candle --target all`
 # resolves ONE gen-core rev (no skew).
-candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1875,7 +1875,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1908,7 +1908,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1917,12 +1917,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1930,7 +1930,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3a
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1939,7 +1939,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1947,7 +1947,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1961,7 +1961,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1988,7 +1988,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1999,7 +1999,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "7a16611a707f940d56fc0ec599a31904f2c369bf", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -544,7 +544,7 @@ sceneworks-core = { path = "../sceneworks-core" }
 # block below moves `c077d724` -> `f572005c` IN LOCKSTEP (candle-gen main adopted the contract via sc-11794
 # + re-pins its OWN gen-core -> b568fdb) so `--features backend-candle` resolves the SINGLE gen-core rev
 # b568fdb. mlx-rs (38e1cc1) + mlx-llm (7041411f) UNCHANGED across the range — MLX does not rebuild.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -918,7 +918,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # lockstep to f2ec6e3 (candle-gen #428, which re-pins gen-core to THIS 592419c) and the skew gate resolves
 # ONE gen-core rev on BOTH lanes. Real-weight A/B (byte-identical): turbo 22.4->18.1, raw 22.0->18.1, edit
 # 25.7->20.2 (Q8), control 42.8->35.5 GiB (bf16). Adds the 4 krea ids to SEQUENTIAL_CAPABLE_ENGINES below.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -934,23 +934,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7c
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -958,7 +958,7 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fd
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
 # mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
 # mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
@@ -966,7 +966,7 @@ mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdb
 # conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
 # DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
 # generator-cache load path drives.
-mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # Anima 2B anime t2i provider (native MLX, CircleStone Labs Non-Commercial License v1.2; epic 10512,
 # sc-10523). Same git rev as mlx-gen so MLX builds once. Self-registers `anima_base` / `anima_aesthetic`
 # / `anima_turbo` (Cosmos-Predict2 DiT + Qwen3-0.6B T5-query-token adapter conditioner + Qwen-Image VAE)
@@ -975,59 +975,59 @@ mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fd
 # scheduler (sc-10519) and strong prompt-weighting on the T5 query tokens (sc-10566). Carries the
 # install-time q4/q8/bf16 converter the model_jobs.rs Anima path drives (sc-10517). Pinned to merged
 # mlx-gen main 6a10ae1 (PR #680), which carries both the Anima crate and gen-core's is_hidden_file.
-mlx-gen-anima = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-anima = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -1036,19 +1036,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fd
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -1057,7 +1057,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568f
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -1065,7 +1065,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -1076,7 +1076,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -1087,7 +1087,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568f
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -1109,7 +1109,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fd
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -1120,7 +1120,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b56
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -1152,7 +1152,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568fdbfd7cfe3cc6c93dc836c2bd92b348ab2b7" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "4679195ed94b0f82324f5040c2ada5d0c8088c0e" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1752,15 +1752,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "b568
 # mlx-gen move. Additive (a Raw txt2img job with no reference is byte-identical). Points at the branch content
 # commit (durable ancestor once #497's merge reconciles onto candle-gen main). ALL candle-gen-* pins move
 # together; backend-candle check --locked green.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1774,7 +1774,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1782,7 +1782,7 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle SANA 1600M provider (sc-11780, epic 8485) — Windows/CUDA + Linux sibling of mlx-gen-sana
 # (candle-gen #495, PART 4a). Self-registers ONE T2I id: `sana_1600m` (NVIDIA's 1.6B Linear-DiT +
 # 32x DC-AE f32 autoencoder + the shared gemma-2-2b-it CHI caption encoder reused from candle-gen-pid).
@@ -1793,17 +1793,17 @@ candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2
 # (`use candle_gen_sana as _;`). Same git rev as every candle-gen provider above (one candle build,
 # single gen-core pin) — 293f2af pins gen-core b568fdbf, IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev (the skew gate stays green).
-candle-gen-sana = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-sana = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1813,7 +1813,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1821,21 +1821,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1844,7 +1844,7 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "2
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle Bernini still-image companion (sc-10996, epic 6562) — the Windows/CUDA sibling of
 # `mlx-gen-bernini`, built ON candle-gen-wan (the full Qwen2.5-VL/MAR semantic planner driving a
 # Wan2.2-A14B dual-expert renderer, `frames:1` for a single still). Self-registers the full `bernini`
@@ -1856,17 +1856,17 @@ candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # main HEAD, the merged #421 planner-components commit — contains the #419 full generator sc-10995) — its
 # gen-core pin (951227a) MATCHES the worker's mlx pin, so `--features backend-candle --target all`
 # resolves ONE gen-core rev (no skew).
-candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1875,7 +1875,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1908,7 +1908,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1917,12 +1917,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1930,7 +1930,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1939,7 +1939,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1947,7 +1947,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1961,7 +1961,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -1988,7 +1988,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -1999,7 +1999,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "293f2afcf22c0b986e3d5ef6589ed5c6639890fc", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "5ca3ab4a62704412a56fd9da70810ac461c38d54", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -2591,6 +2591,10 @@ fn generate_one(
     // generator was loaded with `LoadSpec::with_pid` (the engine rejects a mismatch); the caller keeps
     // the two in lockstep. The candle path passes `false` (candle PiD is Phase 4, sc-7853).
     use_pid: bool,
+    // Krea "text style" tap-reweight gain (sc-11878) — `None` for every non-Krea family (the engine
+    // ignores the field regardless). The caller resolves it from the manifest `textStyleGain` slider +
+    // `advanced` only when the model declares the control, so a non-Krea render passes `None`.
+    text_style_gain: Option<f32>,
     enhance: &PromptEnhance,
     cancel: &CancelFlag,
     on_progress: &mut dyn FnMut(Progress),
@@ -2632,6 +2636,7 @@ fn generate_one(
         scheduler_shift,
         guidance_method: guidance_method.map(str::to_owned),
         use_pid,
+        text_style_gain,
         conditioning,
         cancel: cancel.clone(),
         ..Default::default()
@@ -3679,6 +3684,15 @@ async fn generate_stream(
     // base picks whether the output lands on ~2K or ~4K. `4k`/native leave the requested dims untouched;
     // `2k` caps the base (also lowering the F-013 decode peak). Rebind before `generate_one`.
     let (width, height) = pid_effective_dims(width, height, use_pid, pid_output_tier(request));
+    // Krea "text style" tap-reweight gain (sc-11878): set ONLY when the model's manifest (`ui`) declares
+    // the `textStyleGain` slider — Krea/Qwen-Image-family only, so this self-gates and every other family
+    // passes `None`. The user value comes from `advanced.textStyleGain` (the manifest object isn't a
+    // scalar, so the helper's `1.0` default applies when absent), clamped to the GPU-validated [0.25, 1.75].
+    let text_style_gain = request
+        .model_manifest_entry
+        .get("textStyleGain")
+        .is_some()
+        .then(|| advanced::f32_clamped(&request.advanced, "textStyleGain", 1.0, 0.25..=1.75));
     let mut spec = load_spec(weights_dir, quant, adapters, flux_ip_dir);
     if let Some(pid) = pid_weights {
         spec = spec.with_pid(pid.checkpoint, pid.gemma);
@@ -3742,6 +3756,7 @@ async fn generate_stream(
                         scheduler_shift,
                         guidance_method.as_deref(),
                         use_pid,
+                        text_style_gain,
                         &enhance,
                         &cancel,
                         on_progress,
@@ -4242,6 +4257,15 @@ async fn generate_candle_stream(
     // PiD output tier (sc-10054): 2K caps the effective base so PiD's fixed 4× lands on ~2048 (default
     // 4K/native leaves the requested dims untouched). Rebind before `generate_one`.
     let (width, height) = pid_effective_dims(width, height, use_pid, pid_output_tier(request));
+    // Krea "text style" tap-reweight gain (sc-11878): set ONLY when the model's manifest (`ui`) declares
+    // the `textStyleGain` slider — Krea/Qwen-Image-family only, so this self-gates and every other family
+    // passes `None`. The user value comes from `advanced.textStyleGain` (the manifest object isn't a
+    // scalar, so the helper's `1.0` default applies when absent), clamped to the GPU-validated [0.25, 1.75].
+    let text_style_gain = request
+        .model_manifest_entry
+        .get("textStyleGain")
+        .is_some()
+        .then(|| advanced::f32_clamped(&request.advanced, "textStyleGain", 1.0, 0.25..=1.75));
     // VRAM fit-gate (epic 10765, sc-10766 Phase 0 + sc-10821 Phase 1b + sc-10856): when the selected
     // tier's predicted resident peak won't fit the card, either RUN SEQUENTIALLY (a provider that
     // supports sequential component residency — the candle FLUX lane, sc-10769 — drops the text encoders
@@ -4410,6 +4434,7 @@ async fn generate_candle_stream(
                         // else the native VAE. Every candle image provider reads `spec.pid` (sc-7853), so
                         // the whole off-Mac catalog honors the toggle in lockstep with `spec.pid` above.
                         use_pid,
+                        text_style_gain,
                         &enhance,
                         &cancel,
                         on_progress,


### PR DESCRIPTION
Ships the Krea "text style" tap-reweight control end-to-end — the implementation of the sc-8596 spike ([sc-11878](https://app.shortcut.com/trefry/story/11878), epic 8588). A single slider reweights the 12 Qwen3-VL select-layer taps before the DiT's `TextFusionTransformer` aggregates them: > 1 emphasizes the early (low-level) taps for a warmer/richer look, < 1 biases the late (semantic) taps, 1.0 is a no-op. GPU-validated in the engine PR.

**Depends on** (merge order): mlx-gen#724 (gen-core field) → candle-gen#499 (engine) → this. Pins are lockstep (skew gate).

### Changes
- **Pins** (lockstep): mlx-gen `b568fdb → 4679195`, candle-gen `293f2af → 5ca3ab4`.
- **Manifest** (`builtin.models.jsonc`): `ui.textStyleGain` slider (`{default 1.0, min 0.25, max 1.75, step 0.05}`) on `krea_2_turbo` + `krea_2_raw`. Presence self-gates the control to Krea/Qwen-Image-family.
- **Worker** (`base.rs`): `generate_one` gains a `text_style_gain` param set on `GenerationRequest`; the two generic call sites resolve it from `advanced.textStyleGain` (clamped `0.25..=1.75`) **only when the manifest declares the slider** — every non-Krea family passes `None`. Uses the ungated `advanced::f32_clamped` so the "neither" build stays green.
- **Web** (`ImageStudio.jsx` / `imageJobRequest.js` / `imageJobAdvanced.js`): a "Text style" range slider in the Advanced section, shown only for models declaring `ui.textStyleGain`; emits `advanced.textStyleGain` only when off the 1.0 default (recipes stay byte-identical). Single + batch paths.

### Verification
- `cargo check -p sceneworks-worker --features backend-candle` — green.
- Web: eslint (0 errors), vitest **1661 passed** (incl. new gating test), `vite build` green.
- `check-scaffold.mjs` — passed (manifest valid).
- Engine GPU A/B (candle-gen#499): `g=1.0` byte-identical to no-gain; `g=1.75` reproduces the spike's early-ramp (MAD 52.5); monotone; coherent across the range.

### Follow-up
- mlx-gen-krea (Mac) parity — the MLX engine reading the field — tracked as a Mac-validated follow-up story (I can't validate MLX on Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)