### PR TITLE
feat(training): preserve dataset draft + fix config re-seed race + real unsaved guard (sc-11970)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -85,7 +85,7 @@ const ImageEditor = React.lazy(() =>
 // Library/Assets) keeps today's conditional unmount-on-navigation behavior. Training
 // contributes two view ids — the default "Train" workspace and the "LibraryDataSets"
 // Data Sets mode — both part of the Training Studio family.
-const KEEP_ALIVE_VIEWS = Object.freeze(
+export const KEEP_ALIVE_VIEWS = Object.freeze(
   new Set([
     "Image",
     "Video",
@@ -586,6 +586,41 @@ export function App() {
     }
     if (decision === false) return; // guard returned false → user cancelled the leave
     setActiveView(viewId);
+  }, []);
+
+  // A screen holding an unsaved draft (Training Studio / Data Sets, sc-11970) can register
+  // a guard consulted before the active PROJECT is switched — which would otherwise silently
+  // reset the screen and discard the draft. Distinct from the nav leave-guard above: project
+  // switch bypasses navTo entirely, and keep-alive screens must NOT prompt on plain nav, only
+  // on a project change. Like the nav guard, a promise defers the switch until the user
+  // answers; only a falsy answer cancels it. The guard receives the target project.
+  const projectSwitchGuardRef = useRef(null);
+  const registerProjectSwitchGuard = useCallback((guard) => {
+    projectSwitchGuardRef.current = guard;
+    return () => {
+      if (projectSwitchGuardRef.current === guard) projectSwitchGuardRef.current = null;
+    };
+  }, []);
+  const selectProject = useCallback((project) => {
+    // No-op re-selection (same project) and clears bypass the guard — nothing is discarded.
+    if (!project || project.id === activeProjectRef.current?.id) {
+      setActiveProject(project);
+      return;
+    }
+    const guard = projectSwitchGuardRef.current;
+    if (!guard) {
+      setActiveProject(project);
+      return;
+    }
+    const decision = guard(project);
+    if (decision && typeof decision.then === "function") {
+      decision.then((ok) => {
+        if (ok) setActiveProject(project);
+      });
+      return;
+    }
+    if (decision === false) return; // guard returned false → user kept editing
+    setActiveProject(project);
   }, []);
 
   // sc-4194: defined here (above the data hooks) because useTimelines takes it as a
@@ -2186,6 +2221,8 @@ export function App() {
     // Navigation
     setActiveView,
     registerLeaveGuard,
+    // Unsaved-draft guard consulted before a project switch (sc-11970)
+    registerProjectSwitchGuard,
     // Image-Editor scratch-op survivor coordination (sc-8850)
     trackEditorScratchOp,
     releaseEditorScratchOp,
@@ -2236,7 +2273,7 @@ export function App() {
     refreshTrainingDatasets, loadTrainingDataset, loadTrainingDatasetReadiness, setTrainingDatasetItemQualityAck, createTrainingDataset, uploadTrainingDatasetItem,
     updateTrainingDataset, batchRenameTrainingDataset, writeTrainingDatasetCaptionSidecars,
     createTrainingDatasetCaptionJob, createTrainingDatasetUpscaleJob, createTrainingDatasetAnalysisJob, createTrainingDatasetFaceAnalysisJob, smartCropTrainingDataset, stripExifTrainingDataset, createTrainingJob, trainingPresets, trainingPresetsError,
-    trainingTargets, trainingTargetsError, setActiveView, registerLeaveGuard,
+    trainingTargets, trainingTargetsError, setActiveView, registerLeaveGuard, registerProjectSwitchGuard,
     trackEditorScratchOp, releaseEditorScratchOp, registerEditorScratchClaim, characters,
     createCharacter, updateCharacter, archiveCharacter, unarchiveCharacter, listArchivedCharacters,
     addCharacterReference, updateCharacterReference,
@@ -2264,7 +2301,7 @@ export function App() {
           activeProject={activeProject}
           disabled={!authenticated}
           onCreate={createProject}
-          onSelect={setActiveProject}
+          onSelect={selectProject}
           projects={projects}
         />
 

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -601,27 +601,32 @@ export function App() {
       if (projectSwitchGuardRef.current === guard) projectSwitchGuardRef.current = null;
     };
   }, []);
-  const selectProject = useCallback((project) => {
+  // Consult the project-switch guard (if any) then switch. Resolves to whether the switch
+  // actually happened, so imperative callers — creating a NEW workspace (createProject) — can
+  // gate their follow-up (navigating into it) on the user confirming the discard (sc-11970).
+  const requestProjectSwitch = useCallback(async (project) => {
     // No-op re-selection (same project) and clears bypass the guard — nothing is discarded.
     if (!project || project.id === activeProjectRef.current?.id) {
       setActiveProject(project);
-      return;
+      return true;
     }
     const guard = projectSwitchGuardRef.current;
-    if (!guard) {
-      setActiveProject(project);
-      return;
+    if (guard) {
+      const decision = guard(project);
+      const proceed =
+        decision && typeof decision.then === "function" ? await decision : decision !== false;
+      if (!proceed) return false; // guard cancelled → user kept editing, nothing discarded
     }
-    const decision = guard(project);
-    if (decision && typeof decision.then === "function") {
-      decision.then((ok) => {
-        if (ok) setActiveProject(project);
-      });
-      return;
-    }
-    if (decision === false) return; // guard returned false → user kept editing
     setActiveProject(project);
+    return true;
   }, []);
+  // The ProjectSwitcher's onSelect fires the guarded switch and forgets the result.
+  const selectProject = useCallback(
+    (project) => {
+      void requestProjectSwitch(project);
+    },
+    [requestProjectSwitch],
+  );
 
   // sc-4194: defined here (above the data hooks) because useTimelines takes it as a
   // dependency; a stable identity keeps the timeline hook's queue action stable too.
@@ -1384,8 +1389,14 @@ export function App() {
         body: JSON.stringify({ name: trimmed }),
       });
       setProjects((items) => [created, ...items.filter((item) => item.id !== created.id)]);
-      setActiveProject(created);
-      setActiveView("Image");
+      // Switching to the new workspace resets keep-alive screens — including a Data Sets draft.
+      // Route through the guard so a dirty draft prompts (consistent with picking an EXISTING
+      // project) instead of silently wiping it (sc-11970). On cancel: stay on the current
+      // project + view, draft intact; the created workspace remains in the list to open later.
+      const switched = await requestProjectSwitch(created);
+      if (switched) {
+        setActiveView("Image");
+      }
       setError("");
       return created;
     } catch (err) {

--- a/apps/web/src/App.projectSwitchGuard.test.jsx
+++ b/apps/web/src/App.projectSwitchGuard.test.jsx
@@ -1,0 +1,150 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// sc-11970 (S11): creating a NEW workspace while a Data Sets draft is unsaved must route
+// through the SAME project-switch guard as picking an EXISTING project — otherwise the switch
+// silently resets the Training Studio (keyed on activeProject.id) and wipes the draft, while an
+// existing-project pick would have prompted. These tests render the full App, dirty a Data Sets
+// draft, then create a workspace via the ProjectSwitcher and assert the guard behaves the same:
+// cancel keeps the current project + draft; confirm switches to the new workspace.
+const appConfirmMock = vi.fn(() => Promise.resolve(true));
+vi.mock("./appConfirm.jsx", () => ({
+  appConfirm: (...args) => appConfirmMock(...args),
+  useConfirm: () => appConfirmMock,
+  ConfirmHost: () => null,
+  normalizeConfirmOptions: (options) => options,
+}));
+
+import { App } from "./main.jsx";
+import { FakeEventSource, response, settle, field, changeField } from "./main.testSupport.jsx";
+
+function installFetch() {
+  global.fetch = vi.fn((url, options = {}) => {
+    const path = new URL(url).pathname;
+    const method = options.method ?? "GET";
+    if (path.endsWith("/health")) {
+      return Promise.resolve(response({ status: "ok", authRequired: false }));
+    }
+    if (path.endsWith("/access")) {
+      return Promise.resolve(response({ authRequired: false }));
+    }
+    if (path.endsWith("/jobs/events/ticket")) {
+      return Promise.resolve(response({ ticket: "stream-ticket" }));
+    }
+    if (path.endsWith("/projects") && method === "POST") {
+      return Promise.resolve(response({ id: "project-new", name: "Fresh Set Project" }));
+    }
+    if (path.endsWith("/projects")) {
+      return Promise.resolve(response([{ id: "project-a", name: "Project A" }]));
+    }
+    // Everything else (training datasets, characters, assets, models, …) is empty — no saved
+    // datasets means the Data Sets library opens on a fresh "New dataset" draft.
+    return Promise.resolve(response([]));
+  });
+}
+
+describe("createProject routes the workspace switch through the Data Sets guard (sc-11970)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    FakeEventSource.instances = [];
+    window.EventSource = FakeEventSource;
+    window.localStorage.clear();
+    appConfirmMock.mockReset();
+    appConfirmMock.mockResolvedValue(true);
+    installFetch();
+  });
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount();
+    });
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  function projectPillText() {
+    return container.querySelector(".project-pill")?.textContent ?? "";
+  }
+
+  // Boot the app on Project A and navigate to the Data Sets library (which registers the
+  // project-switch guard). Returns once the datasets screen is mounted.
+  async function bootIntoDataSets() {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+    // Auto-selected the only workspace.
+    expect(projectPillText()).toContain("Project A");
+
+    await act(async () => {
+      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Data Sets").click();
+    });
+    await settle();
+    expect(field(container, "Dataset name")).toBeTruthy();
+  }
+
+  // Drive the ProjectSwitcher's "New workspace" flow to create + attempt to switch to a project.
+  async function createWorkspace(name) {
+    await act(async () => {
+      container.querySelector(".project-pill").click();
+    });
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "New workspace").click();
+    });
+    await changeField(container.querySelector('input[aria-label="New workspace name"]'), name);
+    await act(async () => {
+      container.querySelector(".project-menu-create button[type='submit']").click();
+    });
+    await settle();
+    await settle();
+  }
+
+  it("prompts and, on cancel, keeps the current workspace and the unsaved draft", async () => {
+    appConfirmMock.mockResolvedValue(false);
+    await bootIntoDataSets();
+
+    // Dirty the draft — a brand-new dataset with a name is unsaved work the guard protects.
+    await changeField(field(container, "Dataset name"), "Fresh Set");
+    expect(appConfirmMock).not.toHaveBeenCalled();
+
+    await createWorkspace("Fresh Set Project");
+
+    // The guard fired with the desktop-safe danger dialog...
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    expect(appConfirmMock.mock.calls[0][0]).toMatchObject({ tone: "danger", confirmLabel: "Discard" });
+    // ...and cancelling kept us on Project A with the draft intact (the new project still
+    // exists in the list — 2 workspaces — and can be opened later).
+    expect(projectPillText()).toContain("Project A");
+    expect(projectPillText()).not.toContain("Fresh Set Project");
+    expect(field(container, "Dataset name").value).toBe("Fresh Set");
+  });
+
+  it("switches to the new workspace when the discard prompt is confirmed", async () => {
+    appConfirmMock.mockResolvedValue(true);
+    await bootIntoDataSets();
+
+    await changeField(field(container, "Dataset name"), "Fresh Set");
+    await createWorkspace("Fresh Set Project");
+
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    // Confirming discarded the draft and switched to the freshly created workspace.
+    expect(projectPillText()).toContain("Fresh Set Project");
+  });
+
+  it("does NOT prompt when creating a workspace with no unsaved Data Sets draft", async () => {
+    await bootIntoDataSets();
+
+    // No edits → nothing to lose → the guard resolves without ever raising appConfirm.
+    await createWorkspace("Fresh Set Project");
+
+    expect(appConfirmMock).not.toHaveBeenCalled();
+    expect(projectPillText()).toContain("Fresh Set Project");
+  });
+});

--- a/apps/web/src/screens/TrainingStudio.datasetGuard.test.jsx
+++ b/apps/web/src/screens/TrainingStudio.datasetGuard.test.jsx
@@ -1,0 +1,225 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// sc-11970 (S11): a dataset draft (name / membership / captions / character / config) must
+// survive plain navigation (keep-alive, verified structurally below), and destructive
+// transitions — opening another dataset or switching project while there are unsaved
+// changes — must confirm via the desktop-safe appConfirm dialog (never window.confirm),
+// before discarding. These tests spy appConfirm to assert the guard fires.
+const appConfirmMock = vi.fn(() => Promise.resolve(true));
+vi.mock("../appConfirm.jsx", () => ({
+  appConfirm: (...args) => appConfirmMock(...args),
+  useConfirm: () => appConfirmMock,
+  ConfirmHost: () => null,
+  normalizeConfirmOptions: (options) => options,
+}));
+
+import { AppContext } from "../context/AppContext.js";
+import { TrainingDataSetsLibrary } from "./TrainingStudio.jsx";
+import { KEEP_ALIVE_VIEWS } from "../App.jsx";
+
+const datasetOne = { id: "dataset-1", name: "Mira Set", version: 2, characterId: "", items: [] };
+const datasetTwo = { id: "dataset-2", name: "Other Set", version: 1, characterId: "", items: [] };
+
+function baseContext(overrides = {}) {
+  return {
+    activeProject: { id: "project-a", name: "Project A" },
+    authenticated: true,
+    assets: [],
+    characters: [],
+    jobs: [],
+    setPreviewAsset: () => {},
+    trainingDatasets: [datasetOne, datasetTwo],
+    trainingDatasetsProjectId: "project-a",
+    loadingTrainingDatasets: false,
+    refreshTrainingDatasets: () => {},
+    loadTrainingDataset: vi.fn(async (id) => (id === "dataset-2" ? datasetTwo : datasetOne)),
+    createTrainingDataset: vi.fn(),
+    updateTrainingDataset: vi.fn(),
+    // No targets → the Configure-job config effect early-returns, so the datasets panel
+    // renders in isolation without a training catalog.
+    trainingPresets: { presets: [] },
+    trainingTargets: { targets: [] },
+    setActiveView: () => {},
+    models: [],
+    createModelDownloadJob: () => {},
+    // Auto-open dataset-1 on mount (Character Studio "Open" hand-off path), so the tests
+    // don't have to drive the CompactSelector to get an active dataset.
+    studioLaunch: { id: "launch-1", view: "LibraryDataSets", datasetId: "dataset-1" },
+    ...overrides,
+  };
+}
+
+async function settle() {
+  await act(async () => {
+    for (let index = 0; index < 6; index += 1) {
+      await Promise.resolve();
+    }
+  });
+}
+
+function nameInput(container) {
+  return container.querySelector('input[aria-label="Dataset name"]');
+}
+
+async function typeName(container, value) {
+  const input = nameInput(container);
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(input.constructor.prototype, "value")?.set;
+    setter?.call(input, value);
+    input.dispatchEvent(new window.Event("input", { bubbles: true }));
+  });
+}
+
+describe("TrainingStudio dataset draft guard (sc-11970)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    appConfirmMock.mockReset();
+    appConfirmMock.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount();
+    });
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the Train and Data Sets views mounted across plain nav (no prompt path)", () => {
+    // Acceptance #1: keep-alive preserves the draft across plain navigation. Both views are
+    // registered as keep-alive, so the screen is hidden — not unmounted — and no leave prompt
+    // is wired for plain nav (the guard fires only on project switch / opening another dataset).
+    expect(KEEP_ALIVE_VIEWS.has("Train")).toBe(true);
+    expect(KEEP_ALIVE_VIEWS.has("LibraryDataSets")).toBe(true);
+  });
+
+  it("does NOT prompt when auto-opening a dataset with no unsaved draft", async () => {
+    const context = baseContext();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<AppContext.Provider value={context}>{<TrainingDataSetsLibrary />}</AppContext.Provider>);
+    });
+    await settle();
+    // dataset-1 loaded, nothing edited → the initial open must not raise a discard prompt.
+    expect(context.loadTrainingDataset).toHaveBeenCalledWith("dataset-1");
+    expect(appConfirmMock).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("Version 2");
+  });
+
+  it("prompts via appConfirm before opening another dataset while dirty, and cancels on decline", async () => {
+    appConfirmMock.mockResolvedValue(false);
+    const context = baseContext();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<AppContext.Provider value={context}>{<TrainingDataSetsLibrary />}</AppContext.Provider>);
+    });
+    await settle();
+    expect(context.loadTrainingDataset).toHaveBeenCalledTimes(1);
+
+    // Dirty the draft (rename), then request another dataset via a fresh studioLaunch.
+    await typeName(container, "Mira Set edited");
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={{ ...context, studioLaunch: { id: "launch-2", view: "LibraryDataSets", datasetId: "dataset-2" } }}>
+          {<TrainingDataSetsLibrary />}
+        </AppContext.Provider>,
+      );
+    });
+    await settle();
+
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    expect(appConfirmMock.mock.calls[0][0]).toMatchObject({ tone: "danger", confirmLabel: "Discard" });
+    // Declined → dataset-2 was never loaded; only the original dataset-1 open happened.
+    expect(context.loadTrainingDataset).toHaveBeenCalledTimes(1);
+    expect(context.loadTrainingDataset).not.toHaveBeenCalledWith("dataset-2");
+  });
+
+  it("opens another dataset when the discard prompt is confirmed", async () => {
+    appConfirmMock.mockResolvedValue(true);
+    const context = baseContext();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<AppContext.Provider value={context}>{<TrainingDataSetsLibrary />}</AppContext.Provider>);
+    });
+    await settle();
+
+    await typeName(container, "Mira Set edited");
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={{ ...context, studioLaunch: { id: "launch-2", view: "LibraryDataSets", datasetId: "dataset-2" } }}>
+          {<TrainingDataSetsLibrary />}
+        </AppContext.Provider>,
+      );
+    });
+    await settle();
+
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    expect(context.loadTrainingDataset).toHaveBeenCalledWith("dataset-2");
+  });
+
+  it("registers a project-switch guard that prompts only when the draft is dirty", async () => {
+    let capturedGuard = null;
+    const registerProjectSwitchGuard = vi.fn((guard) => {
+      capturedGuard = guard;
+      return () => {};
+    });
+    const context = baseContext({ registerProjectSwitchGuard });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<AppContext.Provider value={context}>{<TrainingDataSetsLibrary />}</AppContext.Provider>);
+    });
+    await settle();
+
+    expect(registerProjectSwitchGuard).toHaveBeenCalledTimes(1);
+    expect(typeof capturedGuard).toBe("function");
+
+    // Clean draft → the guard resolves true WITHOUT prompting (project switch proceeds).
+    let cleanDecision;
+    await act(async () => {
+      cleanDecision = await capturedGuard({ id: "project-b" });
+    });
+    expect(cleanDecision).toBe(true);
+    expect(appConfirmMock).not.toHaveBeenCalled();
+
+    // Dirty the draft → the same guard now routes through appConfirm before allowing the switch.
+    appConfirmMock.mockResolvedValue(false);
+    await typeName(container, "Mira Set edited");
+    let dirtyDecision;
+    await act(async () => {
+      dirtyDecision = await capturedGuard({ id: "project-b" });
+    });
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    expect(appConfirmMock.mock.calls[0][0]).toMatchObject({ tone: "danger" });
+    expect(dirtyDecision).toBe(false);
+  });
+
+  it("promotes the unsaved pill: a Discard action reverts the draft to the saved state", async () => {
+    const context = baseContext();
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<AppContext.Provider value={context}>{<TrainingDataSetsLibrary />}</AppContext.Provider>);
+    });
+    await settle();
+
+    await typeName(container, "Mira Set edited");
+    expect(container.textContent).toContain("Unsaved changes");
+    const discard = [...container.querySelectorAll("button")].find((button) => button.textContent === "Discard");
+    expect(discard).toBeTruthy();
+
+    await act(async () => {
+      discard.click();
+    });
+    await settle();
+    // Reverted to the saved name → clean again, version pill returns.
+    expect(nameInput(container).value).toBe("Mira Set");
+    expect(container.textContent).toContain("Version 2");
+    expect(container.textContent).not.toContain("Unsaved changes");
+  });
+});

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -34,11 +34,13 @@ import {
 } from "../training/datasetReadiness.js";
 import {
   configDraftFromTarget,
+  configReseedDecision,
   configValidation,
   defaultGpuOptions,
   defaultOptimizerOptions,
   defaultPresetForTarget,
   lrSchedulerOptions,
+  mergeCustomizedConfigDraft,
   presetForQualityTier,
   presetsForTarget,
   promptListToLines,
@@ -48,6 +50,7 @@ import {
   trainingAdapterVersionOptions,
   trainingConfigSnapshot,
 } from "../training/trainingConfig.js";
+import { appConfirm } from "../appConfirm.jsx";
 import { useValidation } from "../validation/useValidation.js";
 import { ConfigureJobPanel } from "./training/ConfigureJobPanel.jsx";
 import { DatasetEditorPanel } from "./training/DatasetEditorPanel.jsx";
@@ -325,6 +328,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
     models = [],
     createModelDownloadJob,
     macCapabilities = DEFAULT_MAC_CAPABILITIES,
+    registerProjectSwitchGuard,
   } = useAppContext();
   const datasets = trainingDatasetsProjectId === activeProject?.id ? trainingDatasets : [];
   const datasetsError = trainingDatasetsError;
@@ -387,7 +391,14 @@ export function TrainingStudio({ mode = "training" } = {}) {
   // until the user edits them (sc-8671), mirroring configTriggerFollowsCaptions.
   const [configPromptsFollowTrigger, setConfigPromptsFollowTrigger] = useState(true);
   const [submittingJob, setSubmittingJob] = useState(false);
-  const configBasisRef = useRef("");
+  // The config-draft basis, keyed on (target, dataset, default-preset). Value-preserving
+  // across an async trainingPresets load (sc-11970): a preset-only basis flip no longer
+  // wipes the user's config edits. See the basis effect below.
+  const configBasisRef = useRef({ targetId: "", datasetId: "", presetId: "" });
+  // Live mirror of customizedConfigFields so the basis effect can read the current set
+  // without listing it as a dependency (which would re-run the effect on every keystroke).
+  const customizedConfigFieldsRef = useRef(customizedConfigFields);
+  customizedConfigFieldsRef.current = customizedConfigFields;
 
   const datasetAssets = useMemo(
     () => datasetOwnedAssets(activeDataset, activeProject?.id, assets),
@@ -460,6 +471,13 @@ export function TrainingStudio({ mode = "training" } = {}) {
       selectedAssetIds.length !== originalAssetIds.length ||
       selectedAssetIds.some((id, index) => id !== originalAssetIds[index]) ||
       captionsDirty);
+  // Unsaved work the destructive-transition guards protect (sc-11970): an edited saved
+  // dataset (dirty) OR a brand-new dataset the user has started building (name / members /
+  // character) but not yet saved. A new draft isn't "dirty" (no baseline), but discarding
+  // it is just as destructive, so the guard covers it too.
+  const hasUnsavedDatasetDraft = activeDataset
+    ? dirty
+    : Boolean(draftName.trim() || selectedAssetIds.length || associatedCharacterId);
   // One summary gates Save and feeds the chip row, so they cannot disagree (epic 10644).
   // `savingDataset` and "nothing changed" are non-validation gates — like submittingJob on
   // the Train button — so they stay in the disabled expression rather than becoming issues.
@@ -714,7 +732,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
     setConfigError("");
     setConfigTriggerFollowsCaptions(true);
     setConfigPromptsFollowTrigger(true);
-    configBasisRef.current = "";
+    configBasisRef.current = { targetId: "", datasetId: "", presetId: "" };
   }, [activeProject?.id]);
 
   // sc-2022: open a dataset requested from elsewhere (Character Studio's
@@ -747,18 +765,46 @@ export function TrainingStudio({ mode = "training" } = {}) {
 
   useEffect(() => {
     if (!selectedTarget) {
-      if (configBasisRef.current) {
-        configBasisRef.current = "";
+      if (configBasisRef.current.targetId) {
+        configBasisRef.current = { targetId: "", datasetId: "", presetId: "" };
         setConfigDraft({});
       }
       return;
     }
     const defaultPreset = defaultPresetForTarget(trainingPresets, selectedTarget.id);
-    const basis = `${selectedTarget.id}\u0000${activeDataset?.id ?? ""}\u0000${defaultPreset?.id ?? ""}`;
-    if (configBasisRef.current === basis) {
+    const nextBasis = {
+      targetId: selectedTarget.id,
+      datasetId: activeDataset?.id ?? "",
+      presetId: defaultPreset?.id ?? "",
+    };
+    const customizedFields = customizedConfigFieldsRef.current;
+    const decision = configReseedDecision(configBasisRef.current, nextBasis, customizedFields.size);
+    if (decision === "noop") {
       return;
     }
-    configBasisRef.current = basis;
+    configBasisRef.current = nextBasis;
+    if (decision === "merge") {
+      // The trainingPresets catalog resolved async AFTER the user tweaked config (sc-11970).
+      // Re-seed only the fields they did NOT customize from the now-available default preset,
+      // preserving their edits + the customized-field set. Do NOT reset the follow-flags or
+      // clear the customized set — that would discard genuine user input on a catalog load.
+      setSelectedPresetId((currentId) => currentId || (defaultPreset?.id ?? ""));
+      setConfigDraft((current) => {
+        const seeded = configDraftFromTarget(
+          selectedTarget,
+          activeDataset,
+          gpuOptions,
+          current.triggerWord || triggerPhraseFromText(activeDataset?.name),
+          defaultPreset,
+          { outputName: current.outputName },
+        );
+        return mergeCustomizedConfigDraft(seeded, current, customizedFields);
+      });
+      setConfigSnapshot(null);
+      return;
+    }
+    // "seed": a genuine target/dataset switch (or a preset resolve with no pending edits) —
+    // safe to (re)seed the whole draft from the target + default preset.
     setSelectedPresetId(defaultPreset?.id ?? "");
     setCustomizedConfigFields(new Set());
     setConfigDraft(configDraftFromTarget(selectedTarget, activeDataset, gpuOptions, triggerPhraseFromText(activeDataset?.name), defaultPreset));
@@ -814,7 +860,52 @@ export function TrainingStudio({ mode = "training" } = {}) {
     });
   }, [gpuOptionsKey]);
 
+  // Live mirror of the unsaved-draft flag so imperative guards (the project-switch guard
+  // registered with App, and the leave-guard callbacks) read the current value without
+  // being re-created on every keystroke (sc-11970).
+  const hasUnsavedDatasetDraftRef = useRef(hasUnsavedDatasetDraft);
+  hasUnsavedDatasetDraftRef.current = hasUnsavedDatasetDraft;
+
+  // Desktop-safe confirm before a transition would discard the current dataset draft
+  // (sc-11970). Resolves true (proceed) when there's nothing unsaved or the user confirms.
+  // Uses appConfirm (a real Modal) — window.confirm silently no-ops in the Tauri WebView.
+  function confirmDiscardUnsavedDraft() {
+    if (!hasUnsavedDatasetDraftRef.current) {
+      return Promise.resolve(true);
+    }
+    return appConfirm({
+      title: "Discard unsaved changes?",
+      message: "This dataset has unsaved changes. They will be lost if you continue.",
+      confirmLabel: "Discard",
+      cancelLabel: "Keep editing",
+      tone: "danger",
+    });
+  }
+
+  // Register a project-switch guard with App (sc-11970). Switching the active project
+  // resets this screen (the reset effect above), silently discarding the dataset draft.
+  // The guard is consulted BEFORE the switch and defers it until the user answers. Scoped
+  // to Data Sets mode — that's where a dataset draft is authored — so the single App-level
+  // registration slot isn't contended by the Train-mode twin. Keep-alive keeps this mounted
+  // across plain nav, so the guard stays live even when Data Sets isn't the foreground view.
+  useEffect(() => {
+    if (!datasetLibraryMode || typeof registerProjectSwitchGuard !== "function") {
+      return undefined;
+    }
+    // confirmDiscardUnsavedDraft reads a ref, so the registration itself is stable.
+    return registerProjectSwitchGuard(() => confirmDiscardUnsavedDraft());
+  }, [datasetLibraryMode, registerProjectSwitchGuard]);
+
   async function openDataset(datasetId) {
+    // Opening a DIFFERENT dataset re-seeds the whole editor; confirm before discarding an
+    // unsaved draft (sc-11970). Re-opening the SAME dataset (internal reloads after a save)
+    // never prompts — the ids match and the draft is already persisted.
+    if (datasetId && datasetId !== activeDataset?.id) {
+      const proceed = await confirmDiscardUnsavedDraft();
+      if (!proceed) {
+        return;
+      }
+    }
     if (!datasetId) {
       setActiveDataset(null);
       setDraftName("");
@@ -846,7 +937,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
     setSelectedAssetIds((current) => current.filter((id) => id !== assetId));
   }
 
-  function startNewDataset() {
+  function clearDatasetDraft() {
     setActiveDataset(null);
     setDatasetError("");
     setDatasetMessage("");
@@ -855,6 +946,36 @@ export function TrainingStudio({ mode = "training" } = {}) {
     setAssociatedCharacterId("");
     setUploadedDatasetAssets([]);
     setSelectedDatasetId("");
+  }
+
+  // Starting a new dataset abandons the current draft — confirm before discarding unsaved
+  // work (sc-11970), then clear to a blank draft.
+  async function startNewDataset() {
+    const proceed = await confirmDiscardUnsavedDraft();
+    if (!proceed) {
+      return;
+    }
+    clearDatasetDraft();
+  }
+
+  // Revert the draft to the last saved state (sc-11970): the actionable half of the
+  // "Unsaved changes" pill. A saved dataset restores from `activeDataset` in place (no
+  // reload); an unstarted draft clears. `activeDataset` is unchanged, so the caption-seed
+  // effect won't fire — reset the per-field drafts explicitly.
+  function discardDraft() {
+    if (!hasUnsavedDatasetDraft) {
+      return;
+    }
+    if (!activeDataset) {
+      clearDatasetDraft();
+      return;
+    }
+    setDatasetError("");
+    setDatasetMessage("");
+    setDraftName(activeDataset.name ?? "");
+    setSelectedAssetIds(normalizeDatasetAssetIds(activeDataset, assets));
+    setAssociatedCharacterId(activeDataset.characterId ?? "");
+    setCaptionDraftById(captionDraftsFromDataset(activeDataset));
   }
 
   // Editing a caption marks it as manually authored (sc-2025) — caption source
@@ -1489,6 +1610,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
                 draftName={draftName}
                 setDraftName={setDraftName}
                 dirty={dirty}
+                discardDraft={discardDraft}
                 setAddDialogOpen={setAddDialogOpen}
                 renamePrefix={renamePrefix}
                 setRenamePrefix={setRenamePrefix}

--- a/apps/web/src/screens/training/DatasetEditorPanel.jsx
+++ b/apps/web/src/screens/training/DatasetEditorPanel.jsx
@@ -94,6 +94,7 @@ export function DatasetEditorPanel({
   draftName,
   setDraftName,
   dirty,
+  discardDraft,
   setAddDialogOpen,
   renamePrefix,
   setRenamePrefix,
@@ -193,10 +194,25 @@ export function DatasetEditorPanel({
   // never silently ready (sc-6534).
   const readyCount = readiness ? memberAssets.filter((asset) => !isFlagged(asset)).length : 0;
 
+  // The unsaved-state chip is now a real affordance (sc-11970): when there are unsaved
+  // changes it pairs the "Unsaved changes" pill with a Discard action that reverts the
+  // draft to the last saved state (Save lives in the actions row above). A saved, clean
+  // dataset shows its version; an unstarted draft shows "Draft".
   const statusPill = dirty ? (
-    <span className="dataset-status-pill unsaved">
-      <span className="dataset-status-dot" aria-hidden="true" />
-      Unsaved changes
+    <span className="dataset-status-row">
+      <span className="dataset-status-pill unsaved">
+        <span className="dataset-status-dot" aria-hidden="true" />
+        Unsaved changes
+      </span>
+      {typeof discardDraft === "function" ? (
+        <button
+          className="link-button dataset-discard-button"
+          onClick={discardDraft}
+          type="button"
+        >
+          Discard
+        </button>
+      ) : null}
     </span>
   ) : activeDataset ? (
     <span className="dataset-status-pill">Version {activeDataset.version}</span>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3604,6 +3604,20 @@ input.dataset-name-input.boxed:focus {
   background: var(--warn);
 }
 
+/* The unsaved chip is a real affordance (sc-11970): the "Unsaved changes" pill paired
+   with an inline Discard action that reverts the draft to the last saved state. */
+.dataset-status-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.dataset-discard-button {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: color-mix(in oklch, var(--warn) 78%, var(--text));
+}
+
 .dataset-tools-row {
   display: flex;
   align-items: flex-end;

--- a/apps/web/src/training/trainingConfig.js
+++ b/apps/web/src/training/trainingConfig.js
@@ -184,6 +184,41 @@ export function configDraftFromTarget(target, dataset, gpuOptions, triggerPhrase
   };
 }
 
+// Decide how the config-draft basis effect should react to a basis change (sc-11970).
+// The basis is keyed on (targetId, datasetId, defaultPresetId). Distinguishing a genuine
+// USER action from an ASYNC catalog load is the whole point (mirrors S3, sc-11962):
+//   - target OR dataset changed  → the user switched context → fully re-SEED the draft.
+//   - ONLY the default preset id changed (target+dataset stable) → the trainingPresets
+//     catalog just resolved async. If the user has already customized fields, MERGE the
+//     newly-available preset defaults UNDER their edits rather than wiping them ("merge").
+//     With no pending edits it's safe to seed the freshly-resolved preset ("seed").
+//   - nothing changed → "noop".
+// `prev`/`next` are `{ targetId, datasetId, presetId }` basis records.
+export function configReseedDecision(prev, next, customizedFieldCount = 0) {
+  const previous = prev ?? {};
+  const userChange = previous.targetId !== next.targetId || previous.datasetId !== next.datasetId;
+  if (!userChange && previous.presetId === next.presetId) {
+    return "noop";
+  }
+  if (!userChange && customizedFieldCount > 0) {
+    return "merge";
+  }
+  return "seed";
+}
+
+// Overlay the user's customized field values onto a freshly-seeded draft (sc-11970). Used
+// on the "merge" path above so an async preset-catalog load re-seeds the fields the user
+// did NOT touch from the now-available preset while preserving the ones they did.
+export function mergeCustomizedConfigDraft(seeded, current = {}, customizedFields = new Set()) {
+  const merged = { ...seeded };
+  for (const field of customizedFields) {
+    if (Object.prototype.hasOwnProperty.call(current, field)) {
+      merged[field] = current[field];
+    }
+  }
+  return merged;
+}
+
 // The training config's rule set, in the shape `useValidation` wants: a pure
 // `(draft, ctx) => Issue[]` living beside the draft it validates (epic 10644).
 //

--- a/apps/web/src/training/trainingConfig.test.js
+++ b/apps/web/src/training/trainingConfig.test.js
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import { summarize } from "../validation/issues.js";
-import { configDraftFromTarget, configValidation, trainingConfigSnapshot } from "./trainingConfig.js";
+import {
+  configDraftFromTarget,
+  configReseedDecision,
+  configValidation,
+  mergeCustomizedConfigDraft,
+  trainingConfigSnapshot,
+} from "./trainingConfig.js";
 
 // sc-4199: configDraftFromTarget (target/preset → form draft) and
 // trainingConfigSnapshot (form draft → worker payload) were pure builders buried
@@ -271,5 +277,72 @@ describe("configValidation", () => {
     it("defaults to trainable when readiness is unknown", () => {
       expect(summarize(configValidation(wholeDraft, ctx)).ready).toBe(true);
     });
+  });
+});
+
+// sc-11970: the config-draft basis effect must NOT wipe a user's config edits when the
+// trainingPresets catalog resolves ASYNC. These two pure helpers encode that decision so
+// the (hook-driven) screen effect stays thin and the async-vs-user distinction is testable.
+describe("configReseedDecision (sc-11970)", () => {
+  const basis = (over = {}) => ({ targetId: "sdxl_lora", datasetId: "ds-1", presetId: "", ...over });
+
+  it("seeds on the first pass (empty previous basis)", () => {
+    expect(configReseedDecision({ targetId: "", datasetId: "", presetId: "" }, basis(), 0)).toBe("seed");
+  });
+
+  it("seeds when the user switches target", () => {
+    const prev = basis({ presetId: "balanced" });
+    const next = basis({ targetId: "z_image_lora", presetId: "balanced" });
+    // Even with customized fields, a genuine target switch fully re-seeds.
+    expect(configReseedDecision(prev, next, 3)).toBe("seed");
+  });
+
+  it("seeds when the user switches dataset", () => {
+    const prev = basis({ presetId: "balanced" });
+    const next = basis({ datasetId: "ds-2", presetId: "balanced" });
+    expect(configReseedDecision(prev, next, 3)).toBe("seed");
+  });
+
+  it("MERGES (does not wipe) when only the default preset resolves async AND the user has edits", () => {
+    // target + dataset stable, preset id appears (catalog just loaded), user tweaked fields.
+    const prev = basis({ presetId: "" });
+    const next = basis({ presetId: "balanced" });
+    expect(configReseedDecision(prev, next, 2)).toBe("merge");
+  });
+
+  it("seeds on an async preset resolve when the user has NOT customized anything", () => {
+    const prev = basis({ presetId: "" });
+    const next = basis({ presetId: "balanced" });
+    expect(configReseedDecision(prev, next, 0)).toBe("seed");
+  });
+
+  it("no-ops when nothing changed", () => {
+    const prev = basis({ presetId: "balanced" });
+    expect(configReseedDecision(prev, { ...prev }, 4)).toBe("noop");
+  });
+});
+
+describe("mergeCustomizedConfigDraft (sc-11970)", () => {
+  it("overlays only the customized fields onto the freshly-seeded draft", () => {
+    const seeded = { learningRate: "0.0001", steps: "1000", rank: "8" };
+    const current = { learningRate: "0.0005", steps: "2500", rank: "16" };
+    const merged = mergeCustomizedConfigDraft(seeded, current, new Set(["learningRate", "steps"]));
+    // Customized fields keep the user's value; untouched fields take the preset seed.
+    expect(merged.learningRate).toBe("0.0005");
+    expect(merged.steps).toBe("2500");
+    expect(merged.rank).toBe("8");
+  });
+
+  it("ignores customized field names absent from the current draft", () => {
+    const seeded = { learningRate: "0.0001" };
+    const merged = mergeCustomizedConfigDraft(seeded, {}, new Set(["learningRate", "ghost"]));
+    expect(merged).toEqual({ learningRate: "0.0001" });
+  });
+
+  it("returns a fresh object (no mutation of the seed)", () => {
+    const seeded = { steps: "1000" };
+    const merged = mergeCustomizedConfigDraft(seeded, { steps: "2000" }, new Set(["steps"]));
+    expect(merged).not.toBe(seeded);
+    expect(seeded.steps).toBe("1000");
   });
 });


### PR DESCRIPTION
## Summary

S11 of the screen-state persistence epic (sc-11958). TrainingStudio (and Data Sets via `mode="datasets"`) holds a full unsaved draft — name, membership, per-image captions, associated character, and training config. This PR closes three gaps.

### 1. Config re-seed race (fixed)
`configBasisRef` was keyed on `(target, dataset, defaultPreset)` and did a full `setConfigDraft(...)` + `setCustomizedConfigFields(new Set())` on any basis change. When `trainingPresets` load **async** after the user tweaks config, the default-preset id appears → the basis flips → the user's config edits were **wiped**.

Now the basis is value-preserving:
- **target/dataset switch** (genuine user action) → full re-seed (as before).
- **preset-only flip with pending edits** (async catalog load) → **merge**: re-seed only the fields the user did *not* customize from the now-available preset, preserving their edits and the `customizedConfigFields` set.
- The async-vs-user distinction lives in two pure, unit-tested helpers — `configReseedDecision` and `mergeCustomizedConfigDraft` — mirroring S3 (sc-11962).

### 2. Real unsaved guards via `appConfirm` (not `window.confirm`)
- **Opening another dataset / starting a new one while dirty** → `appConfirm` prompts before discarding (`openDataset` skips the prompt on internal same-id reloads after a save).
- **Project switch while dirty** → new App-level `registerProjectSwitchGuard`, consulted by the `ProjectSwitcher` before `setActiveProject`. Deliberately **distinct** from the nav leave-guard so plain keep-alive navigation is **not** prompted — only a project change is. Scoped to Data Sets mode so the single registration slot isn't contended by the Train-mode twin.

### 3. Promoted the cosmetic "Unsaved changes" pill
It now pairs with an inline **Discard** action that reverts the draft to the last saved state.

### Keep-alive (acceptance #1)
S1 keep-alive already keeps the screen mounted across plain nav (`Train` and `LibraryDataSets` are keep-alive views), so the draft survives with **no prompt** — verified structurally; no nav prompt added.

## Tests
- `trainingConfig.test.js`: `configReseedDecision` (seed / merge / seed-when-clean / noop) + `mergeCustomizedConfigDraft`.
- `TrainingStudio.datasetGuard.test.jsx` (new): renders Data Sets with a spied `appConfirm` — asserts opening another dataset while dirty prompts (and cancels on decline / opens on confirm), the project-switch guard prompts only when dirty, the Discard affordance reverts, and the keep-alive views are registered.
- Full web suite green: **1741 passed** (`vitest run --environment jsdom`). ESLint: 0 errors on changed files.

Web-only, no Rust touched.

Closes sc-11970.

🤖 Generated with [Claude Code](https://claude.com/claude-code)