### PR TITLE
fix(worker): calibrate MLX fit-gate HEADROOM_GB from measured footprints (sc-10863)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6063,6 +6063,7 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
+ "tracing-subscriber",
  "uuid",
  "zip 2.4.2",
 ]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -576,6 +576,10 @@ uuid = { version = "1.11", features = ["v4"] }
 [dev-dependencies]
 axum = "0.7"
 tower = { version = "0.5", features = ["util"] }
+# sc-10863 fit-gate A/B: a stdout tracing subscriber so the `#[ignore]`d emulation A/B smoke
+# (`footprint_measure::fit_gate_ab_*`) surfaces the real `mlx_sequential_residency_selected`
+# decision event `apply_residency_policy` emits. Dev-only ⇒ never enters the worker binary.
+tracing-subscriber = { workspace = true }
 # sc-6541 closed-loop study: the LoRA eval harness (test-only, src/lora_eval_harness.rs) reuses
 # the canonical Dataset Doctor blur measurement (`scalars_from_image(..).blur_variance`) for the
 # output-sharpness Y axis. GPU-free path crate (image/imageproc/core), builds anywhere; dev-only

--- a/crates/sceneworks-worker/src/footprint_measure.rs
+++ b/crates/sceneworks-worker/src/footprint_measure.rs
@@ -268,7 +268,10 @@ const SDXL_SENTINEL: &str = "unet/diffusion_pytorch_model.safetensors";
 const SDXL_BF16_SENTINEL: &str = "unet/diffusion_pytorch_model.fp16.safetensors";
 // Lens turnkeys pack the DiT under transformer/diffusion_pytorch_model.safetensors …
 const LENS_SENTINEL: &str = "transformer/diffusion_pytorch_model.safetensors";
-// … while Z-Image turnkeys pack it under transformer/model.safetensors.
+// … but the DENSE bf16 lens-turbo DiT is SHARDED (diffusion_pytorch_model-0000N-of-0000M.safetensors),
+// so its tier-presence sentinel is the shard index file that the plain name would otherwise miss.
+const LENS_SHARDED_SENTINEL: &str = "transformer/diffusion_pytorch_model.safetensors.index.json";
+// … while Z-Image AND Qwen-Image turnkeys pack the DiT under transformer/model.safetensors.
 const ZIMAGE_SENTINEL: &str = "transformer/model.safetensors";
 
 #[test]
@@ -432,4 +435,183 @@ fn footprint_lens_turbo_q4() {
         &dir,
         turbo_request(4, Some(1.0)),
     );
+}
+
+// ── sc-10863 HEADROOM calibration set ─────────────────────────────────────────────────────────────
+// Four already-on-disk tiers spanning a small→large hold-all spread (illustrious q8 ~5 GiB → qwen-image
+// q8 ~36 GiB) drive the fit-gate `HEADROOM_GB` calibration: the gate predicts peak = Σon-disk-weights +
+// HEADROOM, so the measured `headroom = peakMemoryBytes − diskSizeBytes` (Σsafetensors) per tier fixes
+// the constant. Each RESIDENT hold-all peak is measured through the SAME `measure_footprint` seam as the
+// tiers above (default `LoadSpec` ⇒ `OffloadPolicy::Resident`, no fit-gate in the loop, no memory cap),
+// so the peak is the true hold-all ceiling over summed weights — not a Sequential-staged number.
+// illustrious q8 is covered by `footprint_illustrious_v{1,2}_q8` above; the other three are here.
+
+#[test]
+#[ignore = "footprint measurement; needs SceneWorks/lens-mlx q4 cached + an Apple-Silicon Mac"]
+fn footprint_lens_q4() {
+    // Base (non-turbo) lens: real CFG at 20 steps / guidance 5.0 (the `lens_base_q4_mlx_smoke` defaults).
+    let dir = resolve_tier_dir(
+        "FP_LENS_BASE_Q4_DIR",
+        "SceneWorks/lens-mlx",
+        "q4",
+        LENS_SENTINEL,
+    );
+    measure_footprint("lens", "q4", "lens", &dir, turbo_request(20, Some(5.0)));
+}
+
+#[test]
+#[ignore = "footprint measurement; needs SceneWorks/lens-turbo-mlx bf16 cached + an Apple-Silicon Mac"]
+fn footprint_lens_turbo_bf16() {
+    // Dense bf16 lens-turbo: SHARDED DiT ⇒ the shard-index sentinel. Turbo schedule (4 steps, CFG-scale 1).
+    let dir = resolve_tier_dir(
+        "FP_LENS_TURBO_BF16_DIR",
+        "SceneWorks/lens-turbo-mlx",
+        "bf16",
+        LENS_SHARDED_SENTINEL,
+    );
+    measure_footprint(
+        "lens_turbo",
+        "bf16",
+        "lens_turbo",
+        &dir,
+        turbo_request(4, Some(1.0)),
+    );
+}
+
+#[test]
+#[ignore = "footprint measurement; needs SceneWorks/qwen-image-mlx q8 cached + an Apple-Silicon Mac"]
+fn footprint_qwen_image_q8() {
+    // Qwen-Image base is a non-distilled true-CFG model (packs the DiT under transformer/model.safetensors
+    // like Z-Image). 1024², guidance 4.0; few steps (the peak is set by load + one denoise, not step count).
+    let dir = resolve_tier_dir(
+        "FP_QWEN_IMAGE_Q8_DIR",
+        "SceneWorks/qwen-image-mlx",
+        "q8",
+        ZIMAGE_SENTINEL,
+    );
+    measure_footprint(
+        "qwen_image",
+        "q8",
+        "qwen_image",
+        &dir,
+        turbo_request(8, Some(4.0)),
+    );
+}
+
+// ── sc-10863 emulation A/B: the calibrated HEADROOM_GB through the REAL cold-load gate ─────────────
+/// End-to-end check that the sc-10863-calibrated `HEADROOM_GB` behaves correctly through the exact gate
+/// the worker's cold-load path runs — `mlx_fit_gate::apply_residency_policy`, which `generator_cache.rs`
+/// invokes right before `gen_core::load` (the piece the pure `mlx_fit_gate` unit tests can't cover: the
+/// real on-disk byte sums + the live `SCENEWORKS_MLX_MEMORY_CAP_GB` budget resolution). Emulates three
+/// Mac sizes via the cap and asserts the decision at each, then runs a REAL generation on the Resident
+/// path so the calibrated value is confirmed against an actual load+gen, not just arithmetic:
+///   * cap BELOW even the staged peak ⇒ Reject with the actionable over-budget message (the reject event);
+///   * cap BETWEEN the staged and resident peaks ⇒ Sequential selected (emits
+///     `mlx_sequential_residency_selected`, surfaced on stdout by the dev-only tracing subscriber);
+///   * cap ABOVE the resident peak ⇒ Resident (spec unchanged) AND a real render succeeds.
+///
+/// Caps are derived from the SAME predictor the gate uses (`predicted_peak_gb` /
+/// `predicted_sequential_peak_gb`), so the A/B stays valid if `HEADROOM_GB` is retuned. Mutates the
+/// process-global cap env ⇒ `#[ignore]`d and run one-per-process like the footprint smokes.
+#[test]
+#[ignore = "sc-10863 fit-gate A/B; needs SceneWorks/illustrious-xl-v1-mlx q8 cached + an Apple-Silicon Mac"]
+fn fit_gate_ab_illustrious_q8() {
+    use crate::mlx_fit_gate::{
+        apply_residency_policy, predicted_peak_gb, predicted_sequential_peak_gb,
+        sum_safetensors_bytes, sum_text_encoder_bytes, MLX_MEMORY_CAP_ENV,
+    };
+    use gen_core::OffloadPolicy;
+
+    // Dev-only stdout subscriber so the real `mlx_sequential_residency_selected` INFO event is visible
+    // under --nocapture (the gate emits it via `tracing::info!` — silent without a subscriber).
+    let _ = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_target(false)
+        .without_time()
+        .try_init();
+
+    let dir = resolve_tier_dir(
+        "FP_ILL_V1_DIR",
+        "SceneWorks/illustrious-xl-v1-mlx",
+        "q8",
+        SDXL_SENTINEL,
+    );
+    // Illustrious loads on the sequential-capable `sdxl` engine, so all three outcomes are reachable.
+    let engine = "sdxl";
+    let disk = sum_safetensors_bytes(&dir);
+    let te = sum_text_encoder_bytes(&dir);
+    let resident_peak = predicted_peak_gb(disk).expect("weights measured");
+    let staged_peak = predicted_sequential_peak_gb(disk, te).expect("weights measured");
+    let gib = 1024.0 * 1024.0 * 1024.0;
+    assert!(
+        staged_peak < resident_peak,
+        "need a text-encoder split for a Sequential window (staged {staged_peak:.1} < resident {resident_peak:.1})"
+    );
+    println!(
+        "[ab] illustrious q8: disk {:.2} GiB, te {:.2} GiB ⇒ predicted resident peak {resident_peak:.1} GiB, staged peak {staged_peak:.1} GiB",
+        disk as f64 / gib,
+        te as f64 / gib,
+    );
+
+    let make_spec = || LoadSpec::new(WeightsSource::Dir(dir.to_path_buf())).with_quant(Quant::Q8);
+    let set_cap = |gb: f64| std::env::set_var(MLX_MEMORY_CAP_ENV, format!("{gb}"));
+
+    // (C) cap BELOW the staged peak ⇒ reject even one-component-at-a-time, with the actionable message.
+    let cap_reject = staged_peak - 2.0;
+    set_cap(cap_reject);
+    let err = apply_residency_policy(make_spec(), engine)
+        .expect_err("cap below the staged peak must reject");
+    let crate::WorkerError::InvalidPayload(msg) = &err else {
+        panic!("expected an actionable InvalidPayload reject, got {err:?}");
+    };
+    assert!(msg.contains("unified memory"), "actionable reject: {msg}");
+    assert!(
+        msg.contains("one component at a time"),
+        "reject names the staged requirement: {msg}"
+    );
+    println!("[ab] cap {cap_reject:.1} GiB (< staged) ⇒ REJECT: {msg}");
+
+    // (B) cap BETWEEN the staged and resident peaks ⇒ Sequential (won't fit resident, staged will).
+    let cap_seq = (staged_peak + resident_peak) / 2.0;
+    set_cap(cap_seq);
+    let spec = apply_residency_policy(make_spec(), engine).expect("staged fits ⇒ Ok(Sequential)");
+    assert_eq!(
+        spec.offload_policy,
+        OffloadPolicy::Sequential,
+        "a cap between staged and resident selects Sequential"
+    );
+    println!("[ab] cap {cap_seq:.1} GiB (staged < cap < resident) ⇒ SEQUENTIAL (mlx_sequential_residency_selected)");
+
+    // (A) cap ABOVE the resident peak ⇒ Resident, and a real generation confirms the calibrated value
+    //     lets the hold-all path actually load + render.
+    let cap_resident = resident_peak + 8.0;
+    set_cap(cap_resident);
+    let spec = apply_residency_policy(make_spec(), engine).expect("fits resident ⇒ Ok(Resident)");
+    assert_eq!(
+        spec.offload_policy,
+        OffloadPolicy::Resident,
+        "a cap above the resident peak keeps the warm Resident path"
+    );
+    println!(
+        "[ab] cap {cap_resident:.1} GiB (> resident) ⇒ RESIDENT; running a real generation ..."
+    );
+    let generator =
+        gen_core::load(engine, &spec).unwrap_or_else(|e| panic!("resident load: {e:?}"));
+    let output = generator
+        .generate(&sdxl_request(), &mut |_| {})
+        .unwrap_or_else(|e| panic!("resident generate: {e:?}"));
+    let image = match output {
+        GenerationOutput::Images(mut images) => images.pop().expect("engine returned no image"),
+        other => panic!("expected Images output, got {other:?}"),
+    };
+    let std = image_std(&image);
+    assert!(
+        std > DEGENERATE_STD_FLOOR_DEFAULT,
+        "resident render looks degenerate (std {std:.2})"
+    );
+    println!(
+        "[ab] RESIDENT generation ok (render std {std:.1}) — calibrated HEADROOM_GB confirmed through the real gate"
+    );
+
+    std::env::remove_var(MLX_MEMORY_CAP_ENV);
 }

--- a/crates/sceneworks-worker/src/footprint_measure.rs
+++ b/crates/sceneworks-worker/src/footprint_measure.rs
@@ -518,7 +518,7 @@ fn footprint_qwen_image_q8() {
 fn fit_gate_ab_illustrious_q8() {
     use crate::mlx_fit_gate::{
         apply_residency_policy, predicted_peak_gb, predicted_sequential_peak_gb,
-        sum_safetensors_bytes, sum_text_encoder_bytes, MLX_MEMORY_CAP_ENV,
+        resolve_text_encoder_bytes, sum_safetensors_bytes, MLX_MEMORY_CAP_ENV,
     };
     use gen_core::OffloadPolicy;
 
@@ -538,8 +538,19 @@ fn fit_gate_ab_illustrious_q8() {
     );
     // Illustrious loads on the sequential-capable `sdxl` engine, so all three outcomes are reachable.
     let engine = "sdxl";
+    let make_spec = || LoadSpec::new(WeightsSource::Dir(dir.to_path_buf())).with_quant(Quant::Q8);
     let disk = sum_safetensors_bytes(&dir);
-    let te = sum_text_encoder_bytes(&dir);
+    // Derive `te` through the SAME footprint-preferred path the gate uses
+    // (`resolve_text_encoder_bytes`), NOT the bare `text_encoder*` subdir scan. If sdxl's declared
+    // per-component footprint TE differs from the subdir sum, the gate's internal staged peak would
+    // shift off this test's midpoint `cap_seq` window (~0.7 GiB each side) and the Sequential assertion
+    // would flake. Querying the footprint here keeps the derived caps exactly on the gate's staged peak
+    // (sc-10863).
+    let footprint_te = gen_core::footprint(engine, &make_spec())
+        .ok()
+        .flatten()
+        .map(|fp| fp.text_encoder);
+    let te = resolve_text_encoder_bytes(footprint_te, &dir);
     let resident_peak = predicted_peak_gb(disk).expect("weights measured");
     let staged_peak = predicted_sequential_peak_gb(disk, te).expect("weights measured");
     let gib = 1024.0 * 1024.0 * 1024.0;
@@ -553,7 +564,6 @@ fn fit_gate_ab_illustrious_q8() {
         te as f64 / gib,
     );
 
-    let make_spec = || LoadSpec::new(WeightsSource::Dir(dir.to_path_buf())).with_quant(Quant::Q8);
     let set_cap = |gb: f64| std::env::set_var(MLX_MEMORY_CAP_ENV, format!("{gb}"));
 
     // (C) cap BELOW the staged peak ⇒ reject even one-component-at-a-time, with the actionable message.

--- a/crates/sceneworks-worker/src/mlx_fit_gate.rs
+++ b/crates/sceneworks-worker/src/mlx_fit_gate.rs
@@ -71,16 +71,47 @@ pub(crate) fn engine_supports_sequential(engine_id: &str) -> bool {
 /// as on real small hardware. Unset / non-positive ⇒ use the real `sysctl hw.memsize` total.
 pub(crate) const MLX_MEMORY_CAP_ENV: &str = "SCENEWORKS_MLX_MEMORY_CAP_GB";
 
-/// Headroom (GB) added on top of the summed on-disk component weights to cover MLX Metal activation
-/// spikes during denoise/decode plus the OS + other apps drawing from the same unified pool.
+/// Headroom (GiB) added on top of the summed on-disk component weights to cover the MLX Metal
+/// activation transient during denoise/decode plus the OS + other apps drawing from the same unified
+/// pool (the gate budgets against TOTAL physical RAM, so the OS share must come out of this headroom).
 ///
-/// PROVISIONAL — calibrate against `get_peak_memory` telemetry per the sc-10835 measurement
-/// sub-task. Anchor: the candle FLUX A/B (sc-10769) measured ~11 GB of transient over ~33 GB of
-/// resident weights at 1024²; a Mac additionally shares the pool with the OS + app. 10 GB is a
-/// deliberately conservative floor that keeps the gate from over-rejecting borderline models while
-/// still catching the genuinely-too-big ones; the real activation term scales with resolution and is
-/// refined once measured.
-const HEADROOM_GB: f64 = 10.0;
+/// CALIBRATED (sc-10863) from real `get_peak_memory` footprints measured through
+/// `footprint_measure.rs` (one tier per process; peak = load + one 1024² generation, RESIDENT
+/// hold-all path, no memory cap). Measured `transient = peak − resident` and `headroom = peak − disk`:
+///
+/// | model            | disk GiB | resident | peak  | transient | headroom(peak−disk) |
+/// |------------------|---------:|---------:|------:|----------:|--------------------:|
+/// | illustrious q8   |     5.01 |     4.74 | 18.78 |     14.04 |               13.77 |
+/// | lens q4          |    17.67 |    16.46 | 30.50 |     14.04 |               12.83 |
+/// | qwen-image q8    |    35.90 |    33.45 | 41.11 |      7.66 |                5.20 |
+/// | lens-turbo bf16  |    28.43 |    45.67 | 75.55 |     29.88 |               47.12 |
+///
+/// FINDING — the transient is NOT a function of on-disk weight bytes: qwen-image q8 has the LARGEST
+/// weights (35.9 GiB) but the SMALLEST transient (7.66 — its VAE decode is tiled, sc-11747), while
+/// illustrious q8 has the smallest weights but a 14 GiB transient. It is architecture- and
+/// resolution-bound (dominated by the VAE decode + attention at the output resolution), so a
+/// disk-SCALED predictor (`Σweights · k`) would over-reject the large-but-efficient models and
+/// under-predict the small ones — the wrong shape. And the load-time gate cannot see the request
+/// resolution (the generator is cached across resolutions), so a per-request `f(resolution)` term is
+/// not threadable at this seam. A conservative CONSTANT is therefore the right structure.
+///
+/// 18 GiB = the max measured transient at 1024² (14.04, illustrious q8 & lens q4) + ~4 GiB macOS/app
+/// reserve. This replaces the provisional 10.0, which UNDER-predicted 3 of the 4 measured tiers
+/// (illustrious 15.0<18.8, lens 27.7<30.5, lens-turbo 38.4<75.6) — i.e. was a latent SIGKILL risk on
+/// Macs sized between the predicted and the real peak. All three resident≈disk tiers are now covered
+/// with margin without over-rejecting a model that fits (illustrious q8: 5.01+18=23.0 still fits a
+/// 24 GiB Mac, where its real 18.8 GiB peak + OS does too).
+///
+/// NOT covered by this constant (surfaced sc-10863, tracked follow-ups — see the story): (1) IN-MEMORY
+/// WEIGHT EXPANSION — lens-turbo bf16's headroom is 47 because its mxfp4-on-disk gpt-oss text encoder
+/// loads to bf16 (resident 45.67 = 1.61× disk 28.43), so `sum_safetensors_bytes` under-counts the
+/// in-memory weights and the gate under-predicts this tier REGARDLESS of headroom (pre-existing: 10
+/// under-predicted it by 37 GiB, 18 by 33). A blanket bf16 expansion factor can't fix it (a bf16 tier
+/// whose encoder is bf16-on-disk would then be over-rejected ~1.6×); the real fix needs the weight-byte
+/// input to reflect in-memory size, per family, backed by bf16 measurements across models. (2) Output
+/// RESOLUTION > 1024² grows the VAE-decode transient past 14 GiB — all four points are 1024², so 18 is
+/// a 1024²-worst-case; a higher-res campaign is a follow-up.
+const HEADROOM_GB: f64 = 18.0;
 
 /// Bytes per binary gigabyte (GiB) — matches `gpu::total_unified_memory_gb`, which divides
 /// `hw.memsize` by 1024³, and the epic's measured on-disk table.
@@ -530,17 +561,20 @@ mod tests {
     #[test]
     fn fit_decision_rejects_only_a_genuine_overflow() {
         let budget = MemoryBudget { total_gb: 16.0 };
-        // qwen-image q8: ~36 GiB weights + 10 headroom = 46 ⇒ too big for a 16 GB Mac.
+        // qwen-image q8: ~36 GiB weights + 18 headroom (sc-10863) = 54 ⇒ too big for a 16 GB Mac.
         assert_eq!(
             fit_decision(predicted_peak_gb(36 * 1024 * 1024 * 1024_u64), Some(budget)),
             FitDecision::TooBig {
-                needed_gb: 46.0,
+                needed_gb: 36.0 + HEADROOM_GB,
                 available_gb: 16.0,
             }
         );
-        // A ~3 GiB model fits.
+        // A ~3 GiB model fits a roomy budget (3 + 18 headroom = 21 < 32).
         assert_eq!(
-            fit_decision(predicted_peak_gb(3 * 1024 * 1024 * 1024_u64), Some(budget)),
+            fit_decision(
+                predicted_peak_gb(3 * 1024 * 1024 * 1024_u64),
+                Some(MemoryBudget { total_gb: 32.0 })
+            ),
             FitDecision::Fits
         );
         // Exactly-fits is not a rejection: budget 46, need 46.
@@ -795,8 +829,8 @@ mod tests {
     #[test]
     fn decide_residency_picks_resident_sequential_or_reject_by_budget() {
         let gib = 1024 * 1024 * 1024_u64;
-        // illustrious q8-class: total ~5 GiB (TE ~1, DiT+VAE ~4). Resident peak = 5+10 = 15;
-        // staged peak = max(1, 4)+10 = 14.
+        // illustrious q8-class: total ~5 GiB (TE ~1, DiT+VAE ~4). With HEADROOM_GB=18 (sc-10863):
+        // resident peak = 5+18 = 23; staged peak = max(1, 4)+18 = 22.
         let total = 5 * gib;
         let te = gib;
 
@@ -805,23 +839,23 @@ mod tests {
             decide_residency(total, te, Some(MemoryBudget { total_gb: 128.0 }), true),
             ResidencyOutcome::Resident
         );
-        // Budget between staged (14) and resident (15): resident won't fit, staged will, provider
+        // Budget between staged (22) and resident (23): resident won't fit, staged will, provider
         // stages ⇒ Sequential. This is the fit-gate SELECTING sequential residency.
         assert_eq!(
-            decide_residency(total, te, Some(MemoryBudget { total_gb: 14.5 }), true),
+            decide_residency(total, te, Some(MemoryBudget { total_gb: 22.5 }), true),
             ResidencyOutcome::Sequential
         );
         // Same budget but a provider that can't stage ⇒ reject (never a silent Resident that OOMs).
         assert!(matches!(
-            decide_residency(total, te, Some(MemoryBudget { total_gb: 14.5 }), false),
+            decide_residency(total, te, Some(MemoryBudget { total_gb: 22.5 }), false),
             ResidencyOutcome::Reject {
                 staged_gb: None,
                 ..
             }
         ));
-        // Budget below even the staged peak ⇒ reject, naming the staged requirement.
+        // Budget below even the staged peak (22) ⇒ reject, naming the staged requirement.
         assert!(matches!(
-            decide_residency(total, te, Some(MemoryBudget { total_gb: 12.0 }), true),
+            decide_residency(total, te, Some(MemoryBudget { total_gb: 20.0 }), true),
             ResidencyOutcome::Reject {
                 staged_gb: Some(_),
                 ..
@@ -935,10 +969,11 @@ mod tests {
         // boogu-class: whole model 22 GiB (mllm 13 + transformer 8 + vae 1). No `text_encoder*` subdir,
         // so the subdir scan reads 0.
         let total = 22 * gib;
-        let budget = Some(MemoryBudget { total_gb: 25.0 });
+        // Budget between the staged (31) and resident (40) peaks under HEADROOM_GB=18 (sc-10863).
+        let budget = Some(MemoryBudget { total_gb: 34.0 });
 
         // Fallback path (footprint None on a dir with no `text_encoder*`) → te = 0 → staged == resident
-        // peak (22 + 10 = 32) > 25 → Reject, even though one-component-at-a-time WOULD fit.
+        // peak (22 + 18 = 40) > 34 → Reject, even though one-component-at-a-time WOULD fit.
         let te_fallback = resolve_text_encoder_bytes(None, std::path::Path::new("/nonexistent"));
         assert_eq!(te_fallback, 0);
         assert!(matches!(
@@ -946,7 +981,7 @@ mod tests {
             ResidencyOutcome::Reject { .. }
         ));
 
-        // Provider footprint (te = 13 GiB) → staged = max(13, 22 − 13 = 9) + 10 = 23 ≤ 25 → Sequential.
+        // Provider footprint (te = 13 GiB) → staged = max(13, 22 − 13 = 9) + 18 = 31 ≤ 34 → Sequential.
         let te_footprint =
             resolve_text_encoder_bytes(Some(13 * gib), std::path::Path::new("/ignored"));
         assert_eq!(te_footprint, 13 * gib);

--- a/crates/sceneworks-worker/src/mlx_fit_gate.rs
+++ b/crates/sceneworks-worker/src/mlx_fit_gate.rs
@@ -95,20 +95,29 @@ pub(crate) const MLX_MEMORY_CAP_ENV: &str = "SCENEWORKS_MLX_MEMORY_CAP_GB";
 /// resolution (the generator is cached across resolutions), so a per-request `f(resolution)` term is
 /// not threadable at this seam. A conservative CONSTANT is therefore the right structure.
 ///
-/// 18 GiB = the max measured transient at 1024² (14.04, illustrious q8 & lens q4) + ~4 GiB macOS/app
-/// reserve. This replaces the provisional 10.0, which UNDER-predicted 3 of the 4 measured tiers
-/// (illustrious 15.0<18.8, lens 27.7<30.5, lens-turbo 38.4<75.6) — i.e. was a latent SIGKILL risk on
-/// Macs sized between the predicted and the real peak. All three resident≈disk tiers are now covered
-/// with margin without over-rejecting a model that fits (illustrious q8: 5.01+18=23.0 still fits a
-/// 24 GiB Mac, where its real 18.8 GiB peak + OS does too).
+/// 18 GiB = the max COMMON-CASE transient at 1024² (14.04, illustrious q8 & lens q4 — the three
+/// resident≈disk tiers; lens-turbo's larger 29.88 transient is a separate architecture outlier, below)
+/// plus a ~4 GiB macOS/app reserve. This replaces the provisional 10.0, which UNDER-predicted 3 of the
+/// 4 measured tiers (illustrious 15.0<18.8, lens 27.7<30.5, lens-turbo 38.4<75.6) — i.e. was a latent
+/// SIGKILL risk on Macs sized between the predicted and the real peak. All three resident≈disk tiers
+/// are now covered with margin without over-rejecting a model that fits (illustrious q8: 5.01+18=23.0
+/// still fits a 24 GiB Mac, where its real 18.8 GiB peak + OS does too).
 ///
-/// NOT covered by this constant (surfaced sc-10863, tracked follow-ups — see the story): (1) IN-MEMORY
-/// WEIGHT EXPANSION — lens-turbo bf16's headroom is 47 because its mxfp4-on-disk gpt-oss text encoder
-/// loads to bf16 (resident 45.67 = 1.61× disk 28.43), so `sum_safetensors_bytes` under-counts the
-/// in-memory weights and the gate under-predicts this tier REGARDLESS of headroom (pre-existing: 10
-/// under-predicted it by 37 GiB, 18 by 33). A blanket bf16 expansion factor can't fix it (a bf16 tier
-/// whose encoder is bf16-on-disk would then be over-rejected ~1.6×); the real fix needs the weight-byte
-/// input to reflect in-memory size, per family, backed by bf16 measurements across models. (2) Output
+/// NOT covered by this constant (surfaced sc-10863, tracked follow-ups — see the story): (1) the
+/// lens-turbo bf16 OUTLIER, whose 47.12 GiB headroom (peak 75.55 − disk 28.43) is NOT one effect but
+/// TWO that must be modeled together. It DECOMPOSES as (a) 17.24 GiB IN-MEMORY WEIGHT EXPANSION
+/// (resident 45.67 − disk 28.43) — its mxfp4-on-disk gpt-oss text encoder expands loading to bf16
+/// (45.67 = 1.61× disk 28.43), so `sum_safetensors_bytes` under-counts the in-memory weights — PLUS
+/// (b) a 29.88 GiB ACTIVATION TRANSIENT (peak 75.55 − resident 45.67), which is architecture-bound (the
+/// large gpt-oss encoder's activations) and ~2× the ~14 GiB the other three tiers show at the same
+/// 1024². HEADROOM=18 covers the common-case transient (~14) + ~4 GiB OS/app reserve, but UNDER-predicts
+/// this class by ~29 GiB even AFTER a weight-byte correction — because the 29.88 transient ALONE exceeds
+/// 18 (75.55 − (28.43 + 18) = 29.12; the old provisional 10 under-predicted it by ~37: 75.55 −
+/// (28.43 + 10) = 37.12). So correcting only the weight bytes is INSUFFICIENT: both the in-memory weight
+/// size AND the outsized transient must be modeled for these tiers. (A blanket bf16 expansion factor
+/// also can't fix the weight half — a bf16 tier whose encoder is bf16-on-disk would then be
+/// over-rejected ~1.6× — so that fix needs per-family in-memory weight sizing plus a per-architecture
+/// transient term, backed by bf16 measurements across models.) Tracked in sc-11924. (2) Output
 /// RESOLUTION > 1024² grows the VAE-decode transient past 14 GiB — all four points are 1024², so 18 is
 /// a 1024²-worst-case; a higher-res campaign is a follow-up.
 const HEADROOM_GB: f64 = 18.0;


### PR DESCRIPTION
## sc-10863 — Calibrate MLX fit-gate `HEADROOM_GB` from measured footprints

Worker-only (epic 10834). Replaces the provisional `HEADROOM_GB = 10.0` in `crates/sceneworks-worker/src/mlx_fit_gate.rs` with a **measured 18.0**. No pin bump, no candle-gen change.

### Measured footprints
`footprint_measure.rs`, one tier per process (MLX peak counter is process-global), 1024², RESIDENT hold-all path (default `LoadSpec`, no memory cap — so the gate never auto-selects Sequential during measurement). `headroom = peak − disk`; `transient = peak − resident`.

| model | disk GiB | resident | peak | transient | headroom (peak−disk) |
|---|---:|---:|---:|---:|---:|
| illustrious q8 | 5.01 | 4.74 | 18.78 | 14.04 | 13.77 |
| lens q4 | 17.67 | 16.46 | 30.50 | 14.04 | 12.83 |
| qwen-image q8 | 35.90 | 33.45 | 41.11 | 7.66 | 5.20 |
| lens-turbo bf16 | 28.43 | 45.67 | 75.55 | 29.88 | 47.12 |

### Decision: **constant `HEADROOM_GB = 18`** (not scaled)
- Headroom does **not** scale with on-disk weight bytes: qwen-image has the *largest* weights (35.9 GiB) but the *smallest* transient (7.66 — its VAE decode is tiled, sc-11747); illustrious the smallest weights but a 14 GiB transient. So `Σweights·k` is the wrong shape (it would over-reject large-but-efficient models and under-predict small ones). The load-time gate also can't see the request resolution (the generator is cached across resolutions), so an `f(resolution)` term isn't threadable here → a conservative **constant** is the right structure.
- `18` = the max measured 1024² transient (**14.04**, illustrious q8 & lens q4) + ~4 GiB macOS/app reserve (the gate budgets against *total* physical RAM, so the OS share comes out of headroom).
- The provisional `10` **under-predicted 3 of 4 measured tiers** (illustrious 15.0<18.8, lens 27.7<30.5, lens-turbo 38.4<75.6) — a latent SIGKILL risk this closes for the resident≈disk tiers, without over-rejecting a model that fits (illustrious q8: 5.01+18=23 still fits a 24 GiB Mac, where its real 18.8 GiB peak + OS does too).

### Emulation A/B (through the real gate path)
`fit_gate_ab_illustrious_q8` drives the exact `apply_residency_policy` that `generator_cache.rs` invokes on the cold-load path, under `SCENEWORKS_MLX_MEMORY_CAP_GB`, with caps derived from the gate's own predictor:
- **cap 19.9** (< staged 21.9) → **REJECT**: *"sdxl needs ~23 GB of unified memory (~22 GB even loading one component at a time)… but this machine has ~20 GB. Choose a smaller quant tier, lower the output resolution, or run on a Mac with more memory."*
- **cap 22.5** (staged < cap < resident 23) → **SEQUENTIAL** — `mlx_sequential_residency_selected` fired (`engine=sdxl budget_gb=22`).
- **cap 31** (> resident) → **RESIDENT** + a real generation succeeded (render std 81.3).

### Not covered by the constant (surfaced, tracked follow-ups)
- **sc-11924** (bug): the lens-turbo bf16 outlier (peak 75.55 vs disk 28.43, headroom **47.12**) is **two effects that must be modeled together**, not one. It decomposes as **(a) 17.24 GiB in-memory weight expansion** (resident 45.67 − disk 28.43) — its mxfp4-on-disk gpt-oss text encoder loads to bf16 (45.67 = 1.61× disk), so `sum_safetensors_bytes` under-counts in-memory weights — **plus (b) a 29.88 GiB activation transient** (peak 75.55 − resident 45.67), which is architecture-bound (the large gpt-oss encoder's activations), ~2× the ~14 GiB the other three tiers show at 1024². HEADROOM=18 under-predicts this class by **~29 GiB even *after* a weight-byte correction** — because the 29.88 transient *alone* exceeds 18 (75.55 − (28.43 + 18) = 29.12; the old 10 under-predicted it by ~37). So correcting only the weight bytes is **insufficient**: both the in-memory weight size **and** the outsized transient must be modeled for these tiers. (A blanket bf16 factor can't fix the weight half either — it would over-reject bf16-on-disk-encoder tiers ~1.6×.) Needs per-family in-memory weight sizing + a per-architecture transient term, backed by bf16 measurements across families.
- **sc-11925** (chore): all four points are 1024²; the VAE-decode transient grows with output resolution → measure >1024² and decide whether to raise the floor or add a generate-time check.

### Validation
- `mlx_fit_gate` unit tests updated for the new headroom (17 passed).
- `npm run rust:check` (fmt + clippy `--all-targets -D warnings` + test + build) green.
- All four footprint measurements + the A/B ran on this Apple-Silicon dev box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

