### PR TITLE
feat(web): selective lazy keep-alive shell + useScreenActive context (sc-11959)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -37,6 +37,7 @@ import { useAccessGate } from "./hooks/useAccessGate.js";
 import { useDropNavigationGuard } from "./hooks/useDropNavigationGuard.js";
 import { useJobEvents } from "./hooks/useJobEvents.js";
 import { AppStaticContext, AppLiveContext } from "./context/AppContext.js";
+import { ScreenActiveContext } from "./context/ScreenActiveContext.js";
 import { DEFAULT_MAC_CAPABILITIES } from "./macGating.js";
 import { isAccentId } from "./accents.js";
 import { writeDefaultGenerationQuality } from "./generationQuality.js";
@@ -74,6 +75,46 @@ import {
 const ImageEditor = React.lazy(() =>
   import("./screens/ImageEditor.jsx").then((module) => ({ default: module.ImageEditor })),
 );
+
+// Selective lazy keep-alive (sc-11959, backbone for epic 11949's edit persistence).
+// These view ids mount on FIRST visit and then stay mounted (hidden) so their React
+// state — in-progress prompt, settings, edits — survives leaving and returning, and
+// the studios stop re-hydrating (and clobbering) from localStorage on every visit.
+// Everything NOT listed here (Queue, Settings, Stats, Logs, Licenses, Models, and
+// Library/Assets) keeps today's conditional unmount-on-navigation behavior. Training
+// contributes two view ids — the default "Train" workspace and the "LibraryDataSets"
+// Data Sets mode — both part of the Training Studio family.
+const KEEP_ALIVE_VIEWS = Object.freeze(
+  new Set([
+    "Image",
+    "Video",
+    "Characters",
+    "Document",
+    "Train",
+    "LibraryDataSets",
+    "Presets",
+    "Poses",
+    "Keypoints",
+    "Editor",
+    "ImageEditor",
+  ]),
+);
+
+// Wrapper for a kept-alive screen (sc-11959). The screen mounts once and then stays
+// mounted; navigating away toggles `active` false, which hides the pane instead of
+// unmounting it. `display: contents` (see .keep-alive-pane in styles.css) keeps the
+// wrapper transparent to the .workspace flex column while visible — the child screen
+// lays out exactly as a direct .workspace child would — and the `hidden` attribute
+// drops it from layout and the accessibility tree while backgrounded. The pane also
+// publishes `active` on ScreenActiveContext so the screen can pause expensive work
+// when hidden (S2) or drop a leave-guard when it isn't the foreground view.
+function KeepAlivePane({ active, children }) {
+  return (
+    <div className="keep-alive-pane" hidden={!active}>
+      <ScreenActiveContext.Provider value={active}>{children}</ScreenActiveContext.Provider>
+    </div>
+  );
+}
 
 // Product version, injected at build time from package.json (see vite.config.js).
 // Empty in unconfigured contexts (e.g. some test paths); the footer is hidden then.
@@ -342,6 +383,10 @@ export function App() {
   const [setupCompleted, setSetupCompleted] = useState(isDesktopShell ? null : true);
   const [activeProject, setActiveProject] = useState(null);
   const [activeView, setActiveView] = useState("Library");
+  // Selective lazy keep-alive (sc-11959): the set of keep-alive views the user has
+  // visited at least once. A view mounts on first visit (activeView === view) and,
+  // once here, stays mounted (hidden) across navigation so its state survives.
+  const [visitedKeepAliveViews, setVisitedKeepAliveViews] = useState(() => new Set());
   const [jobs, setJobs] = useState([]);
   const [localGenerationJobIds, setLocalGenerationJobIds] = useState({ image: [], video: [], document: [] });
   const [workers, setWorkers] = useState([]);
@@ -850,6 +895,15 @@ export function App() {
 
   useEffect(() => {
     activeViewRef.current = activeView;
+  }, [activeView]);
+
+  // Record a keep-alive view the first time it becomes active so it stays mounted
+  // thereafter (sc-11959). Never-visited keep-alive views are absent from the DOM.
+  useEffect(() => {
+    if (!KEEP_ALIVE_VIEWS.has(activeView)) {
+      return;
+    }
+    setVisitedKeepAliveViews((prev) => (prev.has(activeView) ? prev : new Set(prev).add(activeView)));
   }, [activeView]);
 
   useEffect(() => {
@@ -1928,6 +1982,9 @@ export function App() {
   );
 
   const titleInfo = viewTitles[activeView] ?? { title: activeView, blurb: "" };
+  // A keep-alive view is rendered once it is active OR has been visited before
+  // (sc-11959): it mounts on first visit and then stays mounted (hidden) thereafter.
+  const keepAliveMounted = (view) => activeView === view || visitedKeepAliveViews.has(view);
   // Activity dots only — counts live in the topbar so nav button textContent stays clean.
   const activeIndicators = {
     Editor: timelines.length > 0,
@@ -2316,67 +2373,91 @@ export function App() {
           <FirstRunProjectGate disabled={!authenticated} onCreate={createProject} />
         ) : (
           <>
-        {activeView === "Library" ? (
-          <LibraryScreen />
-        ) : null}
-
-        {activeView === "LibraryDataSets" ? (
-          <TrainingDataSetsLibrary />
-        ) : null}
-
-        {activeView === "Poses" ? (
-          <PoseLibraryScreen />
-        ) : null}
-
-        {activeView === "Keypoints" ? (
-          <KeyPointLibraryScreen />
-        ) : null}
-
-        {activeView === "Image" ? (
-          <ImageStudio key={activeProject?.id ?? "default"} />
-        ) : null}
-
-        {activeView === "Video" ? (
-          <VideoStudio key={activeProject?.id ?? "default"} />
-        ) : null}
-
-        {activeView === "Document" ? (
-          <DocumentStudio />
-        ) : null}
-
-        {activeView === "Train" ? (
-          <TrainingStudio />
-        ) : null}
-
-        {activeView === "Presets" ? (
-          <PresetManagerScreen />
-        ) : null}
-
-        {activeView === "Queue" ? (
-          <QueueScreen />
-        ) : null}
-
-        {activeView === "Models" ? (
-          <ModelManagerScreen />
-        ) : null}
-
-        {activeView === "Editor" ? (
-          <EditorScreen />
-        ) : null}
-
-        {activeView === "ImageEditor" ? (
-          <React.Suspense fallback={<section className="page-frame">Loading editor…</section>}>
-            <ImageEditor key={activeProject?.id ?? "default"} />
-          </React.Suspense>
-        ) : null}
-
-        {activeView === "Characters" ? (
-          <CharacterStudio key={activeProject?.id ?? "default"} />
-        ) : null}
+        {/* OUT screens (Library/Assets, Queue, Models, Settings, Stats, Logs,
+            Licenses): keep the conditional-unmount behavior — mounted only while
+            active, unmounted on navigation (sc-11959). */}
+        {activeView === "Library" ? <LibraryScreen /> : null}
+        {activeView === "Queue" ? <QueueScreen /> : null}
+        {activeView === "Models" ? <ModelManagerScreen /> : null}
         {activeView === "Settings" ? <SettingsScreen /> : null}
         {activeView === "Stats" ? <StatsScreen /> : null}
         {activeView === "Logs" ? <LogsScreen /> : null}
         {activeView === "Licenses" ? <LicensesScreen /> : null}
+
+        {/* Keep-alive screens (sc-11959): mounted on first visit via keepAliveMounted,
+            then kept mounted and toggled visible/hidden by KeepAlivePane so their
+            state survives navigation. The key={activeProject?.id} on the studios +
+            Image Editor is preserved so a PROJECT switch still remounts (resets) them
+            even while kept alive. The studioLaunch apply effects inside each studio are
+            keyed on the launch token id, not on mount, so a fresh "Use this Recipe" /
+            "Use in Studio" injection still fires on an already-mounted studio. */}
+        {keepAliveMounted("Image") ? (
+          <KeepAlivePane active={activeView === "Image"}>
+            <ImageStudio key={activeProject?.id ?? "default"} />
+          </KeepAlivePane>
+        ) : null}
+
+        {keepAliveMounted("Video") ? (
+          <KeepAlivePane active={activeView === "Video"}>
+            <VideoStudio key={activeProject?.id ?? "default"} />
+          </KeepAlivePane>
+        ) : null}
+
+        {keepAliveMounted("Characters") ? (
+          <KeepAlivePane active={activeView === "Characters"}>
+            <CharacterStudio key={activeProject?.id ?? "default"} />
+          </KeepAlivePane>
+        ) : null}
+
+        {keepAliveMounted("Document") ? (
+          <KeepAlivePane active={activeView === "Document"}>
+            <DocumentStudio />
+          </KeepAlivePane>
+        ) : null}
+
+        {keepAliveMounted("Train") ? (
+          <KeepAlivePane active={activeView === "Train"}>
+            <TrainingStudio />
+          </KeepAlivePane>
+        ) : null}
+
+        {keepAliveMounted("LibraryDataSets") ? (
+          <KeepAlivePane active={activeView === "LibraryDataSets"}>
+            <TrainingDataSetsLibrary />
+          </KeepAlivePane>
+        ) : null}
+
+        {keepAliveMounted("Presets") ? (
+          <KeepAlivePane active={activeView === "Presets"}>
+            <PresetManagerScreen />
+          </KeepAlivePane>
+        ) : null}
+
+        {keepAliveMounted("Poses") ? (
+          <KeepAlivePane active={activeView === "Poses"}>
+            <PoseLibraryScreen />
+          </KeepAlivePane>
+        ) : null}
+
+        {keepAliveMounted("Keypoints") ? (
+          <KeepAlivePane active={activeView === "Keypoints"}>
+            <KeyPointLibraryScreen />
+          </KeepAlivePane>
+        ) : null}
+
+        {keepAliveMounted("Editor") ? (
+          <KeepAlivePane active={activeView === "Editor"}>
+            <EditorScreen />
+          </KeepAlivePane>
+        ) : null}
+
+        {keepAliveMounted("ImageEditor") ? (
+          <KeepAlivePane active={activeView === "ImageEditor"}>
+            <React.Suspense fallback={<section className="page-frame">Loading editor…</section>}>
+              <ImageEditor key={activeProject?.id ?? "default"} />
+            </React.Suspense>
+          </KeepAlivePane>
+        ) : null}
           </>
         )}
       </section>

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -2411,7 +2411,7 @@ export function App() {
 
         {keepAliveMounted("Document") ? (
           <KeepAlivePane active={activeView === "Document"}>
-            <DocumentStudio />
+            <DocumentStudio key={activeProject?.id ?? "default"} />
           </KeepAlivePane>
         ) : null}
 

--- a/apps/web/src/App.keepAlive.test.jsx
+++ b/apps/web/src/App.keepAlive.test.jsx
@@ -74,6 +74,10 @@ describe("selective lazy keep-alive shell (sc-11959)", () => {
   const videoStudio = () => document.body.querySelector(".video-studio");
   const modelsSurface = () => document.body.querySelector(".models-surface");
   const promptField = () => document.body.querySelector("textarea[aria-label='Prompt']");
+  const documentStudio = () => document.body.querySelector(".document-studio");
+  // DocumentStudio's Prompt textarea is the first textarea in its compose form (it wraps
+  // the control in a <label> rather than carrying an aria-label).
+  const documentPromptField = () => document.body.querySelector(".document-studio .studio-form textarea");
 
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
@@ -182,6 +186,68 @@ describe("selective lazy keep-alive shell (sc-11959)", () => {
     expect(studioAfter).not.toBe(studioBefore);
     expect(promptField().value).toBe(defaultPrompt);
     expect(promptField().value).not.toBe("project-1 in-progress prompt");
+  });
+
+  it("DocumentStudio survives a same-project nav round trip but RESETS on a project switch (sc-11959)", async () => {
+    // DocumentStudio holds project-scoped local state (prompt + sourceAssetIds) with no
+    // activeProject.id reset effect, so like its sibling studios it must be keyed on the
+    // project id — otherwise a project switch keeps the previous project's draft + source-
+    // asset selection and submit() would stamp those stale ids under the NEW project.
+    mockFetch({
+      projects: [
+        { id: "project-1", name: "Project One" },
+        { id: "project-2", name: "Project Two" },
+      ],
+      // Compose form only renders behind the model-availability gate, so provide an
+      // interleave-capable model.
+      models: [
+        {
+          id: "sensenova_u1",
+          name: "SenseNova-U1",
+          type: "image",
+          family: "sensenova",
+          capabilities: ["interleave"],
+        },
+      ],
+    });
+    await renderApp();
+    await clickButton("Document");
+
+    const studioBefore = documentStudio();
+    expect(studioBefore).not.toBeNull();
+    expect(documentPromptField().value).toBe("");
+
+    await changeField(documentPromptField(), "project-1 illustrated guide");
+    expect(documentPromptField().value).toBe("project-1 illustrated guide");
+
+    // Same-project nav round trip: the studio stays mounted (kept alive), so its in-
+    // progress draft survives with no remount.
+    await clickButton("Assets");
+    expect(documentStudio()).not.toBeNull();
+    await clickButton("Document");
+    expect(documentStudio()).toBe(studioBefore);
+    expect(documentPromptField().value).toBe("project-1 illustrated guide");
+
+    // Switch workspace via the project switcher.
+    await act(async () => {
+      document.body.querySelector(".project-pill")?.click();
+    });
+    await settle();
+    await act(async () => {
+      [...document.body.querySelectorAll(".project-menu-item")]
+        .find((item) => item.textContent.includes("Project Two"))
+        ?.click();
+    });
+    await settle();
+
+    // key={activeProject.id} changed → DocumentStudio remounts (a fresh DOM node) and its
+    // project-scoped prompt drops back to the new workspace's defaults, so no stale draft
+    // or sourceAssetIds can leak across the project boundary.
+    const studioAfter = documentStudio();
+    expect(studioAfter).not.toBeNull();
+    expect(studioAfter).not.toBe(studioBefore);
+    expect(documentPromptField().value).toBe("");
+    expect(documentPromptField().value).not.toBe("project-1 illustrated guide");
   });
 
   it("applies a 'Use this recipe' injection on an ALREADY-mounted studio (token-id re-fire)", async () => {

--- a/apps/web/src/App.keepAlive.test.jsx
+++ b/apps/web/src/App.keepAlive.test.jsx
@@ -1,0 +1,272 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { App } from "./main.jsx";
+import { FakeEventSource, response, settle, changeField } from "./main.testSupport.jsx";
+
+// Selective lazy keep-alive shell (sc-11959). These tests drive the FULL <App /> so the
+// keep-alive shell — the visited-set tracking, the KeepAlivePane wrapper, and the
+// OUT-screen conditional unmount — is exercised end to end. jsdom does not apply
+// styles.css, so the panes are not visually hidden here; we assert the MECHANISM via DOM
+// node presence/identity (a kept-alive screen is the SAME node across a nav round trip;
+// an OUT screen's node disappears) rather than via computed visibility.
+describe("selective lazy keep-alive shell (sc-11959)", () => {
+  let container;
+  let root;
+
+  function mockFetch(overrides = {}) {
+    const {
+      projects = [{ id: "project-1", name: "Project One" }],
+      models = [{ id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image" }],
+      assets = [],
+      loras = [],
+      presets = [],
+    } = overrides;
+    global.fetch = vi.fn((url) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/jobs/events/ticket")) {
+        return Promise.resolve(response({ ticket: "stream-ticket" }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response(projects));
+      }
+      if (path.endsWith("/models")) {
+        return Promise.resolve(response(models));
+      }
+      if (path.endsWith("/assets")) {
+        return Promise.resolve(response(assets));
+      }
+      if (path.endsWith("/loras")) {
+        return Promise.resolve(response(loras));
+      }
+      if (path.endsWith("recipe-presets")) {
+        return Promise.resolve(response(presets));
+      }
+      return Promise.resolve(response([]));
+    });
+  }
+
+  async function renderApp() {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+  }
+
+  // Click a top-level nav item (or any button) by its exact visible text. The sidebar
+  // renders before the workspace content, so a nav button always wins over any
+  // identically-labelled button inside a kept-alive pane.
+  async function clickButton(label) {
+    await act(async () => {
+      [...document.body.querySelectorAll("button")].find((button) => button.textContent === label)?.click();
+    });
+    await settle();
+  }
+
+  const imageStudio = () => document.body.querySelector(".image-studio");
+  const videoStudio = () => document.body.querySelector(".video-studio");
+  const modelsSurface = () => document.body.querySelector(".models-surface");
+  const promptField = () => document.body.querySelector("textarea[aria-label='Prompt']");
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    FakeEventSource.instances = [];
+    window.EventSource = FakeEventSource;
+    window.localStorage.clear();
+    mockFetch();
+  });
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount();
+    });
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("does not mount a keep-alive screen until it is first visited", async () => {
+    await renderApp();
+    // Initial view is Library/Assets — no creative screen has been visited yet.
+    expect(imageStudio()).toBeNull();
+    expect(videoStudio()).toBeNull();
+
+    await clickButton("Image");
+    expect(imageStudio()).not.toBeNull();
+    // Video was still never visited, so it is absent from the DOM.
+    expect(videoStudio()).toBeNull();
+  });
+
+  it("keeps a visited studio mounted (same node) across a nav round trip, preserving edits", async () => {
+    await renderApp();
+    await clickButton("Image");
+
+    const studioBefore = imageStudio();
+    expect(studioBefore).not.toBeNull();
+
+    await changeField(promptField(), "a keep-alive draft prompt");
+    expect(promptField().value).toBe("a keep-alive draft prompt");
+
+    // Clear localStorage so a hypothetical remount could NOT re-hydrate the prompt from
+    // the persisted snapshot — the only way the value can survive is if the studio was
+    // never unmounted.
+    window.localStorage.clear();
+
+    await clickButton("Assets");
+    // The studio stays mounted (hidden) while Library/Assets is active.
+    expect(imageStudio()).not.toBeNull();
+
+    await clickButton("Image");
+    // Same DOM node → the studio was never unmounted/remounted.
+    expect(imageStudio()).toBe(studioBefore);
+    // And its React state survived with no re-hydrate from (now-empty) localStorage.
+    expect(promptField().value).toBe("a keep-alive draft prompt");
+  });
+
+  it("unmounts OUT screens on navigation but keeps IN screens mounted (hidden)", async () => {
+    await renderApp();
+
+    // OUT screen: Models mounts when active, unmounts on navigation away.
+    await clickButton("Models");
+    expect(modelsSurface()).not.toBeNull();
+    await clickButton("Assets");
+    expect(modelsSurface()).toBeNull();
+
+    // IN screen: Image mounts when active and STAYS mounted after navigating away.
+    await clickButton("Image");
+    expect(imageStudio()).not.toBeNull();
+    await clickButton("Models");
+    expect(modelsSurface()).not.toBeNull(); // OUT screen back
+    expect(imageStudio()).not.toBeNull(); // IN screen still resident (hidden)
+  });
+
+  it("resets a kept-alive studio when the project changes (key change remounts it)", async () => {
+    mockFetch({
+      projects: [
+        { id: "project-1", name: "Project One" },
+        { id: "project-2", name: "Project Two" },
+      ],
+    });
+    await renderApp();
+    await clickButton("Image");
+
+    const studioBefore = imageStudio();
+    const defaultPrompt = promptField().value;
+    await changeField(promptField(), "project-1 in-progress prompt");
+    expect(promptField().value).toBe("project-1 in-progress prompt");
+
+    // Switch workspace via the project switcher.
+    await act(async () => {
+      document.body.querySelector(".project-pill")?.click();
+    });
+    await settle();
+    await act(async () => {
+      [...document.body.querySelectorAll(".project-menu-item")]
+        .find((item) => item.textContent.includes("Project Two"))
+        ?.click();
+    });
+    await settle();
+
+    // key={activeProject.id} changed → the studio remounts (a fresh DOM node) and drops
+    // the in-progress prompt back to the new workspace's defaults.
+    const studioAfter = imageStudio();
+    expect(studioAfter).not.toBeNull();
+    expect(studioAfter).not.toBe(studioBefore);
+    expect(promptField().value).toBe(defaultPrompt);
+    expect(promptField().value).not.toBe("project-1 in-progress prompt");
+  });
+
+  it("applies a 'Use this recipe' injection on an ALREADY-mounted studio (token-id re-fire)", async () => {
+    const generatedAsset = {
+      id: "asset-recipe",
+      projectId: "project-1",
+      generationSetId: "genset-recipe",
+      type: "image",
+      displayName: "Atrium still",
+      file: { path: "assets/images/atrium.png", mimeType: "image/png" },
+      status: { favorite: false, rating: 0, rejected: false, trashed: false },
+      generationSet: {
+        recipe: {
+          mode: "text_to_image",
+          model: "z_image_turbo",
+          prompt: "mist over a glass atrium",
+          negativePrompt: "flat lighting",
+          seed: 1234,
+          normalizedSettings: { width: 1024, height: 1024, count: 2 },
+          rawAdapterSettings: { steps: 14, guidanceScale: 2.5 },
+        },
+      },
+    };
+    mockFetch({ assets: [generatedAsset] });
+    await renderApp();
+
+    // Mount the studio FIRST and leave a local edit on it, so the recipe must apply to an
+    // already-mounted (kept-alive) studio rather than seeding a fresh mount.
+    await clickButton("Image");
+    const studioBefore = imageStudio();
+    await changeField(promptField(), "my own untouched draft");
+    expect(promptField().value).toBe("my own untouched draft");
+
+    // Open the asset in the fullscreen preview and inject its recipe into the studio.
+    await clickButton("Assets");
+    await act(async () => {
+      document.body.querySelector(".asset-tile")?.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+    });
+    await settle();
+    await clickButton("Use this recipe");
+
+    // The studio was NOT remounted (same node), yet the recipe applied because its apply
+    // effect is keyed on the studioLaunch token id, which changed.
+    expect(imageStudio()).toBe(studioBefore);
+    expect(promptField().value).toBe("mist over a glass atrium");
+  });
+
+  it("toggles a general preset into the stack on an already-mounted studio (epic 11949 launch)", async () => {
+    mockFetch({
+      presets: [
+        {
+          id: "gp-filmic",
+          name: "Filmic Look",
+          kind: "general",
+          scope: "global",
+          defaults: { aspect: "16:9", prompt: "cinematic, filmic grade" },
+        },
+      ],
+    });
+    await renderApp();
+
+    // Mount the studio; the general chip is available but NOT active yet.
+    await clickButton("Image");
+    const studioBefore = imageStudio();
+    const generalChip = () =>
+      [...document.body.querySelectorAll(".general-preset-chips .preset-chip")].find((chip) =>
+        chip.textContent.includes("Filmic Look"),
+      );
+    expect(generalChip()).toBeTruthy();
+    expect(generalChip().classList.contains("active")).toBe(false);
+
+    // Launch the general preset from the Preset Manager ("Use in Studio"): epic 11949's
+    // sendPresetToStudio stamps a fresh studioLaunch token that toggles it into the stack.
+    // (The button pairs an icon with the label, so match on trimmed text.)
+    await clickButton("Presets");
+    await act(async () => {
+      [...document.body.querySelectorAll("button")]
+        .find((button) => button.textContent.trim() === "Use in Studio")
+        ?.click();
+    });
+    await settle();
+
+    // Back on the already-mounted studio (same node) — the stack-toggle launch re-fired on
+    // the token-id change and the general preset is now active in the stack.
+    expect(imageStudio()).toBe(studioBefore);
+    expect(generalChip().classList.contains("active")).toBe(true);
+  });
+});

--- a/apps/web/src/context/ScreenActiveContext.js
+++ b/apps/web/src/context/ScreenActiveContext.js
@@ -1,0 +1,19 @@
+import { createContext, useContext } from "react";
+
+// Selective keep-alive (sc-11959): whether the screen reading this context is the
+// currently-active view. Under the keep-alive shell a creative screen stays mounted
+// after its first visit and is merely hidden when another view is active, so it can no
+// longer rely on unmount/remount to learn it was backgrounded. This context surfaces
+// that signal so a screen can pause expensive work while hidden (consumed by a later
+// story, S2) or drop an editor leave-guard when it isn't the foreground view.
+//
+// Defaults to `true`: any screen rendered OUTSIDE a keep-alive pane — the OUT screens
+// (still conditionally mounted) and unit tests that render a screen directly under a
+// bare provider — reads as "active", preserving today's behavior with no wiring.
+export const ScreenActiveContext = createContext(true);
+
+// Read whether the current screen is the active view. Returns `true` unless a
+// KeepAlivePane above it says otherwise.
+export function useScreenActive() {
+  return useContext(ScreenActiveContext);
+}

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -304,6 +304,22 @@ export function leaveGuardMessage({ dirty, aiOpPending }) {
   return null;
 }
 
+// Decide which of the two leave-guards to arm (sc-11959). The browser-unload
+// (close/refresh) guard must arm whenever there are unsaved edits or an in-flight AI op,
+// EVEN when the editor is backgrounded under keep-alive — an app close/refresh would
+// otherwise silently discard a backgrounded editor's unsaved edits (a safeguard that
+// predates keep-alive). The in-app nav guard, by contrast, only arms while the editor is
+// the foreground view, so a backgrounded (still-mounted) editor doesn't re-fire its
+// confirm() on every UNRELATED navigation between other screens.
+export function leaveGuardArming({ dirty, aiOpPending, screenActive }) {
+  const message = leaveGuardMessage({ dirty, aiOpPending });
+  return {
+    message,
+    beforeUnload: Boolean(message),
+    inApp: Boolean(message) && Boolean(screenActive),
+  };
+}
+
 // Compose the multi-reference edit's `referenceAssetIds`: the working image (staged as the scratch
 // source) FIRST so it anchors the edit, then the user's reference images — trimmed, de-duped, and
 // capped at `max` total. The worker prefers a non-empty `referenceAssetIds` list over `sourceAssetId`
@@ -2304,21 +2320,21 @@ export function ImageEditor() {
   // the App-level survivor sweep, orphaning the scratch upload).
   const aiOpPending = Boolean(aiOp);
   useEffect(() => {
-    // Only guard while the editor is the foreground view. Under keep-alive the editor
-    // stays mounted (hidden) after navigation, so without this an unsaved-but-
-    // backgrounded editor would re-fire its confirm() on every UNRELATED navigation
-    // between other screens (sc-11959). When backgrounded, the cleanup below drops both
-    // the in-app guard and the beforeunload handler; re-focusing re-registers if dirty.
-    const message = leaveGuardMessage({ dirty, aiOpPending });
-    if (!message || !screenActive) return undefined;
+    // See leaveGuardArming: the beforeunload handler arms whenever there are unsaved
+    // edits / an in-flight op (even backgrounded); the in-app nav guard only arms while
+    // this editor is foregrounded (sc-11959).
+    const { message, beforeUnload, inApp } = leaveGuardArming({ dirty, aiOpPending, screenActive });
+    if (!beforeUnload) return undefined;
     const onBeforeUnload = (event) => {
       event.preventDefault();
       event.returnValue = "";
     };
     window.addEventListener("beforeunload", onBeforeUnload);
-    const unregister = registerLeaveGuard?.(
-      () => typeof window.confirm !== "function" || window.confirm(message),
-    );
+    const unregister = inApp
+      ? registerLeaveGuard?.(
+          () => typeof window.confirm !== "function" || window.confirm(message),
+        )
+      : undefined;
     return () => {
       window.removeEventListener("beforeunload", onBeforeUnload);
       if (typeof unregister === "function") unregister();

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -5,6 +5,7 @@ import { Stage, Layer, Image as KonvaImage, Line, Rect, Transformer } from "reac
 import { apiFetch } from "../api.js";
 import { terminalStatuses } from "../jobTypes.js";
 import { useAppContext } from "../context/AppContext.js";
+import { useScreenActive } from "../context/ScreenActiveContext.js";
 import { DEFAULT_MAC_CAPABILITIES, macFeatureBlock } from "../macGating.js";
 import { assetUrl, assetCanRenderAsImage } from "../components/assetMedia.jsx";
 import { DatasetAddDialog } from "../components/DatasetAddDialog.jsx";
@@ -641,6 +642,11 @@ export function ImageEditor() {
     theme = "light",
     changeTheme,
   } = useAppContext();
+  // Under the keep-alive shell (sc-11959) the editor stays mounted (hidden) after the
+  // user navigates away, so it can no longer rely on unmount to drop its leave-guard.
+  // `true` unless a KeepAlivePane says this editor is backgrounded (defaults to true
+  // for the direct-render unit tests, which carry no ScreenActiveContext).
+  const screenActive = useScreenActive();
   // Mac UI gating (sc-3486): the upscale tool itself runs in-process on Rust (Real-ESRGAN,
   // sc-3489), so it is available on a gated Mac — this block is a defensive guard that stays
   // null. The second engine (AuraSR) is dropped on Mac (sc-3668) and gated per-engine below.
@@ -2298,8 +2304,13 @@ export function ImageEditor() {
   // the App-level survivor sweep, orphaning the scratch upload).
   const aiOpPending = Boolean(aiOp);
   useEffect(() => {
+    // Only guard while the editor is the foreground view. Under keep-alive the editor
+    // stays mounted (hidden) after navigation, so without this an unsaved-but-
+    // backgrounded editor would re-fire its confirm() on every UNRELATED navigation
+    // between other screens (sc-11959). When backgrounded, the cleanup below drops both
+    // the in-app guard and the beforeunload handler; re-focusing re-registers if dirty.
     const message = leaveGuardMessage({ dirty, aiOpPending });
-    if (!message) return undefined;
+    if (!message || !screenActive) return undefined;
     const onBeforeUnload = (event) => {
       event.preventDefault();
       event.returnValue = "";
@@ -2312,7 +2323,7 @@ export function ImageEditor() {
       window.removeEventListener("beforeunload", onBeforeUnload);
       if (typeof unregister === "function") unregister();
     };
-  }, [dirty, aiOpPending, registerLeaveGuard]);
+  }, [dirty, aiOpPending, registerLeaveGuard, screenActive]);
 
   // Claim the in-flight AI op's jobId with App so its survivor sweep (sc-8850) knows this
   // editor is alive and owns loading the result back before the scratch/result assets are

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -77,6 +77,7 @@ import {
   editReferenceIds,
   MAX_EDIT_REFERENCES,
   leaveGuardMessage,
+  leaveGuardArming,
 } from "./ImageEditor.jsx";
 import { verifyCaption, serializeCaption, ELEMENT_KEY_ORDER_OBJ } from "../ideogramCaption.js";
 
@@ -293,6 +294,34 @@ describe("in-flight AI-op scratch survival (sc-8850)", () => {
     // Unsaved edits still take precedence over the AI-op wording.
     expect(leaveGuardMessage({ dirty: true, aiOpPending: false })).toContain("unsaved edits");
     expect(leaveGuardMessage({ dirty: true, aiOpPending: true })).toContain("unsaved edits");
+  });
+
+  it("arms the beforeunload guard even when backgrounded, but the in-app guard only when foregrounded (sc-11959)", () => {
+    // The regression under keep-alive: gating BOTH guards on screenActive meant a dirty
+    // BACKGROUNDED (kept-alive) editor registered no beforeunload handler, so an app
+    // close/refresh discarded its unsaved edits with no warning.
+
+    // Dirty + backgrounded: browser-unload guard still arms; in-app nav guard does not.
+    expect(leaveGuardArming({ dirty: true, aiOpPending: false, screenActive: false })).toMatchObject({
+      beforeUnload: true,
+      inApp: false,
+    });
+    // Dirty + foregrounded: both guards arm.
+    expect(leaveGuardArming({ dirty: true, aiOpPending: false, screenActive: true })).toMatchObject({
+      beforeUnload: true,
+      inApp: true,
+    });
+    // In-flight AI op + backgrounded: browser-unload guard arms (the op is still abandonable).
+    expect(leaveGuardArming({ dirty: false, aiOpPending: true, screenActive: false })).toMatchObject({
+      beforeUnload: true,
+      inApp: false,
+    });
+    // Clean + foregrounded: neither guard arms.
+    expect(leaveGuardArming({ dirty: false, aiOpPending: false, screenActive: true })).toMatchObject({
+      message: null,
+      beforeUnload: false,
+      inApp: false,
+    });
   });
 
   it("registers a survivor claim with App on mount and drops it on unmount", async () => {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1104,6 +1104,36 @@ button:focus-visible {
   margin-top: 18px;
 }
 
+/* Selective keep-alive panes (sc-11959). A kept-alive creative screen is wrapped in a
+   .keep-alive-pane so it can stay mounted (state preserved) and merely toggle
+   visibility on navigation. `display: contents` makes the pane transparent to the
+   .workspace flex column — its child screen becomes the flex item and lays out exactly
+   as a direct .workspace child would — so the flex/margin rules above are mirrored here
+   for that grandchild. When backgrounded the pane carries the `hidden` attribute →
+   display:none (dropped from layout and the a11y tree). */
+.keep-alive-pane {
+  display: contents;
+}
+.keep-alive-pane[hidden] {
+  display: none;
+}
+.workspace > .keep-alive-pane > * {
+  flex: 0 0 auto;
+}
+.workspace > .keep-alive-pane > section[class*="-surface"],
+.workspace > .keep-alive-pane > section[class*="-layout"],
+.workspace > .keep-alive-pane > .page-frame {
+  margin: 0 22px;
+}
+.workspace > .keep-alive-pane > section[class*="-surface"]:first-of-type,
+.workspace > .keep-alive-pane > .page-frame:first-of-type {
+  margin-top: var(--pad-panel);
+}
+.workspace > .keep-alive-pane > section[class*="-surface"]:last-of-type,
+.workspace > .keep-alive-pane > .page-frame:last-of-type {
+  margin-bottom: 30px;
+}
+
 .notice {
   padding: 10px 14px;
   border: 1px solid color-mix(in oklch, var(--danger) 35%, var(--border));
@@ -8199,6 +8229,14 @@ details[open] > summary.lora-scope-group-heading::before,
 /* The editor is a full-bleed canvas app: cancel the workspace edge margin the
    `[class*="-surface"]` rules apply to every other screen. */
 .workspace > section.image-editor-surface {
+  flex: 1 1 auto;
+  min-height: 0;
+  margin: 0;
+}
+
+/* Keep-alive (sc-11959): the Image Editor is a full-bleed canvas; mirror the direct-child
+   full-bleed override for when it renders inside a .keep-alive-pane (display:contents). */
+.workspace > .keep-alive-pane > section.image-editor-surface {
   flex: 1 1 auto;
   min-height: 0;
   margin: 0;


### PR DESCRIPTION
## What & why (sc-11959 — S1)

The architectural backbone for the creative-screen edit-persistence epic. Creative/editable screens now **mount on first visit and then stay mounted (hidden)** instead of unmounting on navigation, so their React state — in-progress prompt, settings, edits — survives leaving and returning. This removes the remount that made studios re-hydrate (and clobber) from `localStorage` on every visit, and sets up epic 11949's persistence work.

## Keep-alive scope

**IN (11 view ids — mount-once, stay resident):** Image, Video, Characters, Document, **Train + LibraryDataSets** (both Training Studio family), Presets, Poses, Keypoints, Editor (Video Editor), ImageEditor.

**OUT (unchanged — conditional unmount on nav):** Library/Assets, Queue, Models, Settings, Stats, Logs, Licenses.

## Implementation

- **`App.jsx`** — track the set of visited keep-alive views; render each IN screen once it has been visited, wrapped in a new `<KeepAlivePane active>` that toggles visibility instead of unmounting. `display: contents` keeps the pane transparent to the `.workspace` flex column while active; the `hidden` attribute (→ `display:none`) drops it from layout and the a11y tree while backgrounded. Never-visited IN screens are absent from the DOM. OUT screens keep the exact `{activeView === "X" ? <Screen/> : null}` pattern.
- **Project-switch reset preserved** — `key={activeProject?.id ?? "default"}` stays on the studios + Image Editor, so a project switch still remounts/resets them even while kept alive (verified in tests).
- **Image Editor stays lazy** — still `React.lazy` + `Suspense` inside its pane, so it only imports/mounts on first visit (build still emits a separate `ImageEditor-*.js` chunk).
- **`ScreenActiveContext` / `useScreenActive()`** (new) — surfaces active-vs-hidden to each kept-alive screen. Provided by `KeepAlivePane`; defaults to `true` for OUT screens and direct-render unit tests. This is the mechanism S2 will consume. It is already wired to one real consumer: the Image Editor arms its leave-guard only while foregrounded, so a dirty *backgrounded* editor (now kept alive) no longer re-fires `confirm()` on unrelated navigation.
- **`styles.css`** — mirror the `.workspace` flex/margin rules and the full-bleed `image-editor-surface` override onto `.keep-alive-pane` grandchildren so `display: contents` layout is byte-for-byte unchanged.

## Injection under keep-alive (epic 11949 just merged)

The studios' recipe/preset apply effects are keyed on the **studioLaunch token id**, not on mount. Because keep-alive means a studio mounts once, a fresh injection must re-fire on a token-id change — verified end to end:

- **"Use this Recipe"** applies to an already-mounted studio (test types a draft into the mounted studio, then injects a recipe from a library asset; asserts the studio is the **same DOM node** yet the recipe applied).
- **epic 11949 general-preset stack toggle** — `sendPresetToStudio` ("Use in Studio") toggles a general preset into the stack of an already-mounted studio (test asserts same node + the general chip flips to `active`).

## Tests

New `App.keepAlive.test.jsx` (6, drive the full `<App />`):
1. never-visited IN screen absent from DOM until first visited;
2. state survives an Image → Assets → Image round trip on the **same DOM node**, with `localStorage` cleared to prove no re-hydrate;
3. OUT screen (Models) unmounts on nav while IN screen (Image) stays resident;
4. project switch remounts/resets the studio (new node, prompt back to defaults);
5. "Use this Recipe" injection applies on an already-mounted studio;
6. 11949 stack-toggle applies on an already-mounted studio.

**Full web suite green: 122 files / 1686 tests.** `eslint src` clean (0 errors). `vite build` succeeds; Image Editor remains a separate lazy chunk.

## Follow-ups

- Keep-alive IN screens **without** a project `key` (Document, Train, LibraryDataSets, Presets, Poses, Keypoints, Editor) no longer remount on a project switch. Those that seed project-scoped state on mount (rather than reading live from context) should be audited and given a `key` if needed — deliberately not expanded here since the story scoped `key` to the studios + Image Editor. Recommend a tracked story before broadening keep-alive reliance.

Story: sc-11959.