### PR TITLE
feat(catalog): label the PiD decoder entries as v1.5 + refresh sizes (sc-12145 follow-up)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -7342,7 +7342,7 @@
       "id": "pid_qwenimage",
       "autoDownload": false,
       "nonCommercial": true,
-      "name": "PiD Decoder (Qwen-Image)",
+      "name": "PiD 1.5 Decoder (Qwen-Image)",
       "family": "pid",
       "type": "utility",
       "adapter": "pid",
@@ -7355,7 +7355,7 @@
           "provider": "huggingface",
           "repo": "SceneWorks/pid-qwenimage",
           "files": [],
-          "estimatedSizeBytes": 2724745532
+          "estimatedSizeBytes": 5525193754
         },
         {
           // PiD caption encoder (Gemma-2-2B-IT). Non-gated `SceneWorks/gemma-2-2b-it` mirror (sc-8025) —
@@ -7424,7 +7424,7 @@
       "id": "pid_flux",
       "autoDownload": false,
       "nonCommercial": true,
-      "name": "PiD Decoder (FLUX.1 / Boogu / Chroma / Z-Image)",
+      "name": "PiD 1.5 Decoder (FLUX.1 / Boogu / Chroma / Z-Image)",
       "family": "pid",
       "type": "utility",
       "adapter": "pid",
@@ -7437,7 +7437,7 @@
           // 2K-tuned `res2k` student (`pid_flux_2k.safetensors`, sc-10056) the 2K output tier prefers.
           // Size ≈ 2× the single 2.72 GB student.
           "files": [],
-          "estimatedSizeBytes": 5449491064
+          "estimatedSizeBytes": 8249939286
         },
         {
           "provider": "huggingface",
@@ -7501,7 +7501,7 @@
       "id": "pid_flux2",
       "autoDownload": false,
       "nonCommercial": true,
-      "name": "PiD Decoder (FLUX.2 / Lens / Ideogram 4)",
+      "name": "PiD 1.5 Decoder (FLUX.2 / Lens / Ideogram 4)",
       "family": "pid",
       "type": "utility",
       "adapter": "pid",
@@ -7514,7 +7514,7 @@
           // 2K-tuned `res2k` student (`pid_flux2_2k.safetensors`, sc-10056) the 2K output tier prefers.
           // Size ≈ 2× the single 2.73 GB student.
           "files": [],
-          "estimatedSizeBytes": 5451555464
+          "estimatedSizeBytes": 8252298598
         },
         {
           "provider": "huggingface",


### PR DESCRIPTION
Follow-up to the PiD 1.5 ship (sc-12145): the engine + re-host + worker fallback all landed, but the **builtin catalog still named the decoder entries "PiD Decoder (…)" with no version** and carried stale pre-v1.5 sizes — so the UI never told the user they're getting v1.5. (Caught by Michael during the sc-12146 A/B.)

## Change (`config/manifests/builtin.models.jsonc`)
- **Names → say v1.5** for the spaces that got it:
  - `PiD 1.5 Decoder (FLUX.1 / Boogu / Chroma / Z-Image)`
  - `PiD 1.5 Decoder (FLUX.2 / Lens / Ideogram 4)`
  - `PiD 1.5 Decoder (Qwen-Image)`
- **SDXL unchanged** — `PiD Decoder (SDXL / RealVisXL / Kolors)` stays unversioned; NVIDIA shipped no v1.5 for the sdxl latent space, so the absence of "1.5" correctly distinguishes it.
- **`estimatedSizeBytes` refreshed** to the current HF repo footprint (each pid-* repo now carries the v1.5 checkpoint alongside v1.0): flux/flux2 5.45→8.25 GB, qwen 2.72→5.53 GB. gemma co-requisite sizes untouched.

The web UI reads the display name from the manifest, so no web change is needed.

## Verification
`sceneworks-rust-api` catalog tests green (53/53 — they parse + validate the real manifest via `include_str`). jsonc parses cleanly (65 models). No test asserted the old names/sizes.

Follow-up **sc-12170** will trim the redundant v1.0 `2kto4k` from fresh downloads, which brings these sizes back down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)