### PR TITLE
fix(web): migrate remaining window.confirm sites to desktop-safe appConfirm (sc-12068)

### DIFF
--- a/apps/web/src/App.character.test.jsx
+++ b/apps/web/src/App.character.test.jsx
@@ -7,6 +7,18 @@ import { CharacterStudio } from "./screens/CharacterStudio.jsx";
 import { CharacterAssets, CharacterDatasets } from "./screens/characterPanels.jsx";
 import { withAppContext, FakeEventSource, response, errorResponse, settle, field, changeField } from "./main.testSupport.jsx";
 
+// sc-12068: destructive/confirm actions (Character Studio archive, the asset Trashcan
+// "Empty Trash") now route through the shared desktop-safe appConfirm dialog rather than
+// the raw window.confirm, which silently no-ops inside the Tauri WebView. Mock it so
+// tests control the user's choice and assert the guard fired. The full-App shell tests in
+// this file never trigger a confirm, so the no-op ConfirmHost is harmless there.
+const { appConfirmMock } = vi.hoisted(() => ({ appConfirmMock: vi.fn(async () => true) }));
+vi.mock("./appConfirm.jsx", () => ({
+  appConfirm: appConfirmMock,
+  useConfirm: () => appConfirmMock,
+  ConfirmHost: () => null,
+}));
+
 describe("SceneWorks app shell", () => {
   let container;
   let root;
@@ -442,19 +454,24 @@ describe("SceneWorks app shell", () => {
     const archiveButton = () =>
       [...document.body.querySelectorAll("#character-panel-character button")].find((button) => button.textContent === "Archive");
 
-    // Declining the confirm leaves the character untouched.
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    // sc-12068: archiving now confirms via the desktop-safe appConfirm dialog. Declining
+    // the confirm leaves the character untouched.
+    appConfirmMock.mockClear();
+    appConfirmMock.mockResolvedValue(false);
     await act(async () => {
       archiveButton().click();
     });
-    expect(confirmSpy).toHaveBeenCalled();
+    await settle();
+    expect(appConfirmMock).toHaveBeenCalled();
+    expect(appConfirmMock.mock.calls[0][0]).toMatchObject({ title: "Archive character?" });
     expect(archiveCharacter).not.toHaveBeenCalled();
 
     // Confirming archives it.
-    confirmSpy.mockReturnValue(true);
+    appConfirmMock.mockResolvedValue(true);
     await act(async () => {
       archiveButton().click();
     });
+    await settle();
     expect(archiveCharacter).toHaveBeenCalledWith("char-1");
 
     // The archived view is hidden until opened, then lazily fetches archived characters.
@@ -473,8 +490,6 @@ describe("SceneWorks app shell", () => {
     await settle();
     expect(unarchiveCharacter).toHaveBeenCalledWith("char-archived");
     expect(document.body.querySelector(".archived-character-list")).toBeNull();
-
-    confirmSpy.mockRestore();
   });
 
   it("surfaces character videos alongside images in the Assets tab (sc-2296)", async () => {
@@ -1770,7 +1785,9 @@ describe("SceneWorks app shell", () => {
   });
 
   it("Empty Trash purges all discarded images for the character and only in the Trashcan view", async () => {
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    // sc-12068: Empty Trash confirms via the desktop-safe appConfirm dialog before purging.
+    appConfirmMock.mockClear();
+    appConfirmMock.mockResolvedValue(true);
     const purgeAsset = vi.fn();
     const assets = [
       { id: "img-active", type: "image", displayName: "keep", recipe: { normalizedSettings: { characterId: "char-1" } } },
@@ -1842,11 +1859,12 @@ describe("SceneWorks app shell", () => {
     await act(async () => {
       emptyButton.click();
     });
+    await settle();
+    expect(appConfirmMock).toHaveBeenCalledWith(expect.objectContaining({ tone: "danger" }));
     expect(purgeAsset).toHaveBeenCalledTimes(2);
     expect(purgeAsset).toHaveBeenCalledWith(expect.objectContaining({ id: "img-trash-1" }));
     expect(purgeAsset).toHaveBeenCalledWith(expect.objectContaining({ id: "img-trash-2" }));
     expect(purgeAsset).not.toHaveBeenCalledWith(expect.objectContaining({ id: "img-other" }));
-    confirm.mockRestore();
   });
 
   it("launches reference-based generation from an approved character reference", async () => {

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -49,7 +49,7 @@ import {
 } from "./assetVariants.js";
 import { buildWorkersById } from "./workers.js";
 import { createEditorScratchRegistry } from "./editorScratch.js";
-import { ConfirmHost } from "./appConfirm.jsx";
+import { appConfirm, ConfirmHost } from "./appConfirm.jsx";
 import { isDesktop as isDesktopShell, tauriInvoke } from "./runtime.js";
 import {
   buildLocalJobStack,
@@ -1959,10 +1959,16 @@ export function App() {
       try {
         let result = await apiFetch(`/api/v1/projects/${asset.projectId}/assets/${asset.id}/purge`, token, { method: "DELETE" });
         // The purge first tries the OS trash (recoverable). If that fails nothing was
-        // removed; confirm before falling back to a permanent delete.
+        // removed; confirm before falling back to a permanent delete. Routed through the
+        // desktop-safe appConfirm (sc-12068) — window.confirm no-ops in the Tauri WebView.
         if (result?.status === "trash_unavailable") {
-          const proceed = typeof window.confirm !== "function" ||
-            window.confirm("Cannot move to trash. Continue to permanently delete.");
+          const proceed = await appConfirm({
+            title: "Move to trash failed",
+            message: "Cannot move to trash. Continue to permanently delete.",
+            confirmLabel: "Delete permanently",
+            cancelLabel: "Cancel",
+            tone: "danger",
+          });
           if (!proceed) {
             setError("");
             return;

--- a/apps/web/src/App.library.test.jsx
+++ b/apps/web/src/App.library.test.jsx
@@ -8,6 +8,16 @@ import { LibraryScreen } from "./screens/LibraryScreen.jsx";
 import { ReplacePersonPanel } from "./screens/ReplacePersonPanel.jsx";
 import { withAppContext, FakeEventSource, response, settle, changeField } from "./main.testSupport.jsx";
 
+// sc-12068: the Library Trashcan "Empty Trash" purge confirms through the shared desktop-safe
+// appConfirm dialog rather than the raw window.confirm, which silently no-ops inside the Tauri
+// WebView. Mock it so the test controls the choice and asserts the guard fired.
+const { appConfirmMock } = vi.hoisted(() => ({ appConfirmMock: vi.fn(async () => true) }));
+vi.mock("./appConfirm.jsx", () => ({
+  appConfirm: appConfirmMock,
+  useConfirm: () => appConfirmMock,
+  ConfirmHost: () => null,
+}));
+
 describe("SceneWorks app shell", () => {
   let container;
   let root;
@@ -989,7 +999,8 @@ describe("SceneWorks app shell", () => {
   });
 
   it("Empty Trash purges every discarded asset in the Library Trashcan view only", async () => {
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    appConfirmMock.mockClear();
+    appConfirmMock.mockResolvedValue(true);
     const purgeAsset = vi.fn();
     const active = {
       id: "asset-active",
@@ -1052,12 +1063,12 @@ describe("SceneWorks app shell", () => {
     await act(async () => {
       emptyButton.click();
     });
-    expect(confirm).toHaveBeenCalled();
+    await settle();
+    expect(appConfirmMock).toHaveBeenCalledWith(expect.objectContaining({ tone: "danger" }));
     expect(purgeAsset).toHaveBeenCalledTimes(2);
     expect(purgeAsset).toHaveBeenCalledWith(trashedA);
     expect(purgeAsset).toHaveBeenCalledWith(trashedB);
     expect(purgeAsset).not.toHaveBeenCalledWith(active);
-    confirm.mockRestore();
   });
 
   it("gates Document Studio behind a model download when no interleave model is present", async () => {

--- a/apps/web/src/App.models.test.jsx
+++ b/apps/web/src/App.models.test.jsx
@@ -5,6 +5,17 @@ import { App, eventUrl } from "./main.jsx";
 import { liveElapsedSeconds } from "./formatting.js";
 import { withModelManagerContext, FakeEventSource, response, settle, field, loraPanel, modelImportPanel, buttonInside, changeField, changeFile, selectModelTab, familyFilter } from "./main.testSupport.jsx";
 
+// sc-12068: model / LoRA deletes confirm through the shared desktop-safe appConfirm dialog
+// rather than the raw window.confirm, which silently no-ops inside the Tauri WebView. Mock it
+// so the delete test controls the choice and asserts the guard fired with the right message.
+// The full-App tests in this file never trigger a confirm, so the no-op ConfirmHost is safe.
+const { appConfirmMock } = vi.hoisted(() => ({ appConfirmMock: vi.fn(async () => true) }));
+vi.mock("./appConfirm.jsx", () => ({
+  appConfirm: appConfirmMock,
+  useConfirm: () => appConfirmMock,
+  ConfirmHost: () => null,
+}));
+
 describe("SceneWorks app shell", () => {
   let container;
   let root;
@@ -973,7 +984,8 @@ describe("SceneWorks app shell", () => {
   it("confirms and deletes models and LoRAs from the Models page", async () => {
     const onDeleteModel = vi.fn(async () => ({ removedManifestEntry: true, warnings: ["Recipe presets reference this model: Moody"] }));
     const onDeleteLora = vi.fn(async () => ({ removedManifestEntry: true, warnings: ["Recipe presets reference this lora: Moody"] }));
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    appConfirmMock.mockClear();
+    appConfirmMock.mockResolvedValue(true);
     root = createRoot(container);
     await act(async () => {
       root.render(
@@ -995,9 +1007,14 @@ describe("SceneWorks app shell", () => {
     await act(async () => {
       document.body.querySelector(".model-card .danger-action").click();
     });
+    await settle();
 
-    expect(confirm).toHaveBeenCalledWith(expect.stringContaining('Delete model "Z-Image Turbo"?'));
-    expect(confirm.mock.calls[0][0]).toContain("Referenced by presets: Moody.");
+    // sc-12068: the delete confirms through appConfirm (danger tone), carrying the same
+    // "Delete model …? Referenced by presets" message the raw confirm used to show.
+    expect(appConfirmMock).toHaveBeenCalledWith(
+      expect.objectContaining({ tone: "danger", message: expect.stringContaining('Delete model "Z-Image Turbo"?') }),
+    );
+    expect(appConfirmMock.mock.calls[0][0].message).toContain("Referenced by presets: Moody.");
     expect(onDeleteModel).toHaveBeenCalledWith(expect.objectContaining({ id: "z_image_turbo" }));
     expect(container.textContent).toContain("Removed the registry entry for Z-Image Turbo.");
 
@@ -1005,8 +1022,11 @@ describe("SceneWorks app shell", () => {
     await act(async () => {
       document.body.querySelector(".lora-row .danger-action").click();
     });
+    await settle();
 
-    expect(confirm).toHaveBeenCalledWith(expect.stringContaining('Delete lora "Ready Style"?'));
+    expect(appConfirmMock).toHaveBeenCalledWith(
+      expect.objectContaining({ tone: "danger", message: expect.stringContaining('Delete lora "Ready Style"?') }),
+    );
     expect(onDeleteLora).toHaveBeenCalledWith(expect.objectContaining({ id: "ready_style" }));
     expect(container.textContent).toContain("Removed the registry entry for Ready Style.");
   });

--- a/apps/web/src/App.purgeConfirm.test.jsx
+++ b/apps/web/src/App.purgeConfirm.test.jsx
@@ -1,0 +1,118 @@
+// sc-12068: App.purgeAsset's trash-unavailable → permanent-delete fallback confirms through
+// the shared desktop-safe appConfirm dialog rather than the raw window.confirm, which silently
+// no-ops in the Tauri WebView. This drives the REAL App callback end-to-end (Library Trashcan →
+// select a discarded asset → Purge) against a purge endpoint that reports `trash_unavailable`,
+// and asserts the guard fired via appConfirm and gated the permanent delete.
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { App } from "./main.jsx";
+import { FakeEventSource, response, settle } from "./main.testSupport.jsx";
+
+const { appConfirmMock } = vi.hoisted(() => ({ appConfirmMock: vi.fn(async () => true) }));
+vi.mock("./appConfirm.jsx", () => ({
+  appConfirm: appConfirmMock,
+  useConfirm: () => appConfirmMock,
+  ConfirmHost: () => null,
+}));
+
+const TRASHED_ASSET = {
+  id: "asset-trash",
+  projectId: "project-default",
+  type: "image",
+  displayName: "Discarded Frame",
+  status: { favorite: false, rating: 0, rejected: false, trashed: true },
+  recipe: { prompt: "discarded" },
+};
+
+describe("App purgeAsset trash-unavailable confirm (sc-12068)", () => {
+  let container;
+  let root;
+  let purgeRequests;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    FakeEventSource.instances = [];
+    window.EventSource = FakeEventSource;
+    window.localStorage.clear();
+    appConfirmMock.mockClear();
+    appConfirmMock.mockResolvedValue(true);
+    purgeRequests = [];
+    global.fetch = vi.fn((url, options = {}) => {
+      const parsed = new URL(url);
+      const path = parsed.pathname;
+      const method = options.method ?? "GET";
+      if (path.endsWith("/health")) return Promise.resolve(response({ status: "ok", authRequired: false }));
+      if (path.endsWith("/access")) return Promise.resolve(response({ authRequired: false }));
+      if (path.endsWith("/jobs/events/ticket")) return Promise.resolve(response({ ticket: "stream-ticket" }));
+      if (path.endsWith("/projects") && method === "GET") {
+        return Promise.resolve(response([{ id: "project-default", name: "Default Project" }]));
+      }
+      if (path.endsWith("/assets") && method === "GET") {
+        return Promise.resolve(response([TRASHED_ASSET]));
+      }
+      if (path.endsWith("/purge") && method === "DELETE") {
+        const permanent = parsed.searchParams.get("permanent") === "true";
+        purgeRequests.push({ permanent });
+        return Promise.resolve(response({ status: permanent ? "purged" : "trash_unavailable" }));
+      }
+      return Promise.resolve(response([]));
+    });
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  async function openTrashcanPurge() {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    // The default view is the Library/Assets tab; switch to the Trashcan collection.
+    const trashcanButton = [...document.body.querySelectorAll("button")].find((b) => b.textContent === "Trashcan");
+    expect(trashcanButton).toBeTruthy();
+    await act(async () => {
+      trashcanButton.click();
+    });
+    await settle();
+
+    // Select the discarded asset so its detail panel (with the Purge control) renders.
+    const tile = [...document.body.querySelectorAll(".asset-tile")].find((t) => t.textContent.includes("Discarded Frame"));
+    expect(tile).toBeTruthy();
+    await act(async () => {
+      tile.click();
+    });
+    await settle();
+
+    const purgeButton = [...document.body.querySelectorAll("button")].find((b) => b.textContent === "Purge");
+    expect(purgeButton).toBeTruthy();
+    await act(async () => {
+      purgeButton.click();
+    });
+    await settle();
+  }
+
+  it("confirms via appConfirm (danger) then issues the permanent purge when accepted", async () => {
+    await openTrashcanPurge();
+
+    expect(appConfirmMock).toHaveBeenCalledWith(expect.objectContaining({ tone: "danger" }));
+    // First the trash attempt (trash_unavailable), then — after the confirm — the permanent delete.
+    expect(purgeRequests).toContainEqual({ permanent: true });
+  });
+
+  it("does not permanently purge when the confirm is declined", async () => {
+    appConfirmMock.mockResolvedValue(false);
+    await openTrashcanPurge();
+
+    expect(appConfirmMock).toHaveBeenCalledWith(expect.objectContaining({ tone: "danger" }));
+    // Only the initial trash attempt was made — the permanent retry was gated off.
+    expect(purgeRequests).toEqual([{ permanent: false }]);
+  });
+});

--- a/apps/web/src/appConfirm.jsx
+++ b/apps/web/src/appConfirm.jsx
@@ -16,10 +16,13 @@
 // handlers, or a leave-guard callback), and `useConfirm()` is a thin React accessor that
 // returns it. Both resolve to `true` (proceed) or `false` (cancel).
 //
-// Adopters: the Image Editor Close/Discard + its leave-guard use this today. The other
-// window.confirm call sites (PresetManager, Training, Pose Library, the video EditorScreen
-// timeline-switch guard, App's trash-unavailable confirm) should migrate to it too so the
-// whole app is desktop-safe — tracked as follow-ups on sc-11968's siblings (S10–S12).
+// Adopters: every in-app confirm now routes through this helper so the whole app is
+// desktop-safe — the Image Editor Close/Discard + leave-guard, PresetManager, Training,
+// Pose Library, the video EditorScreen timeline-switch guard, ModelManager model/LoRA/
+// tier deletes, Character Studio archive, the asset Trashcan empty/purge, and both
+// trash-unavailable permanent-delete fallbacks (App.purgeAsset, useModelsAndLoras). No
+// raw window.confirm call sites remain (migrations: sc-11968's siblings S10–S12, then
+// sc-12018 and sc-12068).
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Modal } from "./components/Modal.jsx";
 

--- a/apps/web/src/components/assetPanels.emptyTrash.test.jsx
+++ b/apps/web/src/components/assetPanels.emptyTrash.test.jsx
@@ -1,0 +1,67 @@
+// sc-12068: emptyTrash confirms a permanent purge through the shared desktop-safe
+// appConfirm helper (a real in-app dialog) instead of the raw window.confirm, which
+// silently no-ops inside the Tauri WebView. These tests mock appConfirm so they can
+// control the user's choice and assert the guard fired with the destructive (danger)
+// tone, and that nothing is purged when the confirm is declined.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { appConfirmMock } = vi.hoisted(() => ({ appConfirmMock: vi.fn(async () => true) }));
+vi.mock("../appConfirm.jsx", () => ({
+  appConfirm: appConfirmMock,
+  useConfirm: () => appConfirmMock,
+  ConfirmHost: () => null,
+}));
+
+import { emptyTrash } from "./assetPanels.jsx";
+
+const trashed = (id) => ({ id, status: { trashed: true } });
+const kept = (id) => ({ id, status: { trashed: false } });
+
+describe("emptyTrash desktop-safe confirm (sc-12068)", () => {
+  beforeEach(() => {
+    appConfirmMock.mockClear();
+    appConfirmMock.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("confirms via appConfirm (danger tone) and purges every trashed item when accepted", async () => {
+    const purgeAsset = vi.fn(async () => {});
+    await emptyTrash([trashed("a"), trashed("b"), kept("c")], purgeAsset);
+
+    // The guard went through appConfirm — not the raw window.confirm.
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    expect(appConfirmMock.mock.calls[0][0]).toMatchObject({ tone: "danger" });
+    expect(appConfirmMock.mock.calls[0][0].message).toContain("2 discarded items");
+
+    // Only the trashed items are purged, in order; the kept one is untouched.
+    expect(purgeAsset).toHaveBeenCalledTimes(2);
+    expect(purgeAsset.mock.calls.map((call) => call[0].id)).toEqual(["a", "b"]);
+  });
+
+  it("purges nothing when the confirm is declined", async () => {
+    appConfirmMock.mockResolvedValue(false);
+    const purgeAsset = vi.fn(async () => {});
+    await emptyTrash([trashed("a")], purgeAsset);
+
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    expect(purgeAsset).not.toHaveBeenCalled();
+  });
+
+  it("uses the singular label for a single discarded item", async () => {
+    const purgeAsset = vi.fn(async () => {});
+    await emptyTrash([trashed("only")], purgeAsset);
+
+    expect(appConfirmMock.mock.calls[0][0].message).toContain("1 discarded item?");
+  });
+
+  it("never prompts when there is nothing trashed", async () => {
+    const purgeAsset = vi.fn(async () => {});
+    await emptyTrash([kept("c")], purgeAsset);
+
+    expect(appConfirmMock).not.toHaveBeenCalled();
+    expect(purgeAsset).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { isAbortError } from "../api.js";
+import { appConfirm } from "../appConfirm.jsx";
 import { assetMatchesCharacter } from "../characterMembership.js";
 import { saveAssetAs, revealAsset } from "../assetActions.js";
 import { isDesktop, isPageFullscreen, setViewerFullscreen } from "../runtime.js";
@@ -64,20 +65,24 @@ export function clampPan(view, stageWidth, stageHeight) {
 
 // Permanently purge every discarded asset in a single Trashcan view. The caller
 // passes only the assets visible in that view, so per-character and per-filter
-// trashcans empty their own scope and nothing else. Confirms first (guarded so
-// headless/test environments skip the prompt) and purges sequentially.
+// trashcans empty their own scope and nothing else. Confirms first through the
+// desktop-safe appConfirm (sc-12068) — window.confirm silently no-ops in the Tauri
+// WebView. appConfirm still falls back to window.confirm (or proceeds) when no
+// ConfirmHost is mounted, preserving the "skip the prompt → proceed" behavior in
+// headless/test contexts. Purges sequentially.
 export async function emptyTrash(trashedAssets, purgeAsset) {
   const items = (trashedAssets ?? []).filter((asset) => asset?.status?.trashed);
   if (!items.length || typeof purgeAsset !== "function") {
     return;
   }
-  if (
-    typeof window !== "undefined" &&
-    typeof window.confirm === "function" &&
-    !window.confirm(
-      `Permanently delete ${items.length} discarded item${items.length === 1 ? "" : "s"}? This cannot be undone.`,
-    )
-  ) {
+  const proceed = await appConfirm({
+    title: "Empty trash?",
+    message: `Permanently delete ${items.length} discarded item${items.length === 1 ? "" : "s"}? This cannot be undone.`,
+    confirmLabel: "Delete permanently",
+    cancelLabel: "Cancel",
+    tone: "danger",
+  });
+  if (!proceed) {
     return;
   }
   for (const asset of items) {

--- a/apps/web/src/hooks/useModelsAndLoras.js
+++ b/apps/web/src/hooks/useModelsAndLoras.js
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import { apiFetch, isAbortError } from "../api.js";
+import { appConfirm } from "../appConfirm.jsx";
 import { upsertJobNewest } from "../sorters.js";
 
 const maxLoraUploadBytes = 2 * 1024 * 1024 * 1024;
@@ -12,10 +13,18 @@ function uploadLimitLabel(bytes) {
 
 // A delete first tries to move the artifacts to the OS trash (Recycle Bin / Trash).
 // When that fails the API removes nothing and returns `trashUnavailable`; the user is
-// then asked whether to fall back to a permanent delete. Returns true to proceed.
+// then asked whether to fall back to a permanent delete. Resolves true to proceed.
+// Routed through the desktop-safe appConfirm (sc-12068) — window.confirm silently
+// no-ops in the Tauri WebView; the delete actions below await this Promise<boolean>.
 export const TRASH_UNAVAILABLE_CONFIRM = "Cannot move to trash. Continue to permanently delete.";
 function confirmPermanentDelete() {
-  return typeof window.confirm !== "function" || window.confirm(TRASH_UNAVAILABLE_CONFIRM);
+  return appConfirm({
+    title: "Move to trash failed",
+    message: TRASH_UNAVAILABLE_CONFIRM,
+    confirmLabel: "Delete permanently",
+    cancelLabel: "Cancel",
+    tone: "danger",
+  });
 }
 
 // Owns the model + LoRA catalogs and their import/download/convert/delete actions.
@@ -72,7 +81,7 @@ export function useModelsAndLoras({
         method: "DELETE",
       });
       if (result?.trashUnavailable) {
-        if (!confirmPermanentDelete()) {
+        if (!(await confirmPermanentDelete())) {
           return { cancelled: true };
         }
         result = await apiFetch(
@@ -103,7 +112,7 @@ export function useModelsAndLoras({
       )}`;
       let result = await apiFetch(base, token, { method: "DELETE" });
       if (result?.trashUnavailable) {
-        if (!confirmPermanentDelete()) {
+        if (!(await confirmPermanentDelete())) {
           return { cancelled: true };
         }
         result = await apiFetch(`${base}?permanent=true`, token, { method: "DELETE" });
@@ -129,7 +138,7 @@ export function useModelsAndLoras({
       method: "DELETE",
     });
     if (result?.trashUnavailable) {
-      if (!confirmPermanentDelete()) {
+      if (!(await confirmPermanentDelete())) {
         return { cancelled: true };
       }
       params.set("permanent", "true");

--- a/apps/web/src/hooks/useModelsAndLoras.trashConfirm.test.jsx
+++ b/apps/web/src/hooks/useModelsAndLoras.trashConfirm.test.jsx
@@ -1,0 +1,121 @@
+// sc-12068: when a model/LoRA delete can't move artifacts to the OS trash, the hook
+// falls back to a permanent delete only after confirming. That confirm now routes
+// through the shared desktop-safe appConfirm helper (a real in-app dialog) instead of
+// the raw window.confirm, which silently no-ops inside the Tauri WebView. These tests
+// drive the hook's delete actions with an apiFetch that reports `trashUnavailable` and
+// assert the guard fired via appConfirm (danger tone), gating the permanent retry.
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { appConfirmMock } = vi.hoisted(() => ({ appConfirmMock: vi.fn(async () => true) }));
+vi.mock("../appConfirm.jsx", () => ({
+  appConfirm: appConfirmMock,
+  useConfirm: () => appConfirmMock,
+  ConfirmHost: () => null,
+}));
+
+const { apiFetchMock } = vi.hoisted(() => ({ apiFetchMock: vi.fn() }));
+vi.mock("../api.js", () => ({
+  apiFetch: (...args) => apiFetchMock(...args),
+  isAbortError: () => false,
+}));
+
+import { useModelsAndLoras } from "./useModelsAndLoras.js";
+
+let container;
+let root;
+let hookApi;
+
+function Harness() {
+  hookApi = useModelsAndLoras({
+    token: "tok",
+    activeProject: { id: "proj-1" },
+    activeProjectRef: { current: { id: "proj-1" } },
+    setError: () => {},
+    setJobs: () => {},
+    setActiveView: () => {},
+    refreshData: async () => {},
+    refreshDataWithLoraOverlay: async () => {},
+  });
+  return null;
+}
+
+beforeEach(async () => {
+  global.IS_REACT_ACT_ENVIRONMENT = true;
+  appConfirmMock.mockClear();
+  appConfirmMock.mockResolvedValue(true);
+  apiFetchMock.mockReset();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root.render(<Harness />);
+  });
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+describe("useModelsAndLoras trash-unavailable permanent-delete confirm (sc-12068)", () => {
+  it("model delete: prompts via appConfirm (danger) and retries permanently when accepted", async () => {
+    apiFetchMock
+      .mockResolvedValueOnce({ trashUnavailable: true })
+      .mockResolvedValueOnce({ removedManifestEntry: true });
+
+    let result;
+    await act(async () => {
+      result = await hookApi.deleteModel({ id: "m1" });
+    });
+
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    expect(appConfirmMock.mock.calls[0][0]).toMatchObject({ tone: "danger" });
+    expect(apiFetchMock).toHaveBeenCalledTimes(2);
+    expect(apiFetchMock.mock.calls[1][0]).toContain("permanent=true");
+    expect(result).toMatchObject({ removedManifestEntry: true });
+  });
+
+  it("model delete: cancels (no permanent retry) when the confirm is declined", async () => {
+    appConfirmMock.mockResolvedValue(false);
+    apiFetchMock.mockResolvedValueOnce({ trashUnavailable: true });
+
+    let result;
+    await act(async () => {
+      result = await hookApi.deleteModel({ id: "m1" });
+    });
+
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    expect(apiFetchMock).toHaveBeenCalledTimes(1); // no permanent retry issued
+    expect(result).toEqual({ cancelled: true });
+  });
+
+  it("lora delete: prompts via appConfirm (danger) and retries permanently when accepted", async () => {
+    apiFetchMock
+      .mockResolvedValueOnce({ trashUnavailable: true })
+      .mockResolvedValueOnce({ removedManifestEntry: true });
+
+    let result;
+    await act(async () => {
+      result = await hookApi.deleteLora({ id: "l1", scope: "global" });
+    });
+
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    expect(appConfirmMock.mock.calls[0][0]).toMatchObject({ tone: "danger" });
+    expect(apiFetchMock).toHaveBeenCalledTimes(2);
+    expect(apiFetchMock.mock.calls[1][0]).toContain("permanent=true");
+    expect(result).toMatchObject({ removedManifestEntry: true });
+  });
+
+  it("does not prompt when the trash delete succeeds outright", async () => {
+    apiFetchMock.mockResolvedValueOnce({ removedManifestEntry: true });
+
+    await act(async () => {
+      await hookApi.deleteModel({ id: "m1" });
+    });
+
+    expect(appConfirmMock).not.toHaveBeenCalled();
+    expect(apiFetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -10,6 +10,7 @@ import {
   CharacterTest,
   editableLora,
 } from "./characterPanels.jsx";
+import { appConfirm } from "../appConfirm.jsx";
 import { CompactSelector } from "../components/CompactSelector.jsx";
 import { WorkPanel } from "../components/WorkPanel.jsx";
 import { assetMatchesCharacter } from "../characterMembership.js";
@@ -458,18 +459,21 @@ export function CharacterStudio() {
   }, [archivedOpen, loadArchived]);
 
   // sc-6066: archiving is destructive-feeling (the character vanishes from the list),
-  // so confirm first — a single misclick shouldn't silently hide a character.
+  // so confirm first — a single misclick shouldn't silently hide a character. Routed
+  // through the desktop-safe appConfirm (sc-12068); window.confirm silently no-ops in
+  // the Tauri WebView. Archiving is reversible ("Show archived characters"), so this
+  // uses the default (non-danger) tone.
   async function handleArchiveSelected() {
     if (!selectedCharacter) {
       return;
     }
-    if (
-      typeof window !== "undefined" &&
-      typeof window.confirm === "function" &&
-      !window.confirm(
-        `Archive "${selectedCharacter.name || "this character"}"? It will be hidden from the active list. You can restore it later from "Show archived characters".`,
-      )
-    ) {
+    const proceed = await appConfirm({
+      title: "Archive character?",
+      message: `Archive "${selectedCharacter.name || "this character"}"? It will be hidden from the active list. You can restore it later from "Show archived characters".`,
+      confirmLabel: "Archive",
+      cancelLabel: "Cancel",
+    });
+    if (!proceed) {
       return;
     }
     await archiveCharacter(selectedCharacter.id);

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -14,6 +14,7 @@ import {
 import { useAppContext } from "../context/AppContext.js";
 import { DEFAULT_MAC_CAPABILITIES, macModelBlock } from "../macGating.js";
 import { apiFetch } from "../api.js";
+import { appConfirm } from "../appConfirm.jsx";
 import { KeywordTagEditor } from "../components/KeywordTagEditor.jsx";
 import { isDesktop, tauriInvoke } from "../runtime.js";
 import { tierLabel } from "../quantTier.js";
@@ -947,7 +948,16 @@ export function ModelManagerScreen() {
     if (!onDeleteModel || model.removable === false) {
       return;
     }
-    if (typeof window.confirm === "function" && !window.confirm(deleteConfirmation("model", model, recipePresets))) {
+    // Desktop-safe confirm (sc-12068) — window.confirm no-ops in the Tauri WebView.
+    if (
+      !(await appConfirm({
+        title: "Delete model?",
+        message: deleteConfirmation("model", model, recipePresets),
+        confirmLabel: "Delete",
+        cancelLabel: "Cancel",
+        tone: "danger",
+      }))
+    ) {
       return;
     }
     setDeletingItem(`model:${model.id}`);
@@ -983,7 +993,16 @@ export function ModelManagerScreen() {
       `Delete the ${tierName} tier of "${model.name ?? model.id}"?`,
       `${sizeClause} only this tier — the model and its other tiers stay installed.`,
     ].join("\n\n");
-    if (typeof window.confirm === "function" && !window.confirm(message)) {
+    // Desktop-safe confirm (sc-12068) — window.confirm no-ops in the Tauri WebView.
+    if (
+      !(await appConfirm({
+        title: "Delete tier?",
+        message,
+        confirmLabel: "Delete",
+        cancelLabel: "Cancel",
+        tone: "danger",
+      }))
+    ) {
       return;
     }
     setDeletingItem(`variant:${model.id}:${tier}`);
@@ -1010,7 +1029,16 @@ export function ModelManagerScreen() {
     if (!onDeleteLora || lora.removable === false) {
       return;
     }
-    if (typeof window.confirm === "function" && !window.confirm(deleteConfirmation("lora", lora, recipePresets))) {
+    // Desktop-safe confirm (sc-12068) — window.confirm no-ops in the Tauri WebView.
+    if (
+      !(await appConfirm({
+        title: "Delete LoRA?",
+        message: deleteConfirmation("lora", lora, recipePresets),
+        confirmLabel: "Delete",
+        cancelLabel: "Cancel",
+        tone: "danger",
+      }))
+    ) {
       return;
     }
     setDeletingItem(`lora:${lora.scope ?? "global"}:${lora.id}`);

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -3,6 +3,27 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { click } from "../testUtils/dom.js";
 
+// sc-12068: model / LoRA / tier deletes confirm through the shared desktop-safe appConfirm
+// dialog rather than the raw window.confirm, which silently no-ops inside the Tauri WebView.
+// Mock it so tests control the user's choice and assert the guard fired. resetModules in the
+// per-describe beforeEach re-imports the screen fresh; this static mock still intercepts it.
+const { appConfirmMock } = vi.hoisted(() => ({ appConfirmMock: vi.fn(async () => true) }));
+vi.mock("../appConfirm.jsx", () => ({
+  appConfirm: appConfirmMock,
+  useConfirm: () => appConfirmMock,
+  ConfirmHost: () => null,
+}));
+
+// The delete handlers await appConfirm (a Promise) before calling the delete action, so the
+// action runs a microtask after the click. Flush those microtasks before asserting.
+async function flushConfirm() {
+  await act(async () => {
+    for (let i = 0; i < 4; i += 1) {
+      await Promise.resolve();
+    }
+  });
+}
+
 // The screen is a tabbed interface (epic 10309): Image / Video / Utility / LoRAs tabs,
 // each showing only its own models, plus a transient Search Results tab. A model card
 // or the LoRA import form is only in the DOM while its tab is active, so tests select
@@ -1106,7 +1127,8 @@ describe("ModelManagerScreen quant-tier download panel (sc-8509)", () => {
   // not-installed tier has none. Clicking it (after the confirm) calls deleteModelVariant with the
   // tier key, so the backend removes just that tier's files/blobs and leaves the rest installed.
   it("shows a per-tier delete on installed tiers only, and deletes that tier", async () => {
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    appConfirmMock.mockReset();
+    appConfirmMock.mockResolvedValue(true);
     await render([matrixModel({ installed: ["q8"] })]);
     const rowFor = (label) =>
       tierRows().find((row) => row.querySelector(".model-tier-label").textContent.includes(label));
@@ -1115,18 +1137,21 @@ describe("ModelManagerScreen quant-tier download panel (sc-8509)", () => {
     expect(rowFor("Q4").querySelector(".model-tier-delete")).toBeNull();
     expect(rowFor("bf16").querySelector(".model-tier-delete")).toBeNull();
     await click(rowFor("Q8").querySelector(".model-tier-delete"));
+    await flushConfirm();
+    // sc-12068: the per-tier delete confirms through the desktop-safe appConfirm dialog.
+    expect(appConfirmMock).toHaveBeenCalledWith(expect.objectContaining({ tone: "danger" }));
     expect(deleteModelVariant).toHaveBeenCalledTimes(1);
     expect(deleteModelVariant).toHaveBeenCalledWith(
       expect.objectContaining({ id: "z_image_turbo" }),
       "q8",
     );
-    confirmSpy.mockRestore();
   });
 
   // sc-12025: convert-at-install models (mlxTiers, e.g. Anima) render no download panel, so they get
   // a compact installed-tiers list with per-tier delete instead — reusing the same deleteModelVariant.
   it("shows an installed-tiers delete list for a convert-at-install (mlxTiers) model", async () => {
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    appConfirmMock.mockReset();
+    appConfirmMock.mockResolvedValue(true);
     const convertModel = {
       id: "anima_base",
       name: "Anima",
@@ -1150,11 +1175,12 @@ describe("ModelManagerScreen quant-tier download panel (sc-8509)", () => {
     expect(labels[2]).toContain("Q4");
     const q4Row = rows.find((row) => row.querySelector(".model-tier-label").textContent.includes("Q4"));
     await click(q4Row.querySelector(".model-tier-delete"));
+    await flushConfirm();
+    expect(appConfirmMock).toHaveBeenCalledWith(expect.objectContaining({ tone: "danger" }));
     expect(deleteModelVariant).toHaveBeenCalledWith(
       expect.objectContaining({ id: "anima_base" }),
       "q4",
     );
-    confirmSpy.mockRestore();
   });
 
   it("leaves a single-variant model's download UX unchanged (no tier panel)", async () => {
@@ -1265,5 +1291,130 @@ describe("ModelManagerScreen convert-at-install Update button", () => {
     expect(mlxButtons().some((button) => button.textContent === "Update")).toBe(false);
     expect(mlxButtons().some((button) => button.textContent === "MLX ready")).toBe(true);
     expect(createModelDownloadJob).not.toHaveBeenCalled();
+  });
+});
+
+// sc-12068: the whole-model and whole-LoRA delete buttons confirm through the desktop-safe
+// appConfirm dialog (danger tone) before invoking the delete action, so a misclick can't
+// silently remove installed weights and the guard actually renders on the Tauri desktop.
+describe("ModelManagerScreen model & LoRA delete confirms (sc-12068)", () => {
+  let container;
+  let root;
+  let deleteModel;
+  let deleteLora;
+  let ModelManagerScreen;
+  let AppContext;
+
+  beforeEach(async () => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.__TAURI__ = { core: { invoke: vi.fn(async () => null) } };
+    deleteModel = vi.fn(async () => ({ removedManifestEntry: true }));
+    deleteLora = vi.fn(async () => ({ removedManifestEntry: true }));
+    vi.resetModules();
+    ({ AppContext } = await import("../context/AppContext.js"));
+    ({ ModelManagerScreen } = await import("./ModelManagerScreen.jsx"));
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    delete window.__TAURI__;
+    vi.restoreAllMocks();
+  });
+
+  async function render({ models = [], loras = [] } = {}) {
+    const value = {
+      activeProject: null,
+      jobs: [],
+      loras,
+      models,
+      presets: [],
+      workersById: new Map(),
+      visibleWorkers: [],
+      jobAction: () => {},
+      setActiveView: () => {},
+      deleteLora,
+      deleteModel,
+      createModelDownloadJob: () => {},
+      createLoraDownloadJob: () => {},
+      createModelConvertJob: () => {},
+      createLoraImportJob: () => {},
+      createModelImportJob: () => {},
+    };
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={value}>
+          <ModelManagerScreen />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  const installedModel = {
+    id: "z_image_turbo",
+    name: "Z-Image-Turbo",
+    type: "image",
+    family: "z-image",
+    capabilities: ["text_to_image"],
+    installState: "installed",
+    removable: true,
+  };
+
+  const modelDeleteButton = () =>
+    [...container.querySelectorAll(".model-card .danger-action")].find((button) => button.textContent === "Delete");
+
+  it("confirms a model delete via appConfirm (danger) and removes it when accepted", async () => {
+    appConfirmMock.mockReset();
+    appConfirmMock.mockResolvedValue(true);
+    await render({ models: [installedModel] });
+
+    const button = modelDeleteButton();
+    expect(button).toBeTruthy();
+    await click(button);
+    await flushConfirm();
+
+    expect(appConfirmMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Delete model?", tone: "danger" }),
+    );
+    expect(deleteModel).toHaveBeenCalledWith(expect.objectContaining({ id: "z_image_turbo" }));
+  });
+
+  it("does not delete a model when the confirm is declined", async () => {
+    appConfirmMock.mockReset();
+    appConfirmMock.mockResolvedValue(false);
+    await render({ models: [installedModel] });
+
+    await click(modelDeleteButton());
+    await flushConfirm();
+
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    expect(deleteModel).not.toHaveBeenCalled();
+  });
+
+  it("confirms a LoRA delete via appConfirm (danger) and removes it when accepted", async () => {
+    appConfirmMock.mockReset();
+    appConfirmMock.mockResolvedValue(true);
+    await render({
+      loras: [{ id: "my_lora", name: "My LoRA", scope: "global", family: "flux", removable: true }],
+    });
+    await selectTab(container, "LoRAs");
+
+    const button = [...container.querySelectorAll(".lora-row-actions .danger-action")].find(
+      (candidate) => candidate.textContent === "Delete",
+    );
+    expect(button).toBeTruthy();
+    await click(button);
+    await flushConfirm();
+
+    expect(appConfirmMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Delete LoRA?", tone: "danger" }),
+    );
+    expect(deleteLora).toHaveBeenCalledWith(expect.objectContaining({ id: "my_lora" }));
   });
 });


### PR DESCRIPTION
## What & why

`window.confirm` silently no-ops inside the Tauri desktop WebView (returns `undefined` rather than a boolean), so a "Discard?"/"Delete?" guard built on it is **dead on desktop** — it can neither confirm nor cancel. This migrates every remaining raw `window.confirm` call site in `apps/web/src` to the shared, desktop-safe `appConfirm` dialog (sc-11968), completing the sweep started by sc-11968 (S9) and sc-12018 (S8 follow-up).

Closes **[sc-12068](https://app.shortcut.com/trefry/story/12068)**.

## Sites migrated
| Site | Tone |
|---|---|
| `components/assetPanels.jsx` → `emptyTrash` (Trashcan "Empty Trash") | danger |
| `screens/CharacterStudio.jsx` → `handleArchiveSelected` | default (archive is reversible) |
| `screens/ModelManagerScreen.jsx` → `deleteModel`, `deleteModelVariant`, `deleteLora` | danger |
| `hooks/useModelsAndLoras.js` → `confirmPermanentDelete` (now async; awaited at the 3 callers) | danger |
| `App.jsx` → `purgeAsset` trash-unavailable fallback | danger |

`appConfirm.jsx`'s adopter/TODO comment is refreshed — **no raw `window.confirm` call sites remain** (only `appConfirm`'s own intentional fallback for non-DOM/test contexts).

> Note: `useModelsAndLoras.confirmPermanentDelete` became `async`; all three delete actions (`deleteModel`/`deleteModelVariant`/`deleteLora`) were already `async` and now `await` it.

## Tests (assert `appConfirm` is used at each site)
- **New** `assetPanels.emptyTrash.test.jsx`, `useModelsAndLoras.trashConfirm.test.jsx`.
- **New** `App.purgeConfirm.test.jsx` — drives the **real** `App.purgeAsset` end-to-end through the full `<App/>` (Library → Trashcan → select → Purge) against a `trash_unavailable` purge endpoint.
- **Updated** `ModelManagerScreen.test.jsx` (moved the 2 tier-delete tests off the `window.confirm` spy + added whole-model/LoRA delete tests), `App.character.test.jsx`, `App.models.test.jsx`, `App.library.test.jsx`.

## Validation
- Web suite: **135 files / 1805 tests pass** (`vitest run --environment jsdom`).
- Lint: **0 errors** (`eslint src`). Only pre-existing warnings; the one unused `no-await-in-loop` directive in `assetPanels.jsx` is on a line this PR does not touch.
- No Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)