### PR TITLE
test(candle sdxl): cepstral ghost/double-exposure coherence guard for the txt2img default path (sc-10852)

### DIFF
--- a/crates/sceneworks-worker/src/realvisxl_lightning_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/realvisxl_lightning_gpu_smoke.rs
@@ -11,9 +11,10 @@
 //! `vae/`). `candle-gen-sdxl::load` packed-detects the tier from disk (sc-9416/9527), so the SAME seam
 //! serves both — this is the sc-10812 packed-tier eyeball: the routing flip to `candle_quant_lora` keeps
 //! a quant tier-select on candle, and a packed lightning render must stay coherent at 5-step. Point it
-//! at the cached `SceneWorks/sdxl-base-mlx` `q8/` tier (with `RVXL_SAMPLER=` unset → engine default,
+//! at the cached `SceneWorks/sdxl-base-mlx` `q8/` tier (with `RVXL_SAMPLER=default` → the engine default,
 //! since the non-distilled base isn't a lightning checkpoint) to exercise the shared candle-gen-sdxl
-//! packed loader on this box when the lightning turnkey isn't pulled.
+//! packed loader on this box when the lightning turnkey isn't pulled. That engine-default path is the one
+//! sc-10826 ghosted on and the one the sc-10852 structural coherence guard below most needs to cover.
 //!
 //! Setup (PowerShell; the components must be in the HF cache — download via the Model Manager / the
 //! manifest `realvisxl_lightning` entry):
@@ -24,6 +25,10 @@
 //! # $env:REALVISXL_LIGHTNING_DIR="D:\.cache\huggingface\hub\models--SceneWorks--realvisxl-lightning-mlx\snapshots\<hash>\q8"
 //! $env:RVXL_OUT_DIR="D:\sceneworks-sampler-validate\rvxl-lightning"
 //! # optional: RVXL_STEPS=5 RVXL_W=1024 RVXL_H=1024 RVXL_PROMPT="..." RVXL_CONTRAST=1 (also render ddim@steps)
+//! # engine-default (sc-10826/sc-10852) path against a dense diffusers snapshot + real CFG:
+//! #   $env:RVXL_SAMPLER="default"; $env:RVXL_GUIDANCE="7.5"; $env:RVXL_STEPS="28"
+//! # RVXL_GHOST_GUARD=0 relaxes the sc-10852 structural coherence assert to a warning (the ghost
+//! # self-check still runs) — for deliberately texture-heavy eyeball prompts that can read as an echo.
 //! cargo test -p sceneworks-worker --features backend-candle --release realvisxl_lightning_candle_gpu_smoke -- --ignored --nocapture
 //! ```
 
@@ -31,7 +36,10 @@ use std::path::PathBuf;
 
 use gen_core::{GenerationOutput, GenerationRequest, Image, LoadSpec, WeightsSource};
 
-use super::smoke_support::{env_or, image_std, save_png, DEGENERATE_STD_FLOOR_DEFAULT};
+use super::smoke_support::{
+    env_or, ghost_cepstrum_score, image_std, save_png, DEGENERATE_STD_FLOOR_DEFAULT,
+    GHOST_CEPSTRUM_Z_CEILING,
+};
 
 fn env_path(key: &str) -> PathBuf {
     // Trim: a cmd `set VAR=value && ...` keeps the trailing space before `&&`.
@@ -81,6 +89,36 @@ fn render(
     }
 }
 
+/// Blend the image 50/50 with a diagonally shifted (wrap-around) copy of itself — a synthetic
+/// double-exposure. The sc-10852 ghost self-check runs this on the real render and asserts the coherence
+/// guard fires on it, proving the guard is live on this render's actual content (not just that the
+/// coherent number happened to land low). The ~8% diagonal offset is a pronounced, clearly off-origin
+/// echo that scores well above the ceiling on any real image.
+fn synth_double_exposure(img: &Image) -> Image {
+    let (w, h) = (img.width as usize, img.height as usize);
+    if w == 0 || h == 0 {
+        return img.clone();
+    }
+    let (dx, dy) = ((w / 12).max(1), (h / 16).max(1));
+    let mut pixels = vec![0u8; img.pixels.len()];
+    for y in 0..h {
+        let sy = (y + h - dy) % h;
+        for x in 0..w {
+            let sx = (x + w - dx) % w;
+            let (d, s) = ((y * w + x) * 3, (sy * w + sx) * 3);
+            for c in 0..3 {
+                pixels[d + c] =
+                    (img.pixels[d + c] as f64 * 0.5 + img.pixels[s + c] as f64 * 0.5).round() as u8;
+            }
+        }
+    }
+    Image {
+        width: img.width,
+        height: img.height,
+        pixels,
+    }
+}
+
 #[test]
 #[ignore = "real-weight GPU smoke; needs the candle RealVisXL_V5.0_Lightning diffusers snapshot"]
 fn realvisxl_lightning_candle_gpu_smoke() {
@@ -119,9 +157,15 @@ fn realvisxl_lightning_candle_gpu_smoke() {
     // The shipped behavior: realvisxl_lightning forces the few-step `lightning` sampler, CFG-off
     // (guidance 1.0 — the distilled checkpoint is trained CFG-free). Overridable so this harness can also
     // exercise the shared candle-gen-sdxl packed loader against the cached non-distilled `sdxl-base-mlx`
-    // q8 tier (sc-10812): `RVXL_SAMPLER=` (empty) → engine default, `RVXL_GUIDANCE=7.5` for real CFG.
+    // q8 tier (sc-10812): `RVXL_SAMPLER=default` → the ENGINE default (the sc-10826 curated-ddim path the
+    // ghost guard below most needs to cover), `RVXL_GUIDANCE=7.5` for real CFG. A `default`/`none` sentinel
+    // — not a bare empty value — because `env_or` filters set-but-empty back to the fallback AND Windows
+    // shells can't pass a set-but-empty env var at all, so the sentinel is the portable way to reach None.
     let sampler_name = env_or("RVXL_SAMPLER", "lightning");
-    let sampler = (!sampler_name.trim().is_empty()).then_some(sampler_name.trim());
+    let sampler = match sampler_name.trim() {
+        "" | "default" | "engine-default" | "none" => None,
+        s => Some(s),
+    };
     let guidance: f32 = env_or("RVXL_GUIDANCE", "1.0")
         .parse()
         .expect("RVXL_GUIDANCE");
@@ -131,15 +175,23 @@ fn realvisxl_lightning_candle_gpu_smoke() {
     );
     let lightning = render(&*generator, &prompt, w, h, steps, guidance, sampler);
     let lightning_std = image_std(&lightning);
+    // Structural ghost/double-exposure guard (sc-10852): the std floor below is blind to a ghosted
+    // render — the sc-10826 double-exposure on the candle sdxl DEFAULT sampler path scored std 39.86,
+    // well above the floor, so std alone would NOT have caught it. `ghost_cepstrum_score` flags the echo
+    // (translated-copy) signature the floor misses; assert it on this render (the engine-default + real
+    // CFG invocation — `RVXL_SAMPLER=default`, `RVXL_GUIDANCE=7.5` — is the exact ghost-prone path).
+    let lightning_ghost = ghost_cepstrum_score(&lightning);
     save_png(
         &lightning,
         &out_dir.join(format!("lightning_{steps}step.png")),
     );
     println!(
-        "[smoke] lightning {}x{} std {:.2} -> {}",
+        "[smoke] {} {}x{} std {:.2} ghost-z {:.2} -> {}",
+        sampler.unwrap_or("engine-default"),
         lightning.width,
         lightning.height,
         lightning_std,
+        lightning_ghost,
         out_dir.join(format!("lightning_{steps}step.png")).display()
     );
 
@@ -151,9 +203,12 @@ fn realvisxl_lightning_candle_gpu_smoke() {
         println!("[smoke] rendering ddim @ {steps} steps (contrast) ...");
         let ddim = render(&*generator, &prompt, w, h, steps, 7.5, Some("ddim"));
         save_png(&ddim, &out_dir.join(format!("ddim_{steps}step.png")));
+        // Ghost z reported for the eyeball only — the low-step ddim contrast is deliberately the "wrong"
+        // under-denoised render, so it is not asserted (it may legitimately look bad).
         println!(
-            "[smoke] ddim contrast std {:.2} -> {}",
+            "[smoke] ddim contrast std {:.2} ghost-z {:.2} -> {}",
             image_std(&ddim),
+            ghost_cepstrum_score(&ddim),
             out_dir.join(format!("ddim_{steps}step.png")).display()
         );
     }
@@ -162,5 +217,35 @@ fn realvisxl_lightning_candle_gpu_smoke() {
         lightning_std > DEGENERATE_STD_FLOOR_DEFAULT,
         "lightning render looks degenerate (std {lightning_std:.2}) — possible NaN / all-black decode"
     );
-    println!("[smoke] DONE: lightning render coherent at {steps} steps");
+
+    // Structural coherence (sc-10852). Two-sided, on REAL pixels: the coherent render must clear the
+    // ceiling, AND a synthesized double-exposure of that same render (blended with a shifted copy of
+    // itself) must trip it — proving the guard is live on this content, not just that the number is low.
+    // `RVXL_GHOST_GUARD=0` relaxes the coherent-side assert to a warning for deliberately texture-heavy
+    // eyeball prompts (a strongly periodic scene — brick, fabric — can read as an echo); the self-check
+    // still runs so a broken guard is caught.
+    let ghosted = synth_double_exposure(&lightning);
+    let ghosted_z = ghost_cepstrum_score(&ghosted);
+    save_png(&ghosted, &out_dir.join("selfcheck_ghosted.png"));
+    println!(
+        "[smoke] ghost self-check: coherent z {lightning_ghost:.2} vs synth-ghost z {ghosted_z:.2} \
+         (ceiling {GHOST_CEPSTRUM_Z_CEILING})"
+    );
+    assert!(
+        ghosted_z > GHOST_CEPSTRUM_Z_CEILING,
+        "ghost guard is not live: a synthesized double-exposure of the render only scored z \
+         {ghosted_z:.2} (< ceiling {GHOST_CEPSTRUM_Z_CEILING}) — the metric would miss a real ghost"
+    );
+    let guard_on = env_or("RVXL_GHOST_GUARD", "1") != "0";
+    if lightning_ghost >= GHOST_CEPSTRUM_Z_CEILING {
+        let msg = format!(
+            "render shows a ghost/double-exposure: cepstral z {lightning_ghost:.2} >= ceiling \
+             {GHOST_CEPSTRUM_Z_CEILING} (std {lightning_std:.2} alone would have passed this)"
+        );
+        assert!(guard_on, "{msg}");
+        println!("[smoke] WARN (RVXL_GHOST_GUARD=0): {msg}");
+    }
+    println!(
+        "[smoke] DONE: render coherent at {steps} steps (std {lightning_std:.2}, ghost-z {lightning_ghost:.2})"
+    );
 }

--- a/crates/sceneworks-worker/src/smoke_support.rs
+++ b/crates/sceneworks-worker/src/smoke_support.rs
@@ -88,6 +88,272 @@ pub(crate) fn image_std(img: &Image) -> f64 {
     var.sqrt()
 }
 
+/// Ceiling on the ghost/double-exposure cepstral score (sc-10852). See [`ghost_cepstrum_score`].
+///
+/// A coherent render leaves the score (a robust z-score of the strongest off-origin **cepstral** peak)
+/// well under this; a ghosted double-exposure (the subject spatially translated and alpha-blended over
+/// itself) is a textbook *echo*, which plants a sharp cepstral peak at the echo delay that clears it.
+/// This exists because the [`DEGENERATE_STD_FLOOR_DEFAULT`] std floor is blind to ghosting: the sc-10826
+/// double-exposure on the candle sdxl **default** sampler path scored per-pixel std 39.86 — far above the
+/// floor — so std alone would NOT have caught it. This structural guard would.
+///
+/// Why the cepstrum and not plain spatial autocorrelation (the first thing sc-10852 tried): a real
+/// coherent render is full of oriented / near-periodic structure (a forest of vertical trunks, hair,
+/// foliage) whose raw autocorrelation has *large* off-origin peaks — on a real 1024² RealVisXL fox render
+/// the autocorrelation peak (0.58) landed ABOVE several synthetic double-exposures, so no threshold
+/// separated clean from ghost. The cepstrum (inverse FFT of the log power spectrum) takes the `log`, which
+/// turns the echo's multiplicative `|1 + a·e^{-i·2π(u·dx+v·dy)}|²` ripple into an *additive* full-band
+/// component that lands as one sharp peak at the delay, while the image's own smooth spectral envelope
+/// stays at low quefrency (near the origin, excluded). On the same real fox render this scores ≈13 vs
+/// ≈30–107 for pronounced double-exposures — a real, if not infinite, separation.
+///
+/// It is NOT a silver bullet: a *strongly periodic* legit texture (a full-frame brick grid) is
+/// mathematically a sum of translated copies and can also peak here — so this is a golden-free guard tuned
+/// to catch the pronounced double-exposure class (which sc-10826 was: a plainly-visible ghost), not to
+/// grade quality. The [`GHOST_CEPSTRUM_Z_CEILING`] is tunable and the GPU smoke lets a maintainer relax it
+/// (`RVXL_GHOST_GUARD=0`) when deliberately eyeballing a texture-heavy prompt. The saved-PNG eyeball
+/// remains the quality call. Validated GPU-free by the unit tests below and, on the RTX PRO 6000 box, by
+/// the `realvisxl_lightning_candle_gpu_smoke` engine-default run (real render passes; a synthesized ghost
+/// of that same real render trips it).
+//
+// Lane-conditional consumer set (see the std floors above): the ghost guard is asserted by the off-Mac
+// candle `realvisxl_lightning_gpu_smoke`, so on the macOS lane the smoke is cfg'd out — but the unit
+// tests in this module reference it on both lanes, so it is not dead. allow(dead_code) is belt-and-braces
+// consistency with the floors, a no-op where the const is used.
+#[allow(dead_code)]
+pub(crate) const GHOST_CEPSTRUM_Z_CEILING: f64 = 20.0;
+
+/// Power-of-two working grid the luminance is area-averaged onto before the 2-D FFT (sc-10852). A
+/// ghost/double-exposure is a large-scale structure that survives aggressive downsampling, and a small
+/// fixed grid keeps the hand-rolled radix-2 FFT cheap enough to run inline in a GPU smoke in well under a
+/// second even from a 1024²+ render.
+#[allow(dead_code)]
+const CEP_DIM: usize = 128;
+/// L∞ radius of the low-quefrency exclusion zone: cepstral samples this close to the origin are the
+/// image's own smooth spectral envelope, not an echo, so they are skipped in the peak search.
+#[allow(dead_code)]
+const CEP_EXCLUDE: usize = 3;
+
+/// Structural ghost / double-exposure score: a robust z-score of the strongest off-origin peak of the
+/// image's **cepstrum** (sc-10852). Higher = more echo-like; a coherent render sits low, a double-exposure
+/// spikes. See [`GHOST_CEPSTRUM_Z_CEILING`] for the why-cepstrum-not-autocorrelation rationale.
+///
+/// Method (all on a small [`CEP_DIM`]² grid, hand-rolled FFT — no external dependency):
+///  1. Rec.601 luminance, area-averaged down onto the grid, mean-subtracted, separable-Hann windowed
+///     (the window kills the FFT's periodic-wrap edge seam that would otherwise read as a false echo).
+///  2. 2-D FFT → `log(|F|² + ε)` → 2-D inverse FFT → real cepstrum.
+///  3. over all quefrencies outside the [`CEP_EXCLUDE`] central zone, out to 3/8 of the grid, take the
+///     max `(value − median) / MAD` — a median/MAD z-score so the bar is scale- and content-robust.
+#[allow(dead_code)]
+pub(crate) fn ghost_cepstrum_score(img: &Image) -> f64 {
+    let (luma, w, h) = downsample_luma(img, CEP_DIM);
+    if w < 2 * CEP_EXCLUDE + 4 || h < 2 * CEP_EXCLUDE + 4 {
+        return 0.0;
+    }
+    let n = CEP_DIM;
+    let mean = luma.iter().sum::<f64>() / luma.len() as f64;
+    // Mean-subtract + separable Hann window, content centered in the N×N (zero-padded) grid.
+    let hann = |i: usize, len: usize| -> f64 {
+        if len <= 1 {
+            1.0
+        } else {
+            0.5 - 0.5 * (2.0 * std::f64::consts::PI * i as f64 / (len as f64 - 1.0)).cos()
+        }
+    };
+    let mut re = vec![0.0_f64; n * n];
+    let mut im = vec![0.0_f64; n * n];
+    let (oy, ox) = ((n - h) / 2, (n - w) / 2);
+    for y in 0..h {
+        let wy = hann(y, h);
+        for x in 0..w {
+            re[(oy + y) * n + (ox + x)] = (luma[y * w + x] - mean) * wy * hann(x, w);
+        }
+    }
+    fft_2d(&mut re, &mut im, n, false);
+    // Real cepstrum = IFFT(log power spectrum).
+    for i in 0..n * n {
+        re[i] = (re[i] * re[i] + im[i] * im[i] + 1e-6).ln();
+        im[i] = 0.0;
+    }
+    fft_2d(&mut re, &mut im, n, true);
+
+    // Robust peak z-score over the off-origin quefrency search window (cepstrum is centered at index 0
+    // and wraps, so negative quefrencies are indexed modulo n).
+    let search = (n * 3 / 8) as isize;
+    let excl = CEP_EXCLUDE as isize;
+    let at = |dy: isize, dx: isize| -> f64 {
+        re[dy.rem_euclid(n as isize) as usize * n + dx.rem_euclid(n as isize) as usize]
+    };
+    let mut vals: Vec<f64> = Vec::new();
+    for dy in -search..=search {
+        for dx in -search..=search {
+            if dx.abs().max(dy.abs()) <= excl {
+                continue;
+            }
+            vals.push(at(dy, dx));
+        }
+    }
+    if vals.is_empty() {
+        return 0.0;
+    }
+    let med = median(&mut vals.clone());
+    let mut dev: Vec<f64> = vals.iter().map(|v| (v - med).abs()).collect();
+    let mad = median(&mut dev) + 1e-9;
+    let mut best = 0.0_f64;
+    for dy in -search..=search {
+        for dx in -search..=search {
+            if dx.abs().max(dy.abs()) <= excl {
+                continue;
+            }
+            let z = (at(dy, dx) - med) / mad;
+            if z > best {
+                best = z;
+            }
+        }
+    }
+    best
+}
+
+/// Median of `v` (mutates: sorts in place). Empty → 0.0.
+#[allow(dead_code)]
+fn median(v: &mut [f64]) -> f64 {
+    if v.is_empty() {
+        return 0.0;
+    }
+    v.sort_by(|a, b| a.partial_cmp(b).expect("no NaN in cepstrum"));
+    let m = v.len() / 2;
+    if v.len() % 2 == 1 {
+        v[m]
+    } else {
+        (v[m - 1] + v[m]) / 2.0
+    }
+}
+
+/// In-place iterative radix-2 Cooley-Tukey FFT of a power-of-two-length complex signal (`re`/`im`
+/// parallel arrays). `inverse` runs the IFFT (conjugate twiddles + 1/N scaling).
+#[allow(dead_code)]
+fn fft_1d(re: &mut [f64], im: &mut [f64], inverse: bool) {
+    let n = re.len();
+    if n <= 1 {
+        return;
+    }
+    // Bit-reversal permutation.
+    let mut j = 0usize;
+    for i in 1..n {
+        let mut bit = n >> 1;
+        while j & bit != 0 {
+            j ^= bit;
+            bit >>= 1;
+        }
+        j |= bit;
+        if i < j {
+            re.swap(i, j);
+            im.swap(i, j);
+        }
+    }
+    let mut len = 2;
+    while len <= n {
+        let ang = if inverse { 1.0 } else { -1.0 } * 2.0 * std::f64::consts::PI / len as f64;
+        let (wr, wi) = (ang.cos(), ang.sin());
+        let half = len / 2;
+        let mut i = 0;
+        while i < n {
+            let (mut cr, mut ci) = (1.0_f64, 0.0_f64);
+            for k in 0..half {
+                let (a, b) = (i + k, i + k + half);
+                let (tr, ti) = (re[b] * cr - im[b] * ci, re[b] * ci + im[b] * cr);
+                re[b] = re[a] - tr;
+                im[b] = im[a] - ti;
+                re[a] += tr;
+                im[a] += ti;
+                let ncr = cr * wr - ci * wi;
+                ci = cr * wi + ci * wr;
+                cr = ncr;
+            }
+            i += len;
+        }
+        len <<= 1;
+    }
+    if inverse {
+        let inv = 1.0 / n as f64;
+        for x in re.iter_mut() {
+            *x *= inv;
+        }
+        for x in im.iter_mut() {
+            *x *= inv;
+        }
+    }
+}
+
+/// 2-D FFT of an `n × n` row-major complex grid, via 1-D FFTs over rows then columns.
+#[allow(dead_code)]
+fn fft_2d(re: &mut [f64], im: &mut [f64], n: usize, inverse: bool) {
+    let (mut lr, mut li) = (vec![0.0_f64; n], vec![0.0_f64; n]);
+    for y in 0..n {
+        let base = y * n;
+        lr.copy_from_slice(&re[base..base + n]);
+        li.copy_from_slice(&im[base..base + n]);
+        fft_1d(&mut lr, &mut li, inverse);
+        re[base..base + n].copy_from_slice(&lr);
+        im[base..base + n].copy_from_slice(&li);
+    }
+    for x in 0..n {
+        for y in 0..n {
+            lr[y] = re[y * n + x];
+            li[y] = im[y * n + x];
+        }
+        fft_1d(&mut lr, &mut li, inverse);
+        for y in 0..n {
+            re[y * n + x] = lr[y];
+            im[y * n + x] = li[y];
+        }
+    }
+}
+
+/// Rec.601 luminance area-averaged down so the long side is ≤ `max_dim` (never upscaled). Returns the
+/// row-major `f64` luma plane and its `(width, height)`. When the source already fits, each target maps
+/// to a single source pixel (identity).
+#[allow(dead_code)]
+fn downsample_luma(img: &Image, max_dim: usize) -> (Vec<f64>, usize, usize) {
+    let (sw, sh) = (img.width as usize, img.height as usize);
+    if sw == 0 || sh == 0 || img.pixels.len() < sw * sh * 3 {
+        return (Vec::new(), 0, 0);
+    }
+    let long = sw.max(sh);
+    let (tw, th) = if long <= max_dim {
+        (sw, sh)
+    } else {
+        let scale = max_dim as f64 / long as f64;
+        (
+            ((sw as f64 * scale).round() as usize).max(1),
+            ((sh as f64 * scale).round() as usize).max(1),
+        )
+    };
+    let mut out = vec![0.0_f64; tw * th];
+    for ty in 0..th {
+        let sy0 = ty * sh / th;
+        let sy1 = (((ty + 1) * sh / th).max(sy0 + 1)).min(sh);
+        for tx in 0..tw {
+            let sx0 = tx * sw / tw;
+            let sx1 = (((tx + 1) * sw / tw).max(sx0 + 1)).min(sw);
+            let mut acc = 0.0_f64;
+            let mut n = 0.0_f64;
+            for sy in sy0..sy1 {
+                let row = sy * sw;
+                for sx in sx0..sx1 {
+                    let p = (row + sx) * 3;
+                    acc += 0.299 * img.pixels[p] as f64
+                        + 0.587 * img.pixels[p + 1] as f64
+                        + 0.114 * img.pixels[p + 2] as f64;
+                    n += 1.0;
+                }
+            }
+            out[ty * tw + tx] = acc / n;
+        }
+    }
+    (out, tw, th)
+}
+
 /// Whether EVERY pixel byte is exactly 0 — the precise degenerate signature of a broken decode.
 // Only the macOS MLX packed-tier smokes (chroma1_base/lens*/sdxl) assert the all-zero floor; the
 // off-Mac candle smokes don't, so this is legitimately unused on the candle-only lane. `allow` rather
@@ -103,4 +369,173 @@ pub(crate) fn save_png(img: &Image, path: &Path) {
         .expect("rgb buffer")
         .save(path)
         .unwrap_or_else(|e| panic!("save {}: {e}", path.display()));
+}
+
+/// GPU-free structural coverage for the ghost/double-exposure guard (sc-10852). The `*_gpu_smoke`
+/// harness that consumes [`ghost_cepstrum_score`] is `#[ignore]`d and needs multi-GB weights, so these
+/// tests lock the metric + the [`GHOST_CEPSTRUM_Z_CEILING`] threshold against *synthetic* clean vs.
+/// double-exposure frames — a coherent frame must clear the ceiling with margin, and a
+/// translated-and-blended copy of itself (the exact echo signature the std floor missed on sc-10826) must
+/// trip it. A round-trip FFT identity test guards the hand-rolled transform. These run in the ordinary
+/// `cargo test` pass, no hardware required.
+#[cfg(test)]
+mod ghost_guard_tests {
+    use super::*;
+
+    /// Deterministic value in `[0, 1)` — a cheap integer-hash noise field, so the synthetic subject
+    /// carries broadband, non-periodic high-frequency content (no self-similarity of its own to bias the
+    /// cepstral peak).
+    fn hash01(x: usize, y: usize) -> f64 {
+        let h = (x as u64).wrapping_mul(73_856_093) ^ (y as u64).wrapping_mul(19_349_663);
+        let h = h.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        ((h >> 40) & 0xFFFF) as f64 / 65_536.0
+    }
+
+    /// A single-subject luminance field `S(x, y)`: a smooth gradient base, a couple of Gaussian "subject"
+    /// blobs (structure/edges), and broadband noise. Non-periodic — a faithful stand-in for a coherent
+    /// single-subject render (the class the guard must clear).
+    fn subject_luma(w: usize, h: usize) -> Vec<f64> {
+        let mut s = vec![0.0_f64; w * h];
+        let blob = |x: f64, y: f64, cx: f64, cy: f64, sig: f64, amp: f64| {
+            let dx = x - cx;
+            let dy = y - cy;
+            amp * (-(dx * dx + dy * dy) / (2.0 * sig * sig)).exp()
+        };
+        for y in 0..h {
+            for x in 0..w {
+                let (fx, fy) = (x as f64, y as f64);
+                let base = 40.0 + 60.0 * fx / w as f64 + 20.0 * fy / h as f64;
+                let structure = blob(
+                    fx,
+                    fy,
+                    w as f64 * 0.35,
+                    h as f64 * 0.40,
+                    w as f64 * 0.12,
+                    150.0,
+                ) + blob(
+                    fx,
+                    fy,
+                    w as f64 * 0.62,
+                    h as f64 * 0.58,
+                    w as f64 * 0.08,
+                    120.0,
+                );
+                let noise = 40.0 * (hash01(x, y) - 0.5);
+                s[y * w + x] = (base + structure + noise).clamp(0.0, 255.0);
+            }
+        }
+        s
+    }
+
+    /// Wrap a luminance plane into an RGB8 [`Image`] (grayscale: luma → R = G = B).
+    fn gray_image(luma: &[f64], w: usize, h: usize) -> Image {
+        let mut pixels = vec![0u8; w * h * 3];
+        for (i, &l) in luma.iter().enumerate() {
+            let v = l.round().clamp(0.0, 255.0) as u8;
+            pixels[i * 3] = v;
+            pixels[i * 3 + 1] = v;
+            pixels[i * 3 + 2] = v;
+        }
+        Image {
+            width: w as u32,
+            height: h as u32,
+            pixels,
+        }
+    }
+
+    /// A double-exposure: `alpha·S(x, y) + (1 − alpha)·S(x − dx, y − dy)` — the subject alpha-blended over
+    /// a translated (wrap-around, so no seam) copy of itself. This is a textbook echo, the signature the
+    /// cepstrum is built to flag.
+    fn double_exposure(
+        base: &[f64],
+        w: usize,
+        h: usize,
+        dx: usize,
+        dy: usize,
+        alpha: f64,
+    ) -> Vec<f64> {
+        let mut out = vec![0.0_f64; w * h];
+        for y in 0..h {
+            for x in 0..w {
+                let sx = (x + w - dx % w) % w;
+                let sy = (y + h - dy % h) % h;
+                out[y * w + x] = alpha * base[y * w + x] + (1.0 - alpha) * base[sy * w + sx];
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn coherent_frame_clears_the_ghost_ceiling() {
+        let clean = gray_image(&subject_luma(256, 256), 256, 256);
+        let z = ghost_cepstrum_score(&clean);
+        assert!(
+            z < GHOST_CEPSTRUM_Z_CEILING,
+            "coherent single-subject frame should clear the ceiling, got cepstral z {z:.2} \
+             (ceiling {GHOST_CEPSTRUM_Z_CEILING})"
+        );
+    }
+
+    #[test]
+    fn double_exposure_trips_the_ghost_ceiling() {
+        let s = subject_luma(256, 256);
+        // Pronounced ghosts (the sc-10826 failure class was a plainly-visible double-exposure). A faint
+        // near-invisible echo (alpha >= ~0.8) is intentionally NOT asserted — it blurs into the noise
+        // floor and isn't the regression this guards.
+        for (dx, dy, alpha) in [(40usize, 24usize, 0.5_f64), (30, 30, 0.6), (48, 20, 0.65)] {
+            let ghost = gray_image(&double_exposure(&s, 256, 256, dx, dy, alpha), 256, 256);
+            let z = ghost_cepstrum_score(&ghost);
+            assert!(
+                z > GHOST_CEPSTRUM_Z_CEILING,
+                "double-exposure (dx={dx}, dy={dy}, alpha={alpha}) should trip the ceiling, got \
+                 cepstral z {z:.2} (ceiling {GHOST_CEPSTRUM_Z_CEILING})"
+            );
+        }
+    }
+
+    #[test]
+    fn ghost_separates_from_clean_with_margin() {
+        // The whole point: clean and ghosted scores sit on opposite sides of the ceiling with a real
+        // dead-band between them (not a hairline split).
+        let s = subject_luma(256, 256);
+        let clean_z = ghost_cepstrum_score(&gray_image(&s, 256, 256));
+        let ghost_z = ghost_cepstrum_score(&gray_image(
+            &double_exposure(&s, 256, 256, 36, 20, 0.55),
+            256,
+            256,
+        ));
+        eprintln!(
+            "[ghost-guard] clean_z={clean_z:.2} ghost_z={ghost_z:.2} ceiling={GHOST_CEPSTRUM_Z_CEILING}"
+        );
+        assert!(
+            ghost_z > clean_z + 10.0,
+            "ghost/clean separation too thin: clean {clean_z:.2} vs ghost {ghost_z:.2}"
+        );
+    }
+
+    #[test]
+    fn flat_and_tiny_frames_are_safe() {
+        // A flat frame has no echo → z stays finite and under the ceiling (no false ghost). A
+        // sub-grid-size frame returns 0 rather than panicking.
+        let flat_px = vec![128.0_f64; 256 * 256];
+        let flat = gray_image(&flat_px, 256, 256);
+        assert!(ghost_cepstrum_score(&flat) < GHOST_CEPSTRUM_Z_CEILING);
+        let tiny_px = vec![10.0_f64; 3 * 3];
+        let tiny = gray_image(&tiny_px, 3, 3);
+        assert_eq!(ghost_cepstrum_score(&tiny), 0.0);
+    }
+
+    #[test]
+    fn fft_round_trips() {
+        // IFFT(FFT(x)) == x guards the hand-rolled radix-2 transform the cepstrum relies on.
+        let n = 8;
+        let mut re: Vec<f64> = (0..n * n).map(|i| (i as f64 * 0.37).sin() * 10.0).collect();
+        let mut im = vec![0.0_f64; n * n];
+        let orig = re.clone();
+        fft_2d(&mut re, &mut im, n, false);
+        fft_2d(&mut re, &mut im, n, true);
+        for (a, b) in orig.iter().zip(re.iter()) {
+            assert!((a - b).abs() < 1e-9, "fft round-trip drift: {a} vs {b}");
+        }
+    }
 }


### PR DESCRIPTION
Closes sc-10852. Follow-up to sc-10826 (the candle sdxl default-sampler ghost fix): adds the automated **structural coherence guard** that a `std` floor can't provide.

## Why
`DEGENERATE_STD_FLOOR_DEFAULT` only sees global contrast, not spatial structure. The sc-10826 double-exposure scored per-pixel std **39.86** — well above the floor — so std alone would never have caught it. This adds a golden-free guard for the echo/double-exposure signature.

## The design is evidence-driven (not the story's first guess)
The story proposed an **off-origin autocorrelation peak**. I implemented it, then GPU-validated on a real 1024² RealVisXL engine-default render — and it **false-positived hard**:

| | autocorrelation peak | cepstrum z |
|---|---|---|
| **real coherent fox render** | **0.58** | **12.8** |
| synthetic double-exposures | 0.52–0.64 | 30–107 |

A coherent fox in a snowy forest (vertical trunks = strong translational self-similarity) out-scored several ghosts on autocorrelation — **no threshold separates clean from ghost**. So I switched to the **cepstrum** (IFFT of the log power spectrum): the `log` turns a double-exposure's multiplicative echo ripple into an additive full-band component landing as one sharp peak at the delay, while the image's own spectral envelope stays at low quefrency (excluded). Same real render: coherent **z=12.84** vs a synthesized double-exposure of it **z=77.94**.

It is honestly **not a silver bullet** — a strongly periodic legit texture (full-frame brick grid) is mathematically a sum of translated copies and can also peak. So the guard is tuned to catch the *pronounced* double-exposure class sc-10826 was, with a documented relax valve.

## What's here
- **`smoke_support.rs`**: `ghost_cepstrum_score` + `GHOST_CEPSTRUM_Z_CEILING` (z=20), on a dependency-free hand-rolled radix-2 FFT (no new crate). GPU-free unit tests lock the metric (clean 9.4 vs ghost 67), plus an FFT round-trip identity test.
- **`realvisxl_lightning_gpu_smoke.rs`**: asserts the guard **two-sided on real pixels** — the coherent render must clear the ceiling AND a synthesized double-exposure of that same render must trip it (proves the guard is live on this content, not just that the number is low). Also fixes the engine-default path so it's actually reachable (`RVXL_SAMPLER=default` sentinel — `env_or` filters set-but-empty and Windows shells can't pass an empty env var), and adds `RVXL_GHOST_GUARD=0` to relax the coherent-side assert for texture-heavy eyeball prompts.

## Validation
- `cargo test -p sceneworks-worker --lib --features backend-candle ghost_guard_tests` → **5 passed** (clean 9.4 / ghost 67 / FFT round-trip).
- `cargo fmt -p sceneworks-worker --check` clean; `cargo clippy -p sceneworks-worker --features backend-candle --tests -- -D warnings` clean.
- **GPU-validated on the RTX PRO 6000 box** (RealVisXL_V5.0 dense snapshot, engine-default + CFG 7.5, 28 steps): coherent render **z=12.84 passes**, synthesized double-exposure of it **z=77.94 trips**.

The smoke also runs a synthesized-ghost self-check on the real render — it produced a textbook double-exposure (two overlaid foxes, doubled faces and ears — the exact sc-10826 failure mode) scoring z=77.94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

