### PR TITLE
fix(web): surface Video Editor edit/generation conflict on deleted target + desktop-safe re-select confirm (sc-12018)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -800,6 +800,7 @@ export function App() {
     activeProject,
     activeProjectRef,
     setError,
+    pushNotice,
     requestedGpu,
     setActiveView,
     createVideoJob,

--- a/apps/web/src/hooks/useTimelines.js
+++ b/apps/web/src/hooks/useTimelines.js
@@ -9,6 +9,35 @@ function serializeTimeline(timeline) {
   return timeline ? JSON.stringify(timeline) : null;
 }
 
+// sc-12018: the notice `kind` for the edit/generation conflict (a completed generation whose
+// target the dirty working copy has removed). A dedicated kind so it neither clobbers nor is
+// clobbered by the "general" error notice, and can be cleared once the conflict is resolved.
+const TIMELINE_GENERATION_CONFLICT_NOTICE = "timelineGenerationConflict";
+
+// sc-12018: whether the generation's target still exists in `timeline`. A replace rewrites a
+// specific item (context.itemId) inside its track; an extend/bridge only appends a new item to
+// the target track (context.trackId). applyTimelineGenerationResult ALWAYS returns a fresh
+// object when the timelineId matches (it maps `tracks`), so a reference check cannot detect a
+// content no-op — this presence check can. Absent target ⇒ applying the generation to this
+// copy changes nothing, so it would silently vanish from the live editor.
+function timelineGenerationTargetPresent(timeline, job) {
+  const payload = job.payload ?? {};
+  const action = payload.advanced?.timelineAction;
+  const context = payload.advanced?.timelineContext ?? {};
+  if (!action || !timeline || context.timelineId !== timeline.id) {
+    return false;
+  }
+  const track = (timeline.tracks ?? []).find((candidate) => candidate.id === context.trackId);
+  if (!track) {
+    return false;
+  }
+  if (action === "replace") {
+    return (track.items ?? []).some((item) => item.id === context.itemId);
+  }
+  // extend / bridge only need the target track to exist — they append a new item to it.
+  return true;
+}
+
 // Owns the editor's timeline state (list, selection, the loaded timeline) plus every
 // timeline mutation, frame extraction, and the SSE-driven "apply generated clip to the
 // timeline" pipeline. Extracted from App.jsx (sc-1651) — the largest, most coupled
@@ -23,6 +52,7 @@ export function useTimelines({
   activeProject,
   activeProjectRef,
   setError,
+  pushNotice,
   requestedGpu,
   setActiveView,
   createVideoJob,
@@ -114,6 +144,9 @@ export function useTimelines({
       setActiveTimeline(timeline);
       activeTimelineRef.current = timeline;
       savedTimelineSnapshotRef.current = serializeTimeline(timeline);
+      // sc-12018: a fresh load pulls the server copy (which received any conflicting
+      // generation), so a prior edit/generation conflict notice is now stale — clear it.
+      pushNotice?.(TIMELINE_GENERATION_CONFLICT_NOTICE, "");
       setError("");
     } catch (err) {
       setError(err.message);
@@ -163,6 +196,9 @@ export function useTimelines({
         // re-select/SSE guards kept firing on an already-saved timeline).
         activeTimelineRef.current = saved;
         savedTimelineSnapshotRef.current = serializeTimeline(saved);
+        // sc-12018: the saved copy is now authoritative, so any prior edit/generation conflict
+        // notice ("saving will discard it") has been resolved one way or the other — clear it.
+        pushNotice?.(TIMELINE_GENERATION_CONFLICT_NOTICE, "");
         refreshTimelines(activeProject.id);
         setError("");
         return saved;
@@ -171,7 +207,7 @@ export function useTimelines({
         return null;
       }
     },
-    [token, activeProject, setError, refreshTimelines],
+    [token, activeProject, setError, pushNotice, refreshTimelines],
   );
 
   const exportTimeline = useCallback(
@@ -361,10 +397,27 @@ export function useTimelines({
           // the server copy would silently discard them, so merge the generation onto the
           // working copy instead. The baseline is left untouched, so the copy stays dirty and
           // the user still owns the decision to save their edits.
-          const merged = applyTimelineGenerationResult(workingCopy, job);
-          if (merged !== workingCopy) {
+          if (timelineGenerationTargetPresent(workingCopy, job)) {
+            const merged = applyTimelineGenerationResult(workingCopy, job);
             setActiveTimeline(merged);
             activeTimelineRef.current = merged;
+          } else {
+            // sc-12018 (S8 follow-up): the dirty working copy has DELETED the item/track this
+            // generation targets, so merging is a content no-op — the generation would be
+            // invisible in the live editor. It IS durably persisted to the server copy above,
+            // but if the user now SAVES their conflicting deletion the server copy is
+            // overwritten and the generation is lost. Surface the conflict instead of silently
+            // swallowing it; the working copy is left untouched so the user's deletion — and
+            // the ownership of the save decision — is preserved.
+            const action = job.payload?.advanced?.timelineAction;
+            const clipName = job.result?.assets?.[0]?.displayName;
+            const target = action === "replace" ? "a clip you removed" : "a track you removed";
+            pushNotice?.(
+              TIMELINE_GENERATION_CONFLICT_NOTICE,
+              `A generation finished for ${target} from this timeline${clipName ? ` (“${clipName}”)` : ""}. ` +
+                "It was saved to the stored timeline, but saving your current edits will discard it. " +
+                "Re-open this timeline to keep the generated clip.",
+            );
           }
         } else {
           // Clean (or the item the generation targets is gone) → adopt the persisted server

--- a/apps/web/src/hooks/useTimelines.js
+++ b/apps/web/src/hooks/useTimelines.js
@@ -420,9 +420,10 @@ export function useTimelines({
             );
           }
         } else {
-          // Clean (or the item the generation targets is gone) → adopt the persisted server
-          // copy and reset the baseline so the timeline stays clean (no spurious dirty on a
-          // later re-select). This is the pre-sc-11967 behavior.
+          // Clean working copy → adopt the persisted server copy (which received the
+          // generation) and reset the baseline so the timeline stays clean (no spurious dirty
+          // on a later re-select). This is the pre-sc-11967 behavior. (The dirty-but-target-
+          // deleted case is handled above as an sc-12018 conflict, not here.)
           setActiveTimeline(saved);
           activeTimelineRef.current = saved;
           savedTimelineSnapshotRef.current = serializeTimeline(saved);

--- a/apps/web/src/hooks/useTimelines.test.jsx
+++ b/apps/web/src/hooks/useTimelines.test.jsx
@@ -70,12 +70,31 @@ function makeExtendJob() {
   };
 }
 
+// A completed replace-generation job for an existing item on tl_1's main track.
+// applyTimelineGenerationResult rewrites context.itemId in place; if that item is gone the
+// apply is a content no-op.
+function makeReplaceJob() {
+  return {
+    id: "job_replace",
+    projectId: "proj_1",
+    result: { assetIds: ["asset_replace"], assets: [{ displayName: "Replacement clip", createdAt: "2026-07-14T00:00:00Z" }] },
+    payload: {
+      advanced: {
+        timelineAction: "replace",
+        timelineContext: { timelineId: "tl_1", trackId: "track_main", itemId: "item_target" },
+      },
+    },
+  };
+}
+
 let container;
 let root;
+let pushNoticeSpy;
 
 beforeEach(() => {
   global.IS_REACT_ACT_ENVIRONMENT = true;
   apiCalls.length = 0;
+  pushNoticeSpy = vi.fn();
   container = document.createElement("div");
   document.body.appendChild(container);
 });
@@ -97,6 +116,7 @@ function mount() {
         activeProject,
         activeProjectRef,
         setError: () => {},
+        pushNotice: pushNoticeSpy,
         requestedGpu: "auto",
         setActiveView: () => {},
         createVideoJob: async () => null,
@@ -253,5 +273,149 @@ describe("useTimelines SSE apply is unchanged when clean (sc-11967 no-regression
     // Clean timeline that received a generation is still clean afterwards — the server
     // copy it adopted is the persisted one, so a later re-select must not prompt.
     expect(get().api.isActiveTimelineDirty()).toBe(false);
+    // No conflict was surfaced on the happy path.
+    expect(pushNoticeSpy.mock.calls.some((c) => c[0] === "timelineGenerationConflict" && c[1])).toBe(false);
+  });
+});
+
+// sc-12018 (S8 follow-up): the dirty working copy has DELETED the item/track a completed
+// generation targets. Merging is a content no-op, so the generation is invisible in the live
+// editor — and if the user then saves their deletion, the server copy (which DID receive the
+// generation) is overwritten and the generation is lost. The apply must not silently swallow
+// this: it surfaces a conflict notice while preserving the durable server-copy persistence.
+describe("useTimelines SSE apply surfaces edit/generation conflict on deleted target (sc-12018)", () => {
+  it("EXTEND: dirty copy deleted the target track → conflict notice, gen persisted, not injected", async () => {
+    const get = mount();
+    await loadSelected(get, makeTimeline());
+
+    // User deletes the whole target track (a structural edit → dirty).
+    act(() => {
+      const current = get().api.activeTimeline;
+      get().api.setActiveTimeline({ ...current, tracks: [] });
+    });
+    await settle();
+    expect(get().api.isActiveTimelineDirty()).toBe(true);
+
+    // Server copy still has track_main (the deletion is unsaved).
+    const serverCopy = makeTimeline();
+    apiRouter = ({ method, path, body }) => {
+      if (method === "PUT") return { ...body.timeline };
+      if (path.endsWith("/timelines")) return [{ id: "tl_1", name: "Main" }];
+      if (method === "GET") return serverCopy;
+      return serverCopy;
+    };
+
+    await act(async () => {
+      get().api.enqueueTimelineGenerationApply(makeExtendJob());
+    });
+    await settle();
+
+    // (a) The conflict is surfaced to the user via the existing notice mechanism (a truthy
+    // message — an empty push is the clear-on-resolve signal, not a surfaced conflict).
+    const conflictCall = pushNoticeSpy.mock.calls.find((c) => c[0] === "timelineGenerationConflict" && c[1]);
+    expect(conflictCall).toBeTruthy();
+    expect(conflictCall[1]).toMatch(/generation/i);
+    // (b) The generation was NOT silently swallowed — it was durably persisted to the server.
+    const put = apiCalls.find((c) => c.method === "PUT");
+    expect(put).toBeTruthy();
+    expect(put.body.timeline.tracks.flatMap((t) => t.items).some((it) => it.assetId === "asset_gen")).toBe(true);
+    // The live working copy still reflects the user's deletion (generation not resurrected onto
+    // a phantom track), and stays dirty so the user still owns the save decision.
+    expect(get().api.activeTimeline.tracks).toHaveLength(0);
+    expect(get().api.isActiveTimelineDirty()).toBe(true);
+  });
+
+  it("REPLACE: dirty copy deleted the target item → conflict notice, gen persisted", async () => {
+    const get = mount();
+    const withItem = makeTimeline({
+      tracks: [
+        {
+          id: "track_main",
+          name: "Main",
+          items: [{ id: "item_target", assetId: "orig_asset", type: "video", trackId: "track_main", timelineStart: 0, timelineEnd: 4 }],
+        },
+      ],
+    });
+    await loadSelected(get, withItem);
+
+    // User deletes the item the replacement targets (dirty).
+    act(() => {
+      const current = get().api.activeTimeline;
+      get().api.setActiveTimeline({
+        ...current,
+        tracks: current.tracks.map((t) => ({ ...t, items: t.items.filter((it) => it.id !== "item_target") })),
+      });
+    });
+    await settle();
+    expect(get().api.isActiveTimelineDirty()).toBe(true);
+
+    // Server copy still has item_target.
+    const serverCopy = makeTimeline({
+      tracks: [
+        {
+          id: "track_main",
+          name: "Main",
+          items: [{ id: "item_target", assetId: "orig_asset", type: "video", trackId: "track_main", timelineStart: 0, timelineEnd: 4 }],
+        },
+      ],
+    });
+    apiRouter = ({ method, path, body }) => {
+      if (method === "PUT") return { ...body.timeline };
+      if (path.endsWith("/timelines")) return [{ id: "tl_1", name: "Main" }];
+      if (method === "GET") return serverCopy;
+      return serverCopy;
+    };
+
+    await act(async () => {
+      get().api.enqueueTimelineGenerationApply(makeReplaceJob());
+    });
+    await settle();
+
+    const conflictCall = pushNoticeSpy.mock.calls.find((c) => c[0] === "timelineGenerationConflict" && c[1]);
+    expect(conflictCall).toBeTruthy();
+    expect(conflictCall[1]).toBeTruthy();
+    // Generation durably persisted onto the server copy's surviving item.
+    const put = apiCalls.find((c) => c.method === "PUT");
+    expect(put).toBeTruthy();
+    const replaced = put.body.timeline.tracks.flatMap((t) => t.items).find((it) => it.id === "item_target");
+    expect(replaced.assetId).toBe("asset_replace");
+    // Working copy still has the item removed and stays dirty.
+    expect(get().api.activeTimeline.tracks.flatMap((t) => t.items).some((it) => it.id === "item_target")).toBe(false);
+    expect(get().api.isActiveTimelineDirty()).toBe(true);
+  });
+
+  it("does NOT fire a conflict notice when the dirty copy still has the target (merge path)", async () => {
+    const get = mount();
+    await loadSelected(get, makeTimeline());
+
+    // Dirty edit that keeps the target track intact.
+    act(() => {
+      const current = get().api.activeTimeline;
+      get().api.setActiveTimeline({
+        ...current,
+        tracks: current.tracks.map((t) => ({
+          ...t,
+          items: [...t.items, { id: "item_user_edit", assetId: "user_asset", type: "video", trackId: "track_main", timelineStart: 0, timelineEnd: 4 }],
+        })),
+      });
+    });
+    await settle();
+
+    const serverCopy = makeTimeline();
+    apiRouter = ({ method, path, body }) => {
+      if (method === "PUT") return { ...body.timeline };
+      if (path.endsWith("/timelines")) return [{ id: "tl_1", name: "Main" }];
+      if (method === "GET") return serverCopy;
+      return serverCopy;
+    };
+
+    await act(async () => {
+      get().api.enqueueTimelineGenerationApply(makeExtendJob());
+    });
+    await settle();
+
+    // Merged in place, no conflict.
+    expect(get().api.activeTimeline.tracks.flatMap((t) => t.items).some((it) => it.assetId === "asset_gen")).toBe(true);
+    expect(pushNoticeSpy.mock.calls.some((c) => c[0] === "timelineGenerationConflict" && c[1])).toBe(false);
   });
 });

--- a/apps/web/src/hooks/useTimelines.test.jsx
+++ b/apps/web/src/hooks/useTimelines.test.jsx
@@ -87,6 +87,24 @@ function makeReplaceJob() {
   };
 }
 
+// A completed bridge-generation job for tl_1's main track. Like extend, applyTimelineGenerationResult
+// only appends a fresh video item to context.trackId, so its target presence hinges on the track
+// existing — it shares the identical presence-check branch as extend in production.
+function makeBridgeJob() {
+  return {
+    id: "job_bridge",
+    projectId: "proj_1",
+    result: { assetIds: ["asset_bridge"], assets: [{ displayName: "Bridge clip", createdAt: "2026-07-14T00:00:00Z" }] },
+    payload: {
+      duration: 2,
+      advanced: {
+        timelineAction: "bridge",
+        timelineContext: { timelineId: "tl_1", trackId: "track_main", timelineStart: 4, timelineEnd: 6 },
+      },
+    },
+  };
+}
+
 let container;
 let root;
 let pushNoticeSpy;
@@ -319,6 +337,47 @@ describe("useTimelines SSE apply surfaces edit/generation conflict on deleted ta
     const put = apiCalls.find((c) => c.method === "PUT");
     expect(put).toBeTruthy();
     expect(put.body.timeline.tracks.flatMap((t) => t.items).some((it) => it.assetId === "asset_gen")).toBe(true);
+    // The live working copy still reflects the user's deletion (generation not resurrected onto
+    // a phantom track), and stays dirty so the user still owns the save decision.
+    expect(get().api.activeTimeline.tracks).toHaveLength(0);
+    expect(get().api.isActiveTimelineDirty()).toBe(true);
+  });
+
+  it("BRIDGE: dirty copy deleted the target track → conflict notice, gen persisted, not injected", async () => {
+    const get = mount();
+    await loadSelected(get, makeTimeline());
+
+    // User deletes the whole target track (a structural edit → dirty).
+    act(() => {
+      const current = get().api.activeTimeline;
+      get().api.setActiveTimeline({ ...current, tracks: [] });
+    });
+    await settle();
+    expect(get().api.isActiveTimelineDirty()).toBe(true);
+
+    // Server copy still has track_main (the deletion is unsaved).
+    const serverCopy = makeTimeline();
+    apiRouter = ({ method, path, body }) => {
+      if (method === "PUT") return { ...body.timeline };
+      if (path.endsWith("/timelines")) return [{ id: "tl_1", name: "Main" }];
+      if (method === "GET") return serverCopy;
+      return serverCopy;
+    };
+
+    await act(async () => {
+      get().api.enqueueTimelineGenerationApply(makeBridgeJob());
+    });
+    await settle();
+
+    // (a) The conflict is surfaced to the user via the existing notice mechanism (a truthy
+    // message — an empty push is the clear-on-resolve signal, not a surfaced conflict).
+    const conflictCall = pushNoticeSpy.mock.calls.find((c) => c[0] === "timelineGenerationConflict" && c[1]);
+    expect(conflictCall).toBeTruthy();
+    expect(conflictCall[1]).toMatch(/generation/i);
+    // (b) The generation was NOT silently swallowed — it was durably persisted to the server.
+    const put = apiCalls.find((c) => c.method === "PUT");
+    expect(put).toBeTruthy();
+    expect(put.body.timeline.tracks.flatMap((t) => t.items).some((it) => it.assetId === "asset_bridge")).toBe(true);
     // The live working copy still reflects the user's deletion (generation not resurrected onto
     // a phantom track), and stays dirty so the user still owns the save decision.
     expect(get().api.activeTimeline.tracks).toHaveLength(0);

--- a/apps/web/src/screens/EditorScreen.jsx
+++ b/apps/web/src/screens/EditorScreen.jsx
@@ -14,6 +14,7 @@ import {
 } from "../timeline.js";
 import { useAppStatic } from "../context/AppContext.js";
 import { useScreenActive } from "../context/ScreenActiveContext.js";
+import { appConfirm } from "../appConfirm.jsx";
 
 export function EditorScreen() {
   const {
@@ -151,17 +152,21 @@ export function EditorScreen() {
   // replaces the in-memory working copy, dropping any unsaved structural edits. Guard the
   // switch when the active timeline is dirty. The <select> is controlled by
   // `selectedTimelineId`, so returning early (no state change) snaps its value back to the
-  // current timeline. Uses window.confirm to match the app's existing discard-edits confirm
-  // (ImageEditor.confirmDiscardEdits / App.purgeAsset); when confirm is unavailable it falls
-  // through to allow, matching those call sites.
-  function handleSelectTimeline(nextId) {
+  // current timeline. sc-12018 (S8 follow-up): routed through the desktop-safe appConfirm
+  // (a real in-app dialog) rather than the raw window.confirm — window.confirm silently
+  // no-ops inside the Tauri WebView, so the guard would neither confirm nor cancel there.
+  async function handleSelectTimeline(nextId) {
     if (nextId === selectedTimelineId) {
       return;
     }
     if (isActiveTimelineDirty?.()) {
-      const proceed =
-        typeof window.confirm !== "function" ||
-        window.confirm("You have unsaved timeline edits. Switch timelines and discard them?");
+      const proceed = await appConfirm({
+        title: "Discard timeline edits?",
+        message: "You have unsaved timeline edits. Switch timelines and discard them?",
+        confirmLabel: "Discard & switch",
+        cancelLabel: "Keep editing",
+        tone: "danger",
+      });
       if (!proceed) {
         return;
       }

--- a/apps/web/src/screens/EditorScreen.test.jsx
+++ b/apps/web/src/screens/EditorScreen.test.jsx
@@ -9,6 +9,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AppContext } from "../context/AppContext.js";
 import { ScreenActiveContext } from "../context/ScreenActiveContext.js";
+
+// sc-12018 (S8 follow-up): the re-select guard now routes through the desktop-safe appConfirm
+// dialog (not the raw window.confirm, which no-ops in the Tauri WebView). Mock it so a test
+// controls the user's choice and can assert the guard fired, without mounting a ConfirmHost.
+const { appConfirmMock } = vi.hoisted(() => ({ appConfirmMock: vi.fn(async () => true) }));
+vi.mock("../appConfirm.jsx", () => ({ appConfirm: appConfirmMock }));
+
 import { EditorScreen } from "./EditorScreen.jsx";
 
 function makeTimeline(id, name) {
@@ -20,9 +27,19 @@ let root;
 
 beforeEach(() => {
   global.IS_REACT_ACT_ENVIRONMENT = true;
+  appConfirmMock.mockClear();
+  appConfirmMock.mockResolvedValue(true);
   container = document.createElement("div");
   document.body.appendChild(container);
 });
+
+// The re-select guard awaits appConfirm, so its setSelectedTimelineId runs a microtask later.
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
 
 afterEach(() => {
   act(() => root?.unmount());
@@ -73,36 +90,40 @@ function selectTimeline(nextId) {
   return select;
 }
 
-describe("EditorScreen timeline re-select guard (sc-11967)", () => {
-  it("switches without prompting when the timeline is clean (no regression)", () => {
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+describe("EditorScreen timeline re-select guard (sc-11967, sc-12018)", () => {
+  it("switches without prompting when the timeline is clean (no regression)", async () => {
     const { setSelectedTimelineId } = render({ isActiveTimelineDirty: () => false });
 
     selectTimeline("tl_2");
+    await flush();
 
-    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(appConfirmMock).not.toHaveBeenCalled();
     expect(setSelectedTimelineId).toHaveBeenCalledWith("tl_2");
   });
 
-  it("does NOT switch (keeps the current timeline) when dirty and the user cancels the confirm", () => {
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+  it("does NOT switch (keeps the current timeline) when dirty and the user cancels the confirm", async () => {
+    appConfirmMock.mockResolvedValue(false);
     const { setSelectedTimelineId } = render({ isActiveTimelineDirty: () => true });
 
     const select = selectTimeline("tl_2");
+    await flush();
 
-    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    // sc-12018: the guard used the desktop-safe appConfirm dialog (not the raw window.confirm).
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    expect(appConfirmMock.mock.calls[0][0]).toMatchObject({ tone: "danger" });
     expect(setSelectedTimelineId).not.toHaveBeenCalled();
     // Controlled <select> snaps back to the still-active timeline.
     expect(select.value).toBe("tl_1");
   });
 
-  it("switches when dirty and the user accepts the confirm", () => {
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+  it("switches when dirty and the user accepts the confirm", async () => {
+    appConfirmMock.mockResolvedValue(true);
     const { setSelectedTimelineId } = render({ isActiveTimelineDirty: () => true });
 
     selectTimeline("tl_2");
+    await flush();
 
-    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
     expect(setSelectedTimelineId).toHaveBeenCalledWith("tl_2");
   });
 });


### PR DESCRIPTION
## Summary

S8 (sc-11967) adversarial-review follow-up for the Video Editor. Two parts.

### Part A (primary): surface the edit/generation conflict on a deleted target

**Defect.** In `apps/web/src/hooks/useTimelines.js`, when the DIRTY working copy has DELETED the item/track that a completed `replace`/`extend`/`bridge` generation targets, `applyTimelineGenerationResult(workingCopy, job)` is a *content* no-op (the target is gone). The old dirty-branch guard `if (merged !== workingCopy)` could not detect this — `applyTimelineGenerationResult` always returns a fresh object when the `timelineId` matches (it maps `tracks`), so a reference check never trips. The generation was still durably persisted to the server copy (the PUT), so it was not *immediately* lost — but if the user then SAVES their conflicting deletion, the server copy is overwritten and the generation is gone, silently.

**Fix.**
- New pure helper `timelineGenerationTargetPresent(timeline, job)` — a *presence* check: a `replace` needs its `context.itemId` inside the target track; an `extend`/`bridge` only needs the target track to exist.
- In the dirty branch: if the target is present → merge onto the working copy as before; if absent → push a dedicated `timelineGenerationConflict` notice through the existing kinded notice store (`pushNotice`, threaded in from App), e.g. *"A generation finished for a clip you removed … saving your current edits will discard it. Re-open this timeline to keep the generated clip."* The working copy is left untouched (deletion + save ownership preserved), and server-copy persistence is unchanged.
- The conflict notice is cleared on the resolution paths (`loadTimeline` re-open pulls the server copy that received the generation; `saveTimeline` makes the saved copy authoritative).
- A dedicated notice `kind` means an unrelated success/error never clobbers it, and it never clobbers the general error.

### Part B (confirm unification, per the story note)

- **EditorScreen re-select guard**: migrated the raw `window.confirm` idiom to the shared desktop-safe `appConfirm` dialog (sc-11968) — `window.confirm` silently no-ops in the Tauri WebView, so the guard was dead on desktop. `handleSelectTimeline` is now async and awaits `appConfirm({ tone: "danger", … })`.
- **PresetManager destructive-transition confirm (S10)**: already migrated to `appConfirm` on `main` (`guardDiscard` / `discardChanges`), so no change was needed. Verified.

## Tests
- `useTimelines.test.jsx`: added an `sc-12018` block — EXTEND (deleted target track) and REPLACE (deleted target item) both assert (a) a conflict notice is surfaced via `pushNotice` and (b) the generation is durably persisted to the server copy and NOT silently swallowed / resurrected onto a phantom; plus a no-regression test that the merge path fires no conflict notice. Written test-first (confirmed red, then green).
- `EditorScreen.test.jsx`: re-select guard tests now mock `appConfirm` and assert it (not `window.confirm`) drives the dirty-switch decision, with `tone: "danger"`.
- Full web suite green: **1782 passed / 132 files**. `vite build` succeeds. `eslint` on changed files: 0 errors (only pre-existing `react-hooks/exhaustive-deps` warnings, none introduced here).

Relates to sc-11967. Closes sc-12018.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
