### PR TITLE
feat(models): wire PiD 1.5 — runtime repin + v1.5→v1.0 decoder fallback (sc-12145)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 name = "candle-core"
 version = "0.10.2"
-source = "git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87#c1e6756a89faefa888ea57b056394a0619925b87"
+source = "git+https://github.com/huggingface/candle?rev=1e6aa85e867eb007cba1b8bae517a10d1aaf0c0d#1e6aa85e867eb007cba1b8bae517a10d1aaf0c0d"
 dependencies = [
  "byteorder",
  "candle-kernels",
@@ -418,7 +418,6 @@ dependencies = [
  "float8",
  "gemm 0.19.0",
  "half",
- "libc",
  "libm",
  "memmap2",
  "num-traits",
@@ -430,13 +429,13 @@ dependencies = [
  "thiserror 2.0.18",
  "tokenizers 0.22.2",
  "yoke 0.8.2",
- "zip 8.6.0",
+ "zip 7.2.0",
 ]
 
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -454,7 +453,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -465,7 +464,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -478,7 +477,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -491,7 +490,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -510,6 +509,7 @@ dependencies = [
  "candle-gen-krea",
  "candle-gen-lens",
  "candle-gen-ltx",
+ "candle-gen-mochi",
  "candle-gen-pid",
  "candle-gen-pulid",
  "candle-gen-qwen-image",
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -555,7 +555,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -575,7 +575,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -620,7 +620,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -633,7 +633,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -696,9 +696,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-gen-mochi"
+version = "0.0.0"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
+dependencies = [
+ "candle-gen",
+ "candle-gen-flux",
+ "image",
+ "rand 0.9.4",
+ "serde_json",
+ "tokenizers 0.22.2",
+]
+
+[[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-gen",
  "image",
@@ -708,7 +721,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -725,7 +738,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -738,7 +751,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -749,7 +762,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -759,7 +772,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -773,7 +786,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -789,7 +802,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -808,7 +821,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -819,7 +832,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -831,7 +844,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -841,7 +854,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -853,7 +866,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -870,7 +883,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87#c1e6756a89faefa888ea57b056394a0619925b87"
+source = "git+https://github.com/huggingface/candle?rev=1e6aa85e867eb007cba1b8bae517a10d1aaf0c0d#1e6aa85e867eb007cba1b8bae517a10d1aaf0c0d"
 dependencies = [
  "cudaforge",
 ]
@@ -878,7 +891,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -890,7 +903,7 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.10.2"
-source = "git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87#c1e6756a89faefa888ea57b056394a0619925b87"
+source = "git+https://github.com/huggingface/candle?rev=1e6aa85e867eb007cba1b8bae517a10d1aaf0c0d#1e6aa85e867eb007cba1b8bae517a10d1aaf0c0d"
 dependencies = [
  "candle-core",
  "half",
@@ -905,7 +918,7 @@ dependencies = [
 [[package]]
 name = "candle-transformers"
 version = "0.10.2"
-source = "git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87#c1e6756a89faefa888ea57b056394a0619925b87"
+source = "git+https://github.com/huggingface/candle?rev=1e6aa85e867eb007cba1b8bae517a10d1aaf0c0d#1e6aa85e867eb007cba1b8bae517a10d1aaf0c0d"
 dependencies = [
  "byteorder",
  "candle-core",
@@ -923,7 +936,7 @@ dependencies = [
 [[package]]
 name = "candle-ug"
 version = "0.10.2"
-source = "git+https://github.com/huggingface/candle?rev=c1e6756a89faefa888ea57b056394a0619925b87#c1e6756a89faefa888ea57b056394a0619925b87"
+source = "git+https://github.com/huggingface/candle?rev=1e6aa85e867eb007cba1b8bae517a10d1aaf0c0d#1e6aa85e867eb007cba1b8bae517a10d1aaf0c0d"
 dependencies = [
  "ug",
  "ug-cuda",
@@ -1173,7 +1186,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -1841,9 +1854,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
-version = "0.18.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -3632,7 +3645,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3645,7 +3658,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3657,7 +3670,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3670,7 +3683,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3683,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3702,6 +3715,7 @@ dependencies = [
  "mlx-gen-krea",
  "mlx-gen-lens",
  "mlx-gen-ltx",
+ "mlx-gen-mochi",
  "mlx-gen-pid",
  "mlx-gen-pulid",
  "mlx-gen-qwen-image",
@@ -3721,7 +3735,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3734,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -3744,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3753,7 +3767,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3762,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3775,7 +3789,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3787,7 +3801,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -3799,7 +3813,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3811,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -3820,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3832,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3846,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3859,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3868,9 +3882,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mlx-gen-mochi"
+version = "0.0.0"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
+dependencies = [
+ "mlx-gen",
+ "mlx-gen-flux",
+ "pmetal-mlx-rs",
+ "serde_json",
+]
+
+[[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3881,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3892,7 +3917,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3903,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3912,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3921,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3931,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -3942,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3956,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3969,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3979,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -3990,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4000,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4013,7 +4038,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4037,7 +4062,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "core-llm",
  "half",
@@ -4342,7 +4367,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5578,7 +5603,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5588,7 +5613,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "candle-gen-catalog",
  "candle-llm",
@@ -5598,7 +5623,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "mlx-gen-catalog",
  "mlx-llm",
@@ -5876,7 +5901,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.3-rc.0#8d2793831479ea09fcb23ffa4f565f5b91583120"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4-rc.0#358a8d367bdb390bca963be0aec733c07c057e14"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -8288,7 +8313,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9199,6 +9224,18 @@ dependencies = [
  "crc32fast",
  "indexmap 2.14.0",
  "memchr",
+]
+
+[[package]]
+name = "zip"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
+ "typed-path",
 ]
 
 [[package]]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.3-rc.0" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.4-rc.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.3-rc.0" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.4-rc.0" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.3-rc.0", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.4-rc.0", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/pid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pid.rs
@@ -36,6 +36,15 @@ const PID_SDXL_FILE: &str = "pid_sdxl_2kto4k.safetensors";
 // real 2K output). Live alongside the 2kto4k files in the SAME re-host repos (whole-repo download).
 const PID_FLUX_FILE_2K: &str = "pid_flux_2k.safetensors";
 const PID_FLUX2_FILE_2K: &str = "pid_flux2_2k.safetensors";
+// PiD v1.5 `2kto4k` students (sc-12144, epic 7840 PiD-1.5) — flux / flux2 / qwenimage ONLY. NVIDIA
+// shipped no v1.5 for the sdxl latent space and no v1.5 `res2k`, so sdxl stays on its v1.0 2kto4k student
+// and the 2K output tier stays on the v1.0 `res2k` student (which NVIDIA notes is sharper at 2048px than
+// the v1.5 2kto4k). Re-hosted ALONGSIDE the v1.0 files in the SAME repos, so `pid_2kto4k_file` prefers
+// v1.5 when cached and falls back to the on-disk v1.0 for installs that predate it. The engine sniffs the
+// topology (v1.0 vs v1.5) from the weights (sc-12142), so these are just alternative filenames.
+const PID_FLUX_FILE_V1PT5: &str = "pid_flux_2kto4k_v1pt5.safetensors";
+const PID_FLUX2_FILE_V1PT5: &str = "pid_flux2_2kto4k_v1pt5.safetensors";
+const PID_QWENIMAGE_FILE_V1PT5: &str = "pid_qwenimage_2kto4k_v1pt5.safetensors";
 // gemma-2-2b-it is the PiD caption encoder (shared by every backbone). sc-8025 re-hosts the stock
 // weights (no conversion) at the non-gated `SceneWorks/gemma-2-2b-it` mirror so the in-app download
 // needs no Gemma-gated HF token; the catalog `downloads[]` + `pidDecoders.<bb>.gemmaRepo` point here
@@ -192,12 +201,39 @@ fn pid_res2k_file(backbone: &str) -> Option<&'static str> {
     }
 }
 
+/// The PiD **v1.5** `2kto4k` student filename for a backbone that ships one — flux / flux2 / qwenimage
+/// (sc-12144). sdxl has NO v1.5 (NVIDIA shipped none) → `None`, so it stays on its v1.0 2kto4k student.
+fn pid_v1pt5_file(backbone: &str) -> Option<&'static str> {
+    match backbone {
+        "flux" => Some(PID_FLUX_FILE_V1PT5),
+        "flux2" => Some(PID_FLUX2_FILE_V1PT5),
+        "qwenimage" => Some(PID_QWENIMAGE_FILE_V1PT5),
+        _ => None, // sdxl: no v1.5
+    }
+}
+
+/// Resolve the effective `2kto4k` student filename with the **v1.5 → v1.0** fallback (sc-12145): prefer
+/// the re-hosted v1.5 student when this backbone ships one AND it is cached on disk; otherwise the v1.0
+/// `2kto4k` file. The engine sniffs the actual topology from the weights (sc-12142), so the worker only
+/// resolves a path — an install that predates the v1.5 file keeps decoding on its cached v1.0 student
+/// (turning PiD on never breaks after an app update). Same on-disk-check discipline as the res2k swap.
+fn pid_2kto4k_file(backbone: &str, snapshot: &Path, file_v1: &'static str) -> &'static str {
+    if let Some(v1pt5) = pid_v1pt5_file(backbone) {
+        if snapshot.join(v1pt5).exists() {
+            return v1pt5;
+        }
+    }
+    file_v1
+}
+
 /// The effective default PiD checkpoint filename for `backbone` at `tier`, given the resolved `snapshot`
-/// dir (sc-10057). The 2K tier prefers the 2K-tuned res2k student when this backbone ships one AND it is
-/// actually present on disk; otherwise (4K tier, no res2k student, or res2k not yet cached) the multi-res
-/// `2kto4k` student. The on-disk check is the graceful fallback: an install that predates the res2k file
-/// keeps working on 2kto4k rather than resolving a missing path. A per-request `advanced.pidCheckpoint`
-/// override still wins over this (applied by the caller).
+/// dir (sc-10057, sc-12145). Resolution, all on-disk-gated so a partial install degrades gracefully:
+/// - **2K tier**: the 2K-tuned `res2k` student when this backbone ships one AND it's cached — it stays on
+///   **v1.0** (NVIDIA notes v1.5 2kto4k is *less sharp at 2048px*, and there is no v1.5 res2k).
+/// - otherwise (4K tier, or 2K tier with no res2k cached): the `2kto4k` student with the **v1.5 → v1.0**
+///   fallback ([`pid_2kto4k_file`]) — prefer the cached v1.5 student, else the v1.0 file.
+///
+/// A per-request `advanced.pidCheckpoint` override still wins over this (applied by the caller).
 fn pid_default_file(
     backbone: &str,
     tier: PidOutputTier,
@@ -211,7 +247,7 @@ fn pid_default_file(
             }
         }
     }
-    file_2kto4k
+    pid_2kto4k_file(backbone, snapshot, file_2kto4k)
 }
 
 /// Resolve the per-generation PiD decoder weights for `model`, or `None` to keep the native VAE decode.
@@ -471,6 +507,88 @@ mod pid_tests {
         assert_eq!(pid_res2k_file("flux2"), Some(PID_FLUX2_FILE_2K));
         assert_eq!(pid_res2k_file("qwenimage"), None);
         assert_eq!(pid_res2k_file("sdxl"), None);
+    }
+
+    #[test]
+    fn pid_v1pt5_file_flux_flux2_qwen_only() {
+        // sc-12144: v1.5 ships for flux / flux2 / qwenimage. sdxl has no v1.5.
+        assert_eq!(pid_v1pt5_file("flux"), Some(PID_FLUX_FILE_V1PT5));
+        assert_eq!(pid_v1pt5_file("flux2"), Some(PID_FLUX2_FILE_V1PT5));
+        assert_eq!(pid_v1pt5_file("qwenimage"), Some(PID_QWENIMAGE_FILE_V1PT5));
+        assert_eq!(pid_v1pt5_file("sdxl"), None);
+    }
+
+    #[test]
+    fn pid_2kto4k_file_prefers_v1pt5_when_cached_else_v1() {
+        // sc-12145 fallback: v1.5 on disk → v1.5; only v1.0 on disk → v1.0.
+        let dir = tempfile::tempdir().unwrap();
+        let snap = dir.path();
+        // Neither cached → v1.0 file (the passed fallback).
+        assert_eq!(
+            pid_2kto4k_file("flux", snap, PID_FLUX_FILE),
+            PID_FLUX_FILE,
+            "no v1.5 on disk → v1.0"
+        );
+        // v1.5 cached → v1.5.
+        std::fs::write(snap.join(PID_FLUX_FILE_V1PT5), b"x").unwrap();
+        assert_eq!(
+            pid_2kto4k_file("flux", snap, PID_FLUX_FILE),
+            PID_FLUX_FILE_V1PT5,
+            "v1.5 cached → v1.5"
+        );
+        // qwenimage too.
+        let qdir = tempfile::tempdir().unwrap();
+        std::fs::write(qdir.path().join(PID_QWENIMAGE_FILE_V1PT5), b"x").unwrap();
+        assert_eq!(
+            pid_2kto4k_file("qwenimage", qdir.path(), PID_QWENIMAGE_FILE),
+            PID_QWENIMAGE_FILE_V1PT5
+        );
+        // sdxl has no v1.5 → always the v1.0 2kto4k, even with a stray v1.5-named file present.
+        let sdir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            pid_2kto4k_file("sdxl", sdir.path(), PID_SDXL_FILE),
+            PID_SDXL_FILE
+        );
+    }
+
+    #[test]
+    fn pid_default_file_4k_tier_prefers_v1pt5() {
+        let dir = tempfile::tempdir().unwrap();
+        let snap = dir.path();
+        // 4K tier, only v1.0 cached → v1.0.
+        assert_eq!(
+            pid_default_file("flux", PidOutputTier::Res4k, snap, PID_FLUX_FILE),
+            PID_FLUX_FILE
+        );
+        // 4K tier, v1.5 cached → v1.5.
+        std::fs::write(snap.join(PID_FLUX_FILE_V1PT5), b"x").unwrap();
+        assert_eq!(
+            pid_default_file("flux", PidOutputTier::Res4k, snap, PID_FLUX_FILE),
+            PID_FLUX_FILE_V1PT5
+        );
+    }
+
+    #[test]
+    fn pid_default_file_2k_tier_res2k_beats_v1pt5_2kto4k() {
+        // sc-12145: at the 2K output tier the v1.0 res2k student wins over the v1.5 2kto4k (sharper at
+        // 2048px), even when both are cached. Only when res2k is absent does the 2K tier fall to the
+        // v1.5-preferred 2kto4k.
+        let dir = tempfile::tempdir().unwrap();
+        let snap = dir.path();
+        std::fs::write(snap.join(PID_FLUX_FILE_2K), b"x").unwrap(); // res2k (v1.0)
+        std::fs::write(snap.join(PID_FLUX_FILE_V1PT5), b"x").unwrap(); // v1.5 2kto4k
+        assert_eq!(
+            pid_default_file("flux", PidOutputTier::Res2k, snap, PID_FLUX_FILE),
+            PID_FLUX_FILE_2K,
+            "2K tier prefers the v1.0 res2k student over the v1.5 2kto4k"
+        );
+        // res2k absent but v1.5 present → 2K tier falls to the v1.5 2kto4k.
+        let d2 = tempfile::tempdir().unwrap();
+        std::fs::write(d2.path().join(PID_FLUX_FILE_V1PT5), b"x").unwrap();
+        assert_eq!(
+            pid_default_file("flux", PidOutputTier::Res2k, d2.path(), PID_FLUX_FILE),
+            PID_FLUX_FILE_V1PT5
+        );
     }
 
     #[test]


### PR DESCRIPTION
Lands **NVIDIA PiD v1.5** in the app (epic 7840, PiD 1.5 upgrade). The engine side merged in `SceneWorks/inference` (mlx [#22](https://github.com/SceneWorks/inference/pull/22), candle [#24](https://github.com/SceneWorks/inference/pull/24)); the checkpoints are re-hosted (sc-12144). This PR pins the runtime and threads v1.5 through the worker's decoder resolve.

## What changed
- **Runtime re-pin** — `Cargo.toml` / `Cargo.lock`: `sceneworks-gen-core` / `runtime-macos` / `runtime-cuda` → **`runtime-2026.07.4-rc.0`** (main @ `358a8d36`, both engine PRs merged + CI-green).
- **`image_jobs/pid.rs`** — v1.5 filename consts (`pid_{flux,flux2,qwenimage}_2kto4k_v1pt5.safetensors`); `pid_v1pt5_file` + `pid_2kto4k_file` implement the **v1.5 → v1.0 on-disk fallback** so turning PiD on never breaks after an update (prefer the cached v1.5 student, else the cached v1.0, else native VAE). `pid_default_file`: the **2K tier stays on the v1.0 `res2k`** student (sharper at 2048px; NVIDIA shipped no v1.5 res2k), the **4K tier prefers v1.5**. **sdxl unchanged** (no v1.5). The engine sniffs v1.0-vs-v1.5 from the weights, so the worker only resolves a path.

## Coverage
v1.5 lands for **flux / flux2 / qwenimage** (so FLUX.1/Boogu/Chroma/Z-Image, FLUX.2/klein/Lens/Ideogram, Qwen-Image/Krea). **sdxl-space models** (SDXL/RealVisXL/Kolors/InstantID/Illustrious) stay on v1.0 — NVIDIA released no v1.5 for that latent space.

## Notes
- Catalog needs no change — PiD footprint auto-sizes from the live HF estimate, and the whole-repo download now fetches the v1.5 file.
- Fresh-install footprint dedup (whole-repo also pulls the now-redundant v1.0 2kto4k) is tracked as a follow-up (sc-12170).

## Verification
- **17 pid unit tests green** — v1.5-cached→v1.5, only-v1.0→v1.0, 2K-tier res2k beats v1.5, res2k-absent→v1.5, sdxl→v1.0, mapping.
- **`npm run rust:check` green** against the new runtime tag (full workspace build + test).
- Engine parity (both backends, all three backbones) verified in #22/#24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)