### PR TITLE
fix(models): correct Krea candle VRAM tiers (sc-12126)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2514,7 +2514,7 @@
         // measurement. It gates the `int8-convrot` variant through the SAME per-tier memory-eligibility
         // path as q4/q8/bf16 (the third of the three ConvRot gates; the candle lane + sm_89 compute-cap
         // are the worker's `int8_convrot` capability).
-        "vramGbByTier": { "q4": 26.4, "q8": 31.0, "bf16": 44.0, "int8-convrot": 31.0 },
+        "vramGbByTier": { "q4": 26.4, "q8": 35.9, "bf16": 55.6, "int8-convrot": 31.0 },
         "measured": false,
         // Pose-ControlNet lane VRAM fit ladder (sc-11754, epic 8459 → epic 10765). The control lane loads
         // the base at the installed tier PLUS the trained ~6.6 GB bf16 control branch, so its render peak

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -252,6 +252,21 @@ def test_z_image_turbo_manifest_has_mlx_block():
     )
 
 
+def test_krea_2_turbo_candle_vram_tiers_match_measured_peaks():
+    """sc-12126: never regress the measured q8/bf16 peaks to estimates."""
+    manifest = _load_builtin_models_manifest()
+    krea = next(model for model in manifest["models"] if model["id"] == "krea_2_turbo")
+    measured_tiers = {
+        tier: krea["candle"]["vramGbByTier"][tier] for tier in ("q4", "q8", "bf16")
+    }
+
+    assert measured_tiers == {
+        "q4": 26.4,
+        "q8": 35.9,
+        "bf16": 55.6,
+    }
+
+
 def test_sdxl_manifest_has_mlx_block():
     # sdxl carries an mlx block (no `limits` override here — the MLX SDXL schedule
     # matches the torch EulerDiscrete default, and there's no per-model sampler menu


### PR DESCRIPTION
## Summary

- correct the Krea 2 candle q8 peak from 31.0 GB to the measured 35.9 GB
- correct the bf16 peak from 44.0 GB to the measured 55.6 GB
- add a manifest regression test for the measured q4/q8/bf16 tier values

## Root cause and impact

The q8 and bf16 values were extrapolated rather than measured and under-predicted real peak VRAM by 4.9 GB and 11.6 GB respectively. The candle admission gate therefore allowed configurations such as q8 on a 32 GB card, which then OOMed during model loading.

These values now match the RTX PRO 6000 measurements, so affected cards are rejected or downgraded before loading instead of failing mid-run. The measured q4 value and the unmeasured, non-shipping `int8-convrot` value remain unchanged. `sequentialPeakGb` and `measured: true` remain scoped to sc-12131.

## Validation

- `python -m pytest tests/test_builtin_manifest_audit.py -q -p no:cacheprovider` — 8 passed
- `node scripts/check-scaffold.mjs` — passed
- `git diff --check` — passed

Shortcut: [sc-12126](https://app.shortcut.com/trefry/story/12126)
