### PR TITLE
fix(studios): apply preset LoRAs and standardize LoRA weight range

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -636,6 +636,12 @@ pub(crate) struct ImageJobRequest {
     pub(crate) style_preset: String,
     #[serde(default)]
     pub(crate) recipe_preset_id: Option<String>,
+    // The web studio seeds a selected preset's LoRAs straight into `loras`, so it — not the
+    // server — is authoritative for which preset LoRAs apply. When set, the preset-LoRA merge
+    // is skipped so an edited or removed preset LoRA sticks. Headless/API clients omit it and
+    // keep the server-side merge.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) preset_loras_resolved_client_side: Option<bool>,
     #[serde(default)]
     pub(crate) loras: Vec<Value>,
     #[serde(default)]
@@ -764,6 +770,10 @@ pub(crate) struct VideoJobRequest {
     pub(crate) seed: Option<i64>,
     #[serde(default)]
     pub(crate) recipe_preset_id: Option<String>,
+    // See ImageJobRequest::preset_loras_resolved_client_side — the studio seeds preset LoRAs
+    // into `loras`, so the server skips its merge when this is set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) preset_loras_resolved_client_side: Option<bool>,
     #[serde(default)]
     pub(crate) loras: Vec<Value>,
     #[serde(default)]

--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -271,6 +271,7 @@ pub(crate) async fn apply_recipe_preset_to_image_payload(
         preset,
         job_payload,
         Some(snapshot),
+        payload.preset_loras_resolved_client_side.unwrap_or(false),
     )
     .await
 }
@@ -279,6 +280,13 @@ pub(crate) async fn apply_recipe_preset_to_image_payload(
 /// skipping ids that are already present. Records ids the catalog can't resolve
 /// under advanced.presetMissingLoras and stamps advanced.recipePresetId. Shared
 /// by the image and video job paths so preset-LoRA semantics stay identical.
+///
+/// When `client_resolved` is set (the web studio seeds a selected preset's LoRAs
+/// straight into `loras` and sends presetLorasResolvedClientSide), the client is
+/// authoritative for the preset's LoRAs — including weight edits and removals — so
+/// the merge is skipped and `loras` is left exactly as sent; only the advanced
+/// recipePresetId stamp is applied. Headless/API clients that send only
+/// recipePresetId leave the flag unset and get the server-side merge.
 pub(crate) async fn merge_preset_loras_into_payload(
     state: &AppState,
     project_id: &str,
@@ -286,7 +294,33 @@ pub(crate) async fn merge_preset_loras_into_payload(
     preset: &Value,
     job_payload: &mut JsonObject,
     snapshot: Option<&JobCatalogSnapshot>,
+    client_resolved: bool,
 ) -> Result<(), ApiError> {
+    // Stamp the resolved preset id onto advanced regardless of who owns the LoRAs.
+    let advanced = job_payload
+        .entry("advanced".to_owned())
+        .or_insert_with(|| Value::Object(JsonObject::new()));
+    if !advanced.is_object() {
+        *advanced = Value::Object(JsonObject::new());
+    }
+    let advanced = advanced
+        .as_object_mut()
+        .ok_or_else(|| ApiError::internal("advanced payload must be an object"))?;
+    advanced.insert(
+        "recipePresetId".to_owned(),
+        Value::String(preset_id.to_owned()),
+    );
+    advanced.remove("recipePresetName");
+    advanced.remove("recipePresetPrompt");
+
+    // Client owns the preset LoRAs — leave `loras` untouched. There's no server-resolved
+    // "missing" set in this path (the studio only seeds LoRAs it can actually apply), so
+    // clear any stale marker and return.
+    if client_resolved {
+        advanced.remove("presetMissingLoras");
+        return Ok(());
+    }
+
     // Reuse the request-scoped LoRA catalog snapshot when threaded (sc-8819), else build
     // fresh. Both paths see identical catalog contents.
     let loras = match snapshot {
@@ -323,21 +357,12 @@ pub(crate) async fn merge_preset_loras_into_payload(
         preset_loras.push(serialize_preset_lora(lora, &preset_lora, lora_id));
         seen_lora_ids.push(lora_id.to_owned());
     }
+
+    // Re-borrow advanced (the stamp borrow above has ended) to record any unresolved ids.
     let advanced = job_payload
-        .entry("advanced".to_owned())
-        .or_insert_with(|| Value::Object(JsonObject::new()));
-    if !advanced.is_object() {
-        *advanced = Value::Object(JsonObject::new());
-    }
-    let advanced = advanced
-        .as_object_mut()
+        .get_mut("advanced")
+        .and_then(Value::as_object_mut)
         .ok_or_else(|| ApiError::internal("advanced payload must be an object"))?;
-    advanced.insert(
-        "recipePresetId".to_owned(),
-        Value::String(preset_id.to_owned()),
-    );
-    advanced.remove("recipePresetName");
-    advanced.remove("recipePresetPrompt");
     if missing_lora_ids.is_empty() {
         advanced.remove("presetMissingLoras");
     } else {
@@ -420,6 +445,7 @@ pub(crate) async fn apply_recipe_preset_to_video_payload(
         preset,
         job_payload,
         Some(snapshot),
+        payload.preset_loras_resolved_client_side.unwrap_or(false),
     )
     .await
 }

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -2214,6 +2214,149 @@ async fn preset_image_job_builds_each_catalog_once() {
 }
 
 #[tokio::test]
+async fn preset_image_job_skips_server_lora_merge_when_client_resolved() {
+    // The web studio seeds a selected preset's LoRAs into the visible picker and sends them in
+    // `loras`, so it — not the server — is authoritative for which preset LoRAs apply. When it
+    // also sends presetLorasResolvedClientSide, the server must NOT re-merge the preset's LoRAs:
+    // that is what lets a user REMOVE a preset LoRA (send it absent) and have the removal stick,
+    // instead of the server silently adding it back. Headless clients that omit the flag keep the
+    // server-side merge (covered by preset_image_job_builds_each_catalog_once).
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "models": [
+            {
+              "id": "img-model",
+              "name": "Img Model",
+              "family": "z-image",
+              "type": "image",
+              "adapter": "z_image",
+              "capabilities": ["text_to_image"],
+              "downloads": [
+                { "provider": "huggingface", "repo": "owner/img", "files": ["*.safetensors"], "default": true }
+              ],
+              "paths": {},
+              "defaults": {},
+              "limits": {},
+              "loraCompatibility": { "families": ["z-image"] },
+              "ui": { "label": "Img" }
+            }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin models writes");
+    std::fs::write(
+        config_dir.join("user.models.jsonc"),
+        r#"{ "schemaVersion": 1, "models": [] }"#,
+    )
+    .expect("user models writes");
+    std::fs::write(
+        config_dir.join("builtin.loras.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "loras": [
+            {
+              "id": "style-lora",
+              "name": "Style LoRA",
+              "family": "z-image",
+              "triggerWords": ["style"],
+              "compatibility": { "families": ["z-image"] },
+              "source": { "provider": "local", "path": "loras/style.safetensors" }
+            }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin loras writes");
+    std::fs::write(
+        config_dir.join("user.loras.jsonc"),
+        r#"{ "schemaVersion": 1, "loras": [] }"#,
+    )
+    .expect("user loras writes");
+    std::fs::write(
+        config_dir.join("builtin.recipe-presets.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "presets": [
+            {
+              "id": "dream_style",
+              "name": "Dream Style",
+              "workflow": "text_to_image",
+              "model": "img-model",
+              "defaults": { "count": 1, "resolution": "1024x1024" },
+              "prompt": { "prefix": "cinematic" },
+              "loras": [{ "id": "style-lora", "weight": 0.5 }]
+            }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin recipe presets writes");
+    std::fs::write(
+        config_dir.join("user.recipe-presets.jsonc"),
+        r#"{ "schemaVersion": 1, "presets": [] }"#,
+    )
+    .expect("user recipe presets writes");
+    let lora_dir = temp_dir.path().join("data/loras");
+    std::fs::create_dir_all(&lora_dir).expect("lora dir creates");
+    write_test_safetensors(&lora_dir.join("style.safetensors"));
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Client Resolved Preset Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id").to_owned();
+
+    // The client selected the preset (recipePresetId) but removed its only LoRA in the picker, so
+    // it sends an empty `loras` plus the client-resolved flag.
+    let (status, image_job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/image/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_image",
+            "prompt": "a fox",
+            "model": "img-model",
+            "count": 1,
+            "width": 1024,
+            "height": 1024,
+            "recipePresetId": "dream_style",
+            "presetLorasResolvedClientSide": true,
+            "loras": []
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "job created: {image_job:?}");
+
+    // The preset prompt is still folded in and the preset id is stamped, but the server left the
+    // client's (empty) `loras` untouched — style-lora was NOT re-added.
+    assert_eq!(image_job["payload"]["prompt"], "cinematic, a fox");
+    assert_eq!(
+        image_job["payload"]["advanced"]["recipePresetId"],
+        "dream_style"
+    );
+    assert_eq!(
+        image_job["payload"]["loras"],
+        json!([]),
+        "client-resolved preset LoRAs must not be re-merged by the server"
+    );
+}
+
+#[tokio::test]
 async fn generation_routes_reject_invalid_payloads() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let app = create_app(test_settings(&temp_dir)).expect("app creates");

--- a/apps/web/src/App.imageGeneration.test.jsx
+++ b/apps/web/src/App.imageGeneration.test.jsx
@@ -778,7 +778,7 @@ describe("SceneWorks app shell", () => {
     expect(createImageJob).not.toHaveBeenCalled();
   });
 
-  it("applies preset defaults and hidden preset LoRAs to image jobs", async () => {
+  it("applies preset defaults and seeds the preset's LoRAs into the visible picker for image jobs", async () => {
     const createImageJob = vi.fn();
     root = createRoot(container);
     await act(async () => {
@@ -799,7 +799,6 @@ describe("SceneWorks app shell", () => {
               family: "z-image",
               scope: "builtin",
               defaultWeight: 0.55,
-              presetManaged: true,
             },
           ],
           onPreview: () => {},
@@ -832,12 +831,22 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Cinematic");
     expect(container.textContent).toContain("Balanced cinematic color, contrast, and detail.");
     expect(container.textContent).toContain("Adds: cinematic lighting");
-    expect(container.textContent).toContain("Preset LoRA applied at generation: Cinematic Detail");
+    // The preset's installed LoRA is now seeded into the visible picker (not hidden), so the
+    // guidance strip no longer claims it's "applied at generation" — it's a normal selection.
+    expect(container.textContent).not.toContain("Preset LoRA applied at generation");
+    // Open Advanced (where the LoRA rail lives): the preset's LoRA is a real selection sitting
+    // at the preset's weight (0.4), ready to retune.
+    await act(async () => {
+      document.body.querySelector(".advanced-section-toggle").click();
+    });
+    expect(document.body.querySelector(".lora-slot-weight-value").textContent).toBe("0.40");
 
     await act(async () => {
       [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Generate").click();
     });
 
+    // The seeded preset LoRA rides in `loras` at its preset weight, and the client tells the
+    // server it already resolved the preset's LoRAs so the server won't re-merge them.
     expect(createImageJob).toHaveBeenCalledWith(
       expect.objectContaining({
         count: 2,
@@ -846,10 +855,18 @@ describe("SceneWorks app shell", () => {
         negativePrompt: "flat lighting",
         prompt: "A cinematic frame of a neon street at midnight",
         recipePresetId: "cinematic",
-        loras: [],
+        presetLorasResolvedClientSide: true,
+        loras: [expect.objectContaining({ id: "cinematic_detail", weight: 0.4 })],
         advanced: { resolution: "1280x720" },
       }),
     );
+
+    // Deselecting the preset (→ None) removes the LoRA it seeded — the picker restores to the
+    // pre-preset selection (empty here), so the seed is a reversible overlay, not a one-way dump.
+    await act(async () => {
+      [...document.body.querySelectorAll(".preset-chip")].find((chip) => chip.textContent.trim() === "None").click();
+    });
+    expect(document.body.querySelector(".lora-slot-weight-value")).toBeNull();
   });
 
   it("prefills Image Studio from a saved generation recipe launch without reusing the seed", async () => {
@@ -2120,6 +2137,12 @@ describe("SceneWorks app shell", () => {
     await settle();
     const weightSlider = document.body.querySelector(".lora-slot-weight input[type=range]");
     expect(weightSlider).toBeTruthy();
+    // The weight slider is the shared bidirectional -2..2 range (LORA_WEIGHT_*), not the
+    // old 0..2 — slider LoRAs run negative for the inverse direction, and the range must
+    // match the studios, the Preset Manager, and the recipe-preset normalizer (a preset
+    // LoRA stuck at the old center of 0 generated at scale 0 and looked "not applied").
+    expect(weightSlider.getAttribute("min")).toBe("-2");
+    expect(weightSlider.getAttribute("max")).toBe("2");
     expect(document.body.querySelector(".lora-slot-weight-value").textContent).toBe("0.80");
     await changeField(weightSlider, "0.5");
 

--- a/apps/web/src/App.videoPresets.test.jsx
+++ b/apps/web/src/App.videoPresets.test.jsx
@@ -194,7 +194,9 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Dream Motion");
     expect(container.textContent).toContain("Soft camera motion.");
     expect(container.textContent).toContain("Adds: smooth camera motion");
-    expect(container.textContent).toContain("Preset LoRA applied at generation: Video Motion");
+    // The preset's installed LoRA is seeded into the visible picker, so the strip no longer
+    // claims it's applied invisibly at generation.
+    expect(container.textContent).not.toContain("Preset LoRA applied at generation");
 
     await act(async () => {
       [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Render clip").click();
@@ -209,11 +211,13 @@ describe("SceneWorks app shell", () => {
         quality: "best",
         negativePrompt: "jitter",
         recipePresetId: "dream_motion",
-        // Preset prompt prefix/suffix and preset LoRAs are now folded in
-        // server-side from recipePresetId, so the client sends the raw prompt
-        // and only its own picker selections (none here).
+        // The preset prompt prefix/suffix is still folded in server-side from recipePresetId,
+        // so the client sends the raw prompt. The preset's LoRA, though, is now a visible
+        // picker selection: it rides in `loras` at its resolved weight and the client flags
+        // presetLorasResolvedClientSide so the server won't re-merge it.
         prompt: "Camera slowly pushes in while the scene comes alive",
-        loras: [],
+        presetLorasResolvedClientSide: true,
+        loras: [expect.objectContaining({ id: "video_motion", weight: 0.8 })],
         advanced: expect.objectContaining({
           resolution: "1280x720",
         }),

--- a/apps/web/src/components/LoraPickerField.jsx
+++ b/apps/web/src/components/LoraPickerField.jsx
@@ -1,6 +1,14 @@
 import React from "react";
 import { LoraKeywordSummary } from "./LoraKeywordSummary.jsx";
-import { MAX_JOB_LORAS_TOTAL, loraMatchesModel, loraWeight, serializeLora } from "../presetUtils.js";
+import {
+  LORA_WEIGHT_MAX,
+  LORA_WEIGHT_MIN,
+  LORA_WEIGHT_STEP,
+  MAX_JOB_LORAS_TOTAL,
+  loraMatchesModel,
+  loraWeight,
+  serializeLora,
+} from "../presetUtils.js";
 
 // The per-job total cap (sc-8936): this Character Studio picker doesn't distinguish
 // builtin vs user LoRAs, so it gates on the hard total the worker enforces.
@@ -95,10 +103,10 @@ export function LoraPickerField({ selection, label = "Style LoRAs (optional)" })
                   <span>Weight</span>
                   <input
                     aria-label={`${lora.name ?? lora.id} weight`}
-                    max="2"
-                    min="0"
+                    max={LORA_WEIGHT_MAX}
+                    min={LORA_WEIGHT_MIN}
                     onChange={(event) => setWeight(lora.id, Number(event.target.value))}
-                    step="0.05"
+                    step={LORA_WEIGHT_STEP}
                     type="range"
                     value={weight}
                   />

--- a/apps/web/src/imageJobRequest.js
+++ b/apps/web/src/imageJobRequest.js
@@ -102,6 +102,12 @@ export function buildImageJobRequest(state) {
     width: resolutionOverride?.width ?? width,
     height: resolutionOverride?.height ?? height,
     recipePresetId,
+    // The studio seeds a selected preset's LoRAs straight into the visible `loras` above
+    // (generationStudio's preset-LoRA seed effect), so the client — not the server — is
+    // authoritative for which preset LoRAs apply and at what weight. This flag tells the
+    // server to skip its own preset-LoRA merge so an edited or removed preset LoRA sticks.
+    // Headless/API clients that send only recipePresetId omit it and keep the server merge.
+    presetLorasResolvedClientSide: recipePresetId ? true : undefined,
     characterId: mode === "character_image" ? characterId || null : null,
     characterLookId: mode === "character_image" ? characterLookId || null : null,
     // edit_image: a single source image, except for a multi-reference model (sc-6211,

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -17,6 +17,21 @@ export const MAX_JOB_LORAS_TOTAL = 5;
 export const MAX_USER_JOB_LORAS = 4;
 export const MAX_PRESET_LORAS = 5;
 
+// LoRA apply-weight slider bounds. Single source of truth so the range can't drift
+// between surfaces — it used to: the studios' pickers were 0..2 while the Preset
+// Manager (and character-LoRA editor) were -2..2, and a preset LoRA that landed on
+// the -2..2 slider's *center* (0) generated at scale 0 with no effect, reading as
+// "the preset's LoRA isn't applied". The scale is bidirectional on purpose: many
+// LoRAs (Civitai "slider" LoRAs — Detail Tweaker, age/weight/style axes) are trained
+// to be run negative for the inverse direction, and 0 is a valid neutral. Applies to
+// user-selected LoRA weights only; specialized magnitude knobs (edit/identity
+// strength, ControlNet pose-lock) keep their own semantics-specific ranges. The
+// recipe-preset normalizer (apps/rust-api/src/recipe_presets.rs) accepts the same
+// -2..=2 band. The worker applies the weight as a raw adapter scale (no clamp).
+export const LORA_WEIGHT_MIN = -2;
+export const LORA_WEIGHT_MAX = 2;
+export const LORA_WEIGHT_STEP = 0.05;
+
 export function rememberPresetDefault(snapshots, key, currentValue, appliedValue) {
   const previousSnapshot = snapshots.current[key];
   snapshots.current[key] = {
@@ -296,6 +311,32 @@ export function loraWeight(lora, presetLora = {}) {
   const fallback = loraFamilies(lora).includes("krea-2") ? KREA_LORA_DEFAULT_WEIGHT : 0.8;
   const value = Number(presetLora.weight ?? lora?.defaultWeight ?? lora?.weight ?? fallback);
   return Number.isFinite(value) ? value : fallback;
+}
+
+// Resolve a preset's declared LoRAs into [{ id, weight }] entries ready to seed into the
+// studio's visible LoRA picker. Only LoRAs present in `catalogLoras` (the studio's
+// installed + model-compatible set) are returned — a preset LoRA that isn't installed or
+// isn't compatible can't be a live selection, so it's left out (the preset guidance strip
+// still surfaces it). Weight resolution matches the server's preset_lora_weight (explicit
+// preset weight → catalog defaultWeight/weight → family fallback), so the seeded weight is
+// exactly what a plain preset job would have applied.
+export function presetLoraSeedEntries(preset, catalogLoras = []) {
+  const byId = new Map(catalogLoras.map((lora) => [lora.id, lora]));
+  const entries = [];
+  const seen = new Set();
+  for (const presetLora of presetLoras(preset)) {
+    const id = presetLoraId(presetLora);
+    if (!id || seen.has(id)) {
+      continue;
+    }
+    const catalogLora = byId.get(id);
+    if (!catalogLora) {
+      continue;
+    }
+    seen.add(id);
+    entries.push({ id, weight: loraWeight(catalogLora, presetLora) });
+  }
+  return entries;
 }
 
 export function serializePresetLora(lora, presetLora = {}) {

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -10,7 +10,14 @@ import { assetUrl, assetCanRenderAsImage } from "../components/assetMedia.jsx";
 import { DatasetAddDialog } from "../components/DatasetAddDialog.jsx";
 import { FitModeControl, effectiveFitMode } from "../components/FitModeControl.jsx";
 import { useLoraSelection } from "../components/LoraPickerField.jsx";
-import { MAX_JOB_LORAS_TOTAL, findModelEditLora, loraIsInstalled } from "../presetUtils.js";
+import {
+  LORA_WEIGHT_MAX,
+  LORA_WEIGHT_MIN,
+  LORA_WEIGHT_STEP,
+  MAX_JOB_LORAS_TOTAL,
+  findModelEditLora,
+  loraIsInstalled,
+} from "../presetUtils.js";
 import { guidanceDefaultFromModel } from "../samplerOptions.js";
 import {
   BLEND_MODES,
@@ -2975,10 +2982,10 @@ export function ImageEditor() {
                   <input
                     aria-label={`${lora.name ?? lora.id} weight`}
                     className="ie-range"
-                    max={2}
-                    min={0}
+                    max={LORA_WEIGHT_MAX}
+                    min={LORA_WEIGHT_MIN}
                     onChange={(event) => setWeight(lora.id, Number(event.target.value))}
-                    step={0.05}
+                    step={LORA_WEIGHT_STEP}
                     type="range"
                     value={weightFor(lora)}
                   />

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -4,6 +4,9 @@ import { AdvancedSection } from "../components/AdvancedSection.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { WorkPanel } from "../components/WorkPanel.jsx";
 import {
+  LORA_WEIGHT_MAX,
+  LORA_WEIGHT_MIN,
+  LORA_WEIGHT_STEP,
   MAX_PRESET_LORAS,
   compactModeList,
   loraMatchesModel,
@@ -1228,15 +1231,16 @@ export function PresetManagerScreen() {
                     <span>Weight</span>
                     <span className="lora-slot-weight-value">{Number.isFinite(weight) ? weight.toFixed(2) : "—"}</span>
                   </label>
-                  {/* -2..2 is the range the preset normalizer accepts, wider than the
-                      studios' 0..2 slider — a preset may carry a negative weight. */}
+                  {/* Bidirectional -2..2 (LORA_WEIGHT_*), matching the studio pickers and
+                      the preset normalizer: slider LoRAs run negative for the inverse
+                      direction, and 0 is a valid neutral. */}
                   <input
                     aria-label={`${name} weight`}
                     disabled={!editable || missing || incompatible}
-                    max="2"
-                    min="-2"
+                    max={LORA_WEIGHT_MAX}
+                    min={LORA_WEIGHT_MIN}
                     onChange={(event) => updateLoraWeight(selected.id, event.target.value)}
-                    step="0.05"
+                    step={LORA_WEIGHT_STEP}
                     type="range"
                     value={Number.isFinite(weight) ? weight : 0}
                   />

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -728,6 +728,10 @@ export function VideoStudio() {
         quality,
         seed: seed === "" ? null : Number(seed),
         recipePresetId: selectedPreset?.id ?? null,
+        // The studio seeds a selected preset's LoRAs into the visible `loras` (generationStudio's
+        // preset-LoRA seed effect), so the client is authoritative for preset LoRAs — tell the
+        // server to skip its own merge so edits/removals stick. Parity with the Image Studio.
+        presetLorasResolvedClientSide: selectedPreset ? true : undefined,
         characterId: characterId || null,
         characterLookId: characterLookId || null,
         sourceAssetId: ["image_to_video", "first_last_frame"].includes(mode) ? sourceAssetId || null : null,

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -11,7 +11,12 @@ import { LoraPickerField, useLoraSelection } from "../components/LoraPickerField
 import { CharacterAdvancedOptions, useCharacterAdvancedOptions } from "../components/CharacterAdvancedOptions.jsx";
 import { KeypointCollectionField } from "../components/KeypointCollectionField.jsx";
 import { usePoseLibrary, useUserPoseLoader } from "../poseLibrary.js";
-import { extractFamilies } from "../presetUtils.js";
+import {
+  LORA_WEIGHT_MAX,
+  LORA_WEIGHT_MIN,
+  LORA_WEIGHT_STEP,
+  extractFamilies,
+} from "../presetUtils.js";
 import { resolveJobResultAssets } from "../jobResultAssets.js";
 
 // Curated negative prompts seeded into the advanced panel for each Character
@@ -305,10 +310,10 @@ export function CharacterLoras({
                 <label>
                   Weight
                   <input
-                    max="2"
-                    min="-2"
+                    max={LORA_WEIGHT_MAX}
+                    min={LORA_WEIGHT_MIN}
                     onChange={(event) => setLoraEdit(link.id, "defaultWeight", event.target.value)}
-                    step="0.05"
+                    step={LORA_WEIGHT_STEP}
                     type="number"
                     value={edit.defaultWeight}
                   />

--- a/apps/web/src/screens/generationStudio.jsx
+++ b/apps/web/src/screens/generationStudio.jsx
@@ -3,6 +3,9 @@ import { LoraKeywordSummary } from "../components/LoraKeywordSummary.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { terminalStatuses } from "../jobTypes.js";
 import {
+  LORA_WEIGHT_MAX,
+  LORA_WEIGHT_MIN,
+  LORA_WEIGHT_STEP,
   MAX_USER_JOB_LORAS,
   applyPresetDefault,
   buildStudioPresetPayload,
@@ -11,6 +14,7 @@ import {
   loraMatchesModel,
   loraWeight,
   noPresetId,
+  presetLoraSeedEntries,
   presetLoraDetails as buildPresetLoraDetails,
   presetMatchesModel,
   presetMatchesWorkflow,
@@ -290,6 +294,61 @@ export function useGenerationStudio({
     setLoraWeights((current) => ({ ...current, [id]: value }));
   }
 
+  // Preset LoRAs are first-class, visible picker entries — not a hidden server-side merge.
+  // Selecting a preset seeds its LoRAs (at the preset's weights) into the selection so they
+  // show up and can be retuned, added to, or removed; deselecting it (→ None or another
+  // preset) removes the LoRAs it added and restores any weights it overrode. A user's own
+  // LoRAs are preserved (the seed is a union computed from the live selection). The server
+  // skips its own preset-LoRA merge when the studio sends presetLorasResolvedClientSide, so
+  // a removed preset LoRA stays removed instead of being silently re-added at generation.
+  const presetLoraSeed = useRef({ presetId: null, addedIds: [], prevWeights: {} });
+  // On hydrate, the persisted selection already includes the snapshot preset's LoRAs, so the
+  // first pass must adopt (not re-seed) it. Mirrors useSavePreset's skipPresetDefaultsOnHydrate.
+  const skipPresetLoraSeedOnHydrate = useRef(initialPresetId != null && initialPresetId !== noPresetId);
+  useEffect(() => {
+    if (skipPresetLoraSeedOnHydrate.current) {
+      skipPresetLoraSeedOnHydrate.current = false;
+      if (selectedPreset && selectedPreset.id === initialPresetId) {
+        // The restored selection already reflects this preset; adopt it without re-seeding.
+        // addedIds is left empty so a post-reload deselect doesn't strip LoRAs we can't prove
+        // the preset added (the user removes them by hand instead).
+        presetLoraSeed.current = { presetId: selectedPreset.id, addedIds: [], prevWeights: {} };
+        return;
+      }
+    }
+    const seed = presetLoraSeed.current;
+    const nextPresetId = selectedPreset?.id ?? null;
+    if (seed.presetId === nextPresetId) {
+      return;
+    }
+    // Undo the previous preset's contributions, then apply the new preset's LoRAs — both
+    // computed from the current selection so the user's own LoRAs survive the switch.
+    let ids = selectedLoraIds.filter((id) => !seed.addedIds.includes(id));
+    const weights = { ...loraWeights };
+    for (const [id, prev] of Object.entries(seed.prevWeights)) {
+      if (prev === undefined) {
+        delete weights[id];
+      } else {
+        weights[id] = prev;
+      }
+    }
+    const entries = selectedPreset ? presetLoraSeedEntries(selectedPreset, compatibleLoras) : [];
+    const addedIds = [];
+    const prevWeights = {};
+    for (const { id, weight } of entries) {
+      if (!ids.includes(id)) {
+        ids = [...ids, id];
+        addedIds.push(id);
+      }
+      prevWeights[id] = Object.prototype.hasOwnProperty.call(weights, id) ? weights[id] : undefined;
+      weights[id] = weight;
+    }
+    setSelectedLoraIds(ids);
+    setLoraWeights(weights);
+    presetLoraSeed.current = { presetId: nextPresetId, addedIds, prevWeights };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedPreset?.id]);
+
   return {
     availablePresets,
     selectedPreset,
@@ -541,10 +600,10 @@ export function LoraPickerSection({
                       </label>
                       <input
                         aria-label={`${lora.name ?? lora.id} weight`}
-                        max="2"
-                        min="0"
+                        max={LORA_WEIGHT_MAX}
+                        min={LORA_WEIGHT_MIN}
                         onChange={(event) => setLoraWeight(lora.id, Number(event.target.value))}
-                        step="0.05"
+                        step={LORA_WEIGHT_STEP}
                         type="range"
                         value={weight}
                       />
@@ -690,15 +749,18 @@ export function PresetGuidanceStrip({ selectedPreset, presetPromptParts, presetL
   if (!selectedPreset) {
     return null;
   }
+  // A selected preset's installed LoRAs are seeded into the LoRA picker (visible + adjustable),
+  // so the strip no longer lists them — it only calls out ones that couldn't be seeded because
+  // they aren't installed, so the user knows to import them before the preset fully applies.
+  const missingLoras = presetLoraDetails.filter((lora) => lora.missing);
   return (
     <div className="guidance-strip">
       <strong>{selectedPreset.ui?.description ?? "Preset defaults active"}</strong>
       <span>
         {presetPromptParts.length ? `Adds: ${presetPromptParts.join(", ")}` : "No prompt fragments"}
-        {presetLoraDetails.length
-          ? ` | Preset LoRA applied at generation: ${presetLoraDetails.map((lora) => lora.name ?? lora.id).join(", ")}`
-          : " | No preset LoRAs"}
-        {presetLoraDetails.some((lora) => lora.missing) ? " | Import still pending" : ""}
+        {missingLoras.length
+          ? ` | Preset LoRA not installed: ${missingLoras.map((lora) => lora.name ?? lora.id).join(", ")} — import to apply`
+          : ""}
       </span>
     </div>
   );


### PR DESCRIPTION
## Problem

Preset LoRAs weren't taking effect in the Image/Video studios. Investigating a real preset ("Fine Art" → Realism Engine) surfaced **two** root causes:

1. **Weight-0 footgun from an inconsistent slider.** The Preset Manager's LoRA-weight slider ran `-2..2` while every other picker ran `0..2`. On a `-2..2` slider the **center is 0**, so a preset LoRA easily landed on weight `0` — merged into every generation but applied at scale 0, i.e. no visible effect. (Verified against the real job records: the LoRA was resolved, installed, `presetManaged`, in the payload — at weight `0.0`.)
2. **Hidden server-side merge that couldn't be adjusted.** Preset LoRAs were merged invisibly from `recipePresetId`, so they never appeared in the picker and collided with **"Use this recipe"**: the server dedup kept the recipe's LoRA weight and silently dropped the preset's, so selecting a preset couldn't change an already-selected LoRA's weight.

## Changes

**1 — Standardize the LoRA weight range (`-2..2` app-wide).** Slider LoRAs (Civitai "slider"/Detail-Tweaker-style adapters) are trained bidirectionally, so `-2..2` is correct — but it must be consistent. All user LoRA-weight controls now share `LORA_WEIGHT_MIN/MAX/STEP` (single source of truth in `presetUtils.js`): studio picker, studio rail, Image Editor list, Preset Manager, character LoRA editor. Identity-strength and ControlNet pose-lock magnitude knobs keep their own semantics-specific ranges.

**2 — Make preset LoRAs visible and client-authoritative.** Selecting a preset now **seeds its LoRAs into the visible picker** at the preset's weights (union with the current selection; preset weight wins for its LoRAs), with remember/restore on deselect — mirroring how the preset's scalar defaults already behave. The client sends `presetLorasResolvedClientSide` so the server **skips its own merge** and weight edits / removals stick; headless/API clients that send only `recipePresetId` keep the server-side merge. The guidance strip no longer claims "applied at generation" (they're in the picker) and instead surfaces preset LoRAs that aren't installed.

**Behavior note:** preset LoRAs now count as normal visible selections (they sit in the on-screen list and against the 4-user-LoRA cap) rather than being free server-merged extras — the correct consequence of making them editable.

## Verification

- **Web:** full suite green — 120 files / 1661 tests. Updated the image + video preset tests (seeded LoRA rides in `loras` at the preset weight + marker; strip no longer claims hidden application) and added seed → generate → deselect-restore coverage; plus a regression test pinning the slider to `-2..2`.
- **rust-api:** 271 tests pass, fmt + clippy clean. Added `preset_image_job_skips_server_lora_merge_when_client_resolved` (a removed preset LoRA + flag is not re-added); the existing no-flag test still proves headless merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)