### PR TITLE
fix(studios): don't clobber restored snapshot on restart when catalogs load after mount (sc-11962)

### DIFF
--- a/apps/web/src/hooks/useStudioSettings.js
+++ b/apps/web/src/hooks/useStudioSettings.js
@@ -24,13 +24,24 @@ export function loadStudioSettings(studio, workspaceId) {
 // Persist `settings` for the workspace whenever they change. Serializing on every
 // render is cheap for a couple dozen fields and lets the effect skip writes when
 // nothing actually changed.
-export function useStudioSettingsWriter(studio, workspaceId, settings) {
+//
+// `ready` gates the live writer during the initial restart-restore/settle window
+// (sc-11962): a studio restores its snapshot at mount, then the async model / LoRA /
+// preset catalogs resolve. Until they do, a stray defaults-reset could momentarily
+// overwrite a restored value — and this writer would persist that transient, making
+// the clobber permanent. While `ready` is false we leave the stored snapshot untouched
+// (it already holds the restored values); the studio flips `ready` true once its
+// catalog has loaded, at which point the current (settled) state is persisted normally.
+export function useStudioSettingsWriter(studio, workspaceId, settings, ready = true) {
   const serialized = JSON.stringify(settings);
   useEffect(() => {
+    if (!ready) {
+      return;
+    }
     try {
       window.localStorage.setItem(storageKey(studio, workspaceId), serialized);
     } catch {
       // localStorage unavailable — settings just won't persist this session.
     }
-  }, [studio, workspaceId, serialized]);
+  }, [studio, workspaceId, serialized, ready]);
 }

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -986,10 +986,22 @@ export function ImageStudio() {
   }, [structuredActive, caption]);
   // Reset the reference tuning to the selected model's declared defaults whenever the
   // model changes, so InstantID starts at its tuned 0.8/0.8 and Kolors at 0.6, and the
-  // view angle never carries over to a model that doesn't support it. Skip the mount
-  // run when restoring a snapshot so the user's saved tuning survives.
-  const skipReferenceTuningReset = useRef(saved.ipAdapterScale != null);
+  // view angle never carries over to a model that doesn't support it.
+  //
+  // Tracks the PREVIOUS model VALUE rather than a one-shot bool (sc-11962): a one-shot is
+  // consumed on the mount pass, so a later async model "snap" (catalog arriving) would be
+  // mistaken for a user model change and reset the restored tuning. Keying on the actual
+  // value means an async catalog that leaves the model unchanged never fires the reset.
+  // Seeded from the model when restoring (so the restored tuning survives mount) and null
+  // otherwise (so a fresh mount still gets the model's declared defaults). `skip*` stays
+  // for the recipe path, which sets the model AND the tuning together.
+  const skipReferenceTuningReset = useRef(false);
+  const referenceTuningModel = useRef(saved.ipAdapterScale != null ? model : null);
   useEffect(() => {
+    if (referenceTuningModel.current === model) {
+      return;
+    }
+    referenceTuningModel.current = model;
     if (skipReferenceTuningReset.current) {
       skipReferenceTuningReset.current = false;
       return;
@@ -1170,13 +1182,22 @@ export function ImageStudio() {
   // Snap the sampler / scheduler back to the model's declared default when the
   // current value is no longer in the menu (e.g. user switched to a sealed
   // model whose only option is "default"). Mirrors the resolution-snap effect.
+  // Guard on a resolved model (sc-11962): before the model catalog loads,
+  // `samplerOptions` falls back to ["default"], so an un-guarded snap would revert a
+  // restored non-default sampler during the restart-restore window and never recover.
   useEffect(() => {
+    if (!selectedModel) {
+      return;
+    }
     if (samplerOptions.includes(sampler)) {
       return;
     }
     setSampler(preferredOption(samplerDefaultFromModel(selectedModel), samplerOptions));
   }, [samplerOptions, sampler, selectedModel]);
   useEffect(() => {
+    if (!selectedModel) {
+      return;
+    }
     if (schedulerOptions.includes(scheduler)) {
       return;
     }
@@ -1186,6 +1207,9 @@ export function ImageStudio() {
   // the active backend for this model (e.g. switching off the SDXL family drops
   // CFG++) — the N3 guard at the UI layer, so an unsupported method is never sent.
   useEffect(() => {
+    if (!selectedModel) {
+      return;
+    }
     if (guidanceMethodOptions.includes(guidanceMethod)) {
       return;
     }
@@ -1196,7 +1220,13 @@ export function ImageStudio() {
   // Keep the selected resolution valid for the current model's buckets. Switching
   // to a model whose options exclude the current value snaps to its default (or
   // 1024x1024, then the first option) rather than leaving a stale, unselectable value.
+  // Guard on a resolved model (sc-11962): before the catalog loads `resolutionOptions`
+  // falls back to DEFAULT_RESOLUTION_OPTIONS, so an un-guarded snap would revert a
+  // restored model-specific resolution (e.g. 1536x1536) during restart-restore.
   useEffect(() => {
+    if (!selectedModel) {
+      return;
+    }
     if (resolutionOptions.includes(resolution)) {
       return;
     }
@@ -1725,7 +1755,12 @@ export function ImageStudio() {
     bf16Precision,
     usePid,
     pidTarget,
-  });
+  },
+  // Suppress the live writer until the model catalog has loaded (sc-11962), so a
+  // transient defaults-reset during the restart-restore/settle window can't be
+  // persisted over the restored snapshot. When there are no models the studio shows
+  // the availability gate (no editable form), so nothing meaningful is lost by waiting.
+  imageModels.length > 0);
 
   // Each stacked run carries its already-resolved completed assets + the
   // expected count, which the WorkerProgressCard image-grid variant uses to

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -351,7 +351,13 @@ export function VideoStudio() {
   );
   const showSamplerPicker = samplerOptions.length > 1;
   const showSchedulerPicker = schedulerOptions.length > 1;
+  // Guard on a resolved model (sc-11962): before the video catalog loads `samplerOptions`
+  // falls back to ["default"], so an un-guarded snap would revert a restored non-default
+  // sampler during the restart-restore window and never recover once the catalog lands.
   useEffect(() => {
+    if (!selectedModel) {
+      return;
+    }
     if (samplerOptions.includes(sampler)) {
       return;
     }
@@ -361,6 +367,9 @@ export function VideoStudio() {
     setSampler(preferred);
   }, [samplerOptions, sampler, selectedModel]);
   useEffect(() => {
+    if (!selectedModel) {
+      return;
+    }
     if (schedulerOptions.includes(scheduler)) {
       return;
     }
@@ -588,7 +597,11 @@ export function VideoStudio() {
     videoConditioningStrength,
     bridgeRightVideoConditioningStrength,
     fitMode,
-  });
+  },
+  // Suppress the live writer until the video catalog has loaded (sc-11962), so a transient
+  // defaults-reset during the restart-restore/settle window can't overwrite the restored
+  // snapshot before the async catalogs settle.
+  videoModels.length > 0);
 
   useEffect(() => {
     if (mode !== "replace_person") {

--- a/apps/web/src/screens/generationStudio.jsx
+++ b/apps/web/src/screens/generationStudio.jsx
@@ -139,7 +139,14 @@ export function useGenerationStudio({
   const [showIncompatibleLoras, setShowIncompatibleLoras] = useState(initialShowIncompatibleLoras);
 
   // Snap the model back into range when the catalog changes out from under it.
+  // Guard on a loaded catalog (sc-11962): on the first mount after a restart the model
+  // catalog is still resolving (empty), and an empty `models` would otherwise snap the
+  // restored model to the fallback — permanently, since the fallback IS in the catalog
+  // once it lands. Only snap once there is a real catalog to validate against.
   useEffect(() => {
+    if (!models.length) {
+      return;
+    }
     if (!models.some((item) => item.id === model)) {
       setModel(models[0]?.id ?? fallbackModelId);
     }
@@ -195,23 +202,35 @@ export function useGenerationStudio({
 
   // An explicitly chosen preset that drops out of the available set falls back to
   // the first available preset (or None) rather than showing stale config.
+  // Guard on loaded catalogs (sc-11962): `availablePresets` filters on both the preset
+  // catalog AND the resolved model, so an empty `presets`/`models` during the
+  // restart-restore window would strip the restored base preset to None. Wait until
+  // there is a real catalog to validate the restored id against.
   useEffect(() => {
+    if (!presets.length || !models.length) {
+      return;
+    }
     if (!selectedPresetId || selectedPresetId === noPresetId) {
       return;
     }
     if (!selectedPreset) {
       setSelectedPresetId(availablePresets[0]?.id ?? noPresetId);
     }
-  }, [availablePresets, selectedPresetId, selectedPreset]);
+  }, [presets.length, models.length, availablePresets, selectedPresetId, selectedPreset]);
 
   // Prune stacked general presets that leave the catalog (archived/deleted). Unlike the
   // base slot this drops silently — a stack has no single "fall back to the first" notion.
+  // Guard on a loaded preset catalog (sc-11962) so the restored stack isn't pruned to
+  // empty while the catalog is still resolving after a restart.
   useEffect(() => {
+    if (!presets.length) {
+      return;
+    }
     setGeneralStackIds((ids) => {
       const next = ids.filter((id) => availableGeneralPresets.some((preset) => preset.id === id));
       return next.length === ids.length ? ids : next;
     });
-  }, [availableGeneralKey]);
+  }, [presets.length, availableGeneralKey]);
 
   // Add/remove a general preset from the stack. Toggling never touches the model, mode, or
   // the LoRA picker — general presets carry none of those. Composition into the prompt is
@@ -299,9 +318,17 @@ export function useGenerationStudio({
         : `No installed LoRAs match ${selectedModel.name ?? selectedModel.id}.`;
 
   // Drop selections that fall out of the compatible set (model/filter change).
+  // Guard on loaded inputs (sc-11962): `compatibleLoras` is empty both when the LoRA
+  // catalog hasn't resolved yet AND when the model hasn't (loraMatchesModel needs a
+  // model). Running the filter during that restart-restore window would strip the
+  // restored LoRA ids permanently. Only prune once both the LoRA catalog and the model
+  // are present, so a genuine model/filter change still drops incompatible selections.
   useEffect(() => {
+    if (!loras.length || !selectedModel) {
+      return;
+    }
     setSelectedLoraIds((ids) => ids.filter((id) => compatibleLoras.some((lora) => lora.id === id)));
-  }, [compatibleLoraKey]);
+  }, [loras.length, selectedModel, compatibleLoraKey]);
   // Auto-open the advanced panel when an incompatible LoRA is selected so the
   // generate-blocking warning is visible.
   useEffect(() => {
@@ -350,8 +377,16 @@ export function useGenerationStudio({
   const skipPresetLoraSeedOnHydrate = useRef(initialPresetId != null && initialPresetId !== noPresetId);
   useEffect(() => {
     if (skipPresetLoraSeedOnHydrate.current) {
+      // On the first mount after a restart the preset catalog is still resolving, so the
+      // restored preset hasn't materialized yet (selectedPreset is null). Wait for it —
+      // consuming the one-shot on the empty-catalog pass would make the preset re-SEED
+      // (instead of adopt) its LoRAs once it lands, double-counting the restored ones
+      // (sc-11962). Only decide once the preset has actually resolved.
+      if (!selectedPreset) {
+        return;
+      }
       skipPresetLoraSeedOnHydrate.current = false;
-      if (selectedPreset && selectedPreset.id === initialPresetId) {
+      if (selectedPreset.id === initialPresetId) {
         // The restored selection already reflects this preset; adopt it without re-seeding.
         // addedIds is left empty so a post-reload deselect doesn't strip LoRAs we can't prove
         // the preset added (the user removes them by hand instead).

--- a/apps/web/src/screens/studioRestore.test.jsx
+++ b/apps/web/src/screens/studioRestore.test.jsx
@@ -1,0 +1,413 @@
+import React, { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { click, mountRoot, unmountRoot } from "../testUtils/dom.js";
+
+// Pose loaders + any best-effort fetches must never touch the network on mount.
+vi.mock("../api.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    apiFetch: vi.fn(async () => ({})),
+  };
+});
+
+import { AppContext } from "../context/AppContext.js";
+import { ImageStudio } from "./ImageStudio.jsx";
+import { VideoStudio } from "./VideoStudio.jsx";
+
+// sc-11962 — S3: restart-restore must not clobber a restored studio snapshot when the
+// model / LoRA / preset catalogs resolve asynchronously AFTER the studio has mounted.
+//
+// The failure mode: on the first mount after an app restart the studio restores its
+// settings from localStorage, then empty catalogs (still loading) make the model
+// "snap" to a fallback and the preset / general-stack / LoRA prune + the sampler /
+// resolution snaps fire against the empty catalog — silently reverting the restored
+// values to model/preset defaults. These tests seed a snapshot, mount with EMPTY
+// catalogs, then feed the real catalogs in AFTER mount (in several orderings) and
+// assert every restored value survives.
+
+// ---- Image fixtures ----------------------------------------------------------------
+const Z_IMAGE = {
+  id: "z_image_turbo",
+  name: "Z Image Turbo",
+  type: "image",
+  family: "z-image",
+  capabilities: ["text_to_image"],
+  defaults: { resolution: "1024x1024" },
+  limits: { resolutions: ["1024x1024"], samplers: ["default"], schedulers: ["default"] },
+  loraCompatibility: {},
+  ui: {},
+};
+const FLUX = {
+  id: "flux2_dev",
+  name: "FLUX.2 Dev",
+  type: "image",
+  family: "flux2",
+  capabilities: ["text_to_image"],
+  defaults: { resolution: "1024x1024", sampler: "euler", scheduler: "shift", steps: 20, guidanceScale: 3.5 },
+  limits: {
+    resolutions: ["1024x1024", "1536x1536"],
+    samplers: ["default", "euler", "dpmpp_2m"],
+    schedulers: ["default", "shift", "karras"],
+  },
+  loraCompatibility: {},
+  ui: {},
+};
+const IMAGE_LORA = { id: "lora-a", name: "Lora A", family: "flux2", scope: "global", installState: "installed" };
+const IMAGE_BASE_PRESET = {
+  id: "cine",
+  name: "Cinematic",
+  kind: "model",
+  scope: "global",
+  workflow: "text_to_image",
+  modes: ["text_to_image"],
+  model: "flux2_dev",
+  loras: [],
+  defaults: {},
+};
+const IMAGE_GENERAL_PRESET = {
+  id: "enhance",
+  name: "Enhance",
+  kind: "general",
+  scope: "global",
+  defaults: { prompt: { append: "cinematic lighting" } },
+};
+
+// The full snapshot a user leaves behind: a non-default model (NOT the catalog's first
+// entry, so a fallback snap is visibly wrong), a resolution + sampler + scheduler that
+// only the restored model declares, and a restored LoRA + base preset + general stack.
+const IMAGE_SNAPSHOT = {
+  mode: "text_to_image",
+  prompt: "a restored studio prompt",
+  model: "flux2_dev",
+  resolution: "1536x1536",
+  sampler: "dpmpp_2m",
+  scheduler: "karras",
+  steps: 24,
+  guidanceScale: 5,
+  ipAdapterScale: 0.85,
+  selectedLoraIds: ["lora-a"],
+  loraWeights: { "lora-a": 0.9 },
+  selectedPresetId: "cine",
+  generalStackIds: ["enhance"],
+  advancedOpen: false,
+};
+
+function imageContext(overrides = {}) {
+  return {
+    token: "test-token",
+    activeProject: { id: "project_1", name: "My Project" },
+    assets: [],
+    characters: [],
+    createImageJob: vi.fn(),
+    createPreset: vi.fn(async (payload) => ({ id: payload.id })),
+    refinePrompt: vi.fn(),
+    magicPrompt: vi.fn(),
+    imageCaption: vi.fn(),
+    imageDescribe: vi.fn(),
+    createModelDownloadJob: vi.fn(),
+    createLoraDownloadJob: vi.fn(),
+    deleteAsset: vi.fn(),
+    purgeAsset: vi.fn(),
+    gpuOptions: [],
+    imageModels: [],
+    models: [],
+    jobs: [],
+    importAsset: vi.fn(),
+    latestImageAssets: [],
+    recentImageAssets: [],
+    studioLaunch: null,
+    imageLocalJobs: [],
+    loras: [],
+    jobAction: vi.fn(),
+    rememberLocalGenerationJob: vi.fn(),
+    setActiveView: vi.fn(),
+    setPreviewAsset: vi.fn(),
+    presets: [],
+    promptBatches: [],
+    createPromptBatch: vi.fn(),
+    updatePromptBatch: vi.fn(),
+    deletePromptBatch: vi.fn(),
+    requestedGpu: "",
+    selectedAsset: null,
+    setRequestedGpu: vi.fn(),
+    updateAssetStatus: vi.fn(),
+    visibleWorkers: [],
+    ...overrides,
+  };
+}
+
+const IMAGE_FULL = {
+  imageModels: [Z_IMAGE, FLUX],
+  models: [Z_IMAGE, FLUX],
+  loras: [IMAGE_LORA],
+  presets: [IMAGE_BASE_PRESET, IMAGE_GENERAL_PRESET],
+};
+
+// ---- Video fixtures ----------------------------------------------------------------
+const LTX = {
+  id: "ltx_2_3",
+  name: "LTX 2.3",
+  type: "video",
+  family: "ltx-video",
+  capabilities: ["image_to_video", "text_to_video", "first_last_frame"],
+  defaults: { duration: 6, resolution: "768x512", fps: 25 },
+  limits: {},
+  quantization: {},
+  loraCompatibility: {},
+  ui: {},
+};
+const WAN = {
+  id: "wan_t2v",
+  name: "Wan T2V",
+  type: "video",
+  family: "wan",
+  capabilities: ["text_to_video", "image_to_video"],
+  defaults: { duration: 6, resolution: "1280x720", fps: 24 },
+  limits: {
+    resolutions: ["768x512", "1280x720"],
+    samplers: ["default", "unipc", "dpmpp_2m"],
+    schedulers: ["default", "karras"],
+  },
+  quantization: {},
+  loraCompatibility: {},
+  ui: {},
+};
+const VIDEO_LORA = { id: "vlora-a", name: "Vid Lora A", family: "wan", scope: "global", installState: "installed" };
+const VIDEO_BASE_PRESET = {
+  id: "vcine",
+  name: "Video Cinematic",
+  kind: "model",
+  scope: "global",
+  workflow: "text_to_video",
+  modes: ["text_to_video"],
+  model: "wan_t2v",
+  loras: [],
+  defaults: {},
+};
+const VIDEO_GENERAL_PRESET = {
+  id: "venhance",
+  name: "Video Enhance",
+  kind: "general",
+  scope: "global",
+  defaults: { prompt: { append: "cinematic" } },
+};
+
+const VIDEO_SNAPSHOT = {
+  mode: "text_to_video",
+  prompt: "a restored video prompt",
+  model: "wan_t2v",
+  resolution: "1280x720",
+  sampler: "unipc",
+  scheduler: "karras",
+  selectedLoraIds: ["vlora-a"],
+  loraWeights: { "vlora-a": 0.9 },
+  selectedPresetId: "vcine",
+  generalStackIds: ["venhance"],
+  advancedOpen: false,
+};
+
+function videoContext(overrides = {}) {
+  return {
+    token: "test-token",
+    activeProject: { id: "project_1", name: "My Project" },
+    assets: [],
+    characters: [],
+    createPersonDetectionJob: vi.fn(),
+    createPersonTrackJob: vi.fn(),
+    createVideoJob: vi.fn(),
+    createPreset: vi.fn(async (payload) => ({ id: payload.id })),
+    refinePrompt: vi.fn(),
+    deleteAsset: vi.fn(),
+    purgeAsset: vi.fn(),
+    gpuOptions: [],
+    latestVideoAssets: [],
+    recentVideoAssets: [],
+    studioLaunch: null,
+    loras: [],
+    jobs: [],
+    videoLocalJobs: [],
+    jobAction: vi.fn(),
+    rememberLocalGenerationJob: vi.fn(),
+    setActiveView: vi.fn(),
+    setSelectedAssetId: vi.fn(),
+    setPreviewAsset: vi.fn(),
+    personTracks: [],
+    personReadiness: {},
+    presets: [],
+    requestedGpu: "",
+    saveTrackCorrections: vi.fn(),
+    selectedAsset: null,
+    setRequestedGpu: vi.fn(),
+    updateAssetStatus: vi.fn(),
+    videoModels: [],
+    models: [],
+    ...overrides,
+  };
+}
+
+const VIDEO_FULL = {
+  videoModels: [LTX, WAN],
+  models: [LTX, WAN],
+  loras: [VIDEO_LORA],
+  presets: [VIDEO_BASE_PRESET, VIDEO_GENERAL_PRESET],
+};
+
+// ---- shared helpers ----------------------------------------------------------------
+function seedSnapshot(studio, snapshot) {
+  window.localStorage.setItem(`sceneworks-studio-${studio}-project_1`, JSON.stringify(snapshot));
+}
+function readSnapshot(studio) {
+  return JSON.parse(window.localStorage.getItem(`sceneworks-studio-${studio}-project_1`) || "{}");
+}
+const modelSelectValue = () => document.body.querySelector(".settings-field-model select")?.value;
+const aspectSelectValue = () => document.body.querySelector(".settings-field-aspect select")?.value;
+const activeBasePresetName = () =>
+  document.body.querySelector(".preset-chips:not(.general-preset-chips) button.preset-chip.active")?.textContent?.trim();
+const activeGeneralNames = () =>
+  [...document.body.querySelectorAll(".general-preset-chips button.preset-chip.active")].map((n) => n.textContent.trim());
+const loraSlotNames = () =>
+  [...document.body.querySelectorAll(".lora-slot .lora-slot-meta strong")].map((n) => n.textContent.trim());
+
+describe("studio restart-restore does not clobber the restored snapshot (sc-11962)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  // Render a sequence of context snapshots into the SAME root, flushing effects
+  // between each — this is how "catalogs resolve after mount" is simulated.
+  async function renderSequence(Studio, contexts) {
+    for (const ctx of contexts) {
+      await act(async () => {
+        root.render(
+          <AppContext.Provider value={ctx}>
+            <Studio />
+          </AppContext.Provider>,
+        );
+      });
+      await act(async () => {});
+    }
+  }
+
+  // ---- Image Studio ----------------------------------------------------------------
+  it("Image: restores model + resolution + sampler + preset + stack + LoRA when catalogs arrive after mount", async () => {
+    seedSnapshot("image", IMAGE_SNAPSHOT);
+    await renderSequence(ImageStudio, [imageContext(), imageContext(IMAGE_FULL)]);
+
+    // Open Advanced so the LoRA slot renders.
+    await click(document.body.querySelector(".advanced-section-toggle"));
+
+    expect(modelSelectValue()).toBe("flux2_dev");
+    expect(aspectSelectValue()).toBe("1536x1536");
+    expect(activeBasePresetName()).toBe("Cinematic");
+    expect(activeGeneralNames()).toEqual(["Enhance"]);
+    expect(loraSlotNames()).toContain("Lora A");
+
+    const snap = readSnapshot("image");
+    expect(snap.model).toBe("flux2_dev");
+    expect(snap.resolution).toBe("1536x1536");
+    expect(snap.sampler).toBe("dpmpp_2m");
+    expect(snap.scheduler).toBe("karras");
+    expect(snap.steps).toBe(24);
+    expect(snap.guidanceScale).toBe(5);
+    expect(snap.ipAdapterScale).toBe(0.85);
+    expect(snap.selectedLoraIds).toEqual(["lora-a"]);
+    expect(snap.selectedPresetId).toBe("cine");
+    expect(snap.generalStackIds).toEqual(["enhance"]);
+  });
+
+  it("Image: survives a LoRA-first / models+presets-later load ordering", async () => {
+    seedSnapshot("image", IMAGE_SNAPSHOT);
+    await renderSequence(ImageStudio, [
+      imageContext(),
+      imageContext({ loras: [IMAGE_LORA] }), // loras resolve first, models/presets still empty
+      imageContext(IMAGE_FULL), // then everything else
+    ]);
+
+    expect(modelSelectValue()).toBe("flux2_dev");
+    expect(aspectSelectValue()).toBe("1536x1536");
+    expect(activeBasePresetName()).toBe("Cinematic");
+    expect(activeGeneralNames()).toEqual(["Enhance"]);
+
+    const snap = readSnapshot("image");
+    expect(snap.model).toBe("flux2_dev");
+    expect(snap.resolution).toBe("1536x1536");
+    expect(snap.sampler).toBe("dpmpp_2m");
+    expect(snap.selectedLoraIds).toEqual(["lora-a"]);
+    expect(snap.selectedPresetId).toBe("cine");
+    expect(snap.generalStackIds).toEqual(["enhance"]);
+  });
+
+  it("Image: survives a models-first / loras+presets-later load ordering", async () => {
+    seedSnapshot("image", IMAGE_SNAPSHOT);
+    await renderSequence(ImageStudio, [
+      imageContext(),
+      imageContext({ imageModels: [Z_IMAGE, FLUX], models: [Z_IMAGE, FLUX] }), // models first
+      imageContext(IMAGE_FULL),
+    ]);
+
+    expect(modelSelectValue()).toBe("flux2_dev");
+    expect(aspectSelectValue()).toBe("1536x1536");
+
+    const snap = readSnapshot("image");
+    expect(snap.model).toBe("flux2_dev");
+    expect(snap.resolution).toBe("1536x1536");
+    expect(snap.sampler).toBe("dpmpp_2m");
+    expect(snap.selectedLoraIds).toEqual(["lora-a"]);
+    expect(snap.selectedPresetId).toBe("cine");
+    expect(snap.generalStackIds).toEqual(["enhance"]);
+  });
+
+  // ---- Video Studio ----------------------------------------------------------------
+  it("Video: restores model + resolution + sampler + preset + stack + LoRA when catalogs arrive after mount", async () => {
+    seedSnapshot("video", VIDEO_SNAPSHOT);
+    await renderSequence(VideoStudio, [videoContext(), videoContext(VIDEO_FULL)]);
+
+    await click(document.body.querySelector(".advanced-section-toggle"));
+
+    expect(modelSelectValue()).toBe("wan_t2v");
+    expect(aspectSelectValue()).toBe("1280x720");
+    expect(activeBasePresetName()).toBe("Video Cinematic");
+    expect(activeGeneralNames()).toEqual(["Video Enhance"]);
+    expect(loraSlotNames()).toContain("Vid Lora A");
+
+    const snap = readSnapshot("video");
+    expect(snap.model).toBe("wan_t2v");
+    expect(snap.resolution).toBe("1280x720");
+    expect(snap.sampler).toBe("unipc");
+    expect(snap.scheduler).toBe("karras");
+    expect(snap.selectedLoraIds).toEqual(["vlora-a"]);
+    expect(snap.selectedPresetId).toBe("vcine");
+    expect(snap.generalStackIds).toEqual(["venhance"]);
+  });
+
+  it("Video: survives a LoRA-first / models+presets-later load ordering", async () => {
+    seedSnapshot("video", VIDEO_SNAPSHOT);
+    await renderSequence(VideoStudio, [
+      videoContext(),
+      videoContext({ loras: [VIDEO_LORA] }),
+      videoContext(VIDEO_FULL),
+    ]);
+
+    expect(modelSelectValue()).toBe("wan_t2v");
+    expect(aspectSelectValue()).toBe("1280x720");
+
+    const snap = readSnapshot("video");
+    expect(snap.model).toBe("wan_t2v");
+    expect(snap.resolution).toBe("1280x720");
+    expect(snap.sampler).toBe("unipc");
+    expect(snap.selectedLoraIds).toEqual(["vlora-a"]);
+    expect(snap.selectedPresetId).toBe("vcine");
+    expect(snap.generalStackIds).toEqual(["venhance"]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the restart-restore **clobber** in Image Studio and Video Studio (sc-11962, S3).

On the first mount after an app restart, the studios restore their per-workspace settings from `localStorage`, then the async **model / LoRA / preset / tier** catalogs resolve. While those catalogs were empty, several catalog-driven effects treated *"not loaded yet"* as *"the restored value is invalid"* and silently reverted it to a model/preset default — **non-deterministically**, depending on async load order. Symptom: sampler / steps / guidance / reference-strength / resolution — and post-11949 the restored **base preset**, **general-preset stack**, and **LoRA selection** — snap back to defaults.

### Re-validation vs epic 11949 (#1522)

11949 rewrote the preset machinery (scalar `selectedPresetId` → base slot + ordered general-preset **stack**). I re-validated against current `main`: **the clobber still reproduces after 11949.** A new failing test (below) confirmed the restored model deterministically reverts to the fallback (`z_image_turbo` / `ltx_2_3`) across every load ordering, taking the resolution/sampler/preset/stack/LoRA with it. This was NOT already fixed — so this PR fixes it (rather than only adding regression locks).

## What changed

Make the restored snapshot **authoritative**: catalog-driven resets fire only once the relevant catalog has actually loaded, never on the empty-catalog hydrate window.

**`useGenerationStudio` (`generationStudio.jsx`)**
- Model snap: guard on a loaded model catalog (empty `models` no longer snaps the restored model to the fallback).
- Base-preset fallback: guard on loaded preset **and** model catalogs.
- General-preset **stack** prune: guard on a loaded preset catalog (protects 11949's restored stack).
- Compatible-LoRA filter: guard on a loaded LoRA catalog **and** a resolved model (so restored LoRA ids aren't stripped before `loras` arrive).
- `skipPresetLoraSeedOnHydrate`: wait for the restored preset to actually resolve before consuming the one-shot, so it **adopts** (not re-seeds) the preset's LoRAs once the catalog lands.

**`ImageStudio.jsx`**
- Sampler / scheduler / guidance-method / resolution snaps: guard on a resolved model (their option lists fall back to defaults before the catalog loads).
- Reference-tuning reset: converted from a one-shot bool to tracking the **previous model VALUE**, so an async catalog snap isn't mistaken for a user model change.
- Writer gated on `imageModels.length > 0`.

**`VideoStudio.jsx`**
- Sampler / scheduler snaps: guard on a resolved model.
- Writer gated on `videoModels.length > 0`.
- (Video's resolution/duration/fps reset was already `!selectedModel`-guarded; fixing the model snap makes it survive too.)

**`useStudioSettings.js`**
- `useStudioSettingsWriter(studio, workspaceId, settings, ready = true)` — suppresses the live writer during the hydrate/settle window so a transient reset can't be persisted over the restored snapshot.

### Injection preserved

"Use this Recipe" and Preset / general-stack "Use in Studio" still apply on a fresh mount — the `skip*` refs continue to short-circuit the resets when a launch sets model + values together. Covered by the existing `App.imageGeneration` / `App.videoPresets` / `PresetManagerScreen` suites (all green).

## Tests

- **New** `apps/web/src/screens/studioRestore.test.jsx` (5 tests): seeds a snapshot, mounts with empty catalogs, then feeds the real catalogs in **after mount** across multiple load orderings (all-at-once, LoRA-first, models-first), asserting model / resolution / sampler / scheduler / steps / guidance / reference-strength + LoRA + base preset + general stack all survive — for both Image and Video. These fail on `main` (model reverts to fallback) and pass with this change.
- Full web suite: **1699 passed / 125 files**. Lint: **0 errors** (no new warnings). Web-only — no Rust.

Closes sc-11962.

🤖 Generated with [Claude Code](https://claude.com/claude-code)