### PR TITLE
feat(worker): NVFP4 as a distinct, Blackwell-gated quant tier (sc-11042)

### DIFF
--- a/apps/web/src/imageJobAdvanced.js
+++ b/apps/web/src/imageJobAdvanced.js
@@ -1,5 +1,5 @@
 import { buildStructuredPromptRecipe } from "./ideogramCaption.js";
-import { tierQuantize, isConvRotTier } from "./quantTier.js";
+import { tierQuantize, isConvRotTier, isNvfp4Tier, NVFP4_TIER } from "./quantTier.js";
 
 // sc-8854 (F-052): pure builder for the Image Studio job's `advanced` payload. Extracted
 // verbatim from ImageStudio.submit() — the ~110-line object literal that assembled the
@@ -158,6 +158,18 @@ export function buildImageJobAdvanced(state) {
     // (weights = Dir(bf16 snapshot) + text_encoder = File(convrot DiT)). Emitted only when the picker
     // is shown AND the picked tier is int8-convrot — disjoint from the mlxQuantize spread above.
     ...(showTierPicker && isConvRotTier(quantTier) ? { convRot: true } : {}),
+    // NVFP4 tier (sc-11042, epic 11037): like int8-convrot, NVFP4 is NOT a bits-based quant — E2M1
+    // elements + FP8-E4M3 block scales, ~4.5 effective bits/weight — so it can't ride `mlxQuantize`
+    // (its `tierQuantize` is null, so the spread above omits it and mlxQuantize stays out of the
+    // payload entirely). Instead send the distinct `quantTier: "nvfp4"` label the worker's tier-select
+    // reads (`nvfp4_requested` → the `nvfp4/` tier subdir + `Quant::Nvfp4`). sc-12006 already
+    // established this exact key/value as the tier's identity on the asset record, so the signal the
+    // studio sends and the telemetry the worker stores are the same string.
+    //
+    // Emitted ONLY when the picker is shown AND the user explicitly picked nvfp4 — disjoint from both
+    // spreads above. This is the SC#5 opt-in at the payload layer: absent this deliberate pick no
+    // request ever carries the label, so no q4 render can be silently upgraded to NVFP4 on Blackwell.
+    ...(showTierPicker && isNvfp4Tier(quantTier) ? { quantTier: NVFP4_TIER } : {}),
     // PiD decoder (epic 7840, sc-7851): emit usePid:true only when the toggle is shown
     // (model PiD-eligible AND checkpoint installed) AND on. The worker swaps the native
     // VAE for the PiD decode + 2K/4K super-resolve pass; it rides `advanced` (opaque

--- a/apps/web/src/imageJobAdvanced.test.js
+++ b/apps/web/src/imageJobAdvanced.test.js
@@ -223,6 +223,35 @@ describe("buildImageJobAdvanced", () => {
     expect(buildImageJobAdvanced(offState({ showTierPicker: true, quantTier: "q4" }))).not.toHaveProperty("convRot");
   });
 
+  it("emits quantTier (not mlxQuantize) for the NVFP4 tier (sc-11042)", () => {
+    const advanced = buildImageJobAdvanced(offState({ showTierPicker: true, quantTier: "nvfp4" }));
+    expect(advanced.quantTier).toBe("nvfp4");
+    // NVFP4 is not a bits-based quant (~4.5 effective bits/weight), so it must NOT leak an
+    // mlxQuantize — `4` there would select the int4-affine q4 tier (epic 11037 SC#5 aliasing).
+    expect(advanced).not.toHaveProperty("mlxQuantize");
+    // …and it is a different tier from int8-convrot, so it never sends that signal either.
+    expect(advanced).not.toHaveProperty("convRot");
+    // quantTier is only emitted when the tier picker is shown AND nvfp4 is picked.
+    expect(
+      buildImageJobAdvanced(offState({ showTierPicker: false, quantTier: "nvfp4" })),
+    ).not.toHaveProperty("quantTier");
+  });
+
+  // epic 11037 SC#5: no existing tier's payload changes. A q4/q8/bf16 pick never carries the NVFP4
+  // label, so it can never be silently re-routed to the FP4 tier — on Blackwell or anywhere else.
+  it("never emits quantTier for a bits-based tier (sc-11042)", () => {
+    for (const [tier, bits] of [
+      ["q4", 4],
+      ["q8", 8],
+      ["bf16", 0],
+    ]) {
+      const advanced = buildImageJobAdvanced(offState({ showTierPicker: true, quantTier: tier }));
+      expect(advanced).not.toHaveProperty("quantTier");
+      // …and the tier's own mlxQuantize value is untouched.
+      expect(advanced.mlxQuantize).toBe(bits);
+    }
+  });
+
   it("emits usePid only when the PiD toggle is shown and on", () => {
     expect(buildImageJobAdvanced(offState({ showPidToggle: false, usePid: true }))).not.toHaveProperty("usePid");
     expect(buildImageJobAdvanced(offState({ showPidToggle: true, usePid: true })).usePid).toBe(true);

--- a/apps/web/src/quantTier.js
+++ b/apps/web/src/quantTier.js
@@ -14,6 +14,11 @@
 // Tier key → `advanced.mlxQuantize` value. bf16 → 0 (the worker's `<= 0` ⇒ dense/bf16 sentinel),
 // q8 → 8, q4 → 4. A dense-TE model keeps its TE bf16 internally regardless (the worker forces
 // that); the UI just sends the tier's nominal quant value and lets the worker handle the nuance.
+//
+// NOTE this map is BITS-VALUED, and that is why neither int8-convrot NOR nvfp4 appears in it: the
+// worker parses `mlxQuantize` as an integer that NAMES a tier (`<= 0` ⇒ bf16, `<= 4` ⇒ q4, else q8),
+// so a tier with no honest integer must not ride this key. `nvfp4` sending `4` here would select the
+// int4-affine q4 tier — the exact aliasing epic 11037 SC#5 forbids. See NVFP4_TIER below.
 const TIER_QUANTIZE = {
   bf16: 0,
   q8: 8,
@@ -21,8 +26,10 @@ const TIER_QUANTIZE = {
 };
 
 // The three user-facing generation-quality tiers, in fidelity order — the vocabulary the global
-// "default generation quality" setting (epic 10721 / sc-10728) ranges over. int8-convrot is
-// intentionally excluded: it's a candle-only niche tier, not a sensible app-wide default.
+// "default generation quality" setting (epic 10721 / sc-10728) ranges over. int8-convrot and nvfp4 are
+// intentionally excluded: both are candle-only niche tiers, not sensible app-wide defaults. Excluding
+// nvfp4 is also an epic 11037 SC#5 requirement — a tier reachable only by an explicit, per-generation
+// pick can never become the silent default for anyone.
 export const GENERATION_QUALITY_TIERS = ["bf16", "q8", "q4"];
 
 // The app-wide base default generation tier used when no global setting, sticky, or manifest default
@@ -43,6 +50,26 @@ export function isConvRotTier(tier) {
   return tier === INT8_CONVROT_TIER;
 }
 
+// The candle-only NVFP4 tier key (sc-11042, epic 11037). NVFP4 = E2M1 4-bit elements over 16-element
+// blocks + FP8-E4M3 micro-scales + an FP32 per-tensor scale (~4.5 effective bits/weight), served by the
+// cuBLASLt FP4 GEMM on consumer Blackwell (sm_120).
+//
+// A DISTINCT, user-selectable tier — the sc-11042 "Option A" packaging decision. It is deliberately NOT
+// a Blackwell execution backend auto-substituted for q4: NVFP4's numerics differ from int4-affine q4, so
+// auto-selecting it on a Blackwell host would silently change what a picked q4 tier renders — the
+// creative-choice violation epic 11037 SC#5 forbids. Picking NVFP4 is always an explicit user action.
+//
+// Like INT8_CONVROT_TIER, it is NOT a bits-based quant, so it is DELIBERATELY absent from TIER_QUANTIZE
+// (`tierQuantize` returns null for it, so `mlxQuantize` stays out of the payload) and instead sends a
+// distinct `advanced.quantTier: "nvfp4"` signal (see imageJobAdvanced.js) that the worker's tier-select
+// reads.
+export const NVFP4_TIER = "nvfp4";
+
+// Whether a tier key names the candle NVFP4 tier.
+export function isNvfp4Tier(tier) {
+  return tier === NVFP4_TIER;
+}
+
 // Human labels for the picker, keyed by tier. Unknown/"default" tiers fall back to the raw key.
 // "training" is NOT a quant tier: it's the flat-diffusers LoRA-training base some tiered models
 // (lens, sc-8797) additionally host on macOS. It's absent from TIER_QUANTIZE, so the generation
@@ -54,11 +81,17 @@ const TIER_LABELS = {
   training: "LoRA training base (bf16 diffusers)",
   // Candle-only (Windows/Linux, sm_89+). Online-rotation int8 DiT — closer to bf16 than Q4 (sc-9300).
   [INT8_CONVROT_TIER]: "INT8-ConvRot (candle, sm_89+)",
+  // Candle-only (Windows/Linux, Blackwell sm_120+). FP4 tensor-core tier (sc-11042). Named distinctly
+  // from Q4 on purpose — it is a different numeric regime, not a faster q4.
+  [NVFP4_TIER]: "NVFP4 (candle, Blackwell sm_120+)",
 };
 
 // Display order (smallest → largest); tiers not in this list sort after, alphabetically. int8-convrot
 // sits between q4 and q8 by footprint/fidelity (int8 DiT, PSNR 34.4 dB — better than Q4's 22.7 dB).
-const TIER_ORDER = ["q4", INT8_CONVROT_TIER, "q8", "bf16"];
+// nvfp4 sits just above q4: ~4.5 effective bits/weight vs q4's 4, with weight accuracy measured at
+// roughly the int4 tier's (spike sc-11038: rel-RMS ~0.094) — so it is the nearest neighbour above q4
+// and below the int8 tier by footprint.
+const TIER_ORDER = ["q4", NVFP4_TIER, INT8_CONVROT_TIER, "q8", "bf16"];
 
 // Map a tier key to its `advanced.mlxQuantize` value, or null when the key isn't a known quant
 // tier (e.g. "default" on a single-variant model — such models never render the picker).
@@ -72,24 +105,31 @@ export function tierLabel(tier) {
   return TIER_LABELS[tier] ?? tier;
 }
 
-// Whether a tier key is a user-selectable generation tier: a known bits-based quant (bf16/q8/q4) OR
-// the candle INT8-ConvRot tier. Excludes the "default" pseudo-variant of a single-variant model and
-// non-generation pseudo-tiers like "training". Distinct from `tierQuantize` (which returns null for
-// int8-convrot because it has no mlxQuantize value — the tier still selects, via `advanced.convRot`).
+// Whether a tier key is a user-selectable generation tier: a known bits-based quant (bf16/q8/q4) OR one
+// of the candle-only non-bits tiers (INT8-ConvRot, NVFP4). Excludes the "default" pseudo-variant of a
+// single-variant model and non-generation pseudo-tiers like "training". Distinct from `tierQuantize`
+// (which returns null for both non-bits tiers because they have no mlxQuantize value — they still
+// select, via `advanced.convRot` / `advanced.quantTier`).
 export function isSelectableTier(tier) {
-  return tierQuantize(tier) !== null || isConvRotTier(tier);
+  return tierQuantize(tier) !== null || isConvRotTier(tier) || isNvfp4Tier(tier);
 }
 
 // The installed, selectable quant tiers of a model, in display order. A tier is selectable when it is
-// a known quant tier (bf16/q8/q4) OR the candle INT8-ConvRot tier (`isSelectableTier` — the "default"
-// pseudo-variant of a single-variant model is excluded) AND its files are installed. Returns [] when
-// the model has no variant matrix.
+// a known quant tier (bf16/q8/q4) OR one of the candle-only tiers (INT8-ConvRot, NVFP4)
+// (`isSelectableTier` — the "default" pseudo-variant of a single-variant model is excluded) AND its
+// files are installed. Returns [] when the model has no variant matrix.
 //
 // `options.convRotEligible` (sc-9300, default true) gates the candle-only INT8-ConvRot tier: the
 // caller passes `false` when NO live worker advertises the `int8_convrot` capability (macOS/MLX, or a
 // pre-Ada NVIDIA GPU that fails the sm_89 compute-cap probe), so the tier is HIDDEN on an ineligible
 // host even when its files happen to be present in the cache. Every other tier is unaffected. Default
 // true keeps existing single-lane call sites (and tests) unchanged.
+//
+// `options.nvfp4Eligible` (sc-11042, default true) gates the candle-only NVFP4 tier identically: the
+// caller passes `false` when NO live worker advertises the `nvfp4` capability (macOS/MLX, or an NVIDIA
+// GPU below the sm_120 Blackwell compute-cap floor). Hiding an unservable tier is the FIRST of the two
+// Blackwell gates; the worker re-checks the cap at tier-select (`nvfp4_host_eligible` in
+// image_jobs/base.rs) so a hand-crafted API call that bypasses this picker still falls back cleanly.
 // Sort tier keys by display order (smallest → largest); unknown keys sort after, alphabetically.
 function sortByTierOrder(a, b) {
   const ai = TIER_ORDER.indexOf(a);
@@ -107,7 +147,11 @@ function sortByTierOrder(a, b) {
 }
 
 export function installedTiers(model, options = {}) {
-  const { convRotEligible = true } = options;
+  const { convRotEligible = true, nvfp4Eligible = true } = options;
+  // Whether a tier survives the per-host capability gates: the candle-only tiers are hidden when no live
+  // worker can serve them; every bits-based tier is unaffected.
+  const hostEligible = (tier) =>
+    (convRotEligible || !isConvRotTier(tier)) && (nvfp4Eligible || !isNvfp4Tier(tier));
   // Download-matrix models (sc-8508): per-tier DOWNLOAD entries, install-tracked individually.
   if (model?.hasVariantMatrix && Array.isArray(model.variants)) {
     return model.variants
@@ -115,7 +159,7 @@ export function installedTiers(model, options = {}) {
         (variant) =>
           variant &&
           isSelectableTier(variant.variant) &&
-          (convRotEligible || !isConvRotTier(variant.variant)) &&
+          hostEligible(variant.variant) &&
           variant.installState === "installed",
       )
       .map((variant) => variant.variant)
@@ -126,17 +170,17 @@ export function installedTiers(model, options = {}) {
   // Models download panel (`hasVariantMatrix`) is untouched. Anima (and other convert-at-install models)
   // get a Studio generation-time tier picker this way.
   if (Array.isArray(model?.mlxTiers) && model.mlxTiers.length > 0) {
-    return model.mlxTiers
-      .filter((tier) => isSelectableTier(tier) && (convRotEligible || !isConvRotTier(tier)))
-      .sort(sortByTierOrder);
+    return model.mlxTiers.filter((tier) => isSelectableTier(tier) && hostEligible(tier)).sort(sortByTierOrder);
   }
   return [];
 }
 
 // Quality rank of a generation quant tier: higher = more faithful (bf16 > q8 > q4). Derived from
 // GENERATION_QUALITY_TIERS (highest-fidelity first), so it stays in lockstep with that vocabulary.
-// Unknown / non-quality tiers (e.g. int8-convrot, "training") rank 0 so they never take part in a floor
-// comparison — a below-floor advisory or default clamp only ever fires between two known quality tiers.
+// Unknown / non-quality tiers (e.g. int8-convrot, nvfp4, "training") rank 0 so they never take part in a
+// floor comparison — a below-floor advisory or default clamp only ever fires between two known quality
+// tiers. For nvfp4 that is deliberate as well as incidental: it is a distinct numeric regime, not a rung
+// on the bf16/q8/q4 fidelity ladder, so ranking it against a floor would be a category error.
 function tierQualityRank(tier) {
   const i = GENERATION_QUALITY_TIERS.indexOf(tier);
   return i === -1 ? 0 : GENERATION_QUALITY_TIERS.length - i;
@@ -168,8 +212,8 @@ export function isBelowFloor(tier, model) {
 
 // Whether the studio should render the tier picker: only when MORE THAN ONE quant tier is
 // installed (a single installed tier — the common case — shows no toggle, per acceptance).
-// `options` (sc-9300) forwards the `convRotEligible` gate so an ineligible host doesn't count the
-// hidden INT8-ConvRot tier toward the >1 threshold.
+// `options` forwards the `convRotEligible` (sc-9300) / `nvfp4Eligible` (sc-11042) gates so an
+// ineligible host doesn't count a hidden candle-only tier toward the >1 threshold.
 export function shouldShowTierPicker(model, options = {}) {
   return installedTiers(model, options).length > 1;
 }
@@ -202,8 +246,16 @@ function defaultInstalledTier(model, tiers) {
 // prior explicit pick, honored as-is. The clamp is capped by clamp-to-installed (a floor tier not on
 // disk resolves to the nearest installed clean tier).
 // Returns null when nothing is installed (no picker will render anyway). `options` also forwards the
-// `convRotEligible` gate (sc-9300) so a hidden INT8-ConvRot tier is never seeded as the selection —
-// and because `defaultQuality` can only ever be bf16|q8|q4, it never re-introduces a filtered tier.
+// `convRotEligible` (sc-9300) / `nvfp4Eligible` (sc-11042) gates so a hidden candle-only tier is never
+// seeded as the selection — and because `defaultQuality` can only ever be bf16|q8|q4, it never
+// re-introduces a filtered tier.
+//
+// NVFP4 can only ever be reached here by rung 1 (the sticky — i.e. a PRIOR EXPLICIT pick by this user
+// on this model), never by rungs 2–4: `variant.default` is dead against the real catalog, `base` is
+// drawn from GENERATION_QUALITY_TIERS (which excludes nvfp4), and `cleanFallback` lists only q8/bf16/q4.
+// Rung 4 (`tiers[0]`) cannot reach it either — TIER_ORDER puts q4 first, and nvfp4 is only present when
+// an nvfp4 tier is installed, which by itself implies the user chose to install it. That is epic 11037
+// SC#5 holding at the UI layer: NVFP4 never becomes anyone's default by accident.
 export function defaultTierSelection(model, lastUsed, options = {}) {
   const tiers = installedTiers(model, options);
   if (tiers.length === 0) {

--- a/apps/web/src/quantTier.test.js
+++ b/apps/web/src/quantTier.test.js
@@ -6,12 +6,14 @@ import {
   installedTiers,
   isBelowFloor,
   isConvRotTier,
+  isNvfp4Tier,
   isSelectableTier,
   modelQualityFloor,
   shouldShowTierPicker,
   tierLabel,
   tierQuantize,
   INT8_CONVROT_TIER,
+  NVFP4_TIER,
 } from "./quantTier.js";
 
 // Build a /models-shaped model with a variant matrix. `installed` is the set of tier keys whose
@@ -90,6 +92,89 @@ describe("INT8-ConvRot tier (sc-9300)", () => {
     expect(shouldShowTierPicker(model)).toBe(true);
     // On an ineligible host only bf16 remains → single tier → no picker.
     expect(shouldShowTierPicker(model, { convRotEligible: false })).toBe(false);
+  });
+});
+
+describe("NVFP4 tier (sc-11042, epic 11037)", () => {
+  it("is a selectable tier but has no mlxQuantize value", () => {
+    expect(isNvfp4Tier(NVFP4_TIER)).toBe(true);
+    expect(isNvfp4Tier("q4")).toBe(false);
+    expect(isSelectableTier(NVFP4_TIER)).toBe(true);
+    // It rides a distinct advanced.quantTier signal, not mlxQuantize — so tierQuantize is null.
+    // Critically NOT 4: `mlxQuantize: 4` names the int4-affine q4 tier, so sending it for NVFP4 would
+    // alias one creative choice onto another (epic 11037 SC#5).
+    expect(tierQuantize(NVFP4_TIER)).toBe(null);
+    expect(tierLabel(NVFP4_TIER)).toBe("NVFP4 (candle, Blackwell sm_120+)");
+  });
+
+  it("is offered only when nvfp4Eligible (candle + sm_120 Blackwell worker present)", () => {
+    const model = matrixModel({
+      tiers: ["q4", NVFP4_TIER, "bf16"],
+      installed: ["q4", NVFP4_TIER, "bf16"],
+    });
+    // Eligible host (default): the tier appears, ordered just above q4.
+    expect(installedTiers(model)).toEqual(["q4", NVFP4_TIER, "bf16"]);
+    // Ineligible host (macOS/MLX or pre-Blackwell NVIDIA — no nvfp4 worker): the tier is hidden even
+    // though its files are installed.
+    expect(installedTiers(model, { nvfp4Eligible: false })).toEqual(["q4", "bf16"]);
+  });
+
+  it("gates independently of the convrot tier", () => {
+    const model = matrixModel({
+      tiers: ["q4", NVFP4_TIER, INT8_CONVROT_TIER],
+      installed: ["q4", NVFP4_TIER, INT8_CONVROT_TIER],
+    });
+    // An sm_89 Ada host clears ConvRot but NOT NVFP4 — the real hardware split this gate exists for.
+    expect(installedTiers(model, { nvfp4Eligible: false })).toEqual(["q4", INT8_CONVROT_TIER]);
+    // Both hidden (macOS/MLX).
+    expect(installedTiers(model, { convRotEligible: false, nvfp4Eligible: false })).toEqual(["q4"]);
+    // Both offered (an sm_120 candle host).
+    expect(installedTiers(model)).toEqual(["q4", NVFP4_TIER, INT8_CONVROT_TIER]);
+  });
+
+  it("does not count a hidden nvfp4 tier toward the picker's >1 threshold", () => {
+    const model = matrixModel({
+      tiers: ["bf16", NVFP4_TIER],
+      installed: ["bf16", NVFP4_TIER],
+    });
+    expect(shouldShowTierPicker(model)).toBe(true);
+    // On an ineligible host only bf16 remains → single tier → no picker.
+    expect(shouldShowTierPicker(model, { nvfp4Eligible: false })).toBe(false);
+  });
+
+  // epic 11037 SC#5 at the UI layer: NVFP4 is an explicit choice, never a default anyone lands on.
+  it("is never the app-wide default quality vocabulary", () => {
+    expect(GENERATION_QUALITY_TIERS).not.toContain(NVFP4_TIER);
+    // …so even asking for it as the global default falls back to the q8 base rather than selecting it.
+    const model = matrixModel({
+      tiers: ["q4", NVFP4_TIER, "q8"],
+      installed: ["q4", NVFP4_TIER, "q8"],
+      defaultTier: null,
+    });
+    expect(defaultTierSelection(model, null, { defaultQuality: NVFP4_TIER })).toBe("q8");
+  });
+
+  it("is never seeded as the default over an installed q4/q8 (SC#5: no auto-swap of q4)", () => {
+    const model = matrixModel({
+      tiers: ["q4", NVFP4_TIER, "q8"],
+      installed: ["q4", NVFP4_TIER, "q8"],
+      defaultTier: null,
+    });
+    // On a fully NVFP4-eligible Blackwell host with the tier installed, the default is still q8 — the
+    // presence of FP4 hardware never re-points an existing tier's default.
+    expect(defaultTierSelection(model, null)).toBe("q8");
+    // A q4 sticky stays q4 — it is NOT silently upgraded to NVFP4 on Blackwell (the Option B this
+    // story rejected). This is the web-side twin of the worker's SC#5 regression guard.
+    expect(defaultTierSelection(model, "q4")).toBe("q4");
+    // NVFP4 is reachable as a sticky — i.e. only because the user explicitly picked it before.
+    expect(defaultTierSelection(model, NVFP4_TIER)).toBe(NVFP4_TIER);
+  });
+
+  it("never participates in a quality-floor comparison", () => {
+    // NVFP4 is a distinct numeric regime, not a rung on the bf16/q8/q4 ladder — ranking it against a
+    // floor would be a category error, so it is never flagged as "below floor".
+    expect(isBelowFloor(NVFP4_TIER, { minQualityTier: "q8" })).toBe(false);
+    expect(isBelowFloor(NVFP4_TIER, { minQualityTier: "bf16" })).toBe(false);
   });
 });
 

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -338,7 +338,26 @@ export function ImageStudio() {
       ),
     [visibleWorkers],
   );
-  const tierOptions = useMemo(() => ({ convRotEligible }), [convRotEligible]);
+  // NVFP4 eligibility (sc-11042, epic 11037): identical shape to the ConvRot gate above — the
+  // candle-only FP4 tier is offered ONLY when a live worker advertises the `nvfp4` capability, which
+  // the worker emits solely on the candle lane AND when its GPU clears the sm_120 consumer-Blackwell
+  // compute-cap floor (gpu.rs). macOS/MLX (no FP4 hardware) and pre-Blackwell NVIDIA hosts HIDE the
+  // tier rather than only failing at submit. Hiding is the picker-side gate; the worker independently
+  // re-checks the cap at tier-select, so this is UX, not the security boundary.
+  const nvfp4Eligible = useMemo(
+    () =>
+      visibleWorkers.some(
+        (worker) =>
+          worker?.status !== "offline" &&
+          Array.isArray(worker?.capabilities) &&
+          worker.capabilities.includes("nvfp4"),
+      ),
+    [visibleWorkers],
+  );
+  const tierOptions = useMemo(
+    () => ({ convRotEligible, nvfp4Eligible }),
+    [convRotEligible, nvfp4Eligible],
+  );
   // Prompt-refinement model catalog entry (sc-5605) — drives the "download the
   // refinement model" affordance in RefinePromptControl when Refine fails because the
   // model isn't provisioned on the native worker.

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -29,11 +29,17 @@ pub(crate) async fn discover_gpu(settings: &Settings) -> DiscoveredGpu {
             .find(|gpu| gpu.id == requested_gpu_id)
             .unwrap_or_else(|| fallback_gpu(requested_gpu_id))
     };
-    // Compute-capability probe for the INT8-ConvRot sm_89 gate (sc-9300). Probed here (the async
-    // discovery) and threaded into the sync `with_candle_capabilities` — the worker has no nvml, so
-    // this is a bounded `nvidia-smi --query-gpu=compute_cap` subprocess like the utilization query.
+    // Compute-capability probe for the INT8-ConvRot sm_89 gate (sc-9300) and the NVFP4 sm_120 gate
+    // (sc-11042). Probed here (the async discovery) and threaded into the sync
+    // `with_candle_capabilities` — the worker has no nvml, so this is a bounded
+    // `nvidia-smi --query-gpu=compute_cap` subprocess like the utilization query.
     // Only meaningful on the candle lane; a cheap no-op probe on CPU / non-NVIDIA (returns `None`).
     let compute_cap = nvidia_max_compute_cap().await;
+    // Publish the probed cap for the SYNC tier-select path (sc-11042). `discover_gpu` runs once at
+    // startup (`lib.rs`) BEFORE the job-claim loop, so every generation resolves against a populated
+    // value; a worker that somehow never probed reads `None` and is treated as NVFP4-INELIGIBLE
+    // (fail-safe: the tier falls back rather than routing an FP4 load at hardware that can't run it).
+    cache_compute_cap(compute_cap);
     with_candle_capabilities(gpu, settings, compute_cap)
 }
 
@@ -188,6 +194,20 @@ fn with_candle_capabilities(
                     INT8_CONVROT_CAPABILITY.to_owned(),
                 ));
             }
+            // NVFP4 tier eligibility marker (sc-11042, epic 11037). Advertised ONLY when this candle
+            // worker's GPU clears the sm_120 consumer-Blackwell floor (the FP4 tensor cores the
+            // cuBLASLt NVFP4 GEMM needs). Exactly the `int8_convrot` shape above: bundling the candle
+            // lane with the compute-cap check into one advertised capability lets the api/web picker
+            // HIDE the `nvfp4` tier on an ineligible card (macOS/MLX never reaches here; a pre-Blackwell
+            // NVIDIA GPU probes < 12.0) rather than only erroring at generate time.
+            //
+            // NVFP4 is an OPT-IN tier (epic 11037 SC#5): advertising the capability only says the host
+            // COULD serve NVFP4 if the user picks it — it never selects NVFP4 for anyone, and never
+            // alters what `q4`/`q8`/`bf16` resolve to on this worker.
+            if compute_cap_meets_nvfp4(compute_cap) {
+                gpu.capabilities
+                    .push(WorkerCapability::Unknown(NVFP4_CAPABILITY.to_owned()));
+            }
         }
     }
     gpu
@@ -291,6 +311,58 @@ pub(crate) fn parse_max_compute_cap(output: &str) -> Option<f32> {
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 pub(crate) fn compute_cap_meets_int8_convrot(cap: Option<f32>) -> bool {
     cap.is_some_and(|c| c >= INT8_CONVROT_MIN_COMPUTE_CAP)
+}
+
+/// The advertised marker capability meaning "this candle worker can run the NVFP4 tier" (sc-11042,
+/// epic 11037). Mirrors [`INT8_CONVROT_CAPABILITY`]: it bundles the candle lane (only pushed under
+/// `backend_candle_enabled` in [`with_candle_capabilities`]) AND a GPU compute capability >= 12.0
+/// (consumer Blackwell sm_120 — the FP4 tensor cores the cuBLASLt NVFP4 GEMM dispatches on). The api
+/// surfaces it on the worker snapshot and the web picker (`quantTier.js`) shows the `nvfp4` tier only
+/// when a registered worker advertises it, so an ineligible host hides the tier gracefully.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+pub(crate) const NVFP4_CAPABILITY: &str = "nvfp4";
+
+/// The minimum NVIDIA compute capability the NVFP4 tier requires: **12.0** (consumer Blackwell
+/// sm_120 — RTX PRO 6000 / RTX 50-series), the hardware epic 11037 targets and validates on.
+///
+/// A FLOOR, matching [`INT8_CONVROT_MIN_COMPUTE_CAP`]'s shape. Note this deliberately excludes
+/// **datacenter Blackwell sm_100** (B100/B200, which probes `10.0`): sm_100 *has* FP4 tensor cores,
+/// but it is explicitly out of scope for epic 11037 and the lane is neither built for it
+/// (`CUDA_COMPUTE_CAP=120` emits sm_120 SASS + compute_120 PTX, not sm_100) nor validated on it — so
+/// `10.0 < 12.0` keeps it off the tier by construction rather than by accident.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const NVFP4_MIN_COMPUTE_CAP: f32 = 12.0;
+
+/// Whether a probed compute cap clears the NVFP4 sm_120 floor. `None` (no probe — CPU / non-NVIDIA /
+/// nvidia-smi absent) ⇒ ineligible, so an unprobed host never routes an FP4 load at hardware that
+/// can't run it.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+pub(crate) fn compute_cap_meets_nvfp4(cap: Option<f32>) -> bool {
+    cap.is_some_and(|c| c >= NVFP4_MIN_COMPUTE_CAP)
+}
+
+/// Process-wide cache of the startup compute-cap probe, published by [`discover_gpu`].
+///
+/// The NVFP4 tier gate (sc-11042) is consulted from the SYNC tier-select path (`image_jobs/base.rs`),
+/// which has no async context to re-probe `nvidia-smi` from and must not spawn a subprocess per job.
+/// `discover_gpu` already probes the cap once at startup, before the job-claim loop, so caching that
+/// value here gives the resolver a free, always-populated read. The outer `OnceLock` distinguishes
+/// "never probed" (⇒ `None` ⇒ ineligible, fail-safe) from "probed, no NVIDIA GPU" (also `None`).
+static COMPUTE_CAP: std::sync::OnceLock<Option<f32>> = std::sync::OnceLock::new();
+
+/// Publish the startup compute-cap probe. First call wins; later calls are ignored (the cap of a
+/// running worker's GPU cannot change mid-process, and tests set it explicitly).
+pub(crate) fn cache_compute_cap(cap: Option<f32>) {
+    let _ = COMPUTE_CAP.set(cap);
+}
+
+/// The cached startup compute-cap probe, or `None` when never probed. See [`COMPUTE_CAP`].
+///
+/// Consumed only by the candle-lane NVFP4 tier gate, so gate it to the candle build to avoid a
+/// dead-code warning on the macOS / neither builds.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+pub(crate) fn cached_compute_cap() -> Option<f32> {
+    COMPUTE_CAP.get().copied().flatten()
 }
 
 pub(crate) fn parse_nvidia_smi_gpus(output: &str) -> Vec<DiscoveredGpu> {

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1011,8 +1011,16 @@ fn nvfp4_host_eligible() -> bool {
 
 /// The tier subdir name a request prefers, given its explicit `advanced.mlxQuantize` `bits`, the
 /// model's per-model quality `floor` (`mlx.minQualityTier`, sc-10731 — `None` = no floor), and whether
-/// the request selected the distinct NVFP4 tier (`nvfp4`, sc-11042 — an explicit
+/// the request is a CANDIDATE for the distinct NVFP4 tier (`nvfp4`, sc-11042 — an explicit
 /// [`nvfp4_requested`] label AND an [`nvfp4_host_eligible`] host).
+///
+/// `nvfp4` here is deliberately the TWO-part gate, NOT the fully-resolved [`nvfp4_selected`]: this
+/// function is what CHOOSES the tier dir, so it necessarily runs before any dir exists to probe (asking
+/// for `nvfp4_selected` would be circular). The third half of the gate — the `nvfp4/` tier dir actually
+/// being installed — is the caller's own `present()` fallback chain, which is exactly what
+/// [`nvfp4_selected`] reads back afterwards to confirm what this resolver landed on. So a host-eligible
+/// NVFP4 pick with no converted tier on disk falls through this function's chain to an installed tier,
+/// and `nvfp4_selected` then reports `false` for it — the two agree by construction.
 ///
 /// An explicit, host-eligible **NVFP4** pick (`nvfp4 == true`) resolves the distinct [`NVFP4_TIER`] and
 /// short-circuits the bits map below — NVFP4 has no honest `mlxQuantize` integer, so it cannot be
@@ -7836,6 +7844,44 @@ mod capability_downtier_tests {
         // No installed candidate in range (defensive — the default itself is normally present) → Keep,
         // deferring to the plain gate.
         assert_eq!(choose_downtier("q8", &[]), DowntierPick::Keep);
+    }
+
+    /// sc-11042 (epic 11037 SC#5) × sc-10733: the capability clamp NEVER downtiers a selected NVFP4
+    /// tier. Downtiering it to q4/q8 would silently swap the numerics of an explicitly-picked tier —
+    /// the exact creative-choice violation SC#5 forbids.
+    ///
+    /// This is load-bearing BECAUSE nvfp4 does not escape the clamp via `mlxQuantizeExplicit`: the web
+    /// emits that flag only inside the `tierQuantize(quantTier) !== null` bits branch, and nvfp4 has no
+    /// honest `mlxQuantize` integer, so an nvfp4 job reaches the clamp with `explicit_pick == false`.
+    /// What saves it is that nvfp4 is UNRANKABLE on purpose (`tier_quality_rank` ⇒ 0): it is a distinct
+    /// numeric regime, not a rung on the bf16/q8/q4 ladder, so no tier is ever in `[floor, nvfp4]` and
+    /// the chooser keeps it. These two facts are a silent pair — pin them together, since making nvfp4
+    /// rankable would quietly arm the downtier.
+    #[test]
+    fn nvfp4_tier_is_never_downtiered_by_the_capability_clamp() {
+        // Unrankable by construction — the fact the whole guard rests on.
+        assert_eq!(tier_quality_rank(NVFP4_TIER), 0);
+        assert!(tier_quality_rank(NVFP4_TIER) < tier_quality_rank("q4"));
+
+        // The `downtier_candidate_tiers` range math (installed-filtering aside) admits NOTHING when the
+        // default is nvfp4: `rank <= 0 && rank >= floor_rank(>= 1)` is unsatisfiable for every tier.
+        let in_range = |tier: &str, default: &str, floor: Option<&str>| {
+            let default_rank = tier_quality_rank(default);
+            let floor_rank = floor.map_or(1, tier_quality_rank).max(1);
+            let rank = tier_quality_rank(tier);
+            rank <= default_rank && rank >= floor_rank
+        };
+        for floor in [None, Some("q4"), Some("q8"), Some("bf16")] {
+            for tier in ["bf16", "q8", "q4", NVFP4_TIER] {
+                assert!(
+                    !in_range(tier, NVFP4_TIER, floor),
+                    "nvfp4 must admit NO downtier candidate (tier={tier} floor={floor:?})"
+                );
+            }
+        }
+
+        // …so the chooser is handed an empty candidate list and KEEPS nvfp4, deferring to the plain gate.
+        assert_eq!(choose_downtier(NVFP4_TIER, &[]), DowntierPick::Keep);
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -5223,11 +5223,34 @@ fn image_settings_metrics(
 /// The effective quant label + bit count for a request (epic 10402): the Krea
 /// INT8-ConvRot tier, then dense-TE turnkey tiers (which `resolve_quant` reports
 /// as bf16 to keep the dense TE full-precision), else `resolve_quant`.
+///
+/// **The NVFP4 arm matches the VARIANT, not the bit count (sc-11042, epic 11037 SC#5)** — the image
+/// lane's instance of the same footgun `video_quant_label` carries, and it fails in the opposite
+/// direction. This maps [`resolve_quant`]'s *bits* onto a label, and NVFP4's bits are deliberately
+/// `None` (~4.5 EFFECTIVE bits/weight — `Some(4)` would alias it onto q4), so a bits-only match would
+/// drop NVFP4 into the `_ => bf16` arm and stamp an NVFP4 render as **`"bf16"`**: a full-precision
+/// label on a 4-bit render, the inverse mislabel but the same SC#5 violation. Matching the variant is
+/// what makes both directions impossible. The tier's own arm is placed alongside int8-convrot's — both
+/// are tiers with no honest integer width, and both report `None` bits for that reason.
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn effective_quant_label(request: &ImageRequest) -> (Option<String>, Option<i64>) {
+    effective_quant_label_gated(request, nvfp4_host_eligible())
+}
+
+/// [`effective_quant_label`] with the NVFP4 **host** gate passed in rather than probed (sc-11042).
+/// Split out for testability, exactly like [`resolve_quant_gated`], which it delegates to. Production
+/// has one caller.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn effective_quant_label_gated(
+    request: &ImageRequest,
+    nvfp4_host: bool,
+) -> (Option<String>, Option<i64>) {
     if request
         .advanced
         .get("convRot")
@@ -5244,9 +5267,12 @@ fn effective_quant_label(request: &ImageRequest) -> (Option<String>, Option<i64>
             _ => (Some("bf16".to_owned()), None),
         };
     }
-    match resolve_quant(request).1 {
-        Some(8) => (Some("q8".to_owned()), Some(8)),
-        Some(4) => (Some("q4".to_owned()), Some(4)),
+    match resolve_quant_gated(request, nvfp4_host) {
+        // The distinct NVFP4 tier, matched on the VARIANT (see the note above): its bit count is
+        // `None`, so a bits-only match would silently label it "bf16".
+        (Some(Quant::Nvfp4), _) => (Some(NVFP4_TIER.to_owned()), None),
+        (_, Some(8)) => (Some("q8".to_owned()), Some(8)),
+        (_, Some(4)) => (Some("q4".to_owned()), Some(4)),
         _ => (Some("bf16".to_owned()), None),
     }
 }
@@ -6393,6 +6419,56 @@ mod standard_tier_tests {
             assert_eq!(
                 resolve_quant_gated(&request(json!({ "mlxQuantize": 0 })), nvfp4_host),
                 (None, None)
+            );
+        }
+    }
+
+    /// sc-11042 / epic 11037 SC#5 — **the image lane's aliasing guard**, the sibling of
+    /// `video_quant_label_never_aliases_nvfp4_to_q4`.
+    ///
+    /// [`effective_quant_label`] maps [`resolve_quant`]'s BIT COUNT onto a label, and NVFP4's bits are
+    /// deliberately `None`, so a bits-only match drops it into the `_ => bf16` arm — stamping a 4-bit
+    /// NVFP4 render as full-precision `"bf16"`. The inverse of the video lane's `q4` mislabel, the same
+    /// violation. Matching the variant is what pins it.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn effective_quant_label_never_aliases_nvfp4_to_bf16_or_q4() {
+        let picked = request(json!({ "quantTier": "nvfp4" }));
+        let (label, bits) = effective_quant_label_gated(&picked, true);
+        assert_eq!(label, Some("nvfp4".to_owned()));
+        // Neither mislabel is possible: not the "bf16" a bits-only match produced…
+        assert_ne!(label, Some("bf16".to_owned()));
+        // …nor the "q4" the video lane's bits-derived form produced.
+        assert_ne!(label, Some("q4".to_owned()));
+        // No honest integer width — same reason the tier reports None everywhere else.
+        assert_eq!(bits, None);
+
+        // Off Blackwell the label reports what actually ran (the q8 fallback), not the tier asked for.
+        assert_eq!(
+            effective_quant_label_gated(&picked, false),
+            (Some("q8".to_owned()), Some(8))
+        );
+        // SC#5: the existing labels are unchanged on both host classes.
+        for nvfp4_host in [false, true] {
+            assert_eq!(
+                effective_quant_label_gated(&request(json!({ "mlxQuantize": 4 })), nvfp4_host),
+                (Some("q4".to_owned()), Some(4))
+            );
+            assert_eq!(
+                effective_quant_label_gated(&request(json!({ "mlxQuantize": 8 })), nvfp4_host),
+                (Some("q8".to_owned()), Some(8))
+            );
+            assert_eq!(
+                effective_quant_label_gated(&request(json!({ "mlxQuantize": 0 })), nvfp4_host),
+                (Some("bf16".to_owned()), None)
+            );
+            // The int8-convrot tier still wins its early return.
+            assert_eq!(
+                effective_quant_label_gated(&request(json!({ "convRot": true })), nvfp4_host),
+                (Some("int8-convrot".to_owned()), None)
             );
         }
     }

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -923,13 +923,67 @@ pub(crate) const NVFP4_TIER: &str = "nvfp4";
 ///
 /// PURE + UNGATED (like [`preferred_tier`], its caller): reads only the request, so the "did the user
 /// ask for NVFP4" question is testable on every platform without a GPU. The sm_120 host gate is the
-/// separate [`nvfp4_host_eligible`]; the tier is selected only when BOTH hold.
+/// separate [`nvfp4_host_eligible`], and the on-disk gate is [`tier_dir_is_nvfp4`]; the tier is
+/// SELECTED only when all three hold — see [`nvfp4_selected`].
 fn nvfp4_requested(request: &ImageRequest) -> bool {
     request
         .advanced
         .get("quantTier")
         .and_then(Value::as_str)
         .is_some_and(|tier| tier.trim().eq_ignore_ascii_case(NVFP4_TIER))
+}
+
+/// Whether the RESOLVED tier dir is the distinct `nvfp4/` tier — i.e. whether the NVFP4 tier is
+/// actually what [`standard_tier_subdir`] landed on (sc-11042).
+///
+/// The DISK half of the NVFP4 gate. `standard_tier_subdir` only returns the `nvfp4/` dir when that dir
+/// exists with weights in it; a request for a tier that isn't converted yet (sc-11043 owns the
+/// convert-at-install loop — **no shipping model packs an `nvfp4/` dir today**) rejoins the clean
+/// q8 → bf16 → q4 fallback chain. So "the resolved basename is `nvfp4`" is exactly "the NVFP4 tier is
+/// installed AND was chosen", read off the same value the loader will read.
+///
+/// `None` (tier dir unknown — a lane that resolves no standard-tier subdir: a flat diffusers snapshot,
+/// a `modelPath` override, or a caller with no dir in scope) ⇒ **false**. A tier we cannot verify is a
+/// tier we must not claim: the conservative direction is to fall through to the request-derived
+/// q4/q8/bf16 (which is what such a lane actually loads), never to stamp NVFP4 on it.
+///
+/// Gated to the lanes that HAVE a quant resolver ([`resolve_quant`]'s cfg): the neither-MLX-nor-candle
+/// build resolves no load quant at all, so this would be dead code there (`-D warnings`).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn tier_dir_is_nvfp4(tier_dir: Option<&Path>) -> bool {
+    tier_dir.and_then(Path::file_name).and_then(|name| name.to_str()) == Some(NVFP4_TIER)
+}
+
+/// Whether this job actually SELECTS the distinct NVFP4 tier (sc-11042, epic 11037 SC#5) — the single
+/// predicate behind the tier's load quant ([`resolve_quant`]), its recorded label
+/// ([`effective_quant_label`]), and its VRAM sizing (`vram_gate::requested_tier_key`), so those three
+/// can never disagree about what ran.
+///
+/// **All THREE halves are required:**
+/// 1. [`nvfp4_requested`] — the user EXPLICITLY named the tier. The SC#5 opt-in: never inferred from
+///    `bits`, a manifest default, or hardware detection. Being on Blackwell alone selects nothing.
+/// 2. [`nvfp4_host_eligible`] — this host can serve FP4 (sm_120 on the candle lane).
+/// 3. [`tier_dir_is_nvfp4`] — the `nvfp4/` tier is INSTALLED and is the dir that resolved.
+///
+/// Half 3 is why this takes the RESOLVED dir rather than trusting the request: halves 1+2 alone say
+/// only what the user WANTED on hardware that COULD serve it, and `standard_tier_subdir` independently
+/// falls back to q8 when the `nvfp4/` dir is absent — the shipping case on every model today. Deriving
+/// the label from 1+2 therefore stamped `"nvfp4"` on a render that actually ran the **q8** weights: a
+/// creative choice falsified in the asset record, precisely the SC#5 aliasing this tier exists to
+/// avoid. The label must describe what RAN, so it is read off the same dir the loader loads.
+///
+/// Gated to [`resolve_quant`]'s cfg, like [`tier_dir_is_nvfp4`]: every caller (the quant resolver, the
+/// label, and the candle fit gate) lives on the MLX or candle lane, so compiling it on the
+/// neither-backend build would be dead code under `-D warnings`.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn nvfp4_selected(request: &ImageRequest, nvfp4_host: bool, tier_dir: Option<&Path>) -> bool {
+    nvfp4_requested(request) && nvfp4_host && tier_dir_is_nvfp4(tier_dir)
 }
 
 /// Whether THIS HOST can serve the NVFP4 tier: the candle lane on a GPU clearing the sm_120
@@ -1088,12 +1142,21 @@ fn standard_tier_subdir_gated(root: &Path, request: &ImageRequest, nvfp4_host: b
     // rejoins the SAME clean-tier fallback chain, so a request for a tier that isn't converted yet
     // (sc-11043 owns the convert-at-install loop; no shipping model packs an `nvfp4/` dir today) lands
     // on an installed tier exactly like an uninstalled q4/bf16 pick does — never a load error, and never
-    // an FP4 load on hardware that can't serve it (`nvfp4` is already false off Blackwell). That
-    // fallback is NOT silent: `reconcile_resolved_tier_quant` records the tier actually resolved and
-    // fires `quant_tier_downgraded` when it differs from the pick, the same honesty path every tier uses.
+    // an FP4 load on hardware that can't serve it (`nvfp4` is already false off Blackwell).
     //
-    // BOTH halves are required (the SC#5 opt-in): the user explicitly named the tier AND the host can
-    // serve it. Neither alone selects NVFP4.
+    // That NVFP4 fallback is currently NOT event-surfaced, and deliberately so — say what is true here:
+    // `reconcile_resolved_tier_quant` (which `warn!`s + fires `quant_tier_downgraded` on a tier
+    // downgrade) is `#[cfg(target_os = "macos")]`, while `nvfp4_host_eligible()` is hard-`false` on
+    // macOS — so the reconcile path and an NVFP4 pick are MUTUALLY EXCLUSIVE by construction and nothing
+    // reconciles NVFP4 on any lane. What keeps the fallback HONEST instead is [`nvfp4_selected`]: the
+    // recorded label + the load quant are gated on this resolver's OWN output (the resolved dir), so a
+    // pick that lands on q8 is recorded `"q8"` — the asset record tells the truth even with no event.
+    // Wiring a candle-lane reconcile so the downgrade is also OBSERVABLE (an event, not just an honest
+    // record) is worth doing when a tier is actually converted; sc-11043 owns that tier.
+    //
+    // BOTH halves are required HERE (the SC#5 opt-in): the user explicitly named the tier AND the host
+    // can serve it. Neither alone selects NVFP4. The third half — the tier is actually installed — is
+    // this function's own `present()` chain below, which is what [`nvfp4_selected`] reads back.
     let preferred = preferred_tier(
         bits,
         min_quality_floor(request),
@@ -1714,20 +1777,25 @@ fn quant_int(value: &Value) -> Option<i64> {
 /// `model.supports_quant()` gate), so the Q8 default applies to Lens exactly like the MLX families;
 /// the sc-3675/sc-5096 candle families advertise no quant and never reach this resolver (stay dense).
 ///
-/// **NVFP4 (sc-11042, epic 11037 SC#5)** is checked FIRST and ONLY on an explicit, host-eligible
-/// [`nvfp4_requested`] + [`nvfp4_host_eligible`] pick — never from `bits`, a manifest default, or
-/// hardware detection alone. Its recipe
+/// **NVFP4 (sc-11042, epic 11037 SC#5)** is selected ONLY on a full [`nvfp4_selected`] — an explicit
+/// pick, a Blackwell-eligible host, AND the `nvfp4/` tier actually resolved on disk — never from
+/// `bits`, a manifest default, or hardware detection alone, and never on a `tier_dir` that resolved to
+/// some other tier (that would load FP4 against q8 weights and record the wrong tier). Its recipe
 /// bit count is `None`, not `Some(4)`: `Quant::Nvfp4::bits()` returns 4 (its E2M1 elements are 4-bit),
 /// but NVFP4 is ~4.5 EFFECTIVE bits/weight and is a different tier from int4-affine `q4`, so reporting
 /// `4` here would stamp an NVFP4 render with `q4`'s bit count in the recipe — the aliasing SC#5 forbids
 /// (the same footgun `video_quant_label` carries; see its note). Every non-NVFP4 request takes the
 /// unchanged path below.
+///
+/// `tier_dir` is the RESOLVED tier subdir this job will load (`standard_tier_subdir`'s output), or
+/// `None` on a lane with no standard-tier layout in scope — see [`tier_dir_is_nvfp4`] for why `None`
+/// conservatively means "not NVFP4".
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
-fn resolve_quant(request: &ImageRequest) -> (Option<Quant>, Option<i64>) {
-    resolve_quant_gated(request, nvfp4_host_eligible())
+fn resolve_quant(request: &ImageRequest, tier_dir: Option<&Path>) -> (Option<Quant>, Option<i64>) {
+    resolve_quant_gated(request, nvfp4_host_eligible(), tier_dir)
 }
 
 /// [`resolve_quant`] with the NVFP4 **host** gate passed in rather than probed (sc-11042). Split out
@@ -1738,21 +1806,34 @@ fn resolve_quant(request: &ImageRequest) -> (Option<Quant>, Option<i64>) {
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
-fn resolve_quant_gated(request: &ImageRequest, nvfp4_host: bool) -> (Option<Quant>, Option<i64>) {
-    // The distinct NVFP4 tier (sc-11042): an EXPLICIT `advanced.quantTier: "nvfp4"` pick AND a
-    // Blackwell-eligible host — both halves, the SC#5 opt-in. Checked before the dense-TE carve-out and
-    // the bits map: it is a tier identity, not a point on the bits ladder. Off Blackwell / off the
-    // candle lane `nvfp4_host` is false, so this arm is unreachable there and every request resolves
-    // exactly as it always has.
-    if nvfp4_requested(request) && nvfp4_host {
-        return (Some(Quant::Nvfp4), None);
-    }
+fn resolve_quant_gated(
+    request: &ImageRequest,
+    nvfp4_host: bool,
+    tier_dir: Option<&Path>,
+) -> (Option<Quant>, Option<i64>) {
     // Dense-TE turnkeys (FLUX.2-klein, sc-8711): the tier subdir already holds a packed transformer
     // + a DENSE bf16 text encoder, so the load Quant must be None — quantizing here would crush the
     // dense bf16 TE we deliberately kept full-precision. The packed transformer self-describes its
     // quant regardless. Tier selection (q4/q8/bf16) is driven by the resolved subdir, not this.
+    //
+    // Ordered FIRST, ahead of the NVFP4 arm (sc-11042): `flux2_klein_9b`/`_kv` are BOTH in
+    // `DENSE_TE_TIER_MODELS` and on the candle txt2img lane (whose `resolve_quant` call is gated only
+    // by `model.supports_quant()`), so an NVFP4 arm placed above this could return `Some(Nvfp4)` for a
+    // crafted `quantTier: "nvfp4"` on a dense-TE turnkey and skip the carve-out — re-quantizing the
+    // bf16 text encoder sc-8711/sc-9362 deliberately kept dense. The carve-out is the wider invariant
+    // (the TE must never be quantized by ANY tier), so it wins outright rather than being an exception
+    // the NVFP4 arm has to remember.
     if is_dense_te_tier(request) {
         return (None, None);
+    }
+    // The distinct NVFP4 tier (sc-11042): an EXPLICIT `advanced.quantTier: "nvfp4"` pick AND a
+    // Blackwell-eligible host AND the `nvfp4/` tier resolved on disk — all three halves, the SC#5
+    // opt-in (see [`nvfp4_selected`]). Checked before the bits map: it is a tier identity, not a point
+    // on the bits ladder. Off Blackwell / off the candle lane `nvfp4_host` is false, and no shipping
+    // model packs an `nvfp4/` dir today, so this arm is unreachable there and every request resolves
+    // exactly as it always has.
+    if nvfp4_selected(request, nvfp4_host, tier_dir) {
+        return (Some(Quant::Nvfp4), None);
     }
     let raw = request
         .advanced
@@ -4000,7 +4081,11 @@ async fn generate_stream(
     // other matrix model. The `else` arm stays for any future engine that genuinely advertises no
     // quant — such a model loads dense.
     let (quant, quant_bits) = if model.supports_quant() {
-        resolve_quant(request)
+        // `weights_dir` is the resolved tier subdir (sc-11042). NVFP4 is unreachable on this lane
+        // regardless (`nvfp4_host_eligible()` is hard-`false` on macOS — Metal has no FP4 hardware), so
+        // this is the same `(quant, bits)` it has always produced; passing the dir keeps the resolver's
+        // one contract — the tier is read off what resolved — uniform across both lanes.
+        resolve_quant(request, Some(&weights_dir))
     } else {
         (None, None)
     };
@@ -4678,7 +4763,10 @@ async fn generate_candle_stream(
         // router doesn't strip. A dense DiT + LoRA/LoKr still folds (Quant None ⇒ no sc-10578 reject).
         (None, None)
     } else if model.supports_quant() {
-        resolve_quant(request)
+        // `weights_dir` is the tier subdir this lane is about to load (resolved above), so the NVFP4
+        // tier is picked only when the `nvfp4/` dir is what actually resolved (sc-11042) — never FP4
+        // against a q8 fallback.
+        resolve_quant(request, Some(&weights_dir))
     } else {
         (None, None)
     };
@@ -4856,10 +4944,26 @@ async fn generate_candle_stream(
     // budgeted. ConvRot loads an int8 DiT over the bf16 base surface (its footprint is neither the bf16
     // nor the q8 tier), and a `modelPath`/flat root has no recognizable tier basename — fall back to the
     // manifest key there, preserving today's behavior.
+    //
+    // sc-11042: the NVFP4 tier composes with the sc-12090 disk probe rather than bypassing it.
+    // `tier_key_from_resolved_dir` only recognizes the bits-based basenames (bf16/q8/q4), so a resolved
+    // `nvfp4/` dir yields `None` and falls through to `requested_tier_key`, whose `nvfp4` short-circuit
+    // names the tier by IDENTITY (never by bits — `Quant::Nvfp4.bits()` is 4, which would alias q4).
+    // `nvfp4_selected` reads that same resolved `weights_dir`, so a `quantTier: "nvfp4"` label that fell
+    // back to another tier's dir is sized/named as the tier that will actually load, not as nvfp4.
+    let nvfp4_sel = nvfp4_selected(request, nvfp4_host_eligible(), Some(&weights_dir));
     let mut tier = match convrot {
-        Some(_) => crate::vram_gate::requested_tier_key(&request.advanced, &request.model_manifest_entry),
+        Some(_) => crate::vram_gate::requested_tier_key(
+            &request.advanced,
+            &request.model_manifest_entry,
+            nvfp4_sel,
+        ),
         None => tier_key_from_resolved_dir(&weights_dir).unwrap_or_else(|| {
-            crate::vram_gate::requested_tier_key(&request.advanced, &request.model_manifest_entry)
+            crate::vram_gate::requested_tier_key(
+                &request.advanced,
+                &request.model_manifest_entry,
+                nvfp4_sel,
+            )
         }),
     };
     // The candle FLUX.1 (sc-10769), FLUX.2 txt2img (sc-10868), and Qwen-Image txt2img (sc-10867) lanes
@@ -4879,6 +4983,16 @@ async fn generate_candle_stream(
     // installed tier that does — floored at the per-model quality floor — rejecting only when nothing
     // >= floor fits. An explicit pick (`mlxQuantizeExplicit`) is HONORED: it skips the downtier and runs
     // the plain gate below (fits → run; too big → reject-before-OOM), never silently downtiered (#7).
+    //
+    // sc-11042 (epic 11037 SC#5): a selected NVFP4 tier is never downtiered either, and does not rely on
+    // `mlxQuantizeExplicit` to escape — the web omits that flag for nvfp4 (it rides inside the
+    // `tierQuantize(quantTier) !== null` bits branch, and nvfp4 has no honest `mlxQuantize` integer).
+    // Instead NVFP4 is unrankable ON PURPOSE: `tier_quality_rank("nvfp4")` is 0 because nvfp4 is a
+    // distinct numeric regime, not a rung on the bf16/q8/q4 fidelity ladder, so
+    // `downtier_candidate_tiers` yields NO candidates in `[floor, nvfp4]` and `choose_downtier` returns
+    // `Keep`. Downtiering NVFP4 to q4/q8 would silently swap the numerics of an explicitly-picked tier —
+    // exactly the creative-choice violation SC#5 forbids. Pinned by
+    // `nvfp4_tier_is_never_downtiered_by_the_capability_clamp`.
     let explicit_pick = request
         .advanced
         .get("mlxQuantizeExplicit")
@@ -5232,12 +5346,24 @@ fn image_settings_metrics(
 /// label on a 4-bit render, the inverse mislabel but the same SC#5 violation. Matching the variant is
 /// what makes both directions impossible. The tier's own arm is placed alongside int8-convrot's — both
 /// are tiers with no honest integer width, and both report `None` bits for that reason.
+///
+/// **The label describes what RAN — so it is disk-aware, not just host-aware (sc-11042).** `tier_dir`
+/// is the RESOLVED tier subdir, and NVFP4 is labelled only when that dir IS the `nvfp4/` one (the
+/// [`nvfp4_selected`] third half). Host-awareness alone was NOT enough: `standard_tier_subdir`
+/// independently falls back to q8 when the `nvfp4/` dir is absent — the shipping case on every model
+/// today, since sc-11043 has not converted a tier yet — so an explicit pick on a Blackwell host
+/// recorded `"nvfp4"` on a render whose weights were **q8**. Same SC#5 creative-choice aliasing this
+/// tier exists to eliminate, merely displaced out of selection and into telemetry. Reading the label
+/// off the resolver's own output is what makes the two agree by construction.
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
-fn effective_quant_label(request: &ImageRequest) -> (Option<String>, Option<i64>) {
-    effective_quant_label_gated(request, nvfp4_host_eligible())
+fn effective_quant_label(
+    request: &ImageRequest,
+    tier_dir: Option<&Path>,
+) -> (Option<String>, Option<i64>) {
+    effective_quant_label_gated(request, nvfp4_host_eligible(), tier_dir)
 }
 
 /// [`effective_quant_label`] with the NVFP4 **host** gate passed in rather than probed (sc-11042).
@@ -5250,6 +5376,7 @@ fn effective_quant_label(request: &ImageRequest) -> (Option<String>, Option<i64>
 fn effective_quant_label_gated(
     request: &ImageRequest,
     nvfp4_host: bool,
+    tier_dir: Option<&Path>,
 ) -> (Option<String>, Option<i64>) {
     if request
         .advanced
@@ -5267,7 +5394,7 @@ fn effective_quant_label_gated(
             _ => (Some("bf16".to_owned()), None),
         };
     }
-    match resolve_quant_gated(request, nvfp4_host) {
+    match resolve_quant_gated(request, nvfp4_host, tier_dir) {
         // The distinct NVFP4 tier, matched on the VARIANT (see the note above): its bit count is
         // `None`, so a bits-only match would silently label it "bf16".
         (Some(Quant::Nvfp4), _) => (Some(NVFP4_TIER.to_owned()), None),
@@ -5288,8 +5415,9 @@ fn build_image_metrics(
     request: &ImageRequest,
     effective_steps: Option<u32>,
     image_count: u32,
+    tier_dir: Option<&Path>,
 ) -> GenerationMetrics {
-    let (quant_label, quant_bits) = effective_quant_label(request);
+    let (quant_label, quant_bits) = effective_quant_label(request, tier_dir);
     let guidance = mlx_model(&request.model).and_then(|model| resolve_guidance(request, &model));
     image_settings_metrics(
         request,
@@ -5308,6 +5436,7 @@ fn build_image_metrics(
     request: &ImageRequest,
     effective_steps: Option<u32>,
     image_count: u32,
+    _tier_dir: Option<&Path>,
 ) -> GenerationMetrics {
     image_settings_metrics(request, effective_steps, None, None, None, image_count)
 }
@@ -5584,7 +5713,19 @@ async fn consume_gen_events(
     // Post the effective-settings + per-phase timing block (epic 10402,
     // sc-10405/sc-10406). Best-effort; coalesce-merges with the S2 hardware block
     // (which owns totalMs/backend/peaks) server-side.
-    let mut metrics = build_image_metrics(&plan.request, effective_steps, total as u32);
+    // The RESOLVED tier dir, so the recorded quant label describes the tier that actually RAN rather
+    // than the one requested (sc-11042). Re-resolving here is the same pure path-join + `is_dir` probe
+    // the lane already did before loading (no fetch, no I/O beyond a stat), and it runs once per job.
+    // `.ok().flatten()` because a metrics block must never fail a completed generation: an unresolvable
+    // dir yields `None`, which conservatively reports the request-derived q4/q8/bf16 label exactly as
+    // it did before this parameter existed.
+    let tier_dir = resolve_weights_dir(&plan.request, settings).ok().flatten();
+    let mut metrics = build_image_metrics(
+        &plan.request,
+        effective_steps,
+        total as u32,
+        tier_dir.as_deref(),
+    );
     if let Some(phase) = phase_timer.into_metrics(Instant::now()) {
         metrics.load_ms = phase.load_ms;
         metrics.sample_ms = phase.sample_ms;
@@ -6395,32 +6536,113 @@ mod standard_tier_tests {
     #[test]
     fn resolve_quant_returns_the_distinct_nvfp4_tier_only_on_an_explicit_blackwell_pick() {
         let picked = request(json!({ "quantTier": "nvfp4" }));
-        // Explicit pick + Blackwell → the distinct tier, and NOT `Some(4)` bits.
-        assert_eq!(resolve_quant_gated(&picked, true), (Some(Quant::Nvfp4), None));
+        let nvfp4_dir = PathBuf::from("/models/klein").join(NVFP4_TIER);
+        let q8_dir = PathBuf::from("/models/klein").join("q8");
+        // Explicit pick + Blackwell + the nvfp4 tier RESOLVED → the distinct tier, and NOT `Some(4)` bits.
+        assert_eq!(
+            resolve_quant_gated(&picked, true, Some(&nvfp4_dir)),
+            (Some(Quant::Nvfp4), None)
+        );
         // Off Blackwell → the label is ignored; the unchanged q8 default. A clean fallback.
-        assert_eq!(resolve_quant_gated(&picked, false), (Some(Quant::Q8), Some(8)));
+        assert_eq!(
+            resolve_quant_gated(&picked, false, Some(&nvfp4_dir)),
+            (Some(Quant::Q8), Some(8))
+        );
+        // On Blackwell but the resolver landed on q8 (the `nvfp4/` dir isn't installed — the shipping
+        // case today): the LOAD quant must be q8 too. Loading FP4 against q8 weights is not a mislabel,
+        // it's a wrong load.
+        assert_eq!(
+            resolve_quant_gated(&picked, true, Some(&q8_dir)),
+            (Some(Quant::Q8), Some(8))
+        );
+        // Tier dir unknown ⇒ never claim NVFP4 (see `tier_dir_is_nvfp4`).
+        assert_eq!(
+            resolve_quant_gated(&picked, true, None),
+            (Some(Quant::Q8), Some(8))
+        );
 
-        // SC#5: every existing mapping is untouched on BOTH host classes — being on sm_120 never
-        // converts an unlabeled q4/q8/bf16 request into an NVFP4 one.
+        // SC#5: every existing mapping is untouched on BOTH host classes and on EVERY tier dir — being
+        // on sm_120, even with the `nvfp4/` tier resolved, never converts an unlabeled q4/q8/bf16
+        // request into an NVFP4 one.
         for nvfp4_host in [false, true] {
+            for dir in [None, Some(&nvfp4_dir), Some(&q8_dir)] {
+                assert_eq!(
+                    resolve_quant_gated(&request(json!({})), nvfp4_host, dir.map(PathBuf::as_path)),
+                    (Some(Quant::Q8), Some(8))
+                );
+                assert_eq!(
+                    resolve_quant_gated(
+                        &request(json!({ "mlxQuantize": 4 })),
+                        nvfp4_host,
+                        dir.map(PathBuf::as_path)
+                    ),
+                    (Some(Quant::Q4), Some(4)),
+                    "a q4 pick must stay int4-affine q4 on every host (epic 11037 SC#5)"
+                );
+                assert_eq!(
+                    resolve_quant_gated(
+                        &request(json!({ "mlxQuantize": 8 })),
+                        nvfp4_host,
+                        dir.map(PathBuf::as_path)
+                    ),
+                    (Some(Quant::Q8), Some(8))
+                );
+                assert_eq!(
+                    resolve_quant_gated(
+                        &request(json!({ "mlxQuantize": 0 })),
+                        nvfp4_host,
+                        dir.map(PathBuf::as_path)
+                    ),
+                    (None, None)
+                );
+            }
+        }
+    }
+
+    /// sc-11042 — **the dense-TE carve-out outranks the NVFP4 tier** (sc-8711 / sc-9362).
+    ///
+    /// `flux2_klein_9b`/`_kv` are in [`DENSE_TE_TIER_MODELS`] AND ride the candle txt2img lane, whose
+    /// `resolve_quant` call is gated only by `model.supports_quant()`. With the NVFP4 arm ordered ahead
+    /// of the carve-out, a crafted `quantTier: "nvfp4"` returned `Some(Nvfp4)` and skipped it — which
+    /// would re-quantize the bf16 text encoder those stories deliberately kept dense. The carve-out is
+    /// the wider invariant (the TE must never be quantized by ANY tier), so it wins outright.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn the_nvfp4_arm_never_short_circuits_the_dense_te_carve_out() {
+        let nvfp4_dir = PathBuf::from("/models/klein").join(NVFP4_TIER);
+        // Both the registry form and the manifest-flag form of a dense-TE turnkey, with EVERY gate for
+        // the NVFP4 arm satisfied: explicit pick, Blackwell host, and the `nvfp4/` tier resolved.
+        let mut by_id = request(json!({ "quantTier": "nvfp4" }));
+        by_id.model = "flux2_klein_9b".to_owned();
+        let by_manifest = ImageRequest::from_payload(
+            json!({
+                "model": "some_matrix_model",
+                "advanced": { "quantTier": "nvfp4" },
+                "modelManifestEntry": { "mlx": { "denseTextEncoderTier": true } }
+            })
+            .as_object()
+            .unwrap(),
+        );
+
+        for dense_te in [&by_id, &by_manifest] {
+            assert!(is_dense_te_tier(dense_te), "test fixture must be dense-TE");
             assert_eq!(
-                resolve_quant_gated(&request(json!({})), nvfp4_host),
-                (Some(Quant::Q8), Some(8))
-            );
-            assert_eq!(
-                resolve_quant_gated(&request(json!({ "mlxQuantize": 4 })), nvfp4_host),
-                (Some(Quant::Q4), Some(4)),
-                "a q4 pick must stay int4-affine q4 on every host (epic 11037 SC#5)"
-            );
-            assert_eq!(
-                resolve_quant_gated(&request(json!({ "mlxQuantize": 8 })), nvfp4_host),
-                (Some(Quant::Q8), Some(8))
-            );
-            assert_eq!(
-                resolve_quant_gated(&request(json!({ "mlxQuantize": 0 })), nvfp4_host),
-                (None, None)
+                resolve_quant_gated(dense_te, true, Some(&nvfp4_dir)),
+                (None, None),
+                "a dense-TE turnkey must load with quant None — the NVFP4 arm must not preempt the \
+                 sc-8711 carve-out that keeps its bf16 text encoder dense"
             );
         }
+
+        // The carve-out is not a general NVFP4 kill-switch: a NON-dense-TE model on the same terms
+        // still selects the tier, so the fix can't be masking the arm entirely.
+        assert_eq!(
+            resolve_quant_gated(&request(json!({ "quantTier": "nvfp4" })), true, Some(&nvfp4_dir)),
+            (Some(Quant::Nvfp4), None)
+        );
     }
 
     /// sc-11042 / epic 11037 SC#5 — **the image lane's aliasing guard**, the sibling of
@@ -6437,7 +6659,8 @@ mod standard_tier_tests {
     #[test]
     fn effective_quant_label_never_aliases_nvfp4_to_bf16_or_q4() {
         let picked = request(json!({ "quantTier": "nvfp4" }));
-        let (label, bits) = effective_quant_label_gated(&picked, true);
+        let nvfp4_dir = PathBuf::from("/models/klein").join(NVFP4_TIER);
+        let (label, bits) = effective_quant_label_gated(&picked, true, Some(&nvfp4_dir));
         assert_eq!(label, Some("nvfp4".to_owned()));
         // Neither mislabel is possible: not the "bf16" a bits-only match produced…
         assert_ne!(label, Some("bf16".to_owned()));
@@ -6448,28 +6671,128 @@ mod standard_tier_tests {
 
         // Off Blackwell the label reports what actually ran (the q8 fallback), not the tier asked for.
         assert_eq!(
-            effective_quant_label_gated(&picked, false),
+            effective_quant_label_gated(&picked, false, Some(&nvfp4_dir)),
             (Some("q8".to_owned()), Some(8))
         );
         // SC#5: the existing labels are unchanged on both host classes.
         for nvfp4_host in [false, true] {
             assert_eq!(
-                effective_quant_label_gated(&request(json!({ "mlxQuantize": 4 })), nvfp4_host),
+                effective_quant_label_gated(
+                    &request(json!({ "mlxQuantize": 4 })),
+                    nvfp4_host,
+                    Some(&nvfp4_dir)
+                ),
                 (Some("q4".to_owned()), Some(4))
             );
             assert_eq!(
-                effective_quant_label_gated(&request(json!({ "mlxQuantize": 8 })), nvfp4_host),
+                effective_quant_label_gated(
+                    &request(json!({ "mlxQuantize": 8 })),
+                    nvfp4_host,
+                    Some(&nvfp4_dir)
+                ),
                 (Some("q8".to_owned()), Some(8))
             );
             assert_eq!(
-                effective_quant_label_gated(&request(json!({ "mlxQuantize": 0 })), nvfp4_host),
+                effective_quant_label_gated(
+                    &request(json!({ "mlxQuantize": 0 })),
+                    nvfp4_host,
+                    Some(&nvfp4_dir)
+                ),
                 (Some("bf16".to_owned()), None)
             );
             // The int8-convrot tier still wins its early return.
             assert_eq!(
-                effective_quant_label_gated(&request(json!({ "convRot": true })), nvfp4_host),
+                effective_quant_label_gated(
+                    &request(json!({ "convRot": true })),
+                    nvfp4_host,
+                    Some(&nvfp4_dir)
+                ),
                 (Some("int8-convrot".to_owned()), None)
             );
+        }
+    }
+
+    /// sc-11042 / epic 11037 SC#5 — **the recorded label must describe the tier that RAN.**
+    ///
+    /// The regression this pins: `effective_quant_label` was host-aware but DISK-BLIND. It returned
+    /// `Nvfp4` from `nvfp4_requested && nvfp4_host` alone, while [`standard_tier_subdir`] independently
+    /// (and correctly) fell back to `q8/` when the `nvfp4/` dir was absent — **the shipping case on
+    /// every model today**, since sc-11043 has not converted a tier yet. So on a Blackwell candle host
+    /// the resolver loaded the **q8** weights and the asset record stamped them **`"nvfp4"`**: a q8
+    /// render sold as NVFP4. Exactly the SC#5 creative-choice aliasing this tier exists to eliminate,
+    /// displaced out of selection and into telemetry.
+    ///
+    /// The suite already contained both halves of the contradiction — `standard_tier_subdir_gated(bare,
+    /// picked, true) == q8` and `effective_quant_label_gated(picked, true) == "nvfp4"` — and never
+    /// connected them. This test connects them: it drives the SAME request through the resolver and the
+    /// label and asserts they agree, so the two can never drift apart again.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn effective_quant_label_reports_the_resolved_tier_not_the_requested_one() {
+        let picked = request(json!({ "quantTier": "nvfp4" }));
+
+        // A Blackwell host whose turnkey has NO `nvfp4/` dir — the shipping case today.
+        let bare = tempfile::tempdir().unwrap();
+        seed_tier(bare.path(), "q4", "diffusion_pytorch_model.safetensors");
+        seed_tier(bare.path(), "q8", "diffusion_pytorch_model.safetensors");
+
+        // The resolver falls back to q8 (this half already passed before the fix)…
+        let resolved = standard_tier_subdir_gated(bare.path(), &picked, true);
+        assert_eq!(resolved, bare.path().join("q8"));
+        // …so the label MUST say q8. Before the fix this returned `Some("nvfp4")` with bits None —
+        // a q8 render recorded as an NVFP4 one.
+        let (label, bits) = effective_quant_label_gated(&picked, true, Some(&resolved));
+        assert_ne!(
+            label,
+            Some(NVFP4_TIER.to_owned()),
+            "an NVFP4 pick that RESOLVED q8 must never be recorded as nvfp4 (epic 11037 SC#5)"
+        );
+        assert_eq!((label, bits), (Some("q8".to_owned()), Some(8)));
+
+        // Same host, same request, but the tier IS installed → the label is nvfp4. This is what proves
+        // the fix pins the label to the DISK and isn't just disabling the tier.
+        let converted = tempfile::tempdir().unwrap();
+        seed_tier(converted.path(), "q8", "diffusion_pytorch_model.safetensors");
+        seed_tier(
+            converted.path(),
+            NVFP4_TIER,
+            "diffusion_pytorch_model.safetensors",
+        );
+        let resolved = standard_tier_subdir_gated(converted.path(), &picked, true);
+        assert_eq!(resolved, converted.path().join(NVFP4_TIER));
+        assert_eq!(
+            effective_quant_label_gated(&picked, true, Some(&resolved)),
+            (Some(NVFP4_TIER.to_owned()), None)
+        );
+
+        // The resolver and the label agree on EVERY tier/host/install combination — the invariant, not
+        // just the two cases above. Each `expected` is read off the resolver's own output.
+        for install in [vec!["q4", "q8"], vec!["q4", "q8", NVFP4_TIER]] {
+            let root = tempfile::tempdir().unwrap();
+            for tier in &install {
+                seed_tier(root.path(), tier, "diffusion_pytorch_model.safetensors");
+            }
+            for nvfp4_host in [false, true] {
+                for advanced in [
+                    json!({ "quantTier": "nvfp4" }),
+                    json!({}),
+                    json!({ "mlxQuantize": 4 }),
+                ] {
+                    let req = request(advanced.clone());
+                    let resolved = standard_tier_subdir_gated(root.path(), &req, nvfp4_host);
+                    let (label, _) = effective_quant_label_gated(&req, nvfp4_host, Some(&resolved));
+                    let resolved_tier = resolved.file_name().unwrap().to_str().unwrap();
+                    assert_eq!(
+                        label.as_deref() == Some(NVFP4_TIER),
+                        resolved_tier == NVFP4_TIER,
+                        "label {label:?} disagrees with the resolved tier {resolved_tier} \
+                         (host={nvfp4_host}, advanced={advanced}, installed={install:?})"
+                    );
+                }
+            }
         }
     }
 
@@ -6608,7 +6931,7 @@ mod standard_tier_tests {
         let base_default =
             ImageRequest::from_payload(json!({ "model": "anima_base" }).as_object().unwrap());
         assert_eq!(
-            resolve_quant(&base_default),
+            resolve_quant(&base_default, None),
             (Some(Quant::Q8), Some(8)),
             "anima_base with no mlxQuantize must default to Q8 — the reason adding an adapter used to \
              fail at load on the DEFAULT tier"
@@ -6619,19 +6942,19 @@ mod standard_tier_tests {
                 .as_object()
                 .unwrap(),
         );
-        assert_eq!(resolve_quant(&aesthetic), (Some(Quant::Q4), Some(4)));
+        assert_eq!(resolve_quant(&aesthetic, None), (Some(Quant::Q4), Some(4)));
         // Only an explicit bf16 opt-out escaped the bug.
         let bf16 = ImageRequest::from_payload(
             json!({ "model": "anima_base", "advanced": { "mlxQuantize": 0 } })
                 .as_object()
                 .unwrap(),
         );
-        assert_eq!(resolve_quant(&bf16), (None, None));
+        assert_eq!(resolve_quant(&bf16, None), (None, None));
 
         // 2. The LoadSpec the worker hands the engine carries a quant AND the adapter together — the
         //    exact `quantize.is_some() && !adapters.is_empty()` shape mlx-gen-anima rejected on
         //    `6a10ae1` and accepts on `a5c1fcd`.
-        let (quant, _) = resolve_quant(&base_default);
+        let (quant, _) = resolve_quant(&base_default, None);
         let adapters = vec![AdapterSpec::new(
             PathBuf::from("/tmp/anima-style-lora.safetensors"),
             1.0,
@@ -7330,7 +7653,7 @@ mod quant_tier_reconcile_tests {
         let resolved = standard_tier_subdir(root, &req);
         assert_eq!(resolved, root.join("q4"));
         // The request would have recorded dense bf16 — reconcile corrects it to the resolved Q4 tier.
-        let requested = resolve_quant(&req);
+        let requested = resolve_quant(&req, Some(&resolved));
         assert_eq!(requested, (None, None), "bf16 request derives dense");
         let (quant, bits) =
             reconcile_resolved_tier_quant(requested, &resolved, true, "sd3_5_large", "job1", "mlx");
@@ -7389,7 +7712,7 @@ mod quant_tier_reconcile_tests {
         let resolved = standard_tier_subdir(root, &req);
         assert_eq!(resolved, root.join("q8"));
         // resolve_quant keeps dense-TE at `(None, None)` (never re-quantize the dense bf16 TE)…
-        assert_eq!(resolve_quant(&req), (None, None));
+        assert_eq!(resolve_quant(&req, Some(&resolved)), (None, None));
         // …but reconcile against the REQUESTED transformer tier (q8) records the real transformer
         // precision (Q8) with the load quant still `None`, and — since resolved == requested — with no
         // downgrade (the requested/resolved tiers match, so it's a clean pass-through).

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -902,10 +902,73 @@ fn tier_static_name(tier: &str) -> &'static str {
     }
 }
 
-/// The tier subdir name a request prefers, given its explicit `advanced.mlxQuantize` `bits` and the
-/// model's per-model quality `floor` (`mlx.minQualityTier`, sc-10731 — `None` = no floor).
+/// The tier subdir name of the NVFP4 tier (sc-11042, epic 11037), and the value of the
+/// `advanced.quantTier` label that selects it.
 ///
-/// An EXPLICIT pick maps directly (`<= 0` → bf16, `> 4` → q8, `1..=4` → q4) and is HONORED even below
+/// A DISTINCT, user-selectable tier — **not** an int4-affine equivalent and never an auto-swap of `q4`
+/// (epic 11037 SC#5 / the sc-11042 Option A decision). NVFP4 is E2M1 4-bit elements over 16-element
+/// blocks with FP8-E4M3 micro-scales + an FP32 per-tensor scale (~4.5 effective bits/weight), a
+/// different numeric regime from `q4`; auto-selecting it for a `q4` pick on Blackwell would silently
+/// change that tier's output.
+pub(crate) const NVFP4_TIER: &str = "nvfp4";
+
+/// Whether the request EXPLICITLY asked for the NVFP4 tier, via the `advanced.quantTier: "nvfp4"`
+/// label (sc-12006 established the label as asset telemetry; sc-11042 makes it a selection input).
+///
+/// NVFP4 rides `quantTier` and NOT `advanced.mlxQuantize` because `mlxQuantize` is a BITS-VALUED knob:
+/// every consumer parses it as an integer that NAMES A TIER (`quant_int` → `<= 0` ⇒ bf16, `<= 4` ⇒ q4,
+/// else q8), so **no integer is honest for NVFP4** — `4` would select the int4-affine `q4` tier, and
+/// every other value names bf16/q8. So `mlxQuantize` stays `null` for NVFP4 and the tier identity rides
+/// this distinct label, exactly the sc-9300 `convRot` precedent.
+///
+/// PURE + UNGATED (like [`preferred_tier`], its caller): reads only the request, so the "did the user
+/// ask for NVFP4" question is testable on every platform without a GPU. The sm_120 host gate is the
+/// separate [`nvfp4_host_eligible`]; the tier is selected only when BOTH hold.
+fn nvfp4_requested(request: &ImageRequest) -> bool {
+    request
+        .advanced
+        .get("quantTier")
+        .and_then(Value::as_str)
+        .is_some_and(|tier| tier.trim().eq_ignore_ascii_case(NVFP4_TIER))
+}
+
+/// Whether THIS HOST can serve the NVFP4 tier: the candle lane on a GPU clearing the sm_120
+/// consumer-Blackwell compute-cap floor (sc-11042).
+///
+/// The RUNTIME half of the Blackwell gate, and deliberately defence-in-depth. The web picker already
+/// hides the tier unless a live worker advertises the `nvfp4` capability (`gpu.rs`), but `advanced` is
+/// free-form pass-through (`rawAdapterSettings` has no strict deserializer), so a hand-crafted API call
+/// can put `quantTier: "nvfp4"` on a request to ANY worker. Checking here means such a request falls
+/// back cleanly to an installed tier instead of routing an FP4 load at hardware with no FP4 tensor
+/// cores. Mirrors ConvRot's belt-and-braces (`int8_convrot` capability + engine-side `ensure_int8_floor`).
+///
+/// Always `false` off the candle lane: macOS/MLX (Metal has no FP4 hardware — explicitly out of scope
+/// for epic 11037, and the runtime's MLX side `reject_quant`s NVFP4) and the non-candle build (no FP4
+/// compute) can never serve it, so the tier is never selected there.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn nvfp4_host_eligible() -> bool {
+    crate::gpu::compute_cap_meets_nvfp4(crate::gpu::cached_compute_cap())
+}
+
+#[cfg(not(all(not(target_os = "macos"), feature = "backend-candle")))]
+fn nvfp4_host_eligible() -> bool {
+    false
+}
+
+/// The tier subdir name a request prefers, given its explicit `advanced.mlxQuantize` `bits`, the
+/// model's per-model quality `floor` (`mlx.minQualityTier`, sc-10731 — `None` = no floor), and whether
+/// the request selected the distinct NVFP4 tier (`nvfp4`, sc-11042 — an explicit
+/// [`nvfp4_requested`] label AND an [`nvfp4_host_eligible`] host).
+///
+/// An explicit, host-eligible **NVFP4** pick (`nvfp4 == true`) resolves the distinct [`NVFP4_TIER`] and
+/// short-circuits the bits map below — NVFP4 has no honest `mlxQuantize` integer, so it cannot be
+/// expressed there (epic 11037 SC#5 / sc-11042 Option A). It is NOT floor-clamped: like every explicit
+/// pick it is a deliberate creative choice, honored as asked. `nvfp4 == false` — every request that did
+/// not explicitly ask for NVFP4, which is all of them today — leaves this function's behavior **exactly**
+/// as it was: the mapping below is untouched, so no existing tier's resolution changes (guarded by
+/// `preferred_tier_bits_map_is_unchanged_by_the_nvfp4_tier`).
+///
+/// An EXPLICIT bits pick maps directly (`<= 0` → bf16, `> 4` → q8, `1..=4` → q4) and is HONORED even below
 /// the floor — a quant tier is a deliberate quality/creative choice, so the worker never silently
 /// overrides it (the web surfaces a non-blocking advisory on a below-floor pick instead). With NO
 /// explicit pick, the app-wide default (Q8, epic 10721 / sc-10726) is CLAMPED UP to the floor: a floored
@@ -915,7 +978,12 @@ fn tier_static_name(tier: &str) -> &'static str {
 /// to the best installed tier). This is the SHARED default-tier logic behind both [`standard_tier_subdir`]
 /// and [`anima_tier_subdir`]; it REPLACES the sc-10714 anima-specific `None => "q8"` hardcode so Anima's
 /// q8 default is now floor-driven from the manifest, not a resolver special-case.
-fn preferred_tier(bits: Option<i64>, floor: Option<&str>) -> &'static str {
+fn preferred_tier(bits: Option<i64>, floor: Option<&str>, nvfp4: bool) -> &'static str {
+    // The distinct NVFP4 tier (sc-11042). Checked FIRST and returned as-is: it is not a point on the
+    // bf16/q8/q4 fidelity ladder, so it takes no part in the floor clamp or the bits map below.
+    if nvfp4 {
+        return NVFP4_TIER;
+    }
     match bits {
         Some(b) if b <= 0 => "bf16",
         Some(b) if b > 4 => "q8",
@@ -965,6 +1033,18 @@ fn min_quality_floor(request: &ImageRequest) -> Option<&str> {
 /// is a flat `model.safetensors` (or sharded `*.index.json`) directly in the tier dir. The presence
 /// check also accepts weights at the tier root so a flat unified tier resolves like a component one.
 fn standard_tier_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
+    standard_tier_subdir_gated(root, request, nvfp4_host_eligible())
+}
+
+/// [`standard_tier_subdir`] with the NVFP4 **host** gate passed in rather than probed (sc-11042).
+///
+/// Split out ONLY for testability, and the injected value is deliberately the HARDWARE fact
+/// (`nvfp4_host` = "this host clears the sm_120 floor"), not the finished decision: the live
+/// compute-cap probe is the one thing a test can't control, while reading the request's `quantTier`
+/// label stays real. So a test can drive both host classes and still exercise the actual
+/// request-parsing + SC#5 opt-in. Production has exactly one caller ([`standard_tier_subdir`]), which
+/// passes the real probe.
+fn standard_tier_subdir_gated(root: &Path, request: &ImageRequest, nvfp4_host: bool) -> PathBuf {
     let bits = request
         .advanced
         .get("mlxQuantize")
@@ -1003,7 +1083,22 @@ fn standard_tier_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
     // asked for (an explicit below-floor pick is honored — the web flags it, the worker never overrides).
     // Fallback prefers the clean tiers (q8 → bf16 → q4) so a partial install never silently lands on the
     // washed q4, and the (possibly floored) default is clamped to what's on disk.
-    let preferred = preferred_tier(bits, min_quality_floor(request));
+    //
+    // An explicit, host-eligible NVFP4 pick (sc-11042) prefers the distinct `nvfp4/` tier dir and then
+    // rejoins the SAME clean-tier fallback chain, so a request for a tier that isn't converted yet
+    // (sc-11043 owns the convert-at-install loop; no shipping model packs an `nvfp4/` dir today) lands
+    // on an installed tier exactly like an uninstalled q4/bf16 pick does — never a load error, and never
+    // an FP4 load on hardware that can't serve it (`nvfp4` is already false off Blackwell). That
+    // fallback is NOT silent: `reconcile_resolved_tier_quant` records the tier actually resolved and
+    // fires `quant_tier_downgraded` when it differs from the pick, the same honesty path every tier uses.
+    //
+    // BOTH halves are required (the SC#5 opt-in): the user explicitly named the tier AND the host can
+    // serve it. Neither alone selects NVFP4.
+    let preferred = preferred_tier(
+        bits,
+        min_quality_floor(request),
+        nvfp4_requested(request) && nvfp4_host,
+    );
     present(preferred)
         .or_else(|| present("q8"))
         .or_else(|| present("bf16"))
@@ -1079,7 +1174,11 @@ fn anima_tier_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
     // for max fidelity/speed on this small 2B DiT, and an explicit q4 pick is still honored (the web
     // flags a below-floor pick with an advisory). Fallback prefers the clean tiers (q8 → bf16 → q4) so a
     // partial install never silently lands on the washed q4.
-    let preferred = preferred_tier(bits, min_quality_floor(request));
+    //
+    // `nvfp4: false` (sc-11042): Anima is an MLX convert-at-install family and hosts no NVFP4 tier — the
+    // lane is candle/Blackwell-only. Passing `false` keeps this resolver byte-identical to its pre-sc-11042
+    // behavior; wire it here if an Anima NVFP4 tier is ever converted.
+    let preferred = preferred_tier(bits, min_quality_floor(request), false);
     present(preferred)
         .or_else(|| present("q8"))
         .or_else(|| present("bf16"))
@@ -1152,7 +1251,10 @@ fn ideogram_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
     // catalog repo, never an in-turnkey subdir), so a preferred `bf16` — an explicit `<=0` pick, or a
     // hypothetical bf16 floor — simply isn't present and falls through the clean-tiers chain (q8 → q4) to
     // the best installed tier, exactly as the prior resolver did.
-    let preferred = preferred_tier(bits, min_quality_floor(request));
+    //
+    // `nvfp4: false` (sc-11042): the Ideogram turnkey hosts no NVFP4 tier. Byte-identical to its
+    // pre-sc-11042 behavior; wire it here if one is ever converted.
+    let preferred = preferred_tier(bits, min_quality_floor(request), false);
     present(preferred)
         .or_else(|| present("q8"))
         .or_else(|| present("q4"))
@@ -1227,7 +1329,10 @@ fn boogu_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
     // landing below a floor should one ever be declared — a bf16 floor would raise the picker-less default
     // from the packed Q8 up to the dense `<variant>-bf16`, capped by what's installed. The clean-tiers
     // fallback (Q8 → q4 → bf16) is unchanged, so a partial bundle still surfaces as a load error.
-    let preferred = preferred_tier(bits, min_quality_floor(request));
+    //
+    // `nvfp4: false` (sc-11042): Boogu's `<variant>-bf16` MLX layout hosts no NVFP4 tier. Byte-identical
+    // to its pre-sc-11042 behavior; wire it here if one is ever converted.
+    let preferred = preferred_tier(bits, min_quality_floor(request), false);
     present(&variant_folder(preferred))
         .or_else(|| present(variant))
         .or_else(|| present(&q4))
@@ -1247,6 +1352,12 @@ fn boogu_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
 /// resolved `spec.quantize` is a no-op on it. Mirrors [`ideogram_model_subdir`] (q4/q8 subdirs) with
 /// Boogu's packed-transformer filename and a Q8-default selection.
 fn krea_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
+    krea_model_subdir_gated(root, request, nvfp4_host_eligible())
+}
+
+/// [`krea_model_subdir`] with the NVFP4 **host** gate passed in rather than probed (sc-11042). Split
+/// out for testability, exactly like [`standard_tier_subdir_gated`]; production has one caller.
+fn krea_model_subdir_gated(root: &Path, request: &ImageRequest, nvfp4_host: bool) -> PathBuf {
     let bits = request
         .advanced
         .get("mlxQuantize")
@@ -1274,7 +1385,19 @@ fn krea_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
     // floor should one ever be declared (a bf16 floor would raise the picker-less default from q8 to the
     // dense bf16, capped by what's installed). Fallback stays krea's q8 → q4 → bf16 (bf16 last — it is the
     // heaviest dense tree), so a partial bundle still surfaces as a load error.
-    let preferred = preferred_tier(bits, min_quality_floor(request));
+    //
+    // NVFP4 (sc-11042): wired here as well as in [`standard_tier_subdir`] because Krea 2 Turbo is epic
+    // 11037's named SC#1/SC#2 validation vehicle (the 2026-07-15 Sana → Krea redirect, sc-12110) and its
+    // per-tier subdir shape takes an `nvfp4/` dir with no new logic — the same packed
+    // `transformer/diffusion_pytorch_model.safetensors` the q4/q8 tiers carry. No `nvfp4/` dir exists on
+    // disk yet (sc-11043 owns the convert-at-install loop), so today this always falls through the
+    // unchanged q8 → q4 → bf16 chain; wiring it now means the tier resolves the moment the converter
+    // lands, rather than needing a second edit here.
+    let preferred = preferred_tier(
+        bits,
+        min_quality_floor(request),
+        nvfp4_requested(request) && nvfp4_host,
+    );
     present(preferred)
         .or_else(|| present("q8"))
         .or_else(|| present("q4"))
@@ -1582,19 +1705,48 @@ fn quant_int(value: &Value) -> Option<i64> {
         .or_else(|| value.as_str()?.trim().parse().ok())
 }
 
-/// Resolve quantization: `advanced.mlxQuantize` → `manifest.mlx.quantize` → Q8
-/// default. The engine supports Q4/Q8; map (<=0 → dense, <=4 → Q4, else Q8). Returns the
-/// engine quant + the effective bit count for the recipe (None = dense bf16).
+/// Resolve quantization: the explicit `advanced.quantTier: "nvfp4"` label → `advanced.mlxQuantize` →
+/// `manifest.mlx.quantize` → Q8 default. The engine supports Q4/Q8/NVFP4; map (<=0 → dense, <=4 → Q4,
+/// else Q8). Returns the engine quant + the effective bit count for the recipe (None = dense bf16).
 ///
 /// Shared by the MLX path and the candle lane (sc-5126). On the candle lane it is called ONLY for a
 /// family whose descriptor advertises `supported_quants` (i.e. Lens — see `generate_candle_stream`'s
 /// `model.supports_quant()` gate), so the Q8 default applies to Lens exactly like the MLX families;
 /// the sc-3675/sc-5096 candle families advertise no quant and never reach this resolver (stay dense).
+///
+/// **NVFP4 (sc-11042, epic 11037 SC#5)** is checked FIRST and ONLY on an explicit, host-eligible
+/// [`nvfp4_requested`] + [`nvfp4_host_eligible`] pick — never from `bits`, a manifest default, or
+/// hardware detection alone. Its recipe
+/// bit count is `None`, not `Some(4)`: `Quant::Nvfp4::bits()` returns 4 (its E2M1 elements are 4-bit),
+/// but NVFP4 is ~4.5 EFFECTIVE bits/weight and is a different tier from int4-affine `q4`, so reporting
+/// `4` here would stamp an NVFP4 render with `q4`'s bit count in the recipe — the aliasing SC#5 forbids
+/// (the same footgun `video_quant_label` carries; see its note). Every non-NVFP4 request takes the
+/// unchanged path below.
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn resolve_quant(request: &ImageRequest) -> (Option<Quant>, Option<i64>) {
+    resolve_quant_gated(request, nvfp4_host_eligible())
+}
+
+/// [`resolve_quant`] with the NVFP4 **host** gate passed in rather than probed (sc-11042). Split out
+/// for testability, exactly like [`standard_tier_subdir_gated`] — and necessarily so: the candle CI
+/// lane runs ON the sm_120 rig, so a test that let this probe the live cap would assert different
+/// things on the rig and on a developer box. Production has one caller.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn resolve_quant_gated(request: &ImageRequest, nvfp4_host: bool) -> (Option<Quant>, Option<i64>) {
+    // The distinct NVFP4 tier (sc-11042): an EXPLICIT `advanced.quantTier: "nvfp4"` pick AND a
+    // Blackwell-eligible host — both halves, the SC#5 opt-in. Checked before the dense-TE carve-out and
+    // the bits map: it is a tier identity, not a point on the bits ladder. Off Blackwell / off the
+    // candle lane `nvfp4_host` is false, so this arm is unreachable there and every request resolves
+    // exactly as it always has.
+    if nvfp4_requested(request) && nvfp4_host {
+        return (Some(Quant::Nvfp4), None);
+    }
     // Dense-TE turnkeys (FLUX.2-klein, sc-8711): the tier subdir already holds a packed transformer
     // + a DENSE bf16 text encoder, so the load Quant must be None — quantizing here would crush the
     // dense bf16 TE we deliberately kept full-precision. The packed transformer self-describes its
@@ -5782,13 +5934,13 @@ mod standard_tier_tests {
     fn default_tier_is_q8_not_q4_regression() {
         // The shared default-tier primitive: no explicit `mlxQuantize`, no per-model floor → q8, never q4.
         assert_eq!(
-            preferred_tier(None, None),
+            preferred_tier(None, None, false),
             "q8",
             "app-wide gen default MUST be q8 (epic 10721 / sc-10726) — a revert to q4 is the regression \
              this guards"
         );
         assert_ne!(
-            preferred_tier(None, None),
+            preferred_tier(None, None, false),
             "q4",
             "the pre-epic-10721 blind-q4 default has been reverted — do NOT reinstate it (sc-10726/sc-10732)"
         );
@@ -6044,21 +6196,237 @@ mod standard_tier_tests {
     #[test]
     fn preferred_tier_clamps_default_up_to_the_floor_only() {
         // No explicit pick, no floor → the app-wide q8 default (unchanged, non-floored models).
-        assert_eq!(preferred_tier(None, None), "q8");
+        assert_eq!(preferred_tier(None, None, false), "q8");
         // Floor at/below q8 leaves the q8 default untouched (the floor only ever RAISES).
-        assert_eq!(preferred_tier(None, Some("q8")), "q8");
-        assert_eq!(preferred_tier(None, Some("q4")), "q8");
+        assert_eq!(preferred_tier(None, Some("q8"), false), "q8");
+        assert_eq!(preferred_tier(None, Some("q4"), false), "q8");
         // A floor ABOVE q8 raises the default to the floor tier.
-        assert_eq!(preferred_tier(None, Some("bf16")), "bf16");
+        assert_eq!(preferred_tier(None, Some("bf16"), false), "bf16");
         // Explicit picks map directly and are HONORED even below the floor (no clamp on an explicit pick).
-        assert_eq!(preferred_tier(Some(4), Some("q8")), "q4");
-        assert_eq!(preferred_tier(Some(0), Some("q8")), "bf16");
-        assert_eq!(preferred_tier(Some(8), None), "q8");
-        assert_eq!(preferred_tier(Some(2), None), "q4");
+        assert_eq!(preferred_tier(Some(4), Some("q8"), false), "q4");
+        assert_eq!(preferred_tier(Some(0), Some("q8"), false), "bf16");
+        assert_eq!(preferred_tier(Some(8), None, false), "q8");
+        assert_eq!(preferred_tier(Some(2), None, false), "q4");
         // Rank order + normalization helpers.
         assert!(tier_quality_rank("bf16") > tier_quality_rank("q8"));
         assert!(tier_quality_rank("q8") > tier_quality_rank("q4"));
         assert_eq!(tier_quality_rank("mystery"), 0);
+    }
+
+    /// sc-11042 / epic 11037 SC#5 — **the regression guard for "no existing tier changes"**.
+    ///
+    /// The whole `mlxQuantize` bits map must resolve EXACTLY as it did before NVFP4 existed, for every
+    /// (bits, floor) pair, on every host. `nvfp4: false` is what every non-NVFP4 request passes — i.e.
+    /// every request in existence today — so this pins the claim that adding the tier is purely
+    /// additive. If someone ever "helpfully" routes q4 → NVFP4 on Blackwell (the Option B this story
+    /// rejected), these assertions fail.
+    #[test]
+    fn preferred_tier_bits_map_is_unchanged_by_the_nvfp4_tier() {
+        // The exact pre-sc-11042 mapping, re-asserted with the new parameter defaulted off.
+        for floor in [None, Some("bf16"), Some("q8"), Some("q4"), Some("mystery")] {
+            // Explicit bits picks: `<= 0` → bf16, `> 4` → q8, `1..=4` → q4 — floor-independent.
+            assert_eq!(preferred_tier(Some(0), floor, false), "bf16");
+            assert_eq!(preferred_tier(Some(-1), floor, false), "bf16");
+            assert_eq!(preferred_tier(Some(4), floor, false), "q4");
+            assert_eq!(preferred_tier(Some(1), floor, false), "q4");
+            assert_eq!(preferred_tier(Some(8), floor, false), "q8");
+            assert_eq!(preferred_tier(Some(16), floor, false), "q8");
+        }
+        // No pick → the q8 default, clamped UP to a higher floor only.
+        assert_eq!(preferred_tier(None, None, false), "q8");
+        assert_eq!(preferred_tier(None, Some("q4"), false), "q8");
+        assert_eq!(preferred_tier(None, Some("q8"), false), "q8");
+        assert_eq!(preferred_tier(None, Some("bf16"), false), "bf16");
+        // And NOTHING in the bits map can ever produce the NVFP4 tier: only the explicit flag does.
+        for bits in [None, Some(-1), Some(0), Some(1), Some(4), Some(8), Some(16)] {
+            for floor in [None, Some("bf16"), Some("q8"), Some("q4")] {
+                assert_ne!(
+                    preferred_tier(bits, floor, false),
+                    NVFP4_TIER,
+                    "NVFP4 must never be reachable from the bits map (bits={bits:?}, floor={floor:?})"
+                );
+            }
+        }
+    }
+
+    /// sc-11042: an explicit, host-eligible NVFP4 pick resolves the distinct `nvfp4` tier and takes no
+    /// part in the bits map or the floor clamp — it is a tier identity, not a rung on the fidelity ladder.
+    #[test]
+    fn preferred_tier_resolves_the_distinct_nvfp4_tier_on_an_explicit_pick() {
+        // Wins regardless of what bits/floor say — NVFP4 has no honest `mlxQuantize` integer, so a
+        // stray/stale bits value must not steer a request that explicitly named the NVFP4 tier.
+        for bits in [None, Some(0), Some(4), Some(8)] {
+            for floor in [None, Some("bf16"), Some("q8")] {
+                assert_eq!(preferred_tier(bits, floor, true), NVFP4_TIER);
+            }
+        }
+        // It is NOT floor-clamped: a bf16 floor does not raise/replace an explicit NVFP4 pick.
+        assert_eq!(preferred_tier(None, Some("bf16"), true), NVFP4_TIER);
+        // The label is distinct from q4 — the aliasing SC#5 forbids (see `video_quant_label`).
+        assert_ne!(NVFP4_TIER, "q4");
+    }
+
+    /// sc-11042: [`nvfp4_requested`] reads ONLY the explicit `advanced.quantTier: "nvfp4"` label, and no
+    /// `mlxQuantize` value — not even `4` — can stand in for it. This is the request-side half of SC#5.
+    #[test]
+    fn nvfp4_requested_reads_only_the_explicit_quant_tier_label() {
+        // The explicit label, tolerant of surrounding whitespace / casing like the sibling parsers.
+        assert!(nvfp4_requested(&request(json!({ "quantTier": "nvfp4" }))));
+        assert!(nvfp4_requested(&request(json!({ "quantTier": "  nvfp4 " }))));
+        assert!(nvfp4_requested(&request(json!({ "quantTier": "NVFP4" }))));
+        // Nothing else asks for NVFP4: no label, another tier's label, a non-string, or ANY bits value.
+        assert!(!nvfp4_requested(&request(json!({}))));
+        assert!(!nvfp4_requested(&request(json!({ "quantTier": "q4" }))));
+        assert!(!nvfp4_requested(&request(json!({ "quantTier": "int8-convrot" }))));
+        assert!(!nvfp4_requested(&request(json!({ "quantTier": 4 }))));
+        assert!(!nvfp4_requested(&request(json!({ "quantTier": true }))));
+        for bits in [0, 4, 8] {
+            assert!(
+                !nvfp4_requested(&request(json!({ "mlxQuantize": bits }))),
+                "mlxQuantize {bits} must never request NVFP4 — it is a bits-valued knob naming q4/q8/bf16"
+            );
+        }
+    }
+
+    /// sc-11042 — **the SC#5 opt-in guard at the resolver**: with NO explicit `quantTier` label, a
+    /// Blackwell-eligible host resolves EXACTLY the tier it resolved before this story. Being on sm_120
+    /// selects nothing by itself; NVFP4 is only ever reached by a deliberate user pick.
+    #[test]
+    fn nvfp4_never_selected_without_an_explicit_pick() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        seed_tier(root, "q4", "diffusion_pytorch_model.safetensors");
+        seed_tier(root, "q8", "diffusion_pytorch_model.safetensors");
+        seed_tier(root, "bf16", "diffusion_pytorch_model.safetensors.index.json");
+        seed_tier(root, NVFP4_TIER, "diffusion_pytorch_model.safetensors");
+
+        // The injected `true` says "the HOST is Blackwell-eligible" — the hardware gate is ON, but no
+        // request below carries the `quantTier` label. Every answer is the pre-sc-11042 one, even though
+        // an `nvfp4/` tier is sitting right there on disk. That is SC#5: hardware selects nothing.
+        for (advanced, expected) in [
+            (json!({}), "q8"),                   // default
+            (json!({ "mlxQuantize": 4 }), "q4"), // the tier NVFP4 must never silently replace
+            (json!({ "mlxQuantize": 8 }), "q8"),
+            (json!({ "mlxQuantize": 0 }), "bf16"),
+        ] {
+            assert_eq!(
+                standard_tier_subdir_gated(root, &request(advanced.clone()), true),
+                root.join(expected),
+                "an unlabeled request must resolve {expected} on a Blackwell host (advanced={advanced})"
+            );
+        }
+    }
+
+    /// sc-11042: the NVFP4 tier resolves on an sm_120 host and falls back CLEANLY off Blackwell.
+    ///
+    /// The two host classes are exercised through the injected gate rather than a live compute-cap
+    /// probe, so the rig isn't needed; [`nvfp4_host_eligible`] is what maps hardware → this bool, and
+    /// its floor is pinned separately by `gpu::tests`.
+    #[test]
+    fn nvfp4_tier_resolves_on_blackwell_and_falls_back_off_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        seed_tier(root, "q4", "diffusion_pytorch_model.safetensors");
+        seed_tier(root, "q8", "diffusion_pytorch_model.safetensors");
+        seed_tier(root, NVFP4_TIER, "diffusion_pytorch_model.safetensors");
+        let picked = request(json!({ "quantTier": "nvfp4" }));
+
+        // sm_120 + the tier installed → the distinct `nvfp4/` dir.
+        assert_eq!(
+            standard_tier_subdir_gated(root, &picked, true),
+            root.join(NVFP4_TIER)
+        );
+        // NOT Blackwell (pre-sm_120 NVIDIA, macOS/MLX, or the neither build) → the label is ignored and
+        // the request lands on an installed tier via the normal chain. A clean fallback, not an error.
+        assert_eq!(standard_tier_subdir_gated(root, &picked, false), root.join("q8"));
+
+        // sm_120 but the tier ISN'T converted yet (sc-11043 owns the converter; the shipping case today)
+        // → rejoins the same clean chain rather than failing the load.
+        let bare = tempfile::tempdir().unwrap();
+        seed_tier(bare.path(), "q4", "diffusion_pytorch_model.safetensors");
+        seed_tier(bare.path(), "q8", "diffusion_pytorch_model.safetensors");
+        assert_eq!(
+            standard_tier_subdir_gated(bare.path(), &picked, true),
+            bare.path().join("q8")
+        );
+        // …and with only q4 on disk it clamps to q4 — never a half-load, never an FP4 load with no
+        // FP4 weights.
+        let only_q4 = tempfile::tempdir().unwrap();
+        seed_tier(only_q4.path(), "q4", "diffusion_pytorch_model.safetensors");
+        assert_eq!(
+            standard_tier_subdir_gated(only_q4.path(), &picked, true),
+            only_q4.path().join("q4")
+        );
+    }
+
+    /// sc-11042: [`resolve_quant`] returns the distinct `Quant::Nvfp4` for an explicit, host-eligible
+    /// pick — with **no** bit count (NVFP4 is ~4.5 EFFECTIVE bits/weight; `Some(4)` would alias the
+    /// recipe onto q4) — and is otherwise completely unchanged.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn resolve_quant_returns_the_distinct_nvfp4_tier_only_on_an_explicit_blackwell_pick() {
+        let picked = request(json!({ "quantTier": "nvfp4" }));
+        // Explicit pick + Blackwell → the distinct tier, and NOT `Some(4)` bits.
+        assert_eq!(resolve_quant_gated(&picked, true), (Some(Quant::Nvfp4), None));
+        // Off Blackwell → the label is ignored; the unchanged q8 default. A clean fallback.
+        assert_eq!(resolve_quant_gated(&picked, false), (Some(Quant::Q8), Some(8)));
+
+        // SC#5: every existing mapping is untouched on BOTH host classes — being on sm_120 never
+        // converts an unlabeled q4/q8/bf16 request into an NVFP4 one.
+        for nvfp4_host in [false, true] {
+            assert_eq!(
+                resolve_quant_gated(&request(json!({})), nvfp4_host),
+                (Some(Quant::Q8), Some(8))
+            );
+            assert_eq!(
+                resolve_quant_gated(&request(json!({ "mlxQuantize": 4 })), nvfp4_host),
+                (Some(Quant::Q4), Some(4)),
+                "a q4 pick must stay int4-affine q4 on every host (epic 11037 SC#5)"
+            );
+            assert_eq!(
+                resolve_quant_gated(&request(json!({ "mlxQuantize": 8 })), nvfp4_host),
+                (Some(Quant::Q8), Some(8))
+            );
+            assert_eq!(
+                resolve_quant_gated(&request(json!({ "mlxQuantize": 0 })), nvfp4_host),
+                (None, None)
+            );
+        }
+    }
+
+    /// sc-11042: the Krea 2 Turbo resolver (epic 11037's named SC#1/SC#2 validation vehicle, sc-12110)
+    /// wires the NVFP4 tier on the same terms — explicit pick + Blackwell, clean fallback otherwise —
+    /// and its q4/q8/bf16 selection is unchanged.
+    #[test]
+    fn krea_model_subdir_wires_nvfp4_without_changing_its_existing_tiers() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        for tier in ["q4", "q8", NVFP4_TIER] {
+            seed_tier(root, tier, "diffusion_pytorch_model.safetensors");
+        }
+        let picked = request(json!({ "quantTier": "nvfp4" }));
+        // Explicit pick on Blackwell → the distinct tier.
+        assert_eq!(
+            krea_model_subdir_gated(root, &picked, true),
+            root.join(NVFP4_TIER)
+        );
+        // Off Blackwell → clean fallback to the shipped q8 default.
+        assert_eq!(krea_model_subdir_gated(root, &picked, false), root.join("q8"));
+        // SC#5: krea's existing tiers resolve exactly as before on a Blackwell host with an `nvfp4/`
+        // dir present.
+        for (advanced, expected) in [
+            (json!({}), "q8"),
+            (json!({ "mlxQuantize": 4 }), "q4"),
+            (json!({ "mlxQuantize": 8 }), "q8"),
+        ] {
+            assert_eq!(
+                krea_model_subdir_gated(root, &request(advanced), true),
+                root.join(expected)
+            );
+        }
     }
 
     /// sc-10731: [`min_quality_floor`] reads the forwarded manifest `mlx.minQualityTier`, honoring only a

--- a/crates/sceneworks-worker/src/image_jobs/detail.rs
+++ b/crates/sceneworks-worker/src/image_jobs/detail.rs
@@ -389,12 +389,15 @@ pub(crate) async fn run_image_detail_job(
     let backend = backend_label(&settings.gpu_id);
 
     let params = resolve_detail_params(&request);
-    let (quant, _) = resolve_quant(&request);
     // Reuse the model's manifest/modelPath/cache resolution; engine_model gives the default repo.
     let weights_dir = resolve_weights_dir(&request, settings)?
         .or_else(|| huggingface_snapshot_dir(&settings.data_dir, engine_model.default_repo()));
     let weights_dir = weights_dir
         .ok_or_else(|| WorkerError::InvalidPayload("SDXL detail weights not found".to_owned()))?;
+    // Resolved AFTER `weights_dir` (sc-11042): the tier dir is an input to the quant resolution, so the
+    // NVFP4 tier can only be picked when it is the tier that actually resolved. Pure reorder — the
+    // q4/q8/bf16 mapping reads only the request and is unaffected.
+    let (quant, _) = resolve_quant(&request, Some(&weights_dir));
     let control_repo = advanced::str(
         &request.advanced,
         "tileControlNetRepo",

--- a/crates/sceneworks-worker/src/image_jobs/flux1_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux1_control.rs
@@ -252,7 +252,7 @@ async fn generate_flux1_dev_control_stream(
     let weights_dir = resolve_weights_dir(request, settings)?
         .ok_or_else(|| WorkerError::InvalidPayload("FLUX.1-dev weights not found".to_owned()))?;
     let control_weights = ensure_flux1_control_weights(api, settings, job, request).await?;
-    let (quant, quant_bits) = resolve_quant(request);
+    let (quant, quant_bits) = resolve_quant(request, Some(&weights_dir));
     let model = mlx_model("flux_dev")
         .ok_or_else(|| WorkerError::InvalidPayload("flux_dev model row missing".to_owned()))?;
     let steps = resolve_steps(request, &model);

--- a/crates/sceneworks-worker/src/image_jobs/flux2.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2.rs
@@ -383,7 +383,7 @@ async fn generate_flux2_edit_stream(
         .ok_or_else(|| WorkerError::InvalidPayload("not a FLUX.2 edit model".to_owned()))?;
     let weights_dir = resolve_weights_dir(request, settings)?
         .ok_or_else(|| WorkerError::InvalidPayload("FLUX.2 weights not found".to_owned()))?;
-    let (quant, quant_bits) = resolve_quant(request);
+    let (quant, quant_bits) = resolve_quant(request, Some(&weights_dir));
     let steps = resolve_steps(request, &model);
     let guidance = resolve_guidance(request, &model);
     // Identity strength (sc-8278): map the UI `referenceStrength` slider onto the engine's
@@ -847,7 +847,7 @@ async fn generate_flux2_dev_control_stream(
     let weights_dir = resolve_weights_dir(request, settings)?
         .ok_or_else(|| WorkerError::InvalidPayload("FLUX.2-dev weights not found".to_owned()))?;
     let control_weights = ensure_flux2_control_weights(api, settings, job, request).await?;
-    let (quant, quant_bits) = resolve_quant(request);
+    let (quant, quant_bits) = resolve_quant(request, Some(&weights_dir));
     let model = mlx_model("flux2_dev")
         .ok_or_else(|| WorkerError::InvalidPayload("flux2_dev model row missing".to_owned()))?;
     let steps = resolve_steps(request, &model);

--- a/crates/sceneworks-worker/src/image_jobs/flux2_comfyui_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_comfyui_candle.rs
@@ -120,9 +120,25 @@ fn flux2_comfyui_available(request: &ImageRequest, settings: &Settings) -> bool 
         && matches!(resolve_flux2_comfyui_paths(request, settings), Ok(Some(_)))
 }
 
-/// The compute quant the DiT + snapshot TE fold onto the GPU at: `advanced.quant` (`q4`/`q8`), else the
+/// The compute quant the DiT + snapshot TE fold onto the GPU at: the explicit NVFP4 tier
+/// (`advanced.quantTier: "nvfp4"` on a Blackwell host), else `advanced.quant` (`q4`/`q8`), else the
 /// [`FLUX2_COMFYUI_DEFAULT_QUANT`]. The 32B dev needs a quant to fit; there is no dense option.
+///
+/// **NVFP4 (sc-11042, epic 11037 SC#5).** sc-12006 established `quantTier: "nvfp4"` as the tier's
+/// identity but only ever WROTE it (asset telemetry); this reads it, making the label a real selection
+/// input and NVFP4 an actually-reachable tier on this lane. It rides `quantTier` rather than
+/// `advanced.quant` / `advanced.mlxQuantize` for the reason spelled out in
+/// [`flux2_comfyui_raw_settings`]: `mlxQuantize` is bits-valued and no integer is honest for NVFP4.
+///
+/// The pick needs BOTH halves — an explicit label ([`nvfp4_requested`]) and a Blackwell host
+/// ([`nvfp4_host_eligible`]): NVFP4 is never auto-selected for a `q4` request on sm_120 (that is
+/// precisely the Option-B behavior sc-11042 rejected), and a `quantTier: "nvfp4"` request on a
+/// non-Blackwell host falls through to the UNCHANGED `q4`/`q8`/default arms below rather than erroring
+/// — the clean off-Blackwell fallback the story requires.
 fn flux2_comfyui_quant(request: &ImageRequest) -> Quant {
+    if nvfp4_requested(request) && nvfp4_host_eligible() {
+        return Quant::Nvfp4;
+    }
     match request
         .advanced
         .get("quant")
@@ -201,8 +217,20 @@ fn flux2_comfyui_raw_settings(
     );
     // The explicit tier label. Emitted only for the tier `mlxQuantize` cannot express, so existing
     // q4/q8 asset telemetry keeps its exact shape (the sc-9300 `convRot` pattern).
+    //
+    // The `else` REMOVE is load-bearing (sc-11042), and is the symmetric twin of the unconditional
+    // `mlxQuantize` insert above: `raw` starts as a clone of `request.advanced`, so on the Q4/Q8 path a
+    // caller-supplied stale `advanced.quantTier` would otherwise survive into the asset record and
+    // mislabel a q4/q8 render as `nvfp4`. That matters more now than when sc-12006 wrote this key as
+    // pure telemetry: as of this story `quantTier` is a SELECTION input (`nvfp4_requested` in
+    // image_jobs/base.rs), so a request carrying `quantTier: "nvfp4"` that resolved to Q4/Q8 anyway —
+    // an off-Blackwell host, or a tier that isn't converted yet — is exactly the case that must not
+    // record the tier it did not run. Removing (not skipping) keeps the record honest in both
+    // directions, and the q4/q8 record shape byte-identical to sc-12006's.
     if matches!(quant, Quant::Nvfp4) {
         raw.insert("quantTier".to_owned(), Value::String("nvfp4".to_owned()));
+    } else {
+        raw.remove("quantTier");
     }
     if let Some(scale) = guidance {
         raw.insert("guidanceScale".to_owned(), json!(scale));

--- a/crates/sceneworks-worker/src/image_jobs/flux2_comfyui_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_comfyui_candle.rs
@@ -140,9 +140,11 @@ fn flux2_comfyui_available(request: &ImageRequest, settings: &Settings) -> bool 
 ///    on EXACTLY the Blackwell hardware the tier targets, while off-Blackwell hosts fell back fine.
 ///
 /// So a `quantTier: "nvfp4"` request on this lane falls through to the UNCHANGED `q4`/`q8`/default arms
-/// below on every host. That fall-through IS the clean fallback: the label is still recorded as asset
-/// telemetry (sc-12006), but selection is a normal tier. `quantTier` is the tier's identity precisely
-/// because `mlxQuantize` is bits-valued and no integer is honest for NVFP4 (see
+/// below on every host. That fall-through IS the clean fallback the story requires. The asset record
+/// stays honest about it: [`flux2_comfyui_raw_settings`] STRIPS the stale `quantTier` label on the
+/// q4/q8 path (its `else` branch — the only reachable one here), so the record names the tier that
+/// actually rendered rather than the one that was asked for. `quantTier` is the tier's identity
+/// precisely because `mlxQuantize` is bits-valued and no integer is honest for NVFP4 (see
 /// [`flux2_comfyui_raw_settings`]); that identity simply has no servable target on this lane. Pinned by
 /// `flux2_comfyui_never_selects_nvfp4`.
 fn flux2_comfyui_quant(request: &ImageRequest) -> Quant {

--- a/crates/sceneworks-worker/src/image_jobs/flux2_comfyui_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_comfyui_candle.rs
@@ -120,25 +120,32 @@ fn flux2_comfyui_available(request: &ImageRequest, settings: &Settings) -> bool 
         && matches!(resolve_flux2_comfyui_paths(request, settings), Ok(Some(_)))
 }
 
-/// The compute quant the DiT + snapshot TE fold onto the GPU at: the explicit NVFP4 tier
-/// (`advanced.quantTier: "nvfp4"` on a Blackwell host), else `advanced.quant` (`q4`/`q8`), else the
+/// The compute quant the DiT + snapshot TE fold onto the GPU at: `advanced.quant` (`q4`/`q8`), else the
 /// [`FLUX2_COMFYUI_DEFAULT_QUANT`]. The 32B dev needs a quant to fit; there is no dense option.
 ///
-/// **NVFP4 (sc-11042, epic 11037 SC#5).** sc-12006 established `quantTier: "nvfp4"` as the tier's
-/// identity but only ever WROTE it (asset telemetry); this reads it, making the label a real selection
-/// input and NVFP4 an actually-reachable tier on this lane. It rides `quantTier` rather than
-/// `advanced.quant` / `advanced.mlxQuantize` for the reason spelled out in
-/// [`flux2_comfyui_raw_settings`]: `mlxQuantize` is bits-valued and no integer is honest for NVFP4.
+/// **This lane does NOT offer the NVFP4 tier (sc-11042, epic 11037), on ANY host — including Blackwell.**
+/// It is structurally incapable of serving it, for two independent reasons:
 ///
-/// The pick needs BOTH halves — an explicit label ([`nvfp4_requested`]) and a Blackwell host
-/// ([`nvfp4_host_eligible`]): NVFP4 is never auto-selected for a `q4` request on sm_120 (that is
-/// precisely the Option-B behavior sc-11042 rejected), and a `quantTier: "nvfp4"` request on a
-/// non-Blackwell host falls through to the UNCHANGED `q4`/`q8`/default arms below rather than erroring
-/// — the clean off-Blackwell fallback the story requires.
+/// 1. **No packed tier dir to serve from.** NVFP4 is served by `Nvfp4Linear` reading an OFFLINE-PACKED
+///    `Nvfp4Tensor` out of an `nvfp4/` tier subdir. This lane never calls `standard_tier_subdir`: the
+///    DiT is the user's OWN in-place ComfyUI fp8 single-file, and [`FLUX2_COMFYUI_SNAPSHOT_TIERS`] probes
+///    only for the TE/VAE/tokenizer snapshot. An arbitrary user single-file can never carry packed
+///    NVFP4 weights, so there is nothing to point `Nvfp4Linear` at.
+/// 2. **The fold path cannot express it.** This lane's `quant` is the ON-THE-FLY GGUF fold target:
+///    `load_from_comfyui_dit(.., Some(quant))` → `QLinear::quantize_onto` → `fold(..)` → `ggml_dtype(quant)`,
+///    which BAILS for `Quant::Nvfp4` by design ("no GGUF block type; NVFP4 is served by `Nvfp4Linear`
+///    from a packed `Nvfp4Tensor`, not the in-place GGUF fold" — candle-gen pins this with
+///    `fold_rejects_nvfp4_strategy`). Returning `Quant::Nvfp4` here therefore did not select a tier; it
+///    aborted the load with `WorkerError::Engine("ComfyUI FLUX.2-dev load failed: …")` — killing the job
+///    on EXACTLY the Blackwell hardware the tier targets, while off-Blackwell hosts fell back fine.
+///
+/// So a `quantTier: "nvfp4"` request on this lane falls through to the UNCHANGED `q4`/`q8`/default arms
+/// below on every host. That fall-through IS the clean fallback: the label is still recorded as asset
+/// telemetry (sc-12006), but selection is a normal tier. `quantTier` is the tier's identity precisely
+/// because `mlxQuantize` is bits-valued and no integer is honest for NVFP4 (see
+/// [`flux2_comfyui_raw_settings`]); that identity simply has no servable target on this lane. Pinned by
+/// `flux2_comfyui_never_selects_nvfp4`.
 fn flux2_comfyui_quant(request: &ImageRequest) -> Quant {
-    if nvfp4_requested(request) && nvfp4_host_eligible() {
-        return Quant::Nvfp4;
-    }
     match request
         .advanced
         .get("quant")
@@ -221,11 +228,16 @@ fn flux2_comfyui_raw_settings(
     // The `else` REMOVE is load-bearing (sc-11042), and is the symmetric twin of the unconditional
     // `mlxQuantize` insert above: `raw` starts as a clone of `request.advanced`, so on the Q4/Q8 path a
     // caller-supplied stale `advanced.quantTier` would otherwise survive into the asset record and
-    // mislabel a q4/q8 render as `nvfp4`. That matters more now than when sc-12006 wrote this key as
-    // pure telemetry: as of this story `quantTier` is a SELECTION input (`nvfp4_requested` in
-    // image_jobs/base.rs), so a request carrying `quantTier: "nvfp4"` that resolved to Q4/Q8 anyway —
-    // an off-Blackwell host, or a tier that isn't converted yet — is exactly the case that must not
-    // record the tier it did not run. Removing (not skipping) keeps the record honest in both
+    // mislabel a q4/q8 render as `nvfp4`.
+    //
+    // On THIS lane the `else` is the only reachable branch, which makes it the whole point rather than a
+    // guard: [`flux2_comfyui_quant`] never returns `Quant::Nvfp4` (this lane cannot serve the tier — no
+    // packed tier dir, and the GGUF fold rejects it), so EVERY request here renders Q4/Q8 — including one
+    // that explicitly asked for `quantTier: "nvfp4"` on a Blackwell host. That request is exactly the case
+    // that must not record the tier it did not run, so the stale label is stripped and the record names
+    // the tier that actually rendered. The `Nvfp4` arm is retained only to keep this function total over
+    // `Quant` (it is shared shape with the tier-serving lanes, and an exhaustive match is what stops a
+    // future variant from silently defaulting). Removing (not skipping) keeps the record honest in both
     // directions, and the q4/q8 record shape byte-identical to sc-12006's.
     if matches!(quant, Quant::Nvfp4) {
         raw.insert("quantTier".to_owned(), Value::String("nvfp4".to_owned()));

--- a/crates/sceneworks-worker/src/image_jobs/flux2_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_control_candle.rs
@@ -323,7 +323,7 @@ async fn generate_candle_flux2_control_stream(
 
     // dev (32B) loads Q4 (manifest `mlx.quantize: 4` → `resolve_quant`); the control overlay quantizes
     // in place. The control context is clean + constant across the denoise (encoded once).
-    let (quant, quant_bits) = resolve_quant(request);
+    let (quant, quant_bits) = resolve_quant(request, Some(&base));
     let steps = flux2_control_candle_steps(request);
     let guidance = flux2_control_candle_guidance(request);
     let control_scale = advanced::f32_clamped(

--- a/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
@@ -251,7 +251,7 @@ async fn generate_candle_flux2_edit_stream(
     // engine query-row-chunks its joint attention (sc-6217/sc-7523), so a device OOM surfaces as a load/
     // generate error rather than silently corrupting; no Mac-style unified-memory pre-guard applies here.
     let (quant, quant_bits) = if is_dev {
-        resolve_quant(request)
+        resolve_quant(request, Some(&flux2_base))
     } else {
         (None, None)
     };

--- a/crates/sceneworks-worker/src/image_jobs/kolors.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors.rs
@@ -327,7 +327,7 @@ async fn generate_kolors_control_stream(
         project_path,
     )?;
 
-    let (quant, quant_bits) = resolve_quant(request);
+    let (quant, quant_bits) = resolve_quant(request, Some(&weights_dir));
     let steps = resolve_steps(request, &kolors);
     let guidance = resolve_guidance(request, &kolors);
     let negative_prompt = resolve_negative_prompt(request, &kolors);

--- a/crates/sceneworks-worker/src/image_jobs/krea_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control.rs
@@ -441,7 +441,7 @@ async fn generate_krea_control_stream(
     let stickwidth = crate::openpose_skeleton::body_stickwidth(width, height);
     // The base runs at the `mlxQuantize`-selected tier (sc-11730); the pose overlay rides it bf16. User
     // LoRA/LoKr adapters (resolved above) install additively on the base DiT (mlx-gen sc-11720).
-    let (quant, _quant_bits) = resolve_quant(request);
+    let (quant, _quant_bits) = resolve_quant(request, Some(&weights_dir));
     let spec = krea_control_spec(weights_dir, control_weights, quant, adapters);
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),

--- a/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
@@ -444,8 +444,14 @@ async fn generate_candle_krea_control_stream(
     // sc-11745) slot in ahead of branch-quant here once their candle-gen mechanism lands. NB: this lane uses
     // the UNcached `start_gen_stream` (it doesn't evict the single-slot generator cache), so budget against
     // raw live free VRAM — the cache's pages are NOT reclaimable by this load, unlike the base.rs gate.
-    let tier =
-        crate::vram_gate::requested_tier_key(&request.advanced, &request.model_manifest_entry);
+    // sc-11042: `base` is the tier dir this lane resolved (`krea_model_subdir`'s output when the user has
+    // the packed MLX turnkey; a dense diffusers snapshot root otherwise, which is never an `nvfp4/` dir),
+    // so the NVFP4 tier is sized only when it is the tier that actually resolved.
+    let tier = crate::vram_gate::requested_tier_key(
+        &request.advanced,
+        &request.model_manifest_entry,
+        nvfp4_selected(request, nvfp4_host_eligible(), Some(&base)),
+    );
     let budget = crate::vram_gate::apply_vram_cap(
         crate::gpu::nvidia_vram_budget_gb(&settings.gpu_id).await,
         crate::vram_gate::cuda_vram_cap_gb(),

--- a/crates/sceneworks-worker/src/image_jobs/krea_edit.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_edit.rs
@@ -172,7 +172,7 @@ async fn generate_krea_edit_stream(
         ));
     }
 
-    let (quant, quant_bits) = resolve_quant(request);
+    let (quant, quant_bits) = resolve_quant(request, Some(&weights_dir));
     let steps = resolve_steps(request, &model);
     let guidance = resolve_guidance(request, &model);
     let negative_prompt = resolve_negative_prompt(request, &model);

--- a/crates/sceneworks-worker/src/image_jobs/pulid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid.rs
@@ -315,7 +315,7 @@ async fn generate_pulid_flux_stream(
     // harmless no-op; the bf16 tier resolves to `None`. The PuLID conditioning (EVA/IDFormer/CA) stays f32
     // in every case — `load_flux1` quantizes only the backbone linears (sc-3076).
     let (quant, recipe_bits) = reconcile_resolved_tier_quant(
-        resolve_quant(request),
+        resolve_quant(request, Some(&flux_base)),
         &flux_base,
         true,
         &request.model,

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -241,7 +241,7 @@ async fn generate_qwen_control_stream(
             strict_control_default_repo(QWEN_CONTROL_ENGINE_ID)
         ))
     })?;
-    let (quant, quant_bits) = resolve_quant(request);
+    let (quant, quant_bits) = resolve_quant(request, Some(&weights_dir));
     let steps = resolve_steps(request, &qwen);
     let guidance = resolve_guidance(request, &qwen).unwrap_or(qwen.default_guidance());
     let negative_prompt = resolve_negative_prompt(request, &qwen);

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -702,7 +702,7 @@ async fn generate_qwen_edit_stream(
     let weights_dir = resolve_weights_dir(request, settings)?.ok_or_else(|| {
         WorkerError::InvalidPayload("Qwen-Image-Edit weights not found".to_owned())
     })?;
-    let (quant, quant_bits) = resolve_quant(request);
+    let (quant, quant_bits) = resolve_quant(request, Some(&weights_dir));
     let steps = resolve_steps(request, &model);
     let guidance = resolve_qwen_edit_guidance(request, &model);
     let negative_prompt = resolve_negative_prompt(request, &model);

--- a/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
@@ -361,8 +361,15 @@ async fn generate_candle_qwen_edit_stream(
             crate::gpu::nvidia_vram_budget_gb(&settings.gpu_id).await,
             crate::vram_gate::cuda_vram_cap_gb(),
         );
-        let tier =
-            crate::vram_gate::requested_tier_key(&request.advanced, &request.model_manifest_entry);
+        // sc-11042: `nvfp4 = false` — the Qwen-Image-Edit lane resolves no standard tier subdir (it
+        // loads the edit repo snapshot directly), so no `nvfp4/` tier can be what runs here and the
+        // bits-derived key is the honest one. Wire `nvfp4_selected` with the resolved dir if this lane
+        // ever grows a tier layout.
+        let tier = crate::vram_gate::requested_tier_key(
+            &request.advanced,
+            &request.model_manifest_entry,
+            /* nvfp4 */ false,
+        );
         let needed = crate::vram_gate::predicted_peak_gb(&request.model_manifest_entry, tier);
         match crate::vram_gate::resolve_offload(
             crate::vram_gate::fit_decision(needed, budget),

--- a/crates/sceneworks-worker/src/image_jobs/sdxl.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl.rs
@@ -186,7 +186,7 @@ async fn generate_sdxl_advanced_stream(
         .ok_or_else(|| WorkerError::InvalidPayload("not an SDXL advanced job".to_owned()))?;
     let weights_dir = resolve_weights_dir(request, settings)?
         .ok_or_else(|| WorkerError::InvalidPayload("SDXL weights not found".to_owned()))?;
-    let (quant, quant_bits) = resolve_quant(request);
+    let (quant, quant_bits) = resolve_quant(request, Some(&weights_dir));
     let steps = resolve_steps(request, &model);
     let guidance = resolve_guidance(request, &model);
     let negative_prompt = resolve_negative_prompt(request, &model);

--- a/crates/sceneworks-worker/src/image_jobs/sensenova.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sensenova.rs
@@ -163,7 +163,7 @@ async fn generate_sensenova_edit_stream(
     let engine_id = model.engine_id();
     let weights_dir = resolve_weights_dir(request, settings)?
         .ok_or_else(|| WorkerError::InvalidPayload("SenseNova-U1 weights not found".to_owned()))?;
-    let (quant, quant_bits) = resolve_quant(request);
+    let (quant, quant_bits) = resolve_quant(request, Some(&weights_dir));
     let steps = resolve_steps(request, &model);
     // Dual CFG: the text CFG flows through `guidance` (Some — SenseNova `supports_guidance`); the
     // image-conditioning guidance through `true_cfg`.

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -175,15 +175,21 @@ fn quant_mapping_defaults_to_q8_and_maps_bits() {
     use gen_core::Quant;
     let default = request(json!({ "projectId": "p" }));
     assert!(matches!(
-        resolve_quant(&default),
+        resolve_quant(&default, None),
         (Some(Quant::Q8), Some(8))
     ));
     let q4 = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 4 } }));
-    assert!(matches!(resolve_quant(&q4), (Some(Quant::Q4), Some(4))));
+    assert!(matches!(
+        resolve_quant(&q4, None),
+        (Some(Quant::Q4), Some(4))
+    ));
     let dense = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 0 } }));
-    assert!(matches!(resolve_quant(&dense), (None, None)));
+    assert!(matches!(resolve_quant(&dense, None), (None, None)));
     let six = request(json!({ "projectId": "p", "advanced": { "mlxQuantize": 6 } }));
-    assert!(matches!(resolve_quant(&six), (Some(Quant::Q8), Some(8))));
+    assert!(matches!(
+        resolve_quant(&six, None),
+        (Some(Quant::Q8), Some(8))
+    ));
 }
 
 #[cfg(target_os = "macos")]
@@ -3281,7 +3287,7 @@ fn sc3031_ab_dump_txt2img() {
     let steps = resolve_steps(&req, &model);
     let guidance = resolve_guidance(&req, &model);
     let negative = resolve_negative_prompt(&req, &model);
-    let (quant, _bits) = resolve_quant(&req);
+    let (quant, _bits) = resolve_quant(&req, None);
     let weights = resolve_weights_dir(&req, &settings)
         .expect("weights resolve")
         .expect("weights in HF cache");
@@ -3348,7 +3354,7 @@ fn sc3031_ab_dump_pose() {
     let control_weights = resolve_control_weights(&req, &settings)
         .expect("control-weights filename resolves")
         .expect("Fun-Controlnet-Union weights");
-    let (quant, _bits) = resolve_quant(&req);
+    let (quant, _bits) = resolve_quant(&req, None);
     let zimage = mlx_model("z_image_turbo").expect("z-image model row");
     let steps = resolve_steps(&req, &zimage);
     let control_scale = resolve_control_scale(&req);
@@ -6397,19 +6403,19 @@ fn ideogram_engine_defaults_and_quant_resolution() {
     assert_eq!(resolve_guidance(&req(json!({})), &model), Some(7.0));
     // Default → Q4 (manifest packed default); advanced.mlxQuantize overrides to Q8 / bf16-dense.
     assert!(matches!(
-        resolve_quant(&req(json!({}))),
+        resolve_quant(&req(json!({})), None),
         (Some(Quant::Q4), Some(4))
     ));
     assert!(matches!(
-        resolve_quant(&req(json!({ "mlxQuantize": 8 }))),
+        resolve_quant(&req(json!({ "mlxQuantize": 8 })), None),
         (Some(Quant::Q8), Some(8))
     ));
     assert!(matches!(
-        resolve_quant(&req(json!({ "mlxQuantize": 4 }))),
+        resolve_quant(&req(json!({ "mlxQuantize": 4 })), None),
         (Some(Quant::Q4), Some(4))
     ));
     assert!(matches!(
-        resolve_quant(&req(json!({ "mlxQuantize": 0 }))),
+        resolve_quant(&req(json!({ "mlxQuantize": 0 })), None),
         (None, None)
     ));
 }
@@ -6521,15 +6527,15 @@ fn boogu_engine_defaults_and_quant_resolution() {
     );
     // Default → Q8 (the shipped pre-packed turnkey); advanced.mlxQuantize overrides to Q4 / bf16-dense.
     assert!(matches!(
-        resolve_quant(&req("boogu_image", json!({}))),
+        resolve_quant(&req("boogu_image", json!({})), None),
         (Some(Quant::Q8), Some(8))
     ));
     assert!(matches!(
-        resolve_quant(&req("boogu_image", json!({ "mlxQuantize": 4 }))),
+        resolve_quant(&req("boogu_image", json!({ "mlxQuantize": 4 })), None),
         (Some(Quant::Q4), Some(4))
     ));
     assert!(matches!(
-        resolve_quant(&req("boogu_image", json!({ "mlxQuantize": 0 }))),
+        resolve_quant(&req("boogu_image", json!({ "mlxQuantize": 0 })), None),
         (None, None)
     ));
 }
@@ -6634,7 +6640,7 @@ fn ideogram_raw_settings_records_recipe_and_structured_prompt() {
         "modelManifestEntry": { "mlx": { "quantize": 4 } },
     }));
     // Resolve the quant the real path would (manifest packed default → Q4, sc-6237), then record it.
-    let (_quant, quant_bits) = resolve_quant(&req);
+    let (_quant, quant_bits) = resolve_quant(&req, None);
     let raw = mlx_raw_settings(&req, "SceneWorks/ideogram-4-mlx", 48, quant_bits, Some(7.0));
     assert_eq!(raw.get("realModelInference"), Some(&json!(true)));
     assert_eq!(raw.get("repo"), Some(&json!("SceneWorks/ideogram-4-mlx")));
@@ -6706,7 +6712,7 @@ fn ideogram_4_real_weights_generates_caption_and_plain_images() {
         "modelManifestEntry": { "mlx": { "quantize": 4 } },
     }));
     // Q4 spec matching the packed q4 weights — the exact production path (sc-6237).
-    let (quant, _bits) = resolve_quant(&req);
+    let (quant, _bits) = resolve_quant(&req, None);
     let guidance = resolve_guidance(&req, &model); // 7.0
 
     let generator = load_engine("ideogram_4", dir, quant, Vec::new(), None).unwrap();
@@ -6905,7 +6911,7 @@ fn ideogram_4_headless_auto_caption_renders_real_image() {
         "projectId": "p", "model": "ideogram_4", "prompt": "p", "advanced": {},
         "modelManifestEntry": { "mlx": { "quantize": 4 } },
     }));
-    let (quant, _bits) = resolve_quant(&req);
+    let (quant, _bits) = resolve_quant(&req, None);
     let guidance = resolve_guidance(&req, &model);
     let generator = load_engine("ideogram_4", ideogram, quant, Vec::new(), None).unwrap();
     let cancel = CancelFlag::new();
@@ -7016,7 +7022,7 @@ fn ideogram_4_real_weights_edit_img2img_and_inpaint() {
         "projectId": "p", "model": "ideogram_4", "prompt": "p", "advanced": {},
         "modelManifestEntry": { "mlx": { "quantize": 4 } },
     }));
-    let (quant, _bits) = resolve_quant(&req);
+    let (quant, _bits) = resolve_quant(&req, None);
     let guidance = resolve_guidance(&req, &model);
     let generator = load_engine("ideogram_4", dir, quant, Vec::new(), None).unwrap();
     let cancel = gen_core::CancelFlag::new();
@@ -7242,7 +7248,7 @@ fn boogu_real_weights_generates_base_turbo_edit() {
         // The exact production spec: Q8 over the packed `<variant>/` weights, with the resolved
         // guidance (4.0 Base/Edit, None Turbo) + true_cfg (None for all boogu — Base/Edit forward
         // CFG via the `guidance` scalar; Turbo is CFG-free).
-        let (quant, _bits) = resolve_quant(&req);
+        let (quant, _bits) = resolve_quant(&req, None);
         let guidance = resolve_guidance(&req, &model);
         let true_cfg = resolve_true_cfg(&req, &model);
 
@@ -9580,7 +9586,7 @@ fn krea_control_lora_end_to_end_mlx_smoke() {
     );
     println!("[smoke] Bug 2 OK — resolved {} adapter(s)", adapters.len());
 
-    let (quant, _) = resolve_quant(&req);
+    let (quant, _) = resolve_quant(&req, None);
     let load = |adapters: Vec<AdapterSpec>| {
         let spec = krea_control_spec(base.clone(), overlay.clone(), quant, adapters);
         load_control_engine(KREA_CONTROL_ENGINE_ID, &spec)

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -937,6 +937,69 @@ fn bernini_image_task_and_quant_mapping() {
     ));
 }
 
+/// sc-11042 (epic 11037 SC#5): the ComfyUI FLUX.2-dev lane NEVER selects `Quant::Nvfp4` — not even for
+/// an explicit `quantTier: "nvfp4"` pick, and not on a Blackwell host.
+///
+/// This lane is structurally incapable of serving the tier: its `quant` is the ON-THE-FLY GGUF fold
+/// target (`load_from_comfyui_dit` → `QLinear::quantize_onto` → `fold` → `ggml_dtype`), and
+/// `ggml_dtype` BAILS for `Nvfp4` by design — NVFP4 is served by `Nvfp4Linear` from an offline-packed
+/// `Nvfp4Tensor`, which this lane has no tier dir to load (the DiT is the user's own in-place ComfyUI
+/// fp8 single-file; `FLUX2_COMFYUI_SNAPSHOT_TIERS` probes only for the TE/VAE snapshot). An earlier
+/// revision returned `Quant::Nvfp4` here, which did not select a tier — it aborted the load with
+/// `WorkerError::Engine("ComfyUI FLUX.2-dev load failed: …")`, killing the job on EXACTLY the hardware
+/// the tier targets. Falling through to the normal q4/q8/default arms IS the clean fallback.
+///
+/// The host gate is NOT injected here on purpose: the arm is gone, so the answer must be a normal tier
+/// on EVERY host — which is precisely what this pins. (`nvfp4_host_eligible()` is a real compute-cap
+/// probe; this test must not depend on the rig's GPU.)
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn flux2_comfyui_never_selects_nvfp4() {
+    let req = |advanced: Value| {
+        request(json!({
+            "projectId": "p", "model": "external_base_flux2", "prompt": "p", "advanced": advanced,
+        }))
+    };
+    // Guard the guard: `nvfp4_requested` must actually SEE this label, so the assertions below are
+    // about the deleted arm and not about a mis-built request that never carried the key.
+    assert!(
+        nvfp4_requested(&req(json!({ "quantTier": "nvfp4" }))),
+        "test scaffolding is wrong — the label never reached `advanced`, so the rest is vacuous"
+    );
+
+    // The explicit pick the web can emit — on this lane it must resolve the lane default, never Nvfp4.
+    assert!(matches!(
+        flux2_comfyui_quant(&req(json!({ "quantTier": "nvfp4" }))),
+        FLUX2_COMFYUI_DEFAULT_QUANT
+    ));
+    // …and the label must not disturb an explicit q4/q8 pick either (the fall-through is UNCHANGED).
+    assert!(matches!(
+        flux2_comfyui_quant(&req(json!({ "quantTier": "nvfp4", "quant": "q4" }))),
+        Quant::Q4
+    ));
+    assert!(matches!(
+        flux2_comfyui_quant(&req(json!({ "quantTier": "nvfp4", "quant": "q8" }))),
+        Quant::Q8
+    ));
+    // No request shape on this lane may ever produce Nvfp4 — including the `mlxQuantize: null` an NVFP4
+    // request actually carries (sc-12006), and a stale bits knob alongside the label.
+    for advanced in [
+        json!({ "quantTier": "nvfp4" }),
+        json!({ "quantTier": "nvfp4", "mlxQuantize": null }),
+        json!({ "quantTier": "nvfp4", "mlxQuantize": 4 }),
+        json!({ "quantTier": "nvfp4", "quant": "q4" }),
+        json!({ "quantTier": "nvfp4", "quant": "q8" }),
+        json!({ "quantTier": "nvfp4", "quant": "bogus" }),
+        json!({}),
+    ] {
+        assert!(
+            !matches!(flux2_comfyui_quant(&req(advanced.clone())), Quant::Nvfp4),
+            "the comfyui lane cannot serve NVFP4 — the GGUF fold rejects it, so selecting it \
+             hard-fails the job (advanced={advanced})"
+        );
+    }
+}
+
 /// Candle Bernini tier-subdir selection (sc-11003): the published `SceneWorks/bernini` layout nests
 /// `bf16/`|`q8/`|`q4/` component trees, so the candle lane descends into the requested quant tier and
 /// pairs it with the matching load quant. Asserts the pure selection helpers: bf16-dense DEFAULT

--- a/crates/sceneworks-worker/src/image_jobs/zimage.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage.rs
@@ -255,7 +255,7 @@ async fn generate_zimage_control_stream(
             strict_control_default_repo(ZIMAGE_CONTROL_ENGINE_ID)
         ))
     })?;
-    let (quant, quant_bits) = resolve_quant(request);
+    let (quant, quant_bits) = resolve_quant(request, Some(&weights_dir));
     let zimage = mlx_model("z_image_turbo")
         .ok_or_else(|| WorkerError::InvalidPayload("z-image model row missing".to_owned()))?;
     let steps = resolve_steps(request, &zimage);

--- a/crates/sceneworks-worker/src/image_jobs/zimage.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage.rs
@@ -505,7 +505,7 @@ async fn generate_zimage_base_control_stream(
             strict_control_default_repo(ZIMAGE_BASE_CONTROL_ENGINE_ID)
         ))
     })?;
-    let (quant, quant_bits) = resolve_quant(request);
+    let (quant, quant_bits) = resolve_quant(request, Some(&weights_dir));
     let steps = resolve_steps(request, &zimage);
     let guidance = resolve_guidance(request, &zimage).unwrap_or(zimage.default_guidance());
     let negative_prompt = resolve_negative_prompt(request, &zimage);

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -58,6 +58,31 @@ fn compute_cap_parse_takes_the_highest_and_tolerates_junk() {
     assert_eq!(parse_max_compute_cap("\n[N/A]\n"), None);
 }
 
+/// sc-11042 (epic 11037): the NVFP4 tier's Blackwell gate floors at compute cap **12.0** (consumer
+/// Blackwell sm_120 — the FP4 tensor cores the cuBLASLt NVFP4 GEMM dispatches on).
+///
+/// This is the ONLY place hardware maps onto NVFP4 eligibility, so the boundary is pinned here: the
+/// tier-select tests inject the resulting bool rather than probing a live GPU.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn nvfp4_gate_floors_at_blackwell_sm_120() {
+    use crate::gpu::compute_cap_meets_nvfp4;
+    // Consumer Blackwell (RTX PRO 6000 / RTX 50-series = 12.0) — the epic's target, and eligible.
+    assert!(compute_cap_meets_nvfp4(Some(12.0)));
+    // A hypothetical future cap above the floor stays eligible (a floor, matching the ConvRot shape).
+    assert!(compute_cap_meets_nvfp4(Some(12.8)));
+    // Ada (8.9) and Ampere (8.6) have no FP4 tensor cores → ineligible, and fall back cleanly.
+    assert!(!compute_cap_meets_nvfp4(Some(8.9)));
+    assert!(!compute_cap_meets_nvfp4(Some(8.6)));
+    // DATACENTER Blackwell sm_100 (B100/B200) probes 10.0. It HAS FP4 hardware but is explicitly out of
+    // scope for epic 11037 — the lane is neither built for it (`CUDA_COMPUTE_CAP=120` emits sm_120 SASS
+    // + compute_120 PTX) nor validated on it — so the 12.0 floor keeps it off the tier BY CONSTRUCTION.
+    assert!(!compute_cap_meets_nvfp4(Some(10.0)));
+    // No probe (nvidia-smi absent / CPU / non-NVIDIA) ⇒ ineligible. Fail-safe: an unprobed host must
+    // never route an FP4 load at hardware that may not have FP4 tensor cores.
+    assert!(!compute_cap_meets_nvfp4(None));
+}
+
 #[test]
 fn auto_worker_ids_and_child_environment_match_python_supervisor() {
     assert_eq!(gpu_worker_id("worker-gpu-auto-0", "0"), "worker-gpu-auto-0");

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -4105,19 +4105,33 @@ impl VideoSettingsSnapshot {
 }
 
 /// Normalized quant label + bit-width for a resolved video [`Quant`] (epic 10402,
-/// sc-10418): `Q8` → ("q8", 8), `Q4` → ("q4", 4), `None` (dense/bf16) → ("bf16", None).
-/// Mirrors the image lane's `effective_quant_label` mapping so the Stats charts group
-/// video and image runs on the same tier labels.
+/// sc-10418): `Q8` → ("q8", 8), `Q4` → ("q4", 4), `Nvfp4` → ("nvfp4", None), `None`
+/// (dense/bf16) → ("bf16", None). Mirrors the image lane's `effective_quant_label` mapping
+/// so the Stats charts group video and image runs on the same tier labels.
+///
+/// **MATCH THE VARIANT — never derive a tier label from [`Quant::bits`] (sc-11042, epic 11037 SC#5).**
+/// This function used to `format!("q{bits}")` from `q.bits()`, which was correct only while `Quant` was
+/// `{Q4, Q8}`. `Quant::Nvfp4::bits()` returns **4** (its E2M1 elements are 4-bit), so the bits-derived
+/// form stamped an NVFP4 video render as `"q4"` + bits 4 in Stats telemetry — falsely reporting one
+/// creative choice as another, exactly the tier aliasing this epic forbids. **The compiler could not
+/// catch it**: reading `.bits()` raises no E0004 when a variant is added, so it compiled silently on the
+/// `backend-candle` lane. The explicit arms below make any future `Quant` variant a hard compile error
+/// here instead of a silent mislabel — do not collapse them back into a catch-all or a `bits()` map.
+///
+/// NVFP4 reports **no** bit count: it is ~4.5 EFFECTIVE bits/weight (E2M1 elements + FP8-E4M3 block
+/// scales + an FP32 per-tensor scale), so `Some(4)` would re-introduce the same `q4` aliasing in the
+/// `quant_bits` column that the label fix removes. `None` is the honest "no integer width applies" —
+/// the same signal the dense/bf16 arm uses, and the same reason `flux2_comfyui_raw_settings` writes
+/// `mlxQuantize: null` for this tier.
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn video_quant_label(quant: Option<Quant>) -> (Option<String>, Option<u32>) {
     match quant {
-        Some(q) => {
-            let bits = q.bits() as u32;
-            (Some(format!("q{bits}")), Some(bits))
-        }
+        Some(Quant::Q4) => (Some("q4".to_owned()), Some(4)),
+        Some(Quant::Q8) => (Some("q8".to_owned()), Some(8)),
+        Some(Quant::Nvfp4) => (Some("nvfp4".to_owned()), None),
         None => (Some("bf16".to_owned()), None),
     }
 }
@@ -9905,6 +9919,44 @@ mod tests {
             (Some("q4".to_owned()), Some(4))
         );
         assert_eq!(video_quant_label(None), (Some("bf16".to_owned()), None));
+    }
+
+    /// sc-11042 / epic 11037 SC#5 — **the NVFP4 aliasing guard**.
+    ///
+    /// `Quant::Nvfp4::bits()` returns **4** (E2M1 elements are 4-bit), so the previous
+    /// `format!("q{bits}")` implementation stamped an NVFP4 video render as `"q4"` + bits 4 — reporting
+    /// the int4-affine tier the user did NOT pick. The compiler cannot catch that class of bug (reading
+    /// `.bits()` raises no E0004 on a new variant), so it is pinned here instead.
+    ///
+    /// The `bits()`-is-4 assertion is deliberate: it documents WHY the label must be matched from the
+    /// variant, and fails loudly if a future contract change makes the old bits-derived form look safe
+    /// again.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn video_quant_label_never_aliases_nvfp4_to_q4() {
+        let (label, bits) = video_quant_label(Some(Quant::Nvfp4));
+        // The label names the tier the user actually picked — NOT "q4".
+        assert_eq!(label, Some("nvfp4".to_owned()));
+        assert_ne!(
+            label,
+            Some("q4".to_owned()),
+            "NVFP4 must never be stamped as the q4 tier (epic 11037 SC#5)"
+        );
+        // No integer bit-width is honest for NVFP4 (~4.5 EFFECTIVE bits/weight), so `quant_bits` stays
+        // empty rather than repeating the q4 aliasing in the numeric column.
+        assert_eq!(bits, None);
+        // The trap this guards: the element width really is 4, which is exactly why a bits-derived
+        // label silently aliased onto q4.
+        assert_eq!(Quant::Nvfp4.bits(), 4);
+        assert_eq!(Quant::Q4.bits(), 4);
+        // And the q4 tier still reports itself truthfully — NVFP4 took nothing away from it.
+        assert_eq!(
+            video_quant_label(Some(Quant::Q4)),
+            (Some("q4".to_owned()), Some(4))
+        );
     }
 
     /// sc-10418 (mirrors the S4 image `image_settings_metrics` tests): the video

--- a/crates/sceneworks-worker/src/vram_gate.rs
+++ b/crates/sceneworks-worker/src/vram_gate.rs
@@ -142,15 +142,33 @@ pub(crate) fn reclaimable_pool_gb(gpu_id: &str) -> f64 {
         .unwrap_or(0.0)
 }
 
-/// The tier key (`bf16`/`q8`/`q4`) the request selected — derived the SAME way the tier-subdir
+/// The tier key (`nvfp4`/`bf16`/`q8`/`q4`) the request selected — derived the SAME way the tier-subdir
 /// resolvers pick their folder (`advanced.mlxQuantize` → manifest `mlx.quantize` → `q8` default;
 /// `<= 0` ⇒ `bf16`; `<= 4` ⇒ `q4`; else `q8`). Deliberately NOT derived from the resolved `Quant`,
 /// which is `None` on packed-tier candle families whose tier is the resolved subdir, not a load-time
 /// quantize (see `resolve_quant`'s candle-lane note).
+///
+/// **`nvfp4` (sc-11042) is passed IN, not parsed here.** NVFP4 carries no `mlxQuantize` by design (no
+/// integer is honest for a ~4.5-effective-bit tier), so a bits-derived key can only ever return `q8`
+/// for it — which sized an NVFP4 render against `candle.vramGbByTier["q8"]`, roughly 2× its real
+/// footprint. That failed CONSERVATIVE (a spurious `TooBig`/`Offload`, never an OOM), but it was the
+/// fourth bits-derived site of the same aliasing and is now keyed off the tier IDENTITY like the other
+/// three. The caller passes `image_jobs::base::nvfp4_selected` — the same predicate behind the load
+/// quant and the recorded label, so all four agree on what ran by construction. This module stays pure
+/// (no GPU probe, no filesystem) precisely because the flag arrives resolved.
+///
+/// Mirrors [`preferred_tier`](crate::image_jobs::base)'s `(bits, floor, nvfp4)` shape: `nvfp4 == false`
+/// leaves every existing mapping byte-identical.
 pub(crate) fn requested_tier_key(
     advanced: &JsonObject,
     manifest_entry: &JsonObject,
+    nvfp4: bool,
 ) -> &'static str {
+    // The distinct NVFP4 tier short-circuits the bits map: it is a tier identity, not a point on the
+    // bits ladder, and it has no honest `mlxQuantize` integer to be derived from.
+    if nvfp4 {
+        return NVFP4_TIER;
+    }
     let raw = advanced.get("mlxQuantize").and_then(quant_int).or_else(|| {
         manifest_entry
             .get("mlx")
@@ -169,14 +187,34 @@ pub(crate) fn requested_tier_key(
 /// `candle.vramGbByTier[tier_key]` (measured peak) + [`HEADROOM_GB`], else `candle.minMemoryGb`
 /// (already padded), else `None` — an unmeasured model (no `candle` block, e.g. the dense sc-3675
 /// families) skips the gate entirely.
+///
+/// **An `nvfp4` tier with no measured row degrades to the `q8` row, NOT to `minMemoryGb` (sc-11042).**
+/// sc-11043 owns the convert-at-install loop and **must add an `nvfp4` row to `vramGbByTier` when it
+/// converts a tier** — this is the documented behavior until it does. `minMemoryGb` is the WRONG floor
+/// to land on here: per the manifest schema it is "the measured overall-peak of the DEFAULT (lightest,
+/// typically q4) hosted tier", which heavier tiers are explicitly allowed to exceed — so falling
+/// through to it would size an FP4 render against the lightest tier's number and fail PERMISSIVELY
+/// (an under-prediction admits a load that can OOM). The `q8` row instead OVER-predicts (q8's weights
+/// are ~2× NVFP4's ~4.5 effective bits), which is both safe and exactly the number this gate already
+/// used for an NVFP4 request before the tier had its own key — the bits-derived
+/// [`requested_tier_key`] returned `"q8"` for it. So the sizing is no less conservative than the
+/// status quo, and a missing row can only ever cost a spurious `TooBig`/`Offload`, never an OOM.
 pub(crate) fn predicted_peak_gb(manifest_entry: &JsonObject, tier_key: &str) -> Option<f64> {
     let candle = manifest_entry.get("candle")?;
-    if let Some(gb) = candle
-        .get("vramGbByTier")
-        .and_then(|tiers| tiers.get(tier_key))
-        .and_then(json_f64)
-    {
+    let measured = |key: &str| {
+        candle
+            .get("vramGbByTier")
+            .and_then(|tiers| tiers.get(key))
+            .and_then(json_f64)
+    };
+    if let Some(gb) = measured(tier_key) {
         return Some(gb + HEADROOM_GB);
+    }
+    // NVFP4 with no measured row → the q8 row (a deliberate over-prediction; see the note above).
+    if tier_key == NVFP4_TIER {
+        if let Some(gb) = measured("q8") {
+            return Some(gb + HEADROOM_GB);
+        }
     }
     candle.get("minMemoryGb").and_then(json_f64)
 }
@@ -186,15 +224,18 @@ pub(crate) fn predicted_peak_gb(manifest_entry: &JsonObject, tier_key: &str) -> 
 /// [`predicted_peak_gb`]'s headroom. `None` when unmeasured (no `sequentialPeakGb`, or no entry for this
 /// tier) — then the [`FitDecision::Offload`] path keeps today's best-effort behavior: run sequentially
 /// and lean on the reactive Metal/CUDA-OOM containment backstop rather than reject.
+///
+/// An `nvfp4` tier with no measured row falls back to the `q8` row, mirroring [`predicted_peak_gb`]'s
+/// NVFP4 note (q8's sequential working set is an over-prediction of NVFP4's, so the second-stage gate
+/// degrades conservatively rather than best-effort). sc-11043 must add the real `nvfp4` rows.
 pub(crate) fn predicted_sequential_peak_gb(
     manifest_entry: &JsonObject,
     tier_key: &str,
 ) -> Option<f64> {
-    manifest_entry
-        .get("candle")?
-        .get("sequentialPeakGb")
-        .and_then(|tiers| tiers.get(tier_key))
-        .and_then(json_f64)
+    let sequential = manifest_entry.get("candle")?.get("sequentialPeakGb")?;
+    let measured = |key: &str| sequential.get(key).and_then(json_f64);
+    measured(tier_key)
+        .or_else(|| (tier_key == NVFP4_TIER).then(|| measured("q8")).flatten())
         .map(|gb| gb + HEADROOM_GB)
 }
 
@@ -328,29 +369,130 @@ mod tests {
     fn requested_tier_key_mirrors_the_subdir_resolvers() {
         let empty = obj(json!({}));
         // No pick anywhere ⇒ q8 default (sc-10726).
-        assert_eq!(requested_tier_key(&empty, &empty), "q8");
+        assert_eq!(requested_tier_key(&empty, &empty, false), "q8");
         // advanced.mlxQuantize wins, number or numeric string.
         assert_eq!(
-            requested_tier_key(&obj(json!({"mlxQuantize": 0})), &empty),
+            requested_tier_key(&obj(json!({"mlxQuantize": 0})), &empty, false),
             "bf16"
         );
         assert_eq!(
-            requested_tier_key(&obj(json!({"mlxQuantize": 4})), &empty),
+            requested_tier_key(&obj(json!({"mlxQuantize": 4})), &empty, false),
             "q4"
         );
         assert_eq!(
-            requested_tier_key(&obj(json!({"mlxQuantize": 8})), &empty),
+            requested_tier_key(&obj(json!({"mlxQuantize": 8})), &empty, false),
             "q8"
         );
         assert_eq!(
-            requested_tier_key(&obj(json!({"mlxQuantize": "4"})), &empty),
+            requested_tier_key(&obj(json!({"mlxQuantize": "4"})), &empty, false),
             "q4"
         );
         // Falls back to the manifest mlx.quantize when advanced is silent.
         assert_eq!(
-            requested_tier_key(&empty, &obj(json!({"mlx": {"quantize": 4}}))),
+            requested_tier_key(&empty, &obj(json!({"mlx": {"quantize": 4}})), false),
             "q4"
         );
+    }
+
+    /// sc-11042 (epic 11037 SC#5): the fit gate keys off the tier IDENTITY, never bits.
+    ///
+    /// The FOURTH bits-derived site of the same aliasing. NVFP4 carries no `mlxQuantize` by design (no
+    /// integer is honest for a ~4.5-effective-bit tier), so a bits-derived key returned `"q8"` for it
+    /// and sized an NVFP4 render against `vramGbByTier["q8"]` — ~2× its real footprint. Conservative
+    /// (spurious TooBig/Offload, never an OOM), but wrong, and it made this the one selection site that
+    /// disagreed with the load quant + the recorded label about which tier was running.
+    #[test]
+    fn requested_tier_key_honors_the_nvfp4_tier_identity() {
+        let empty = obj(json!({}));
+        // The selected NVFP4 tier short-circuits the bits map — including the `mlxQuantize: null` an
+        // NVFP4 request actually carries (sc-12006), which `quant_int` reads as "no pick" ⇒ `q8`.
+        assert_eq!(requested_tier_key(&empty, &empty, true), NVFP4_TIER);
+        assert_eq!(
+            requested_tier_key(&obj(json!({"mlxQuantize": null})), &empty, true),
+            NVFP4_TIER
+        );
+        // …and it is NOT the q4 whose numerics it must never be confused with, nor the q8 the
+        // bits-derived key produced.
+        assert_ne!(requested_tier_key(&empty, &empty, true), "q4");
+        assert_ne!(requested_tier_key(&empty, &empty, true), "q8");
+
+        // `nvfp4 = false` ⇒ every existing mapping is byte-identical (the caller's `nvfp4_selected` is
+        // false for every request that didn't explicitly pick the tier on eligible hardware with the
+        // tier installed — i.e. all of them today).
+        for (advanced, manifest, expected) in [
+            (json!({}), json!({}), "q8"),
+            (json!({"mlxQuantize": 0}), json!({}), "bf16"),
+            (json!({"mlxQuantize": 4}), json!({}), "q4"),
+            (json!({"mlxQuantize": 8}), json!({}), "q8"),
+            (json!({}), json!({"mlx": {"quantize": 4}}), "q4"),
+            // A `quantTier: "nvfp4"` label with the gate closed (not Blackwell, or the tier isn't
+            // installed) sizes the tier that will actually load — never nvfp4.
+            (json!({"quantTier": "nvfp4"}), json!({}), "q8"),
+        ] {
+            assert_eq!(
+                requested_tier_key(&obj(advanced.clone()), &obj(manifest.clone()), false),
+                expected,
+                "advanced={advanced} manifest={manifest}"
+            );
+        }
+    }
+
+    /// sc-11042: an `nvfp4` tier with no measured `vramGbByTier` row degrades CONSERVATIVELY — to the
+    /// `q8` row, not to `minMemoryGb`.
+    ///
+    /// `minMemoryGb` is the manifest's DEFAULT (lightest, typically q4) tier peak, which heavier tiers
+    /// are explicitly allowed to exceed — landing there would UNDER-predict and admit a load that can
+    /// OOM. The q8 row over-predicts (q8's weights are ~2× NVFP4's), which is exactly the number this
+    /// gate already used for an NVFP4 request when the bits-derived key returned `"q8"`. sc-11043 must
+    /// add the real `nvfp4` rows when it converts a tier; until then this is the documented behavior.
+    #[test]
+    fn nvfp4_without_a_measured_row_degrades_to_q8_not_min_memory() {
+        let manifest = obj(json!({
+            "candle": {
+                "minMemoryGb": 40,
+                "vramGbByTier": { "q4": 47.2, "q8": 58, "bf16": 72 },
+                "sequentialPeakGb": { "q4": 20.0, "q8": 26.0 }
+            }
+        }));
+        // No `nvfp4` row ⇒ the q8 row + headroom, NOT the lighter (permissive) minMemoryGb…
+        assert_eq!(
+            predicted_peak_gb(&manifest, NVFP4_TIER),
+            Some(58.0 + HEADROOM_GB)
+        );
+        assert_ne!(predicted_peak_gb(&manifest, NVFP4_TIER), Some(40.0));
+        // …and the same for the second-stage sequential gate.
+        assert_eq!(
+            predicted_sequential_peak_gb(&manifest, NVFP4_TIER),
+            Some(26.0 + HEADROOM_GB)
+        );
+
+        // Once sc-11043 measures the tier, its own row wins outright.
+        let measured = obj(json!({
+            "candle": {
+                "minMemoryGb": 40,
+                "vramGbByTier": { "q8": 58, "nvfp4": 31.5 },
+                "sequentialPeakGb": { "q8": 26.0, "nvfp4": 14.0 }
+            }
+        }));
+        assert_eq!(
+            predicted_peak_gb(&measured, NVFP4_TIER),
+            Some(31.5 + HEADROOM_GB)
+        );
+        assert_eq!(
+            predicted_sequential_peak_gb(&measured, NVFP4_TIER),
+            Some(14.0 + HEADROOM_GB)
+        );
+
+        // The q8 back-stop is NVFP4-only: every other tier keeps the unchanged
+        // measured-row → minMemoryGb chain.
+        let sparse = obj(json!({ "candle": { "minMemoryGb": 40, "vramGbByTier": { "q8": 58 } } }));
+        assert_eq!(predicted_peak_gb(&sparse, "q4"), Some(40.0));
+        assert_eq!(predicted_peak_gb(&sparse, "bf16"), Some(40.0));
+        assert_eq!(predicted_sequential_peak_gb(&sparse, "q4"), None);
+        // No q8 row either ⇒ nvfp4 falls all the way through to minMemoryGb rather than panicking.
+        let no_q8 = obj(json!({ "candle": { "minMemoryGb": 40, "vramGbByTier": {} } }));
+        assert_eq!(predicted_peak_gb(&no_q8, NVFP4_TIER), Some(40.0));
+        assert_eq!(predicted_sequential_peak_gb(&no_q8, NVFP4_TIER), None);
     }
 
     #[test]


### PR DESCRIPTION
Worker half of **sc-11042** (epic 11037). The runtime half shipped in `runtime-2026.07.3` (sc-12006); this makes the tier actually reachable.

**Decision: Option A** — NVFP4 is its own user-selectable tier, **never an auto-swap of q4 on Blackwell**. NVFP4's numerics differ from int4-affine q4 (E2M1 elements + FP8-E4M3 block scales, W4A4 regime), so auto-selecting it for a q4 pick would silently change what that tier renders — the creative-choice violation **SC#5** forbids.

## Two required fixes (found by the sc-12006 review, [activity-12150](https://app.shortcut.com/trefry/story/11042#activity-12150))

Both were unreachable until now — nothing produced a `Quant::Nvfp4`. This story's tier-select is exactly what arms them.

1. **`video_jobs.rs` `video_quant_label` aliased NVFP4 → `"q4"`.** It derived the label via `format!("q{bits}")` from `q.bits()`, and `Quant::Nvfp4.bits()` returns **4** — so an NVFP4 video render was stamped `"q4"` + bits 4 in Stats telemetry. **The compiler could not catch it** (reading `.bits()` raises no E0004 on a new variant), so it compiled silently on the `backend-candle` lane. Now matched per-variant → a future `Quant` variant is a hard compile error here instead of a silent mislabel. NVFP4 reports **no** bit count (~4.5 *effective* bits/weight); `Some(4)` would repeat the aliasing in the numeric column.
   - **Audit:** repo-wide, this was the **only** `.bits()`-derived tier label (one hit across all crates).
2. **`flux2_comfyui_candle.rs` stale `quantTier` key.** The insert was conditional, so a caller-supplied `advanced.quantTier` survived on the q4/q8 path (`raw` is a clone of `request.advanced`). Now `else { raw.remove("quantTier"); }` — the symmetric twin of the deliberately-unconditional `mlxQuantize` insert. This matters more now that `quantTier` is a *selection* input: a labeled request that resolved to q4/q8 anyway (off-Blackwell, or tier not converted) must not record the tier it did not run. **q4/q8 record shape stays byte-identical.**

## Tier-select

NVFP4 rides **`advanced.quantTier: "nvfp4"`** — the label sc-12006 established as write-only telemetry, now *consumed* — and **not** `mlxQuantize`, which is bits-valued and names a tier (`<=0`⇒bf16, `<=4`⇒q4, else q8): no integer is honest for NVFP4, so `mlxQuantize` stays **null** for it. Same shape as the sc-9300 `convRot` precedent.

Selection requires **both** an explicit label **and** an sm_120 host. The Blackwell gate is defence-in-depth, mirroring ConvRot (capability + engine floor):
- **Picker-side:** the worker advertises a new `nvfp4` capability only on the candle lane with compute cap ≥ **12.0**; the web hides the tier otherwise.
- **Worker-side:** `nvfp4_host_eligible()` re-checks the probed cap at tier-select, because `advanced` is free-form pass-through — a hand-crafted API call can put the label on a request to any worker.

The 12.0 floor deliberately excludes **datacenter Blackwell sm_100** (probes 10.0): it *has* FP4 hardware but is explicitly out of scope and the lane isn't built (`CUDA_COMPUTE_CAP=120`) or validated for it.

**Fallback is clean, never an error:** off-Blackwell, or before sc-11043's converter produces an `nvfp4/` dir (no shipping model packs one today), the pick rejoins the existing clean-tier chain. That fallback isn't silent — `reconcile_resolved_tier_quant` still fires `quant_tier_downgraded`.

Wired into `standard_tier_subdir` and `krea_model_subdir` (epic 11037's named SC#1/SC#2 vehicle per the sc-12110 Sana→Krea redirect; its subdir shape takes an `nvfp4/` dir with no new logic). The three MLX-family resolvers (anima/ideogram/boogu) pass `false` with a documented rationale.

## SC#5 guard

Structural, not just review:
- `preferred_tier`'s bits map is **unchanged**, and NVFP4 is proven **unreachable** from it for every `(bits, floor)` pair.
- The resolvers are pinned to their **pre-sc-11042 answers on a Blackwell-eligible host with an `nvfp4/` dir present** — hardware selects nothing; only a deliberate pick does.
- Web: `nvfp4` is excluded from `GENERATION_QUALITY_TIERS`, so it can never become anyone's default; a q4 sticky stays q4.

## SC#6 — measured, not claimed

**Not asserted here, and not this story's to fix.** sc-11045 measured resident VRAM on real Sana/sm_120: blanket W4A4 **0.2822×** ✅, but the **shipping mixed policy 0.6988×** ⚠️ (95/163 layers hold dense bf16), blanket W4A16 1.0000×. Root cause is `Nvfp4Linear::new_dequant` materializing a resident dense bf16 weight — an **inference-repo** defect tracked as **sc-12121**, needing its own fix + a new runtime tag. No NVFP4 weights exist on disk yet (sc-11043), so the tier's footprint is **not observable from the worker today**.

## Verification

- `scripts/check-gen-core-skew.sh` green — exactly one `sceneworks-gen-core` at `runtime-2026.07.3#8c35cd2a`
- `cargo build --locked --features backend-candle` (vcvars64/MSVC 14.44, `CUDA_COMPUTE_CAP=120`) — **0 errors / 0 warnings**
- `cargo clippy --locked --features backend-candle -p sceneworks-worker --all-targets -- -D warnings` — clean
- **Neither build** (`npm run rust:check:neither`) — clean (`nvfp4_host_eligible` has both cfg arms; the CONTRIBUTING cfg trap)
- `cargo fmt --all -- --check` — clean
- **612** worker lib tests pass (**603 before + 9 new**, 0 failed)
- **1814** web tests pass (135 files)

New tests: NVFP4 resolves on sm_120; falls back cleanly off-Blackwell and when unconverted; **existing q4/q8/bf16 selection unchanged on both host classes** (the SC#5 regression guard); `video_quant_label(Nvfp4) != "q4"`; the sm_120 cap floor incl. sm_100 exclusion; label parsing rejects every `mlxQuantize` value; web payload/gating/default-seeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)