### PR TITLE
fix(web): reference-tuning defaults apply on fresh late-catalog mount (sc-12034)

### DIFF
--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -1026,6 +1026,39 @@ export function ImageStudio() {
     // (sc-10165 B4); the picker re-fetches for the new backbone.
     setControlOverlayId(null);
   }, [model]);
+  // sc-12034: On a FRESH mount (no restored snapshot) whose model catalog arrives AFTER mount, the
+  // reset effect above ran once with an empty `ui` (the catalog hadn't surfaced the model yet) and
+  // settled the reference-tuning knobs at the model-agnostic fallbacks (0.6 / 0.8 / 4.0). Because
+  // the fallback model id is a valid installed model that never changes, `model` never changes and
+  // that effect never re-fires — so the model's DECLARED defaults are never applied. Re-apply them
+  // ONCE, the first time the selected model actually resolves in the catalog.
+  //
+  // Fresh-mount ONLY: a restored snapshot seeds this disarmed (its tuning is authoritative and must
+  // survive, mirroring the `referenceTuningModel` seed above), and the recipe path disarms it too
+  // (it injects its own tuning). Mirrors the declared-default writes above; the clears
+  // (viewAngle / poses / control image) are omitted because on a fresh mount they are already at
+  // their initial values and the model never changed, so there is nothing stale to clear.
+  const referenceTuningDeclaredArmed = useRef(saved.ipAdapterScale == null);
+  useEffect(() => {
+    if (!referenceTuningDeclaredArmed.current) {
+      return;
+    }
+    const resolved = imageModels.find((item) => item.id === model);
+    if (!resolved) {
+      return; // Catalog hasn't surfaced this model yet — wait for it to arrive.
+    }
+    referenceTuningDeclaredArmed.current = false;
+    if (skipReferenceTuningReset.current) {
+      // A recipe/preset injection is applying its own tuning in this same commit — don't override it.
+      return;
+    }
+    const ui = resolved.ui ?? {};
+    setIpAdapterScale(typeof ui.referenceStrengthDefault === "number" ? ui.referenceStrengthDefault : 0.6);
+    setControlnetScale(typeof ui.identityStructure?.default === "number" ? ui.identityStructure.default : 0.8);
+    setTrueCfgScale(typeof ui.variationStrength?.default === "number" ? ui.variationStrength.default : 4.0);
+    setControlScale(typeof ui.controlScale?.default === "number" ? ui.controlScale.default : null);
+    setTextStyleGain(typeof ui.textStyleGain?.default === "number" ? ui.textStyleGain.default : 1.0);
+  }, [model, imageModels]);
   // Approved reference images for the selected character (the IP-Adapter identity
   // source). Resolve the full asset from the catalog so thumbnails render even when
   // the character payload only carries assetIds.
@@ -1442,6 +1475,10 @@ export function ImageStudio() {
     );
 
     skipReferenceTuningReset.current = true;
+    // A recipe injects its own reference tuning below (setIpAdapterScale/…), so disarm the
+    // fresh-mount declared-defaults resolver (sc-12034) — it must not overwrite the recipe values
+    // once the catalog resolves, even on a late-catalog mount where `skip*` was already consumed.
+    referenceTuningDeclaredArmed.current = false;
     setSelectedPresetId(noPresetId);
     setMode(nextMode);
     if (recipe.model) {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -183,6 +183,18 @@ const TIER_SCREEN = "image";
 // character share the text_to_image workflow.
 const IMAGE_MODES = ["text_to_image", "edit_image", "character_image"];
 
+// sc-12034: the reference-tuning knobs the fresh-mount declared-defaults resolver owns (see the
+// resolver + the recipe disarm below). A recipe or a saved preset that injects any of these must
+// disarm that resolver so its injected values survive the async catalog arrival instead of being
+// overwritten by the selected model's DECLARED defaults once the catalog resolves.
+const REFERENCE_TUNING_PRESET_KEYS = [
+  "ipAdapterScale",
+  "controlnetScale",
+  "trueCfgScale",
+  "controlScale",
+  "textStyleGain",
+];
+
 // Above this many resolved images a batch run needs explicit confirmation, so a stray
 // value or an over-eager cross-product can't silently queue a huge job (sc-9957).
 const BATCH_RENDER_CAP = 100;
@@ -1720,6 +1732,16 @@ export function ImageStudio() {
       // prompt won't clobber the restored prompt.
       if (Object.prototype.hasOwnProperty.call(defaults, "prompt")) {
         promptEdited.current = true;
+      }
+      // sc-12034: a saved preset that carries its own reference-tuning (a character-mode preset
+      // stores ipAdapterScale / controlnetScale / trueCfgScale — see buildDefaults) must be
+      // protected exactly like a recipe (the disarm at the recipe injection below). If the preset
+      // resolves in the narrow window BEFORE the model catalog first surfaces the model, disarm the
+      // fresh-mount declared-defaults resolver so it can't overwrite the applied preset tuning when
+      // the catalog arrives on a later render. Only disarm when the preset actually carries a tuning
+      // key — a preset with no tuning must still let the model's DECLARED defaults resolve.
+      if (REFERENCE_TUNING_PRESET_KEYS.some((key) => Object.prototype.hasOwnProperty.call(defaults, key))) {
+        referenceTuningDeclaredArmed.current = false;
       }
     },
     buildDefaults: () => ({

--- a/apps/web/src/screens/studioRestore.test.jsx
+++ b/apps/web/src/screens/studioRestore.test.jsx
@@ -563,4 +563,109 @@ describe("reference-tuning declared defaults apply on a fresh late-catalog mount
     expect(snap.controlnetScale).toBe(0.31);
     expect(snap.trueCfgScale).toBe(2.5);
   });
+
+  // ---- The epic's HARD CONSTRAINT: a recipe/preset injection is NEVER clobbered -------------
+  // The fresh-mount resolver exists to fill in the model's declared defaults, but it must yield
+  // to any injected tuning. The recipe path already carries the model-change `skip*` guard, but
+  // that guard is CONSUMED during the injection commit when the recipe sets a model different from
+  // the fresh-mount fallback — so the ONLY thing protecting the recipe's values when the catalog
+  // resolves on a later render is the declared-defaults resolver being disarmed at the recipe path
+  // (ImageStudio.jsx). Deleting that disarm makes this test go red (verified), which is exactly the
+  // regression the epic forbids.
+  const FLUX_TUNED = {
+    ...FLUX,
+    ui: {
+      referenceStrengthDefault: 0.75,
+      identityStructure: { default: 0.9 },
+      variationStrength: { default: 6 },
+    },
+  };
+
+  it("does NOT clobber a recipe's injected reference tuning on a late-catalog mount", async () => {
+    const recipeLaunch = {
+      id: "recipe-launch-1",
+      view: "Image",
+      recipe: {
+        // A model DIFFERENT from the z_image_turbo fallback → the model actually changes during the
+        // injection commit, which consumes the model-change `skip*` guard. That leaves the
+        // declared-defaults resolver's disarm as the sole protector once the catalog lands.
+        model: "flux2_dev",
+        prompt: "a recipe prompt",
+        loras: [],
+        normalizedSettings: {},
+        rawAdapterSettings: { ipAdapterScale: 0.33, controlnetScale: 0.22, trueCfgScale: 1.5 },
+      },
+    };
+    // Fresh mount (no snapshot). First render: the recipe injects its tuning + model while the
+    // catalog is empty. Second render: the catalog arrives CONTAINING flux2_dev, which declares its
+    // OWN distinct defaults (0.75 / 0.9 / 6) — the resolver must leave the recipe's values alone.
+    await renderSequence(ImageStudio, [
+      imageContext({ studioLaunch: recipeLaunch }),
+      imageContext({ studioLaunch: recipeLaunch, imageModels: [FLUX_TUNED], models: [FLUX_TUNED] }),
+    ]);
+
+    expect(modelSelectValue()).toBe("flux2_dev");
+    const snap = readSnapshot("image");
+    // The recipe's injected tuning, NOT flux2_dev's declared 0.75 / 0.9 / 6.
+    expect(snap.ipAdapterScale).toBe(0.33);
+    expect(snap.controlnetScale).toBe(0.22);
+    expect(snap.trueCfgScale).toBe(1.5);
+  });
+
+  // Issue-2 companion: a saved preset that carries its OWN reference tuning (a character-mode preset
+  // stores ipAdapterScale / controlnetScale / trueCfgScale) gets the same protection as a recipe.
+  // When the PRESET catalog resolves BEFORE the MODEL catalog, the preset-apply pass injects the
+  // preset's tuning while the resolver is still armed (the model hasn't surfaced yet); the disarm in
+  // the preset-apply path (onApplyDefaults, ImageStudio.jsx) must keep the resolver from overwriting
+  // it when the model catalog lands on a later render.
+  const Z_IMAGE_CHAR = {
+    ...Z_IMAGE,
+    capabilities: ["text_to_image", "character_image"],
+    ui: {
+      referenceStrengthDefault: 0.75,
+      identityStructure: { default: 0.9 },
+      variationStrength: { default: 6 },
+    },
+  };
+  const CHAR_PRESET_TUNED = {
+    id: "char-tuned",
+    name: "Char Tuned",
+    kind: "model",
+    scope: "global",
+    workflow: "character_image",
+    modes: ["character_image"],
+    model: "z_image_turbo",
+    loras: [],
+    defaults: { mode: "character_image", ipAdapterScale: 0.28, controlnetScale: 0.19, trueCfgScale: 1.7 },
+  };
+
+  it("does NOT clobber a saved preset's injected tuning when presets resolve before models", async () => {
+    const presetLaunch = {
+      id: "preset-launch-1",
+      view: "Image",
+      presetId: "char-tuned",
+      presetMode: "character_image",
+      presetModel: "z_image_turbo",
+    };
+    // Fresh mount. R1: empty catalogs; the launch selects the preset id + character mode.
+    // R2: the PRESET catalog arrives (models STILL empty) → the preset-apply pass injects its tuning
+    // while the resolver is armed. R3: the MODEL catalog arrives → the resolver must stay disarmed.
+    await renderSequence(ImageStudio, [
+      imageContext({ studioLaunch: presetLaunch }),
+      imageContext({ studioLaunch: presetLaunch, presets: [CHAR_PRESET_TUNED] }),
+      imageContext({
+        studioLaunch: presetLaunch,
+        presets: [CHAR_PRESET_TUNED],
+        imageModels: [Z_IMAGE_CHAR],
+        models: [Z_IMAGE_CHAR],
+      }),
+    ]);
+
+    expect(modelSelectValue()).toBe("z_image_turbo");
+    const snap = readSnapshot("image");
+    // The preset's injected tuning, NOT z_image_turbo's declared 0.75 / 0.9 / 6.
+    expect(snap.ipAdapterScale).toBe(0.28);
+    expect(snap.controlnetScale).toBe(0.19);
+    expect(snap.trueCfgScale).toBe(1.7);
+  });
 });

--- a/apps/web/src/screens/studioRestore.test.jsx
+++ b/apps/web/src/screens/studioRestore.test.jsx
@@ -475,3 +475,92 @@ describe("studio restart-restore does not clobber the restored snapshot (sc-1196
     expect(snap.resolution).toBe("768x512");
   });
 });
+
+// sc-12034 — the OTHER late-catalog corner (pre-existing, not introduced by S3): on a FRESH
+// mount (NO saved snapshot) whose model catalog arrives AFTER mount, the reference-tuning knobs
+// (ipAdapterScale / controlnetScale / trueCfgScale …) can settle at the model-agnostic fallbacks
+// (0.6 / 0.8 / 4.0) instead of the model's DECLARED defaults. `model` initializes to the hardcoded
+// fallback id while the catalog is empty; when the catalog arrives it CONTAINS that id (a valid
+// installed model), so the model id never changes and the model-change reset never re-fires — the
+// declared defaults are never applied. The fix re-applies them the first time the model resolves,
+// but ONLY on a fresh mount (a restored snapshot's tuning, and a recipe's injected tuning, survive).
+describe("reference-tuning declared defaults apply on a fresh late-catalog mount (sc-12034)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  async function renderSequence(Studio, contexts) {
+    for (const ctx of contexts) {
+      await act(async () => {
+        root.render(
+          <AppContext.Provider value={ctx}>
+            <Studio />
+          </AppContext.Provider>,
+        );
+      });
+      await act(async () => {});
+    }
+  }
+
+  // The fallback model id ("z_image_turbo" — ImageStudio's hardcoded default) that a fresh mount
+  // lands on before any catalog loads. It DECLARES its own reference-tuning defaults, distinct from
+  // the generic 0.6 / 0.8 / 4.0, so a knob left at the generic value proves the declared default
+  // was never applied.
+  const Z_IMAGE_TUNED = {
+    ...Z_IMAGE,
+    ui: {
+      referenceStrengthDefault: 0.75,
+      identityStructure: { default: 0.9 },
+      variationStrength: { default: 6 },
+    },
+  };
+
+  it("applies the model's DECLARED reference-tuning defaults, not the generic fallbacks", async () => {
+    // No seeded snapshot → fresh mount. First render: empty catalog (model = fallback id).
+    // Second render: the catalog arrives and CONTAINS that same id, so the id never changes.
+    await renderSequence(ImageStudio, [
+      imageContext(),
+      imageContext({ imageModels: [Z_IMAGE_TUNED], models: [Z_IMAGE_TUNED] }),
+    ]);
+
+    expect(modelSelectValue()).toBe("z_image_turbo");
+    const snap = readSnapshot("image");
+    // Declared defaults, NOT the generic 0.6 / 0.8 / 4.0.
+    expect(snap.ipAdapterScale).toBe(0.75);
+    expect(snap.controlnetScale).toBe(0.9);
+    expect(snap.trueCfgScale).toBe(6);
+  });
+
+  it("does NOT clobber a restored snapshot's tuning on a late-catalog mount", async () => {
+    // A restored snapshot (ipAdapterScale present) is authoritative — the fresh-mount resolver must
+    // stay disarmed so the restored value survives the async catalog arrival, even though the model
+    // id (z_image_turbo) is stable and would otherwise look like a fresh mount.
+    seedSnapshot("image", {
+      mode: "text_to_image",
+      model: "z_image_turbo",
+      ipAdapterScale: 0.42,
+      controlnetScale: 0.31,
+      trueCfgScale: 2.5,
+    });
+    await renderSequence(ImageStudio, [
+      imageContext(),
+      imageContext({ imageModels: [Z_IMAGE_TUNED], models: [Z_IMAGE_TUNED] }),
+    ]);
+
+    expect(modelSelectValue()).toBe("z_image_turbo");
+    const snap = readSnapshot("image");
+    expect(snap.ipAdapterScale).toBe(0.42);
+    expect(snap.controlnetScale).toBe(0.31);
+    expect(snap.trueCfgScale).toBe(2.5);
+  });
+});


### PR DESCRIPTION
## Story
[sc-12034](https://app.shortcut.com/scenewrks/story/12034) — S3 follow-up (pre-existing): reference-tuning defaults may settle generic on a fresh late-catalog mount. Discovered during S3 (sc-11962) review; **pre-existing** (identical to the old one-shot code, not introduced by S3). Relates to sc-11962.

## The bug
On a **fresh** `ImageStudio` mount (no saved localStorage snapshot) whose model catalog arrives **after** mount, the reference-tuning knobs (`ipAdapterScale` / `controlnetScale` / `trueCfgScale`, plus `controlScale` / `textStyleGain`) could settle at the model-agnostic fallbacks (0.6 / 0.8 / 4.0) instead of the selected model's **declared** defaults.

Why: the model-change reset effect (`ImageStudio.jsx` ~:1000) keys on the `model` *value*. On a fresh mount `model` initializes to the hardcoded fallback id (`z_image_turbo`) while the catalog is still empty, so that effect runs once with `ui = {}` and applies the generic fallbacks. When the catalog later arrives it *contains* that same id (a valid installed model), so the model value never changes — the reset effect never re-fires and the model's declared defaults are never applied.

(When the fallback id is *not* a valid installed model, the picker snaps `model` to a real one → the model value changes → the existing reset already fires. Only the stable-id case leaks.)

## The fix
A one-shot resolver effect keyed on `[model, imageModels]` that, on a **fresh mount only**, re-applies the model's declared reference-tuning defaults the first time the selected model actually resolves in the catalog, then disarms.

Scope preserved — it re-applies every knob the declared-default block seeds: `ipAdapterScale`, `controlnetScale`, `trueCfgScale`, `controlScale`, `textStyleGain`. (The clears — `viewAngle` / poses / control image — are intentionally omitted: on a fresh mount they're already at their initial values and the model never changed, so there's nothing stale to clear.)

## Why it does not clobber snapshots, recipes, or presets
- **Restored snapshot:** the resolver is armed only when `saved.ipAdapterScale == null` — the exact marker the existing `referenceTuningModel` seed uses. A restored snapshot always persists `ipAdapterScale` (the writer serializes it unconditionally, gated behind the sc-11962 ready gate), so the resolver stays disarmed and the restored tuning survives.
- **Recipe injection (the epic's HARD CONSTRAINT):** the recipe path sets `referenceTuningDeclaredArmed.current = false` alongside `skipReferenceTuningReset.current = true`, so it cannot override recipe-injected tuning even on a late-catalog mount where `skip*` was already consumed by the reset effect (which happens whenever the recipe sets a model different from the fresh-mount fallback).
- **Saved-preset apply (review follow-up):** a character-mode preset carries its own `ipAdapterScale` / `controlnetScale` / `trueCfgScale` (`presetDefaultFields` → `buildDefaults`). The preset-apply path (`useSavePreset` → `onApplyDefaults`) now disarms the resolver too, **but only when the applied preset actually carries a reference-tuning key** — a plain preset with no tuning still lets the model's declared defaults resolve. Without this, a preset applied in the narrow window before the model catalog first resolves would be overwritten when models land on a later render.

## Tests
Added to `apps/web/src/screens/studioRestore.test.jsx` (the sc-11962/11963 late-catalog family) the `sc-12034` describe block:
- **reproduction:** fresh mount, empty catalog first, then a catalog whose model declares non-generic tuning defaults and whose id is stable → asserts the knobs end at the declared defaults (0.75 / 0.9 / 6), not 0.6 / 0.8 / 4.0. Fails on `main` (`expected 0.6 to be 0.75`), passes with the fix.
- **snapshot guard:** a restored snapshot on the same stable-id late-catalog mount → asserts the restored tuning (0.42 / 0.31 / 2.5) survives (resolver stays disarmed).
- **HARD-CONSTRAINT guard (new):** a recipe launch whose model differs from the fallback (so `skip*` is consumed) injects tuning (0.33 / 0.22 / 1.5), then the catalog arrives containing that model with its own declared defaults → asserts the recipe's tuning survives. **Verified red** when the recipe disarm is deleted (`expected 0.33 to be 0.75`), green as-is.
- **preset guard (new):** a character-mode preset carrying tuning (0.28 / 0.19 / 1.7); the **preset** catalog resolves before the **model** catalog → asserts the preset's tuning survives the model catalog landing on a later render. **Verified red** without the `onApplyDefaults` disarm (`expected 0.28 to be 0.75`), green with it.

## Verification
- `studioRestore.test.jsx`: 11/11 pass (4 in the sc-12034 block).
- ImageStudio-adjacent suites (`ImageStudio.test.jsx`, `studioRestore`, `characterPanels.reference`): 80/80 pass.
- Full web suite: **1783/1783 pass** (132 files).
- `vite build`: succeeds.
- `eslint src`: 0 errors; the 4 `react-hooks/exhaustive-deps` warnings on `ImageStudio.jsx` are pre-existing (same set before this change, only line-shifted) — the new code adds no hooks and no warnings.

## Follow-ups
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
