### PR TITLE
feat(web): Pose + Key Point Library unsaved indicator + discard guard; reset Pose Create on project switch (sc-11971)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -2455,12 +2455,20 @@ export function App() {
 
         {keepAliveMounted("Poses") ? (
           <KeepAlivePane active={activeView === "Poses"}>
-            <PoseLibraryScreen />
+            {/* Keyed on the project id (sc-11971): the Create tab's staged sources / phase
+                are PROJECT-SCOPED, so a project switch must remount (reset) the screen —
+                exactly like the studios — while keep-alive preserves in-progress review
+                across a plain nav round trip. Otherwise project-A source picks could submit
+                a pose_detect job under project B. */}
+            <PoseLibraryScreen key={activeProject?.id ?? "default"} />
           </KeepAlivePane>
         ) : null}
 
         {keepAliveMounted("Keypoints") ? (
           <KeepAlivePane active={activeView === "Keypoints"}>
+            {/* NOT keyed on the project id (sc-11971): the Key Point Library is GLOBAL
+                (GLOBAL_KEYPOINTS_PROJECT_ID), so its capture / collection work must survive
+                a project switch as well as a plain nav — keep-alive alone, no remount. */}
             <KeyPointLibraryScreen />
           </KeepAlivePane>
         ) : null}

--- a/apps/web/src/App.keepAlive.test.jsx
+++ b/apps/web/src/App.keepAlive.test.jsx
@@ -250,6 +250,85 @@ describe("selective lazy keep-alive shell (sc-11959)", () => {
     expect(documentPromptField().value).not.toBe("project-1 illustrated guide");
   });
 
+  it("Pose Library survives a same-project nav round trip but RESETS on a project switch (sc-11971)", async () => {
+    // The Pose Library Create tab holds PROJECT-SCOPED local state (staged sources / phase),
+    // so — like the studios — it must be keyed on the project id: keep-alive preserves an
+    // in-progress review across a plain nav, but a project switch remounts (resets) it so
+    // project-1 source picks can't submit a pose_detect job under project-2.
+    mockFetch({
+      projects: [
+        { id: "project-1", name: "Project One" },
+        { id: "project-2", name: "Project Two" },
+      ],
+    });
+    await renderApp();
+    await clickButton("Pose Library");
+
+    const surfaceBefore = document.body.querySelector(".pose-library-surface");
+    expect(surfaceBefore).not.toBeNull();
+
+    // Same-project nav round trip: kept alive → the SAME DOM node (in-progress Create state
+    // rides along with it, no remount).
+    await clickButton("Assets");
+    expect(document.body.querySelector(".pose-library-surface")).not.toBeNull();
+    await clickButton("Pose Library");
+    expect(document.body.querySelector(".pose-library-surface")).toBe(surfaceBefore);
+
+    // Switch workspace via the project switcher.
+    await act(async () => {
+      document.body.querySelector(".project-pill")?.click();
+    });
+    await settle();
+    await act(async () => {
+      [...document.body.querySelectorAll(".project-menu-item")]
+        .find((item) => item.textContent.includes("Project Two"))
+        ?.click();
+    });
+    await settle();
+
+    // key={activeProject.id} changed → the screen remounts (a fresh DOM node), clearing the
+    // Create tab's project-scoped sources/phase.
+    const surfaceAfter = document.body.querySelector(".pose-library-surface");
+    expect(surfaceAfter).not.toBeNull();
+    expect(surfaceAfter).not.toBe(surfaceBefore);
+  });
+
+  it("Key Point Library (GLOBAL) survives BOTH a nav round trip and a project switch (sc-11971)", async () => {
+    // The Key Point Library addresses the GLOBAL keypoints project, so its capture review /
+    // in-progress collection must NOT be dropped by a project switch — it is deliberately
+    // NOT keyed on the project id, so keep-alive preserves it across nav AND project change.
+    mockFetch({
+      projects: [
+        { id: "project-1", name: "Project One" },
+        { id: "project-2", name: "Project Two" },
+      ],
+    });
+    await renderApp();
+    await clickButton("Key Point Library");
+
+    const surfaceBefore = document.body.querySelector(".keypoint-library-surface");
+    expect(surfaceBefore).not.toBeNull();
+
+    await clickButton("Assets");
+    await clickButton("Key Point Library");
+    expect(document.body.querySelector(".keypoint-library-surface")).toBe(surfaceBefore);
+
+    // Switch workspace.
+    await act(async () => {
+      document.body.querySelector(".project-pill")?.click();
+    });
+    await settle();
+    await act(async () => {
+      [...document.body.querySelectorAll(".project-menu-item")]
+        .find((item) => item.textContent.includes("Project Two"))
+        ?.click();
+    });
+    await settle();
+
+    // Not keyed on the project → the GLOBAL screen is the SAME node; its work survives.
+    expect(document.body.querySelector(".keypoint-library-surface")).toBe(surfaceBefore);
+  });
+
   it("applies a 'Use this recipe' injection on an ALREADY-mounted studio (token-id re-fire)", async () => {
     const generatedAsset = {
       id: "asset-recipe",

--- a/apps/web/src/screens/KeyPointLibraryScreen.jsx
+++ b/apps/web/src/screens/KeyPointLibraryScreen.jsx
@@ -6,6 +6,7 @@ import { KpsOverlay } from "../components/KpsOverlay.jsx";
 import { DatasetAddDialog } from "../components/DatasetAddDialog.jsx";
 import { assetUrl } from "../components/assetMedia.jsx";
 import { WorkPanel } from "../components/WorkPanel.jsx";
+import { appConfirm } from "../appConfirm.jsx";
 import {
   BUILTIN_DEFAULT_COLLECTION_ID,
   GLOBAL_KEYPOINTS_PROJECT_ID,
@@ -145,6 +146,28 @@ function KeypointCapturePanel({ hidden, onSaved }) {
     setPhase("idle");
     setJobId(null);
   }, [clearSource]);
+
+  // A completed extraction whose landmarks + typed name are not yet saved — the
+  // destructive-loss surface (the Key Point Library is GLOBAL, so this survives both a
+  // plain nav round trip AND a project switch under keep-alive; only an explicit discard
+  // or a successful save clears it, sc-11971).
+  const hasUnsavedWork = phase === "review" && Boolean(extraction);
+
+  // Explicit, desktop-safe discard (sc-11971): confirm via appConfirm before dropping a
+  // captured face's landmarks + name, so a review isn't lost on a stray click.
+  const discard = useCallback(async () => {
+    if (hasUnsavedWork) {
+      const ok = await appConfirm({
+        title: "Discard captured landmarks?",
+        message: "Discard the detected face landmarks and the preset name you entered?",
+        confirmLabel: "Discard",
+        cancelLabel: "Keep editing",
+        tone: "danger",
+      });
+      if (!ok) return;
+    }
+    reset();
+  }, [hasUnsavedWork, reset]);
 
   // Stage a source, seed the name, and fire the extraction. `previewUrl` backs the overlay
   // preview; `sourceAssetId` records provenance when the source was an existing asset.
@@ -287,6 +310,12 @@ function KeypointCapturePanel({ hidden, onSaved }) {
               <KpsOverlay kps={extraction.kps} imageUrl={source?.previewUrl} label="captured face landmarks" />
             </div>
             <div className="keypoint-capture-form">
+              {hasUnsavedWork ? (
+                <span className="library-unsaved-badge" role="status" title="You have unsaved captured landmarks">
+                  <span className="library-unsaved-dot" aria-hidden="true" />
+                  Unsaved
+                </span>
+              ) : null}
               {extraction.lowConfidence ? (
                 <p className="inline-warning">
                   Low detection confidence — the angle may be extreme or the face small. Check the overlay before
@@ -301,7 +330,7 @@ function KeypointCapturePanel({ hidden, onSaved }) {
                 <button className="primary-action" disabled={!name.trim() || saving} onClick={save} type="button">
                   {saving ? "Saving…" : "Save preset"}
                 </button>
-                <button onClick={reset} type="button">
+                <button disabled={saving} onClick={discard} type="button">
                   Discard
                 </button>
               </div>
@@ -352,6 +381,28 @@ function KeypointCollectionsPanel({ hidden, presets, collections, collectionsLoa
     setEditingId(null);
     setError("");
   }, []);
+
+  // An in-progress (unsaved) collection — a typed name and/or a picked, ordered set — that
+  // a plain nav round trip must preserve (keep-alive) and an explicit Cancel must confirm
+  // before dropping (sc-11971). The Key Point Library is GLOBAL, so this also survives a
+  // project switch.
+  const hasUnsavedWork = Boolean(name.trim()) || orderedIds.length > 0;
+
+  // Explicit, desktop-safe cancel (sc-11971): confirm via appConfirm before discarding an
+  // in-progress collection so a composed, ordered set isn't lost on a stray click.
+  const cancelBuilder = useCallback(async () => {
+    if (hasUnsavedWork) {
+      const ok = await appConfirm({
+        title: editingId ? "Discard changes?" : "Discard collection?",
+        message: "Discard this in-progress collection? Your name and ordered angle set will be cleared.",
+        confirmLabel: "Discard",
+        cancelLabel: "Keep editing",
+        tone: "danger",
+      });
+      if (!ok) return;
+    }
+    resetBuilder();
+  }, [hasUnsavedWork, editingId, resetBuilder]);
 
   const startEdit = useCallback((collection) => {
     setEditingId(collection.id);
@@ -457,7 +508,15 @@ function KeypointCollectionsPanel({ hidden, presets, collections, collectionsLoa
         </div>
 
         <div className="keypoint-section">
-          <p className="eyebrow">{editingId ? "Edit collection" : "New collection"}</p>
+          <p className="eyebrow">
+            {editingId ? "Edit collection" : "New collection"}
+            {hasUnsavedWork ? (
+              <span className="library-unsaved-badge" role="status" title="You have an unsaved collection">
+                <span className="library-unsaved-dot" aria-hidden="true" />
+                Unsaved
+              </span>
+            ) : null}
+          </p>
           <label>
             Name
             <input onChange={(event) => setName(event.target.value)} value={name} placeholder="e.g. LoRA coverage" />
@@ -532,7 +591,7 @@ function KeypointCollectionsPanel({ hidden, presets, collections, collectionsLoa
               {editingId ? "Save changes" : "Create collection"}
             </button>
             {editingId || name || orderedIds.length ? (
-              <button onClick={resetBuilder} type="button">
+              <button onClick={cancelBuilder} type="button">
                 Cancel
               </button>
             ) : null}

--- a/apps/web/src/screens/KeyPointLibraryScreen.test.jsx
+++ b/apps/web/src/screens/KeyPointLibraryScreen.test.jsx
@@ -7,6 +7,11 @@ const apiCalls = [];
 let presets = [];
 let collections = [];
 
+// Desktop-safe confirm (sc-11971): mocked so the explicit discard / cancel guards are
+// deterministic and observable. Defaults to "confirm"; tests flip it to "cancel".
+const { appConfirmMock } = vi.hoisted(() => ({ appConfirmMock: vi.fn(async () => true) }));
+vi.mock("../appConfirm.jsx", () => ({ appConfirm: appConfirmMock }));
+
 vi.mock("../api.js", async (importOriginal) => {
   const actual = await importOriginal();
   return {
@@ -74,10 +79,35 @@ describe("KeyPointLibraryScreen", () => {
     apiCalls.length = 0;
     presets = [];
     collections = [];
+    appConfirmMock.mockClear();
+    appConfirmMock.mockResolvedValue(true);
     window.URL.createObjectURL = () => "blob:test";
     window.URL.revokeObjectURL = () => {};
     ({ container, root } = mountRoot());
   });
+
+  const exactBtn = (text) =>
+    [...document.body.querySelectorAll("button")].find((el) => el.textContent.trim() === text);
+
+  // Drive upload → extract → review so the capture-guard tests start from a completed
+  // extraction with a seeded name (mirrors the capture save-path test's setup).
+  async function reachCaptureReview() {
+    const job = {
+      id: "job_kps_1",
+      type: "kps_extract",
+      status: "completed",
+      result: { detected: true, kps: FRONT_KPS, lowConfidence: false, sourceWidth: 800, sourceHeight: 1000 },
+    };
+    presets = [builtinPreset()];
+    await render(makeContext({ jobs: [job] }));
+    await click(document.body.querySelector("#keypoint-tab-capture"));
+    await click(byText("Choose image"));
+    const fileInput = document.body.querySelector('.modal-backdrop input[type="file"]');
+    const file = new File(["x"], "face.png", { type: "image/png" });
+    Object.defineProperty(fileInput, "files", { value: [file], configurable: true });
+    await act(async () => fileInput.dispatchEvent(new window.Event("change", { bubbles: true })));
+    await act(async () => {}); // flush staging + job post + the job-watch effect
+  }
 
   afterEach(async () => {
     await unmountRoot(root, container);
@@ -266,5 +296,84 @@ describe("KeyPointLibraryScreen", () => {
     expect(
       apiCalls.some((c) => c.method === "PUT" && c.path === "/api/v1/keypoints/collections/col_user/default"),
     ).toBe(true);
+  });
+
+  it("flags a completed capture as unsaved and prompts NO confirm to reach review (sc-11971)", async () => {
+    await reachCaptureReview();
+    // A completed extraction with a seeded name surfaces the unsaved-work pill…
+    expect(document.body.querySelector("#keypoint-panel-capture .library-unsaved-badge")).toBeTruthy();
+    // …and reaching review never prompts; only an explicit discard does.
+    expect(appConfirmMock).not.toHaveBeenCalled();
+  });
+
+  it("explicit capture Discard confirms via appConfirm and resets the review (sc-11971)", async () => {
+    await reachCaptureReview();
+    const nameInput = document.body.querySelector(
+      '#keypoint-panel-capture input[type="text"], #keypoint-panel-capture input:not([type])',
+    );
+    expect(nameInput).toBeTruthy();
+
+    appConfirmMock.mockResolvedValueOnce(true);
+    await click(exactBtn("Discard"));
+
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    expect(appConfirmMock.mock.calls[0][0]).toMatchObject({ tone: "danger" });
+    // Review gone → back to the empty prompt, unsaved pill cleared.
+    expect(document.body.querySelector("#keypoint-panel-capture").textContent).toContain("Choose a clear");
+    expect(document.body.querySelector("#keypoint-panel-capture .library-unsaved-badge")).toBeNull();
+  });
+
+  it("keeps the capture review when Discard is cancelled (sc-11971)", async () => {
+    await reachCaptureReview();
+    appConfirmMock.mockResolvedValueOnce(false);
+    await click(exactBtn("Discard"));
+
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    // Cancelled → the captured landmarks + name stay put.
+    expect(document.body.querySelector("#keypoint-panel-capture .library-unsaved-badge")).toBeTruthy();
+    expect(
+      document.body.querySelector(
+        '#keypoint-panel-capture input[type="text"], #keypoint-panel-capture input:not([type])',
+      ),
+    ).toBeTruthy();
+  });
+
+  it("flags an in-progress collection as unsaved and confirms Cancel via appConfirm (sc-11971)", async () => {
+    presets = [builtinPreset(), customPreset()];
+    collections = [];
+    await render();
+    await click(document.body.querySelector("#keypoint-tab-collections"));
+
+    // Empty builder → no unsaved pill, no Cancel control yet.
+    expect(document.body.querySelector("#keypoint-panel-collections .library-unsaved-badge")).toBeNull();
+
+    const nameInput = document.body.querySelector("#keypoint-panel-collections input");
+    await setInputValue(nameInput, "LoRA coverage");
+    await click(byText("Front", ".keypoint-pick"));
+
+    // In-progress collection → the unsaved pill appears.
+    expect(document.body.querySelector("#keypoint-panel-collections .library-unsaved-badge")).toBeTruthy();
+
+    // Cancel is guarded by appConfirm; confirming clears the builder.
+    appConfirmMock.mockResolvedValueOnce(true);
+    await click(exactBtn("Cancel"));
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    expect(appConfirmMock.mock.calls[0][0]).toMatchObject({ tone: "danger" });
+    expect(document.body.querySelector("#keypoint-panel-collections input").value).toBe("");
+    expect(document.body.querySelector("#keypoint-panel-collections .library-unsaved-badge")).toBeNull();
+  });
+
+  it("keeps an in-progress collection when Cancel is declined (sc-11971)", async () => {
+    presets = [builtinPreset()];
+    collections = [];
+    await render();
+    await click(document.body.querySelector("#keypoint-tab-collections"));
+    const nameInput = document.body.querySelector("#keypoint-panel-collections input");
+    await setInputValue(nameInput, "Keep me");
+
+    appConfirmMock.mockResolvedValueOnce(false);
+    await click(exactBtn("Cancel"));
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    expect(document.body.querySelector("#keypoint-panel-collections input").value).toBe("Keep me");
   });
 });

--- a/apps/web/src/screens/PoseLibraryScreen.jsx
+++ b/apps/web/src/screens/PoseLibraryScreen.jsx
@@ -8,6 +8,7 @@ import { DEFAULT_MAC_CAPABILITIES, macFeatureBlock } from "../macGating.js";
 import { terminalStatuses } from "../jobTypes.js";
 import { GLOBAL_POSES_PROJECT_ID } from "../poseLibrary.js";
 import { WorkPanel } from "../components/WorkPanel.jsx";
+import { appConfirm } from "../appConfirm.jsx";
 
 // The Pose Library screen (epic 2282). Two tabs:
 //  - "Poses": manage the global pose store — user-created type:"pose" assets in the
@@ -259,6 +260,44 @@ function PoseCreatePanel({ hidden, categories, onSaved, existingPoses }) {
 
   const keepCount = candidates.filter((candidate) => candidate.keep).length;
 
+  // Clear the in-progress create session: revoke staged upload URLs and drop the sources,
+  // candidates, phase, and any error. Shared by save (after a successful commit) and the
+  // explicit Discard control. Under keep-alive this local state survives a plain nav round
+  // trip; a project switch remounts the screen (App keys it on activeProject.id), which is
+  // the ONLY reset that fires without going through here.
+  const resetSession = useCallback(() => {
+    setSources((prev) => {
+      for (const source of prev) if (source.objectUrl) URL.revokeObjectURL(source.objectUrl);
+      return [];
+    });
+    setCandidates([]);
+    setPhase("idle");
+    setJobId(null);
+    setError("");
+  }, []);
+
+  // A completed detection whose per-candidate edits (category / tags / keep) are not yet
+  // saved — the destructive-loss surface a nav round trip must preserve and an explicit
+  // discard / project switch must confirm-or-reset (sc-11971).
+  const hasUnsavedWork = phase === "review" && candidates.length > 0;
+
+  // Explicit, desktop-safe discard of the whole review (sc-11971). Confirms via appConfirm
+  // (NOT window.confirm — a no-op in the Tauri WebView) before dropping detected poses +
+  // edits, so a completed detection isn't lost on a stray click.
+  const discardSession = useCallback(async () => {
+    if (hasUnsavedWork) {
+      const ok = await appConfirm({
+        title: "Discard detected poses?",
+        message: "Discard the detected poses and your category / tag edits? This can't be undone.",
+        confirmLabel: "Discard",
+        cancelLabel: "Keep editing",
+        tone: "danger",
+      });
+      if (!ok) return;
+    }
+    resetSession();
+  }, [hasUnsavedWork, resetSession]);
+
   const save = useCallback(async () => {
     const keep = candidates.filter((candidate) => candidate.keep);
     if (!keep.length) return;
@@ -278,19 +317,14 @@ function PoseCreatePanel({ hidden, categories, onSaved, existingPoses }) {
         pose: candidate.pose,
       }));
       await apiFetch("/api/v1/poses", token, { method: "POST", body: JSON.stringify({ poses }) });
-      setSources((prev) => {
-        for (const source of prev) if (source.objectUrl) URL.revokeObjectURL(source.objectUrl);
-        return [];
-      });
-      setCandidates([]);
-      setPhase("idle");
+      resetSession();
       onSaved?.();
     } catch (err) {
       setError(String(err?.message ?? err));
     } finally {
       setSaving(false);
     }
-  }, [candidates, token, onSaved]);
+  }, [candidates, token, onSaved, resetSession]);
 
   return (
     <div aria-labelledby="pose-library-tab-create" hidden={hidden} id="pose-library-panel-create" role="tabpanel">
@@ -342,6 +376,15 @@ function PoseCreatePanel({ hidden, categories, onSaved, existingPoses }) {
                 <p className="eyebrow">
                   Review {candidates.length} candidate{candidates.length === 1 ? "" : "s"} — {keepCount} kept
                 </p>
+                {hasUnsavedWork ? (
+                  <span className="library-unsaved-badge" role="status" title="You have unsaved detected poses">
+                    <span className="library-unsaved-dot" aria-hidden="true" />
+                    Unsaved
+                  </span>
+                ) : null}
+                <button disabled={saving} onClick={discardSession} type="button">
+                  Discard all
+                </button>
                 <button className="primary-action" disabled={!keepCount || saving} onClick={save} type="button">
                   {saving ? "Saving…" : `Save ${keepCount} pose${keepCount === 1 ? "" : "s"}`}
                 </button>

--- a/apps/web/src/screens/PoseLibraryScreen.test.jsx
+++ b/apps/web/src/screens/PoseLibraryScreen.test.jsx
@@ -7,6 +7,11 @@ import { click, mountRoot, unmountRoot } from "../testUtils/dom.js";
 const apiCalls = [];
 let poseAssets = [];
 
+// Desktop-safe confirm (sc-11971): mocked so the explicit-discard guard is deterministic
+// and observable. Defaults to "confirm"; individual tests flip it to "cancel".
+const { appConfirmMock } = vi.hoisted(() => ({ appConfirmMock: vi.fn(async () => true) }));
+vi.mock("../appConfirm.jsx", () => ({ appConfirm: appConfirmMock }));
+
 vi.mock("../api.js", async (importOriginal) => {
   const actual = await importOriginal();
   return {
@@ -183,6 +188,8 @@ describe("PoseLibraryScreen — Create tab", () => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     apiCalls.length = 0;
     poseAssets = [];
+    appConfirmMock.mockClear();
+    appConfirmMock.mockResolvedValue(true);
     ({ container, root } = mountRoot());
   });
 
@@ -204,6 +211,19 @@ describe("PoseLibraryScreen — Create tab", () => {
 
   const byText = (text, selector = "button") =>
     [...document.body.querySelectorAll(selector)].find((el) => el.textContent.includes(text));
+
+  // Drive photo → detect → review so the tests below start from a completed detection with
+  // one editable candidate (mirrors the save-path test's setup).
+  async function reachReview() {
+    await render();
+    await click(document.body.querySelector("#pose-library-tab-create"));
+    await click(byText("Add images"));
+    await click(byText("Asset Library"));
+    await click(byText("Photo"));
+    await click(exactBtn("Add 1"));
+    await click(exactBtn("Done"));
+    await click(byText("Generate poses"));
+  }
   const exactBtn = (text) =>
     [...document.body.querySelectorAll("button")].find((el) => el.textContent.trim() === text);
 
@@ -326,5 +346,43 @@ describe("PoseLibraryScreen — Create tab", () => {
     await render(makeContext({ activeProject: null }));
     await click(document.body.querySelector("#pose-library-tab-create"));
     expect(document.body.querySelector("#pose-library-panel-create").textContent).toContain("Open a workspace");
+  });
+
+  it("flags a completed detection as unsaved and prompts NO confirm to reach review (sc-11971)", async () => {
+    await reachReview();
+    // A completed detection with editable candidates surfaces the unsaved-work pill…
+    expect(container.textContent).toContain("Review 1 candidate");
+    expect(document.body.querySelector(".library-unsaved-badge")).toBeTruthy();
+    // …and simply running detection + landing in review never prompts (only an explicit
+    // discard does). Plain navigation is likewise non-destructive under keep-alive.
+    expect(appConfirmMock).not.toHaveBeenCalled();
+  });
+
+  it("explicit 'Discard all' confirms via appConfirm and clears the review (sc-11971)", async () => {
+    await reachReview();
+    expect(document.body.querySelector('input[list="pose-category-suggestions"]')).toBeTruthy();
+
+    appConfirmMock.mockResolvedValueOnce(true);
+    await click(exactBtn("Discard all"));
+
+    // Guarded through the desktop-safe dialog (danger tone), NOT window.confirm.
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    expect(appConfirmMock.mock.calls[0][0]).toMatchObject({ tone: "danger" });
+    // Review is gone: candidates cleared and phase back to idle (no category input, no
+    // review toolbar, no unsaved pill).
+    expect(document.body.querySelector('input[list="pose-category-suggestions"]')).toBeNull();
+    expect(container.textContent).not.toContain("Review 1 candidate");
+    expect(document.body.querySelector(".library-unsaved-badge")).toBeNull();
+  });
+
+  it("keeps the review when 'Discard all' is cancelled (sc-11971)", async () => {
+    await reachReview();
+    appConfirmMock.mockResolvedValueOnce(false);
+    await click(exactBtn("Discard all"));
+
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    // Cancelled → the detected poses + edits stay put.
+    expect(container.textContent).toContain("Review 1 candidate");
+    expect(document.body.querySelector('input[list="pose-category-suggestions"]')).toBeTruthy();
   });
 });

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -8032,6 +8032,33 @@ details[open] > summary.lora-scope-group-heading::before,
   background: var(--ie-warn, #d97706);
 }
 
+/* Shared unsaved-work pill for the library screens (sc-11971): the Pose Library Create
+   review, the Key Point Capture review, and the Collections builder all flag in-progress
+   work not yet saved, pairing with the appConfirm-guarded Discard/Cancel controls. Uses
+   the global --warn tokens (theme-aware) rather than the editor-scoped --ie-* ones. */
+.library-unsaved-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 1px 9px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in oklch, var(--warn) 40%, var(--border));
+  background: var(--warn-soft);
+  color: color-mix(in oklch, var(--warn) 82%, var(--text));
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  user-select: none;
+  vertical-align: middle;
+}
+.library-unsaved-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--warn);
+}
+
 /* ── Tool rail ── */
 .ie-rail {
   display: flex;


### PR DESCRIPTION
## Summary

Epic 11958 **S12** (sc-11971). Under selective keep-alive (S1, #1525) the Pose Library and Key Point Library stay mounted across navigation, so an in-progress create/review **already survives a plain nav round trip with no prompt** (verified). This PR adds the unsaved indicator + the desktop-safe discard guards that the keep-alive world needs, and closes the S1-review gap where the Pose Create tab's **project-scoped** state leaked across a project switch.

## What changed

- **Pose Create RESET on project switch** — `<PoseLibraryScreen>` is now keyed on `activeProject?.id` in `App.jsx`, matching every studio + the Image Editor (sc-11968). A project switch remounts/clears the Create tab's staged `sources` + `phase`, so project-A source picks can no longer submit a `pose_detect` job under project B; keep-alive still preserves the review across a plain nav. The **Key Point Library is GLOBAL** (`GLOBAL_KEYPOINTS_PROJECT_ID`) and is deliberately **not** keyed, so its capture/collection work survives a project switch as well as a nav.
- **Unsaved-work indicator** — a shared `.library-unsaved-badge` pill (global `--warn` tokens, theme-aware, light + dark) on the Pose Create review, the Key Point Capture review, and the Collections builder.
- **Explicit discard guards via `appConfirm`** (desktop-safe, NOT `window.confirm`) — a new Pose Create **"Discard all"** control, plus the existing Key Point Capture **"Discard"** and Collections **"Cancel"** controls, now confirm (danger tone) before dropping a completed detection/extraction/edits. Plain nav stays non-destructive (no prompt).

## Design decision — project switch is a silent keyed remount, not a prompt

The Fix prose suggested an `appConfirm` guard on the Pose project switch. I implemented the reset via the codebase's **established** mechanism — a `key={activeProject.id}` remount — because **every** studio (Image/Video/Character/Document) and the sc-11968 Image Editor sibling reset their project-scoped state on a project switch **silently** this way (the DocumentStudio keep-alive test asserts the silent reset). A bespoke, pose-only project-switch prompt would be the only such prompt in the app and would be inconsistent. This satisfies the acceptance criterion ("Pose Create panel RESETS on a project switch"). An **app-wide** "confirm before a project switch that would discard in-progress work" is a separate, cross-cutting UX feature — filed as a follow-up rather than shipped pose-only.

## Acceptance

- ✅ Run pose detection, edit per-candidate tags/category/keep, nav away and back (plain nav): review intact, no prompt (keep-alive; App node-identity test).
- ✅ Keypoint capture review + typed name survives plain nav; in-progress collection survives plain nav (global, App node-identity test).
- ✅ Pose Create panel RESETS (sources/phase cleared) on a project switch (keyed remount; App node-identity test).
- ✅ Explicit discard prompts via `appConfirm` (Pose "Discard all", Key Point "Discard", Collections "Cancel"; screen tests).

## Tests — full web suite green (128 files / 1736)

- `App.keepAlive.test.jsx`: Pose Library is the SAME node across a same-project nav round trip and a NEW node after a project switch; Key Point Library is the same node across BOTH.
- `PoseLibraryScreen.test.jsx`: review flags unsaved + reaching it never prompts; "Discard all" confirms via `appConfirm` (danger) and clears the review; cancel keeps it.
- `KeyPointLibraryScreen.test.jsx`: capture review + collections builder flag unsaved; Discard/Cancel confirm via `appConfirm` and reset; cancel keeps the work.

## Follow-ups

- App-wide "confirm before a project switch that discards in-progress work" across all project-scoped kept-alive screens (studios, Image Editor, Pose) — currently every such screen resets silently on project switch; a consistent guard would be its own story.

Shortcut: sc-11971

🤖 Generated with [Claude Code](https://claude.com/claude-code)