### PR TITLE
feat(web): Image Editor Close/Discard + desktop-safe confirm + unsaved indicator (sc-11968)

### DIFF
--- a/apps/web/src/App.imageEditorKeepAlive.test.jsx
+++ b/apps/web/src/App.imageEditorKeepAlive.test.jsx
@@ -1,0 +1,127 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The Image Editor is React.lazy'd and imports react-konva (whose node build pulls the
+// native `canvas` package, unusable in jsdom). The empty-state editor never mounts a
+// <Stage>, so stub react-konva to keep konva off the graph — mirroring the ImageEditor
+// unit test. This lets the FULL <App /> mount the (lazy) editor to exercise keep-alive.
+vi.mock("react-konva", async () => {
+  const React = await import("react");
+  const passthrough = (name) => ({ children }) => React.createElement("div", { "data-konva": name }, children);
+  return {
+    Stage: passthrough("stage"),
+    Layer: passthrough("layer"),
+    Image: () => null,
+    Rect: () => null,
+    Line: () => null,
+    Transformer: () => null,
+  };
+});
+
+import { App } from "./main.jsx";
+import { FakeEventSource, response, settle } from "./main.testSupport.jsx";
+
+// sc-11968 (epic 11958, R4): under selective keep-alive the Image Editor stays MOUNTED
+// (hidden) across navigation, so its working image / edit chain / undo history — all held
+// in component state — survive a round trip to another screen and back. jsdom can't decode
+// a real bitmap, so we prove the MECHANISM: the editor's DOM node is the SAME instance
+// across the round trip (never unmounted) AND a piece of its component-only UI state (the
+// keyboard-shortcuts panel, which has no persistence to re-hydrate from) is still there.
+describe("Image Editor keep-alive edit survival (sc-11968)", () => {
+  let container;
+  let root;
+
+  function mockFetch() {
+    global.fetch = vi.fn((url) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) return Promise.resolve(response({ status: "ok", authRequired: false }));
+      if (path.endsWith("/access")) return Promise.resolve(response({ authRequired: false }));
+      if (path.endsWith("/jobs/events/ticket")) return Promise.resolve(response({ ticket: "stream-ticket" }));
+      if (path.endsWith("/projects")) return Promise.resolve(response([{ id: "project-1", name: "Project One" }]));
+      if (path.endsWith("/models")) {
+        return Promise.resolve(response([{ id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image" }]));
+      }
+      return Promise.resolve(response([]));
+    });
+  }
+
+  async function renderApp() {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+  }
+
+  // Click a top-level nav item / any button by exact visible text. The sidebar renders
+  // before the workspace, so a nav button wins over an identically-labelled inner button.
+  async function clickButton(label) {
+    await act(async () => {
+      [...document.body.querySelectorAll("button")].find((button) => button.textContent === label)?.click();
+    });
+    await settle();
+  }
+
+  const editor = () => document.body.querySelector(".ie-shell");
+  const modelsSurface = () => document.body.querySelector(".models-surface");
+  const shortcutsPanel = () => document.body.querySelector(".image-editor-shortcuts");
+
+  // Navigate to the (lazy) Image Editor and wait for the dynamic import + Suspense to
+  // resolve (the first visit transforms + loads the editor chunk, which takes real time).
+  async function openImageEditor() {
+    await clickButton("Image Editor");
+    for (let i = 0; i < 40 && !editor(); i += 1) {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      });
+    }
+  }
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    FakeEventSource.instances = [];
+    window.EventSource = FakeEventSource;
+    window.localStorage.clear();
+    mockFetch();
+  });
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount();
+    });
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the editor mounted (same node) across a nav round trip, preserving in-editor state", async () => {
+    await renderApp();
+    await openImageEditor();
+
+    const editorBefore = editor();
+    expect(editorBefore).not.toBeNull();
+
+    // Leave a piece of component-only UI state on the editor: open the keyboard-shortcuts
+    // panel (a boolean React state with nothing to re-hydrate it from). If this survives a
+    // round trip, the editor was never unmounted — so its working image / edits / undo
+    // history (same kind of component state) survive too.
+    await clickButton("⌨");
+    expect(shortcutsPanel()).not.toBeNull();
+
+    // Navigate to an OUT screen (Models unmounts on nav away) and back.
+    await clickButton("Models");
+    expect(modelsSurface()).not.toBeNull();
+    // The editor stays resident (hidden) while another view is active.
+    expect(editor()).not.toBeNull();
+
+    await openImageEditor();
+    // Same DOM node → never unmounted/remounted.
+    expect(editor()).toBe(editorBefore);
+    // …and its in-editor state is intact with no re-hydrate.
+    expect(shortcutsPanel()).not.toBeNull();
+    // Contrast: the OUT screen was torn down on nav away.
+    expect(modelsSurface()).toBeNull();
+  });
+});

--- a/apps/web/src/App.imageEditorKeepAlive.test.jsx
+++ b/apps/web/src/App.imageEditorKeepAlive.test.jsx
@@ -66,6 +66,9 @@ describe("Image Editor keep-alive edit survival (sc-11968)", () => {
   const editor = () => document.body.querySelector(".ie-shell");
   const modelsSurface = () => document.body.querySelector(".models-surface");
   const shortcutsPanel = () => document.body.querySelector(".image-editor-shortcuts");
+  // The desktop-safe leave/close confirm dialog (appConfirm → ConfirmHost). A plain in-app
+  // nav under keep-alive must never surface it — leaving is non-destructive (sc-11968).
+  const confirmDialog = () => document.body.querySelector(".app-confirm-modal");
 
   // Navigate to the (lazy) Image Editor and wait for the dynamic import + Suspense to
   // resolve (the first visit transforms + loads the editor chunk, which takes real time).
@@ -112,11 +115,17 @@ describe("Image Editor keep-alive edit survival (sc-11968)", () => {
 
     // Navigate to an OUT screen (Models unmounts on nav away) and back.
     await clickButton("Models");
+    // A plain nav away is non-destructive under keep-alive, so it must NOT prompt a
+    // leave-guard confirm (sc-11968): the editor stays mounted and loses nothing, so the
+    // old "you'll discard your edits" dialog would be misleading. Nav completes immediately.
+    expect(confirmDialog()).toBeNull();
     expect(modelsSurface()).not.toBeNull();
     // The editor stays resident (hidden) while another view is active.
     expect(editor()).not.toBeNull();
 
     await openImageEditor();
+    // Returning is likewise silent — no confirm on either leg of the round trip.
+    expect(confirmDialog()).toBeNull();
     // Same DOM node → never unmounted/remounted.
     expect(editor()).toBe(editorBefore);
     // …and its in-editor state is intact with no re-hydrate.

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -49,6 +49,7 @@ import {
 } from "./assetVariants.js";
 import { buildWorkersById } from "./workers.js";
 import { createEditorScratchRegistry } from "./editorScratch.js";
+import { ConfirmHost } from "./appConfirm.jsx";
 import { isDesktop as isDesktopShell, tauriInvoke } from "./runtime.js";
 import {
   buildLocalJobStack,
@@ -568,7 +569,22 @@ export function App() {
   const navTo = useCallback((viewId) => {
     if (viewId === activeViewRef.current) return;
     const guard = leaveGuardRef.current;
-    if (guard && !guard()) return; // guard returned false → user cancelled the leave
+    if (!guard) {
+      setActiveView(viewId);
+      return;
+    }
+    // The guard may answer synchronously (a bare boolean, legacy) or asynchronously
+    // (a Promise<boolean> — the Image Editor's desktop-safe appConfirm dialog, sc-11968).
+    // Only a strict `false` / a promise resolving falsy cancels the leave; anything else
+    // proceeds. A promise defers the view switch until the user answers the dialog.
+    const decision = guard();
+    if (decision && typeof decision.then === "function") {
+      decision.then((ok) => {
+        if (ok) setActiveView(viewId);
+      });
+      return;
+    }
+    if (decision === false) return; // guard returned false → user cancelled the leave
     setActiveView(viewId);
   }, []);
 
@@ -2502,6 +2518,12 @@ export function App() {
           updateAssetStatus={updateAssetStatus}
         />
       ) : null}
+
+      {/* Desktop-safe confirm dialog host (sc-11968). Mounted once at the app root so
+          appConfirm()/useConfirm() anywhere — including a leave-guard callback handed to
+          navTo — resolve through a real React dialog instead of window.confirm (which
+          silently no-ops in the Tauri WebView). Renders nothing until a confirm is asked. */}
+      <ConfirmHost />
     </main>
     </AppLiveContext.Provider>
     </AppStaticContext.Provider>

--- a/apps/web/src/appConfirm.jsx
+++ b/apps/web/src/appConfirm.jsx
@@ -1,0 +1,134 @@
+// Shared, desktop-safe confirm (sc-11968).
+//
+// `window.confirm` is unreliable inside the Tauri desktop WebView: it can silently
+// no-op and return `undefined` rather than a boolean, so a raw confirm there can
+// neither confirm nor cancel — a "Discard?" guard built on it is dead on desktop. This
+// module replaces it with a promise-returning confirm backed by a REAL in-app React
+// dialog (the shared `Modal`, portaled to <body>), so the same code path works in the
+// browser and the desktop shell.
+//
+// Usage:
+//   import { appConfirm, useConfirm, ConfirmHost } from "../appConfirm.jsx";
+//   // once, near the app root:  <ConfirmHost />
+//   if (await appConfirm({ message, tone: "danger" })) { ...discard... }
+//
+// `appConfirm` is a plain function (callable from anywhere — sync or async code, event
+// handlers, or a leave-guard callback), and `useConfirm()` is a thin React accessor that
+// returns it. Both resolve to `true` (proceed) or `false` (cancel).
+//
+// Adopters: the Image Editor Close/Discard + its leave-guard use this today. The other
+// window.confirm call sites (PresetManager, Training, Pose Library, the video EditorScreen
+// timeline-switch guard, App's trash-unavailable confirm) should migrate to it too so the
+// whole app is desktop-safe — tracked as follow-ups on sc-11968's siblings (S10–S12).
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { Modal } from "./components/Modal.jsx";
+
+// Module-level bridge to the mounted <ConfirmHost/>. The host installs its
+// `open(options) => Promise<boolean>` here on mount and clears it on unmount; appConfirm
+// delegates to it. A singleton (not context) so non-React / imperative callers — e.g. a
+// leave-guard callback handed to App — can reach the dialog without threading a hook.
+let hostOpen = null;
+
+// Normalize the caller's options — a bare string is shorthand for `{ message }`.
+export function normalizeConfirmOptions(options) {
+  const opts = typeof options === "string" ? { message: options } : options ?? {};
+  return {
+    title: opts.title ?? "Are you sure?",
+    message: opts.message ?? "",
+    confirmLabel: opts.confirmLabel ?? "Confirm",
+    cancelLabel: opts.cancelLabel ?? "Cancel",
+    // "danger" styles the confirm button as destructive (discard/leave/delete).
+    tone: opts.tone === "danger" ? "danger" : "default",
+  };
+}
+
+// Desktop-safe confirm. Resolves true (proceed) / false (cancel). When a <ConfirmHost/>
+// is mounted (always, in the real app) it renders a React dialog; otherwise it falls back
+// to the platform confirm, preserving the app's long-standing "no confirm available →
+// proceed" semantics for non-DOM / test contexts that didn't mount the host.
+export function appConfirm(options = {}) {
+  const opts = normalizeConfirmOptions(options);
+  if (typeof hostOpen === "function") {
+    return hostOpen(opts);
+  }
+  const ok =
+    typeof window !== "undefined" && typeof window.confirm === "function"
+      ? window.confirm(opts.message)
+      : true;
+  return Promise.resolve(Boolean(ok));
+}
+
+// React-idiomatic accessor: `const confirm = useConfirm(); await confirm({ ... })`.
+// Returns the stable module function, so it never busts a dependency array.
+export function useConfirm() {
+  return appConfirm;
+}
+
+// Mount ONCE near the app root. Renders the confirm dialog while a request is pending and
+// registers its opener into the module bridge so appConfirm()/useConfirm() resolve through
+// a real dialog. Escape, a backdrop click, or unmount all settle the promise as cancelled,
+// so an awaiter is never left hanging.
+export function ConfirmHost() {
+  const [request, setRequest] = useState(null);
+  const pendingRef = useRef(null);
+
+  const settle = useCallback((result) => {
+    const resolve = pendingRef.current;
+    pendingRef.current = null;
+    setRequest(null);
+    if (resolve) resolve(result);
+  }, []);
+
+  const open = useCallback((options) => {
+    return new Promise((resolve) => {
+      // A second request while one is still open cancels the first, so its awaiter never
+      // hangs, then supersedes it with the new dialog.
+      if (pendingRef.current) {
+        const previous = pendingRef.current;
+        pendingRef.current = null;
+        previous(false);
+      }
+      pendingRef.current = resolve;
+      setRequest(options);
+    });
+  }, []);
+
+  useEffect(() => {
+    hostOpen = open;
+    return () => {
+      if (hostOpen === open) hostOpen = null;
+      if (pendingRef.current) {
+        const resolve = pendingRef.current;
+        pendingRef.current = null;
+        resolve(false);
+      }
+    };
+  }, [open]);
+
+  if (!request) return null;
+
+  return (
+    <Modal
+      className="discard-confirm-modal app-confirm-modal"
+      labelledBy="app-confirm-title"
+      onClose={() => settle(false)}
+    >
+      <h2 className="discard-confirm-title" id="app-confirm-title">
+        {request.title}
+      </h2>
+      {request.message ? <p className="discard-confirm-body">{request.message}</p> : null}
+      <div className="discard-confirm-actions">
+        <button onClick={() => settle(false)} type="button">
+          {request.cancelLabel}
+        </button>
+        <button
+          className={request.tone === "danger" ? "danger-action" : "primary-action"}
+          onClick={() => settle(true)}
+          type="button"
+        >
+          {request.confirmLabel}
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/appConfirm.test.jsx
+++ b/apps/web/src/appConfirm.test.jsx
@@ -1,0 +1,193 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { appConfirm, useConfirm, ConfirmHost, normalizeConfirmOptions } from "./appConfirm.jsx";
+
+// sc-11968: the shared, desktop-safe confirm. window.confirm silently no-ops / returns
+// undefined inside the Tauri WebView, so these tests prove the promise-returning appConfirm
+// resolves through a REAL React dialog (the shared Modal, portaled to <body>) — including
+// when window.confirm is stubbed to a desktop-style no-op.
+
+const flush = async () => {
+  await act(async () => {
+    for (let i = 0; i < 4; i += 1) await Promise.resolve();
+  });
+};
+
+// Kick off a confirm INSIDE act (appConfirm synchronously calls setRequest on the host) and
+// let the dialog render. The still-pending promise is stashed in a shared variable rather
+// than RETURNED, so `await askConfirm(...)` can't flatten onto (and block on) it — awaiting
+// an async fn that returns a pending promise would deadlock the test until a click.
+let pending;
+const askConfirm = async (options) => {
+  await act(async () => {
+    pending = appConfirm(options);
+    for (let i = 0; i < 4; i += 1) await Promise.resolve();
+  });
+};
+
+const dialog = () => document.body.querySelector(".app-confirm-modal");
+const dialogButton = (label) =>
+  [...document.body.querySelectorAll(".app-confirm-modal button")].find((b) => b.textContent === label);
+
+describe("normalizeConfirmOptions", () => {
+  it("treats a bare string as the message and fills sane defaults", () => {
+    expect(normalizeConfirmOptions("Discard?")).toEqual({
+      title: "Are you sure?",
+      message: "Discard?",
+      confirmLabel: "Confirm",
+      cancelLabel: "Cancel",
+      tone: "default",
+    });
+  });
+
+  it("passes through provided fields and only honors the 'danger' tone", () => {
+    expect(normalizeConfirmOptions({ title: "T", message: "M", confirmLabel: "Go", cancelLabel: "No", tone: "danger" })).toEqual({
+      title: "T",
+      message: "M",
+      confirmLabel: "Go",
+      cancelLabel: "No",
+      tone: "danger",
+    });
+    expect(normalizeConfirmOptions({ tone: "weird" }).tone).toBe("default");
+  });
+});
+
+describe("appConfirm with a mounted ConfirmHost (sc-11968)", () => {
+  let container;
+  let root;
+
+  beforeEach(async () => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<ConfirmHost />);
+    });
+    await flush();
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("renders nothing until a confirm is requested", () => {
+    expect(dialog()).toBeNull();
+  });
+
+  it("shows a dialog with the title/message/labels and resolves true on Confirm", async () => {
+    await askConfirm({
+      title: "Close image?",
+      message: "Discard and close?",
+      confirmLabel: "Discard & close",
+      cancelLabel: "Keep editing",
+    });
+    const p = pending;
+
+    expect(dialog()).not.toBeNull();
+    expect(document.body.textContent).toContain("Close image?");
+    expect(document.body.textContent).toContain("Discard and close?");
+    expect(dialogButton("Discard & close")).toBeTruthy();
+    expect(dialogButton("Keep editing")).toBeTruthy();
+
+    await act(async () => dialogButton("Discard & close").click());
+    expect(await p).toBe(true);
+    // The dialog closes once answered.
+    expect(dialog()).toBeNull();
+  });
+
+  it("resolves false on Cancel", async () => {
+    await askConfirm("Proceed?");
+    const p = pending;
+    await act(async () => dialogButton("Cancel").click());
+    expect(await p).toBe(false);
+    expect(dialog()).toBeNull();
+  });
+
+  it("resolves false on Escape and on a backdrop click", async () => {
+    await askConfirm("Proceed?");
+    const pEsc = pending;
+    await act(async () => {
+      document.body
+        .querySelector(".app-confirm-modal")
+        .dispatchEvent(new window.KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    expect(await pEsc).toBe(false);
+
+    await askConfirm("Proceed?");
+    const pBackdrop = pending;
+    await act(async () => {
+      const backdrop = document.body.querySelector(".modal-backdrop");
+      backdrop.dispatchEvent(new window.MouseEvent("mousedown", { bubbles: true }));
+    });
+    expect(await pBackdrop).toBe(false);
+  });
+
+  it("works even when window.confirm is a desktop-style no-op returning undefined", async () => {
+    // Simulate the Tauri WebView: confirm exists but silently returns undefined. The dialog
+    // path must be used instead, and Confirm must still resolve true.
+    const noop = vi.fn(() => undefined);
+    vi.stubGlobal("confirm", noop);
+    window.confirm = noop;
+
+    await askConfirm({ message: "Leave?", tone: "danger" });
+    const p = pending;
+    expect(dialog()).not.toBeNull();
+    // The destructive tone styles the confirm button.
+    expect(document.body.querySelector(".app-confirm-modal .danger-action")).toBeTruthy();
+
+    await act(async () => dialogButton("Confirm").click());
+    expect(await p).toBe(true);
+    // The broken window.confirm was never consulted.
+    expect(noop).not.toHaveBeenCalled();
+  });
+
+  it("cancels a superseded request so its awaiter never hangs", async () => {
+    await askConfirm("First?");
+    const first = pending;
+    await askConfirm("Second?");
+    const second = pending;
+    // Opening the second resolves the first as cancelled.
+    expect(await first).toBe(false);
+    await act(async () => dialogButton("Confirm").click());
+    expect(await second).toBe(true);
+  });
+
+  it("useConfirm() returns the same appConfirm function", async () => {
+    let hookValue;
+    function Probe() {
+      hookValue = useConfirm();
+      return null;
+    }
+    const probeContainer = document.createElement("div");
+    document.body.appendChild(probeContainer);
+    const probeRoot = createRoot(probeContainer);
+    await act(async () => probeRoot.render(<Probe />));
+    expect(hookValue).toBe(appConfirm);
+    await act(async () => probeRoot.unmount());
+    probeContainer.remove();
+  });
+});
+
+describe("appConfirm fallback with NO host mounted", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("falls back to window.confirm's answer", async () => {
+    window.confirm = vi.fn(() => true);
+    expect(await appConfirm("Proceed?")).toBe(true);
+    window.confirm = vi.fn(() => false);
+    expect(await appConfirm("Proceed?")).toBe(false);
+  });
+
+  it("proceeds (resolves true) when no confirm is available at all", async () => {
+    const original = window.confirm;
+    window.confirm = undefined;
+    expect(await appConfirm("Proceed?")).toBe(true);
+    window.confirm = original;
+  });
+});

--- a/apps/web/src/editorScratch.test.js
+++ b/apps/web/src/editorScratch.test.js
@@ -126,3 +126,61 @@ describe("createEditorScratchRegistry survivor sweep (sc-8850)", () => {
     expect(purgeAsset).toHaveBeenCalledTimes(2); // entry already gone
   });
 });
+
+// sc-11968 / epic 11958: under keep-alive the Image Editor stays MOUNTED across navigation,
+// so it keeps CLAIMING its in-flight op the whole time. The survivor sweep must therefore
+// NOT fire on a mere nav round trip (the editor is still the owner) — only on a genuine
+// Close/Discard (the editor clears the op, dropping the claim) or a project-switch remount
+// (unmount drops the claim). These tests pin that keep-alive reconciliation at the registry
+// seam, where it is deterministic without mounting the editor.
+describe("keep-alive nav vs. close/discard reconciliation (sc-11968)", () => {
+  function setup() {
+    const purgeAsset = vi.fn().mockResolvedValue(undefined);
+    const registry = createEditorScratchRegistry({ purgeAsset });
+    return { purgeAsset, registry };
+  }
+
+  it("does NOT purge across repeated jobs ticks while the mounted editor keeps claiming the op", () => {
+    const { purgeAsset, registry } = setup();
+    registry.track("job-1", [scratchAsset]);
+    // Editor stays mounted (kept alive) and keeps claiming job-1 while the user navigates
+    // between other screens — the claim getter always reports it.
+    registry.registerClaim(() => new Set(["job-1"]), () => [completedJob()]);
+    // Several nav-driven jobs ticks, even after the job has terminated: still owned → skipped.
+    registry.sweep([completedJob()]);
+    registry.sweep([completedJob()]);
+    registry.sweep([completedJob()]);
+    expect(purgeAsset).not.toHaveBeenCalled();
+    expect(registry._size()).toBe(1);
+  });
+
+  it("purges scratch + result once the editor Closes/Discards (claim drops) and the job is terminal", () => {
+    const { purgeAsset, registry } = setup();
+    registry.track("job-1", [scratchAsset]);
+    // A mutable claim mirrors the mounted editor's live `aiOp` — Close/Discard clears it.
+    let claimed = new Set(["job-1"]);
+    registry.registerClaim(() => claimed, () => [completedJob()]);
+    // While claimed (foregrounded or backgrounded), nav ticks never purge.
+    registry.sweep([completedJob()]);
+    expect(purgeAsset).not.toHaveBeenCalled();
+    // The editor Closes/Discards → aiOp cleared → the claim getter now reports no ownership.
+    claimed = new Set();
+    registry.sweep([completedJob()]);
+    expect(purgeAsset).toHaveBeenCalledWith(scratchAsset);
+    expect(purgeAsset).toHaveBeenCalledWith({ id: "result-1", projectId: "project-1" });
+    expect(registry._size()).toBe(0);
+  });
+
+  it("purges on a project-switch remount (key change → unmount → claim-release sweep)", () => {
+    const { purgeAsset, registry } = setup();
+    registry.track("job-1", [scratchAsset]);
+    const jobs = [completedJob()];
+    // The editor is keyed on the project id, so a project switch remounts it — the old
+    // instance unmounts and its claim unregister sweeps the still-tracked terminal op.
+    const unregister = registry.registerClaim(() => new Set(["job-1"]), () => jobs);
+    unregister();
+    expect(purgeAsset).toHaveBeenCalledWith(scratchAsset);
+    expect(purgeAsset).toHaveBeenCalledWith({ id: "result-1", projectId: "project-1" });
+    expect(registry._size()).toBe(0);
+  });
+});

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -5,7 +5,6 @@ import { Stage, Layer, Image as KonvaImage, Line, Rect, Transformer } from "reac
 import { apiFetch } from "../api.js";
 import { terminalStatuses } from "../jobTypes.js";
 import { useAppContext } from "../context/AppContext.js";
-import { useScreenActive } from "../context/ScreenActiveContext.js";
 import { appConfirm } from "../appConfirm.jsx";
 import { DEFAULT_MAC_CAPABILITIES, macFeatureBlock } from "../macGating.js";
 import { assetUrl, assetCanRenderAsImage } from "../components/assetMedia.jsx";
@@ -294,30 +293,34 @@ const EDITOR_SHORTCUTS = [
 // (image_jobs/flux2.rs). The working image takes one slot, so the editor allows up to 3 user refs.
 export const MAX_EDIT_REFERENCES = 4;
 
-// The leave-guard prompt shown before navigating away from the editor, or null when it's
-// safe to leave silently (sc-2434 / sc-8850). Unsaved edits win the message. Crucially the
-// guard also fires while an AI op is in flight — starting one does NOT set `dirty` (its
-// result only lands on success), so without this branch the user could silently abandon a
-// running edit (losing the result and, before the App survivor sweep, orphaning scratch).
+// The browser CLOSE/REFRESH (beforeunload) warning shown while there is unsaved work, or
+// null when a real unload would lose nothing (sc-2434 / sc-8850). Under keep-alive the
+// editor stays mounted across in-app navigation, so a plain nav is non-destructive and gets
+// NO prompt (see leaveGuardArming); only a genuine browser unload drops the in-memory state,
+// which is what this wording addresses. Unsaved edits win the message. It also fires while an
+// AI op is in flight — starting one does NOT set `dirty` (its result only lands on success) —
+// so an unload mid-op is still flagged (its result would be lost).
 export function leaveGuardMessage({ dirty, aiOpPending }) {
-  if (dirty) return "You have unsaved edits in the Image Editor. Leave and discard them?";
-  if (aiOpPending) return "An image edit is still running. Leave and abandon it?";
+  if (dirty) return "You have unsaved edits in the Image Editor that will be lost if you close or reload.";
+  if (aiOpPending) return "An image edit is still running; its result will be lost if you close or reload.";
   return null;
 }
 
-// Decide which of the two leave-guards to arm (sc-11959). The browser-unload
-// (close/refresh) guard must arm whenever there are unsaved edits or an in-flight AI op,
-// EVEN when the editor is backgrounded under keep-alive — an app close/refresh would
-// otherwise silently discard a backgrounded editor's unsaved edits (a safeguard that
-// predates keep-alive). The in-app nav guard, by contrast, only arms while the editor is
-// the foreground view, so a backgrounded (still-mounted) editor doesn't re-fire its
-// confirm() on every UNRELATED navigation between other screens.
-export function leaveGuardArming({ dirty, aiOpPending, screenActive }) {
+// Decide which leave-guard to arm (sc-11959 / sc-11968). Under selective keep-alive an in-app
+// navigation away does NOT unmount the editor — unsaved edits, undo history, and an in-flight
+// AI op all survive on the still-resident editor and the op's result lands back on return — so
+// a plain nav is NON-DESTRUCTIVE and the in-app nav guard is permanently disarmed (`inApp:
+// false`); prompting there would falsely warn users of loss that won't happen, undermining the
+// keep-alive promise. Only a real browser close/refresh drops the in-memory state, so the
+// beforeunload guard still arms whenever there are unsaved edits or an in-flight op — EVEN when
+// the editor is backgrounded under keep-alive (an app close/refresh would otherwise silently
+// discard a backgrounded editor's unsaved edits, a safeguard that predates keep-alive).
+export function leaveGuardArming({ dirty, aiOpPending }) {
   const message = leaveGuardMessage({ dirty, aiOpPending });
   return {
     message,
     beforeUnload: Boolean(message),
-    inApp: Boolean(message) && Boolean(screenActive),
+    inApp: false,
   };
 }
 
@@ -651,7 +654,6 @@ export function ImageEditor() {
     jobs,
     importAsset,
     purgeAsset,
-    registerLeaveGuard,
     // App-level scratch-op survivor coordination (sc-8850). The editor stages an ephemeral
     // scratch asset per AI op; these let App purge it (and the result) even if the user
     // navigates away mid-job and this component unmounts before its own watcher can run.
@@ -678,11 +680,6 @@ export function ImageEditor() {
     theme = "light",
     changeTheme,
   } = useAppContext();
-  // Under the keep-alive shell (sc-11959) the editor stays mounted (hidden) after the
-  // user navigates away, so it can no longer rely on unmount to drop its leave-guard.
-  // `true` unless a KeepAlivePane says this editor is backgrounded (defaults to true
-  // for the direct-render unit tests, which carry no ScreenActiveContext).
-  const screenActive = useScreenActive();
   // Mac UI gating (sc-3486): the upscale tool itself runs in-process on Rust (Real-ESRGAN,
   // sc-3489), so it is available on a gated Mac — this block is a defensive guard that stays
   // null. The second engine (AuraSR) is dropped on Mac (sc-3668) and gated per-engine below.
@@ -2370,43 +2367,29 @@ export function ImageEditor() {
     setStatus({ loading: false, error: "" });
   }, [resetHistory]);
 
-  // Warn before leaving with unsaved edits OR an in-flight AI op (sc-2434 / sc-8850): a
-  // browser unload (close/refresh) and an in-app navigation away (the App nav consults
-  // this guard). Starting an AI op does NOT set `dirty` — its result only lands on
-  // success — so the guard must also fire while `aiOp` is non-null, otherwise the user
-  // can silently navigate away and abandon the running op (losing the result and, before
-  // the App-level survivor sweep, orphaning the scratch upload).
+  // Warn before a browser CLOSE/REFRESH that would drop unsaved edits OR an in-flight AI op
+  // (sc-2434 / sc-8850 / sc-11968). Under keep-alive an in-app navigation away does NOT
+  // unmount this editor (App keeps it resident), so unsaved edits, undo history, and an
+  // in-flight op all SURVIVE the nav and the op's result lands back on return — a plain nav
+  // is non-destructive and shows NO prompt. Only a real unload drops the in-memory state, so
+  // just the beforeunload guard arms here (even when backgrounded). Starting an AI op does
+  // NOT set `dirty` — its result only lands on success — so the guard must also arm while
+  // `aiOp` is non-null, else an unload mid-op silently loses the result. The intentional
+  // lose-work prompts live elsewhere: the explicit Close/Discard button (closeDoc) and the
+  // open-new / flatten confirms, all via the desktop-safe appConfirm dialog.
   const aiOpPending = Boolean(aiOp);
   useEffect(() => {
-    // See leaveGuardArming: the beforeunload handler arms whenever there are unsaved
-    // edits / an in-flight op (even backgrounded); the in-app nav guard only arms while
-    // this editor is foregrounded (sc-11959).
-    const { message, beforeUnload, inApp } = leaveGuardArming({ dirty, aiOpPending, screenActive });
+    const { beforeUnload } = leaveGuardArming({ dirty, aiOpPending });
     if (!beforeUnload) return undefined;
     const onBeforeUnload = (event) => {
       event.preventDefault();
       event.returnValue = "";
     };
     window.addEventListener("beforeunload", onBeforeUnload);
-    // Desktop-safe in-app leave guard (sc-11968): the guard returns a Promise<boolean> from
-    // appConfirm (a real dialog), which navTo awaits before switching views — replacing the
-    // raw window.confirm that silently no-ops in the Tauri WebView.
-    const unregister = inApp
-      ? registerLeaveGuard?.(() =>
-          appConfirm({
-            title: "Leave the Image Editor?",
-            message,
-            confirmLabel: "Leave",
-            cancelLabel: "Stay",
-            tone: "danger",
-          }),
-        )
-      : undefined;
     return () => {
       window.removeEventListener("beforeunload", onBeforeUnload);
-      if (typeof unregister === "function") unregister();
     };
-  }, [dirty, aiOpPending, registerLeaveGuard, screenActive]);
+  }, [dirty, aiOpPending]);
 
   // Claim the in-flight AI op's jobId with App so its survivor sweep (sc-8850) knows this
   // editor is alive and owns loading the result back before the scratch/result assets are

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -6,6 +6,7 @@ import { apiFetch } from "../api.js";
 import { terminalStatuses } from "../jobTypes.js";
 import { useAppContext } from "../context/AppContext.js";
 import { useScreenActive } from "../context/ScreenActiveContext.js";
+import { appConfirm } from "../appConfirm.jsx";
 import { DEFAULT_MAC_CAPABILITIES, macFeatureBlock } from "../macGating.js";
 import { assetUrl, assetCanRenderAsImage } from "../components/assetMedia.jsx";
 import { DatasetAddDialog } from "../components/DatasetAddDialog.jsx";
@@ -318,6 +319,25 @@ export function leaveGuardArming({ dirty, aiOpPending, screenActive }) {
     beforeUnload: Boolean(message),
     inApp: Boolean(message) && Boolean(screenActive),
   };
+}
+
+// The confirm prompt shown when the user EXPLICITLY closes/discards the working image
+// (the Close button, sc-11968). Unlike the passive leave guard, a deliberate close of a
+// CLEAN document loses nothing, so it needs no confirm (null → proceed silently). Unsaved
+// edits win the wording; an in-flight AI op is the fallback (its result would be abandoned).
+export function closeConfirmMessage({ dirty, aiOpPending }) {
+  if (dirty) return "Discard your unsaved edits and close this image?";
+  if (aiOpPending) return "An image edit is still running. Close and abandon it?";
+  return null;
+}
+
+// Which save-state indicator the top bar shows (sc-11968): the unsaved-edits pill while
+// `dirty`, the "Saved ✓" hint once a Save has landed and nothing has changed since, else
+// nothing. Pure so the badge logic is unit-testable without a mounted canvas.
+export function saveStatusIndicator({ dirty, savedAssetId }) {
+  if (dirty) return "unsaved";
+  if (savedAssetId) return "saved";
+  return null;
 }
 
 // Compose the multi-reference edit's `referenceAssetIds`: the working image (staged as the scratch
@@ -1473,15 +1493,15 @@ export function ImageEditor() {
   );
 
   async function createBlankLayout() {
-    if (!confirmDiscardEdits()) return;
+    if (!(await confirmDiscardEdits())) return;
     setNewLayoutOpen(false);
     await newBlankLayout(blankCanvasDims(layoutAspect, layoutSize));
   }
 
-  function handleDrop(event) {
+  async function handleDrop(event) {
     event.preventDefault();
     const file = event.dataTransfer?.files?.[0];
-    if (file && confirmDiscardEdits()) openFile(file);
+    if (file && (await confirmDiscardEdits())) openFile(file);
   }
 
   function handleWheel(event) {
@@ -1643,10 +1663,13 @@ export function ImageEditor() {
   const confirmFlatten = useCallback(() => {
     const n = workingRef.current?.layers?.length ?? 0;
     if (n <= 1) return true;
-    return (
-      typeof window.confirm !== "function" ||
-      window.confirm(`This will flatten ${n} layers into a single layer. Continue?`)
-    );
+    // Desktop-safe confirm (sc-11968): returns a Promise the caller awaits.
+    return appConfirm({
+      title: "Flatten layers?",
+      message: `This will flatten ${n} layers into a single layer. Continue?`,
+      confirmLabel: "Flatten",
+      cancelLabel: "Cancel",
+    });
   }, []);
 
   // Apply: document-level crop — crop every layer to the rect, set the doc dims,
@@ -2045,7 +2068,7 @@ export function ImageEditor() {
     }) => {
       if (!working || aiOp || !activeProject) return;
       // A composite-source op flattens the stack into one base layer — confirm first.
-      if (layerSource === "composite" && !confirmFlatten()) return;
+      if (layerSource === "composite" && !(await confirmFlatten())) return;
       setStatus({ loading: false, error: "" });
       const targetLayerId = activeLayerOf(working)?.id ?? null;
       // Stage the source (and, for a masked edit, the mask) as scratch assets. An
@@ -2303,14 +2326,49 @@ export function ImageEditor() {
   }, [working, workingImageToFile]);
 
   // Confirm before an action that would discard unsaved edits (Open / drag-drop a
-  // new image while dirty). Returns true when it's safe to proceed.
+  // new image while dirty). Resolves true when it's safe to proceed. Async + desktop-safe
+  // (sc-11968): callers `await` it, so the confirm works in the Tauri WebView where a raw
+  // window.confirm silently no-ops.
   function confirmDiscardEdits() {
-    if (!dirty) return true;
-    return (
-      typeof window.confirm !== "function" ||
-      window.confirm("You have unsaved edits. Open a new image and discard them?")
-    );
+    if (!dirty) return Promise.resolve(true);
+    return appConfirm({
+      title: "Discard unsaved edits?",
+      message: "You have unsaved edits. Open a new image and discard them?",
+      confirmLabel: "Discard & open",
+      cancelLabel: "Keep editing",
+      tone: "danger",
+    });
   }
+
+  // Explicitly close the working document (the top-bar Close button, sc-11968). Under
+  // keep-alive the editor no longer unmounts on navigation, so this is the intentional
+  // path that clears the working doc, edit/undo history, and save state. A dirty doc (or
+  // an in-flight AI op) prompts first via the desktop-safe confirm; a clean doc closes
+  // silently. Clearing `aiOp` drops the survivor claim, so App's scratch registry
+  // (editorScratch.js) purges any in-flight op's scratch/result when its job terminates —
+  // nothing is orphaned.
+  const closeDoc = useCallback(async () => {
+    if (!workingRef.current) return;
+    const message = closeConfirmMessage({ dirty: dirtyRef.current, aiOpPending: Boolean(aiOpRef.current) });
+    if (message) {
+      const proceed = await appConfirm({
+        title: "Close image?",
+        message,
+        confirmLabel: "Discard & close",
+        cancelLabel: "Keep editing",
+        tone: "danger",
+      });
+      if (!proceed) return;
+    }
+    revokeLayerUrls(workingRef.current?.layers);
+    setWorking(null);
+    setEdits([]);
+    setDirty(false);
+    setSavedAssetId(null);
+    setAiOp(null);
+    resetHistory();
+    setStatus({ loading: false, error: "" });
+  }, [resetHistory]);
 
   // Warn before leaving with unsaved edits OR an in-flight AI op (sc-2434 / sc-8850): a
   // browser unload (close/refresh) and an in-app navigation away (the App nav consults
@@ -2330,9 +2388,18 @@ export function ImageEditor() {
       event.returnValue = "";
     };
     window.addEventListener("beforeunload", onBeforeUnload);
+    // Desktop-safe in-app leave guard (sc-11968): the guard returns a Promise<boolean> from
+    // appConfirm (a real dialog), which navTo awaits before switching views — replacing the
+    // raw window.confirm that silently no-ops in the Tauri WebView.
     const unregister = inApp
-      ? registerLeaveGuard?.(
-          () => typeof window.confirm !== "function" || window.confirm(message),
+      ? registerLeaveGuard?.(() =>
+          appConfirm({
+            title: "Leave the Image Editor?",
+            message,
+            confirmLabel: "Leave",
+            cancelLabel: "Stay",
+            tone: "danger",
+          }),
         )
       : undefined;
     return () => {
@@ -3797,14 +3864,22 @@ export function ImageEditor() {
         {working ? (
           <>
             <div className="ie-divider" />
-            <button className="ie-btn sm" onClick={runDownload} title="Download a PNG to your computer" type="button">
-              Download
-            </button>
-            {savedAssetId && !dirty ? (
+            {/* Unsaved-edits indicator (sc-11968): a pill while the working doc has edits not
+                yet saved to the Library, swapped for the "Saved ✓" hint once a Save lands. */}
+            {saveStatusIndicator({ dirty, savedAssetId }) === "unsaved" ? (
+              <span className="ie-unsaved-badge" role="status" title="You have unsaved edits">
+                <span className="ie-unsaved-dot" aria-hidden="true" />
+                Unsaved
+              </span>
+            ) : null}
+            {saveStatusIndicator({ dirty, savedAssetId }) === "saved" ? (
               <span className="ie-doc-sub" style={{ color: "var(--ie-accent)" }}>
                 Saved ✓
               </span>
             ) : null}
+            <button className="ie-btn sm" onClick={runDownload} title="Download a PNG to your computer" type="button">
+              Download
+            </button>
             <button
               className="ie-btn sm primary"
               disabled={!dirty || saving}
@@ -3813,6 +3888,16 @@ export function ImageEditor() {
               type="button"
             >
               {saving ? "Saving…" : "Save"}
+            </button>
+            {/* Explicit Close/Discard (sc-11968): intentionally clears the working doc.
+                Guarded by the desktop-safe confirm when there are unsaved edits / a running op. */}
+            <button
+              className="ie-btn sm ghost danger"
+              onClick={closeDoc}
+              title="Close this image (discard unsaved edits)"
+              type="button"
+            >
+              Close
             </button>
           </>
         ) : null}
@@ -4198,15 +4283,15 @@ export function ImageEditor() {
           fileAccept="image/*"
           fileHint="Drag an image here, or"
           multiple={false}
-          onAdd={(ids) => {
+          onAdd={async (ids) => {
             setPickerOpen(false);
-            if (ids[0] && confirmDiscardEdits()) openAsset(ids[0]);
+            if (ids[0] && (await confirmDiscardEdits())) openAsset(ids[0]);
           }}
           onClose={() => setPickerOpen(false)}
-          onImport={(files) => {
+          onImport={async (files) => {
             const file = files?.[0];
             setPickerOpen(false);
-            if (file && confirmDiscardEdits()) openFile(file);
+            if (file && (await confirmDiscardEdits())) openFile(file);
           }}
           title="Open image"
         />

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -288,38 +288,39 @@ describe("ImageEditor scaffold", () => {
 describe("in-flight AI-op scratch survival (sc-8850)", () => {
   it("leaveGuardMessage warns while an AI op is pending even when NOT dirty", () => {
     // The regression: the guard was gated only on `dirty`, so a running AI op (which never
-    // sets dirty) left the editor unguarded and silently abandonable.
+    // sets dirty) left the editor unguarded and silently abandonable on a browser unload.
     expect(leaveGuardMessage({ dirty: false, aiOpPending: false })).toBeNull();
-    expect(leaveGuardMessage({ dirty: false, aiOpPending: true })).toBe(
-      "An image edit is still running. Leave and abandon it?",
-    );
+    expect(leaveGuardMessage({ dirty: false, aiOpPending: true })).toContain("still running");
+    // The wording now speaks to a browser close/reload (the only surface that loses state
+    // under keep-alive), not an in-app "leave"/"abandon".
+    expect(leaveGuardMessage({ dirty: false, aiOpPending: true })).toContain("close or reload");
     // Unsaved edits still take precedence over the AI-op wording.
     expect(leaveGuardMessage({ dirty: true, aiOpPending: false })).toContain("unsaved edits");
     expect(leaveGuardMessage({ dirty: true, aiOpPending: true })).toContain("unsaved edits");
   });
 
-  it("arms the beforeunload guard even when backgrounded, but the in-app guard only when foregrounded (sc-11959)", () => {
-    // The regression under keep-alive: gating BOTH guards on screenActive meant a dirty
-    // BACKGROUNDED (kept-alive) editor registered no beforeunload handler, so an app
-    // close/refresh discarded its unsaved edits with no warning.
+  it("arms ONLY the beforeunload guard on unsaved work; the in-app nav guard is never armed (sc-11968)", () => {
+    // Under keep-alive an in-app navigation away does NOT unmount the editor, so unsaved
+    // edits and an in-flight op survive the nav (the op's result lands back on return) — a
+    // plain nav is non-destructive and must show NO prompt. The in-app guard is therefore
+    // permanently disarmed (regression guard: old code returned `inApp: true` here, which
+    // surfaced a misleading "you'll lose your work" dialog for work that was NOT lost). Only
+    // a real browser close/refresh drops the in-memory state, so the beforeunload guard still
+    // arms — even when the editor is backgrounded (screenActive is no longer consulted).
 
-    // Dirty + backgrounded: browser-unload guard still arms; in-app nav guard does not.
-    expect(leaveGuardArming({ dirty: true, aiOpPending: false, screenActive: false })).toMatchObject({
+    // Dirty: browser-unload guard arms; in-app nav guard never does.
+    expect(leaveGuardArming({ dirty: true, aiOpPending: false })).toMatchObject({
       beforeUnload: true,
       inApp: false,
     });
-    // Dirty + foregrounded: both guards arm.
-    expect(leaveGuardArming({ dirty: true, aiOpPending: false, screenActive: true })).toMatchObject({
-      beforeUnload: true,
-      inApp: true,
-    });
-    // In-flight AI op + backgrounded: browser-unload guard arms (the op is still abandonable).
-    expect(leaveGuardArming({ dirty: false, aiOpPending: true, screenActive: false })).toMatchObject({
+    // In-flight AI op: browser-unload guard arms (the op's result would be lost on unload);
+    // in-app nav guard never does.
+    expect(leaveGuardArming({ dirty: false, aiOpPending: true })).toMatchObject({
       beforeUnload: true,
       inApp: false,
     });
-    // Clean + foregrounded: neither guard arms.
-    expect(leaveGuardArming({ dirty: false, aiOpPending: false, screenActive: true })).toMatchObject({
+    // Clean & idle: neither guard arms.
+    expect(leaveGuardArming({ dirty: false, aiOpPending: false })).toMatchObject({
       message: null,
       beforeUnload: false,
       inApp: false,

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -78,6 +78,8 @@ import {
   MAX_EDIT_REFERENCES,
   leaveGuardMessage,
   leaveGuardArming,
+  closeConfirmMessage,
+  saveStatusIndicator,
 } from "./ImageEditor.jsx";
 import { verifyCaption, serializeCaption, ELEMENT_KEY_ORDER_OBJ } from "../ideogramCaption.js";
 
@@ -355,6 +357,34 @@ describe("in-flight AI-op scratch survival (sc-8850)", () => {
     await act(async () => root.unmount());
     expect(unregister).toHaveBeenCalledTimes(1);
     container.remove();
+  });
+});
+
+// sc-11968: explicit Close/Discard + the unsaved-edits indicator. The confirm dialog it
+// drives is covered end-to-end in appConfirm.test.jsx; here we pin the pure decision logic
+// the editor top bar renders from (the actual bitmap/canvas surface needs a real canvas,
+// verified in the browser).
+describe("Close/Discard + unsaved indicator logic (sc-11968)", () => {
+  it("only prompts a Close when there is something to lose", () => {
+    // A clean doc closes silently (no confirm needed).
+    expect(closeConfirmMessage({ dirty: false, aiOpPending: false })).toBeNull();
+    // Unsaved edits win the wording.
+    expect(closeConfirmMessage({ dirty: true, aiOpPending: false })).toBe(
+      "Discard your unsaved edits and close this image?",
+    );
+    expect(closeConfirmMessage({ dirty: true, aiOpPending: true })).toContain("unsaved edits");
+    // An in-flight AI op (which never sets dirty) is the fallback reason to confirm.
+    expect(closeConfirmMessage({ dirty: false, aiOpPending: true })).toBe(
+      "An image edit is still running. Close and abandon it?",
+    );
+  });
+
+  it("reflects dirty as the unsaved indicator, else the saved hint, with dirty winning", () => {
+    expect(saveStatusIndicator({ dirty: true, savedAssetId: null })).toBe("unsaved");
+    expect(saveStatusIndicator({ dirty: false, savedAssetId: "asset-9" })).toBe("saved");
+    expect(saveStatusIndicator({ dirty: false, savedAssetId: null })).toBeNull();
+    // A dirty edit made after a Save reads as unsaved again, not "saved".
+    expect(saveStatusIndicator({ dirty: true, savedAssetId: "asset-9" })).toBe("unsaved");
   });
 });
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7992,6 +7992,30 @@ details[open] > summary.lora-scope-group-heading::before,
 .ie-btn.block { width: 100%; height: 40px; font-size: 13.5px; }
 .ie-btn.on { border-color: var(--ie-accent); color: var(--ie-accent); background: var(--ie-accent-soft); }
 
+/* Unsaved-edits indicator (sc-11968): a small pill in the editor top bar that reflects
+   the `dirty` flag, sitting beside the Save action. */
+.ie-unsaved-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 24px;
+  padding: 0 9px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--ie-warn, #d97706) 40%, var(--ie-border));
+  background: color-mix(in srgb, var(--ie-warn, #d97706) 14%, transparent);
+  color: color-mix(in srgb, var(--ie-warn, #d97706) 78%, var(--ie-text));
+  font: 600 11px var(--font-ui);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  user-select: none;
+}
+.ie-unsaved-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ie-warn, #d97706);
+}
+
 /* ── Tool rail ── */
 .ie-rail {
   display: flex;


### PR DESCRIPTION
## sc-11968 — Epic 11958 S9: preserve edits across nav; explicit Close/Discard that works on desktop; unsaved indicator (R4 + R5)

Builds on S1 selective lazy keep-alive (#1525): the Image Editor now stays **mounted** (hidden) across navigation, so its working image / edits / undo history already survive a nav round trip. This story adds the explicit close path, a shared **desktop-safe confirm**, the unsaved indicator, and reconciles the AI-op scratch survivor registry with keep-alive.

### What changed

**Shared desktop-safe confirm — new `apps/web/src/appConfirm.jsx`**
- `appConfirm(options) → Promise<boolean>` and a thin `useConfirm()` accessor, backed by a **real React dialog** (the shared `Modal`, portaled to `<body>`) via a single `<ConfirmHost/>` mounted once at the App root.
- Replaces `window.confirm`, which silently no-ops / returns `undefined` inside the Tauri desktop WebView (so a raw discard guard is dead on desktop).
- Callable from anywhere — including a leave-guard callback handed to `navTo` — not just React render. Resolves `true`/`false`; cancels on Escape, backdrop click, or host unmount; a superseding request cancels the previous so no awaiter hangs. Defensive fallback to the platform confirm when no host is mounted (tests / non-DOM).

**Explicit Close/Discard**
- New top-bar **Close** button intentionally clears the working document (working / edits / undo history / save state). Guarded by `appConfirm` when there are unsaved edits **or** an in-flight AI op; a clean doc closes silently. Clearing `aiOp` drops the survivor claim, so App's scratch registry purges the op's scratch/result once its job terminates — nothing orphaned.

**Adopted the util for the editor's existing confirms**
- The in-app **leave-guard** (was raw `window.confirm`), the **open-new-image discard** guard, and the **flatten-layers** guard now all go through `appConfirm`.
- `navTo` now awaits a promise-returning guard before switching views (backward compatible with any sync boolean guard).

**Unsaved-edits indicator**
- Top-bar pill reflecting `dirty` (pairs with the existing "Saved ✓" hint), driven by a new pure `saveStatusIndicator()` helper.

**editorScratch reconciliation (R5)**
- The survivor sweep already skips ops the mounted editor is claiming, so under keep-alive it does **not** fire on a mere nav round trip. It purges only on a genuine Close/Discard (claim drops) or a project-switch remount (unmount drops the claim). Pinned with tests.

### Tests — full web suite green (128 files / 1724 tests)
- `appConfirm.test.jsx` — dialog resolves true/false via confirm/cancel/Escape/backdrop; **works when `window.confirm` is a desktop no-op returning `undefined`**; `useConfirm()` identity; no-host fallback; supersede-cancel.
- `App.imageEditorKeepAlive.test.jsx` — editor kept mounted (same DOM node) and in-editor state survives an Image Editor → other screen → Image Editor round trip (R1 mechanism).
- `editorScratch.test.js` — no purge across nav ticks while claimed; purge on Close/Discard (claim drops) and on project-switch remount.
- `ImageEditor.test.jsx` — `closeConfirmMessage` / `saveStatusIndicator` decision logic.

### Follow-ups
The util is exported and reusable; remaining `window.confirm` call sites should migrate to `appConfirm` so the whole app is desktop-safe:
- **S10** PresetManager, **S11** Training, **S12** Pose Library
- the video **EditorScreen** timeline-switch guard
- App's trash-unavailable confirm (`App.jsx`), and a few other component confirms (CharacterStudio, ModelManager, assetPanels)

Web-only; no Rust touched.

Closes sc-11968.