### PR TITLE
feat(web): Asset Library search (name/prompt/tags) + select-all results

### DIFF
--- a/apps/web/src/App.library.test.jsx
+++ b/apps/web/src/App.library.test.jsx
@@ -269,6 +269,99 @@ describe("SceneWorks app shell", () => {
     expect(updateAssetTags).toHaveBeenLastCalledWith(portrait, []);
   });
 
+  it("searches Library assets by prompt or tag and selects all results for batch actions", async () => {
+    const neonPortrait = {
+      id: "asset-neon",
+      projectId: "project-1",
+      type: "image",
+      displayName: "Neon One",
+      tags: ["portrait"],
+      recipe: { prompt: "neon street at night" },
+      status: { favorite: false, rating: 0, rejected: false, trashed: false },
+    };
+    const neonAlley = {
+      id: "asset-neon-alley",
+      projectId: "project-1",
+      type: "image",
+      displayName: "Second Plate",
+      tags: ["cyberpunk"],
+      recipe: { prompt: "a neon-lit rain-slicked alley" },
+      status: { favorite: false, rating: 0, rejected: false, trashed: false },
+    };
+    const forest = {
+      id: "asset-forest",
+      projectId: "project-1",
+      type: "image",
+      displayName: "Forest",
+      tags: ["landscape"],
+      recipe: { prompt: "misty forest" },
+      status: { favorite: false, rating: 0, rejected: false, trashed: false },
+    };
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Searchable" },
+            assets: [neonPortrait, neonAlley, forest],
+            jobs: [],
+            imageModels: [],
+            createVqaJob: vi.fn(),
+            deleteAsset: () => {},
+            purgeAsset: () => {},
+            importAsset: () => {},
+            setPreviewAsset: () => {},
+            sendAssetToImage: () => {},
+            sendAssetToVideo: () => {},
+            selectedAsset: neonPortrait,
+            setSelectedAssetId: () => {},
+            setActiveView: () => {},
+            updateAssetStatus: () => {},
+            updateAssetTags: () => {},
+          },
+          <LibraryScreen />,
+        ),
+      );
+    });
+    await settle();
+
+    const searchInput = document.body.querySelector('input[aria-label="Search assets"]');
+    expect(searchInput).not.toBeNull();
+    // No query: all three tiles show and no "Select all" affordance yet.
+    expect([...document.body.querySelectorAll(".asset-tile")]).toHaveLength(3);
+    expect([...document.body.querySelectorAll("button")].some((button) => button.textContent.startsWith("Select all"))).toBe(false);
+
+    // Search matches prompt text ("neon" appears in both neon prompts, not the forest).
+    await changeField(searchInput, "neon");
+    let tiles = [...document.body.querySelectorAll(".asset-tile")];
+    expect(tiles).toHaveLength(2);
+    expect(tiles.map((tile) => tile.textContent).join(" ")).not.toContain("Forest");
+
+    // Search matches tags too — "landscape" is only a tag on the forest asset.
+    await changeField(searchInput, "landscape");
+    tiles = [...document.body.querySelectorAll(".asset-tile")];
+    expect(tiles).toHaveLength(1);
+    expect(tiles[0].textContent).toContain("Forest");
+
+    // Search matches the display name too — "Second Plate" is in neither prompt nor tags.
+    await changeField(searchInput, "second plate");
+    tiles = [...document.body.querySelectorAll(".asset-tile")];
+    expect(tiles).toHaveLength(1);
+    expect(tiles[0].textContent).toContain("Second Plate");
+
+    // Back to the neon result set, "Select all" picks every visible result for a batch action.
+    await changeField(searchInput, "neon");
+    const selectAll = [...document.body.querySelectorAll("button")].find((button) => button.textContent.startsWith("Select all"));
+    expect(selectAll).toBeTruthy();
+    expect(selectAll.textContent).toContain("(2)");
+    await act(async () => {
+      selectAll.click();
+    });
+    const bar = document.body.querySelector(".batch-selection-bar");
+    expect(bar).toBeTruthy();
+    expect(bar.textContent).toContain("2 selected");
+  });
+
   it("moves a Library asset into a selected character's assets", async () => {
     // sc-10200: a TRUE move — the context action hits the move-to-character
     // endpoint; no character reference (Approved set entry) is created.

--- a/apps/web/src/assetBatch.jsx
+++ b/apps/web/src/assetBatch.jsx
@@ -80,6 +80,14 @@ export function useAssetBatch() {
       else next.add(id);
       return next;
     });
+  // Add every id in `ids` to the selection (union — never drops an existing pick), so a
+  // "Select all" over the current result set stacks onto anything already chosen.
+  const selectAll = (ids) =>
+    setSelectedAssetIds((prev) => {
+      const next = new Set(prev);
+      for (const id of ids) next.add(id);
+      return next;
+    });
   const clearSelection = () => {
     setSelectedAssetIds(new Set());
     setMoveOpen(false);
@@ -224,6 +232,7 @@ export function useAssetBatch() {
   return {
     selectedAssetIds,
     toggleSelect,
+    selectAll,
     clearSelection,
     selectedAssetList,
     eligibleSelected,

--- a/apps/web/src/screens/LibraryScreen.jsx
+++ b/apps/web/src/screens/LibraryScreen.jsx
@@ -6,6 +6,19 @@ import { isLibraryAsset, terminalStatuses } from "../constants.js";
 import { useAppContext } from "../context/AppContext.js";
 import { WorkPanel } from "../components/WorkPanel.jsx";
 
+// Free-text Library search across an asset's display name, prompt, and tags.
+// Case-insensitive substring match; an empty needle matches everything so callers
+// can pass the query unconditionally. `needle` is expected pre-lowercased/trimmed.
+export function assetMatchesSearch(asset, needle) {
+  if (!needle) {
+    return true;
+  }
+  const displayName = asset.displayName ?? "";
+  const prompt = asset.recipe?.prompt ?? "";
+  const tags = Array.isArray(asset.tags) ? asset.tags.join(" ") : "";
+  return `${displayName} ${prompt} ${tags}`.toLowerCase().includes(needle);
+}
+
 export function LibraryScreen() {
   const {
     activeProject,
@@ -41,9 +54,13 @@ export function LibraryScreen() {
   const vqaEnabled = Boolean(createVqaJob) && imageModels.some((model) => (model.capabilities ?? []).includes("vqa"));
   const [typeFilter, setTypeFilter] = useState("all");
   const [tagFilter, setTagFilter] = useState("all");
+  const [searchQuery, setSearchQuery] = useState("");
   const [showRejected, setShowRejected] = useState(false);
   const [assetMode, setAssetMode] = useState("assets");
   const [isImporting, setIsImporting] = useState(false);
+  // Free-text search over prompt + tags. Normalized once here; the matcher expects it
+  // pre-lowercased/trimmed and treats an empty needle as "match everything".
+  const searchNeedle = searchQuery.trim().toLowerCase();
   // Asset Library hygiene (sc-2024 / sc-8339): show only studio-generated and uploaded
   // media via a positive origin allow-list (isLibraryAsset). Character Studio outputs,
   // Pose/Key Point library assets, and any future/foreign origin stay out by default —
@@ -66,6 +83,9 @@ export function LibraryScreen() {
       return false;
     }
     if (tagFilter !== "all" && !(asset.tags ?? []).includes(tagFilter)) {
+      return false;
+    }
+    if (!assetMatchesSearch(asset, searchNeedle)) {
       return false;
     }
     return true;
@@ -98,6 +118,9 @@ export function LibraryScreen() {
     if (tagFilter !== "all" && !(asset.tags ?? []).includes(tagFilter)) {
       return false;
     }
+    if (!assetMatchesSearch(asset, searchNeedle)) {
+      return false;
+    }
     return Boolean(asset.status?.trashed);
   });
 
@@ -125,6 +148,22 @@ export function LibraryScreen() {
             <input accept="image/*,video/*" disabled={isImporting} onChange={handleImport} type="file" />
             {isImporting ? "Importing..." : "Import"}
           </label>
+          <input
+            type="search"
+            aria-label="Search assets"
+            placeholder="Search name, prompt, or tags…"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+          />
+          {searchNeedle ? (
+            <button
+              type="button"
+              disabled={!visibleAssets.length}
+              onClick={() => batch.selectAll(visibleAssets.map((asset) => asset.id))}
+            >
+              Select all ({visibleAssets.length})
+            </button>
+          ) : null}
           <select aria-label="Asset type" onChange={(event) => setTypeFilter(event.target.value)} value={typeFilter}>
             <option value="all">All media</option>
             <option value="image">Images</option>


### PR DESCRIPTION
## What

Adds a **search box to the Asset Library hero** (the `WorkPanel` toolbar) that filters the grid, plus a **"Select all"** for the current result set so it can feed batch actions.

### Search
- Case-insensitive substring match over an asset's **display name**, **`recipe.prompt`**, and **`tags`**.
- The same needle also narrows the **Trashcan / Empty Trash** scope, so Empty Trash can never purge assets the active search is hiding from view.
- Reuses the existing `.toolbar input[type="search"]` styling — no CSS changes.

### Select all
- When a search is active, a **`Select all (N)`** button appears and selects every visible result, surfacing the existing batch toolbar (Batch… / Discard / Move).
- Adds a union `selectAll(ids)` to `useAssetBatch` (never drops an existing pick). Purely additive to the hook — the other consumer (Character Assets) is unaffected.

## Files
- `apps/web/src/screens/LibraryScreen.jsx` — `assetMatchesSearch` helper, search input, `Select all (N)` control, filter wired into the grid + Empty-Trash scope.
- `apps/web/src/assetBatch.jsx` — `selectAll(ids)` on `useAssetBatch`.
- `apps/web/src/App.library.test.jsx` — new test covering search by prompt, by tag, by display name, and select-all → batch bar.

## Testing
- `App.library.test.jsx` — 21/21 pass (incl. new search/select-all test).
- Other `useAssetBatch` consumer green: `assetBatch.split` (9/9), character panels (40/40).
- ESLint clean on touched files.
- Verified behavior via real-component render tests (jsdom); the Library screen needs a running rust-api with project data, so no screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)