### PR TITLE
feat(web): Preset Manager unsaved-changes guard on destructive transitions (sc-11969)

### DIFF
--- a/apps/web/src/App.presetManagerKeepAlive.test.jsx
+++ b/apps/web/src/App.presetManagerKeepAlive.test.jsx
@@ -1,0 +1,130 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { App } from "./main.jsx";
+import { FakeEventSource, field, response, settle } from "./main.testSupport.jsx";
+
+// sc-11969 (epic 11958, S10): the Preset Manager is a keep-alive screen (sc-11959), so an
+// in-progress preset edit is held in component state and survives a plain nav round trip to
+// another screen and back — untouched, and WITHOUT a discard prompt (leaving is
+// non-destructive under keep-alive; only the editor's in-screen transitions guard). This
+// mounts the FULL <App /> to prove the real mechanism end to end. The destructive-transition
+// guards themselves are unit-tested in screens/PresetManagerScreen.test.jsx.
+describe("Preset Manager keep-alive edit survival (sc-11969)", () => {
+  let container;
+  let root;
+
+  const preset = {
+    id: "cinematic",
+    name: "Cinematic Portrait",
+    scope: "global",
+    workflow: "text_to_image",
+    model: "z_image_turbo",
+    defaults: { resolution: "1024x1024", count: 4 },
+  };
+
+  function mockFetch() {
+    global.fetch = vi.fn((url) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) return Promise.resolve(response({ status: "ok", authRequired: false }));
+      if (path.endsWith("/access")) return Promise.resolve(response({ authRequired: false }));
+      if (path.endsWith("/jobs/events/ticket")) return Promise.resolve(response({ ticket: "stream-ticket" }));
+      if (path.endsWith("/projects")) return Promise.resolve(response([{ id: "project-1", name: "Project One" }]));
+      if (path.endsWith("/models")) {
+        return Promise.resolve(
+          response([{ id: "z_image_turbo", name: "Z-Image", type: "image", family: "z-image", capabilities: ["text_to_image"] }]),
+        );
+      }
+      if (path.endsWith("/recipe-presets")) return Promise.resolve(response([preset]));
+      return Promise.resolve(response([]));
+    });
+  }
+
+  async function renderApp() {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+  }
+
+  // Click a button by exact visible text. The sidebar renders before the workspace, so a
+  // nav button wins over an identically-labelled inner button.
+  async function clickButton(label) {
+    await act(async () => {
+      [...document.body.querySelectorAll("button")].find((button) => button.textContent.trim() === label)?.click();
+    });
+    await settle();
+  }
+
+  const editorForm = () => document.body.querySelector(".preset-editor-form");
+  const nameInput = () => field(editorForm(), "Name");
+  // The desktop-safe discard confirm (appConfirm → ConfirmHost). A plain in-app nav under
+  // keep-alive must never surface it — leaving is non-destructive (sc-11969).
+  const confirmDialog = () => document.body.querySelector(".app-confirm-modal");
+
+  async function openPresetForEditing() {
+    await clickButton("Presets");
+    await act(async () => {
+      [...document.body.querySelectorAll(".preset-card")]
+        .find((card) => card.textContent.includes("Cinematic Portrait"))
+        .querySelector(".secondary-action")
+        .click();
+    });
+    await settle();
+  }
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    FakeEventSource.instances = [];
+    window.EventSource = FakeEventSource;
+    window.localStorage.clear();
+    mockFetch();
+  });
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount();
+    });
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("preserves an in-progress preset edit across a plain nav round trip, with no prompt", async () => {
+    await renderApp();
+    await openPresetForEditing();
+
+    const editorBefore = editorForm();
+    expect(editorBefore).not.toBeNull();
+
+    // Make the edit dirty.
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
+      setter.call(nameInput(), "Cinematic Portrait EDITED");
+      nameInput().dispatchEvent(new window.Event("input", { bubbles: true }));
+    });
+    await settle();
+    expect(nameInput().value).toBe("Cinematic Portrait EDITED");
+    expect(document.body.querySelector(".preset-status-pill").textContent).toContain("Unsaved changes");
+
+    // Navigate to an OUT screen (Models unmounts on nav away) and back. A plain nav is
+    // non-destructive under keep-alive, so it must NOT prompt a discard confirm.
+    await clickButton("Models");
+    expect(confirmDialog()).toBeNull();
+    expect(document.body.querySelector(".models-surface")).not.toBeNull();
+    // The Preset Manager stays resident (hidden) while another view is active.
+    expect(editorForm()).not.toBeNull();
+
+    await clickButton("Presets");
+    // Returning is likewise silent — no confirm on either leg of the round trip.
+    expect(confirmDialog()).toBeNull();
+    // Same DOM node → never unmounted/remounted…
+    expect(editorForm()).toBe(editorBefore);
+    // …and the in-progress edit is intact with nothing to re-hydrate it from.
+    expect(nameInput().value).toBe("Cinematic Portrait EDITED");
+    expect(document.body.querySelector(".preset-status-pill").textContent).toContain("Unsaved changes");
+  });
+});

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -27,6 +27,7 @@ import { useValidation } from "../validation/useValidation.js";
 import { ValidationSummary } from "../validation/Validation.jsx";
 import { useAppStatic } from "../context/AppContext.js";
 import { qualityChoices } from "../jobTypes.js";
+import { appConfirm } from "../appConfirm.jsx";
 
 // The Workflow segment a preset editor offers, and how each choice persists.
 //
@@ -111,6 +112,19 @@ const GENERAL_ASPECT_RATIOS = [
 ];
 
 const scopeRank = { builtin: 0, global: 1, project: 2 };
+
+// Desktop-safe discard confirmation for the editor's DESTRUCTIVE in-screen transitions
+// (leave to the list, start/switch a preset, or the explicit Discard action) while the
+// form carries unsaved edits. Routed through appConfirm — window.confirm silently no-ops
+// inside the Tauri desktop WebView, so a raw confirm there would neither confirm nor
+// cancel and the guard would be dead on desktop (sc-11968 / sc-11969).
+const DISCARD_CONFIRM = {
+  title: "Discard changes?",
+  message: "This preset has unsaved changes that will be lost.",
+  confirmLabel: "Discard changes",
+  cancelLabel: "Keep editing",
+  tone: "danger",
+};
 
 // The `defaults` keys this editor renders. Everything else a preset carries —
 // upscale*, ipAdapterScale, controlnetScale, guidanceMethod, trueCfgScale, viewAngle,
@@ -646,24 +660,64 @@ export function PresetManagerScreen() {
     }
   }
 
+  // Guard a DESTRUCTIVE in-screen transition (leave to the list, start a new preset, or
+  // switch to a different preset) that would silently drop an in-progress edit. A clean
+  // form proceeds synchronously — the long-standing no-op path, so nothing that isn't
+  // genuinely dirty ever prompts — while a dirty edit confirms first via the desktop-safe
+  // appConfirm. Plain app navigation is deliberately NOT guarded here: keep-alive
+  // (sc-11959) leaves this screen mounted, so an edit survives a nav round trip untouched
+  // and a nav prompt would be misleading noise (sc-11969).
+  function guardDiscard(proceed) {
+    if (!dirty) {
+      proceed();
+      return;
+    }
+    appConfirm(DISCARD_CONFIRM).then((ok) => {
+      if (ok) {
+        proceed();
+      }
+    });
+  }
+
   function startNewPreset() {
-    setSelectedPresetId("");
-    setShowLoraPicker(false);
-    setAdvancedOpen(false);
-    setEditing(true);
+    guardDiscard(() => {
+      setSelectedPresetId("");
+      setShowLoraPicker(false);
+      setAdvancedOpen(false);
+      setEditing(true);
+    });
   }
 
   function editPreset(preset) {
-    setShowLoraPicker(false);
-    setAdvancedOpen(false);
-    setSelectedPresetId(preset.id);
-    setEditing(true);
+    guardDiscard(() => {
+      setShowLoraPicker(false);
+      setAdvancedOpen(false);
+      setSelectedPresetId(preset.id);
+      setEditing(true);
+    });
   }
 
   function backToList() {
-    setEditing(false);
-    setShowLoraPicker(false);
-    setMessage({ tone: "neutral", text: "" });
+    guardDiscard(() => {
+      setEditing(false);
+      setShowLoraPicker(false);
+      setMessage({ tone: "neutral", text: "" });
+    });
+  }
+
+  // Explicit unsaved-state affordance paired with the "Unsaved changes" pill: revert the
+  // in-progress edit to the last-saved baseline, confirmed the same desktop-safe way. Only
+  // reachable while dirty (the button renders only then), so a clean form is a no-op.
+  function discardChanges() {
+    if (!dirty) {
+      return;
+    }
+    appConfirm(DISCARD_CONFIRM).then((ok) => {
+      if (ok) {
+        setForm(baseline);
+        setMessage({ tone: "neutral", text: "" });
+      }
+    });
   }
 
   const visiblePresets = useMemo(() => {
@@ -984,6 +1038,11 @@ export function PresetManagerScreen() {
         </div>
         <div className="preset-editor-actions">
           {statusPill}
+          {dirty ? (
+            <button className="secondary-action preset-discard" onClick={discardChanges} type="button">
+              Discard
+            </button>
+          ) : null}
           <button className="secondary-action" onClick={backToList} type="button">
             Cancel
           </button>

--- a/apps/web/src/screens/PresetManagerScreen.test.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.test.jsx
@@ -3,6 +3,15 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PresetManagerScreen } from "./PresetManagerScreen.jsx";
 import { withAppContext, field, changeField } from "../main.testSupport.jsx";
+import { appConfirm } from "../appConfirm.jsx";
+
+// The unsaved-changes guard routes through the desktop-safe appConfirm (sc-11969), not
+// window.confirm (which no-ops in the Tauri WebView). Mock it so a test controls the
+// user's choice and can assert the guard fired without mounting a real <ConfirmHost/>.
+vi.mock("../appConfirm.jsx", () => {
+  const appConfirm = vi.fn(() => Promise.resolve(true));
+  return { appConfirm, useConfirm: () => appConfirm, ConfirmHost: () => null };
+});
 
 const imageModel = {
   id: "z_image_turbo",
@@ -92,6 +101,8 @@ describe("PresetManagerScreen", () => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     container = document.createElement("div");
     document.body.appendChild(container);
+    appConfirm.mockClear();
+    appConfirm.mockResolvedValue(true);
   });
 
   afterEach(async () => {
@@ -411,5 +422,120 @@ describe("PresetManagerScreen", () => {
     // …and a workflow filter never surfaces a general preset.
     await changeField(container.querySelector("select[aria-label='Type']"), "text_to_image");
     expect(cardNames()).not.toContain("Film Stock");
+  });
+
+  // sc-11969 (epic 11958, S10): the editor's DESTRUCTIVE in-screen transitions guard an
+  // in-progress edit behind the desktop-safe appConfirm; plain navigation (keep-alive)
+  // never prompts, which is covered at the App level in App.presetManagerKeepAlive.test.jsx.
+  describe("unsaved-changes guard on destructive transitions", () => {
+    const pill = () => container.querySelector(".preset-status-pill")?.textContent ?? "";
+    const editorForm = () => container.querySelector(".preset-editor-form");
+
+    async function editCard(name) {
+      await act(async () => {
+        [...container.querySelectorAll(".preset-card")]
+          .find((card) => card.textContent.includes(name))
+          .querySelector(".secondary-action")
+          .click();
+      });
+    }
+
+    // Click a button by exact visible text, then drain appConfirm()'s promise and its
+    // .then(proceed) plus the resulting re-render — all inside act — so the guarded
+    // transition has fully settled before the assertions run.
+    async function clickAndFlush(label) {
+      await act(async () => {
+        [...container.querySelectorAll("button")].find((button) => button.textContent.trim() === label).click();
+        for (let index = 0; index < 4; index += 1) {
+          await Promise.resolve();
+        }
+      });
+    }
+
+    it("prompts via the desktop-safe appConfirm before leaving a dirty edit, and cancel keeps it", async () => {
+      appConfirm.mockResolvedValue(false);
+      await render();
+      await editCard("Cinematic Portrait");
+      await changeField(field(container, "Name"), "Cinematic Portrait v2");
+      expect(pill()).toContain("Unsaved changes");
+
+      await clickAndFlush("All presets");
+      // A danger-toned confirm was shown (appConfirm, not window.confirm).
+      expect(appConfirm).toHaveBeenCalledWith(expect.objectContaining({ tone: "danger" }));
+      // Cancelled → still in the editor with the edit intact.
+      expect(editorForm()).not.toBeNull();
+      expect(field(container, "Name").value).toBe("Cinematic Portrait v2");
+      expect(pill()).toContain("Unsaved changes");
+    });
+
+    it("discards the edit and returns to the list when the leave is confirmed", async () => {
+      appConfirm.mockResolvedValue(true);
+      await render();
+      await editCard("Cinematic Portrait");
+      await changeField(field(container, "Name"), "Cinematic Portrait v2");
+
+      await clickAndFlush("All presets");
+      expect(appConfirm).toHaveBeenCalledTimes(1);
+      // Back on the list; the edit was dropped (never saved), so the card keeps its name.
+      expect(editorForm()).toBeNull();
+      expect(cardNames()).toContain("Cinematic Portrait");
+    });
+
+    it("leaves a clean edit immediately, without prompting", async () => {
+      await render();
+      await editCard("Cinematic Portrait");
+      // No field change → the form is clean.
+      await clickAndFlush("All presets");
+      expect(appConfirm).not.toHaveBeenCalled();
+      expect(editorForm()).toBeNull();
+    });
+
+    it("guards the Cancel button in the editor footer the same way", async () => {
+      appConfirm.mockResolvedValue(false);
+      await render();
+      await editCard("Cinematic Portrait");
+      await changeField(field(container, "Name"), "Cinematic Portrait v2");
+
+      // Two Cancel buttons (head + footer) both route through the guarded backToList.
+      const cancels = [...container.querySelectorAll("button")].filter((b) => b.textContent.trim() === "Cancel");
+      expect(cancels.length).toBeGreaterThan(1);
+      await act(async () => {
+        cancels[cancels.length - 1].click();
+        for (let index = 0; index < 4; index += 1) {
+          await Promise.resolve();
+        }
+      });
+      expect(appConfirm).toHaveBeenCalledWith(expect.objectContaining({ tone: "danger" }));
+      expect(editorForm()).not.toBeNull();
+    });
+
+    it("reverts to the saved baseline via the explicit Discard action after confirming", async () => {
+      appConfirm.mockResolvedValue(true);
+      await render();
+      await editCard("Cinematic Portrait");
+      await changeField(field(container, "Name"), "Edited Name");
+      expect(pill()).toContain("Unsaved changes");
+      // The Discard affordance only appears while dirty.
+      expect([...container.querySelectorAll("button")].some((b) => b.textContent.trim() === "Discard")).toBe(true);
+
+      await clickAndFlush("Discard");
+      expect(appConfirm).toHaveBeenCalled();
+      // Reverted: name restored to baseline, pill back to Saved, still editing.
+      expect(field(container, "Name").value).toBe("Cinematic Portrait");
+      expect(pill()).toContain("Saved");
+      expect(editorForm()).not.toBeNull();
+    });
+
+    it("keeps the edit when the Discard action is cancelled", async () => {
+      appConfirm.mockResolvedValue(false);
+      await render();
+      await editCard("Cinematic Portrait");
+      await changeField(field(container, "Name"), "Edited Name");
+
+      await clickAndFlush("Discard");
+      expect(appConfirm).toHaveBeenCalled();
+      expect(field(container, "Name").value).toBe("Edited Name");
+      expect(pill()).toContain("Unsaved changes");
+    });
   });
 });


### PR DESCRIPTION
## Summary

Epic 11958 **S10**. Editing a preset (name, model, LoRAs+weights, sampler/scheduler, resolution/steps/guidance, and the epic-11949 general-preset fields) was fully volatile: `dirty` was computed but only drove a **passive** "Unsaved changes" pill, and `backToList()` (plus both Cancel buttons) discarded the edit **silently**. This adds real guards on the editor's **destructive in-screen transitions** and promotes the passive pill into a real affordance.

### Keep-alive verified — plain nav is NOT guarded
Under selective keep-alive (S1, sc-11959) the Preset Manager stays **mounted** across navigation, so an in-progress edit already survives a plain nav round trip untouched. A nav prompt would be misleading noise there, so plain nav is deliberately left un-guarded (App's `navTo` registers no leave-guard for Presets). This is asserted end-to-end in a new App-level test.

### Guards on destructive transitions
- `backToList` (the **"All presets"** back button + **both** Cancel buttons), `startNewPreset`, and `editPreset` now route through a shared `guardDiscard()`:
  - a **clean** form proceeds synchronously (the unchanged no-op path — nothing that isn't genuinely dirty ever prompts);
  - a **dirty** edit confirms first via the shared **desktop-safe `appConfirm`** (sc-11968), **not** `window.confirm` — which silently no-ops in the Tauri desktop WebView, leaving a raw-confirm guard dead on desktop.
- Promoted the passive **"Unsaved changes"** pill into a real affordance: a **dirty-only "Discard" button** that reverts the in-progress edit to the last-saved baseline, confirmed the same desktop-safe way.

## Acceptance
- ✅ Edit a preset, navigate away and back (plain nav): the edit is intact, **no** prompt shown.
- ✅ Click **"All presets"** (back-to-list) or Cancel while dirty: `appConfirm` prompts before discarding; **cancel keeps the edit**.
- ✅ The confirm works on desktop (uses `appConfirm`, not `window.confirm`).

## Tests (full web suite green — 129 files / 1733)
- `screens/PresetManagerScreen.test.jsx` (+6): leave-while-dirty prompts via `appConfirm` (danger tone) and cancel keeps the edit; confirm discards and returns to the list; a clean leave never prompts; the footer Cancel is guarded too; the explicit **Discard** reverts to baseline on confirm and keeps the edit on cancel.
- `App.presetManagerKeepAlive.test.jsx` (new): a dirty edit survives a **Presets → Models → Presets** round trip (same DOM node, value intact) with **no** confirm dialog on either leg.

## Notes / follow-ups
- **"Select a different preset" while dirty** is not an atomic in-editor action in the current UI — the editor is a full-screen replacement with no in-editor preset list, so switching presets necessarily routes through the (now-guarded) back-to-list. `editPreset`/`startNewPreset` are guarded defensively anyway (reached only from the clean list today).
- **Project switch** while editing a project-scoped preset would drop the edit via a prop change (the `presets` list changes and the selected preset vanishes). Intercepting that is an App-level concern (the project switcher lives in App's sidebar, not this screen), out of scope for this screen-local story — flagged as a follow-up.

Shortcut: sc-11969

🤖 Generated with [Claude Code](https://claude.com/claude-code)