### PR TITLE
chore(worker): ship NVFP4 runtime — bump inference pins to runtime-2026.07.3 (sc-12006)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -454,7 +454,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -478,7 +478,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -491,7 +491,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -510,6 +510,7 @@ dependencies = [
  "candle-gen-krea",
  "candle-gen-lens",
  "candle-gen-ltx",
+ "candle-gen-mochi",
  "candle-gen-pid",
  "candle-gen-pulid",
  "candle-gen-qwen-image",
@@ -528,7 +529,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -542,7 +543,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -555,7 +556,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -565,7 +566,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -575,7 +576,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -592,7 +593,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -606,7 +607,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -620,7 +621,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -633,7 +634,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -642,7 +643,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -672,7 +673,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -686,7 +687,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -696,9 +697,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-gen-mochi"
+version = "0.0.0"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
+dependencies = [
+ "candle-gen",
+ "candle-gen-flux",
+ "image",
+ "rand 0.9.4",
+ "serde_json",
+ "tokenizers 0.22.2",
+]
+
+[[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-gen",
  "image",
@@ -708,7 +722,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -725,7 +739,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -738,7 +752,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -749,7 +763,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -759,7 +773,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -773,7 +787,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -789,7 +803,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -808,7 +822,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -819,7 +833,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -831,7 +845,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -841,7 +855,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -853,7 +867,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -878,7 +892,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1173,7 +1187,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -3632,7 +3646,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3645,7 +3659,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3657,7 +3671,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3670,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3683,7 +3697,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3702,6 +3716,7 @@ dependencies = [
  "mlx-gen-krea",
  "mlx-gen-lens",
  "mlx-gen-ltx",
+ "mlx-gen-mochi",
  "mlx-gen-pid",
  "mlx-gen-pulid",
  "mlx-gen-qwen-image",
@@ -3721,7 +3736,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3734,7 +3749,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -3744,7 +3759,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3753,7 +3768,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3762,7 +3777,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3775,7 +3790,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3787,7 +3802,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -3799,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3811,7 +3826,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -3820,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3832,7 +3847,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3846,7 +3861,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3859,7 +3874,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3868,9 +3883,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mlx-gen-mochi"
+version = "0.0.0"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
+dependencies = [
+ "mlx-gen",
+ "mlx-gen-flux",
+ "pmetal-mlx-rs",
+ "serde_json",
+]
+
+[[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3881,7 +3907,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3892,7 +3918,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3903,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3912,7 +3938,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3921,7 +3947,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3931,7 +3957,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -3942,7 +3968,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3956,7 +3982,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3969,7 +3995,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3979,7 +4005,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -3990,7 +4016,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4000,7 +4026,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4013,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4037,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "core-llm",
  "half",
@@ -4342,7 +4368,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5578,7 +5604,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5588,7 +5614,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "candle-gen-catalog",
  "candle-llm",
@@ -5598,7 +5624,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "mlx-gen-catalog",
  "mlx-llm",
@@ -5876,7 +5902,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3#8c35cd2a7523f80bd210f54db474ff792f9013e7"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -8288,7 +8314,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.3-rc.0" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.3" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.3-rc.0" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.3" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.3-rc.0", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.3", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/flux2_comfyui_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_comfyui_candle.rs
@@ -171,13 +171,39 @@ fn flux2_comfyui_raw_settings(
         "externalComfyuiBase".to_owned(),
         Value::String(request.model.clone()),
     );
+    // The tier this render actually used, recorded truthfully (sc-12006, epic 11037 SC#5).
+    //
+    // `mlxQuantize` is a BITS-VALUED key: every consumer parses it as an integer (`vram_gate::
+    // quant_int` = `as_i64` or numeric-string), and those bits NAME A TIER — `<= 0` ⇒ `bf16`,
+    // `<= 4` ⇒ `q4`, else `q8` (`vram_gate::requested_tier_key`). NVFP4 is a *distinct* tier, not
+    // int4-affine `q4`: E2M1 4-bit elements + FP8-E4M3 block scales in a W4A4 regime (~4.5 effective
+    // bits/weight), served by candle-gen's packed `Nvfp4Linear`. So there is NO honest integer for it
+    // — `4` would stamp an NVFP4 render as the `q4` tier in the stored settings, falsifying the user's
+    // creative choice (exactly the aliasing epic 11037 SC#5 forbids), and every other integer names
+    // `bf16`/`q8` instead. A string ("nvfp4") is no better: it is not an integer, so `quant_int`
+    // returns None and the key silently degrades to the `q8` default — a different false label.
+    //
+    // So NVFP4 gets `null` here — the same "no bits value applies" signal `mlx_raw_settings`
+    // (image_jobs/base.rs) already writes for this key — and its identity rides a distinct
+    // `quantTier` label below. This mirrors the sc-9300 INT8-ConvRot precedent: a tier that can't be
+    // expressed as `mlxQuantize` bits carries a distinct signal (`convRot`) instead of a lying number.
+    //
+    // NOTE the insert is unconditional on purpose: `raw` starts as a clone of `request.advanced`, so
+    // merely SKIPPING the insert would leave the caller's own stale `advanced.mlxQuantize` (e.g. a `4`
+    // from the tier picker) sitting in the record — the very mislabel this avoids. Overwrite, never omit.
     raw.insert(
         "mlxQuantize".to_owned(),
-        json!(match quant {
-            Quant::Q4 => 4,
-            Quant::Q8 => 8,
-        }),
+        match quant {
+            Quant::Q4 => json!(4),
+            Quant::Q8 => json!(8),
+            Quant::Nvfp4 => Value::Null,
+        },
     );
+    // The explicit tier label. Emitted only for the tier `mlxQuantize` cannot express, so existing
+    // q4/q8 asset telemetry keeps its exact shape (the sc-9300 `convRot` pattern).
+    if matches!(quant, Quant::Nvfp4) {
+        raw.insert("quantTier".to_owned(), Value::String("nvfp4".to_owned()));
+    }
     if let Some(scale) = guidance {
         raw.insert("guidanceScale".to_owned(), json!(scale));
     }


### PR DESCRIPTION
## What

Ships the NVFP4 (FP4 / Blackwell `sm_120`) lane from `SceneWorks/inference` to the worker by bumping the three tag pins to the immutable **`runtime-2026.07.3`** release (`8c35cd2a`), plus the one companion source fix the bump requires.

`runtime-2026.07.3` captures the complete lane: cuBLASLt FP4 GEMM (sc-11039), packer (sc-11040), `Nvfp4Linear` (sc-11041), on-device W4A4 activation quant (sc-11044), and the `gen_core::Quant::Nvfp4` contract tier + cuda catalog (sc-11042).

## Pins bumped in lockstep

All three, `crates/sceneworks-worker/Cargo.toml` — `runtime-2026.07.3-rc.0` → `runtime-2026.07.3`:

| line | crate |
|---|---|
| 31 | `sceneworks-gen-core` (backend-neutral contract) |
| 75 | `runtime-macos` |
| 81 | `runtime-cuda` |

Lockstep is the point: a split pin lets **two** `sceneworks-gen-core` revisions build side by side, so provider factories speak one revision's traits while worker requests use another's nominally-identical types — the sc-4482 trap. `Cargo.lock` regenerated with `cargo update -p` (never hand-edited); it resolves a single gen-core at `runtime-2026.07.3#8c35cd2a`.

## Required companion fix — and why not `Nvfp4 => 4`

`Quant::Nvfp4` is an additive variant, so the exhaustive `mlxQuantize` match at `image_jobs/flux2_comfyui_candle.rs:176-179` stopped compiling (**E0004**) on exactly the Windows/CUDA lane this tag targets.

The naive `Nvfp4 => 4` arm is **wrong**. That `json!` writes the `mlxQuantize` **telemetry field on the asset record**, and:

- **`mlxQuantize` is bits-valued, and the bits name a tier** — `<= 0` ⇒ `bf16`, `<= 4` ⇒ `q4`, else `q8` (`vram_gate::requested_tier_key`). So `4` would stamp an NVFP4 render as the **`q4` tier** in stored settings.
- **NVFP4 is a distinct tier, not int4-affine `q4`** — E2M1 4-bit elements + FP8-E4M3 block scales in a W4A4 regime (~4.5 effective bits/weight), served by candle-gen's packed `Nvfp4Linear`. A quant tier is a *creative choice*; mislabelling it falsifies the user's pick (epic 11037 **SC#5**, the aliasing that `Quant::Nvfp4`'s own doc comment exists to prevent).
- **No integer is honest** — every value maps onto `bf16`/`q8`/`q4`. There is no free sentinel.
- **A string is no better** — it isn't an integer, so `vram_gate::quant_int` (`as_i64` or numeric-string) returns `None` and the key silently degrades to the `q8` default: a *different* false label.

**So NVFP4 writes `mlxQuantize: null`** — the same "no bits value applies" signal `mlx_raw_settings` (`image_jobs/base.rs`) already emits for this key — **and carries its identity on a distinct `quantTier: "nvfp4"` label.** This mirrors the **sc-9300 INT8-ConvRot precedent**: a tier that can't be expressed as `mlxQuantize` bits is deliberately absent from the bits vocabulary and carries its own signal (`convRot`) instead of a lying number. `q4`/`q8` telemetry keeps its exact shape.

The insert stays **unconditional** on purpose: `raw` starts as a clone of `request.advanced`, so merely *skipping* it would leave the caller's own stale `advanced.mlxQuantize` (e.g. a `4` from the tier picker) sitting in the record — the very mislabel this avoids. Overwrite, never omit.

Note `mlxQuantize` is **not** rehydrated by "Use this recipe" (`ImageStudio.jsx` restores steps/guidance/sampler/scheduler/… but the tier comes from `defaultTierSelection`'s sticky/default), so this field is a stored record of the choice, not a re-render input — which is exactly why it must stay truthful rather than merely parseable.

This PR does **not** add NVFP4 tier *selection* (`flux2_comfyui_quant` still reads `advanced.quant` for `q4`/`q8` only) — that's sc-11042's worker half, which this tag unblocks.

## Blast radius

- `ggml_dtype`, `GgmlDType`, `candle_gen::quant` — **zero** hits in SceneWorks Rust, so sc-11042's `ggml_dtype()` → `Result` signature change costs nothing cross-repo.
- The other two `Quant` matches (`video_jobs.rs:6980,7047`) have `_ =>` catch-alls and are `#[cfg(target_os = "macos")]`; `resolve_scail2_quant` can never yield `Nvfp4`, so the fallthrough is unreachable (and the tag adds an MLX `reject_quant` guard upstream).

## Verification

- `scripts/check-gen-core-skew.sh` — **green**, exactly one gen-core resolution.
- `scripts/check-gen-core-skew.sh --features backend-candle` (the CUDA lane) — **green**, same single resolution.
- `scripts/check-gen-core-skew.sh --self-test` — **PASS** (gate still fires on canned skew).
- `cargo build --locked --features backend-candle` on the sm_120 rig (vcvars64 / MSVC 14.44, `CUDA_COMPUTE_CAP=120`, `-j 1`) — **green**, `Finished` in 4m57s, **0 errors / 0 warnings**. All 37 crates from `runtime-2026.07.3#8c35cd2a` recompiled (incl. `runtime-cuda`), as did `sceneworks-worker` itself — the crate where the E0004 fired. The graph resolves `candle-core`/`candle-gen` **with feature `cuda`**, so the NVFP4 path is genuinely compiled (`cudarc`/`candle-kernels` were already fresh in `target/`, hence absent from the recompile list).

sc-12006

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>

