### PR TITLE
feat(worker): honor Krea text_style_gain on pose-control + edit lanes + repin inference (sc-12009 Part B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -454,7 +454,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -478,7 +478,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -491,7 +491,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -555,7 +555,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -575,7 +575,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -620,7 +620,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -633,7 +633,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-gen",
  "image",
@@ -708,7 +708,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -738,7 +738,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -749,7 +749,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -759,7 +759,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -773,7 +773,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -789,7 +789,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -808,7 +808,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -831,7 +831,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -853,7 +853,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -878,7 +878,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1173,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -3632,7 +3632,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3645,7 +3645,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3670,7 +3670,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3683,7 +3683,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3721,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3734,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -3744,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3753,7 +3753,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3762,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3775,7 +3775,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3787,7 +3787,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -3799,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3811,7 +3811,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -3820,7 +3820,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3832,7 +3832,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3859,7 +3859,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3870,7 +3870,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3881,7 +3881,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3892,7 +3892,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3903,7 +3903,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3912,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3921,7 +3921,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3931,7 +3931,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3956,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3969,7 +3969,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3979,7 +3979,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -3990,7 +3990,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4000,7 +4000,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4013,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4037,7 +4037,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "core-llm",
  "half",
@@ -5578,7 +5578,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5588,7 +5588,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "candle-gen-catalog",
  "candle-llm",
@@ -5598,7 +5598,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "mlx-gen-catalog",
  "mlx-llm",
@@ -5876,7 +5876,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.2#27d7908de401ce9b270d7e53e87f717fee151b23"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.2" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.3-rc.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.2" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.3-rc.0" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.2", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.3-rc.0", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/krea_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control.rs
@@ -326,6 +326,7 @@ fn krea_control_generate_one(
     seed: i64,
     steps: u32,
     conditioning: Vec<Conditioning>,
+    text_style_gain: Option<f32>,
     cancel: &CancelFlag,
     on_progress: &mut dyn FnMut(Progress),
 ) -> WorkerResult<(u32, u32, Vec<u8>)> {
@@ -337,6 +338,7 @@ fn krea_control_generate_one(
         seed: Some(seed as u64),
         steps: Some(steps),
         conditioning,
+        text_style_gain,
         cancel: cancel.clone(),
         ..Default::default()
     };
@@ -432,6 +434,9 @@ async fn generate_krea_control_stream(
     .await;
 
     let prompt = request.prompt.clone();
+    // Krea "text style" tap-reweight gain (sc-12009) — self-gates on `ui.textStyleGain` (Krea only),
+    // applied to the pose-control lane's CFG-free context by the engine (inference sc-12009).
+    let text_style_gain = resolve_text_style_gain(request);
     let (width, height) = (request.width, request.height);
     let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
     // The base runs at the `mlxQuantize`-selected tier (sc-11730); the pose overlay rides it bf16. User
@@ -479,6 +484,7 @@ async fn generate_krea_control_stream(
                     seed,
                     steps,
                     conditioning,
+                    text_style_gain,
                     &cancel,
                     on_progress,
                 )?;

--- a/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
@@ -319,6 +319,10 @@ struct KreaStrictControl {
     height: u32,
     steps: u32,
     control_scale: f32,
+    /// Krea "text style" tap-reweight gain (sc-12009) — self-gates on `ui.textStyleGain` (Krea only);
+    /// `None`/g≈1 is a byte-exact no-op. Applied to the pose-control lane's CFG-free context by the
+    /// engine (inference sc-12009, `Krea2ControlRequest.text_style_gain`).
+    text_style_gain: Option<f32>,
 }
 
 impl CandleStrictControl for KreaStrictControl {
@@ -374,6 +378,7 @@ impl CandleStrictControl for KreaStrictControl {
             height: self.height,
             steps: self.steps as usize,
             control_scale: self.control_scale,
+            text_style_gain: self.text_style_gain,
             seed,
             tile_vae_decode: self.tile_vae_decode,
             cancel: cancel.clone(),
@@ -508,6 +513,7 @@ async fn generate_candle_krea_control_stream(
         height: request.height,
         steps,
         control_scale,
+        text_style_gain: resolve_text_style_gain(request),
     };
 
     run_candle_strict_control(

--- a/crates/sceneworks-worker/src/image_jobs/krea_edit.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_edit.rs
@@ -106,6 +106,7 @@ fn krea_edit_generate_one(
     steps: u32,
     guidance: Option<f32>,
     conditioning: Vec<Conditioning>,
+    text_style_gain: Option<f32>,
     cancel: &CancelFlag,
     on_progress: &mut dyn FnMut(Progress),
 ) -> WorkerResult<(u32, u32, Vec<u8>)> {
@@ -119,6 +120,7 @@ fn krea_edit_generate_one(
         steps: Some(steps),
         guidance,
         conditioning,
+        text_style_gain,
         cancel: cancel.clone(),
         ..Default::default()
     };
@@ -224,6 +226,9 @@ async fn generate_krea_edit_stream(
     let spec = load_spec(weights_dir, quant, adapters, None);
     // Raw → `krea_2_edit` (full-CFG); Turbo → `krea_2_turbo_edit` (CFG-free distilled, sc-11640).
     let engine_id = krea_edit_engine_id(&request.model);
+    // Krea "text style" tap-reweight gain (sc-12009) — self-gates on `ui.textStyleGain` (Krea only),
+    // applied to the edit lane's POSITIVE grounded context by the engine (inference sc-12009).
+    let text_style_gain = resolve_text_style_gain(request);
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
         engine_id,
@@ -246,6 +251,7 @@ async fn generate_krea_edit_stream(
                     steps,
                     guidance,
                     conditioning,
+                    text_style_gain,
                     &cancel,
                     on_progress,
                 )?;

--- a/crates/sceneworks-worker/src/image_jobs/krea_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_edit_candle.rs
@@ -198,6 +198,9 @@ async fn generate_candle_krea_edit_stream(
             "Krea 2 edit requires edit_image mode + a source image".to_owned(),
         ));
     }
+    // Krea "text style" tap-reweight gain (sc-12009) — self-gates on `ui.textStyleGain` (Krea only),
+    // applied to the edit lane's POSITIVE grounded context by the engine (inference sc-12009).
+    let text_style_gain = resolve_text_style_gain(request);
     let weights_dir = resolve_weights_dir(request, settings)?
         .ok_or_else(|| WorkerError::InvalidPayload("Krea 2 Raw weights not found".to_owned()))?;
 
@@ -293,6 +296,7 @@ async fn generate_candle_krea_edit_stream(
                     seed: Some(seed as u64),
                     steps: Some(steps),
                     guidance: Some(guidance),
+                    text_style_gain,
                     cancel: cancel.clone(),
                     ..Default::default()
                 };

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -9618,6 +9618,7 @@ fn krea_control_lora_end_to_end_mlx_smoke() {
             seed,
             steps,
             conditioning,
+            None,
             &CancelFlag::new(),
             &mut |_| {},
         )


### PR DESCRIPTION
## Summary
**Part B** of sc-12009 — makes the Krea "Text style" slider actually work in **pose-control** and **image-edit** modes (it already works in txt2img/img2img via sc-12008 / #1524). Wires the resolved gain into the four Krea lanes that route around the generic `generate_one`, and bumps the inference pin to the engine that applies it.

> ⚠️ **Stacks on #1524 (sc-12008).** This branch is based on it (it reuses the `resolve_text_style_gain` helper). Merge #1524 first — until then this PR's diff shows the sc-12008 commit too; it cleans up once #1524 lands.

## Changes
- **MLX** `krea_control.rs` / `krea_edit.rs`: resolve the gain (`resolve_text_style_gain`, gated on `ui.textStyleGain`) and thread it into the per-item `GenerationRequest`.
- **candle** `krea_control_candle.rs`: set the new `Krea2ControlRequest.text_style_gain`; `krea_edit_candle.rs`: set `text_style_gain` on the edit `GenerationRequest`.
- **Pin bump** `runtime-2026.07.2` → `runtime-2026.07.3-rc.0` (the 3 worker `Cargo.toml` sites + `Cargo.lock`). The tag carries [SceneWorks/inference#4](https://github.com/SceneWorks/inference/pull/4), which applies the gain on the control encode + the grounded edit encode.

The gate self-limits to Krea via `ui.textStyleGain`, so every other family passes `None`; `g=1.0`/absent stays a byte-exact no-op.

## Verification
- `npm run rust:check` green (fmt / clippy / check / build / tests) — MLX arms compiled on Apple Silicon; the sc-12008 gate regression test still passes. candle arms are `backend-candle`-gated (validated by the `candle-worker` CI lane on Linux).
- Engine effect GPU-A/B'd on real weights in inference#4 (this Mac): **control** g=1.0 MAD 0 (no-op) / g=1.75 MAD 25.5 / g=0.5 MAD 15.5; **edit** g=1.0 MAD 0 / g=1.75 MAD 38.6 / g=0.5 MAD 12.2. Early-emphasis dominates on both — parity with txt2img.

## Release note
`runtime-2026.07.3-rc.0` is a **pre-release** tag cut on the inference #4 merge. Promotion to a final `runtime-2026.07.3` (and the pin repin rc→final) is left to the maintainer, matching the prior `runtime-2026.07.2` flow.

Closes sc-12009 (Part B). Refs sc-12008, epic 8588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)