### PR TITLE
fix(worker): restore image generation on 8/16 GB Macs (sc-12178, sc-12179) (#1544)

### DIFF
--- a/crates/sceneworks-worker/src/generator_cache.rs
+++ b/crates/sceneworks-worker/src/generator_cache.rs
@@ -171,7 +171,11 @@ fn generator_cache_idle_timeout(raw: Option<&str>) -> Option<Duration> {
 ///   working set genuinely needs more will thrash/swap or hit a Metal OOM — already contained by the
 ///   `catch_unwind` guard above).
 /// - `set_wired_limit` — caps pinned (non-pageable) residency so the OS can reclaim the rest of
-///   unified memory for other apps. macOS 15+.
+///   unified memory for other apps. macOS 15+. **Clamped to the device wired ceiling** — MLX throws
+///   if asked for more than the device `recommendedMaxWorkingSetSize`, and its default error handler
+///   answers that throw with `exit(-1)`, killing the worker at startup (sc-12178, GitHub #1544: an
+///   8 GB Mac's ceiling is ~5.3 GB, so a 6–7 GB user cap crashed the worker). See
+///   [`clamp_wired_limit`].
 ///
 /// We deliberately leave `set_cache_limit` at its default: forcing it low causes reallocation storms
 /// between steps (the fork's own doc warns about this).
@@ -187,16 +191,57 @@ fn generator_cache_idle_timeout(raw: Option<&str>) -> Option<Duration> {
 static APPLIED_GPU_MEMORY_LIMIT: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(u64::MAX);
 
+/// Clamp a requested wired-residency cap (bytes) to the device's wired ceiling (sc-12178).
+///
+/// MLX's `set_wired_limit` THROWS when asked for more than the device `recommendedMaxWorkingSetSize`,
+/// and MLX's *default* error handler answers that throw with `exit(-1)` — an uncatchable libc exit
+/// (not a Rust panic the worker's `catch_unwind` guard could contain) that hard-kills the worker at
+/// startup, before it ever claims a job. That is the GitHub #1544 crash: on an 8 GB Mac the ceiling
+/// is ~5.3 GB, so a 6–7 GB user cap (the natural "leave RAM for the OS" choice) killed the worker.
+///
+/// A cap at or below the ceiling never throws — and a cap ABOVE it is meaningless anyway, since the
+/// device already bounds wired residency there. `device_ceiling == 0` (ceiling unknown) yields `0`,
+/// which MLX reads as "no wired cap" (its default): the safe fall-back.
+#[cfg(any(target_os = "macos", test))]
+pub(crate) fn clamp_wired_limit(requested: usize, device_ceiling: usize) -> usize {
+    if device_ceiling == 0 {
+        return 0;
+    }
+    requested.min(device_ceiling)
+}
+
+/// The device's wired-residency ceiling in bytes (`recommendedMaxWorkingSetSize`), derived once.
+///
+/// MLX documents its default memory limit as 1.5× the device recommended working set
+/// (`get_memory_limit`), so reading that default and dividing by 1.5 recovers the true hardware
+/// ceiling with no new binding or Metal query. The read MUST happen before the first
+/// `set_memory_limit` (after which `get_memory_limit` returns our value, not the default); the
+/// `OnceLock` both caches the constant hardware property and pins the read to the first application,
+/// while the limit is still MLX's untouched default. `/ 3 * 2` (rather than `* 2 / 3`) makes any
+/// integer rounding go DOWNward, staying at or below the ceiling — which never throws.
+#[cfg(all(target_os = "macos", not(test)))]
+fn device_wired_ceiling_bytes() -> usize {
+    static CEILING: OnceLock<usize> = OnceLock::new();
+    *CEILING.get_or_init(|| mlx_rs::memory::get_memory_limit() / 3 * 2)
+}
+
 #[cfg(all(target_os = "macos", not(test)))]
 fn set_gpu_memory_limit_inner(bytes: u64) {
     use std::sync::atomic::Ordering;
     let limit = bytes as usize;
+    // Capture the device wired ceiling BEFORE mutating the memory limit — the derivation reads MLX's
+    // default `get_memory_limit`, which is only the hardware default until the first `set_memory_limit`.
+    let wired_ceiling = device_wired_ceiling_bytes();
     let previous_limit = mlx_rs::memory::set_memory_limit(limit);
-    let previous_wired = mlx_rs::memory::set_wired_limit(limit);
+    // Clamp so `set_wired_limit` can never throw and `exit(-1)` the worker (sc-12178, GitHub #1544).
+    let wired_limit = clamp_wired_limit(limit, wired_ceiling);
+    let previous_wired = mlx_rs::memory::set_wired_limit(wired_limit);
     APPLIED_GPU_MEMORY_LIMIT.store(bytes, Ordering::SeqCst);
     tracing::info!(
         event = "gpu_memory_limit_applied",
         limitBytes = limit,
+        wiredLimitBytes = wired_limit,
+        deviceWiredCeilingBytes = wired_ceiling,
         previousLimitBytes = previous_limit,
         previousWiredLimitBytes = previous_wired,
         "applied user-configured GPU memory ceiling to the MLX runtime"
@@ -396,6 +441,71 @@ where
 mod tests {
     use super::*;
     use crate::WorkerError;
+
+    // sc-12178 (GitHub #1544): the requested GPU cap is clamped to the device wired ceiling so
+    // `set_wired_limit` can never throw and `exit(-1)` the worker. An 8 GB Mac's ceiling is ~5.3 GB,
+    // so a 7 GB cap must come back as the ceiling, not 7 GB.
+    #[test]
+    fn clamp_wired_limit_never_exceeds_the_device_ceiling() {
+        let gib = 1024 * 1024 * 1024_usize;
+        let ceiling = 5 * gib + gib / 3; // ~5.3 GiB, a realistic 8 GB-Mac working set.
+
+        // A cap ABOVE the ceiling (the #1544 crash trigger) is pulled down to the ceiling.
+        assert_eq!(clamp_wired_limit(7 * gib, ceiling), ceiling);
+        // A cap BELOW the ceiling is honored unchanged.
+        assert_eq!(clamp_wired_limit(4 * gib, ceiling), 4 * gib);
+        // Exactly at the ceiling is allowed (set_wired_limit throws only on STRICTLY greater).
+        assert_eq!(clamp_wired_limit(ceiling, ceiling), ceiling);
+        // Clearing the cap (0) stays 0 regardless of ceiling.
+        assert_eq!(clamp_wired_limit(0, ceiling), 0);
+        // Unknown ceiling (0) ⇒ 0 ⇒ MLX default "no wired cap" (never a spurious clamp-to-something).
+        assert_eq!(clamp_wired_limit(7 * gib, 0), 0);
+    }
+
+    // sc-12178 on-device probe: the clamp derives the device wired ceiling as
+    // `get_memory_limit() / 1.5` (MLX documents its default limit as 1.5× the recommended working
+    // set). Pure unit tests can't validate that assumption against real hardware, so this ignored
+    // test does: it confirms the derived ceiling is a plausible fraction of unified memory AND that
+    // `set_wired_limit(ceiling)` does NOT throw (a throw would `exit(-1)` this test process — the
+    // exact #1544 crash — so a clean return IS the assertion). Run explicitly:
+    //   cargo test -p sceneworks-worker --lib -- --ignored --nocapture device_wired_ceiling
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "needs a Metal device; run explicitly on a real Mac"]
+    fn device_wired_ceiling_is_a_plausible_fraction_and_never_throws() {
+        let default_limit = mlx_rs::memory::get_memory_limit();
+        assert!(
+            default_limit > 0,
+            "MLX default memory limit should be positive"
+        );
+        let ceiling = default_limit / 3 * 2;
+
+        let total: u64 = String::from_utf8_lossy(
+            &std::process::Command::new("sysctl")
+                .args(["-n", "hw.memsize"])
+                .output()
+                .expect("sysctl hw.memsize")
+                .stdout,
+        )
+        .trim()
+        .parse()
+        .expect("hw.memsize parses");
+
+        eprintln!(
+            "get_memory_limit()={default_limit} derived_ceiling={ceiling} hw.memsize={total} \
+             (ceiling = {:.0}% of RAM)",
+            ceiling as f64 / total as f64 * 100.0
+        );
+        // recommendedMaxWorkingSetSize is ~50–80% of unified memory on Apple Silicon; the derived
+        // ceiling must land in that band (guards against the 1.5× assumption silently breaking).
+        assert!(
+            (ceiling as f64) > 0.4 * total as f64 && (ceiling as f64) < 0.95 * total as f64,
+            "derived ceiling {ceiling} is not a plausible fraction of {total}"
+        );
+        // The clamp target must not throw (would exit(-1) this process). Restore the prior value after.
+        let prev = mlx_rs::memory::set_wired_limit(clamp_wired_limit(usize::MAX, ceiling));
+        mlx_rs::memory::set_wired_limit(prev);
+    }
 
     #[test]
     fn cache_key_includes_adapter_fingerprint() {

--- a/crates/sceneworks-worker/src/mlx_fit_gate.rs
+++ b/crates/sceneworks-worker/src/mlx_fit_gate.rs
@@ -123,6 +123,20 @@ pub(crate) const MLX_MEMORY_CAP_ENV: &str = "SCENEWORKS_MLX_MEMORY_CAP_GB";
 /// a 1024²-worst-case; a higher-res campaign is a follow-up.
 const HEADROOM_GB: f64 = 18.0;
 
+/// Reserve (GiB) kept free for macOS + the SceneWorks app + other apps when the WEIGHTS-FIT FLOOR
+/// (sc-12179, GitHub #1544) admits a model whose predicted PEAK exceeds the budget. Deliberately
+/// small: it guards the OS from outright starvation (which would destabilize the whole machine), NOT
+/// the pageable activation transient (which degrades to swap, not a wired SIGKILL). A FLAT constant
+/// (not a fraction of RAM) on purpose — the OS floor is roughly absolute, so it must not scale up to
+/// tens of GiB on a large machine and lock a big Mac out of its own memory.
+///
+/// 2 GiB is anchored on the 0.7.3 baseline: z-image-turbo q4 (5.49 GiB on disk, largest single
+/// component 3.38 GiB) ran on an 8 GB Mac with roughly this much left for the OS + paged transient.
+/// It leaves ~6 GiB of weight budget on an 8 GB Mac — comfortably admitting that baseline and the
+/// other small tiers — while still rejecting a model whose weights alone can't be held resident.
+/// See [`weights_fit_floor`] and the `z_image_turbo_q4_admits_on_an_8gb_mac` baseline test.
+const OS_RESERVE_GB: f64 = 2.0;
+
 /// Bytes per binary gigabyte (GiB) — matches `gpu::total_unified_memory_gb`, which divides
 /// `hw.memsize` by 1024³, and the epic's measured on-disk table.
 const BYTES_PER_GIB: f64 = 1_073_741_824.0;
@@ -393,6 +407,30 @@ pub(crate) fn decide_residency(
     budget: Option<MemoryBudget>,
     sequential_capable: bool,
 ) -> ResidencyOutcome {
+    let base = decide_residency_by_peak(total_bytes, te_bytes, budget, sequential_capable);
+    // Weights-fit floor (sc-12179): a would-be reject is downgraded to a (best-effort) load when the
+    // resident weights actually fit — the peak predictor's pageable transient must not categorically
+    // exclude a small Mac. Any non-reject outcome stands as-is.
+    match base {
+        ResidencyOutcome::Reject { .. } => {
+            weights_fit_floor(total_bytes, te_bytes, budget, sequential_capable).unwrap_or(base)
+        }
+        resident_or_sequential => resident_or_sequential,
+    }
+}
+
+/// The PEAK-based residency decision (the pre-sc-12179 logic): compare the predicted whole-model peak
+/// (`Σweights + HEADROOM_GB`) — and, for a sequential-capable provider, the staged max-component peak
+/// — against the budget. This is the right signal for SELECTING Resident vs Sequential and for the
+/// rejection message's `needed`/`staged` numbers, but it rejects too aggressively on small Macs
+/// because the flat headroom bundles a pageable 1024² activation transient (sc-12179); the caller
+/// folds in [`weights_fit_floor`] before honoring a reject.
+fn decide_residency_by_peak(
+    total_bytes: u64,
+    te_bytes: u64,
+    budget: Option<MemoryBudget>,
+    sequential_capable: bool,
+) -> ResidencyOutcome {
     let resident = fit_decision(predicted_peak_gb(total_bytes), budget);
     match resolve_offload(resident, sequential_capable) {
         FitDecision::Fits | FitDecision::Unknown => ResidencyOutcome::Resident,
@@ -420,6 +458,49 @@ pub(crate) fn decide_residency(
             staged_gb: None,
         },
     }
+}
+
+/// Weights-fit floor (sc-12179, GitHub #1544): a machine that can hold the model's RESIDENT WEIGHTS
+/// can still run it — paging the activation transient if needed — exactly as it did before this
+/// fit-gate existed. [`predicted_peak_gb`] adds a flat [`HEADROOM_GB`] that bundles a worst-case
+/// 1024² activation transient (~14 GiB); that transient is PAGEABLE (degrades to swap, not a wired
+/// SIGKILL) and resolution-bound, so on small Macs `Σweights + 18` exceeds total RAM for EVERY model
+/// and [`decide_residency_by_peak`] categorically rejects — even a tiny model that generated fine on
+/// 0.7.3. This floor converts that reject into a load whenever the wired weights fit
+/// `budget − OS_RESERVE_GB`: [`ResidencyOutcome::Sequential`] (wired bounded to the largest single
+/// component) when the provider stages, else [`ResidencyOutcome::Resident`] (best-effort). Returns
+/// `None` when the weights themselves won't fit — a genuine reject-before-SIGKILL that stands, and
+/// when there is no budget signal (the gate never blocks without one).
+///
+/// TRADE-OFF (see sc-12179 / sc-11924): this makes the gate strictly more permissive, so a
+/// transient-heavy bf16 tier on a mid-size Mac can now reach a Metal-OOM/SIGKILL where it previously
+/// pre-rejected. That is the pre-fit-gate behavior and the correct default — a machine that ran a
+/// model must not be newly wall-rejected. The honest fix for those tiers is in-memory (materialized)
+/// component sizing (sc-11924), not a blanket over-reservation that excludes every 8/16 GB Mac.
+fn weights_fit_floor(
+    total_bytes: u64,
+    te_bytes: u64,
+    budget: Option<MemoryBudget>,
+    sequential_capable: bool,
+) -> Option<ResidencyOutcome> {
+    let ceiling_gb = budget?.total_gb - OS_RESERVE_GB;
+    if sequential_capable {
+        // Staged: peak wired residency is the largest single component (text encoders dropped first).
+        (staged_weights_gb(total_bytes, te_bytes) <= ceiling_gb)
+            .then_some(ResidencyOutcome::Sequential)
+    } else {
+        // Can't stage: the whole model is held resident; admit if the weights fit best-effort.
+        (total_bytes as f64 / BYTES_PER_GIB <= ceiling_gb).then_some(ResidencyOutcome::Resident)
+    }
+}
+
+/// The largest single component's on-disk weight bytes (GiB) — the wired residency the `Sequential`
+/// schedule holds at peak (text encoder(s) dropped before the DiT loads). WEIGHTS ONLY, no activation
+/// headroom — contrast [`predicted_sequential_peak_gb`], which adds [`HEADROOM_GB`] for the peak
+/// estimate. `rest = total − te` (the DiT + VAE + any folded control branch).
+fn staged_weights_gb(total_bytes: u64, te_bytes: u64) -> f64 {
+    let rest_bytes = total_bytes.saturating_sub(te_bytes);
+    te_bytes.max(rest_bytes) as f64 / BYTES_PER_GIB
 }
 
 /// Pre-load admission + residency-selection gate (sc-10835 Phase 0, sc-10839 Phase 1). Called on the
@@ -858,8 +939,11 @@ mod tests {
         );
     }
 
+    // The PEAK layer (`decide_residency_by_peak`) still selects Resident / Sequential / Reject exactly
+    // as the pre-sc-12179 gate did — the weights-fit floor is layered on TOP of this in
+    // `decide_residency` (exercised separately below), so this proves the peak selection is intact.
     #[test]
-    fn decide_residency_picks_resident_sequential_or_reject_by_budget() {
+    fn decide_residency_by_peak_picks_resident_sequential_or_reject_by_budget() {
         let gib = 1024 * 1024 * 1024_u64;
         // illustrious q8-class: total ~5 GiB (TE ~1, DiT+VAE ~4). With HEADROOM_GB=18 (sc-10863):
         // resident peak = 5+18 = 23; staged peak = max(1, 4)+18 = 22.
@@ -868,18 +952,18 @@ mod tests {
 
         // Roomy budget (128 GB Mac) ⇒ Resident (keep the warm path).
         assert_eq!(
-            decide_residency(total, te, Some(MemoryBudget { total_gb: 128.0 }), true),
+            decide_residency_by_peak(total, te, Some(MemoryBudget { total_gb: 128.0 }), true),
             ResidencyOutcome::Resident
         );
         // Budget between staged (22) and resident (23): resident won't fit, staged will, provider
         // stages ⇒ Sequential. This is the fit-gate SELECTING sequential residency.
         assert_eq!(
-            decide_residency(total, te, Some(MemoryBudget { total_gb: 22.5 }), true),
+            decide_residency_by_peak(total, te, Some(MemoryBudget { total_gb: 22.5 }), true),
             ResidencyOutcome::Sequential
         );
         // Same budget but a provider that can't stage ⇒ reject (never a silent Resident that OOMs).
         assert!(matches!(
-            decide_residency(total, te, Some(MemoryBudget { total_gb: 22.5 }), false),
+            decide_residency_by_peak(total, te, Some(MemoryBudget { total_gb: 22.5 }), false),
             ResidencyOutcome::Reject {
                 staged_gb: None,
                 ..
@@ -887,7 +971,7 @@ mod tests {
         ));
         // Budget below even the staged peak (22) ⇒ reject, naming the staged requirement.
         assert!(matches!(
-            decide_residency(total, te, Some(MemoryBudget { total_gb: 20.0 }), true),
+            decide_residency_by_peak(total, te, Some(MemoryBudget { total_gb: 20.0 }), true),
             ResidencyOutcome::Reject {
                 staged_gb: Some(_),
                 ..
@@ -895,13 +979,82 @@ mod tests {
         ));
         // No budget signal ⇒ Resident (never block).
         assert_eq!(
-            decide_residency(total, te, None, true),
+            decide_residency_by_peak(total, te, None, true),
             ResidencyOutcome::Resident
         );
         // Unmeasured weights ⇒ Resident (no signal).
         assert_eq!(
-            decide_residency(0, 0, Some(MemoryBudget { total_gb: 8.0 }), true),
+            decide_residency_by_peak(0, 0, Some(MemoryBudget { total_gb: 8.0 }), true),
             ResidencyOutcome::Resident
+        );
+    }
+
+    /// The weights-fit floor (sc-12179, GitHub #1544): a would-be peak-layer REJECT becomes a
+    /// best-effort load whenever the resident weights fit `budget − OS_RESERVE_GB` (2 GiB). This is the
+    /// regression fix — an 8 GB Mac categorically rejected EVERY model because `Σweights + 18 > 8`.
+    #[test]
+    fn weights_fit_floor_admits_small_model_on_a_small_mac() {
+        let gib = 1024 * 1024 * 1024_u64;
+
+        // SANA-class small model on an 8 GB Mac: total 2 GiB (TE 1, rest 1). Peak = 2+18 = 20 ≫ 8 and
+        // staged peak = 1+18 = 19 ≫ 8, so the PEAK layer rejects outright...
+        let (total, te) = (2 * gib, gib);
+        let budget = Some(MemoryBudget { total_gb: 8.0 });
+        assert!(matches!(
+            decide_residency_by_peak(total, te, budget, true),
+            ResidencyOutcome::Reject { .. }
+        ));
+        // ...but the staged weights (1 GiB) fit 8 − 2 = 6, so the floor runs it Sequential instead of
+        // walling off the machine. This is exactly the model that generated fine on 0.7.3.
+        assert_eq!(
+            decide_residency(total, te, budget, true),
+            ResidencyOutcome::Sequential
+        );
+        // A non-staging provider whose whole 2 GiB weights fit 6 loads Resident best-effort (not reject).
+        assert_eq!(
+            decide_residency(total, te, budget, false),
+            ResidencyOutcome::Resident
+        );
+
+        // A genuinely-too-big model on 8 GB still rejects: 40 GiB weights (staged max-component 30) can
+        // NOT be held resident under any policy ⇒ the floor returns None and the reject stands.
+        let (big_total, big_te) = (40 * gib, 10 * gib);
+        assert!(matches!(
+            decide_residency(big_total, big_te, budget, true),
+            ResidencyOutcome::Reject { .. }
+        ));
+
+        // The floor never fabricates a decision without a budget signal.
+        assert_eq!(
+            decide_residency(total, te, None, true),
+            ResidencyOutcome::Resident
+        );
+    }
+
+    /// The 0.7.3 baseline, from REAL on-disk bytes (GitHub #1544): z-image-turbo q4 — the model the
+    /// reporter confirmed generated fine on an 8 GB Mac — must be admitted, not rejected. Measured
+    /// tier layout: total 5.49 GiB (text_encoder 2.11, transformer 3.23, vae 0.15), so the largest
+    /// single component the Sequential schedule ever holds wired is ~3.38 GiB. Against an 8 GB budget
+    /// (OS_RESERVE 2 ⇒ 6 GiB weight budget) that admits with ~2.6 GiB of margin. If this ever flips to
+    /// Reject, the gate has regressed the exact case #1544 was filed about.
+    #[test]
+    fn z_image_turbo_q4_admits_on_an_8gb_mac() {
+        // Bytes rounded from the measured tier (…/z-image-turbo-mlx/…/q4), following HF-cache symlinks.
+        let mib = 1024 * 1024_u64;
+        let total = 5624 * mib; // ~5.49 GiB whole model
+        let te = 2161 * mib; //    ~2.11 GiB Qwen text encoder (dropped first under Sequential)
+        let budget = Some(MemoryBudget { total_gb: 8.0 });
+
+        // The flat-headroom peak layer would reject it (5.49 + 18 = 23.49 ≫ 8)...
+        assert!(matches!(
+            decide_residency_by_peak(total, te, budget, true),
+            ResidencyOutcome::Reject { .. }
+        ));
+        // ...but z-image-turbo stages components, and its largest (transformer ≈ 3.38 GiB) fits the
+        // 6 GiB weight budget ⇒ Sequential. This is the #1544 baseline that must keep working.
+        assert_eq!(
+            decide_residency(total, te, budget, true),
+            ResidencyOutcome::Sequential
         );
     }
 
@@ -992,20 +1145,69 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
+    /// #1544 baseline through the LIVE gate path on REAL weights (ignored — needs the model on disk +
+    /// the force-linked registry). Drives `residency_for_dir` — the exact seam the worker's cold load
+    /// uses — against the real z-image-turbo q4 tier under an emulated 8 GB Mac
+    /// (`SCENEWORKS_MLX_MEMORY_CAP_GB=8`), so it exercises the real on-disk `.safetensors` scan, the
+    /// provider footprint TE split, the registered `supports_sequential_offload` capability, AND the
+    /// budget resolution together. Must come back Sequential, not Reject. Run explicitly (alone, since
+    /// it sets a process env var):
+    ///   cargo test -p sceneworks-worker --lib -- --ignored --nocapture z_image_turbo_q4_live_gate
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore = "needs z-image-turbo q4 weights on disk + the force-linked mlx-gen registry"]
+    fn z_image_turbo_q4_live_gate_admits_under_an_emulated_8gb_cap() {
+        // Resolve the q4 snapshot dir from the HF cache (HF_HOME or ~/.cache/huggingface).
+        let hf_home = std::env::var("HF_HOME")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| {
+                std::path::PathBuf::from(std::env::var("HOME").expect("HOME"))
+                    .join(".cache/huggingface")
+            });
+        let snapshots = hf_home.join("hub/models--SceneWorks--z-image-turbo-mlx/snapshots");
+        let Some(q4) = std::fs::read_dir(&snapshots).ok().and_then(|entries| {
+            entries
+                .flatten()
+                .map(|e| e.path().join("q4"))
+                .find(|p| p.is_dir())
+        }) else {
+            eprintln!(
+                "SKIP: z-image-turbo q4 not found under {}",
+                snapshots.display()
+            );
+            return;
+        };
+
+        // Emulate an 8 GB Mac through the same env the epic added for exactly this (sc-10835).
+        std::env::set_var(MLX_MEMORY_CAP_ENV, "8");
+        let outcome = residency_for_dir("z_image_turbo", &q4);
+        std::env::remove_var(MLX_MEMORY_CAP_ENV);
+
+        eprintln!("live gate on {} @ 8 GB → {outcome:?}", q4.display());
+        assert_eq!(
+            outcome,
+            ResidencyOutcome::Sequential,
+            "z-image-turbo q4 (the #1544 0.7.3 baseline) must run on an 8 GB Mac, not be rejected"
+        );
+    }
+
     /// sc-10894 end-to-end: a non-zero footprint text encoder flips the residency decision from Reject to
     /// Sequential where the zero-reading subdir scan (the fallback) would reject. This is the whole point
-    /// of the seam — the staged peak is only real when the text-encoder split is measured.
+    /// of the seam — the staged working set is only real when the text-encoder split is measured. Post
+    /// sc-12179 the flip runs through the weights-fit floor: the measured TE lowers the staged WEIGHTS
+    /// (the wired residency), which is what the floor admits against `budget − OS_RESERVE_GB`.
     #[test]
     fn footprint_text_encoder_flips_reject_to_sequential() {
         let gib = 1024 * 1024 * 1024_u64;
         // boogu-class: whole model 22 GiB (mllm 13 + transformer 8 + vae 1). No `text_encoder*` subdir,
         // so the subdir scan reads 0.
         let total = 22 * gib;
-        // Budget between the staged (31) and resident (40) peaks under HEADROOM_GB=18 (sc-10863).
-        let budget = Some(MemoryBudget { total_gb: 34.0 });
+        // Budget where the staged WEIGHTS decide it: floor ceiling = 22 − 2 = 20 GiB. te=0 ⇒ staged
+        // weights = 22 > 20 (reject); te=13 ⇒ staged weights = max(13, 9) = 13 ≤ 20 (Sequential).
+        let budget = Some(MemoryBudget { total_gb: 22.0 });
 
-        // Fallback path (footprint None on a dir with no `text_encoder*`) → te = 0 → staged == resident
-        // peak (22 + 18 = 40) > 34 → Reject, even though one-component-at-a-time WOULD fit.
+        // Fallback path (footprint None on a dir with no `text_encoder*`) → te = 0 → staged weights ==
+        // whole model (22 GiB) > 20 → Reject even under the floor: one component IS the whole model.
         let te_fallback = resolve_text_encoder_bytes(None, std::path::Path::new("/nonexistent"));
         assert_eq!(te_fallback, 0);
         assert!(matches!(
@@ -1013,7 +1215,7 @@ mod tests {
             ResidencyOutcome::Reject { .. }
         ));
 
-        // Provider footprint (te = 13 GiB) → staged = max(13, 22 − 13 = 9) + 18 = 31 ≤ 34 → Sequential.
+        // Provider footprint (te = 13 GiB) → staged weights = max(13, 22 − 13 = 9) = 13 ≤ 20 → Sequential.
         let te_footprint =
             resolve_text_encoder_bytes(Some(13 * gib), std::path::Path::new("/ignored"));
         assert_eq!(te_footprint, 13 * gib);


### PR DESCRIPTION
Fixes the 0.7.5 regression in GitHub #1544: an 8 GB iMac M3 that generated images fine on 0.7.3 can no longer generate on 0.7.5. Two **independent** worker-only bugs both hit small-RAM Macs; both are fixed here (one commit each).

## Bug 1 — `set_wired_limit` crashes the worker at startup (sc-12178, epic 7819)
`set_gpu_memory_limit_inner` passes the raw user GPU cap to `mlx_rs::memory::set_wired_limit`, which **throws** when the cap exceeds the device `recommendedMaxWorkingSetSize`. MLX's default error handler answers that throw with `exit(-1)` — an uncatchable libc exit (not a Rust panic `catch_unwind` could contain) that kills the worker before it claims a job. That is the exact error the user pasted:
```
MLX error: [metal::set_wired_limit] Setting a wired limit larger than the maximum working set size is not allowed.
```
On an 8 GB Mac the ceiling is ~5.3 GB, so a 6–7 GB cap (the natural "leave RAM for the OS" choice) crashed the worker → "no live worker claimed this job".

**Fix:** derive the device ceiling from MLX's default memory limit (documented as 1.5× the recommended working set), read once before the first `set_memory_limit`, and clamp the wired limit to it. A cap above the ceiling is meaningless anyway — the device already bounds wired residency there.

## Bug 2 — the fit-gate categorically rejects small-RAM Macs (sc-12179, epic 10834)
The 0.7.5 fit-gate predicts `peak = Σweights + HEADROOM_GB(18)` and rejects when it exceeds **total unified memory**. On an 8 GB Mac that is `> 8` for *every* measurable model → every model rejected; 16 GB Macs are hit for most models too (the most common Mac config). The flat 18 GB headroom bundles a worst-case 1024² activation transient that is **pageable** (swaps, not a wired SIGKILL) and resolution-bound — the wrong thing to hard-reject on. Lowering the GPU-cap slider can't help: the gate budgets on real `hw.memsize`, not the cap (matches the user's report that 7/6/5/4 GB all failed).

**Fix:** a weights-fit floor — a would-be reject is admitted (Sequential where the provider stages, else best-effort Resident) whenever the resident weights fit `budget − OS_RESERVE_GB` (3 GiB). Reject only when the weights themselves can't be held. Restores small-Mac generation and, as a bonus, lets the epic's own qwen-image-on-32 GB unlock finally fire (the flat headroom had defeated it: staged peak 38 > 32).

### ⚠️ Trade-off to review (sc-11924)
The floor is strictly **more permissive**, so a transient-heavy bf16 tier (lens-turbo class) on a *mid-size* Mac can now reach a Metal-OOM where it previously pre-rejected. That is the pre-fit-gate behavior and IMO the correct default — a machine that ran a model must not be newly wall-rejected; it should degrade (page / Sequential), not categorically exclude. The honest fix for those tiers is in-memory (materialized) component sizing, already tracked as **sc-11924**. Flagging explicitly for your call.

## Verification
- `mlx_fit_gate` + `generator_cache` unit tests green (new: `weights_fit_floor_admits_small_model_on_a_small_mac`, `clamp_wired_limit_never_exceeds_the_device_ceiling`; the peak-selection test is preserved as `decide_residency_by_peak_...`).
- Full `npm run rust:check` (fmt + clippy `-D warnings` + whole-workspace test + build) — exit 0.
- **On-device probe** (ignored test, ran on this 128 GiB Mac): `get_memory_limit() = 130.5 GB` = exactly 1.5× the derived ceiling `87.0 GB` (63% of RAM), and `set_wired_limit(ceiling)` does not throw. By the same 63% ratio an 8 GB Mac's ceiling is ~5.3 GB — confirming the crash and the clamp.

Not verified end-to-end on real 8 GB hardware (I don't have one); the emulated-budget path (`SCENEWORKS_MLX_MEMORY_CAP_GB`) is exercised by the unit tests, and on-device real-weights A/B for the fan-out families is existing verification debt (sc-11922).

Both changes are worker-only — no gen-core / mlx-gen / candle-gen pin lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)