### PR TITLE
fix(models): per-tier quant delete permanently, skip OS trash (sc-12088)

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -526,14 +526,15 @@ pub(crate) async fn delete_model(
 /// the whole model. Unlike `delete_model` — which removes the whole repo dir AND the registry
 /// entry — this is scoped to the tier's `files` and never touches the manifest, so the model
 /// stays catalogued and re-downloadable; deleting the last remaining tier simply flips it back
-/// to not-installed. Mirrors `delete_model`'s trash-first → `trashUnavailable` → `?permanent`
-/// retry contract and the same ownership guard (`<data>/models` + the HF hub cache).
+/// to not-installed. Unlike `delete_model` this deletes PERMANENTLY (never the OS trash): a tier is
+/// many loose HF-cache blobs + snapshot symlinks, and trashing them one-by-one drove a macOS
+/// per-file permission-prompt loop ("you don't have permission to access some of the items") — and a
+/// tier isn't restorable from loose trashed blobs anyway (sc-12088). Same ownership guard as
+/// `delete_model` (`<data>/models` + the HF hub cache).
 pub(crate) async fn delete_model_variant(
     State(state): State<AppState>,
     Path((model_id, variant)): Path<(String, String)>,
-    Query(query): Query<CatalogDeleteQuery>,
 ) -> Result<Json<Value>, ApiError> {
-    let permanent = query.permanent.unwrap_or(false);
     let variant = variant.trim().to_ascii_lowercase();
     let catalog = model_catalog(&state).await?;
     let model = catalog
@@ -566,7 +567,8 @@ pub(crate) async fn delete_model_variant(
         }
         let repo_cache = huggingface_repo_cache_path(data_dir, &repo);
         let managed_dir = Some(data_dir.join("models").join(safe_download_dir(&repo)));
-        remove_tier_artifacts(repo_cache, managed_dir, &files, &allowed_roots, permanent).await?
+        // Always permanent (skip the OS trash) — see the fn doc (sc-12088).
+        remove_tier_artifacts(repo_cache, managed_dir, &files, &allowed_roots, true).await?
     } else if model_has_convert_tier(&model, &variant) {
         // Convert-at-install: the tier is a real dir under the converted MLX tree. Prefer the
         // catalog's resolved `mlxConvertedPath`; fall back to the canonical convert output dir.
@@ -575,27 +577,13 @@ pub(crate) async fn delete_model_variant(
             .and_then(Value::as_str)
             .map(PathBuf::from)
             .unwrap_or_else(|| data_dir.join("models").join("mlx").join(&model_id));
-        remove_converted_tier(converted.join(&variant), &allowed_roots, permanent).await?
+        // Always permanent (skip the OS trash) — see the fn doc (sc-12088).
+        remove_converted_tier(converted.join(&variant), &allowed_roots, true).await?
     } else {
         return Err(ApiError::bad_request(format!(
             "Model does not advertise a '{variant}' quant tier"
         )));
     };
-    // Some owned files could not reach the OS trash and nothing was permanently deleted — ask
-    // the client to confirm a permanent delete (same contract as `delete_model`).
-    if !permanent && !removal.trash_failed_paths.is_empty() {
-        return Ok(Json(json!({
-            "id": model_id,
-            "variant": variant,
-            "kind": "model-variant",
-            "trashUnavailable": true,
-            "trashFailedPaths": removal.trash_failed_paths,
-            "removedLocalArtifacts": !removal.removed_paths.is_empty(),
-            "reclaimedBytes": removal.reclaimed_bytes,
-            "removedPaths": removal.removed_paths,
-            "retainedPaths": removal.retained_paths,
-        })));
-    }
     if removal.removed_paths.is_empty() {
         return Err(ApiError::bad_request(format!(
             "Tier '{variant}' is not installed"
@@ -605,7 +593,8 @@ pub(crate) async fn delete_model_variant(
         "id": model_id,
         "variant": variant,
         "kind": "model-variant",
-        "trashed": !permanent,
+        // Permanent delete: no OS trash, no undo (sc-12088).
+        "trashed": false,
         // A tier delete NEVER removes the registry entry: the model stays in the catalog so the
         // tier can be re-downloaded. Emitted false so the web keeps the model card in place.
         "removedManifestEntry": false,

--- a/apps/web/src/hooks/useModelsAndLoras.js
+++ b/apps/web/src/hooks/useModelsAndLoras.js
@@ -103,20 +103,17 @@ export function useModelsAndLoras({
   // Delete ONE installed quant tier of a model and reclaim its disk (sc-12024). Counterpart to
   // createModelDownloadJob's per-tier install: hits DELETE …/variants/:variant, which removes only
   // that tier's files/blobs and NEVER the registry entry. So — unlike deleteModel — the model card
-  // stays put; the catalog refetch flips the tier from "installed" to "not installed". Mirrors the
-  // trash-first → trashUnavailable → permanent retry contract.
+  // stays put; the catalog refetch flips the tier from "installed" to "not installed". Unlike
+  // deleteModel this deletes PERMANENTLY (the backend never uses the OS trash for a tier): a tier is
+  // many loose HF-cache blobs, so trashing them one-by-one drove a macOS per-file permission-prompt
+  // loop (sc-12088). One DELETE; the confirm dialog makes the permanence explicit.
   const deleteModelVariant = useCallback(
     async (model, variant) => {
-      const base = `/api/v1/models/${encodeURIComponent(model.id)}/variants/${encodeURIComponent(
-        variant,
-      )}`;
-      let result = await apiFetch(base, token, { method: "DELETE" });
-      if (result?.trashUnavailable) {
-        if (!(await confirmPermanentDelete())) {
-          return { cancelled: true };
-        }
-        result = await apiFetch(`${base}?permanent=true`, token, { method: "DELETE" });
-      }
+      const result = await apiFetch(
+        `/api/v1/models/${encodeURIComponent(model.id)}/variants/${encodeURIComponent(variant)}`,
+        token,
+        { method: "DELETE" },
+      );
       setError("");
       await refreshData();
       return result;

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -988,10 +988,12 @@ export function ModelManagerScreen() {
     }
     const tierName = tierLabel(tier);
     const sizeClause =
-      sizeBytes != null ? `This reclaims about ${formatTierSize(sizeBytes)} and removes` : "This removes";
+      sizeBytes != null
+        ? `This permanently frees about ${formatTierSize(sizeBytes)} and removes`
+        : "This permanently removes";
     const message = [
       `Delete the ${tierName} tier of "${model.name ?? model.id}"?`,
-      `${sizeClause} only this tier — the model and its other tiers stay installed.`,
+      `${sizeClause} only this tier — your other tiers stay installed. It skips the Trash and can't be undone.`,
     ].join("\n\n");
     // Desktop-safe confirm (sc-12068) — window.confirm no-ops in the Tauri WebView.
     if (


### PR DESCRIPTION
## Bug
Deleting a quant tier (sc-12024) trashed each artifact via `move_path_to_os_trash` in a loop. A tier is many loose blobs + snapshot symlinks under `~/.cache/huggingface`, so macOS Finder:
1. prompted for the user's **password** on the trash op,
2. failed with *"The operation can't be completed because you don't have permission to access some of the items"* (extensionless blobs), and
3. the `trashUnavailable` → permanent retry, combined with per-file trash attempts, became an **endless permission-prompt cycle**.

Trashing loose HF blobs isn't meaningfully restorable anyway — a tier can't be reassembled from individual trashed blobs.

## Fix
Per-tier delete now deletes **permanently** (never the OS trash):
- `delete_model_variant` drops the `Query(permanent)` extractor + the `trashUnavailable` branch and passes `permanent = true` to `remove_tier_artifacts` / `remove_converted_tier`, so removal is a direct `unlink` — no Finder, no prompt.
- The web `deleteModelVariant` hook does a **single DELETE** (no retry).
- The confirm dialog now states it **permanently frees** the disk, **skips the Trash, and can't be undone** (other tiers stay installed).

Whole-model delete (`delete_model`) is unchanged — it trashes the whole repo dir in one op and wasn't reported broken.

## Tests
Existing tier-delete suite already exercises the permanent path (all 7 pass); web tests green (42); clippy/fmt/eslint clean.

Fixes sc-12088. Follows sc-12024 (epic 8506).

🤖 Generated with [Claude Code](https://claude.com/claude-code)