### PR TITLE
feat(studios): general (model-agnostic) presets that stack (sc-11949)

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -642,6 +642,13 @@ pub(crate) struct ImageJobRequest {
     // keep the server-side merge.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) preset_loras_resolved_client_side: Option<bool>,
+    // The web studio composes the prompt from the full preset stack (base model preset +
+    // stacked general presets) client-side and sends it verbatim, so the server must not
+    // re-fold a single preset's prefix/suffix. When set, `preset_prompt` is skipped and the
+    // sent `prompt` is authoritative. Headless/API clients that send only recipePresetId
+    // omit it and keep the server-side prefix/suffix fold. (epic 11949)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) preset_prompt_resolved_client_side: Option<bool>,
     #[serde(default)]
     pub(crate) loras: Vec<Value>,
     #[serde(default)]
@@ -774,6 +781,10 @@ pub(crate) struct VideoJobRequest {
     // into `loras`, so the server skips its merge when this is set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) preset_loras_resolved_client_side: Option<bool>,
+    // See ImageJobRequest::preset_prompt_resolved_client_side — the studio composes the
+    // preset-stack prompt client-side, so the server skips its prefix/suffix fold when set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) preset_prompt_resolved_client_side: Option<bool>,
     #[serde(default)]
     pub(crate) loras: Vec<Value>,
     #[serde(default)]

--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -245,7 +245,13 @@ pub(crate) async fn apply_recipe_preset_to_image_payload(
     // backend already sees the resolved preset id — stamp lastUsedAt now (sc-10520).
     stamp_recipe_preset_used(state, preset_id).await;
 
-    let expanded_prompt = preset_prompt(&payload.prompt, preset);
+    let expanded_prompt = if payload.preset_prompt_resolved_client_side.unwrap_or(false) {
+        // The studio already composed the full preset-stack prompt client-side; take it
+        // verbatim so we don't double-fold this preset's prefix/suffix (epic 11949).
+        payload.prompt.clone()
+    } else {
+        preset_prompt(&payload.prompt, preset)
+    };
     job_payload.insert("prompt".to_owned(), Value::String(expanded_prompt));
     if payload.model == default_image_model() {
         if let Some(model) = preset
@@ -426,7 +432,13 @@ pub(crate) async fn apply_recipe_preset_to_video_payload(
     // backend already sees the resolved preset id — stamp lastUsedAt now (sc-10520).
     stamp_recipe_preset_used(state, preset_id).await;
 
-    let expanded_prompt = preset_prompt(&payload.prompt, preset);
+    let expanded_prompt = if payload.preset_prompt_resolved_client_side.unwrap_or(false) {
+        // The studio already composed the full preset-stack prompt client-side; take it
+        // verbatim so we don't double-fold this preset's prefix/suffix (epic 11949).
+        payload.prompt.clone()
+    } else {
+        preset_prompt(&payload.prompt, preset)
+    };
     job_payload.insert("prompt".to_owned(), Value::String(expanded_prompt));
     if payload.model == default_video_model() {
         if let Some(model) = preset

--- a/apps/rust-api/src/recipe_presets.rs
+++ b/apps/rust-api/src/recipe_presets.rs
@@ -310,6 +310,18 @@ pub(crate) fn finalize_recipe_preset_entry(
     let object = preset
         .as_object_mut()
         .ok_or_else(|| ApiError::internal("Recipe preset manifest entry must be an object"))?;
+    if recipe_preset_object_is_general(object) {
+        // General presets are deliberately model-agnostic (epic 11949): never infer a
+        // workflow, default a model, synthesize modes, or migrate LoRAs. Just ensure the
+        // open sub-objects exist so consumers can read prefix/suffix + defaults uniformly.
+        object
+            .entry("defaults".to_owned())
+            .or_insert_with(|| Value::Object(JsonObject::new()));
+        object
+            .entry("prompt".to_owned())
+            .or_insert_with(|| Value::Object(JsonObject::new()));
+        return Ok(());
+    }
     let mut migration_notes = Vec::new();
     if !object.contains_key("workflow") {
         if let Some(workflow) = inferred_recipe_preset_workflow(object) {
@@ -647,24 +659,70 @@ pub(crate) fn normalize_recipe_preset_for_write(
         .ok_or_else(|| ApiError::bad_request("Recipe preset must be an object"))?;
     object.insert("scope".to_owned(), Value::String(scope.to_owned()));
     validate_recipe_preset_id(object.get("id").and_then(Value::as_str))?;
+    validate_recipe_preset_kind(object.get("kind"))?;
     validate_required_string_field(
         object,
         "name",
         require_all,
         "Recipe preset name is required",
     )?;
-    validate_required_string_field(
-        object,
-        "model",
-        require_all,
-        "Recipe preset model is required",
-    )?;
-    validate_recipe_preset_workflow(object.get("workflow").and_then(Value::as_str), require_all)?;
+    if recipe_preset_object_is_general(object) {
+        // General presets are model-agnostic prompt-fragment stacks (epic 11949): they
+        // must not pin a model/workflow or carry LoRAs. Reject those fields rather than
+        // silently dropping them, so a mis-built payload is visible. `defaults`/`prompt`
+        // (prefix/suffix, negativePrompt, aspect, count) validate exactly as elsewhere.
+        for field in ["model", "workflow", "loras", "builtInLoras"] {
+            if recipe_preset_field_is_set(object, field) {
+                return Err(ApiError::bad_request(format!(
+                    "General recipe presets cannot set {field}"
+                )));
+            }
+        }
+    } else {
+        validate_required_string_field(
+            object,
+            "model",
+            require_all,
+            "Recipe preset model is required",
+        )?;
+        validate_recipe_preset_workflow(
+            object.get("workflow").and_then(Value::as_str),
+            require_all,
+        )?;
+        normalize_recipe_preset_loras(object)?;
+    }
     validate_recipe_preset_order(object.get("order"))?;
     validate_recipe_preset_defaults(object.get("defaults"))?;
     validate_recipe_preset_prompt(object.get("prompt"))?;
-    normalize_recipe_preset_loras(object)?;
     Ok(preset)
+}
+
+/// A preset is "general" (model-agnostic) when it explicitly declares `kind: "general"`.
+/// Absence of `kind` — every preset predating epic 11949 — reads as a model preset.
+fn recipe_preset_object_is_general(object: &JsonObject) -> bool {
+    object.get("kind").and_then(Value::as_str) == Some("general")
+}
+
+pub(crate) fn validate_recipe_preset_kind(value: Option<&Value>) -> Result<(), ApiError> {
+    match value {
+        None | Some(Value::Null) => Ok(()),
+        Some(Value::String(kind)) if kind == "model" || kind == "general" => Ok(()),
+        _ => Err(ApiError::bad_request(
+            "Recipe preset kind must be \"model\" or \"general\"",
+        )),
+    }
+}
+
+/// Whether a field carries a meaningful value — used to reject model/workflow/LoRA
+/// fields on a general preset while tolerating an omitted, null, or empty payload
+/// (the editor simply omits them; a stray empty array/string is not an error).
+fn recipe_preset_field_is_set(object: &JsonObject, field: &str) -> bool {
+    match object.get(field) {
+        None | Some(Value::Null) => false,
+        Some(Value::String(value)) => !value.trim().is_empty(),
+        Some(Value::Array(items)) => !items.is_empty(),
+        Some(_) => true,
+    }
 }
 
 pub(crate) fn validate_recipe_preset_id(value: Option<&str>) -> Result<(), ApiError> {
@@ -732,6 +790,23 @@ pub(crate) fn validate_recipe_preset_defaults(value: Option<&Value>) -> Result<(
         let (width, height) = parse_recipe_preset_resolution(resolution)?;
         validate_dimension(width, "width", MAX_IMAGE_DIMENSION)?;
         validate_dimension(height, "height", MAX_IMAGE_DIMENSION)?;
+    }
+    // `aspect` is the general-preset ratio (e.g. "16:9"); the studio snaps it to the
+    // active model's nearest supported resolution at apply time. Stored as W:H with both
+    // parts positive integers.
+    if let Some(aspect) = object.get("aspect").and_then(Value::as_str) {
+        let parts: Vec<&str> = aspect.split(':').collect();
+        let valid = parts.len() == 2
+            && parts.iter().all(|part| {
+                !part.is_empty()
+                    && part.chars().all(|character| character.is_ascii_digit())
+                    && part.parse::<u32>().map(|value| value > 0).unwrap_or(false)
+            });
+        if !valid {
+            return Err(ApiError::bad_request(
+                "Recipe preset aspect must be a ratio like \"16:9\"",
+            ));
+        }
     }
     if let Some(count) = object.get("count").and_then(Value::as_u64) {
         if !(1..=8).contains(&count) {

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -2357,6 +2357,143 @@ async fn preset_image_job_skips_server_lora_merge_when_client_resolved() {
 }
 
 #[tokio::test]
+async fn preset_image_job_skips_server_prompt_fold_when_client_resolved() {
+    // General presets stack (epic 11949): the studio composes the full preset-stack prompt
+    // client-side because the server only knows how to fold ONE recipePresetId's prefix/suffix.
+    // When the studio sends presetPromptResolvedClientSide, the server must take `prompt` verbatim
+    // and NOT re-apply preset_prompt — otherwise the base preset's prefix would be folded twice.
+    // Headless clients that omit the flag keep the server-side fold (asserted below as baseline).
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "models": [
+            {
+              "id": "img-model",
+              "name": "Img Model",
+              "family": "z-image",
+              "type": "image",
+              "adapter": "z_image",
+              "capabilities": ["text_to_image"],
+              "downloads": [
+                { "provider": "huggingface", "repo": "owner/img", "files": ["*.safetensors"], "default": true }
+              ],
+              "paths": {},
+              "defaults": {},
+              "limits": {},
+              "loraCompatibility": { "families": ["z-image"] },
+              "ui": { "label": "Img" }
+            }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin models writes");
+    std::fs::write(
+        config_dir.join("user.models.jsonc"),
+        r#"{ "schemaVersion": 1, "models": [] }"#,
+    )
+    .expect("user models writes");
+    std::fs::write(
+        config_dir.join("builtin.recipe-presets.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "presets": [
+            {
+              "id": "dream_style",
+              "name": "Dream Style",
+              "workflow": "text_to_image",
+              "model": "img-model",
+              "defaults": { "count": 1, "resolution": "1024x1024" },
+              "prompt": { "prefix": "cinematic" }
+            }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin recipe presets writes");
+    std::fs::write(
+        config_dir.join("user.recipe-presets.jsonc"),
+        r#"{ "schemaVersion": 1, "presets": [] }"#,
+    )
+    .expect("user recipe presets writes");
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Client Prompt Preset Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id").to_owned();
+
+    // Baseline: no flag → server folds the preset prefix into the prompt (today's behavior).
+    let (status, folded) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/image/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_image",
+            "prompt": "a fox",
+            "model": "img-model",
+            "count": 1,
+            "width": 1024,
+            "height": 1024,
+            "recipePresetId": "dream_style"
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "baseline job created: {folded:?}"
+    );
+    assert_eq!(folded["payload"]["prompt"], "cinematic, a fox");
+
+    // Client-authoritative: the studio already composed "cinematic, a fox" and sends the flag,
+    // so the server must NOT fold the prefix again (would yield "cinematic, cinematic, a fox").
+    let (status, verbatim) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/image/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_image",
+            "prompt": "cinematic, a fox",
+            "model": "img-model",
+            "count": 1,
+            "width": 1024,
+            "height": 1024,
+            "recipePresetId": "dream_style",
+            "presetPromptResolvedClientSide": true
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "client-resolved job created: {verbatim:?}"
+    );
+    assert_eq!(
+        verbatim["payload"]["prompt"], "cinematic, a fox",
+        "client-resolved prompt must be taken verbatim, not re-folded"
+    );
+    // The preset id is still stamped for usage tracking.
+    assert_eq!(
+        verbatim["payload"]["advanced"]["recipePresetId"],
+        "dream_style"
+    );
+}
+
+#[tokio::test]
 async fn generation_routes_reject_invalid_payloads() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let app = create_app(test_settings(&temp_dir)).expect("app creates");

--- a/apps/rust-api/src/tests/recipe_presets.rs
+++ b/apps/rust-api/src/tests/recipe_presets.rs
@@ -1289,3 +1289,199 @@ mod recipe_presets_parity {
         assert!(preset["name"] != "My Cinematic", "new name is different");
     }
 }
+
+#[tokio::test]
+async fn recipe_preset_general_presets_are_model_agnostic() {
+    // General presets (epic 11949) are model-agnostic: no model, no workflow, no LoRAs — just
+    // prompt prefix/suffix, negativePrompt, aspect, and count. The read path must NOT inject a
+    // model/workflow/modes (as it does for legacy model presets), and the write path must reject
+    // model/workflow/loras on a general preset.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    // An installed text_to_image model is present precisely so a regression that re-enabled
+    // model-defaulting would have something to inject — proving the general preset stays bare.
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "models": [
+            {
+              "id": "z_image_turbo",
+              "name": "Z Image Turbo",
+              "family": "z-image",
+              "type": "image",
+              "adapter": "z_image_diffusers",
+              "capabilities": ["text_to_image"],
+              "downloads": [],
+              "paths": {},
+              "defaults": {},
+              "limits": {},
+              "loraCompatibility": {},
+              "ui": {}
+            }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin models writes");
+    std::fs::write(
+        config_dir.join("user.models.jsonc"),
+        r#"{ "schemaVersion": 1, "models": [] }"#,
+    )
+    .expect("user models writes");
+    std::fs::write(
+        config_dir.join("builtin.recipe-presets.jsonc"),
+        r#"{ "schemaVersion": 1, "presets": [] }"#,
+    )
+    .expect("builtin recipe presets writes");
+    std::fs::write(
+        config_dir.join("user.recipe-presets.jsonc"),
+        r#"{ "schemaVersion": 1, "presets": [] }"#,
+    )
+    .expect("user recipe presets writes");
+    std::fs::write(
+        config_dir.join("builtin.loras.jsonc"),
+        r#"{ "schemaVersion": 1, "loras": [] }"#,
+    )
+    .expect("builtin loras writes");
+    std::fs::write(
+        config_dir.join("user.loras.jsonc"),
+        r#"{ "schemaVersion": 1, "loras": [] }"#,
+    )
+    .expect("user loras writes");
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    // 1. Create a general preset with no model/workflow.
+    let (status, created) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/recipe-presets",
+        json!({
+            "name": "Cinematic Look",
+            "kind": "general",
+            "prompt": { "prefix": "cinematic still", "suffix": "shot on 35mm film" },
+            "defaults": { "aspect": "16:9", "count": 2, "negativePrompt": "blurry" }
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "general preset creates: {created:?}"
+    );
+    assert_eq!(created["id"], "cinematic_look");
+    assert_eq!(created["kind"], "general");
+    assert_eq!(created["scope"], "global");
+    assert!(
+        created.get("model").is_none(),
+        "no model injected: {created:?}"
+    );
+    assert!(
+        created.get("workflow").is_none(),
+        "no workflow injected: {created:?}"
+    );
+    assert!(
+        created.get("modes").is_none(),
+        "no modes injected: {created:?}"
+    );
+    assert!(
+        created.get("builtInLoras").is_none(),
+        "no builtInLoras mirror for a general preset: {created:?}"
+    );
+    assert_eq!(created["prompt"]["prefix"], "cinematic still");
+    assert_eq!(created["defaults"]["aspect"], "16:9");
+    assert_eq!(created["defaults"]["count"], 2);
+
+    // 2. GET it back — still model-agnostic after the read-side finalize.
+    let (status, fetched) = request(
+        app.clone(),
+        "GET",
+        "/api/v1/recipe-presets/cinematic_look",
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(fetched["kind"], "general");
+    assert!(
+        fetched.get("model").is_none(),
+        "GET keeps it model-less: {fetched:?}"
+    );
+
+    // 3. PATCH the prompt + aspect — round-trips without re-binding a model or dropping aspect.
+    let (status, updated) = request(
+        app.clone(),
+        "PATCH",
+        "/api/v1/recipe-presets/cinematic_look",
+        json!({
+            "prompt": { "prefix": "moody cinematic still" },
+            "defaults": { "aspect": "2:3", "count": 1 }
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "general preset patches: {updated:?}"
+    );
+    assert_eq!(updated["prompt"]["prefix"], "moody cinematic still");
+    assert_eq!(updated["defaults"]["aspect"], "2:3");
+    assert!(
+        updated.get("model").is_none(),
+        "PATCH keeps it model-less: {updated:?}"
+    );
+
+    // 4. A general preset may not pin a model.
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/recipe-presets",
+        json!({ "name": "Bad Model", "kind": "general", "model": "z_image_turbo" }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "general preset rejects model"
+    );
+
+    // 5. A general preset may not carry LoRAs.
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/recipe-presets",
+        json!({ "name": "Bad Loras", "kind": "general", "loras": [{ "id": "style_lora" }] }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "general preset rejects loras"
+    );
+
+    // 6. Aspect must be a W:H ratio.
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/recipe-presets",
+        json!({ "name": "Bad Aspect", "kind": "general", "defaults": { "aspect": "16-9" } }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "general preset rejects malformed aspect"
+    );
+
+    // 7. kind must be one of the known values.
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/recipe-presets",
+        json!({ "name": "Bad Kind", "kind": "banana" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "unknown kind rejected");
+}

--- a/apps/web/src/App.imageGeneration.test.jsx
+++ b/apps/web/src/App.imageGeneration.test.jsx
@@ -93,6 +93,91 @@ describe("SceneWorks app shell", () => {
     expect(onLocalJobCreated).toHaveBeenCalledWith({ id: "image-job-1" });
   });
 
+  // epic 11949: the flagship stacking case — camera + lens + film general presets on an
+  // arbitrary model. Asserts the flat concatenation IN SELECTION ORDER, the model left
+  // untouched, no LoRA seeded, the aspect snapped to the model's menu, and the
+  // client-authoritative flag. This fails if any guard is reverted (setModel fires, the
+  // matches-any availability is removed, composition falls back to a single preset, or the
+  // presetPromptResolvedClientSide flag is dropped).
+  it("stacks camera + lens + film, composing flat in order without touching the model", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withImageStudioContext({
+          activeProject: { id: "project-1", name: "Noir" },
+          assets: [],
+          characters: [],
+          createImageJob,
+          gpuOptions: ["auto"],
+          imageModels: [
+            {
+              id: "z_image_turbo",
+              name: "Z-Image",
+              type: "image",
+              family: "z-image",
+              capabilities: ["text_to_image"],
+              limits: { resolutions: ["1024x1024", "1280x720", "720x1280"] },
+            },
+          ],
+          latestAssets: [],
+          loras: [],
+          presets: [
+            { id: "camera", name: "Arri", kind: "general", prompt: { suffix: "shot on Arri Alexa" } },
+            { id: "lens", name: "85mm", kind: "general", prompt: { suffix: "85mm f/1.4" } },
+            {
+              id: "film",
+              name: "Portra",
+              kind: "general",
+              prompt: { suffix: "Kodak Portra 400" },
+              defaults: { aspect: "16:9", negativePrompt: "grain" },
+            },
+          ],
+          requestedGpu: "auto",
+          setRequestedGpu: () => {},
+          updateAssetStatus: () => {},
+        }),
+      );
+    });
+    await settle();
+
+    const userPrompt = container.querySelector(".image-studio textarea").value;
+    const modelBefore = field(container, "Model").value;
+    expect(userPrompt.length).toBeGreaterThan(0);
+
+    const clickGeneral = async (name) => {
+      await act(async () => {
+        [...container.querySelectorAll(".general-preset-chips .preset-chip")]
+          .find((chip) => chip.textContent.trim() === name)
+          .click();
+      });
+    };
+    await clickGeneral("Arri");
+    await clickGeneral("85mm");
+    await clickGeneral("Portra");
+    await settle();
+
+    // Model untouched; the preview shows the flat concatenation in selection order.
+    expect(field(container, "Model").value).toBe(modelBefore);
+    const expected = `${userPrompt}, shot on Arri Alexa, 85mm f/1.4, Kodak Portra 400`;
+    expect(container.querySelector(".preset-stack-preview .preset-stack-prompt p").textContent).toBe(expected);
+
+    await act(async () => {
+      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Generate").click();
+    });
+    await settle();
+
+    const call = createImageJob.mock.calls[0][0];
+    expect(call.prompt).toBe(expected);
+    expect(call.presetPromptResolvedClientSide).toBe(true);
+    expect(call.negativePrompt).toBe("grain");
+    // aspect 16:9 snapped to the model's nearest supported resolution.
+    expect(call.width).toBe(1280);
+    expect(call.height).toBe(720);
+    // General presets carry no LoRAs, so nothing is seeded into the picker.
+    expect(call.loras).toEqual([]);
+  });
+
   it("remembers studio settings per workspace across remounts", async () => {
     const imageProps = {
       activeProject: { id: "project-1", name: "Noir" },

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1668,6 +1668,15 @@ export function App() {
     if (!preset?.id) {
       return;
     }
+    // General (model-agnostic) presets don't pin a model/mode — they layer onto whatever the
+    // studio is on (epic 11949). Launching one just toggles it into the general stack; default
+    // to Image Studio, and it stays active if the user switches to Video. Model presets keep
+    // carrying model + sub-mode so they resolve in the target studio (sc-10516).
+    if (preset.kind === "general") {
+      setStudioLaunch({ id: crypto.randomUUID(), view: "Image", presetGeneralId: preset.id });
+      setActiveView("Image");
+      return;
+    }
     const view = workflowModelType(preset.workflow) === "video" ? "Video" : "Image";
     setStudioLaunch({
       id: crypto.randomUUID(),

--- a/apps/web/src/App.videoPresets.test.jsx
+++ b/apps/web/src/App.videoPresets.test.jsx
@@ -125,6 +125,72 @@ describe("SceneWorks app shell", () => {
     expect(field(container, "Steps").value).toBe("41");
   });
 
+  // epic 11949 Phase 3: a general (model-agnostic) preset appears in its own chip group on
+  // any model and toggles into a stack, independently of the single-select model preset,
+  // without changing the model. (Composition into the prompt lands in Phase 4.)
+  it("stacks a general preset onto any model without changing the model", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            assets: [],
+            characters: [],
+            createVideoJob: () => {},
+            gpuOptions: ["auto"],
+            latestVideoAssets: [],
+            loras: [],
+            setPreviewAsset: () => {},
+            rememberLocalGenerationJob: () => {},
+            personTracks: [],
+            purgeAsset: () => {},
+            presets: [
+              {
+                id: "film_look",
+                name: "Film Look",
+                kind: "general",
+                prompt: { suffix: "Kodak Portra 400" },
+                defaults: { aspect: "16:9" },
+              },
+            ],
+            requestedGpu: "auto",
+            setRequestedGpu: () => {},
+            updateAssetStatus: () => {},
+            videoModels: [
+              {
+                id: "ltx_2_3",
+                name: "LTX",
+                type: "video",
+                capabilities: ["text_to_video", "image_to_video"],
+                limits: { durations: [4, 6, 8], fps: [24, 25, 30], resolutions: ["768x512", "1280x720"] },
+              },
+            ],
+          },
+          <VideoStudio />,
+        ),
+      );
+    });
+    await settle();
+
+    // The general preset lives in its own chip group, not the model-preset row.
+    const generalGroup = container.querySelector(".general-preset-chips");
+    expect(generalGroup).not.toBeNull();
+    const chip = [...generalGroup.querySelectorAll(".preset-chip")].find((c) => c.textContent.trim() === "Film Look");
+    expect(chip).toBeDefined();
+    expect(chip.classList.contains("active")).toBe(false);
+
+    const modelBefore = field(container, "Model").value;
+    await act(async () => chip.click());
+
+    // Toggling activates the chip and leaves the model untouched (Phase 3 is state only).
+    const activeGeneral = [...container.querySelectorAll(".general-preset-chips .preset-chip.active")].map((c) =>
+      c.textContent.trim(),
+    );
+    expect(activeGeneral).toEqual(["Film Look"]);
+    expect(field(container, "Model").value).toBe(modelBefore);
+  });
+
   it("applies preset defaults to video jobs", async () => {
     const createVideoJob = vi.fn();
     root = createRoot(container);

--- a/apps/web/src/App.videoPresets.test.jsx
+++ b/apps/web/src/App.videoPresets.test.jsx
@@ -301,6 +301,79 @@ describe("SceneWorks app shell", () => {
     expect(submittedAdvanced).not.toHaveProperty("recipePresetPrompt");
   });
 
+  // epic 11949 Phase 5: with a general preset stacked, the client composes the prompt + negative
+  // and flags presetPromptResolvedClientSide so the server takes them verbatim (no double-fold).
+  it("sends the client-composed prompt + flag when a general preset is stacked", async () => {
+    const createVideoJob = vi.fn();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            assets: [],
+            characters: [],
+            createPersonDetectionJob: () => {},
+            createPersonTrackJob: () => {},
+            createVideoJob,
+            gpuOptions: ["auto"],
+            latestVideoAssets: [],
+            loras: [],
+            setPreviewAsset: () => {},
+            rememberLocalGenerationJob: () => {},
+            personTracks: [],
+            purgeAsset: () => {},
+            presets: [
+              {
+                id: "film_look",
+                name: "Film Look",
+                kind: "general",
+                prompt: { suffix: "Kodak Portra 400" },
+                defaults: { negativePrompt: "flicker" },
+              },
+            ],
+            requestedGpu: "auto",
+            setRequestedGpu: () => {},
+            updateAssetStatus: () => {},
+            videoModels: [
+              {
+                id: "ltx_2_3",
+                name: "LTX",
+                type: "video",
+                capabilities: ["text_to_video", "image_to_video"],
+                defaults: { duration: 6, fps: 25, resolution: "768x512", quality: "balanced" },
+                limits: { durations: [4, 6, 8], fps: [24, 25, 30], resolutions: ["768x512", "1280x720"] },
+              },
+            ],
+          },
+          <VideoStudio />,
+        ),
+      );
+    });
+    await settle();
+
+    // Toggle the general preset into the stack (no base model preset selected).
+    await act(async () => {
+      [...container.querySelectorAll(".general-preset-chips .preset-chip")]
+        .find((chip) => chip.textContent.trim() === "Film Look")
+        .click();
+    });
+    await settle();
+
+    await act(async () => {
+      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Render clip").click();
+    });
+
+    expect(createVideoJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        // base=none, so the user's prompt + the general's append fragment, composed client-side.
+        prompt: "Camera slowly pushes in while the scene comes alive, Kodak Portra 400",
+        negativePrompt: "flicker",
+        presetPromptResolvedClientSide: true,
+      }),
+    );
+  });
+
   it("lets a promptless video model (SVD) submit without a text prompt", async () => {
     const createVideoJob = vi.fn();
     root = createRoot(container);

--- a/apps/web/src/App.videoPresets.test.jsx
+++ b/apps/web/src/App.videoPresets.test.jsx
@@ -189,6 +189,13 @@ describe("SceneWorks app shell", () => {
     );
     expect(activeGeneral).toEqual(["Film Look"]);
     expect(field(container, "Model").value).toBe(modelBefore);
+
+    // epic 11949 Phase 4: toggling a general preset surfaces a live composed-prompt preview
+    // showing exactly what the run will send — the safeguard against messy concatenation.
+    const preview = container.querySelector(".preset-stack-preview");
+    expect(preview).not.toBeNull();
+    expect(preview.querySelector(".preset-stack-prompt p").textContent).toContain("Kodak Portra 400");
+    expect(preview.textContent).toContain("Film Look");
   });
 
   it("applies preset defaults to video jobs", async () => {

--- a/apps/web/src/composePreset.test.js
+++ b/apps/web/src/composePreset.test.js
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { composePreset } from "./presetUtils.js";
+
+// epic 11949: the general-preset stack composes FLAT (fragments, not nested wraps). These pin
+// the exact concatenation the studio preview shows and a client-authoritative job sends.
+describe("composePreset", () => {
+  const general = (id, prompt = {}, defaults = {}) => ({ id, kind: "general", prompt, defaults });
+
+  it("stacks append-only fragments in selection order (the camera/lens/film case)", () => {
+    const { prompt } = composePreset({
+      generalStack: [
+        general("camera", { suffix: "shot on Arri Alexa" }),
+        general("lens", { suffix: "85mm f/1.4" }),
+        general("film", { suffix: "Kodak Portra 400" }),
+      ],
+      userText: "a fox in the snow",
+    });
+    expect(prompt).toBe("a fox in the snow, shot on Arri Alexa, 85mm f/1.4, Kodak Portra 400");
+  });
+
+  it("prepends a leading-style fragment before the user's prompt", () => {
+    const { prompt } = composePreset({
+      generalStack: [general("style", { prefix: "cinematic still" })],
+      userText: "a fox",
+    });
+    expect(prompt).toBe("cinematic still, a fox");
+  });
+
+  it("brackets the base model preset's prefix/suffix outermost, generals inside", () => {
+    const { prompt } = composePreset({
+      base: { id: "m", prompt: { prefix: "masterpiece", suffix: "best quality" } },
+      generalStack: [general("film", { prefix: "moody", suffix: "grainy" })],
+      userText: "a fox",
+    });
+    // base.prefix, gen.prefix, USER, gen.suffix, base.suffix
+    expect(prompt).toBe("masterpiece, moody, a fox, grainy, best quality");
+  });
+
+  it("drops the user slot when the prompt is empty", () => {
+    const { prompt } = composePreset({
+      generalStack: [general("film", { prefix: "cinematic", suffix: "Kodak Portra 400" })],
+      userText: "   ",
+    });
+    expect(prompt).toBe("cinematic, Kodak Portra 400");
+  });
+
+  it("concatenates the user's negative with every stacked general's negative", () => {
+    const { negativePrompt } = composePreset({
+      generalStack: [
+        general("a", {}, { negativePrompt: "blurry" }),
+        general("b", {}, { negativePrompt: "watermark" }),
+      ],
+      userText: "x",
+      userNegative: "lowres",
+    });
+    expect(negativePrompt).toBe("lowres, blurry, watermark");
+  });
+
+  it("resolves the last stacked general's aspect to the nearest supported resolution", () => {
+    const { aspect, resolution } = composePreset({
+      generalStack: [general("a", {}, { aspect: "1:1" }), general("b", {}, { aspect: "16:9" })],
+      userText: "x",
+      resolutionOptions: ["1024x1024", "1280x720", "720x1280"],
+    });
+    expect(aspect).toBe("16:9");
+    expect(resolution).toBe("1280x720");
+  });
+
+  it("lets a base model preset's resolution win over a stacked general's aspect", () => {
+    const { resolution } = composePreset({
+      base: { id: "m", defaults: { resolution: "1024x1024" } },
+      generalStack: [general("b", {}, { aspect: "16:9" })],
+      userText: "x",
+      resolutionOptions: ["1024x1024", "1280x720"],
+    });
+    expect(resolution).toBe("1024x1024");
+  });
+
+  it("takes count from the base preset first, else the last stacked general", () => {
+    expect(
+      composePreset({
+        base: { id: "m", defaults: { count: 4 } },
+        generalStack: [general("b", {}, { count: 2 })],
+      }).count,
+    ).toBe(4);
+    expect(
+      composePreset({
+        generalStack: [general("a", {}, { count: 3 }), general("b", {}, { count: 2 })],
+      }).count,
+    ).toBe(2);
+    // Nothing sets it → null so the studio keeps its own value.
+    expect(composePreset({ generalStack: [general("a")], userText: "x" }).count).toBeNull();
+  });
+
+  it("returns the bare prompt with no presets active", () => {
+    expect(composePreset({ userText: "just me" })).toEqual({
+      prompt: "just me",
+      negativePrompt: "",
+      aspect: null,
+      resolution: null,
+      count: null,
+    });
+  });
+});

--- a/apps/web/src/imageJobRequest.js
+++ b/apps/web/src/imageJobRequest.js
@@ -38,6 +38,7 @@ export function buildImageJobRequest(state) {
     width,
     height,
     recipePresetId,
+    presetPromptResolvedClientSide,
     characterId,
     characterLookId,
     multiReference,
@@ -108,6 +109,11 @@ export function buildImageJobRequest(state) {
     // server to skip its own preset-LoRA merge so an edited or removed preset LoRA sticks.
     // Headless/API clients that send only recipePresetId omit it and keep the server merge.
     presetLorasResolvedClientSide: recipePresetId ? true : undefined,
+    // When a general-preset stack is active the studio composes the prompt client-side (base +
+    // stacked fragments — the server can't reconstruct a stack from one recipePresetId), so it
+    // sends the composed prompt verbatim and this flag tells the server to skip its own
+    // prefix/suffix fold (epic 11949, mirrors presetLorasResolvedClientSide).
+    presetPromptResolvedClientSide: presetPromptResolvedClientSide || undefined,
     characterId: mode === "character_image" ? characterId || null : null,
     characterLookId: mode === "character_image" ? characterLookId || null : null,
     // edit_image: a single source image, except for a multi-reference model (sc-6211,

--- a/apps/web/src/presetSaveValidation.test.js
+++ b/apps/web/src/presetSaveValidation.test.js
@@ -42,6 +42,16 @@ describe("presetSaveValidation", () => {
     expect(summarize(issues).ready).toBe(false);
   });
 
+  // epic 11949: a general preset is model-agnostic, so a missing model must NOT block save.
+  it("does not require a model for a general preset", () => {
+    const issues = presetSaveValidation({ editable: true, name: "Film", model: "", kind: "general" }, clean);
+    expect(kinds(issues, "model")).toEqual([]);
+    expect(summarize(issues).ready).toBe(true);
+    // But a model preset (default) still requires one.
+    const modelIssues = presetSaveValidation({ editable: true, name: "Film", model: "" }, clean);
+    expect(kinds(modelIssues, "model")).toEqual(["requirement"]);
+  });
+
   it("surfaces a preset LoRA still importing, preserving the recognizable copy", () => {
     const summary = summarize(presetSaveValidation(whole, { validation: { missing: ["pending_style"], incompatible: [] } }));
     expect(summary.surfaced).toHaveLength(1);

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -434,7 +434,7 @@ export function presetValidation(preset, loras, model) {
 //
 // `valueErrors` are the out-of-range / out-of-menu default values from defaultValueErrors
 // (sc-10589) — pre-formatted message strings, one error each.
-export function presetSaveValidation({ editable, name, model }, { validation, valueErrors = [] } = {}) {
+export function presetSaveValidation({ editable, name, model, kind }, { validation, valueErrors = [] } = {}) {
   const issues = [];
   if (!editable) {
     issues.push(issue.error(null, "Built-in presets are read-only. Duplicate it to make an editable copy."));
@@ -443,7 +443,9 @@ export function presetSaveValidation({ editable, name, model }, { validation, va
   if (!name?.trim()) {
     issues.push(issue.requirement("name", "Name is required."));
   }
-  if (!model) {
+  // General (model-agnostic) presets have no model to require — they layer prompt
+  // fragments onto whatever model the Studio is on (epic 11949).
+  if (kind !== "general" && !model) {
     issues.push(issue.requirement("model", "Choose a model before saving."));
   }
   for (const message of valueErrors) {

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -261,6 +261,11 @@ export function loraIsInstalled(lora) {
 }
 
 export function presetMatchesWorkflow(preset, mode) {
+  // General (model-agnostic) presets stack onto any model in any workflow, so they match
+  // every mode (epic 11949). Model presets keep their workflow/modes gating.
+  if (preset?.kind === "general") {
+    return true;
+  }
   // A preset has one primary workflow for persistence, but modes describe every
   // Studio entry point where the picker should surface it.
   if (preset?.modes?.length) {

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -1,4 +1,5 @@
 import { issue } from "./validation/issues.js";
+import { pickClosestResolution } from "./resolutionMatch.js";
 
 export const noPresetId = "__no_preset__";
 
@@ -412,6 +413,85 @@ export function presetPromptParts(preset) {
   return [preset?.prompt?.prefix, preset?.prompt?.suffix]
     .map((part) => String(part ?? "").trim())
     .filter(Boolean);
+}
+
+function trimmedFragment(preset, key) {
+  const value = preset?.prompt?.[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+const ASPECT_RATIO_RE = /^[0-9]+:[0-9]+$/;
+
+// Compose the effective generation inputs from the optional base model preset, the ordered
+// general-preset stack, and the user's own prompt/negative (epic 11949). Fragments compose
+// FLAT, not as nested wraps: base prefix/suffix bracket the whole thing (outermost), the
+// stacked general fragments fill in between in selection order. This is what keeps stacking
+// several presets from turning into an unreadable mess — and the studio surfaces the result
+// in a live preview so a bad fragment is visible before generating. Pure and side-effect free.
+//
+//   prompt   = [base.prefix, ...gen.prefix]  +  userText  +  [...gen.suffix, base.suffix]
+//   negative = userNegative + every stacked general's negativePrompt (tags concat cleanly)
+//   resolution = base.resolution if set, else the last stacked general's aspect → nearest
+//                supported resolution (needs resolutionOptions, the active model's menu)
+//   count      = base.count if set, else the last stacked general's count
+//
+// resolution/count are returned as null when nothing in the stack sets them, so the caller
+// keeps the studio's own value. The base model preset's fragments are ALWAYS included so the
+// preview equals what a client-authoritative generation sends (the server skips its fold).
+export function composePreset({
+  base = null,
+  generalStack = [],
+  userText = "",
+  userNegative = "",
+  resolutionOptions = [],
+} = {}) {
+  const stack = Array.isArray(generalStack) ? generalStack.filter(Boolean) : [];
+  const prepends = [trimmedFragment(base, "prefix"), ...stack.map((preset) => trimmedFragment(preset, "prefix"))].filter(
+    Boolean,
+  );
+  const appends = [...stack.map((preset) => trimmedFragment(preset, "suffix")), trimmedFragment(base, "suffix")].filter(
+    Boolean,
+  );
+  const trimmedUser = String(userText ?? "").trim();
+  const prompt = [...prepends, ...(trimmedUser ? [trimmedUser] : []), ...appends].join(", ");
+
+  const negativePrompt = [
+    String(userNegative ?? "").trim(),
+    ...stack.map((preset) => String(preset?.defaults?.negativePrompt ?? "").trim()),
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  // aspect: the last stacked general that declares one wins.
+  let aspect = null;
+  for (const preset of stack) {
+    const value = preset?.defaults?.aspect;
+    if (typeof value === "string" && ASPECT_RATIO_RE.test(value)) {
+      aspect = value;
+    }
+  }
+  const baseResolution =
+    typeof base?.defaults?.resolution === "string" && /^[0-9]+x[0-9]+$/.test(base.defaults.resolution)
+      ? base.defaults.resolution
+      : null;
+  let resolution = baseResolution;
+  if (!resolution && aspect && Array.isArray(resolutionOptions) && resolutionOptions.length) {
+    const [width, height] = aspect.split(":").map(Number);
+    resolution = pickClosestResolution(width, height, resolutionOptions.map(String));
+  }
+
+  // count: base preset's if set, else the last stacked general that declares one.
+  let count = Number.isFinite(Number(base?.defaults?.count)) ? Number(base.defaults.count) : null;
+  if (count === null) {
+    for (const preset of stack) {
+      const value = preset?.defaults?.count;
+      if (Number.isFinite(Number(value))) {
+        count = Number(value);
+      }
+    }
+  }
+
+  return { prompt, negativePrompt, aspect, resolution, count };
 }
 
 export function presetValidation(preset, loras, model) {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -141,7 +141,7 @@ import {
 import { readLastTier, writeLastTier } from "../lastTierStore.js";
 import { readDefaultGenerationQuality } from "../generationQuality.js";
 import { PROMPT_REFINE_MODEL_ID, VISION_CAPTION_MODEL_ID, VISION_CAPTION_MODEL_REPO } from "../constants.js";
-import { pickClosestResolution } from "../resolutionMatch.js";
+import { parseResolution, pickClosestResolution } from "../resolutionMatch.js";
 import {
   DEFAULT_MAC_CAPABILITIES,
   macAvailableModels,
@@ -1383,6 +1383,17 @@ export function ImageStudio() {
     }
     setSelectedPresetId(launchRequest.presetId);
   }, [launchRequest?.id]);
+  // A general-preset launch (epic 11949): toggle it into the stack without touching the model
+  // or mode. The chip is available in every studio, so a Video-bound user can re-add it there.
+  useEffect(() => {
+    if (launchRequest?.view !== "Image" || !launchRequest.presetGeneralId) {
+      return;
+    }
+    if (!generalStackIds.includes(launchRequest.presetGeneralId)) {
+      toggleGeneralPreset(launchRequest.presetGeneralId);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [launchRequest?.id]);
   useEffect(() => {
     if (launchRequest?.view !== "Image" || !launchRequest.recipe) {
       return;
@@ -1826,26 +1837,42 @@ export function ImageStudio() {
   // sendStructured / submitCaption / submitBackend / resolutionOverride). This replaced a
   // hand-copied batch twin that had drifted (dropped the img2img reference + pidTarget/img2img
   // advanced knobs), silently ignoring an img2img reference and PiD "2K" tier on batch runs.
-  const buildJobRequest = (overrides = {}) =>
-    buildImageJobRequest({
+  const buildJobRequest = (overrides = {}) => {
+    // Fold the general-preset stack (epic 11949) into this request. The prompt is composed per
+    // call so it wraps either the single prompt or a per-batch-item prompt; a structured JSON
+    // caption can't take flat fragments, so the prompt fold is skipped there (the stack's
+    // negative/aspect/count still apply). When the stack folds the prompt, the client is
+    // authoritative — presetPromptResolvedClientSide tells the server to skip its own fold.
+    const stackActive = generalStack.length > 0;
+    const isStructured = overrides.sendStructured ?? false;
+    const foldPrompt = stackActive && !isStructured;
+    const promptToSend =
+      foldPrompt && overrides.promptToSend != null
+        ? composePreset({ base: selectedPreset, generalStack, userText: overrides.promptToSend, resolutionOptions })
+            .prompt
+        : overrides.promptToSend;
+    const stackResolution = stackActive && composedStack.resolution ? parseResolution(composedStack.resolution) : null;
+    return buildImageJobRequest({
       // Overrides — the one legitimate single-vs-batch difference.
-      promptToSend: overrides.promptToSend,
+      promptToSend,
       submitIntent: overrides.submitIntent,
-      sendStructured: overrides.sendStructured ?? false,
+      sendStructured: isStructured,
       submitCaption: overrides.submitCaption,
       submitBackend: overrides.submitBackend,
-      resolutionOverride: overrides.resolutionOverride ?? null,
+      // A per-prompt [WxH] batch directive wins; otherwise the stack's aspect drives resolution.
+      resolutionOverride: overrides.resolutionOverride ?? stackResolution,
       // Shared studio settings (identical for both paths).
       resolution,
       mode,
-      negativePrompt,
+      negativePrompt: stackActive ? composedStack.negativePrompt : negativePrompt,
       model,
-      count,
+      count: stackActive && composedStack.count != null ? composedStack.count : count,
       seed,
       posePayload,
       width,
       height,
       recipePresetId: selectedPreset?.id ?? null,
+      presetPromptResolvedClientSide: foldPrompt,
       characterId,
       characterLookId,
       multiReference,
@@ -1897,6 +1924,7 @@ export function ImageStudio() {
       effectiveControlScale,
       controlOverlayId,
     });
+  };
 
   // One image-job request for a single resolved batch prompt. Thin adapter over the shared
   // buildJobRequest: resolves the per-prompt override defaults (structured-caption payload and a

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -1247,6 +1247,9 @@ export function ImageStudio() {
     selectedPreset,
     selectedPresetId,
     setSelectedPresetId,
+    availableGeneralPresets,
+    generalStackIds,
+    toggleGeneralPreset,
     presetPromptParts,
     presetLoraDetails,
     presetValidationResult,
@@ -1287,6 +1290,7 @@ export function ImageStudio() {
     initialSelectedLoraIds: saved.selectedLoraIds ?? [],
     initialLoraWeights: saved.loraWeights ?? {},
     initialShowIncompatibleLoras: saved.showIncompatibleLoras ?? false,
+    initialGeneralStackIds: saved.generalStackIds ?? [],
   });
 
   // ---- Krea-style image edit LoRA (epic 10871, P4.1) ----
@@ -1673,6 +1677,7 @@ export function ImageStudio() {
     loraWeights,
     showIncompatibleLoras,
     selectedPresetId,
+    generalStackIds,
     batchMode,
     batchPromptsText,
     batchVariableValues,
@@ -2820,6 +2825,23 @@ export function ImageStudio() {
                 ))}
               </div>
             </div>
+            {availableGeneralPresets.length ? (
+              <div className="settings-bar-styles">
+                <span className="settings-bar-label">General</span>
+                <div className="preset-chips general-preset-chips">
+                  {availableGeneralPresets.map((preset) => (
+                    <button
+                      className={generalStackIds.includes(preset.id) ? "preset-chip active" : "preset-chip"}
+                      key={preset.id}
+                      onClick={() => toggleGeneralPreset(preset.id)}
+                      type="button"
+                    >
+                      {preset.name ?? preset.id}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ) : null}
           </div>
 
           {macActiveModeBlock ? <p className="mac-gating-note">{macActiveModeBlock.text}</p> : null}

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -106,11 +106,13 @@ import {
   loraIsInstalled,
   serializeLora,
   noPresetId,
+  composePreset,
 } from "../presetUtils.js";
 import {
   LoraPickerSection,
   onPromptKeyDown,
   PresetGuidanceStrip,
+  PresetStackPreview,
   SavePresetPanel,
   useGenerationStudio,
   useSavePreset,
@@ -1248,6 +1250,7 @@ export function ImageStudio() {
     selectedPresetId,
     setSelectedPresetId,
     availableGeneralPresets,
+    generalStack,
     generalStackIds,
     toggleGeneralPreset,
     presetPromptParts,
@@ -1292,6 +1295,22 @@ export function ImageStudio() {
     initialShowIncompatibleLoras: saved.showIncompatibleLoras ?? false,
     initialGeneralStackIds: saved.generalStackIds ?? [],
   });
+
+  // The effective generation inputs once the general-preset stack is folded in (epic 11949).
+  // The live preview shows exactly this; a client-authoritative submit sends it (Phase 5).
+  const composedStack = useMemo(
+    () =>
+      composePreset({
+        base: selectedPreset,
+        generalStack,
+        userText: prompt,
+        userNegative: negativePrompt,
+        resolutionOptions,
+      }),
+    [selectedPreset, generalStack, prompt, negativePrompt, resolutionOptions],
+  );
+  const stackAddsNegative = generalStack.some((preset) => Boolean(preset?.defaults?.negativePrompt));
+  const stackAddsCount = generalStack.some((preset) => Number.isFinite(Number(preset?.defaults?.count)));
 
   // ---- Krea-style image edit LoRA (epic 10871, P4.1) ----
   // The Krea 2 edit surface REQUIRES a dual-conditioning `image_edit` LoRA (R5) that the base
@@ -2850,6 +2869,13 @@ export function ImageStudio() {
             selectedPreset={selectedPreset}
             presetPromptParts={presetPromptParts}
             presetLoraDetails={presetLoraDetails}
+          />
+
+          <PresetStackPreview
+            generalStack={generalStack}
+            composed={composedStack}
+            stackAddsNegative={stackAddsNegative}
+            stackAddsCount={stackAddsCount}
           />
 
           <AdvancedSection

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -97,6 +97,19 @@ const SORT_CHOICES = [
   ["scope", "Scope"],
 ];
 
+// Aspect ratios a general (model-agnostic) preset can pin. A general preset can't store a
+// concrete WxH — resolution menus differ per model — so it stores a ratio and the Studio
+// snaps it to the active model's nearest supported resolution at apply time (epic 11949).
+const GENERAL_ASPECT_RATIOS = [
+  ["1:1", "1:1 · Square"],
+  ["3:2", "3:2 · Landscape"],
+  ["2:3", "2:3 · Portrait"],
+  ["16:9", "16:9 · Wide"],
+  ["9:16", "9:16 · Tall"],
+  ["4:3", "4:3"],
+  ["3:4", "3:4"],
+];
+
 const scopeRank = { builtin: 0, global: 1, project: 2 };
 
 // The `defaults` keys this editor renders. Everything else a preset carries —
@@ -114,6 +127,7 @@ const EDITOR_OWNED_DEFAULTS = [
   "fps",
   "quality",
   "resolution",
+  "aspect",
   "negativePrompt",
   "sampler",
   "scheduler",
@@ -201,11 +215,13 @@ function formFromPreset(preset, fallbackModel) {
   return {
     id: preset?.id ?? "",
     name: preset?.name ?? "",
+    kind: preset?.kind === "general" ? "general" : "model",
     scope: preset?.scope === "project" ? "project" : "global",
     segment: presetSegmentKey(preset),
     model: preset?.model ?? fallbackModel ?? "",
     order: numberFieldValue(preset?.order),
     count: numberFieldValue(defaults.count),
+    aspect: defaults.aspect ?? "",
     duration: numberFieldValue(defaults.duration),
     fps: numberFieldValue(defaults.fps),
     quality: defaults.quality ?? "",
@@ -308,6 +324,9 @@ export function PresetManagerScreen() {
 
   const editable = !selectedPreset || selectedPreset.scope !== "builtin";
   const busy = saving;
+  // General (model-agnostic) presets hide the model/workflow/LoRA/model-specific controls
+  // and carry only prompt fragments + aspect + variations (epic 11949).
+  const isGeneral = form.kind === "general";
   const selectedModel = allModels.find((model) => model.id === form.model) ?? null;
   const modelInstalled = models.some((model) => model.id === form.model);
   const segments = availableSegments(selectedModel);
@@ -339,7 +358,10 @@ export function PresetManagerScreen() {
   // cannot drift (epic 10644, sc-10651). This generalizes the local sc-10500 split into the
   // shared core: name/model stay silent requirements; a read-only built-in, broken default
   // values (valueErrors, sc-10589), and the preset's own LoRA problems surface as chips.
-  const saveDraft = useMemo(() => ({ editable, name: form.name, model: form.model }), [editable, form.name, form.model]);
+  const saveDraft = useMemo(
+    () => ({ editable, name: form.name, model: form.model, kind: form.kind }),
+    [editable, form.name, form.model, form.kind],
+  );
   const saveContext = useMemo(() => ({ validation, valueErrors }), [validation, valueErrors]);
   const saveValidity = useValidation(presetSaveValidation, saveDraft, saveContext);
   const canSave = saveValidity.ready;
@@ -457,7 +479,52 @@ export function PresetManagerScreen() {
     }));
   }
 
+  // A general (model-agnostic) preset carries only prompt fragments + aspect + variations +
+  // negative. It never writes model/workflow/modes/loras — the backend rejects those on a
+  // general preset (epic 11949). Defaults still spread-then-replace so unrendered keys a
+  // studio snapshot wrote survive, and clearing a field really clears it.
+  function buildGeneralPayload() {
+    const defaults = { ...(selectedPreset?.defaults ?? {}) };
+    for (const key of EDITOR_OWNED_DEFAULTS) {
+      delete defaults[key];
+    }
+    if (form.aspect) {
+      defaults.aspect = form.aspect;
+    }
+    if (form.count !== "") {
+      defaults.count = Number(form.count);
+    }
+    if (form.negativePrompt.trim()) {
+      defaults.negativePrompt = form.negativePrompt.trim();
+    }
+    const prompt = {};
+    if (form.promptPrefix.trim()) {
+      prompt.prefix = form.promptPrefix.trim();
+    }
+    if (form.promptSuffix.trim()) {
+      prompt.suffix = form.promptSuffix.trim();
+    }
+    const payload = {
+      id: slugify(form.id || form.name),
+      name: form.name.trim(),
+      kind: "general",
+      scope: form.scope,
+      defaults,
+      ui: { description: form.description.trim() },
+    };
+    if (form.order !== "") {
+      payload.order = Number(form.order);
+    }
+    if (Object.keys(prompt).length) {
+      payload.prompt = prompt;
+    }
+    return payload;
+  }
+
   function buildPayload() {
+    if (form.kind === "general") {
+      return buildGeneralPayload();
+    }
     const segment = segmentByKey(form.segment);
     // Start from the preset's stored defaults so unrendered keys survive; drop the ones
     // this form owns so clearing a field really clears it, then re-add from the form.
@@ -605,8 +672,17 @@ export function PresetManagerScreen() {
       if (scopeFilter !== "all" && (preset.scope ?? "global") !== scopeFilter) {
         return false;
       }
-      if (typeFilter !== "all" && presetSegmentKey(preset) !== typeFilter) {
-        return false;
+      // General presets have no workflow segment, so they only match the "General" and
+      // "All" filters — never a specific workflow segment (which would falsely match the
+      // "text_to_image" default presetSegmentKey returns for them).
+      if (typeFilter !== "all") {
+        if (typeFilter === "general") {
+          if (preset.kind !== "general") {
+            return false;
+          }
+        } else if (preset.kind === "general" || presetSegmentKey(preset) !== typeFilter) {
+          return false;
+        }
       }
       if (!needle) {
         return true;
@@ -649,21 +725,31 @@ export function PresetManagerScreen() {
         <form className="preset-editor-form" onSubmit={savePreset}>
           <WorkPanel className="preset-editor-panel">
             {renderEditorHead()}
+            {renderKind()}
             {renderIdentity()}
-            {renderModel()}
-            {renderWorkflow()}
-            {renderPromptTemplate()}
-            {renderDefaults()}
-            {renderLoras()}
-            <div className="preset-form-section">
-              <AdvancedSection
-                hint="cleared values → model default"
-                onToggle={() => setAdvancedOpen((value) => !value)}
-                open={advancedOpen}
-              >
-                {renderAdvanced()}
-              </AdvancedSection>
-            </div>
+            {isGeneral ? (
+              <>
+                {renderPromptTemplate()}
+                {renderGeneralDefaults()}
+              </>
+            ) : (
+              <>
+                {renderModel()}
+                {renderWorkflow()}
+                {renderPromptTemplate()}
+                {renderDefaults()}
+                {renderLoras()}
+                <div className="preset-form-section">
+                  <AdvancedSection
+                    hint="cleared values → model default"
+                    onToggle={() => setAdvancedOpen((value) => !value)}
+                    open={advancedOpen}
+                  >
+                    {renderAdvanced()}
+                  </AdvancedSection>
+                </div>
+              </>
+            )}
             {renderFooter()}
           </WorkPanel>
         </form>
@@ -719,6 +805,7 @@ export function PresetManagerScreen() {
           </div>
           <select aria-label="Type" onChange={(event) => setTypeFilter(event.target.value)} value={typeFilter}>
             <option value="all">All types</option>
+            <option value="general">General</option>
             {WORKFLOW_SEGMENTS.map((segment) => (
               <option key={segment.key} value={segment.key}>
                 {segment.label}
@@ -765,11 +852,13 @@ export function PresetManagerScreen() {
   );
 
   function renderPresetCard(preset) {
+    const isGeneralPreset = preset.kind === "general";
     const segment = segmentByKey(presetSegmentKey(preset));
     const model = allModels.find((item) => item.id === preset.model);
-    // The studio snaps its model back into the installed catalog, so launching a preset
-    // pinned to an uninstalled model would silently land on a different one.
-    const runnable = models.some((item) => item.id === preset.model);
+    // The studio snaps its model back into the installed catalog, so launching a model preset
+    // pinned to an uninstalled model would silently land on a different one. A general preset
+    // is model-agnostic, so it's always runnable.
+    const runnable = isGeneralPreset || models.some((item) => item.id === preset.model);
     const scope = preset.scope ?? "global";
     const builtin = scope === "builtin";
     const defaults = preset.defaults ?? {};
@@ -777,14 +866,20 @@ export function PresetManagerScreen() {
     const prefix = preset.prompt?.prefix ?? "";
     const suffix = preset.prompt?.suffix ?? "";
 
-    const chips = [defaults.resolution ? defaults.resolution.replace("x", " × ") : "Any size"];
-    if (segment.type === "video") {
-      chips.push(defaults.duration ? `${defaults.duration}s` : "Default length");
-      chips.push(defaults.fps ? `${defaults.fps} fps` : "Default fps");
-    } else {
+    const chips = [];
+    if (isGeneralPreset) {
+      chips.push(defaults.aspect ? `${defaults.aspect} aspect` : "Any aspect");
       chips.push(defaults.count ? `${defaults.count} variations` : "Default count");
+    } else {
+      chips.push(defaults.resolution ? defaults.resolution.replace("x", " × ") : "Any size");
+      if (segment.type === "video") {
+        chips.push(defaults.duration ? `${defaults.duration}s` : "Default length");
+        chips.push(defaults.fps ? `${defaults.fps} fps` : "Default fps");
+      } else {
+        chips.push(defaults.count ? `${defaults.count} variations` : "Default count");
+      }
+      chips.push(qualityLabel(defaults.quality) ?? "Default quality");
     }
-    chips.push(qualityLabel(defaults.quality) ?? "Default quality");
 
     return (
       <article className="preset-card" key={`${scope}-${preset.id}`}>
@@ -792,9 +887,16 @@ export function PresetManagerScreen() {
           <div className="preset-card-title">
             <strong>{preset.name ?? preset.id}</strong>
             <div>
-              {segment.label} · <span className="preset-card-model">{model?.name ?? preset.model}</span>
+              {isGeneralPreset ? (
+                <span className="preset-card-model">General · any model</span>
+              ) : (
+                <>
+                  {segment.label} · <span className="preset-card-model">{model?.name ?? preset.model}</span>
+                </>
+              )}
             </div>
           </div>
+          {isGeneralPreset ? <span className="preset-kind-chip">General</span> : null}
           <span className={scope === "global" ? "preset-scope-chip global" : "preset-scope-chip"}>{scope}</span>
         </div>
 
@@ -810,9 +912,11 @@ export function PresetManagerScreen() {
               {chip}
             </span>
           ))}
-          <span className={loraCount ? "chip accent" : "chip"}>
-            {loraCount ? `${loraCount} LoRA${loraCount === 1 ? "" : "s"}` : "No LoRAs"}
-          </span>
+          {isGeneralPreset ? null : (
+            <span className={loraCount ? "chip accent" : "chip"}>
+              {loraCount ? `${loraCount} LoRA${loraCount === 1 ? "" : "s"}` : "No LoRAs"}
+            </span>
+          )}
         </div>
 
         <div className="preset-card-actions">
@@ -900,6 +1004,40 @@ export function PresetManagerScreen() {
           {optional ? <span className="preset-optional">optional</span> : null}
         </h3>
         {help ? <p>{help}</p> : null}
+      </div>
+    );
+  }
+
+  function renderKind() {
+    // Kind is locked after create (like the id): switching an existing preset between kinds
+    // would strand its model-specific fields or its stacked-fragment semantics. New presets
+    // choose; existing presets show it read-only.
+    const kinds = [
+      ["model", "Model preset", "Pinned to one model + workflow. Full controls and LoRAs."],
+      ["general", "General preset", "Model-agnostic. Prompt + aspect only; stacks onto any model."],
+    ];
+    return (
+      <div className="preset-form-section">
+        {renderSectionHead(
+          "Type",
+          "General presets layer prompt fragments onto any model in any workflow; model presets are pinned to one model.",
+        )}
+        <div aria-label="Preset type" className="segmented-control preset-kind" role="radiogroup">
+          {kinds.map(([value, label, help]) => (
+            <button
+              aria-checked={form.kind === value}
+              className={form.kind === value ? "active" : ""}
+              disabled={!creating || !editable}
+              key={value}
+              onClick={() => updateField("kind", value)}
+              role="radio"
+              title={help}
+              type="button"
+            >
+              {label}
+            </button>
+          ))}
+        </div>
       </div>
     );
   }
@@ -1070,11 +1208,13 @@ export function PresetManagerScreen() {
       <div className="preset-form-section">
         {renderSectionHead(
           "Prompt template",
-          "Text wrapped around whatever you type in the Studio. The preview updates as you edit.",
+          isGeneral
+            ? "Fragments added around your Studio prompt. Stack several general presets to combine them."
+            : "Text wrapped around whatever you type in the Studio. The preview updates as you edit.",
         )}
         <div className="preset-prompt-grid">
           <label className="field">
-            <span>Prefix</span>
+            <span>{isGeneral ? "Prepend to prompt" : "Prefix"}</span>
             <textarea
               disabled={!editable}
               onChange={(event) => updateField("promptPrefix", event.target.value)}
@@ -1084,7 +1224,7 @@ export function PresetManagerScreen() {
             />
           </label>
           <label className="field">
-            <span>Suffix</span>
+            <span>{isGeneral ? "Append to prompt" : "Suffix"}</span>
             <textarea
               disabled={!editable}
               onChange={(event) => updateField("promptSuffix", event.target.value)}
@@ -1182,6 +1322,57 @@ export function PresetManagerScreen() {
             </div>
           </label>
         </div>
+      </div>
+    );
+  }
+
+  function renderGeneralDefaults() {
+    return (
+      <div className="preset-form-section">
+        {renderSectionHead("Defaults", "Applied on top of whatever model and mode the Studio is on.")}
+        <div className="preset-defaults-grid">
+          <label className="field">
+            <span>Aspect</span>
+            <select disabled={!editable} onChange={(event) => updateField("aspect", event.target.value)} value={form.aspect}>
+              <option value="">No default</option>
+              {GENERAL_ASPECT_RATIOS.map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="field">
+            <span>Variations</span>
+            <select disabled={!editable} onChange={(event) => updateField("count", event.target.value)} value={form.count}>
+              <option value="">No default</option>
+              {[1, 2, 3, 4, 6, 8].map((n) => (
+                <option key={n} value={String(n)}>
+                  {n}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="field">
+            <span>Sort order</span>
+            <input
+              disabled={!editable}
+              onChange={(event) => updateField("order", event.target.value)}
+              placeholder="0"
+              type="number"
+              value={form.order}
+            />
+          </label>
+        </div>
+        <label className="field prompt-field">
+          <span>Negative prompt</span>
+          <input
+            disabled={!editable}
+            onChange={(event) => updateField("negativePrompt", event.target.value)}
+            placeholder="oversaturated, hands, text, watermark"
+            value={form.negativePrompt}
+          />
+        </label>
       </div>
     );
   }
@@ -1391,18 +1582,24 @@ export function PresetManagerScreen() {
 
   function renderFooter() {
     const loraCount = form.loras.length;
-    const chips = [
-      selectedModel?.name ?? form.model,
-      form.resolution ? form.resolution.replace("x", " × ") : "Any size",
-      isVideo
-        ? form.duration
-          ? `${form.duration}s`
-          : "Default length"
-        : form.count
-          ? `${form.count} variations`
-          : "Default count",
-      loraCount ? `${loraCount} LoRA${loraCount === 1 ? "" : "s"}` : "No LoRAs",
-    ].filter(Boolean);
+    const chips = isGeneral
+      ? [
+          "General · any model",
+          form.aspect ? `${form.aspect} aspect` : "Any aspect",
+          form.count ? `${form.count} variations` : "Default count",
+        ]
+      : [
+          selectedModel?.name ?? form.model,
+          form.resolution ? form.resolution.replace("x", " × ") : "Any size",
+          isVideo
+            ? form.duration
+              ? `${form.duration}s`
+              : "Default length"
+            : form.count
+              ? `${form.count} variations`
+              : "Default count",
+          loraCount ? `${loraCount} LoRA${loraCount === 1 ? "" : "s"}` : "No LoRAs",
+        ].filter(Boolean);
 
     return (
       <>

--- a/apps/web/src/screens/PresetManagerScreen.test.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.test.jsx
@@ -340,4 +340,76 @@ describe("PresetManagerScreen", () => {
     await changeField(field(container, "Name"), "Cinematic Portrait v2");
     expect(container.querySelector(".preset-status-pill").textContent).toContain("Unsaved changes");
   });
+
+  // epic 11949: a general (model-agnostic) preset carries only prompt fragments + aspect +
+  // variations + negative, with no model/workflow/LoRA controls, and saves with kind:general.
+  it("creates a general preset with prompt fragments and aspect, and no model", async () => {
+    const context = await render();
+    await clickButton("New preset");
+    await clickButton("General preset");
+
+    // The model-specific controls are gone.
+    expect(field(container, "Model")).toBeUndefined();
+    expect(container.querySelector(".preset-workflow")).toBeNull();
+    // Prompt inputs are relabelled to signal the fragment/stacking model.
+    expect(field(container, "Prepend to prompt")).toBeDefined();
+    expect(field(container, "Append to prompt")).toBeDefined();
+    // Aspect is a ratio menu, not a WxH resolution list.
+    expect([...field(container, "Aspect").options].map((o) => o.value)).toEqual([
+      "",
+      "1:1",
+      "3:2",
+      "2:3",
+      "16:9",
+      "9:16",
+      "4:3",
+      "3:4",
+    ]);
+
+    await changeField(field(container, "Name"), "Kodak Portra");
+    await changeField(field(container, "Append to prompt"), "Kodak Portra 400");
+    await changeField(field(container, "Aspect"), "16:9");
+    await changeField(field(container, "Variations"), "2");
+    await changeField(field(container, "Negative prompt"), "blurry");
+    await clickButton("Create preset");
+
+    expect(context.createPreset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "kodak_portra",
+        kind: "general",
+        prompt: { suffix: "Kodak Portra 400" },
+        defaults: expect.objectContaining({ aspect: "16:9", count: 2, negativePrompt: "blurry" }),
+      }),
+    );
+    const [payload] = context.createPreset.mock.calls[0];
+    expect(payload.model).toBeUndefined();
+    expect(payload.workflow).toBeUndefined();
+    expect(payload.loras).toBeUndefined();
+  });
+
+  it("lists a general preset with a badge, always runnable, and filters by General type", async () => {
+    const generalPreset = {
+      id: "film_stock",
+      name: "Film Stock",
+      kind: "general",
+      scope: "global",
+      updatedAt: "2026-07-10T00:00:00Z",
+      prompt: { suffix: "Kodak Portra 400" },
+      defaults: { aspect: "3:2", count: 2 },
+    };
+    await render(baseContext({ presets: [...presets, generalPreset] }));
+
+    const card = [...container.querySelectorAll(".preset-card")].find((c) => c.textContent.includes("Film Stock"));
+    expect(card.querySelector(".preset-kind-chip")?.textContent).toBe("General");
+    expect(card.textContent).toContain("General · any model");
+    // Runnable even though it pins no model (no install gate).
+    expect(card.querySelector(".preset-card-use").disabled).toBe(false);
+
+    // The General type filter shows only general presets…
+    await changeField(container.querySelector("select[aria-label='Type']"), "general");
+    expect(cardNames()).toEqual(["Film Stock"]);
+    // …and a workflow filter never surfaces a general preset.
+    await changeField(container.querySelector("select[aria-label='Type']"), "text_to_image");
+    expect(cardNames()).not.toContain("Film Stock");
+  });
 });

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -36,11 +36,13 @@ import {
   loraLooksLikeIcLora,
   noPresetId,
   serializeLora,
+  composePreset,
 } from "../presetUtils.js";
 import {
   LoraPickerSection,
   onPromptKeyDown,
   PresetGuidanceStrip,
+  PresetStackPreview,
   SavePresetPanel,
   useGenerationStudio,
   useSavePreset,
@@ -290,6 +292,7 @@ export function VideoStudio() {
     selectedPresetId,
     setSelectedPresetId,
     availableGeneralPresets,
+    generalStack,
     generalStackIds,
     toggleGeneralPreset,
     presetPromptParts,
@@ -704,6 +707,22 @@ export function VideoStudio() {
   const [width, height] = resolution.split("x").map((value) => Number(value));
   const durationOptions = selectedModel?.limits?.durations ?? [4, 6, 8, 10];
   const resolutionOptions = selectedModel?.limits?.resolutions ?? ["768x512", "640x640", "1280x720", "720x1280"];
+
+  // Effective inputs once the general-preset stack folds in (epic 11949); drives the live
+  // preview and (Phase 5) the client-authoritative submit.
+  const composedStack = useMemo(
+    () =>
+      composePreset({
+        base: selectedPreset,
+        generalStack,
+        userText: prompt,
+        userNegative: negativePrompt,
+        resolutionOptions,
+      }),
+    [selectedPreset, generalStack, prompt, negativePrompt, resolutionOptions],
+  );
+  const stackAddsNegative = generalStack.some((preset) => Boolean(preset?.defaults?.negativePrompt));
+  const stackAddsCount = generalStack.some((preset) => Number.isFinite(Number(preset?.defaults?.count)));
   const fpsOptions = selectedModel?.limits?.fps ?? [24, 25, 30];
   const durationHint =
     selectedModel?.ui?.durationHint ??
@@ -1206,6 +1225,13 @@ export function VideoStudio() {
             selectedPreset={selectedPreset}
             presetPromptParts={presetPromptParts}
             presetLoraDetails={presetLoraDetails}
+          />
+
+          <PresetStackPreview
+            generalStack={generalStack}
+            composed={composedStack}
+            stackAddsNegative={stackAddsNegative}
+            stackAddsCount={stackAddsCount}
           />
 
           {durationHint ? <p className="helper-copy">{durationHint}</p> : null}

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -289,6 +289,9 @@ export function VideoStudio() {
     selectedPreset,
     selectedPresetId,
     setSelectedPresetId,
+    availableGeneralPresets,
+    generalStackIds,
+    toggleGeneralPreset,
     presetPromptParts,
     presetLoraDetails,
     presetValidationResult,
@@ -327,6 +330,7 @@ export function VideoStudio() {
     initialSelectedLoraIds: saved.selectedLoraIds ?? [],
     initialLoraWeights: saved.loraWeights ?? {},
     initialShowIncompatibleLoras: saved.showIncompatibleLoras ?? false,
+    initialGeneralStackIds: saved.generalStackIds ?? [],
   });
   // Sampler / scheduler menus declared by the model. Video Wan torch
   // declares the full menu; sealed paths (LTX native, MLX) drop to
@@ -568,6 +572,7 @@ export function VideoStudio() {
     seed,
     negativePrompt,
     selectedPresetId,
+    generalStackIds,
     sampler,
     scheduler,
     schedulerShift,
@@ -1178,6 +1183,23 @@ export function VideoStudio() {
                 ))}
               </div>
             </div>
+            {availableGeneralPresets.length ? (
+              <div className="settings-bar-styles">
+                <span className="settings-bar-label">General</span>
+                <div className="preset-chips general-preset-chips">
+                  {availableGeneralPresets.map((preset) => (
+                    <button
+                      className={generalStackIds.includes(preset.id) ? "preset-chip active" : "preset-chip"}
+                      key={preset.id}
+                      onClick={() => toggleGeneralPreset(preset.id)}
+                      type="button"
+                    >
+                      {preset.name ?? preset.id}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ) : null}
           </div>
 
           <PresetGuidanceStrip

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { pickClosestResolution } from "../resolutionMatch.js";
+import { parseResolution, pickClosestResolution } from "../resolutionMatch.js";
 import { AssetPickerField } from "../components/AssetPicker.jsx";
 import { FitModeControl, effectiveFitMode } from "../components/FitModeControl.jsx";
 import { AssetCard } from "../components/assetPanels.jsx";
@@ -740,15 +740,21 @@ export function VideoStudio() {
     }
     setSubmitting(true);
     try {
+      // Fold the general-preset stack (epic 11949): send the composed prompt + negative and,
+      // when a general sets aspect, the snapped resolution. The client is authoritative for the
+      // composed prompt, so presetPromptResolvedClientSide tells the server to skip its fold.
+      // (Video has no `count` field, so the stack's variations don't apply here.)
+      const stackActive = generalStack.length > 0;
+      const stackResolution = stackActive && composedStack.resolution ? parseResolution(composedStack.resolution) : null;
       const job = await createVideoJob({
         mode,
-        prompt,
-        negativePrompt,
+        prompt: stackActive ? composedStack.prompt : prompt,
+        negativePrompt: stackActive ? composedStack.negativePrompt : negativePrompt,
         model,
         duration: Number(duration),
         fps: Number(fps),
-        width,
-        height,
+        width: stackResolution?.width ?? width,
+        height: stackResolution?.height ?? height,
         quality,
         seed: seed === "" ? null : Number(seed),
         recipePresetId: selectedPreset?.id ?? null,
@@ -756,6 +762,7 @@ export function VideoStudio() {
         // preset-LoRA seed effect), so the client is authoritative for preset LoRAs — tell the
         // server to skip its own merge so edits/removals stick. Parity with the Image Studio.
         presetLorasResolvedClientSide: selectedPreset ? true : undefined,
+        presetPromptResolvedClientSide: stackActive || undefined,
         characterId: characterId || null,
         characterLookId: characterLookId || null,
         sourceAssetId: ["image_to_video", "first_last_frame"].includes(mode) ? sourceAssetId || null : null,

--- a/apps/web/src/screens/generationStudio.jsx
+++ b/apps/web/src/screens/generationStudio.jsx
@@ -126,8 +126,13 @@ export function useGenerationStudio({
   initialSelectedLoraIds = [],
   initialLoraWeights = {},
   initialShowIncompatibleLoras = false,
+  // The general-preset stack (epic 11949): an ordered set of model-agnostic presets layered
+  // on top of whatever model + mode the studio is on. Separate from the base model preset
+  // (selectedPresetId) — model presets stay single-select, general presets stack.
+  initialGeneralStackIds = [],
 }) {
   const [selectedPresetId, setSelectedPresetId] = useState(initialPresetId);
+  const [generalStackIds, setGeneralStackIds] = useState(initialGeneralStackIds);
   const [resultFallbackTick, setResultFallbackTick] = useState(0);
   const [selectedLoraIds, setSelectedLoraIds] = useState(initialSelectedLoraIds);
   const [loraWeights, setLoraWeights] = useState(initialLoraWeights);
@@ -148,9 +153,31 @@ export function useGenerationStudio({
     }
   }, [characters, characterId, setCharacterId, setCharacterLookId]);
 
+  // The base slot: model presets that match the current workflow + model, single-select
+  // exactly as before. General presets are excluded here — they live in their own stack.
   const availablePresets = useMemo(
-    () => presets.filter((preset) => presetMatchesWorkflow(preset, mode) && presetMatchesModel(preset, selectedModel, models)),
+    () =>
+      presets.filter(
+        (preset) =>
+          preset.kind !== "general" &&
+          presetMatchesWorkflow(preset, mode) &&
+          presetMatchesModel(preset, selectedModel, models),
+      ),
     [mode, presets, selectedModel?.id, models],
+  );
+  // General (model-agnostic) presets are available on every model in every mode.
+  const availableGeneralPresets = useMemo(
+    () => presets.filter((preset) => preset.kind === "general"),
+    [presets],
+  );
+  const availableGeneralKey = useMemo(
+    () => availableGeneralPresets.map((preset) => preset.id).join("|"),
+    [availableGeneralPresets],
+  );
+  // The active general stack, in selection order. Drops ids no longer in the catalog.
+  const generalStack = useMemo(
+    () => generalStackIds.map((id) => availableGeneralPresets.find((preset) => preset.id === id)).filter(Boolean),
+    [generalStackIds, availableGeneralPresets],
   );
   // sc-5875: presets are opt-in. With no explicit selection (fresh screen / None),
   // resolve to no preset so an unchosen preset's LoRA/resolution/prompt are never
@@ -176,6 +203,22 @@ export function useGenerationStudio({
       setSelectedPresetId(availablePresets[0]?.id ?? noPresetId);
     }
   }, [availablePresets, selectedPresetId, selectedPreset]);
+
+  // Prune stacked general presets that leave the catalog (archived/deleted). Unlike the
+  // base slot this drops silently — a stack has no single "fall back to the first" notion.
+  useEffect(() => {
+    setGeneralStackIds((ids) => {
+      const next = ids.filter((id) => availableGeneralPresets.some((preset) => preset.id === id));
+      return next.length === ids.length ? ids : next;
+    });
+  }, [availableGeneralKey]);
+
+  // Add/remove a general preset from the stack. Toggling never touches the model, mode, or
+  // the LoRA picker — general presets carry none of those. Composition into the prompt is
+  // the studio's job (epic 11949 Phase 4).
+  const toggleGeneralPreset = useCallback((id) => {
+    setGeneralStackIds((ids) => (ids.includes(id) ? ids.filter((existing) => existing !== id) : [...ids, id]));
+  }, []);
 
   const resultVisible = useCallback((job) => {
     if (job.result?.generationSetId) {
@@ -354,6 +397,11 @@ export function useGenerationStudio({
     selectedPreset,
     selectedPresetId,
     setSelectedPresetId,
+    // General-preset stack (epic 11949).
+    availableGeneralPresets,
+    generalStack,
+    generalStackIds,
+    toggleGeneralPreset,
     presetPromptParts,
     presetLoraDetails,
     presetValidationResult,

--- a/apps/web/src/screens/generationStudio.jsx
+++ b/apps/web/src/screens/generationStudio.jsx
@@ -791,6 +791,44 @@ export function SavePresetPanel({
   );
 }
 
+// The live composed-prompt preview shown when a general-preset stack is active (epic 11949).
+// It is the safeguard against messy concatenation: the user sees the exact prompt (and any
+// negative/aspect/count the stack contributes) BEFORE generating, so a bad fragment or a
+// surprising order is obvious and fixable. Renders nothing when the stack is empty.
+export function PresetStackPreview({ generalStack, composed, stackAddsNegative, stackAddsCount }) {
+  if (!generalStack.length) {
+    return null;
+  }
+  const extras = [];
+  if (composed.aspect) {
+    extras.push(`Aspect ${composed.aspect}${composed.resolution ? ` → ${composed.resolution}` : ""}`);
+  }
+  if (stackAddsCount && composed.count != null) {
+    extras.push(`${composed.count} variation${composed.count === 1 ? "" : "s"}`);
+  }
+  if (stackAddsNegative && composed.negativePrompt) {
+    extras.push(`Negative: ${composed.negativePrompt}`);
+  }
+  return (
+    <div className="preset-stack-preview">
+      <div className="preset-stack-order">
+        <span className="eyebrow">Stacked</span>
+        {generalStack.map((preset, index) => (
+          <React.Fragment key={preset.id}>
+            {index > 0 ? <span className="preset-stack-arrow" aria-hidden="true">→</span> : null}
+            <span className="preset-stack-name">{preset.name ?? preset.id}</span>
+          </React.Fragment>
+        ))}
+      </div>
+      <div className="preset-stack-prompt">
+        <span className="eyebrow">Prompt sent</span>
+        <p>{composed.prompt ? composed.prompt : <span className="token">your prompt</span>}</p>
+      </div>
+      {extras.length ? <p className="preset-stack-extras">{extras.join(" · ")}</p> : null}
+    </div>
+  );
+}
+
 // The "what this preset adds" strip shown under the preset picker in both studios.
 export function PresetGuidanceStrip({ selectedPreset, presetPromptParts, presetLoraDetails }) {
   // Nothing to say when no preset is active — the visible controls already describe the run.

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6288,6 +6288,22 @@ details[open] > summary.lora-scope-group-heading::before,
   color: var(--accent-strong);
 }
 
+/* General (model-agnostic) preset badge on the card — epic 11949. Sits beside the scope
+   chip; uses the accent-soft treatment so it reads as a distinct preset kind, not a scope. */
+.preset-kind-chip {
+  flex: none;
+  padding: 3px 9px;
+  border-radius: var(--r-pill);
+  border: 1px solid transparent;
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
 .preset-card-preview {
   padding: 9px 11px;
   background: var(--bg);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7326,6 +7326,63 @@ details[open] > summary.lora-scope-group-heading::before,
   font-size: 13px;
 }
 
+/* Live composed-prompt preview for a general-preset stack (epic 11949). The safeguard
+   against messy concatenation: shows the exact prompt the run will send, plus the active
+   stack order and any negative/aspect/count the stack contributes. */
+.preset-stack-preview {
+  display: grid;
+  gap: 8px;
+  padding: 10px 12px;
+  margin-top: 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+}
+
+.preset-stack-order {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.preset-stack-name {
+  padding: 2px 8px;
+  border-radius: var(--r-pill);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-size: 11.5px;
+  font-weight: 600;
+}
+
+.preset-stack-arrow {
+  color: var(--text-faint);
+  font-size: 12px;
+}
+
+.preset-stack-prompt {
+  display: grid;
+  gap: 3px;
+}
+
+.preset-stack-prompt p {
+  margin: 0;
+  font: 400 12.5px/1.55 var(--font-mono);
+  color: var(--text);
+  word-break: break-word;
+}
+
+.preset-stack-prompt .token {
+  color: var(--text-faint);
+  font-style: italic;
+}
+
+.preset-stack-extras {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
 .lora-picker {
   display: grid;
   gap: 10px;

--- a/packages/schemas/recipe-preset.schema.json
+++ b/packages/schemas/recipe-preset.schema.json
@@ -11,11 +11,28 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["id", "name", "model", "workflow"],
+        "required": ["id", "name"],
         "additionalProperties": true,
+        "allOf": [
+          {
+            "description": "Model (non-general) presets are pinned to a model + workflow. General presets are model-agnostic and omit both. A preset with no `kind` is treated as a model preset.",
+            "if": {
+              "not": {
+                "properties": { "kind": { "const": "general" } },
+                "required": ["kind"]
+              }
+            },
+            "then": { "required": ["model", "workflow"] }
+          }
+        ],
         "properties": {
           "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9_-]*$" },
           "name": { "type": "string", "minLength": 1 },
+          "kind": {
+            "type": "string",
+            "enum": ["model", "general"],
+            "description": "Preset kind. `model` (default when absent) is pinned to a specific model + workflow. `general` is model-agnostic: it carries only prompt prefix/suffix, negative prompt, aspect, and variations, and stacks on top of any model in any workflow. General presets must not set `model`, `workflow`, or `loras`."
+          },
           "scope": { "type": "string", "enum": ["builtin", "global", "project"] },
           "archived": { "type": "boolean" },
           "lastUsedAt": {
@@ -39,6 +56,11 @@
             "properties": {
               "count": { "type": "integer", "minimum": 1 },
               "resolution": { "type": "string", "pattern": "^[0-9]+x[0-9]+$" },
+              "aspect": {
+                "type": "string",
+                "pattern": "^[0-9]+:[0-9]+$",
+                "description": "Aspect ratio (e.g. \"16:9\") for model-agnostic general presets. Resolved to the active model's nearest supported resolution at apply time, since a general preset can't know a concrete WxH. Model presets use `resolution` instead."
+              },
               "negativePrompt": { "type": "string" }
             }
           },


### PR DESCRIPTION
## General (model-agnostic) presets that stack

Epic [sc-11949](https://app.shortcut.com/trefry/epic/11949). Adds a second **kind** of recipe preset that isn't pinned to a model, so users stop recreating a prompt-enhancer preset for every model. General presets **stack** — layer several (e.g. camera + lens + film) on top of an optional model preset, and the studio composes their prompt fragments live.

### The model
`kind: "model" | "general"` on the recipe preset (default `"model"`; **absent = model, so every existing preset is unchanged**). A **general** preset carries only prompt prefix/suffix, negative prompt, aspect, and variations — no model, no workflow, no LoRAs. New `defaults.aspect` stores a ratio (e.g. `16:9`) since a model-agnostic preset can't know a concrete WxH; it snaps to the active model's nearest supported resolution at apply time.

### Composition (the heart)
Stacked presets compose **flat, not nested** — this is what keeps stacking several from becoming a mess:

```
prompt = [base.prefix, …general.prefix] + userText + […general.suffix, base.suffix]   (base outermost)
```

A **mandatory live preview** shows the exact prompt a run will send (plus any negative/aspect/count the stack contributes), so a bad fragment is visible before generating.

### Client-authoritative prompt (mirrors #1518)
The prompt prefix/suffix is folded **server-side** today from a single `recipePresetId`, which a stack of N presets can't route through. So — exactly like #1518 did for LoRAs with `presetLorasResolvedClientSide` — when ≥1 general preset is stacked, the client sends the composed prompt and sets a new `presetPromptResolvedClientSide` flag; the server skips its own fold. **With no general preset stacked, the path is byte-identical to today.**

## Phases (one commit each)
| Story | Commit | |
|---|---|---|
| [sc-11950](https://app.shortcut.com/trefry/story/11950) | `6e851ed5` | Backend: `kind`, schema relax, `defaults.aspect`, `presetPromptResolvedClientSide` |
| [sc-11951](https://app.shortcut.com/trefry/story/11951) | `12c66c75` | Editor: General/Model type toggle + conditional fields |
| [sc-11952](https://app.shortcut.com/trefry/story/11952) | `d379007a` | Studio stack state + "General" chip group |
| [sc-11955](https://app.shortcut.com/trefry/story/11955) | `a760cba9` | `composePreset` + live composed-prompt preview |
| [sc-11953](https://app.shortcut.com/trefry/story/11953) | `9c84d154` | Apply composed stack to generation + launch |
| [sc-11954](https://app.shortcut.com/trefry/story/11954) | `202027b0` | Test hardening + browser verification |

## Verification
- **web vitest 1676** · **rust-api 273** — both green. `cargo fmt --check` + `clippy -D warnings` clean.
- **Fails-when-reverted**: the camera+lens+film test was proven to go red when the general-stack fold is reverted (not a false-green).
- **Live rust-api HTTP round-trip**: POST general preset → 201 with no model/workflow injected; PATCH aspect round-trips with no re-bind; general+model → 400.
- **Real browser** (worktree web + rust-api): an API-created general preset appeared in the studio's "General" group on Anima 2B; toggling it rendered `cinematic still, a fox in the snow, Kodak Portra 400` (Aspect 2:3 → 832×1216) with the model untouched.

## Decisions worth a look on review
- **Per-studio stack** — a launched general preset is available as a chip in both studios but isn't auto-carried across the image→video switch (one click re-adds it). Shared cross-studio state was scoped out of v1.
- **Structured-caption models** (Ideogram) skip the stack's *prompt* fold (a JSON caption can't take flat fragments) but still get its negative/aspect.

## Notes
- Reconciled with `#1518` (merged to main): reused its `presetLoraSeed`/client-authoritative pattern; the base model-preset slot is kept verbatim so LoRA seeding + defaults hydrate are untouched.
- `fmt`/`clippy`/tests were run **scoped to `rust-api`** locally (changes are confined there) rather than the full-workspace `npm run rust:check`, to avoid starving the self-hosted runner; CI runs the full lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
