### PR TITLE
chore(web): pause expensive work for hidden kept-alive screens (sc-11961)

### DIFF
--- a/apps/web/src/components/WorkerProgressCard.jsx
+++ b/apps/web/src/components/WorkerProgressCard.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { actionStatuses, terminalStatuses } from "../jobTypes.js";
 import { formatSeconds, liveElapsedSeconds, percent } from "../formatting.js";
 import { useAppLive } from "../context/AppContext.js";
+import { useScreenActive } from "../context/ScreenActiveContext.js";
 import { deriveWorkerHardware, findWorkerForJob, liveMeters } from "../workers.js";
 import { AssetMedia, AssetThumbnail, assetUrl, posterUrl, suppressThumbnailContextMenu } from "./assetMedia.jsx";
 import { LikenessBadge } from "./LikenessBadge.jsx";
@@ -10,15 +11,26 @@ import { LikenessBadge } from "./LikenessBadge.jsx";
 // sc-2093 cleanup deleted the legacy JobProgress.jsx that originally housed it.
 export function useLiveJobElapsedSeconds(job) {
   const active = !terminalStatuses.has(job.status) && Boolean(job.startedAt);
+  // sc-11961 (S2): this card renders inside kept-alive studios (Image/Video/Document/
+  // Training/Character). Under keep-alive a studio stays mounted while hidden, so its
+  // in-flight job cards would otherwise keep this 1s timer ticking in the background —
+  // and with several studios visited, several timers would run concurrently. Gate the
+  // interval on the screen being the foreground view. `useScreenActive()` defaults to
+  // true outside a KeepAlivePane, so the OUT screens that render this card (Queue, Model
+  // Manager, Setup Wizard) are unaffected.
+  const screenActive = useScreenActive();
   const [nowMs, setNowMs] = useState(() => Date.now());
 
   useEffect(() => {
-    if (!active) {
+    if (!active || !screenActive) {
       return undefined;
     }
+    // Snap to the current time immediately so a card that just became visible again
+    // shows the correct elapsed value without waiting for the first 1s tick.
+    setNowMs(Date.now());
     const timer = window.setInterval(() => setNowMs(Date.now()), 1000);
     return () => window.clearInterval(timer);
-  }, [active, job.startedAt]);
+  }, [active, screenActive, job.startedAt]);
 
   return liveElapsedSeconds(job, nowMs);
 }

--- a/apps/web/src/components/WorkerProgressCard.test.jsx
+++ b/apps/web/src/components/WorkerProgressCard.test.jsx
@@ -1,8 +1,14 @@
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { WorkerProgressCard, deriveJobTitle, getJobTypeChip } from "./WorkerProgressCard.jsx";
+import {
+  WorkerProgressCard,
+  deriveJobTitle,
+  getJobTypeChip,
+  useLiveJobElapsedSeconds,
+} from "./WorkerProgressCard.jsx";
 import { AppContext } from "../context/AppContext.js";
+import { ScreenActiveContext } from "../context/ScreenActiveContext.js";
 import { buildWorkersById } from "../workers.js";
 
 const cudaWorker = {
@@ -596,5 +602,131 @@ describe("WorkerProgressCard thumbnails", () => {
     const placeholder = api.container.querySelector(".asset-thumb-missing");
     expect(placeholder).not.toBeNull();
     expect(placeholder.getAttribute("aria-label")).toBe("Deleted asset");
+  });
+});
+
+// sc-11961 (S2): the live elapsed-seconds timer is the one piece of WorkerProgressCard
+// that runs continuously (a 1s setInterval) while an in-flight job's card is mounted.
+// Under keep-alive a studio stays mounted while backgrounded, so without gating each
+// visited studio's in-flight card would keep ticking — several concurrent timers doing
+// hidden work. These tests assert the interval only runs when the card's screen is the
+// foreground view (ScreenActiveContext=true) and that no timer is created for hidden
+// (backgrounded) kept-alive screens.
+describe("useLiveJobElapsedSeconds keep-alive gating (sc-11961)", () => {
+  const runningJob = {
+    id: "job-elapsed",
+    type: "image_generate",
+    status: "running",
+    startedAt: "2026-05-28T12:00:00Z",
+    elapsedSeconds: 0,
+  };
+
+  // Minimal probe that surfaces the hook's return value into the DOM so we can read it.
+  function ElapsedProbe({ job }) {
+    const seconds = useLiveJobElapsedSeconds(job);
+    return <span data-testid="elapsed">{seconds}</span>;
+  }
+
+  let roots;
+  let priorActEnv;
+
+  beforeEach(() => {
+    priorActEnv = global.IS_REACT_ACT_ENVIRONMENT;
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-28T12:00:05Z"));
+    roots = [];
+  });
+
+  afterEach(() => {
+    act(() => roots.forEach(({ root }) => root.unmount()));
+    roots.forEach(({ container }) => container.remove());
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    global.IS_REACT_ACT_ENVIRONMENT = priorActEnv;
+  });
+
+  function mount(active) {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <ScreenActiveContext.Provider value={active}>
+          <ElapsedProbe job={runningJob} />
+        </ScreenActiveContext.Provider>,
+      );
+    });
+    const entry = { container, root };
+    roots.push(entry);
+    return entry;
+  }
+
+  function elapsed(entry) {
+    return Number(entry.container.querySelector("[data-testid='elapsed']").textContent);
+  }
+
+  it("ticks the elapsed timer only for the ACTIVE (foreground) screen", () => {
+    const activeEntry = mount(true);
+    const hiddenEntry = mount(false);
+
+    // Both start at 5s elapsed (system time is 5s past startedAt).
+    expect(elapsed(activeEntry)).toBe(5);
+    expect(elapsed(hiddenEntry)).toBe(5);
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    // Active screen's interval advanced the clock; hidden screen stayed frozen —
+    // no continuous work ran for the backgrounded card.
+    expect(elapsed(activeEntry)).toBe(8);
+    expect(elapsed(hiddenEntry)).toBe(5);
+  });
+
+  it("creates NO interval for a hidden kept-alive screen, and no duplicates across many mounted screens", () => {
+    const setIntervalSpy = vi.spyOn(window, "setInterval");
+
+    // One active + three hidden (as if four studios were all visited and kept alive).
+    mount(true);
+    mount(false);
+    mount(false);
+    mount(false);
+
+    // Exactly one interval exists — only the foreground card runs its loop. The three
+    // hidden kept-alive cards create none, so mounting many screens does not multiply
+    // the background work.
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts an interval when a hidden screen becomes active again (resume on re-show)", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    roots.push({ container, root });
+
+    act(() => {
+      root.render(
+        <ScreenActiveContext.Provider value={false}>
+          <ElapsedProbe job={runningJob} />
+        </ScreenActiveContext.Provider>,
+      );
+    });
+    // Hidden: frozen at 5s even after time passes.
+    act(() => vi.advanceTimersByTime(2000));
+    expect(Number(container.querySelector("[data-testid='elapsed']").textContent)).toBe(5);
+
+    // Re-show: the effect re-runs, snaps to the current time (now 7s past start), and
+    // resumes ticking.
+    act(() => {
+      root.render(
+        <ScreenActiveContext.Provider value={true}>
+          <ElapsedProbe job={runningJob} />
+        </ScreenActiveContext.Provider>,
+      );
+    });
+    expect(Number(container.querySelector("[data-testid='elapsed']").textContent)).toBe(7);
+    act(() => vi.advanceTimersByTime(1000));
+    expect(Number(container.querySelector("[data-testid='elapsed']").textContent)).toBe(8);
   });
 });

--- a/apps/web/src/screens/EditorScreen.jsx
+++ b/apps/web/src/screens/EditorScreen.jsx
@@ -13,6 +13,7 @@ import {
   transitionOptions,
 } from "../timeline.js";
 import { useAppStatic } from "../context/AppContext.js";
+import { useScreenActive } from "../context/ScreenActiveContext.js";
 
 export function EditorScreen() {
   const {
@@ -51,6 +52,11 @@ export function EditorScreen() {
   const [extensionDuration, setExtensionDuration] = useState(4);
   const [timelineNotice, setTimelineNotice] = useState("");
   const previewVideoRef = useRef(null);
+  // sc-11961 (S2): under keep-alive this editor stays mounted while backgrounded, so it
+  // can no longer rely on unmount to stop preview playback. `screenActive` is false when
+  // another view is foregrounded; the playback effect below gates on it so a hidden
+  // editor does no continuous video decode/audio work.
+  const screenActive = useScreenActive();
 
   const selectedItem = useMemo(() => {
     if (!activeTimeline) {
@@ -84,12 +90,16 @@ export function EditorScreen() {
       setIsPlaying(false);
       return;
     }
-    if (isPlaying) {
+    // Only drive playback while this is the foreground view (sc-11961). When the editor
+    // is backgrounded under keep-alive, pause instead — the <video>'s pause event flips
+    // isPlaying off (onPause), so re-showing the editor lands paused rather than silently
+    // resuming audio/decode work that ran while hidden.
+    if (isPlaying && screenActive) {
       video.play().catch(() => setIsPlaying(false));
       return;
     }
     video.pause();
-  }, [isPlaying, selectedAsset?.id]);
+  }, [isPlaying, selectedAsset?.id, screenActive]);
 
   // Keep the global keydown listener mounted once and read live editor state
   // through a ref, so undo/redo/delete don't re-bind window on every history

--- a/apps/web/src/screens/EditorScreen.test.jsx
+++ b/apps/web/src/screens/EditorScreen.test.jsx
@@ -8,6 +8,7 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AppContext } from "../context/AppContext.js";
+import { ScreenActiveContext } from "../context/ScreenActiveContext.js";
 import { EditorScreen } from "./EditorScreen.jsx";
 
 function makeTimeline(id, name) {
@@ -103,5 +104,123 @@ describe("EditorScreen timeline re-select guard (sc-11967)", () => {
 
     expect(confirmSpy).toHaveBeenCalledTimes(1);
     expect(setSelectedTimelineId).toHaveBeenCalledWith("tl_2");
+  });
+});
+
+// sc-11961 (S2): under keep-alive the editor stays mounted while another view is
+// foregrounded. Its one continuous piece of work is preview playback (video.play()).
+// These tests assert the play effect only drives the <video> when the screen is the
+// active view, and pauses (does no playback work) while hidden.
+describe("EditorScreen preview playback keep-alive gating (sc-11961)", () => {
+  function makeVideoAsset() {
+    return {
+      id: "asset_v1",
+      type: "video",
+      displayName: "Clip A",
+      url: "/api/v1/files/v1.mp4",
+      file: { mimeType: "video/mp4", duration: 4 },
+    };
+  }
+
+  function makeTimelineWithVideoItem() {
+    return {
+      id: "tl_1",
+      name: "Main",
+      aspectRatio: "16:9",
+      fps: 30,
+      width: 1280,
+      height: 720,
+      tracks: [
+        {
+          id: "track_main",
+          name: "Main",
+          items: [
+            {
+              id: "item_1",
+              trackId: "track_main",
+              assetId: "asset_v1",
+              type: "video",
+              displayName: "Clip A",
+              sourceIn: 0,
+              sourceOut: 4,
+              timelineStart: 0,
+              timelineEnd: 4,
+              speed: 1,
+              fit: "fit",
+              volume: 1,
+              versionAssetIds: ["asset_v1"],
+              currentVersionAssetId: "asset_v1",
+              versionHistory: [{ assetId: "asset_v1", createdAt: null, source: "original", jobId: null, note: null }],
+              transitionIn: { id: "t_in", type: "cut", duration: 0 },
+              transitionOut: { id: "t_out", type: "cut", duration: 0 },
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  function renderEditor(screenActive) {
+    const timeline = makeTimelineWithVideoItem();
+    const value = {
+      activeProject: { id: "proj_1", name: "Proj" },
+      activeTimeline: timeline,
+      mediaAssets: [makeVideoAsset()],
+      timelines: [timeline],
+      selectedTimelineId: "tl_1",
+      setSelectedTimelineId: vi.fn(),
+      setActiveTimeline: vi.fn(),
+      setPreviewAsset: vi.fn(),
+      sendAssetToImage: vi.fn(),
+      sendAssetToVideo: vi.fn(),
+      createTimeline: vi.fn(),
+      extractTimelineFrame: vi.fn(),
+      exportTimeline: vi.fn(),
+      queueTimelineVideoJob: vi.fn(),
+      saveTimeline: vi.fn(),
+      isActiveTimelineDirty: () => false,
+    };
+    root = createRoot(container);
+    act(() => {
+      root.render(
+        <AppContext.Provider value={value}>
+          <ScreenActiveContext.Provider value={screenActive}>
+            <EditorScreen />
+          </ScreenActiveContext.Provider>
+        </AppContext.Provider>,
+      );
+    });
+  }
+
+  // Select the timeline clip (renders the preview <video>) then click Play.
+  function selectClipAndPressPlay() {
+    const clip = container.querySelector(".timeline-item");
+    act(() => clip.dispatchEvent(new window.MouseEvent("click", { bubbles: true })));
+    const playButton = container.querySelector(".playback-bar button");
+    act(() => playButton.dispatchEvent(new window.MouseEvent("click", { bubbles: true })));
+  }
+
+  it("plays the preview when it is the ACTIVE view", () => {
+    const play = vi.spyOn(window.HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
+    // Stub pause too (jsdom's is unimplemented); the effect pauses once on selection.
+    vi.spyOn(window.HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+
+    renderEditor(true);
+    selectClipAndPressPlay();
+
+    expect(play).toHaveBeenCalled();
+  });
+
+  it("does NOT play (only pauses) while the editor is HIDDEN under keep-alive", () => {
+    const play = vi.spyOn(window.HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
+    const pause = vi.spyOn(window.HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+
+    renderEditor(false);
+    selectClipAndPressPlay();
+
+    // Pressing Play flips isPlaying, but the hidden screen's effect refuses to drive the
+    // <video>: play is never invoked and the element is kept paused — no background decode.
+    expect(play).not.toHaveBeenCalled();
+    expect(pause).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## S2 — Pause expensive work for hidden kept-alive screens (sc-11961)

Part of the screen-state-persistence epic. S1 keep-alive is merged: the creative screens now stay **mounted (hidden)** across navigation instead of unmounting, so their effects keep running. `context/ScreenActiveContext.js` exposes `useScreenActive()` (false when the screen is not the foreground view). This slice consumes that signal to pause the continuous, mount-driven work so a backgrounded screen does no ongoing work, and audits for any duplicate live subscriptions that keep-alive might have introduced.

### What runs continuously in kept-alive screens (the audit)

I grepped every kept-alive screen (Image/Video/Character/Document/Training studios, Data Sets, Presets, Pose/Key Point libraries, Video Editor, Image Editor) and their rendered components for `requestAnimationFrame` / `setInterval` / recursive `setTimeout` / `new EventSource` / autoplay. Only **two** are continuous work tied to a screen staying mounted:

1. **Video Editor preview playback** (`EditorScreen.jsx`) — `video.play()` while `isPlaying`. **Gated:** the play effect now only drives the `<video>` when `useScreenActive()` is true; a hidden editor pauses instead. The pause event flips `isPlaying` off, so re-showing lands paused (no silent resume of audio/decode).
2. **Live elapsed-seconds timer** (`WorkerProgressCard.useLiveJobElapsedSeconds`) — a 1s `setInterval` per in-flight job card. This card renders inside the kept-alive studios (Image/Video/Document/Training/Character), so without gating each *visited* studio's in-flight card would keep a timer ticking — several concurrent 1s timers doing hidden work. **Gated:** the interval only runs when the card's screen is the foreground view; it snaps `nowMs` to now on re-show (light refresh). `useScreenActive()` defaults to `true` outside a `KeepAlivePane`, so the OUT screens that also render this card (Queue, Model Manager, Setup Wizard) are unaffected.

Not gated (intentionally, with reasoning):
- `ImageEditor.jsx` (Konva) — the `batchDraw()` calls are reactive one-shot redraws from transform/color-grade/box tools; there is **no** `Konva.Animation`/`Tween` or continuous ticker. **No continuous work** — nothing to gate.
- `generationStudio.jsx` completed-result settling `setTimeout` — a bounded, self-terminating fallback that stops within the fallback window once the asset renders. Not continuous.
- `CharacterStudio` `requestAnimationFrame` — a one-shot focus-after-tab-change, not a loop.
- `App.jsx` RAF/`setInterval(…,32)` — App-level WKWebView repaint pump armed on a file-dialog click with a 60s deadline; global and self-limiting, not per-screen.

### Duplicate SSE / polling audit

The only `EventSource` in the web app lives in `hooks/useJobEvents.js` and is consumed **solely by `App.jsx`** (App-level / global job feed). No kept-alive screen opens its own `EventSource` or per-screen polling interval, so keep-alive introduced **no duplicate live subscriptions**. The reconnect/backoff timers in `useJobEvents` and the token-refresh loop in `useAccessGate` are likewise App-level singletons. `LogsScreen`/`SettingsScreen` intervals belong to OUT screens that still unmount on navigation.

### Tests
- `EditorScreen.test.jsx`: asserts the preview `play()` runs only when the screen is active, and is **never** invoked while hidden (element kept paused).
- `WorkerProgressCard.test.jsx`: asserts the elapsed interval ticks only for the active screen, creates **zero** intervals across several hidden mounted screens (no duplication), and resumes/refreshes on re-show.
- Full web suite green: **130 files / 1748 tests** (`vitest run --environment jsdom`).

### Acceptance
- [x] With multiple kept-alive screens mounted, only the ACTIVE one runs its animation/timer loop (asserted via spies + a screen-active gate).
- [x] No duplicate `EventSource`/interval created for multiple mounted kept-alive screens (asserted count for the interval; documented that the single SSE is App-level).
- [x] A hidden kept-alive screen does no continuous work (playback paused; elapsed timer stopped).

Shortcut: sc-11961

🤖 Generated with [Claude Code](https://claude.com/claude-code)