### PR TITLE
fix(web): let users clear the img2img reference image

### DIFF
--- a/apps/web/src/components/AssetPicker.jsx
+++ b/apps/web/src/components/AssetPicker.jsx
@@ -229,6 +229,12 @@ export function ImageEditSourcePickerField({
   assets,
   buttonLabel = "Select image",
   characters = [],
+  // clearable=true renders a "Remove" control next to "Change" that resets the
+  // selection to "" (onChange("")). Opt-in because some callers (e.g. the edit
+  // Source image) require a picked asset; enable it where the source is optional
+  // — img2img reference, the optional second edit image, control images — so a
+  // once-picked image can actually be un-picked rather than sticking until reload.
+  clearable = false,
   emptyLabel = "No source image selected",
   importAsset,
   label = "Source image",
@@ -252,9 +258,18 @@ export function ImageEditSourcePickerField({
     <div className="asset-picker-field">
       <div className="asset-picker-head">
         <span className="asset-picker-label">{label}</span>
-        <button aria-haspopup="dialog" onClick={() => setOpen(true)} type="button">
-          {selectedAsset ? "Change" : buttonLabel}
-        </button>
+        <div className="asset-picker-actions">
+          {/* Gate on `value`, not `selectedAsset`: a still-sent id that no longer
+              resolves (asset trashed/filtered out) must still be clearable. */}
+          {clearable && value ? (
+            <button className="asset-picker-clear" onClick={() => onChange("")} type="button">
+              Remove
+            </button>
+          ) : null}
+          <button aria-haspopup="dialog" onClick={() => setOpen(true)} type="button">
+            {selectedAsset ? "Change" : buttonLabel}
+          </button>
+        </div>
       </div>
       <AssetPreviewChips assets={selectedAsset ? [selectedAsset] : []} emptyLabel={emptyLabel} />
       {open ? (

--- a/apps/web/src/components/AssetPicker.test.jsx
+++ b/apps/web/src/components/AssetPicker.test.jsx
@@ -1,0 +1,58 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ImageEditSourcePickerField } from "./AssetPicker.jsx";
+
+// The picker was previously "Change"/"Select"-only: once an optional source (img2img reference,
+// control image, second edit image) was picked there was no way to un-pick it, so it kept driving
+// generations until reload. `clearable` adds an opt-in "Remove" control that resets to "".
+describe("ImageEditSourcePickerField clear affordance", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render(ui) {
+    await act(async () => root.render(ui));
+  }
+
+  const buttonByLabel = (label) =>
+    [...container.querySelectorAll("button")].find((b) => b.textContent.trim() === label);
+
+  it("renders a Remove control that clears the selection when clearable with a value set", async () => {
+    const onChange = vi.fn();
+    await render(
+      <ImageEditSourcePickerField assets={[]} clearable label="Reference image" onChange={onChange} value="a1" />,
+    );
+    const remove = buttonByLabel("Remove");
+    expect(remove).toBeTruthy();
+    await act(async () => remove.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("omits Remove when clearable but nothing is selected", async () => {
+    await render(
+      <ImageEditSourcePickerField assets={[]} clearable label="Reference image" onChange={() => {}} value="" />,
+    );
+    expect(buttonByLabel("Remove")).toBeFalsy();
+  });
+
+  it("omits Remove when not clearable even with a value (required edit source)", async () => {
+    await render(
+      <ImageEditSourcePickerField assets={[]} label="Source image" onChange={() => {}} value="a1" />,
+    );
+    expect(buttonByLabel("Remove")).toBeFalsy();
+  });
+});

--- a/apps/web/src/components/ControlPanel.jsx
+++ b/apps/web/src/components/ControlPanel.jsx
@@ -142,6 +142,7 @@ export function ControlPanel({
                 assets={controlImageAssets}
                 buttonLabel="Select image"
                 characters={characters}
+                clearable
                 emptyLabel={`No ${activeMode} control image selected`}
                 importAsset={importAsset}
                 label={

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -2410,6 +2410,10 @@ export function ImageStudio() {
               >
                 <span className="prompt-tool-title">
                   <Icon.Image size={15} /> Image reference
+                  {/* Armed indicator: the panel is a collapsible accordion, so once a reference is
+                      picked and the tile is collapsed there's otherwise no sign it's still driving
+                      every generation. Show "On" whenever a reference is set, regardless of expansion. */}
+                  {img2imgReferenceAssetId ? <span className="prompt-tool-flag">On</span> : null}
                 </span>
                 <span className="prompt-tool-desc">Guide the render with an image (image-to-image)</span>
               </button>
@@ -2426,6 +2430,7 @@ export function ImageStudio() {
                     buttonLabel="Select reference image"
                     changeLabel="Change reference"
                     characters={characters}
+                    clearable
                     emptyLabel="No reference image selected"
                     importAsset={importAsset}
                     label="Reference image"
@@ -2594,6 +2599,7 @@ export function ImageStudio() {
                           assets={editImageAssets}
                           buttonLabel="Select image"
                           characters={characters}
+                          clearable
                           emptyLabel="No second image selected (optional)"
                           importAsset={importAsset}
                           label={editReferences.secondaryLabel ?? "Image 2 (optional)"}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1875,6 +1875,21 @@ label {
   color: var(--text-muted);
 }
 
+/* Armed badge on a prompt-tool tile (e.g. img2img has a reference set). Signals
+   the tool is active even when its accordion panel is collapsed. */
+.prompt-tool-flag {
+  margin-left: auto;
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border: 1px solid var(--accent);
+}
+
 /* The inline panel a prompt-tool tile reveals (UI-refinement 1b) — a bordered surface-2 card.
    It wraps the reused ReferenceCaptionPicker / RefinePromptControl, so normalize their internal
    spacing and flatten the refine-review so it's not a card inside a card. */
@@ -10183,6 +10198,24 @@ details[open] > summary.lora-scope-group-heading::before,
   font-size: 12px;
   font-weight: 600;
   letter-spacing: 0.01em;
+}
+
+/* Keep the Change / Remove buttons grouped on the right (the head is a
+   space-between flex row, so bare siblings would spread apart). */
+.asset-picker-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* "Remove" reads as the quieter, secondary action next to "Change". */
+.asset-picker-clear {
+  color: var(--text-muted);
+}
+
+.asset-picker-clear:hover:not(:disabled) {
+  color: var(--danger, var(--text));
+  border-color: var(--danger, var(--border-strong));
 }
 
 /* Edit fit-mode selector (epic 2551): caption above a segmented crop/pad/outpaint control. */


### PR DESCRIPTION
## Problem

Once a reference image was picked for img2img, there was no way to clear it. The picker (`ImageEditSourcePickerField`) only offered **Change**/**Select** — no remove. Collapsing the tile just hid the panel (a `promptTool` visibility flag), and the request builder kept sending the reference on `supportsImg2img && img2imgReferenceAssetId` regardless of panel state. So every generation reused the reference until the app was restarted — with **no visible sign** it was still armed.

## Fix

- Add an opt-in `clearable` prop to `ImageEditSourcePickerField` that renders a **"Remove"** control clearing the selection (`onChange("")`). Gated on `value` (not the resolved asset) so a stale id whose asset was trashed is still clearable.
- Wire it into the three genuinely-**optional** source pickers: img2img reference, the optional second edit image ("Image 2 (optional)"), and the canny/depth control image. The **required** edit "Source image" stays non-clearable.
- Show an **"On"** flag on the collapsed img2img tile whenever a reference is set, so an armed reference is visible even when the accordion panel is folded.

### Deliberate scope call
Collapsing the panel intentionally does **not** auto-clear the reference — coupling generation to the accordion's open/closed state would surprise in the other direction (collapse to save space → img2img silently off). The explicit **Remove** button plus the **On** flag solves "I didn't know it was still on" without that footgun.

## Files
- `apps/web/src/components/AssetPicker.jsx` — `clearable` prop + Remove control
- `apps/web/src/screens/ImageStudio.jsx` — wire img2img reference + optional second image; "On" tile flag
- `apps/web/src/components/ControlPanel.jsx` — wire canny/depth control image
- `apps/web/src/styles.css` — button-group layout, muted Remove, tile badge
- `apps/web/src/components/AssetPicker.test.jsx` — new tests for the clear affordance

## Verification
- `npx vitest run` — **77 passed** (3 new `AssetPicker` tests + existing `ImageStudio`/`ControlPanel` suites), `eslint` clean (0 errors).
- Verified via component/behavior tests rather than the live studio: reaching the img2img panel in a preview needs a running backend with an img2img-capable model and a selected project asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)