### PR TITLE
refactor(web): field-level dirty detection in Character Studio (sc-11996)

### DIFF
--- a/apps/web/src/App.character.test.jsx
+++ b/apps/web/src/App.character.test.jsx
@@ -2167,4 +2167,131 @@ describe("SceneWorks app shell", () => {
     expect(field(container, "Name").value).toBe("Mira Updated");
   });
 
+  // sc-11996: dirty detection is FIELD-level, not whole-object. A background/SSE refresh
+  // syncs each untouched field while preserving only the fields the user actually edited —
+  // a single dirty field no longer freezes its untouched siblings.
+  it("field-level sync: an untouched name syncs while a dirty description is preserved (sc-11996)", async () => {
+    const baseChar = {
+      id: "char-1",
+      name: "Mira",
+      type: "person",
+      description: "",
+      references: [],
+      approvedReferences: [],
+      looks: [],
+      loras: [],
+      updatedAt: "t1",
+    };
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(withAppContext(characterStudioContext([{ ...baseChar }]), <CharacterStudio />));
+    });
+
+    // Dirty ONLY the description; leave the name untouched.
+    await changeField(field(container, "Notes"), "work in progress");
+
+    // A background refresh changes the untouched `name` (bumped updatedAt).
+    await act(async () => {
+      root.render(
+        withAppContext(characterStudioContext([{ ...baseChar, name: "Mira Updated", updatedAt: "t2" }]), <CharacterStudio />),
+      );
+    });
+
+    // The untouched sibling syncs; the dirty field is preserved.
+    expect(field(container, "Name").value).toBe("Mira Updated");
+    expect(field(container, "Notes").value).toBe("work in progress");
+  });
+
+  it("field-level sync: an untouched LoRA entry syncs while a dirty sibling entry is preserved (sc-11996)", async () => {
+    const baseChar = {
+      id: "char-1",
+      name: "Mira",
+      type: "person",
+      description: "",
+      references: [],
+      approvedReferences: [],
+      looks: [],
+      loras: [
+        { id: "lk1", name: "Kelsie", triggerWords: [], defaultWeight: 0.8, scope: "project" },
+        { id: "lk2", name: "Rowan", triggerWords: [], defaultWeight: 0.8, scope: "project" },
+      ],
+      updatedAt: "t1",
+    };
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(withAppContext(characterStudioContext([{ ...baseChar }]), <CharacterStudio />));
+    });
+
+    const weightInputs = () => [...document.body.querySelectorAll(".lora-editor input[type='number']")];
+    expect(weightInputs().map((input) => input.value)).toEqual(["0.8", "0.8"]);
+
+    // Dirty ONLY the first LoRA's weight.
+    await changeField(weightInputs()[0], "1.5");
+
+    // A background refresh changes the untouched second LoRA's weight (bumped updatedAt).
+    await act(async () => {
+      root.render(
+        withAppContext(
+          characterStudioContext([
+            { ...baseChar, loras: [{ ...baseChar.loras[0] }, { ...baseChar.loras[1], defaultWeight: 1.2 }], updatedAt: "t2" },
+          ]),
+          <CharacterStudio />,
+        ),
+      );
+    });
+
+    // The dirty entry is preserved; the untouched sibling entry syncs.
+    expect(weightInputs()[0].value).toBe("1.5");
+    expect(weightInputs()[1].value).toBe("1.2");
+  });
+
+  it("overall dirty + save: syncs untouched fields, preserves edits, and persists the merged draft (sc-11996)", async () => {
+    const updateCharacter = vi.fn();
+    const baseChar = {
+      id: "char-1",
+      name: "Mira",
+      type: "person",
+      description: "original",
+      references: [],
+      approvedReferences: [],
+      looks: [],
+      loras: [],
+      updatedAt: "t1",
+    };
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(withAppContext(characterStudioContext([{ ...baseChar }], { updateCharacter }), <CharacterStudio />));
+    });
+
+    // Dirty the description; leave the name untouched.
+    await changeField(field(container, "Notes"), "edited notes");
+
+    // A background refresh changes the untouched name.
+    await act(async () => {
+      root.render(
+        withAppContext(
+          characterStudioContext([{ ...baseChar, name: "Mira Updated", updatedAt: "t2" }], { updateCharacter }),
+          <CharacterStudio />,
+        ),
+      );
+    });
+
+    // Untouched field synced, edited field preserved — the draft is still dirty overall.
+    expect(field(container, "Name").value).toBe("Mira Updated");
+    expect(field(container, "Notes").value).toBe("edited notes");
+
+    // Saving persists the merged draft: the synced name plus the preserved edit.
+    await act(async () => {
+      container.querySelector(".character-editor button[type='submit']").click();
+    });
+    expect(updateCharacter).toHaveBeenCalledWith("char-1", {
+      name: "Mira Updated",
+      type: "person",
+      description: "edited notes",
+    });
+  });
+
 });

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -42,41 +42,86 @@ function typeLabel(value) {
   return characterTypes.find(([id]) => id === value)?.[1] ?? "Person";
 }
 
-// sc-11965: tell an untouched draft (safe to re-sync from the server) from an
-// in-progress edit (must be preserved) by comparing the current editable state to
-// the last snapshot we seeded from the server. Comparison is by value (not object
-// identity, which a background/SSE refetch always breaks) and whole-object: the
-// draft counts as clean only when every field still matches the last seed, so any
-// one edited field makes the entire draft compare dirty.
+// sc-11965 / sc-11996: tell an untouched *field* (safe to re-sync from the server)
+// from an in-progress edit (must be preserved) by comparing the current editable
+// state to the last snapshot we seeded from the server. Comparison is by value (not
+// object identity, which a background/SSE refetch always breaks). sc-11996 makes the
+// clean/dirty decision FIELD-level rather than whole-object: a single edited field no
+// longer freezes its untouched siblings — each untouched field re-syncs while only the
+// touched fields are preserved (see mergeDraft / mergeLoraEdits below).
+const DRAFT_FIELDS = ["name", "type", "description"];
+
+// Per-field draft equality (name/type/description each compared as text). Used only to
+// tell whether a *field* moved relative to the last seed.
+function draftFieldEqual(a, b, field) {
+  return (a?.[field] ?? "") === (b?.[field] ?? "");
+}
+
+// Whole-draft equality — the "overall dirty" primitive. The draft is clean overall only
+// when every field still matches the last seed, so any one edited field reads dirty
+// overall (preserved for the unsaved-guard semantics from S6).
 function draftsEqual(a, b) {
+  return DRAFT_FIELDS.every((field) => draftFieldEqual(a, b, field));
+}
+
+// Per-entry LoRA-edit equality (one link.id's editable fields). The weight input hands
+// back a string while the seed is a number, so compare weight as text.
+function loraEntryEqual(left, right) {
+  if (!left || !right) {
+    return left === right;
+  }
   return (
-    (a?.name ?? "") === (b?.name ?? "") &&
-    (a?.type ?? "") === (b?.type ?? "") &&
-    (a?.description ?? "") === (b?.description ?? "")
+    (left.name ?? "") === (right.name ?? "") &&
+    (left.triggerWords ?? "") === (right.triggerWords ?? "") &&
+    String(left.defaultWeight ?? "") === String(right.defaultWeight ?? "") &&
+    (left.families ?? "") === (right.families ?? "") &&
+    (left.scope ?? "") === (right.scope ?? "")
   );
 }
 
+// Whole-map LoRA-edit equality — the "overall dirty" primitive for the LoRA edits.
 function loraEditsEqual(a, b) {
   const aKeys = Object.keys(a ?? {});
   const bKeys = Object.keys(b ?? {});
   if (aKeys.length !== bKeys.length) {
     return false;
   }
-  return aKeys.every((key) => {
-    const left = a[key];
-    const right = b?.[key];
-    if (!left || !right) {
-      return left === right;
+  return aKeys.every((key) => loraEntryEqual(a[key], b?.[key]));
+}
+
+// Per-field merge (sc-11996): for each draft field, keep the user's current value when it
+// differs from the last seed (the field is dirty / in-progress), otherwise take the
+// incoming server value. So an untouched `name` still syncs from an SSE/updatedAt refresh
+// even while `description` is being edited, and vice-versa.
+function mergeDraft(current, seed, server) {
+  const merged = {};
+  for (const field of DRAFT_FIELDS) {
+    merged[field] = draftFieldEqual(current, seed, field) ? server?.[field] : current?.[field];
+  }
+  return merged;
+}
+
+// Per-entry merge (sc-11996): each LoRA edit is merged independently by link.id. A dirty
+// entry is preserved; every clean entry re-syncs from the server (including newly attached
+// LoRAs appearing and detached ones being dropped), so one edited LoRA no longer freezes
+// its untouched siblings.
+function mergeLoraEdits(current, seed, server) {
+  const merged = {};
+  const keys = new Set([...Object.keys(server ?? {}), ...Object.keys(current ?? {})]);
+  for (const key of keys) {
+    const dirty = !loraEntryEqual(current?.[key], seed?.[key]);
+    if (dirty) {
+      // Preserve the in-progress edit for this entry. (A dirty entry the server has since
+      // dropped is kept too — harmless, since the panel only renders server-linked LoRAs.)
+      if (current?.[key] !== undefined) {
+        merged[key] = current[key];
+      }
+    } else if (server?.[key] !== undefined) {
+      merged[key] = server[key];
     }
-    return (
-      (left.name ?? "") === (right.name ?? "") &&
-      (left.triggerWords ?? "") === (right.triggerWords ?? "") &&
-      // The weight input hands back a string; the seed is a number. Compare as text.
-      String(left.defaultWeight ?? "") === String(right.defaultWeight ?? "") &&
-      (left.families ?? "") === (right.families ?? "") &&
-      (left.scope ?? "") === (right.scope ?? "")
-    );
-  });
+    // Clean and absent from the server → the server dropped it, so leave it out.
+  }
+  return merged;
 }
 
 export function CharacterStudio() {
@@ -306,16 +351,17 @@ export function CharacterStudio() {
 
   // Seed the editable draft / LoRA edits from the selected character. A genuine
   // identity change (different id) always loads fresh. An `updatedAt` bump on the
-  // SAME character — a background/SSE refetch — re-syncs at object granularity, NOT
-  // per field: the whole draft is re-synced only while it is clean as a whole
-  // (name/type/description compared as a unit via draftsEqual), and the whole loraEdits
-  // map only while it is clean as a whole (loraEditsEqual over the entire map), so it
-  // never clobbers an in-progress, unsaved edit (sc-11965, "class B" clobber,
-  // independent of navigation). Because each check is whole-object, one dirty field
-  // holds its siblings too — a single edited field pins the entire draft (and one
-  // edited LoRA pins the entire loraEdits map) to the prior snapshot until saved.
-  // Reference-pick pruning stays unconditional since it only drops now-invalid ids, and
-  // the CharacterReferences panel keeps its own reference-pick guard (characterPanels.jsx:554).
+  // SAME character — a background/SSE refetch — re-syncs at FIELD granularity
+  // (sc-11996): each untouched field takes the incoming server value while only the
+  // fields the user has actually edited (relative to the last seed) are preserved, so
+  // it never clobbers an in-progress, unsaved edit (sc-11965, "class B" clobber,
+  // independent of navigation) yet a single dirty field no longer freezes its untouched
+  // siblings. The last-seed baseline records the SERVER snapshot each pass, so a field
+  // reads dirty exactly when it differs from the server truth we last observed — and
+  // because a preserved edit never matches that recorded server value, re-recording it
+  // can never later clobber the edit. Reference-pick pruning stays unconditional since it
+  // only drops now-invalid ids, and the CharacterReferences panel keeps its own
+  // reference-pick guard (characterPanels.jsx:554).
   useEffect(() => {
     if (!selectedCharacter) {
       setDraft({ name: "", type: "person", description: "" });
@@ -333,16 +379,16 @@ export function CharacterStudio() {
     const seeded = lastSeededRef.current;
     const identityChanged = !seeded || seeded.id !== selectedCharacter.id;
 
-    let seededDraft = seeded?.draft;
-    if (identityChanged || draftsEqual(draftRef.current, seeded.draft)) {
-      setDraft(serverDraft);
-      seededDraft = serverDraft;
+    const nextDraft = identityChanged ? serverDraft : mergeDraft(draftRef.current, seeded.draft, serverDraft);
+    if (identityChanged || !draftsEqual(nextDraft, draftRef.current)) {
+      setDraft(nextDraft);
     }
 
-    let seededLoraEdits = seeded?.loraEdits;
-    if (identityChanged || loraEditsEqual(loraEditsRef.current, seeded.loraEdits)) {
-      setLoraEdits(serverLoraEdits);
-      seededLoraEdits = serverLoraEdits;
+    const nextLoraEdits = identityChanged
+      ? serverLoraEdits
+      : mergeLoraEdits(loraEditsRef.current, seeded.loraEdits, serverLoraEdits);
+    if (identityChanged || !loraEditsEqual(nextLoraEdits, loraEditsRef.current)) {
+      setLoraEdits(nextLoraEdits);
     }
 
     setSelectedReferenceIds((ids) =>
@@ -352,13 +398,13 @@ export function CharacterStudio() {
       setTestLookId("");
     }
 
-    // Record what we last seeded so the next bump can classify clean vs dirty. Whatever
-    // we kept (a dirty draft or a dirty loraEdits map, each held as a whole) stays pinned
-    // to its prior snapshot, not the newer server value.
+    // Record the SERVER snapshot as the next clean baseline. A field then reads dirty
+    // exactly when the current editable value differs from this last-observed server truth;
+    // any edit we just preserved differs from it, so recording it can never clobber the edit.
     lastSeededRef.current = {
       id: selectedCharacter.id,
-      draft: seededDraft ?? serverDraft,
-      loraEdits: seededLoraEdits ?? serverLoraEdits,
+      draft: serverDraft,
+      loraEdits: serverLoraEdits,
     };
   }, [selectedCharacter?.id, selectedCharacter?.updatedAt]);
 


### PR DESCRIPTION
## What & why

S6 follow-up ([sc-11996](https://app.shortcut.com/sceneworks/story/11996)). Character Studio's reseed effect classified the editable draft as clean-or-dirty at **object granularity**:

- `draftsEqual` compared `name`/`type`/`description` as one unit
- `loraEditsEqual` compared the whole `loraEdits` map as one unit

so a single dirty field **froze its untouched siblings**: an external (SSE / `updatedAt`) change to an untouched sibling field would not sync into the draft while **any** sibling was dirty. Discovered during S6 (sc-11965) adversarial review. Low real-world impact (SceneWorks is primarily single-user desktop), filed per the address-findings policy, and this story exists to implement the improvement.

## Approach — per-field merge

Make the clean/dirty decision **field-level**:

- **Draft** (`mergeDraft`): for each of `name`/`type`/`description`, keep the user's current value when it differs from the last seed (dirty / in-progress), otherwise take the incoming server value.
- **LoRA edits** (`mergeLoraEdits`): each entry is merged independently by `link.id`. A dirty entry is preserved; every clean entry re-syncs from the server (newly attached LoRAs appear, detached ones drop). One edited LoRA no longer freezes its untouched siblings.

The last-seed baseline now records the **server snapshot** each pass, so a field reads dirty exactly when it differs from the last-observed server truth. Because a preserved edit never matches that recorded server value, re-recording the baseline can **never** later clobber the edit.

`draftsEqual` / `loraEditsEqual` are retained as whole-object primitives — used as the `setState` churn guard and as the "overall dirty" signal — so S6's non-clobber behavior (sc-11965) and unsaved-guard semantics are preserved. `loraEntryEqual` was extracted so the per-entry comparison is shared between the merge and the whole-map equality.

## Object-level vs field-level

| Scenario | Before (object-level) | After (field-level) |
|---|---|---|
| `description` dirty, server changes untouched `name` | name frozen, stays stale | name syncs, description preserved |
| One LoRA weight dirty, server changes a different LoRA | other LoRA frozen | untouched LoRA syncs, dirty one preserved |
| Any field dirty → overall dirty / no-clobber | ✓ | ✓ (unchanged) |
| Identity change loads fresh | ✓ | ✓ (unchanged) |

## Tests

3 new cases in `App.character.test.jsx`, all **fail on the old object-level impl and pass on the new one**:

1. dirty `description` → external change to untouched `name` syncs while `description` is preserved
2. one dirty `loraEdits` entry → external change to a sibling entry syncs while the dirty one is preserved
3. overall dirty + save → untouched field syncs, edit preserved, and Save persists the **merged** draft

## Verification

- `App.character.test.jsx`: 38/38 pass (incl. the 4 sc-11965 regression tests + 3 new)
- Full web vitest suite: **1782/1782 pass** (132 files)
- `vite build`: succeeds
- `eslint src`: 0 errors; the 3 `react-hooks/exhaustive-deps` warnings on this file are pre-existing on `main` (verified) and unchanged

Relates to sc-11965.

🤖 Generated with [Claude Code](https://claude.com/claude-code)