### PR TITLE
Video Studio: add MLX quant-tier picker (sc-12165)

### DIFF
--- a/apps/web/src/quantTier.test.js
+++ b/apps/web/src/quantTier.test.js
@@ -129,6 +129,25 @@ describe("shouldShowTierPicker", () => {
   });
 });
 
+describe("quantTier — video model reuse (sc-12165)", () => {
+  const videoModel = (installed) => ({
+    id: "bernini",
+    type: "video",
+    hasVariantMatrix: true,
+    variants: ["q4", "q8", "bf16"].map((variant) => ({
+      variant,
+      installState: installed.includes(variant) ? "installed" : "missing",
+    })),
+  });
+
+  it("derives installed MLX video tiers through the model-agnostic helpers", () => {
+    const model = videoModel(["q4", "q8"]);
+    expect(installedTiers(model)).toEqual(["q4", "q8"]);
+    expect(shouldShowTierPicker(model)).toBe(true);
+    expect(defaultTierSelection(model, null, { defaultQuality: "q4" })).toBe("q4");
+  });
+});
+
 describe("defaultTierSelection", () => {
   it("prefers the last-used tier when it is still installed", () => {
     const model = matrixModel({ installed: ["q4", "q8", "bf16"] });

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -64,6 +64,14 @@ import {
 import { loadStudioSettings, useStudioSettingsWriter } from "../hooks/useStudioSettings.js";
 import { qualityChoices } from "../jobTypes.js";
 import {
+  defaultTierSelection,
+  installedTiers,
+  shouldShowTierPicker,
+  tierLabel,
+  tierQuantize,
+} from "../quantTier.js";
+import { readLastTier, writeLastTier } from "../lastTierStore.js";
+import {
   SAMPLER_LABELS,
   SCHEDULER_LABELS,
   guidanceDefaultFromModel,
@@ -76,6 +84,10 @@ import {
 
 const ltxVideoModelId = "ltx_2_3";
 const ltxIcLoraRequiredModes = new Set(["extend_clip", "video_bridge"]);
+// Keep Video Studio's MLX lane q4-first (sc-10859). Unlike Image Studio, it deliberately does not
+// inherit the app-wide generation-quality setting: video activation peaks need a larger safety margin.
+const TIER_SCREEN = "video";
+const VIDEO_DEFAULT_TIER = "q4";
 
 // Video sub-modes that map onto a recipe workflow. extend_clip / replace_person
 // aren't recipe workflows, so "Save as Preset" is gated to these.
@@ -159,6 +171,10 @@ export function VideoStudio() {
   const [distilledVariant, setDistilledVariant] = useState(saved.distilledVariant ?? "1.1");
   const [precision, setPrecision] = useState(saved.precision ?? "fp8");
   const [quantization, setQuantization] = useState(saved.quantization ?? "auto");
+  // MLX generation tier (sc-12165), separate from the torch/GGUF `quantization` state above.
+  // The explicit pick is persisted per (video, model), outside the workspace settings snapshot.
+  const [quantTier, setQuantTier] = useState("");
+  const [tierSwitching, setTierSwitching] = useState("");
   const [advancedOpen, setAdvancedOpen] = useState(saved.advancedOpen ?? false);
   const [model, setModel] = useState(saved.model ?? videoModels[0]?.id ?? ltxVideoModelId);
   const [guideOpen, setGuideOpen] = useState(false);
@@ -361,6 +377,58 @@ export function VideoStudio() {
   // `macGating` is the worker `mlx_required` master switch, so the menu reflects the
   // manifest's `mlx.limits` override on Mac/MLX and `candle.limits` on the candle build.
   const activeBackend = macGating ? "mlx" : "candle";
+  // MLX tier installs and the torch/GGUF quantization variants can coexist on one catalog model,
+  // but they target different worker lanes. Only derive an MLX tier while the MLX lane is active;
+  // the existing quantization picker owns the non-MLX lane. `convRotEligible: false` keeps the
+  // candle-only INT8-ConvRot image tier out of this MLX video control.
+  const mlxTierLane = activeBackend === "mlx";
+  const tierOptions = useMemo(
+    () => ({ convRotEligible: false, defaultQuality: VIDEO_DEFAULT_TIER }),
+    [],
+  );
+  const availableTiers = useMemo(
+    () => (mlxTierLane ? installedTiers(selectedModel, tierOptions) : []),
+    [mlxTierLane, selectedModel, tierOptions],
+  );
+  const showTierPicker = useMemo(
+    () => mlxTierLane && shouldShowTierPicker(selectedModel, tierOptions),
+    [mlxTierLane, selectedModel, tierOptions],
+  );
+  const showTorchQuantization = !mlxTierLane && supportsQuantization;
+  const selectedMlxQuantize =
+    mlxTierLane && availableTiers.includes(quantTier) ? tierQuantize(quantTier) : null;
+  const tierHasMemoryRisk = showTierPicker && ["q8", "bf16"].includes(quantTier);
+
+  // Seed from the per-(video, model) sticky, then the video-specific q4 base, clamped to installed.
+  // A model transition always re-seeds even when both models happen to expose the same tier list.
+  const availableTiersKey = availableTiers.join(",");
+  const quantTierModelRef = useRef(null);
+  useEffect(() => {
+    const modelChanged = quantTierModelRef.current !== model;
+    quantTierModelRef.current = model;
+    if (!modelChanged && availableTiers.includes(quantTier)) {
+      return;
+    }
+    setQuantTier(
+      defaultTierSelection(selectedModel, readLastTier(TIER_SCREEN, model), tierOptions) ?? "",
+    );
+    // `availableTiersKey` is the stable install-state dependency; the remaining values are read from
+    // the render that produced it, matching Image Studio's catalog-refresh seed behavior.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [model, availableTiersKey]);
+
+  const tierSwitchTimer = useRef(null);
+  useEffect(() => () => clearTimeout(tierSwitchTimer.current), []);
+  const handleTierChange = (nextTier) => {
+    if (nextTier === quantTier) {
+      return;
+    }
+    setQuantTier(nextTier);
+    writeLastTier(TIER_SCREEN, model, nextTier);
+    setTierSwitching(nextTier);
+    clearTimeout(tierSwitchTimer.current);
+    tierSwitchTimer.current = setTimeout(() => setTierSwitching(""), 1500);
+  };
   const samplerOptions = useMemo(
     () => samplerOptionsFromModel(selectedModel, activeBackend),
     [selectedModel, activeBackend],
@@ -928,7 +996,8 @@ export function VideoStudio() {
           selectedPersonTrack: selectedTrack ?? null,
           replacementModeLabel: replacementModeLabels[replacementMode],
           ...(model === ltxVideoModelId ? { ltxPipeline, distilledVariant, precision } : {}),
-          ...(supportsQuantization && quantization !== "auto" ? { quantization } : {}),
+          ...(showTorchQuantization && quantization !== "auto" ? { quantization } : {}),
+          ...(selectedMlxQuantize !== null ? { mlxQuantize: selectedMlxQuantize } : {}),
           // Configurable sampler / scheduler (epic 1753). Sealed adapters
           // (LTX native, MLX) silently fall back to default; only the Wan
           // diffusers (torch) path actually applies these.
@@ -1490,7 +1559,33 @@ export function VideoStudio() {
                   ) : null}
                 </>
               ) : null}
-              {supportsQuantization ? (
+              {showTierPicker ? (
+                <label
+                  className="quant-tier-picker"
+                  title="Switch which installed MLX quant tier generates. Higher precision uses more memory; switching a heavy tier reloads it before the next generation."
+                >
+                  Quant tier
+                  <select onChange={(event) => handleTierChange(event.target.value)} value={quantTier}>
+                    {availableTiers.map((tier) => (
+                      <option key={tier} value={tier}>
+                        {tierLabel(tier)}
+                      </option>
+                    ))}
+                  </select>
+                  {tierSwitching ? (
+                    <span className="field-hint" role="status">
+                      Loading {tierLabel(tierSwitching)}…
+                    </span>
+                  ) : null}
+                  {tierHasMemoryRisk ? (
+                    <span className="field-hint quant-tier-memory-note">
+                      Higher MLX video tiers may run out of memory on long or high-resolution clips.
+                      Your pick is honored.
+                    </span>
+                  ) : null}
+                </label>
+              ) : null}
+              {showTorchQuantization ? (
                 <label>
                   Quantization
                   <select onChange={(event) => setQuantization(event.target.value)} value={quantization}>

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -1,6 +1,6 @@
 import React, { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { click, mountRoot, setInput, unmountRoot } from "../testUtils/dom.js";
+import { click, mountRoot, setInput, setSelect, unmountRoot } from "../testUtils/dom.js";
 
 vi.mock("../api.js", async (importOriginal) => {
   const actual = await importOriginal();
@@ -851,6 +851,154 @@ describe("VideoStudio Mac mode gating (sc-5716)", () => {
     expect([...modelSelect().options].map((o) => o.value)).toEqual(
       expect.arrayContaining(["wan_2_2", "scail2_14b"]),
     );
+  });
+});
+
+describe("VideoStudio MLX quant-tier picker (sc-12165)", () => {
+  let container;
+  let root;
+
+  const MAC_CAPS = {
+    macGatingActive: true,
+    platform: "darwin",
+    notAvailableLabel: "Not available on Mac (MLX only)",
+    features: {},
+    training: { supportedKernels: [], lokrOnWanSupported: false },
+  };
+
+  const tieredVideoModel = (installed, quantization = {}) => ({
+    id: "bernini",
+    name: "Bernini",
+    type: "video",
+    family: "bernini",
+    adapter: "bernini",
+    capabilities: ["text_to_video"],
+    defaults: { duration: 5, resolution: "832x480", fps: 16 },
+    limits: { durations: [5], fps: [16], resolutions: ["832x480"] },
+    quantization,
+    loraCompatibility: {},
+    ui: {},
+    hasVariantMatrix: true,
+    variants: ["q4", "q8", "bf16"].map((tier) => ({
+      variant: tier,
+      installState: installed.includes(tier) ? "installed" : "missing",
+    })),
+    macSupport: {
+      supported: true,
+      features: { videoModes: { text_to_video: true } },
+    },
+  });
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <VideoStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  const openAdvanced = async () => {
+    const toggle = container.querySelector(".advanced-section-toggle");
+    if (toggle?.getAttribute("aria-expanded") !== "true") {
+      await click(toggle);
+    }
+  };
+  const tierPicker = () => container.querySelector("label.quant-tier-picker select");
+  const quantizationPicker = () =>
+    [...container.querySelectorAll("label")]
+      .find((label) => label.textContent.trim().startsWith("Quantization"))
+      ?.querySelector("select") ?? null;
+
+  it("shows installed tiers on MLX, stays q4-first, and hides with one installed tier", async () => {
+    await render(
+      baseContext({
+        videoModels: [tieredVideoModel(["q4", "q8"])],
+        macCapabilities: MAC_CAPS,
+      }),
+    );
+    await openAdvanced();
+
+    expect([...tierPicker().options].map((option) => option.value)).toEqual(["q4", "q8"]);
+    expect(tierPicker().value).toBe("q4");
+
+    await unmountRoot(root, container);
+    ({ container, root } = mountRoot());
+    const context = baseContext({
+      videoModels: [tieredVideoModel(["q4"])],
+      macCapabilities: MAC_CAPS,
+    });
+    await render(context);
+    await openAdvanced();
+
+    expect(tierPicker()).toBeNull();
+    await click(buttonWithText(container, "Render clip"));
+    expect(context.createVideoJob.mock.calls[0][0].advanced.mlxQuantize).toBe(4);
+  });
+
+  it("emits a selected high tier, warns about memory, and restores the video/model sticky", async () => {
+    const model = tieredVideoModel(["q4", "q8", "bf16"]);
+    const context = baseContext({ videoModels: [model], macCapabilities: MAC_CAPS });
+    await render(context);
+    await openAdvanced();
+
+    setSelect(tierPicker(), "q8");
+    await act(async () => {});
+    expect(container.querySelector(".quant-tier-memory-note")?.textContent).toContain(
+      "may run out of memory",
+    );
+    await click(buttonWithText(container, "Render clip"));
+    expect(context.createVideoJob.mock.calls[0][0].advanced.mlxQuantize).toBe(8);
+
+    await unmountRoot(root, container);
+    ({ container, root } = mountRoot());
+    await render(baseContext({ videoModels: [model], macCapabilities: MAC_CAPS }));
+    await openAdvanced();
+    expect(tierPicker().value).toBe("q8");
+  });
+
+  it("keeps MLX tiers disjoint from the torch/GGUF quantization control and payload", async () => {
+    const both = tieredVideoModel(["q4", "q8"], {
+      variants: { q4_k_m: { label: "Q4_K_M" } },
+    });
+    const mlxContext = baseContext({ videoModels: [both], macCapabilities: MAC_CAPS });
+    await render(mlxContext);
+    await openAdvanced();
+
+    expect(tierPicker()).toBeTruthy();
+    expect(quantizationPicker()).toBeNull();
+    setSelect(tierPicker(), "q8");
+    await act(async () => {});
+    await click(buttonWithText(container, "Render clip"));
+    expect(mlxContext.createVideoJob.mock.calls[0][0].advanced).toMatchObject({ mlxQuantize: 8 });
+    expect(mlxContext.createVideoJob.mock.calls[0][0].advanced).not.toHaveProperty("quantization");
+
+    await unmountRoot(root, container);
+    ({ container, root } = mountRoot());
+    const torchContext = baseContext({ videoModels: [both] });
+    await render(torchContext);
+    await openAdvanced();
+
+    expect(tierPicker()).toBeNull();
+    expect(quantizationPicker()).toBeTruthy();
+    setSelect(quantizationPicker(), "q4_k_m");
+    await act(async () => {});
+    await click(buttonWithText(container, "Render clip"));
+    expect(torchContext.createVideoJob.mock.calls[0][0].advanced.quantization).toBe("q4_k_m");
+    expect(torchContext.createVideoJob.mock.calls[0][0].advanced).not.toHaveProperty("mlxQuantize");
   });
 });
 


### PR DESCRIPTION
## What does this PR do?

- adds the installed MLX quant-tier picker to Video Studio with a video-specific Q4-first default
- persists explicit picks per `(video, model)` and warns on Q8/bf16 about long/high-resolution clip memory risk
- emits `advanced.mlxQuantize` for the active MLX tier while keeping the torch/GGUF `quantization` control and payload mutually exclusive
- covers video-model helper reuse, picker show/hide, single-tier emission, sticky restore, advisory, and lane disjointness

## Related story

[sc-12165 — Video Studio quant-tier picker](https://app.shortcut.com/trefry/story/12165/video-studio-quant-tier-picker-give-the-mlx-video-lane-a-lever-above-the-q4-default)

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## How was this tested?

- [x] Not platform-specific (web UI, docs, shared crate)
- `npm --prefix apps/web run lint` (passes with existing warnings)
- `npm --prefix apps/web run test` (135 files, 1,811 tests)
- `npm --prefix apps/web run build`

A physical Bernini/SCAIL-2 generation was not run in this Windows environment; component tests verify the final `createVideoJob` payload for the MLX lane.

## Checklist

- [x] I ran the web lint, test, and build commands
- [x] No Rust files were touched
- [x] All commits are signed off
- [x] The PR is focused on a single logical change