### PR TITLE
test(web): lock studio persistence + injection regressions (sc-11963)

### DIFF
--- a/apps/web/src/App.keepAlive.test.jsx
+++ b/apps/web/src/App.keepAlive.test.jsx
@@ -335,4 +335,62 @@ describe("selective lazy keep-alive shell (sc-11959)", () => {
     expect(imageStudio()).toBe(studioBefore);
     expect(generalChip().classList.contains("active")).toBe(true);
   });
+
+  it("does NOT re-apply a stale launch token on a nav round trip (an edit over an injected recipe survives)", async () => {
+    // The apply effect is keyed on the studioLaunch token id, and keep-alive never remounts
+    // the studio across a nav round trip — so a stale token must not re-fire and clobber a
+    // later edit. This is the flip side of the injection tests above: a NEW token applies,
+    // but re-entering the same studio with the SAME (already-consumed) token must not.
+    const generatedAsset = {
+      id: "asset-recipe",
+      projectId: "project-1",
+      generationSetId: "genset-recipe",
+      type: "image",
+      displayName: "Atrium still",
+      file: { path: "assets/images/atrium.png", mimeType: "image/png" },
+      status: { favorite: false, rating: 0, rejected: false, trashed: false },
+      generationSet: {
+        recipe: {
+          mode: "text_to_image",
+          model: "z_image_turbo",
+          prompt: "mist over a glass atrium",
+          negativePrompt: "flat lighting",
+          seed: 1234,
+          normalizedSettings: { width: 1024, height: 1024, count: 2 },
+          rawAdapterSettings: { steps: 14, guidanceScale: 2.5 },
+        },
+      },
+    };
+    mockFetch({ assets: [generatedAsset] });
+    await renderApp();
+
+    // Mount the studio and inject the recipe (the token fires once).
+    await clickButton("Image");
+    const studioBefore = imageStudio();
+    await clickButton("Assets");
+    await act(async () => {
+      document.body.querySelector(".asset-tile")?.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+    });
+    await settle();
+    await clickButton("Use this recipe");
+    expect(imageStudio()).toBe(studioBefore);
+    expect(promptField().value).toBe("mist over a glass atrium");
+
+    // Edit the prompt OVER the injected recipe value.
+    await changeField(promptField(), "my edit after the recipe applied");
+    expect(promptField().value).toBe("my edit after the recipe applied");
+
+    // Clear localStorage so a hypothetical remount could NOT re-hydrate the prompt — the only
+    // way the edit can survive is if the studio was neither remounted nor re-injected.
+    window.localStorage.clear();
+
+    // Nav away and back: the launch token id is unchanged, so its apply effect must not re-run.
+    await clickButton("Assets");
+    await clickButton("Image");
+
+    // Same DOM node (never remounted) AND the edit survived — the stale token did not re-apply
+    // "mist over a glass atrium" over the user's later edit.
+    expect(imageStudio()).toBe(studioBefore);
+    expect(promptField().value).toBe("my edit after the recipe applied");
+  });
 });

--- a/apps/web/src/screens/studioRestore.test.jsx
+++ b/apps/web/src/screens/studioRestore.test.jsx
@@ -1,6 +1,6 @@
 import React, { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { click, mountRoot, unmountRoot } from "../testUtils/dom.js";
+import { click, mountRoot, unmountRoot, setSelect } from "../testUtils/dom.js";
 
 // Pose loaders + any best-effort fetches must never touch the network on mount.
 vi.mock("../api.js", async (importOriginal) => {
@@ -409,5 +409,69 @@ describe("studio restart-restore does not clobber the restored snapshot (sc-1196
     expect(snap.selectedLoraIds).toEqual(["vlora-a"]);
     expect(snap.selectedPresetId).toBe("vcine");
     expect(snap.generalStackIds).toEqual(["venhance"]);
+  });
+
+  // ---- The OTHER side of the sc-11962 fix (S4 / sc-11963) --------------------------
+  // S3 made the reference-tuning + advanced-defaults resets fire only on a genuine model
+  // VALUE change, not on an async catalog "snap" that leaves the model unchanged — the
+  // tests above lock that async loads DON'T reset. This locks the complementary guarantee:
+  // once the catalogs are LOADED (restore already settled, ready-gated writer live), a real
+  // USER model change STILL resets both the reference tuning and the advanced defaults to the
+  // newly-chosen model's declared values. A one-shot skip bug that silenced the async snap
+  // would also (wrongly) swallow this real change, so the two halves must be tested together.
+  it("Image: a genuine post-load user model change STILL resets reference tuning + advanced defaults", async () => {
+    seedSnapshot("image", IMAGE_SNAPSHOT);
+    // Catalogs resolve after mount → the restore settles with no reset (the S3 guarantee).
+    await renderSequence(ImageStudio, [imageContext(), imageContext(IMAGE_FULL)]);
+
+    // Sanity: the restored FLUX tuning/defaults survived the async catalog arrival.
+    expect(modelSelectValue()).toBe("flux2_dev");
+    let snap = readSnapshot("image");
+    expect(snap.resolution).toBe("1536x1536");
+    expect(snap.sampler).toBe("dpmpp_2m");
+    expect(snap.ipAdapterScale).toBe(0.85);
+
+    // A genuine USER model change (FLUX → Z-Image) through the picker.
+    await act(async () => {
+      setSelect(document.body.querySelector(".settings-field-model select"), "z_image_turbo");
+    });
+    await act(async () => {});
+
+    // Advanced-defaults reset: Z-Image only serves 1024x1024 + the "default" sampler, so the
+    // restored FLUX resolution/sampler snap to Z-Image's declared values.
+    // Reference-tuning reset: Z-Image declares no referenceStrengthDefault, so ipAdapterScale
+    // falls back to the model-agnostic 0.6 — proving the restored 0.85 was NOT preserved here.
+    expect(modelSelectValue()).toBe("z_image_turbo");
+    snap = readSnapshot("image");
+    expect(snap.model).toBe("z_image_turbo");
+    expect(snap.resolution).toBe("1024x1024");
+    expect(snap.sampler).toBe("default");
+    expect(snap.ipAdapterScale).toBe(0.6);
+  });
+
+  // Video counterpart: VideoStudio has no ipAdapter reference-tuning, but its duration/
+  // resolution/fps snap must still fire on a genuine user model change. The restore preserves
+  // WAN's 1280x720 (valid for WAN); switching to LTX — which does not serve 1280x720 — snaps
+  // the resolution to LTX's declared default, so a real user change is not swallowed.
+  it("Video: a genuine post-load user model change snaps a now-invalid resolution to the new model default", async () => {
+    seedSnapshot("video", VIDEO_SNAPSHOT);
+    await renderSequence(VideoStudio, [videoContext(), videoContext(VIDEO_FULL)]);
+
+    // Sanity: WAN's restored resolution survived the async catalog arrival.
+    expect(modelSelectValue()).toBe("wan_t2v");
+    expect(readSnapshot("video").resolution).toBe("1280x720");
+
+    // User switches to LTX, whose limits do not include 1280x720.
+    await act(async () => {
+      setSelect(document.body.querySelector(".settings-field-model select"), "ltx_2_3");
+    });
+    await act(async () => {});
+
+    expect(modelSelectValue()).toBe("ltx_2_3");
+    const snap = readSnapshot("video");
+    expect(snap.model).toBe("ltx_2_3");
+    // LTX declares defaults.resolution "768x512" and no resolution list → the invalid restored
+    // 1280x720 snaps to that default rather than lingering.
+    expect(snap.resolution).toBe("768x512");
   });
 });


### PR DESCRIPTION
## S4 — Studio persistence + injection regression tests (sc-11963)

Locks the epic's persistence + injection guarantees by **filling the gaps** left
by the S1 / S3 / S5 suites, without duplicating what they already cover.

### Audit of existing coverage (before this PR)
- **S1** `App.keepAlive.test.jsx` — nav round-trip keep-alive (same node, edits survive, no re-hydrate), project-switch remount, recipe injection on a mounted studio, general-preset stack toggle on a mounted studio.
- **S3** `screens/studioRestore.test.jsx` — restart-restore does NOT clobber a restored snapshot when model/LoRA/preset catalogs resolve async after mount (image + video, several orderings).
- **S5** `App.videoPresets.test.jsx` — restart-restore of the video source/reference/character/person-track selection fields, plus dangling-selection pruning.

### Gaps filled

**Gap 1 — post-load USER model change STILL resets (the flip side of the S3 fix)** — *newly added*
`screens/studioRestore.test.jsx`:
- **Image**: once catalogs are loaded and the restore has settled, a genuine user model change (FLUX → Z-Image) STILL resets reference tuning (`ipAdapterScale` 0.85 → 0.6) **and** advanced defaults (resolution 1536×1536 → 1024×1024, sampler `dpmpp_2m` → `default`). The existing tests only lock that async catalog snaps *don't* reset; this locks that real user changes *do*.
- **Video**: a genuine post-load user model change snaps a now-invalid restored resolution (WAN 1280×720 → LTX default 768×512).

**Gap 3 — stale launch token not re-applied on nav round trip** — *newly added*
`App.keepAlive.test.jsx`: after injecting a recipe and then editing the prompt over it, a nav round trip keeps the studio mounted (same node) and the edit survives — the already-consumed launch token does not re-fire and clobber the edit. (localStorage is cleared first so a hypothetical remount could not re-hydrate the value.)

### Already covered — no new tests added (verified during audit)
- **Gap 2** injection on a kept-alive studio: recipe re-fire **and** general-preset stack toggle are both already in `App.keepAlive.test.jsx`.
- **Gap 4** restart-restore completeness: image settings + LoRAs + base preset + general stack in `studioRestore.test.jsx`; video selection fields in `App.videoPresets.test.jsx`.

### Tests
- +3 tests (2 in `studioRestore.test.jsx`, 1 in `App.keepAlive.test.jsx`).
- Full web suite green: **130 files, 1746 tests** (`vitest run --environment jsdom`).
- Web-only; no Rust touched.

sc-11963

🤖 Generated with [Claude Code](https://claude.com/claude-code)