### PR TITLE
refactor(worker): unify fit decisions (sc-12127)

### DIFF
--- a/crates/sceneworks-worker/src/fit_gate.rs
+++ b/crates/sceneworks-worker/src/fit_gate.rs
@@ -1,0 +1,38 @@
+//! Backend-neutral fit-gate outcome and sequential-residency transition (sc-12127).
+//!
+//! MLX and candle derive their predicted resident and sequential peaks differently, but once a
+//! resident fit decision exists they share this state transition exactly. Keeping it here prevents
+//! the two admission gates from drifting while leaving their backend-specific budgeting untouched.
+
+/// The shared outcome of comparing a predicted resident peak with an available memory budget.
+/// `Unknown` means the backend has no reliable signal and therefore must not reject the job.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum FitDecision {
+    Unknown,
+    Fits,
+    /// The resident peak does not fit, but the provider supports sequential component residency.
+    /// The caller must still run its backend-specific sequential-peak check before loading.
+    Offload {
+        needed_gb: f64,
+        available_gb: f64,
+    },
+    TooBig {
+        needed_gb: f64,
+        available_gb: f64,
+    },
+}
+
+/// Select sequential residency when a resident load is too large and the provider advertises that
+/// capability. Every other decision is preserved unchanged.
+pub(crate) fn resolve_offload(decision: FitDecision, sequential_capable: bool) -> FitDecision {
+    match decision {
+        FitDecision::TooBig {
+            needed_gb,
+            available_gb,
+        } if sequential_capable => FitDecision::Offload {
+            needed_gb,
+            available_gb,
+        },
+        other => other,
+    }
+}

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -102,6 +102,7 @@ use api_client::*;
 mod engines;
 mod gpu;
 use gpu::*;
+mod fit_gate;
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 mod mlx_fit_gate;
 // CUDA/candle VRAM fit-gate + small-card emulation (epic 10765 Phase 0, sc-10766). Pure helpers wired

--- a/crates/sceneworks-worker/src/mlx_fit_gate.rs
+++ b/crates/sceneworks-worker/src/mlx_fit_gate.rs
@@ -33,6 +33,7 @@ use std::sync::OnceLock;
 
 use gen_core::{LoadSpec, OffloadPolicy, WeightsSource};
 
+pub(crate) use crate::fit_gate::{resolve_offload, FitDecision};
 use crate::{WorkerError, WorkerResult};
 
 /// Whether `engine_id`'s provider drops components in phase order under [`OffloadPolicy::Sequential`]
@@ -135,27 +136,6 @@ pub(crate) struct MemoryBudget {
     pub total_gb: f64,
 }
 
-/// The gate outcome. `Unknown` = no signal (the RAM probe failed, or the weights dir had no
-/// measurable `.safetensors`) ⇒ never block, mirroring the flux2 guard's `available_gb == None`
-/// short-circuit and the candle gate's `Unknown`.
-#[derive(Clone, Debug, PartialEq)]
-pub(crate) enum FitDecision {
-    Unknown,
-    Fits,
-    /// The predicted RESIDENT peak won't fit, but the provider supports sequential component residency
-    /// (sc-10839) — run with [`OffloadPolicy::Sequential`] instead of rejecting. Sequential peak is
-    /// always ≤ resident. The caller then runs the second-stage [`sequential_overflow_gb`] check and
-    /// rejects only if even the staged max-single-component peak won't fit.
-    Offload {
-        needed_gb: f64,
-        available_gb: f64,
-    },
-    TooBig {
-        needed_gb: f64,
-        available_gb: f64,
-    },
-}
-
 /// Read the small-Mac cap from the environment. `Some(gb)` only for a positive number.
 pub(crate) fn mlx_memory_cap_gb() -> Option<f64> {
     parse_memory_cap(std::env::var(MLX_MEMORY_CAP_ENV).ok().as_deref())
@@ -210,24 +190,6 @@ pub(crate) fn predicted_sequential_peak_gb(total_bytes: u64, te_bytes: u64) -> O
     let rest_bytes = total_bytes.saturating_sub(te_bytes);
     let staged_max = te_bytes.max(rest_bytes);
     Some(staged_max as f64 / BYTES_PER_GIB + HEADROOM_GB)
-}
-
-/// Fold sequential-residency capability into a fit decision (sc-10839, mirroring the candle
-/// `vram_gate::resolve_offload`): a [`FitDecision::TooBig`] on a provider that drops components in
-/// phase order becomes [`FitDecision::Offload`] — load→use→drop so peak is the largest single
-/// component (≤ resident) rather than a reject. Every other outcome (Fits / Unknown / TooBig on a
-/// non-capable provider) is unchanged.
-pub(crate) fn resolve_offload(decision: FitDecision, sequential_capable: bool) -> FitDecision {
-    match decision {
-        FitDecision::TooBig {
-            needed_gb,
-            available_gb,
-        } if sequential_capable => FitDecision::Offload {
-            needed_gb,
-            available_gb,
-        },
-        other => other,
-    }
 }
 
 /// Second-stage gate for a [`FitDecision::Offload`] (sc-10839): sequential residency was selected

--- a/crates/sceneworks-worker/src/vram_gate.rs
+++ b/crates/sceneworks-worker/src/vram_gate.rs
@@ -21,6 +21,8 @@
 use super::*;
 use serde_json::Value;
 
+pub(crate) use crate::fit_gate::{resolve_offload, FitDecision};
+
 /// Emulate a smaller card: cap usable VRAM (GB). Set e.g. `SCENEWORKS_CUDA_VRAM_CAP_GB=10` to make the
 /// fit-gate treat this GPU as a 10 GB card, so a too-big model is rejected (and, once Phase 1 lands,
 /// offloaded) exactly as it would be on real small hardware. Unset / non-positive ⇒ use the real
@@ -37,28 +39,6 @@ const HEADROOM_GB: f64 = 2.0;
 pub(crate) struct VramBudget {
     pub free_gb: f64,
     pub total_gb: f64,
-}
-
-/// The gate outcome. `Unknown` = no signal (unmeasured model or non-NVIDIA host) ⇒ never block, exactly
-/// like the flux2 edit guard's `available_gb == None` short-circuit.
-#[derive(Clone, Debug, PartialEq)]
-pub(crate) enum FitDecision {
-    Unknown,
-    Fits,
-    /// The predicted resident peak won't fit, but the model's provider supports sequential component
-    /// residency (the candle FLUX lane, sc-10769) — run with `OffloadPolicy::Sequential` instead of
-    /// rejecting. Sequential peak is always ≤ resident, so this is the best option before a reject.
-    /// When the tier's sequential peak is MEASURED (`candle.sequentialPeakGb`, sc-10856) the caller runs
-    /// a second [`sequential_overflow_gb`] check and rejects if even sequential won't fit; absent that
-    /// number it's best-effort (the reactive Metal/CUDA-OOM containment is the backstop).
-    Offload {
-        needed_gb: f64,
-        available_gb: f64,
-    },
-    TooBig {
-        needed_gb: f64,
-        available_gb: f64,
-    },
 }
 
 /// Read the small-card cap from the environment. `Some(gb)` only for a positive number.
@@ -212,24 +192,6 @@ pub(crate) fn fit_decision(needed_gb: Option<f64>, budget: Option<VramBudget>) -
         }
     } else {
         FitDecision::Fits
-    }
-}
-
-/// Fold sequential-residency capability into a fit decision (epic 10765 Phase 1b, sc-10821): a
-/// [`FitDecision::TooBig`] on a provider that supports sequential offload (the candle FLUX lane) becomes
-/// [`FitDecision::Offload`] — load→use→drop each component so peak VRAM is the largest single working
-/// set (≤ resident) rather than reject. Every other outcome (Fits / Unknown / TooBig on a non-capable
-/// provider) is unchanged.
-pub(crate) fn resolve_offload(decision: FitDecision, sequential_capable: bool) -> FitDecision {
-    match decision {
-        FitDecision::TooBig {
-            needed_gb,
-            available_gb,
-        } if sequential_capable => FitDecision::Offload {
-            needed_gb,
-            available_gb,
-        },
-        other => other,
     }
 }
 


### PR DESCRIPTION
## What changed

- hoist the worker's backend-neutral `FitDecision` into one shared module
- hoist the identical `resolve_offload` transition beside it
- keep MLX and Candle peak prediction, budgets, and sequential overflow logic in their backend-specific gates

## Why

The MLX and Candle admission gates carried separate copies of the same decision type and offload transition. That made capability drift easier to hide and required identical behavior to be maintained twice.

This is a structural dedup only; both callers continue to use their existing backend-specific inputs and second-stage checks.

Shortcut: [sc-12127](https://app.shortcut.com/trefry/story/12127)

## Validation

- `cargo fmt --package sceneworks-worker -- --check`
- `cargo test --locked -p sceneworks-worker` (321 passed, 2 ignored)
- Candle-feature test attempted locally; compilation is blocked before the worker crate by the host's CUDA 12.9 / Visual Studio 2026 STL incompatibility (`STL1002`). CI should exercise this on the supported runner.
