### PR TITLE
fix(web): guard Replace Person mid-save correction edits from clobber (sc-12020)

### DIFF
--- a/apps/web/src/screens/ReplacePersonPanel.jsx
+++ b/apps/web/src/screens/ReplacePersonPanel.jsx
@@ -94,6 +94,20 @@ function meaningfulDraftsSignature(drafts, frames) {
   return JSON.stringify(pendingCorrectionsFromDrafts(drafts, frames).map(comparableCorrection).sort());
 }
 
+// Signature of a persisted corrections ARRAY in the SAME comparable form as
+// meaningfulDraftsSignature. The post-save re-baseline keys off what was actually
+// saved (this save's corrections payload) instead of the live drafts, so an edit
+// made WHILE the save was in flight stays measured as dirty and survives the
+// post-save refetch instead of being folded into the clean baseline (sc-12020).
+function meaningfulCorrectionsSignature(corrections) {
+  return JSON.stringify(
+    (corrections ?? [])
+      .filter((correction) => Number.isInteger(correction?.frameIndex))
+      .map(comparableCorrection)
+      .sort(),
+  );
+}
+
 function maskUrl(projectId, relPath) {
   if (!projectId || !relPath) {
     return "";
@@ -263,8 +277,17 @@ function PersonTrackCorrections({ track, sourceClip, saveTrackCorrections }) {
       // is treated as a dirty conflict and skipped — hiding the external change and
       // letting the next Save silently drop it. Baseline on the MEANINGFUL-
       // corrections signature so it matches the seed effect's dirty measure.
+      //
+      // sc-12020: baseline on the corrections THIS save persisted (`pendingCorrections`,
+      // the POST body captured when Save was clicked) — NOT draftsRef.current at
+      // resolve time. The correction inputs stay enabled during the in-flight save,
+      // so draftsRef.current can already hold an edit the user made mid-save. Keying
+      // the clean baseline off draftsRef.current would fold that concurrent edit into
+      // "clean", and the post-save corrections refetch would then reseed the persisted
+      // value over — clobbering — it. Keying off the saved payload keeps a mid-save
+      // edit measured as dirty, so it survives the refetch.
       if (result) {
-        seededSignatureRef.current = meaningfulDraftsSignature(draftsRef.current, frames);
+        seededSignatureRef.current = meaningfulCorrectionsSignature(pendingCorrections);
       }
     } finally {
       setSaving(false);

--- a/apps/web/src/screens/ReplacePersonPanel.test.jsx
+++ b/apps/web/src/screens/ReplacePersonPanel.test.jsx
@@ -173,6 +173,99 @@ describe("ReplacePersonPanel track corrections drafts (sc-11966)", () => {
     expect(field(container, "Box x").value).toBe("0.7");
   });
 
+  it("preserves a box edit made WHILE a save is in flight (not clobbered by the post-save refetch)", async () => {
+    // sc-12020 — a deferred save lets us edit a box while the request is still
+    // pending. Pre-fix the post-save re-baseline captured draftsRef.current (the
+    // LATEST drafts, including the mid-save edit) at resolve time, marking the
+    // drafts clean against themselves, so the post-save corrections refetch
+    // reseeded the SAVED value over — and clobbered — the concurrent edit.
+    let resolveSave;
+    const saveTrackCorrections = vi.fn(() => new Promise((resolve) => {
+      resolveSave = resolve;
+    }));
+
+    await renderPanel(track("track-1", []), saveTrackCorrections);
+
+    // 1) User nudges frame 0's box, then clicks Save -> the POST carries x=0.55.
+    await changeField(field(container, "Box x"), "0.55");
+    expect(container.textContent).toContain("1 unsaved");
+    await act(async () => {
+      buttonInside(container, "Save corrections").click();
+    });
+    expect(saveTrackCorrections).toHaveBeenCalledWith("track-1", [
+      { frameIndex: 0, box: { x: 0.55, y: 0.2, width: 0.3, height: 0.4 }, rejected: false, author: "ui", source: "manual" },
+    ]);
+
+    // 2) While the save is IN FLIGHT the user keeps editing the same box -> x=0.77.
+    //    (The correction inputs stay enabled so in-progress work is never blocked.)
+    await changeField(field(container, "Box x"), "0.77");
+    expect(field(container, "Box x").value).toBe("0.77");
+
+    // 3) The save RESOLVES with the persisted track (x=0.55 -- the mid-save x=0.77
+    //    was NOT part of this save). save() re-baselines here.
+    await act(async () => {
+      resolveSave(track("track-1", [{ frameIndex: 0, box: { x: 0.55, y: 0.2, width: 0.3, height: 0.4 }, rejected: false }]));
+    });
+    await settle();
+
+    // 4) The post-save refetch replaces the track with the persisted corrections
+    //    (x=0.55) on the SAME track id (no remount).
+    await renderPanel(
+      track("track-1", [{ frameIndex: 0, box: { x: 0.55, y: 0.2, width: 0.3, height: 0.4 }, rejected: false }]),
+      saveTrackCorrections,
+    );
+
+    // The mid-save edit survives and is still dirty. Pre-fix Box x reverted to
+    // 0.55 and the panel read "1 saved" (the edit was silently dropped).
+    expect(field(container, "Box x").value).toBe("0.77");
+    expect(container.textContent).toContain("1 unsaved");
+  });
+
+  it("preserves a reject toggle made WHILE a save is in flight (not clobbered by the post-save refetch)", async () => {
+    // sc-12020 — same race as the box variant, exercised through the reject
+    // checkbox to cover BOTH correction input types.
+    let resolveSave;
+    const saveTrackCorrections = vi.fn(() => new Promise((resolve) => {
+      resolveSave = resolve;
+    }));
+
+    const rejectCheckbox = () => container.querySelector('.person-correction-reject input[type="checkbox"]');
+
+    await renderPanel(track("track-1", []), saveTrackCorrections);
+
+    // 1) Dirty the box and Save it (POST carries frame 0 box x=0.55, rejected:false).
+    await changeField(field(container, "Box x"), "0.55");
+    await act(async () => {
+      buttonInside(container, "Save corrections").click();
+    });
+    expect(saveTrackCorrections).toHaveBeenCalledWith("track-1", [
+      { frameIndex: 0, box: { x: 0.55, y: 0.2, width: 0.3, height: 0.4 }, rejected: false, author: "ui", source: "manual" },
+    ]);
+
+    // 2) While the save is IN FLIGHT the user rejects frame 0 (a distinct edit).
+    await act(async () => {
+      rejectCheckbox().click();
+    });
+    expect(rejectCheckbox().checked).toBe(true);
+
+    // 3) The save resolves with the persisted track (rejected:false).
+    await act(async () => {
+      resolveSave(track("track-1", [{ frameIndex: 0, box: { x: 0.55, y: 0.2, width: 0.3, height: 0.4 }, rejected: false }]));
+    });
+    await settle();
+
+    // 4) The refetch lands the persisted corrections (rejected:false).
+    await renderPanel(
+      track("track-1", [{ frameIndex: 0, box: { x: 0.55, y: 0.2, width: 0.3, height: 0.4 }, rejected: false }]),
+      saveTrackCorrections,
+    );
+
+    // The mid-save reject survives and stays dirty. Pre-fix the checkbox reverted
+    // to unrejected and the panel read "1 saved".
+    expect(rejectCheckbox().checked).toBe(true);
+    expect(container.textContent).toContain("1 unsaved");
+  });
+
   it("a no-op touched draft (reject on->off) reads clean, so a concurrent external correction is reflected, not hidden or dropped", async () => {
     await renderPanel(track("track-1", []));
 


### PR DESCRIPTION
## sc-12020 — Replace Person mid-save edit race can clobber an edit made during save

Pre-existing bug (not introduced by S7 / sc-11966); discovered during sc-11966 round-3 review.

### The race
In `apps/web/src/screens/ReplacePersonPanel.jsx`, `PersonTrackCorrections.save()`:

1. `save()` posts `pendingCorrections` (captured from its render closure) and awaits the result.
2. The box inputs and reject checkbox are **not** disabled while `saving`, so the user can edit a correction while the request is in flight. That edit calls `setDrafts` → re-render → `draftsRef.current` now holds the **latest** drafts (including the mid-save edit).
3. On resolve, the post-save re-baseline set `seededSignatureRef.current = meaningfulDraftsSignature(draftsRef.current, frames)` — capturing the mid-save edit, i.e. marking the drafts **clean against themselves**.
4. `saveTrackCorrections` returns the updated track; the parent refetch bumps `correctionsSignature`. The seed effect then computes `draftsDirty = false` (drafts match the just-set baseline) and **reseeds from the SAVED corrections**, overwriting the mid-save edit.

Result: an edit made during an in-flight save is silently reverted to the saved value and marked clean (data loss).

### The fix
Re-baseline from the corrections **this save actually persisted** — `pendingCorrections`, the POST body captured when Save was clicked — rather than `draftsRef.current` at resolve time. New helper `meaningfulCorrectionsSignature(corrections)` produces the same comparable signature form as `meaningfulDraftsSignature`, so the seed effect's dirty measure still lines up.

Now a mid-save edit no longer matches the baseline → it stays **dirty** and **survives** the post-save refetch. Covers **both** correction input types affected: box edits **and** reject toggles.

`pendingCorrections` is exactly what the server persists (the request body), so it equals what the refetch brings back in the no-race case — existing sc-11966 behavior is preserved (all its tests stay green). The existing sc-11966 test intentionally resolves the save with an empty-`corrections` track, so keying off the response body directly would break it; keying off the sent payload is both robust and test-consistent.

### On "disable inputs while saving" (the other option in the story)
Not implemented, by design. It does **not** match the panel's UX pattern — only the Save button is disabled during an async op; the box inputs are disabled solely when a frame is `rejected` (a semantic, not async, disable). More importantly, disabling the correction inputs would **prevent** the "concurrent edit stays dirty and survives" behavior the primary fix establishes, blocking the user for the duration of the network round-trip. Happy to add it if a reviewer prefers the belt-and-suspenders block over non-blocking editing.

### Tests
Added two vitest cases to `ReplacePersonPanel.test.jsx` that reproduce the race with a **deferred** save (edit made while the request is pending, then resolve + refetch):
- `preserves a box edit made WHILE a save is in flight` — asserts the mid-save box (0.77) survives the refetch and stays `1 unsaved` (pre-fix it reverted to 0.55 / `1 saved`).
- `preserves a reject toggle made WHILE a save is in flight` — asserts the mid-save reject stays checked and dirty (pre-fix it reverted to unrejected / `1 saved`).

Both **failed** before the fix (0.55≠0.77; checkbox false≠true) and **pass** after.

### Verification
- `ReplacePersonPanel.test.jsx`: 8/8 pass.
- Related person-track suites (App.replacePerson, App.library, VideoStudio, studioRestore, hookStability): 68/68 pass.
- Full web suite: 132 files / 1781 tests pass.
- `eslint src`: 0 errors (warning count unchanged vs base — no new warnings introduced).
- `vite build`: succeeds.

### Follow-ups
None. In production `saveTrackCorrections` returns the server's authoritative track; the fix relies on `pendingCorrections` (the persisted POST body), which round-trips to the same comparable signature the panel already assumes for its dirty check.

Relates to sc-11966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)