### PR TITLE
feat(worker): capability-derived MLX sequential-residency fan-out + pin bump to 45428fa (sc-10840)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-nn 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -570,7 +570,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-gen",
  "candle-llm 0.0.0 (git+https://github.com/SceneWorks/candle-llm?rev=3d9fdf04047bf3b1fbf323ab56c919f3a03f0794)",
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-gen",
  "image",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -753,7 +753,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -763,7 +763,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -778,7 +778,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -795,7 +795,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -815,7 +815,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -827,7 +827,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -840,7 +840,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-gen",
  "inventory",
@@ -864,7 +864,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/candle-gen?rev=6709463b8b13e076dd6c499575d47188e8546c07#6709463b8b13e076dd6c499575d47188e8546c07"
+source = "git+https://github.com/michaeltrefry/candle-gen?rev=ef84441c82222df8f63701e761c0834c1699ceb0#ef84441c82222df8f63701e761c0834c1699ceb0"
 dependencies = [
  "candle-core 0.10.2 (git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87)",
  "candle-gen",
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "inventory",
  "pmetal-mlx-rs",
@@ -3714,7 +3714,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "image",
  "inventory",
@@ -3727,7 +3727,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "image",
  "inventory",
@@ -3741,7 +3741,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "image",
  "inventory",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3769,7 +3769,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3780,7 +3780,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3789,7 +3789,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3798,7 +3798,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3850,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3860,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "image",
  "inventory",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "image",
  "inventory",
@@ -3888,7 +3888,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "image",
  "inventory",
@@ -3902,7 +3902,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "image",
  "inventory",
@@ -3914,7 +3914,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3925,7 +3925,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3949,7 +3949,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3967,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3977,7 +3977,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -3989,7 +3989,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "image",
  "inventory",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "image",
  "inventory",
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4029,7 +4029,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4041,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "inventory",
  "mlx-gen",
@@ -4052,7 +4052,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "image",
  "inventory",
@@ -4066,7 +4066,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "image",
  "inventory",
@@ -5900,7 +5900,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/michaeltrefry/mlx-gen?rev=c9faefc5d2e0650dd5679745089f2c03be51ba7a#c9faefc5d2e0650dd5679745089f2c03be51ba7a"
+source = "git+https://github.com/michaeltrefry/mlx-gen?rev=45428fa9727c569f3f3723c7343c96b0944f9007#45428fa9727c569f3f3723c7343c96b0944f9007"
 dependencies = [
  "core-llm",
  "inventory",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -551,7 +551,20 @@ sceneworks-core = { path = "../sceneworks-core" }
 # `7a16611` -> `6709463` IN LOCKSTEP (candle-gen main, MERGED PR #504, sc-10894 candle-gen lockstep, which
 # re-pins its OWN gen-core -> c9faefc) so `--features backend-candle` resolves the SINGLE gen-core rev
 # c9faefc. mlx-rs (38e1cc1) + mlx-llm (7041411f) UNCHANGED across the range — MLX does not rebuild.
-sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+#
+# Rev 45428fa (mlx-gen main, sc-10840 / epic 10834 — MLX Phase-1 sequential-residency fan-out): the mlx-gen
+# pin (all `mlx-gen*` + `sceneworks-gen-core`) moves `c9faefc` -> `45428fa` as every image engine (sd3 /
+# sana / flux / flux2 / chroma / ideogram / kolors / anima / boogu / bernini, alongside the already-wired
+# sdxl / z-image / qwen / lens / krea families) wires the shared `Residency` seam and advertises
+# `Capabilities.supports_sequential_offload = true`. gen-core is BYTE-IDENTICAL: `git diff c9faefc..45428fa
+# -- gen-core/` is EMPTY — the whole delta is per-crate mlx-gen provider Rust, so the DEFAULT skew gate
+# stays single-rev/green. This pin bump is what makes `mlx_fit_gate::engine_supports_sequential` (now
+# DERIVED from the descriptor bit, no hardcoded allowlist) resolve true for every fan-out engine. The
+# candle pin (all `candle-gen*`) moves `6709463` -> `ef84441` IN LOCKSTEP — the MERGED head of candle-gen
+# main (SceneWorks/candle-gen#506, which re-pins candle-gen's OWN gen-core c9faefc -> 45428fa,
+# byte-identical) — so `check-gen-core-skew.sh --features backend-candle` resolves the SINGLE gen-core rev
+# 45428fa. mlx-rs (38e1cc1) + mlx-llm (7041411f) UNCHANGED — MLX does not rebuild.
+sceneworks-gen-core = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -925,7 +938,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # lockstep to f2ec6e3 (candle-gen #428, which re-pins gen-core to THIS 592419c) and the skew gate resolves
 # ONE gen-core rev on BOTH lanes. Real-weight A/B (byte-identical): turbo 22.4->18.1, raw 22.0->18.1, edit
 # 25.7->20.2 (Q8), control 42.8->35.5 GiB (bf16). Adds the 4 krea ids to SEQUENTIAL_CAPABLE_ENGINES below.
-mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # `mlx-rs` (pmetal-mlx-rs fork) — used directly by the native MLX YOLO11 person
 # detector (person_jobs.rs, sc-3633) for the ops the shared `mlx_gen::nn` layer does
 # not cover: CSP channel splits, depthwise convs, SPPF max-pool, the C2PSA attention,
@@ -941,23 +954,23 @@ mlx-gen = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e
 # exactly this rev, so the worker MUST match (a different rev would compile pmetal-mlx-sys twice). This
 # rebuilds MLX from source. Paired with mlx-llm `6c052ba` below (mlx-llm#45 carries the same fork pin).
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
-mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-z-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # Ideogram 4 (native MLX, gated non-commercial; epic 4725, sc-5992). Same git rev as mlx-gen.
 # Self-registers `ideogram_4` via inventory only when force-linked (`use mlx_gen_ideogram as _;` in
 # image_jobs.rs). Loads the packed Q4/Q8 turnkey (quant.rs/convert.rs).
-mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-ideogram = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # Boogu-Image-0.1 (native MLX, ungated Apache-2.0; epic 6387, sc-6399). Same git rev as mlx-gen.
 # Self-registers `boogu_image` (Base true-CFG T2I) / `boogu_image_turbo` (DMD few-step, CFG-free) /
 # `boogu_image_edit` (instruction edit) via inventory only when force-linked (`use mlx_gen_boogu as _;`
 # in image_jobs.rs). Loads the packed Q8 turnkey subfolder (no runtime quantize) or the bf16 build.
-mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-boogu = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # Krea 2 Turbo (native MLX, Krea 2 Community License; epic 7565, sc-7572). Same git rev as mlx-gen.
 # Self-registers `krea_2_turbo` (Qwen3-VL-4B TE + 28-block single-stream DiT + Qwen-Image VAE; CFG-free
 # rectified-flow few-step) via inventory only when force-linked (`use mlx_gen_krea as _;` in
 # image_jobs.rs). Loads the packed Q8/Q4 turnkey subdir (krea_model_subdir; the loader auto-detects the
 # packed quant, so the resolved `spec.quantize` is a no-op on it). Depends on mlx-gen-qwen-image for the
 # shared `AutoencoderKLQwenImage` VAE.
-mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # Stable Diffusion 3.5 provider (native MLX, Stability AI Community License; epic 7841, sc-7871). Same
 # git rev as mlx-gen so MLX builds once. Self-registers `sd3_5_large` (true-CFG, 28 steps / guidance 3.5)
 # + `sd3_5_large_turbo` (ADD-distilled few-step, CFG-off) + `sd3_5_medium` (MMDiT-X, true-CFG, 40 steps /
@@ -965,7 +978,7 @@ mlx-gen-krea = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faef
 # (`use mlx_gen_sd3 as _;` in image_jobs.rs). All three carry a `sd3_5_*_quant` converter. Reuses the SDXL
 # CLIP encoder (×2), the FLUX T5-XXL encoder, and the Z-Image 16-ch VAE — its `quantize_sd3_dir` converter
 # is wired in model_jobs.rs for the `sd3_5_{large,large_turbo,medium}_quant` install-time conversions.
-mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # SANA 1600M provider (native MLX, NVIDIA non-commercial license; epic 8485, sc-8489). Same git rev as
 # mlx-gen so MLX builds once. Self-registers `sana_1600m` (Image/t2i, true-CFG, 32× DC-AE divisor,
 # mac_only) via `register_generators!` into the gen-core inventory — surfaces only when force-linked
@@ -973,7 +986,7 @@ mlx-gen-sd3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc
 # conditioning (sc-8488); the `SanaPipeline` composes SanaTextEncoder -> SanaTransformer (Linear DiT) ->
 # DC-AE f32 decoder and exposes the `from_snapshot`/`from_weights` weight-load entrypoints the generic
 # generator-cache load path drives.
-mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # Anima 2B anime t2i provider (native MLX, CircleStone Labs Non-Commercial License v1.2; epic 10512,
 # sc-10523). Same git rev as mlx-gen so MLX builds once. Self-registers `anima_base` / `anima_aesthetic`
 # / `anima_turbo` (Cosmos-Predict2 DiT + Qwen3-0.6B T5-query-token adapter conditioner + Qwen-Image VAE)
@@ -982,59 +995,59 @@ mlx-gen-sana = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faef
 # scheduler (sc-10519) and strong prompt-weighting on the T5 query tokens (sc-10566). Carries the
 # install-time q4/q8/bf16 converter the model_jobs.rs Anima path drives (sc-10517). Pinned to merged
 # mlx-gen main 6a10ae1 (PR #680), which carries both the Anima crate and gen-core's is_hidden_file.
-mlx-gen-anima = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-anima = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # FLUX.1 schnell/dev provider (epic 3018, sc-3023). Same git rev as mlx-gen so MLX
 # builds once; self-registers `flux1_schnell`/`flux1_dev` via inventory only when
 # linked + referenced (`use mlx_gen_flux as _;` in image_jobs.rs).
-mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-flux = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # Qwen-Image provider (epic 3018, sc-3024). Self-registers `qwen_image`.
-mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-qwen-image = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # FLUX.2-klein provider (epic 3018, sc-3025). Self-registers `flux2_klein_9b`
 # (txt2img) + `flux2_klein_9b_edit` + `flux2_klein_9b_kv_edit` (edit = sc-3029).
-mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-flux2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # SDXL provider (epic 3018, sc-3026). Self-registers `sdxl` (also serves the
 # `realvisxl` finetune — same arch). Replaces the in-process _vendor/mlx_sd path.
-mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-sdxl = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # CLIP ViT-L/14 image embedder for the Dataset Doctor analysis job (epic 6529 P2, sc-6535).
 # Self-registers `clip_vit_l14` (gen_core::ImageEmbedder) via inventory only when force-linked
 # (`use mlx_gen_clip as _;` in dataset_analysis_jobs.rs). Reuses mlx-gen-sdxl's CLIP body → same rev.
-mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-clip = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # Chroma provider (epic 3531, sc-3843). Self-registers `chroma1_hd` / `chroma1_base` /
 # `chroma1_flash` (FLUX.1-schnell-derived DiT, T5-only true-CFG conditioning) via inventory
 # when linked + referenced (`use mlx_gen_chroma as _;` in image_jobs.rs). Same git rev as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-chroma = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # SenseNova-U1 provider (epic 3180, sc-3900 / sc-3905). Self-registers `sensenova_u1_8b` (base) +
 # `sensenova_u1_8b_fast` (8-step distill) via inventory when linked + referenced
 # (`use mlx_gen_sensenova as _;` in image_jobs.rs). Also exposes the public `SenseNova` / `T2iModel`
 # types directly for the VQA + Document-Studio (interleave) paths the `Generator` contract can't
 # express (sc-3905). Same git rev as the other mlx-gen crates so MLX builds once.
-mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-sensenova = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # Wan2.2 video provider (epic 3018, sc-3034). Self-registers `wan2_2_ti2v_5b`
 # (dense T2V/TI2V), `wan2_2_t2v_14b` + `wan2_2_i2v_14b` (dual-expert MoE) via
 # inventory when linked + referenced (`use mlx_gen_wan as _;` in video_jobs.rs).
-mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-wan = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # LTX-2.3 video provider (epic 3018, sc-3035). Self-registers `ltx_2_3` (T2V/I2V +
 # synchronized audio, 2-stage distilled). Linked + referenced (`use mlx_gen_ltx as _;`
 # in video_jobs.rs); the Gemma-3 text encoder is resolved by the engine (HF cache / env).
 # Same rev as the other mlx-gen crates (sc-3060 bump) so MLX + the shared core build once.
-mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-ltx = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # Stable Video Diffusion (SVD-XT) image→video provider (epic 3040, sc-3523). Self-registers
 # `svd_xt` (fixed ~25-frame img2vid burst, no text prompt — animates one source image via the
 # `motion_bucket_id`/`noise_aug_strength`/fps micro-conditioning) into the engine registry when
 # linked + referenced (`use mlx_gen_svd as _;` in video_jobs.rs). Same git rev + mlx-rs pin as the
 # other mlx-gen crates so MLX builds once.
-mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-svd = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # JoyCaption image-to-text provider (epic 3550, sc-3556). Self-registers
 # `fancyfeast/llama-joycaption-beta-one-hf-llava` into mlx-gen's captioner
 # registry for native dataset captioning on the macOS MLX worker.
-mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-joycaption = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # SAM2 (Segment Anything 2) segmenter (epic 3704, sc-3705..3709). A plain utility
 # crate (NOT a self-registering generation provider) — `person_segment.rs` builds a
 # `Sam2Segmenter` directly from the converted MLX weights to produce per-frame person
 # masks in `run_person_track`. Same git rev + mlx-rs pin as the other mlx-gen crates so
 # MLX builds once.
-mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # SAM3 (Segment Anything 3) concept segmenter (epic 4910, sc-4926). A plain utility crate
 # (NOT a self-registering generation provider), like `mlx-gen-sam2` — `person_segment_sam3.rs`
 # builds a `Sam3VideoModel` directly and drives the text-concept PCS video pipeline
@@ -1043,19 +1056,19 @@ mlx-gen-sam2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faef
 # Loads stock `facebook/sam3` weights directly (no conversion, unlike SAM2's `.pt`), then
 # `Sam3VideoModel::quantize(8)` (sc-4925, present at this pin via #402) for a ~0.9 GB Q8 footprint
 # vs F32 ~3.2 GB. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-sam3 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # Native MLX face-analysis stack (epic 3079) — SCRFD 5-pt detector + glintr100 ArcFace
 # (iresnet100) 512-d embedder. A plain utility crate (NOT a self-registering generation
 # provider) consumed by the InstantID provider below to detect the reference face + produce
 # the ArcFace embedding with zero Python (replaces insightface/onnxruntime on the Mac path).
-mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-face = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # Depth Anything V2 (DINOv2 ViT-S/14 + DPT) native-MLX monocular depth estimator (epic 8236,
 # sc-8242). A plain utility crate (NOT a self-registering generation provider): an arbitrary RGB
 # image → a normalized single-channel depth control image, the AUTO depth source for the
 # Fun-Controlnet-Union depth tier (`ControlKind::Depth`) — sibling of the CPU canny/pose
 # preprocessors, but neural so it is macOS-gated (MLX). Consumed by the worker `depth` module /
 # the shared strict-control driver (sc-8243). Same mlx-rs pin as every other mlx-gen crate.
-mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # InstantID identity-preserving SDXL provider (epic 3109 engine / sc-3345 integration). A
 # bespoke API (`InstantId::load(InstantIdPaths{ sdxl_base, identitynet, ip_adapter })` →
 # `.with_face`/`.with_openpose` → `generate`/`generate_angle`/`generate_pose`/`restore_face`),
@@ -1064,7 +1077,7 @@ mlx-gen-depth = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9fae
 # mlx-gen-sdxl (UNet + IdentityNet ControlNet + IP-Adapter Resampler) with mlx-gen-face. The
 # pinned rev (ed8e6a1) carries the base port (#153), the sc-3329 quant fix (#155), AND pose mode
 # + face-restore (#193: with_openpose/generate_pose/restore_face — sc-3117/3380). Same mlx-rs pin.
-mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # Kolors (Kwai-Kolors) provider crate (epic 3090). Registers the inference generator id `kolors`
 # (sc-3874) AND — the piece this worker consumes today — the `KolorsTrainer` LoRA/LoKr trainer under
 # the same id `kolors` (sc-4568), reached via `mlx_gen::load_trainer("kolors", spec)` for the Kolors
@@ -1072,7 +1085,7 @@ mlx-gen-instantid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c
 # force-link the crate (`use mlx_gen_kolors as _;`) or the linker drops the `TrainerRegistration`.
 # Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once. (The inference-side
 # routing cutover is sc-3875; this dep is added now for the trainer registration.)
-mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # PuLID-FLUX face-identity provider (epic 3069 engine / sc-3344 integration). UNLIKE InstantID this
 # IS an inventory-registered `Generator` (engine id `pulid_flux`): EVA02-CLIP-L-336 tower → IDFormer
 # → 20× PerceiverAttentionCA injected into FLUX.1-dev via a generic `DitImageInjector` seam. The
@@ -1083,7 +1096,7 @@ mlx-gen-kolors = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9fa
 # backbone) + mlx-gen-face (the same SCRFD/ArcFace stack InstantID uses, plus BiSeNet parsing). The
 # PuLID adapter + EVA + face weights are fed via the engine's env-var seam from the worker cache
 # (see `image_jobs/pulid.rs`). Same git rev + mlx-rs pin as the other mlx-gen crates.
-mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # Microsoft Lens / Lens-Turbo provider (epic 3164 engine / sc-5105 integration). An
 # inventory-registered `Generator` under TWO ids: `lens` (base, 20-step / CFG 5.0) and
 # `lens_turbo` (distilled, 4-step / guidance 1.0). gpt-oss-20b MoE text encoder + 48-layer
@@ -1094,7 +1107,7 @@ mlx-gen-pulid = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9fae
 # linker drops the `ModelRegistration` (the "no generator registered" trap). Retires the Python
 # `/opt/lens-venv` transformers-5 sidecar on Mac (Win/Linux/Docker keep the torch path). Same git rev
 # + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # SeedVR2 (ByteDance) one-step diffusion-transformer super-resolution provider (epic 4811). An
 # inventory-registered `Generator` under ids `seedvr2` (alias) + `seedvr2_3b`, `Modality::Both`: it
 # upscales a single image (`Conditioning::Reference` → `GenerationOutput::Images`; sc-4815 image
@@ -1116,7 +1129,7 @@ mlx-gen-lens = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faef
 # a Metal large-tensor limit, not precision). New `VAE_SAFE_DECODE_EDGE_PX=1536` forces decode tiling on
 # a CORRECTNESS cap independent of the memory budget (image + video), so a 2048² upscale that fits memory
 # still tiles. Real-weight 1024→2048 pixel-cosine vs the mflux reference 0.9524 → 0.9974.
-mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # Bernini (ByteDance) full pipeline provider (epic 4699, sc-4707). An inventory-registered `Generator`
 # under id `bernini` (`Modality::Both`: t2i/i2i → Images, t2v/v2v/r2v/rv2v → Video): a Qwen2.5-VL-7B
 # semantic planner (MAR loop) driving a Wan2.2-T2V-A14B dual-expert renderer (reuses mlx-gen-wan's
@@ -1127,7 +1140,7 @@ mlx-gen-seedvr2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9f
 # registered" trap). Weights = the turnkey converted `SceneWorks/bernini-mlx` snapshot (~93 GB bf16,
 # self-contained — planner + renderer + stock Wan2.2 UMT5/VAE/tokenizer). Same git rev + mlx-rs pin as
 # the other mlx-gen crates so MLX builds once.
-mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-bernini = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 # The unified LLM engine (epic 7153, sc-7158): the macOS `prompt_refine` job now runs through
 # mlx-llm's generic `mlx-llama` provider (a `core_llm::TextLlm`) resolved model-first via
 # `gen_core::core_llm::load_for_model`, RETIRING the bespoke `mlx-gen-prompt-refine` hand-rolled
@@ -1159,7 +1172,7 @@ mlx-llm = { git = "https://github.com/SceneWorks/mlx-llm", rev = "7041411f395e43
 # → `.generate`), so video_jobs.rs must force-link the crate (`use mlx_gen_scail2 as _;`) or the linker
 # drops the `ModelRegistration` (the "no generator registered" trap). Weights = the turnkey converted
 # `SceneWorks/scail2-mlx` snapshot. Same git rev + mlx-rs pin as the other mlx-gen crates so MLX builds once.
-mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9faefc5d2e0650dd5679745089f2c03be51ba7a" }
+mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "45428fa9727c569f3f3723c7343c96b0944f9007" }
 
 # candle (Windows/CUDA) generative backend (epic 3672, sc-3675) — the Windows sibling of the macOS
 # mlx provider crates above. `candle-gen-sdxl` self-registers `sdxl` into the SAME gen_core inventory
@@ -1766,15 +1779,15 @@ mlx-gen-scail2 = { git = "https://github.com/michaeltrefry/mlx-gen", rev = "c9fa
 # gen-core `b568fdb` matching this worker's mlx-gen pin, so `--features backend-candle` resolves the SINGLE
 # gen-core rev with NO mlx-gen move. Purely additive (the base SANA lane is byte-identical). ALL candle-gen-*
 # pins move together; backend-candle check --locked green.
-candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-sdxl = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle image providers (sc-5096) -- Windows/CUDA siblings of the mlx-gen image crates above. Each
 # self-registers its engine id into the shared gen_core inventory registry; force-linked in
 # `image_jobs.rs` (`use candle_gen_<x> as _;`) so the MSVC release linker keeps the registration.
 # Same git rev as `candle-gen-sdxl` so candle builds once and the gen-core pin stays single.
-candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
-candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
-candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
-candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-z-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
+candle-gen-flux = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
+candle-gen-flux2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
+candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle Anima 2B provider (sc-10525, epic 10512) — Windows/CUDA sibling of mlx-gen-anima. Self-registers
 # `anima_base` / `anima_aesthetic` / `anima_turbo` into the shared gen_core inventory; force-linked in
 # `image_jobs.rs` (`use candle_gen_anima as _;`) so the MSVC release linker keeps the registration.
@@ -1788,7 +1801,7 @@ candle-gen-qwen-image = { git = "https://github.com/michaeltrefry/candle-gen", r
 # gen-core rev. The catalog still leaves `candle_routed = false` — routing the app lane additionally
 # needs a non-mac dense download + dense-load path (Anima's convert-at-install converter is macOS-only),
 # tracked on sc-10625.
-candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle Stable Diffusion 3.5 provider (sc-7880, epic 7982) — Windows/CUDA sibling of mlx-gen-sd3.
 # Self-registers THREE T2I ids: `sd3_5_large` (8B MMDiT, true-CFG) + `sd3_5_large_turbo` (ADD-distilled
 # few-step, CFG-free) + `sd3_5_medium` (2.5B MMDiT-X dual-attention). Triple text encoder (CLIP-L +
@@ -1796,7 +1809,7 @@ candle-gen-anima = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # `image_jobs.rs` (`use candle_gen_sd3 as _;`). Same git rev as the others (one candle build, single
 # gen-core pin); the rev (185fe4a) pins gen-core b6538cb — IDENTICAL to the worker's mlx-gen pin, so
 # `--features backend-candle --target all` still resolves a SINGLE gen-core rev.
-candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle SANA 1600M provider (sc-11780 base / sc-11781 Sprint, epic 8485) — Windows/CUDA + Linux sibling
 # of mlx-gen-sana. Self-registers TWO T2I ids: `sana_1600m` (candle-gen #495 PART 4a — NVIDIA's 1.6B
 # Linear-DiT + 32x DC-AE f32 autoencoder + the shared gemma-2-2b-it CHI caption encoder reused from
@@ -1810,17 +1823,17 @@ candle-gen-sd3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6
 # Same git rev as every candle-gen provider above (one candle build, single gen-core pin) — a71772f pins
 # gen-core b568fdbf, IDENTICAL to the worker's mlx-gen pin, so `--features backend-candle --target all`
 # still resolves a SINGLE gen-core rev (the skew gate stays green).
-candle-gen-sana = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-sana = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle Ideogram 4 provider (sc-6596, epic 6561) - Windows/CUDA sibling of mlx-gen-ideogram.
 # Self-registers `ideogram_4` (asymmetric two-DiT CFG) + `ideogram_4_turbo` (CFG-free single DiT +
 # bundled TurboTime LoRA). T2I; edit/Remix is sc-6598. Force-linked in `image_jobs.rs`
 # (`use candle_gen_ideogram as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-ideogram = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle Chroma provider (sc-5484, epic 3692) — Windows/CUDA sibling of mlx-gen-chroma. Self-registers
 # THREE T2I ids: `chroma1_hd` / `chroma1_base` / `chroma1_flash` (FLUX.1-schnell-derived DiT, distilled-
 # guidance Approximator, T5-only conditioning, true-CFG). Force-linked in `image_jobs.rs`
 # (`use candle_gen_chroma as _;`). Same rev as the others (one candle build, single gen-core pin).
-candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle Boogu-Image-0.1 provider (sc-7524, epic 6831) — Windows/CUDA sibling of mlx-gen-boogu.
 # Self-registers THREE ids: `boogu_image` (Base, true-CFG T2I) + `boogu_image_turbo` (DMD few-step,
 # CFG-free) + `boogu_image_edit` (single-reference instruction TI2I — the source is VAE-encoded into the
@@ -1830,7 +1843,7 @@ candle-gen-chroma = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # gate). Base/Turbo are pure T2I; Edit's reference is resolved in-lane by `generate_candle_stream` (like
 # Ideogram — NOT a separate bespoke stream). Force-linked in `image_jobs.rs` (`use candle_gen_boogu as _;`).
 # Same rev as the others (one candle build, single gen-core pin == the mlx pin 43aa2bf).
-candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle Krea 2 (sc-7581, epic 7565 P4) — Windows/CUDA sibling of the `mlx-gen-krea` pin above.
 # Registers `krea_2_turbo` (12B single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE; CFG-free 8-step
 # rectified-flow). bf16-only on candle (the provider rejects on-the-fly quant); force-linked in
@@ -1838,21 +1851,21 @@ candle-gen-boogu = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # (the MLX twin, sc-7572) — sc-7581 adds the candle force-link + the windows/linux bf16 download from
 # the ungated public `krea/Krea-2-Turbo` (the boogu pattern: snapshot root, no quant subdir). Same rev
 # as the other candle crates (one candle build / one gen-core pin cf6f338c == the mlx pin).
-candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-krea = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle VIDEO providers (sc-5097) — Windows/CUDA siblings of mlx-gen-wan / mlx-gen-ltx. wan registers
 # `wan2_2_ti2v_5b` + the 14B MoE pair (`wan2_2_t2v_14b`/`wan2_2_i2v_14b`, sc-5175) + `wan_vace` (the
 # Wan-VACE controllable-video provider, sc-5494 / epic 5481, the worker routes replace_person /
 # extend_clip / video_bridge onto); ltx registers `ltx_2_3_distilled` (now the full AudioVideo path —
 # synchronized 48 kHz audio, sc-5495). Force-linked in video_jobs.rs
 # (`use candle_gen_<x> as _;`). Same rev as the others.
-candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
-candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-wan = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
+candle-gen-ltx = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle SVD-XT image→video provider (sc-5493, epic 5481) — Windows/CUDA sibling of mlx-gen-svd.
 # Registers `svd_xt` (image→video; loads the stock diffusers fp16 SVD-XT snapshot directly). Force-linked
 # in video_jobs.rs (`use candle_gen_svd as _;`). Same rev as the others. GPU-validated on RTX PRO 6000
 # (candle-gen #66): the UNet runs f32 today — fp16 overflows to NaN in the deep spatio-temporal UNet
 # (native-res fp16+f32-upcast is the sc-5493 GPU follow-up).
-candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle SCAIL-2 character-animation + cross-identity replace_person provider (sc-6837, epic 6563) —
 # the Windows/CUDA sibling of `mlx-gen-scail2`, built ON candle-gen-wan (reuses WanVae16 / Umt5Encoder /
 # FlowScheduler + the per-source RoPE convention; net-new = open-CLIP ViT-H/14, packed-token DiT, 28-ch
@@ -1861,7 +1874,7 @@ candle-gen-svd = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6
 # rev as every candle-gen provider above (fad2539 = candle-gen main HEAD, the merged #114 scail2
 # provider) — its gen-core pin (4d3aa49) MATCHES the worker's mlx pin, so `--features backend-candle
 # --target all` resolves ONE gen-core rev (no skew).
-candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle Bernini still-image companion (sc-10996, epic 6562) — the Windows/CUDA sibling of
 # `mlx-gen-bernini`, built ON candle-gen-wan (the full Qwen2.5-VL/MAR semantic planner driving a
 # Wan2.2-A14B dual-expert renderer, `frames:1` for a single still). Self-registers the full `bernini`
@@ -1873,17 +1886,17 @@ candle-gen-scail2 = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # main HEAD, the merged #421 planner-components commit — contains the #419 full generator sc-10995) — its
 # gen-core pin (951227a) MATCHES the worker's mlx pin, so `--features backend-candle --target all`
 # resolves ONE gen-core rev (no skew).
-candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-bernini = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle JoyCaption captioner (sc-5098; repointed onto candle-llm in sc-7692) — Windows/CUDA sibling of
 # mlx-gen-joycaption. Registers the captioner id `fancyfeast/llama-joycaption-beta-one-hf-llava`
 # (image->text); the in-core model is gone — it now serves through candle-llm's `candle-llava` VLM
 # provider via `core_llm`, so this crate pulls `candle-llm` into the graph. Force-linked in
 # caption_jobs.rs (`use candle_gen_joycaption as _;`). Same rev as the others.
-candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-joycaption = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle CLIP ViT-L/14 image + text embedders (sc-6537) — Windows/CUDA sibling of mlx-gen-clip.
 # Registers `clip_vit_l14` (image) + `clip_vit_l14_text` (text, backend `candle`) for the Dataset
 # Doctor analysis job. Force-linked in dataset_analysis_jobs.rs. Same rev as the others.
-candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle Lens / Lens-Turbo provider (epic 5107 / sc-5126) — Windows/CUDA sibling of mlx-gen-lens.
 # Self-registers TWO ids: `lens` (base, 20-step/CFG 5.0) + `lens_turbo` (distilled, 4-step/g 1.0).
 # gpt-oss-20b MoE text encoder + 48-layer dual-stream MMDiT + the Flux.2 VAE; pure T2I (no
@@ -1892,7 +1905,7 @@ candle-gen-clip = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # `generate_candle_stream`. Force-linked in image_jobs.rs (`use candle_gen_lens as _;`) so the MSVC
 # release linker keeps the `inventory::submit!` registrations. Same rev as the others (one candle build,
 # single gen-core pin). Retires the Python `/opt/lens-venv` transformers-5 inference sidecar off-Mac.
-candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-lens = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle LLM serving engine (epic 7153, sc-7404) — provides the generic `candle-llama`
 # `core_llm::TextLlm` provider the worker's prompt_refine job resolves model-first via
 # `gen_core::core_llm::load_for_model` (the Windows/CUDA twin of the macOS mlx-llm cutover, sc-7158).
@@ -1925,7 +1938,7 @@ candle-llm = { git = "https://github.com/SceneWorks/candle-llm", rev = "d0ba3e66
 # the `kolors` T2I id (SDXL UNet with the SDXL `add_embedding` + the Kolors `encoder_hid_proj`, driven
 # by a from-scratch ChatGLM3-6B text encoder). Pure T2I (edit / IP-reference / pose-control stay on the
 # Python worker). Force-linked in image_jobs.rs (`use candle_gen_kolors as _;`). Same rev as the others.
-candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle SenseNova-U1 NEO-Unify provider (sc-5576, epic 3692) — Windows/CUDA sibling of
 # mlx-gen-sensenova. Self-registers TWO T2I ids: `sensenova_u1_8b` (50 NFE / CFG 4.0) + the 8-step
 # distilled `sensenova_u1_8b_fast` (CFG 1.0; the loader merges the distill LoRA on CPU per candle-gen
@@ -1934,12 +1947,12 @@ candle-gen-kolors = { git = "https://github.com/michaeltrefry/candle-gen", rev =
 # driven OFF the registry via the concrete `T2iModel::{vqa, interleave_gen}` in `sensenova_jobs.rs`
 # (text / text+image output the neutral `Generator` contract can't express), retiring the off-Mac
 # torch path. Force-linked in image_jobs.rs (`use candle_gen_sensenova as _;`). Same rev.
-candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-sensenova = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # candle-gen core (sc-5501): a direct dep so `sensenova_jobs.rs` can build the `[3,H,W]` understanding
 # input tensors for VQA / interleave (`candle_gen::candle_core::Tensor` + `default_device`). Same git
 # rev as every candle-gen provider above, so the `--features backend-candle` graph still resolves ONE
 # candle-gen / gen-core build (the skew gate stays single-rev).
-candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle InstantID identity-preserving SDXL provider (sc-5491, epic 5480) — the Windows/CUDA sibling
 # of `mlx-gen-instantid`, retiring the Python `_vendor/instantid` off-Mac. A BESPOKE provider (not an
 # inventory-registered `Generator`): referenced by name (`InstantId::load`) from the worker's
@@ -1947,7 +1960,7 @@ candle-gen = { git = "https://github.com/michaeltrefry/candle-gen", rev = "67094
 # euler-ancestral / denoise blocks) + candle-gen-face (SCRFD + ArcFace). Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 891bee4, matching mlx-gen).
-candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle PuLID-FLUX face-identity provider (sc-5492, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-pulid`, retiring the torch PuLID adapter off-Mac. A BESPOKE provider (not an inventory-
 # registered `Generator`): referenced by name (`PulidFlux::load`) from the worker's
@@ -1956,7 +1969,7 @@ candle-gen-instantid = { git = "https://github.com/michaeltrefry/candle-gen", re
 # EVA02-CLIP tower / IDFormer / 20 PerceiverAttentionCA modules it owns. Same git rev as every
 # candle-gen provider above, so `--features backend-candle` still resolves ONE candle-gen / gen-core
 # build (the sc-4482 skew gate stays single-rev — this rev pins gen-core 3714e7b, matching mlx-gen).
-candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle SCRFD/ArcFace face-analysis stack (sc-5490, epic 5480) — the Windows/CUDA sibling of
 # `mlx-gen-face`. Already rides in transitively via candle-gen-instantid / candle-gen-pulid (their
 # composed face detector), but the standalone kps_extract surface (sc-5497, epic 5482) calls it
@@ -1964,7 +1977,7 @@ candle-gen-pulid = { git = "https://github.com/michaeltrefry/candle-gen", rev = 
 # direct dep. Same git rev as every candle-gen provider above (one candle build, single gen-core pin),
 # so `--features backend-candle` still resolves ONE candle-gen / gen-core build. Retires the Python
 # InsightFace `kps_extract` path off-Mac.
-candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle SeedVR2 one-step diffusion super-resolution upscaler (sc-5928 Windows / sc-5160 Linux, epic 4811
 # / epic 5482) — the Windows/CUDA + Linux/NVIDIA sibling of `mlx-gen-seedvr2`. Self-registers the upscaler ids `seedvr2` / `seedvr2_3b` /
 # `seedvr2_7b` (`Modality::Both`: image upscale via Reference + video upscale via VideoClip; int8/int4
@@ -1978,7 +1991,7 @@ candle-gen-face = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # video). gen-core pin `82e7599` matches the worker's mlx-gen crates so ALL candle-gen-* + mlx-gen-*
 # crates share ONE `gen_core` (two gen_core revs → `Image` mismatches, which failed candle-worker +
 # build-windows during sc-8301). cuda build gated by candle CI (can't build on Mac).
-candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the Windows/CUDA
 # sibling of `mlx-gen-sam3`, replacing the off-Mac SAM2 box-prompt STUB (media_jobs.rs `maskState =
 # "missing"`). A BESPOKE utility segmenter (NOT an inventory-registered `Generator`, like
@@ -2005,7 +2018,7 @@ candle-gen-seedvr2 = { git = "https://github.com/michaeltrefry/candle-gen", rev 
 # `candle_gen_z_image::ZImageEdit` img2img/edit provider (no gen-core change — the branch is off
 # candle-gen main `7ad1f55`, which already pins gen-core `0b86fad` == the worker's mlx pin), so
 # `--features backend-candle --target all` still resolves ONE gen-core rev. No skew.
-candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # Candle Depth Anything V2 (DINOv2 ViT-S/14 + DPT) monocular depth estimator (sc-8413, epic 8236) — the
 # Windows/CUDA sibling of `mlx-gen-depth`. A BESPOKE utility preprocessor (NOT an inventory-registered
 # `Generator`, like candle-gen-face / candle-gen-sam3): the worker's off-Mac `depth.rs` calls
@@ -2016,7 +2029,7 @@ candle-gen-sam3 = { git = "https://github.com/michaeltrefry/candle-gen", rev = "
 # re-exports gen_core + candle from `candle-gen` (the same workspace pin), so `--features backend-candle`
 # still resolves ONE candle-gen / gen-core build (22c121a pins gen-core 863f98d, matching the worker's mlx
 # pin; no skew). The control-lane routing that drives this is the separate sc-8304.
-candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "6709463b8b13e076dd6c499575d47188e8546c07", features = ["cuda"], optional = true }
+candle-gen-depth = { git = "https://github.com/michaeltrefry/candle-gen", rev = "ef84441c82222df8f63701e761c0834c1699ceb0", features = ["cuda"], optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/mlx_fit_gate.rs
+++ b/crates/sceneworks-worker/src/mlx_fit_gate.rs
@@ -35,33 +35,34 @@ use gen_core::{LoadSpec, OffloadPolicy, WeightsSource};
 
 use crate::{WorkerError, WorkerResult};
 
-/// The MLX engine ids whose provider honors [`OffloadPolicy::Sequential`] — the sc-10839 Phase 1
-/// providers (SDXL + Z-Image-turbo), the sc-11000 T2I `qwen_image`, the sc-11006 fan-out completion of
-/// the qwen family (`qwen_image_edit` drops the Qwen2.5-VL vision-language encoder after the vision+LM
-/// pass; `qwen_image_control` keeps its VACE control branch on the heavy side of the split), and the
-/// sc-11030 `lens` + `lens_turbo` (one crate/arch — drops the gpt-oss text encoder before the DiT +
-/// denoise activations materialize; needs mlx-gen-lens's consuming encoder loader so the encoder LOAD
-/// spike isn't the peak). The gate only SELECTS sequential residency for these; for any other engine
-/// `Sequential` would be a no-op (the advisory contract treats it as `Resident`), so predicting "it
-/// fits staged" and then holding everything resident would SIGKILL — hence the allowlist, which moves
-/// in LOCKSTEP with the provider wiring. Extended per family as the fan-out (sc-10840) wires each engine.
-const SEQUENTIAL_CAPABLE_ENGINES: &[&str] = &[
-    "sdxl",
-    "z_image_turbo",
-    "qwen_image",
-    "qwen_image_edit",
-    "qwen_image_control",
-    "lens",
-    "lens_turbo",
-    "krea_2_turbo",
-    "krea_2_raw",
-    "krea_2_edit",
-    "krea_2_turbo_control",
-];
-
-/// Whether `engine_id`'s provider drops components in phase order under [`OffloadPolicy::Sequential`].
+/// Whether `engine_id`'s provider drops components in phase order under [`OffloadPolicy::Sequential`]
+/// — derived at query time from the engine's REGISTERED descriptor
+/// [`Capabilities`](gen_core::Capabilities)`::supports_sequential_offload` bit, not a hand-maintained
+/// allowlist (sc-10840, epic 10834).
+///
+/// Why the descriptor bit is the right source of truth: [`OffloadPolicy::Sequential`] is *advisory* —
+/// a provider that has NOT wired the load→use→drop residency lifecycle silently treats it as
+/// `Resident` (never an error), so predicting "it fits staged" and then holding everything resident
+/// would SIGKILL. `supports_sequential_offload` is precisely the provider's own machine-readable
+/// attestation that it wired that lifecycle (the gen-core discovery signal, sc-11126). Reading it
+/// per-engine makes the gate self-maintaining: every family the mlx-gen Phase-1 fan-out wires
+/// (sc-10840 — sd3/sana/flux/flux2/chroma/ideogram/kolors/anima/boogu/bernini alongside the earlier
+/// sdxl/z-image/qwen/lens/krea families) is covered the moment its descriptor advertises the bit, with
+/// no lockstep edit here. An engine that does not separate a text encoder (e.g. sensenova's fused MoT,
+/// `footprint` te=0) leaves the bit `false` and is correctly never offered `Sequential` — a no-op that
+/// would OOM.
+///
+/// This is a pre-load, weights-free registry lookup (`(descriptor)()` allocates no tensors), the same
+/// query shape the worker already uses for family/guidance/quant capability advertisement and the
+/// analogous [`gen_core::footprint`] size seam (sc-10894). An id with no registered generator — or a
+/// registered one that does not advertise the bit — yields `false` (the safe default: never select a
+/// residency policy the provider won't honor). Sees exactly the providers the binary force-links (the
+/// sc-4482 dead-strip rule): on macOS every `mlx_gen_*` provider is anchored in `image_jobs`, so the
+/// live worker resolves them; off-Mac the MLX gate no-ops anyway (no `sysctl` budget).
 pub(crate) fn engine_supports_sequential(engine_id: &str) -> bool {
-    SEQUENTIAL_CAPABLE_ENGINES.contains(&engine_id)
+    gen_core::registry::generators()
+        .find(|reg| (reg.descriptor)().id == engine_id)
+        .is_some_and(|reg| (reg.descriptor)().capabilities.supports_sequential_offload)
 }
 
 /// Emulate a smaller Mac: force the total-unified-memory budget (GB). Set e.g.
@@ -607,29 +608,90 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
+    /// The gate derives sequential-capability from each engine's REGISTERED descriptor bit
+    /// (`Capabilities::supports_sequential_offload`) rather than a hand-maintained allowlist (sc-10840,
+    /// epic 10834). This exercises the LIVE registry, so it must see the force-linked `mlx_gen_*`
+    /// providers — anchored (`use mlx_gen_* as _;` in `image_jobs`) only on macOS, the sole platform the
+    /// MLX gate runs on. Off-Mac the image registry is empty, so this is macOS-gated exactly like the
+    /// `engines.rs` descriptor sweeps. At the pinned mlx-gen `45428fa` every image engine advertises the
+    /// bit, so every wired id resolves true through the shared registry query.
+    #[cfg(target_os = "macos")]
     #[test]
-    fn engine_supports_sequential_is_the_wired_provider_allowlist() {
-        assert!(engine_supports_sequential("sdxl"));
-        assert!(engine_supports_sequential("z_image_turbo"));
-        assert!(engine_supports_sequential("qwen_image"));
-        // The sc-11006 fan-out wired the qwen edit + control siblings (separate engine ids).
-        assert!(engine_supports_sequential("qwen_image_edit"));
-        assert!(engine_supports_sequential("qwen_image_control"));
-        // lens + lens_turbo share one crate/arch (sc-11030): both engine ids are wired. The Q8/Q4 win
-        // (Resident 34.5 → Sequential 22.3 GiB at 768², fits a 32 GB Mac) needs the consuming encoder
-        // loader — see mlx-gen-lens `with_selected_layers`.
-        assert!(engine_supports_sequential("lens"));
-        assert!(engine_supports_sequential("lens_turbo"));
-        // The sc-11101 fan-out wired the WHOLE krea_2 family (one crate, TE < DiT — the qwen pattern):
-        // turbo/raw/edit (Q8, 22→18 / 26→20 GiB at 768²) + turbo_control (bf16, 43→35 GiB). The control
-        // branch's `spec.control` bytes are already counted by the fit-gate (sc-11006).
-        assert!(engine_supports_sequential("krea_2_turbo"));
-        assert!(engine_supports_sequential("krea_2_raw"));
-        assert!(engine_supports_sequential("krea_2_edit"));
-        assert!(engine_supports_sequential("krea_2_turbo_control"));
-        // Not-yet-wired providers must NOT be offered sequential (they'd ignore it and SIGKILL).
-        assert!(!engine_supports_sequential("z_image_turbo_control"));
-        assert!(!engine_supports_sequential("flux"));
+    fn engine_supports_sequential_is_derived_from_the_registered_capability() {
+        // The earlier-wired families (sdxl / z-image / qwen / lens / krea) still resolve true — proving
+        // dropping the hardcoded allowlist introduced no regression for the already-covered engines.
+        for id in [
+            "sdxl",
+            "z_image",
+            "z_image_control",
+            "z_image_turbo",
+            "z_image_turbo_control",
+            "qwen_image",
+            "qwen_image_edit",
+            "qwen_image_control",
+            "lens",
+            "lens_turbo",
+            "krea_2_turbo",
+            "krea_2_raw",
+            "krea_2_edit",
+            "krea_2_turbo_edit",
+            "krea_2_turbo_control",
+        ] {
+            assert!(
+                engine_supports_sequential(id),
+                "{id}: earlier-wired family must stay sequential-capable"
+            );
+        }
+        // The sc-10840 Phase-1 fan-out families are AUTO-covered by the capability query with no
+        // allowlist edit here — the whole point of deriving from the descriptor bit. A newly-wired
+        // engine (e.g. `sd3_5_large`) is sequential-capable the moment its provider advertises the bit.
+        for id in [
+            "sd3_5_large",
+            "sd3_5_large_turbo",
+            "sd3_5_medium",
+            "sana_1600m",
+            "sana_sprint_1600m",
+            "flux1_schnell",
+            "flux1_dev",
+            "flux1_dev_control",
+            "flux2_klein_9b",
+            "flux2_klein_9b_edit",
+            "flux2_klein_9b_kv_edit",
+            "flux2_dev",
+            "flux2_dev_control",
+            "flux2_dev_edit",
+            "chroma1_base",
+            "chroma1_flash",
+            "chroma1_hd",
+            "ideogram_4",
+            "ideogram_4_turbo",
+            "kolors",
+            "anima_base",
+            "anima_aesthetic",
+            "anima_turbo",
+            "boogu_image",
+            "boogu_image_turbo",
+            "boogu_image_edit",
+            "bernini",
+        ] {
+            assert!(
+                engine_supports_sequential(id),
+                "{id}: sc-10840 fan-out engine must be sequential-capable at mlx-gen 45428fa"
+            );
+        }
+        // A REGISTERED engine that does NOT advertise the bit stays false: sensenova's encoder is fused
+        // into a unified MoT (`footprint` te=0) — no separable text encoder to drop, so residency buys
+        // nothing and Sequential would be a no-op that OOMs. This proves the query reads the descriptor
+        // BIT, not mere registry membership.
+        assert!(!engine_supports_sequential("sensenova_u1_8b"));
+    }
+
+    /// An id with no registered generator is never sequential-capable (the safe default: never select a
+    /// residency policy the provider won't honor) — a cross-platform invariant that holds even off-Mac
+    /// where the image registry is empty.
+    #[test]
+    fn engine_supports_sequential_is_false_for_an_unregistered_id() {
+        assert!(!engine_supports_sequential("no_such_engine_xyz"));
     }
 
     #[test]


### PR DESCRIPTION
## What

Lands the **worker side** of the MLX Phase-1 sequential-residency fan-out ([sc-10840](https://app.shortcut.com/trefry/story/10840), epic 10834), completing the epic's worker-facing work: the `mlx_fit_gate` now selects `OffloadPolicy::Sequential` for **every** image engine whose provider wired the residency lifecycle, and the pins advance to pick up that fan-out.

## 1. Gating mechanism — capability-derived (replaces the hardcoded allowlist)

`mlx_fit_gate::engine_supports_sequential` no longer consults a hand-maintained `SEQUENTIAL_CAPABLE_ENGINES` list. It now **derives** the answer from the engine's registered descriptor bit:

```rust
gen_core::registry::generators()
    .find(|reg| (reg.descriptor)().id == engine_id)
    .is_some_and(|reg| (reg.descriptor)().capabilities.supports_sequential_offload)
```

Why this is correct (not just convenient): `OffloadPolicy::Sequential` is *advisory* — a provider that hasn't wired load→use→drop silently treats it as `Resident`, so selecting it there would SIGKILL. `Capabilities.supports_sequential_offload` is precisely the provider's own machine-readable attestation that it wired that lifecycle (the gen-core discovery signal, sc-11126). This is the same pre-load, weights-free registry query the worker already uses for family / guidance / quant advertisement and the analogous `gen_core::footprint(id, spec)` size seam (sc-10894). It is **self-maintaining**: every family the mlx-gen fan-out wires is covered the moment its descriptor advertises the bit — no lockstep edit here, now or in future.

**Engines auto-covered at mlx-gen `45428fa`** (verified against the descriptors; unit-tested):
sd3_5_large / sd3_5_large_turbo / sd3_5_medium · sana_1600m / sana_sprint_1600m · flux1_schnell / flux1_dev / flux1_dev_control · flux2_klein_9b / flux2_klein_9b_edit / flux2_klein_9b_kv_edit / flux2_dev / flux2_dev_control / flux2_dev_edit · chroma1_base / chroma1_flash / chroma1_hd · ideogram_4 / ideogram_4_turbo · kolors · anima_base / anima_aesthetic / anima_turbo · boogu_image / boogu_image_turbo / boogu_image_edit · bernini · plus the previously-allowlisted sdxl · z_image / z_image_control / z_image_turbo / z_image_turbo_control · qwen_image / qwen_image_edit / qwen_image_control · lens / lens_turbo · krea_2_turbo / krea_2_raw / krea_2_edit / **krea_2_turbo_edit** (newly picked up) / krea_2_turbo_control.

Correctly **excluded** because their descriptors don't advertise the bit: **sensenova** (fused MoT, no separable text encoder — `footprint` te=0, residency buys nothing). `bernini_renderer` (Modality::Video) advertises the bit but never reaches the image fit-gate.

## 2. flux2_dev_edit guard — KEPT (not subsumed)

The `flux2_dev_edit_memory_guard` (`image_jobs/flux2.rs`) is **retained**. It models an *activation-bound*, per-reference, token-scaled peak (`BASE + PER_TOKEN·(1 + reference_count)·tokens_per_image`) for multi-reference edits — a term the general fit-gate **cannot express** (the fit-gate budgets on-disk *weight* bytes + a fixed 10 GB headroom, with no reference-count or sequence-length term). Sequential residency bounds the *weight* peak (which components are co-resident), which is orthogonal to multi-reference *activation* memory. Removing the guard would lose multi-reference OOM coverage (a 4-reference 1024² edit ~93 GB would slip past the weight-based gate on a 96 GB Mac and SIGKILL). This is exactly the carve-out sc-10840 anticipated ("a per-reference token-scaled estimate the footprint can't express").

## 3. Pins

- All `mlx-gen-*` + `sceneworks-gen-core`: `c9faefc` → **`45428fa`** (mlx-gen main; gen-core BYTE-IDENTICAL — `git diff c9faefc..45428fa -- gen-core/` is empty).
- All `candle-gen*`: `6709463` → **`ef84441`** — the **merged** head of candle-gen main (SceneWorks/candle-gen#506, now landed, which re-pins candle-gen's own gen-core to 45428fa). The pin flip from the pre-merge branch head `589a2c07` → `ef84441` is applied here; `589a2c07` no longer appears in `Cargo.toml`/`Cargo.lock`.
- `Cargo.lock` updated (62 git-source rev migrations; zero transitive crates.io churn).

## Tests

- Rewrote the fit-gate capability test: a macOS-gated assertion that every earlier-wired family **and** every sc-10840 fan-out family (e.g. `sd3_5_large`) resolves sequential-capable through the live registry, that a registered-but-non-advertising engine (`sensenova_u1_8b`) stays `false`, plus a cross-platform test that an unregistered id defaults to `false`.

## Verification (local, macOS — authoritative; the SceneWorks self-hosted lane is offline)

- `npm run rust:check` (fmt + clippy `-D warnings` + test + build) — green
- `scripts/check-gen-core-skew.sh` — single-rev `45428fa`
- `scripts/check-gen-core-skew.sh --features backend-candle` — single-rev `45428fa` (resolves gen-core through the merged candle-gen `ef84441` pin, confirming the cross-repo lockstep holds post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

