### PR TITLE
feat(queue): clear completed items from the queue (sc-12231)

### DIFF
--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -389,6 +389,23 @@ pub(crate) async fn clear_jobs(
     }))
 }
 
+/// Clear a single completed item from the queue (sc-12231, issue #1556) — the
+/// per-card "×" dismiss. Soft-hides one terminal job (see `JobsStore::clear_job`)
+/// so it drops off the queue list + counts while its row (and generated assets)
+/// stay put. Rejects a non-terminal job with 400 (cancel an in-flight job
+/// instead). Returns the updated snapshot and republishes the queue.
+pub(crate) async fn clear_job(
+    State(state): State<AppState>,
+    Path(job_id): Path<String>,
+) -> Result<Json<JobSnapshot>, ApiError> {
+    let job = store_call(state.clone(), move |store, _timeout| {
+        store.clear_job(&job_id)
+    })
+    .await?;
+    publish_queue(&state).await?;
+    Ok(Json(job))
+}
+
 pub(crate) async fn update_job_progress(
     State(state): State<AppState>,
     Path(job_id): Path<String>,

--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -365,6 +365,30 @@ pub(crate) async fn duplicate_job(
     Ok((StatusCode::CREATED, Json(job)))
 }
 
+/// Clear completed items from the queue (sc-12231, issue #1556). Soft-hides every
+/// terminal (completed / failed / canceled / interrupted) job so it drops off the
+/// operator's queue list + counts, optionally scoped to one project via the
+/// request body. The job rows are kept so the Generation Stats feed and the
+/// generated assets are untouched (see `JobsStore::clear_terminal_jobs`). Returns
+/// the cleared ids so the client can prune them from its live queue immediately.
+pub(crate) async fn clear_jobs(
+    State(state): State<AppState>,
+    ApiJson(payload): ApiJson<ClearJobsRequest>,
+) -> Result<Json<ClearJobsResponse>, ApiError> {
+    let cleared_ids = store_call(state.clone(), move |store, _timeout| {
+        store.clear_terminal_jobs(payload.project_id.as_deref())
+    })
+    .await?;
+    // Republish the queue so every subscriber's status counts drop the cleared
+    // jobs; the acting client also prunes them locally from the returned ids.
+    publish_queue(&state).await?;
+    Ok(Json(ClearJobsResponse {
+        cleared: cleared_ids.len(),
+        cleared_ids,
+        extra: Default::default(),
+    }))
+}
+
 pub(crate) async fn update_job_progress(
     State(state): State<AppState>,
     Path(job_id): Path<String>,

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -125,8 +125,8 @@ use generation::{validate_interleave_job, validate_vqa_job};
 mod ideogram;
 mod jobs;
 use jobs::{
-    cancel_job, claim_job, clear_jobs, create_job, duplicate_job, get_job, get_job_metrics,
-    list_jobs, list_metrics, retry_job, update_job_progress, upsert_job_metrics,
+    cancel_job, claim_job, clear_job, clear_jobs, create_job, duplicate_job, get_job,
+    get_job_metrics, list_jobs, list_metrics, retry_job, update_job_progress, upsert_job_metrics,
 };
 mod workers;
 use workers::{
@@ -1326,6 +1326,9 @@ pub(crate) fn create_app_with_state(
         .route("/api/v1/files/ticket", post(create_media_ticket))
         .route("/api/v1/jobs/:job_id", get(get_job))
         .route("/api/v1/jobs/:job_id/cancel", post(cancel_job))
+        // Per-job "clear" (sc-12231, issue #1556) — the per-card × dismiss. Distinct
+        // from the bulk `/api/v1/jobs/clear` above (2 segments vs 3, no conflict).
+        .route("/api/v1/jobs/:job_id/clear", post(clear_job))
         .route("/api/v1/jobs/:job_id/retry", post(retry_job))
         .route("/api/v1/jobs/:job_id/duplicate", post(duplicate_job))
         .route("/api/v1/jobs/:job_id/progress", post(update_job_progress))

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -20,11 +20,11 @@ use axum::{Json, Router};
 use futures_util::future::join_all;
 use parking_lot::Mutex;
 use sceneworks_core::contracts::{
-    ClaimRequest, ClaimResponse, ContractNumber, DuplicateJobRequest, GenerationMetrics,
-    GenerationMetricsRow, ImageUpscaleRequest, JobCreateRequest, JobSnapshot, JobStatus, JobType,
-    JsonObject, ProgressRequest, QueueSummary, RetryJobRequest, WorkerCapability,
-    WorkerHeartbeatRequest, WorkerRegisterRequest, WorkerSnapshot, WorkerStatus,
-    WorkerTerminationRequest,
+    ClaimRequest, ClaimResponse, ClearJobsRequest, ClearJobsResponse, ContractNumber,
+    DuplicateJobRequest, GenerationMetrics, GenerationMetricsRow, ImageUpscaleRequest,
+    JobCreateRequest, JobSnapshot, JobStatus, JobType, JsonObject, ProgressRequest, QueueSummary,
+    RetryJobRequest, WorkerCapability, WorkerHeartbeatRequest, WorkerRegisterRequest,
+    WorkerSnapshot, WorkerStatus, WorkerTerminationRequest,
 };
 use sceneworks_core::hf_home::{huggingface_hub_cache_dir, huggingface_repo_cache_path};
 use sceneworks_core::jobs_store::{
@@ -125,8 +125,8 @@ use generation::{validate_interleave_job, validate_vqa_job};
 mod ideogram;
 mod jobs;
 use jobs::{
-    cancel_job, claim_job, create_job, duplicate_job, get_job, get_job_metrics, list_jobs,
-    list_metrics, retry_job, update_job_progress, upsert_job_metrics,
+    cancel_job, claim_job, clear_jobs, create_job, duplicate_job, get_job, get_job_metrics,
+    list_jobs, list_metrics, retry_job, update_job_progress, upsert_job_metrics,
 };
 mod workers;
 use workers::{
@@ -1316,6 +1316,9 @@ pub(crate) fn create_app_with_state(
         )
         .route("/api/v1/jobs", get(list_jobs).post(create_job))
         .route("/api/v1/jobs/claim", post(claim_job))
+        // Clear completed items from the queue (sc-12231, issue #1556). A static
+        // segment like `/claim`, so it takes priority over `/jobs/:job_id`.
+        .route("/api/v1/jobs/clear", post(clear_jobs))
         .route("/api/v1/jobs/events", get(job_events))
         .route("/api/v1/jobs/events/ticket", post(create_event_ticket))
         // Media ticket (sc-8810): auth-protected mint endpoint; the ticket is honored

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -394,6 +394,140 @@ async fn canceling_queued_job_finishes_without_worker_acknowledgement() {
 }
 
 #[tokio::test]
+async fn clear_jobs_soft_hides_terminal_items_from_the_queue() {
+    // sc-12231 / issue #1556: POST /api/v1/jobs/clear drops every terminal job from
+    // the queue list + counts, returns the cleared ids, and leaves active jobs alone.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    // A queued job we cancel (terminal) + a queued job left active.
+    let (_, terminal) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/jobs",
+        json!({
+            "type": "image_generate",
+            "projectId": "project-1",
+            "projectName": "Project 1",
+            "payload": { "prompt": "done" },
+            "requestedGpu": "auto"
+        }),
+    )
+    .await;
+    let terminal_id = terminal["id"].as_str().expect("job id").to_owned();
+    request(
+        app.clone(),
+        "POST",
+        &format!("/api/v1/jobs/{terminal_id}/cancel"),
+        Value::Null,
+    )
+    .await;
+
+    let (_, active) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/jobs",
+        json!({
+            "type": "image_generate",
+            "projectId": "project-1",
+            "projectName": "Project 1",
+            "payload": { "prompt": "wait" },
+            "requestedGpu": "auto"
+        }),
+    )
+    .await;
+    let active_id = active["id"].as_str().expect("job id").to_owned();
+
+    // Both are listed before clearing.
+    let (_, before) = request(app.clone(), "GET", "/api/v1/jobs", Value::Null).await;
+    assert_eq!(before.as_array().expect("jobs array").len(), 2);
+
+    // Clear (empty body == all projects). Reports the one terminal job by id.
+    let (status, cleared) = request(app.clone(), "POST", "/api/v1/jobs/clear", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(cleared["cleared"], 1);
+    assert_eq!(cleared["clearedIds"], json!([terminal_id]));
+
+    // The queue now lists only the still-active job.
+    let (_, after) = request(app.clone(), "GET", "/api/v1/jobs", Value::Null).await;
+    let ids: Vec<&str> = after
+        .as_array()
+        .expect("jobs array")
+        .iter()
+        .filter_map(|job| job["id"].as_str())
+        .collect();
+    assert_eq!(ids, vec![active_id.as_str()]);
+
+    // Status counts drop the canceled job; the queued one remains.
+    let (_, queue) = request(app, "GET", "/api/v1/queue", Value::Null).await;
+    assert_eq!(queue["counts"]["canceled"], 0);
+    assert_eq!(queue["counts"]["queued"], 1);
+}
+
+#[tokio::test]
+async fn clear_jobs_scopes_to_the_requested_project() {
+    // sc-12231: the clear honors the body's projectId so clearing one workspace's
+    // completed items never touches another's.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    let mut ids = Vec::new();
+    for project in ["project-a", "project-b"] {
+        let (_, job) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/jobs",
+            json!({
+                "type": "image_generate",
+                "projectId": project,
+                "projectName": project,
+                "payload": { "prompt": "done" },
+                "requestedGpu": "auto"
+            }),
+        )
+        .await;
+        let id = job["id"].as_str().expect("job id").to_owned();
+        request(
+            app.clone(),
+            "POST",
+            &format!("/api/v1/jobs/{id}/cancel"),
+            Value::Null,
+        )
+        .await;
+        ids.push(id);
+    }
+
+    // Clear only project-a.
+    let (status, cleared) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/jobs/clear",
+        json!({ "projectId": "project-a" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(cleared["clearedIds"], json!([ids[0]]));
+
+    // project-a is empty; project-b's canceled job is untouched.
+    let (_, a_jobs) = request(
+        app.clone(),
+        "GET",
+        "/api/v1/jobs?projectId=project-a",
+        Value::Null,
+    )
+    .await;
+    assert!(a_jobs.as_array().expect("jobs array").is_empty());
+    let (_, b_jobs) = request(app, "GET", "/api/v1/jobs?projectId=project-b", Value::Null).await;
+    let b_ids: Vec<&str> = b_jobs
+        .as_array()
+        .expect("jobs array")
+        .iter()
+        .filter_map(|job| job["id"].as_str())
+        .collect();
+    assert_eq!(b_ids, vec![ids[1].as_str()]);
+}
+
+#[tokio::test]
 async fn image_job_route_threads_upscale_contract_when_enabled() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -528,6 +528,98 @@ async fn clear_jobs_scopes_to_the_requested_project() {
 }
 
 #[tokio::test]
+async fn clear_single_job_soft_hides_only_that_terminal_job() {
+    // sc-12231 / issue #1556: POST /api/v1/jobs/:id/clear (the per-card ×) drops one
+    // terminal job from the queue and leaves its siblings alone.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    // Two queued jobs; cancel one so it is terminal, leave the other active.
+    let mut ids = Vec::new();
+    for prompt in ["done", "wait"] {
+        let (_, job) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/jobs",
+            json!({
+                "type": "image_generate",
+                "projectId": "project-1",
+                "projectName": "Project 1",
+                "payload": { "prompt": prompt },
+                "requestedGpu": "auto"
+            }),
+        )
+        .await;
+        ids.push(job["id"].as_str().expect("job id").to_owned());
+    }
+    let (terminal_id, active_id) = (ids[0].clone(), ids[1].clone());
+    request(
+        app.clone(),
+        "POST",
+        &format!("/api/v1/jobs/{terminal_id}/cancel"),
+        Value::Null,
+    )
+    .await;
+
+    // Clear just the terminal one.
+    let (status, cleared) = request(
+        app.clone(),
+        "POST",
+        &format!("/api/v1/jobs/{terminal_id}/clear"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(cleared["id"], terminal_id);
+
+    // Only the still-active job remains in the queue.
+    let (_, after) = request(app, "GET", "/api/v1/jobs", Value::Null).await;
+    let remaining: Vec<&str> = after
+        .as_array()
+        .expect("jobs array")
+        .iter()
+        .filter_map(|job| job["id"].as_str())
+        .collect();
+    assert_eq!(remaining, vec![active_id.as_str()]);
+}
+
+#[tokio::test]
+async fn clear_single_job_rejects_a_non_terminal_job() {
+    // sc-12231: clearing an active (queued) job is a 400 — the × only appears on
+    // terminal cards, and the server refuses to soft-hide a live job.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    let (_, job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/jobs",
+        json!({
+            "type": "image_generate",
+            "projectId": "project-1",
+            "projectName": "Project 1",
+            "payload": { "prompt": "wait" },
+            "requestedGpu": "auto"
+        }),
+    )
+    .await;
+    let job_id = job["id"].as_str().expect("job id").to_owned();
+
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        &format!("/api/v1/jobs/{job_id}/clear"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    // The job is untouched — still listed.
+    let (_, jobs) = request(app, "GET", "/api/v1/jobs", Value::Null).await;
+    assert_eq!(jobs.as_array().expect("jobs array").len(), 1);
+}
+
+#[tokio::test]
 async fn image_job_route_threads_upscale_contract_when_enabled() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -2052,6 +2052,32 @@ export function App() {
     [token],
   );
 
+  // Clear completed items from the queue (issue #1556 / sc-12231). The server
+  // soft-hides every terminal job (keeping Generation Stats + generated assets
+  // intact) and returns the cleared ids; prune exactly those from the live jobs
+  // list so the queue empties immediately without waiting for a refetch. Scoped
+  // to the active project filter so it clears exactly what the operator sees
+  // ("all" clears every project).
+  const clearCompletedJobs = useCallback(
+    async (projectId) => {
+      try {
+        const body = projectId && projectId !== "all" ? { projectId } : {};
+        const response = await apiFetch("/api/v1/jobs/clear", token, {
+          method: "POST",
+          body: JSON.stringify(body),
+        });
+        const clearedIds = new Set(response?.clearedIds ?? []);
+        if (clearedIds.size) {
+          setJobs((items) => items.filter((job) => !clearedIds.has(job.id)));
+        }
+        setError("");
+      } catch (err) {
+        setError(err.message);
+      }
+    },
+    [token],
+  );
+
   const titleInfo = viewTitles[activeView] ?? { title: activeView, blurb: "" };
   // A keep-alive view is rendered once it is active OR has been visited before
   // (sc-11959): it mounts on first visit and then stays mounted (hidden) thereafter.
@@ -2140,6 +2166,7 @@ export function App() {
     latestImageAssets,
     // Job actions (creation/control — stable callbacks, NOT the churning jobs list)
     jobAction,
+    clearCompletedJobs,
     createVqaJob,
     createInterleaveJob,
     // Queue screen (sc-1651 Phase B batch 2)
@@ -2276,7 +2303,7 @@ export function App() {
     createTimeline, saveTimeline, exportTimeline, extractTimelineFrame, queueTimelineVideoJob,
     assets, selectedAsset, selectedAssetId, setSelectedAssetId, deleteAsset, purgeAsset, moveAssetToLibrary, moveAssetToCharacter, importAsset,
     updateAssetStatus, updateAssetTags, latestImageAssets,
-    jobAction, createVqaJob, createInterleaveJob, createPlaceholderJob,
+    jobAction, clearCompletedJobs, createVqaJob, createInterleaveJob, createPlaceholderJob,
     jobPrompt, setJobPrompt, projectFilter, setProjectFilter, projects,
     createVideoJob, createVideoUpscaleJob, createImageJob, refinePrompt, magicPrompt, imageCaption, imageDescribe, compareFaceLikeness, latestVideoAssets, recentImageAssets,
     recentVideoAssets, studioLaunch,

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -2078,6 +2078,25 @@ export function App() {
     [token],
   );
 
+  // Clear a single completed item from the queue (issue #1556 / sc-12231) — the
+  // per-card "×". The server soft-hides just this terminal job; drop it from the
+  // live list on success so the card disappears immediately.
+  const clearJob = useCallback(
+    async (job) => {
+      try {
+        await apiFetch(`/api/v1/jobs/${job.id}/clear`, token, {
+          method: "POST",
+          body: JSON.stringify({}),
+        });
+        setJobs((items) => items.filter((item) => item.id !== job.id));
+        setError("");
+      } catch (err) {
+        setError(err.message);
+      }
+    },
+    [token],
+  );
+
   const titleInfo = viewTitles[activeView] ?? { title: activeView, blurb: "" };
   // A keep-alive view is rendered once it is active OR has been visited before
   // (sc-11959): it mounts on first visit and then stays mounted (hidden) thereafter.
@@ -2167,6 +2186,7 @@ export function App() {
     // Job actions (creation/control — stable callbacks, NOT the churning jobs list)
     jobAction,
     clearCompletedJobs,
+    clearJob,
     createVqaJob,
     createInterleaveJob,
     // Queue screen (sc-1651 Phase B batch 2)
@@ -2303,7 +2323,7 @@ export function App() {
     createTimeline, saveTimeline, exportTimeline, extractTimelineFrame, queueTimelineVideoJob,
     assets, selectedAsset, selectedAssetId, setSelectedAssetId, deleteAsset, purgeAsset, moveAssetToLibrary, moveAssetToCharacter, importAsset,
     updateAssetStatus, updateAssetTags, latestImageAssets,
-    jobAction, clearCompletedJobs, createVqaJob, createInterleaveJob, createPlaceholderJob,
+    jobAction, clearCompletedJobs, clearJob, createVqaJob, createInterleaveJob, createPlaceholderJob,
     jobPrompt, setJobPrompt, projectFilter, setProjectFilter, projects,
     createVideoJob, createVideoUpscaleJob, createImageJob, refinePrompt, magicPrompt, imageCaption, imageDescribe, compareFaceLikeness, latestVideoAssets, recentImageAssets,
     recentVideoAssets, studioLaunch,

--- a/apps/web/src/App.queue.test.jsx
+++ b/apps/web/src/App.queue.test.jsx
@@ -421,6 +421,84 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Warm: z_image_turbo");
   });
 
+  it("clears completed queue items scoped to the active project filter (issue #1556)", async () => {
+    const clearCompletedJobs = vi.fn(() => Promise.resolve());
+    const terminalJob = (id, status) => ({
+      id,
+      type: "image_generate",
+      status,
+      stage: status,
+      progress: 1,
+      projectId: "project-1",
+      projectName: "Project 1",
+      requestedGpu: "auto",
+      payload: { prompt: id },
+      attempts: 1,
+    });
+    const baseProps = {
+      activeProject: { id: "project-1", name: "Project 1" },
+      clearCompletedJobs,
+      createPlaceholderJob: (event) => event.preventDefault(),
+      gpuOptions: ["auto", "0"],
+      jobAction: () => {},
+      jobPrompt: "",
+      projectFilter: "project-1",
+      projects: [{ id: "project-1", name: "Project 1" }],
+      requestedGpu: "auto",
+      setJobPrompt: () => {},
+      setProjectFilter: () => {},
+      setRequestedGpu: () => {},
+      visibleWorkers: [],
+    };
+    const findClearButton = () =>
+      [...document.body.querySelectorAll("button")].find((button) =>
+        button.textContent.startsWith("Clear completed"),
+      );
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            ...baseProps,
+            // Two terminal jobs (completed + failed) and one still running.
+            filteredJobs: [
+              terminalJob("job-done", "completed"),
+              terminalJob("job-failed", "failed"),
+              { ...terminalJob("job-running", "running"), progress: 0.3, stage: "generating" },
+            ],
+          },
+          <QueueScreen />,
+        ),
+      );
+    });
+
+    // The button surfaces the terminal count and is enabled.
+    let clearButton = findClearButton();
+    expect(clearButton).toBeTruthy();
+    expect(clearButton.textContent).toBe("Clear completed (2)");
+    expect(clearButton.disabled).toBe(false);
+
+    await act(async () => {
+      clearButton.click();
+    });
+    // Scoped to the active project filter, matching what the operator sees.
+    expect(clearCompletedJobs).toHaveBeenCalledWith("project-1");
+
+    // With nothing terminal in view, the action disables and drops the count.
+    await act(async () => {
+      root.render(
+        withAppContext(
+          { ...baseProps, filteredJobs: [{ ...terminalJob("job-running", "running"), progress: 0.3, stage: "generating" }] },
+          <QueueScreen />,
+        ),
+      );
+    });
+    clearButton = findClearButton();
+    expect(clearButton.textContent).toBe("Clear completed");
+    expect(clearButton.disabled).toBe(true);
+  });
+
   it("updates Queue GPU utilization when worker props change", async () => {
     const queueProps = {
       activeProject: { id: "project-1", name: "Project 1" },

--- a/apps/web/src/App.queue.test.jsx
+++ b/apps/web/src/App.queue.test.jsx
@@ -499,6 +499,63 @@ describe("SceneWorks app shell", () => {
     expect(clearButton.disabled).toBe(true);
   });
 
+  it("dismisses an individual completed queue item via the per-card × (issue #1556)", async () => {
+    const clearJob = vi.fn(() => Promise.resolve());
+    const completedJob = {
+      id: "job-done",
+      type: "image_generate",
+      status: "completed",
+      stage: "completed",
+      progress: 1,
+      projectId: "project-1",
+      projectName: "Project 1",
+      requestedGpu: "auto",
+      payload: { prompt: "a fox" },
+      attempts: 1,
+    };
+    const runningJob = {
+      ...completedJob,
+      id: "job-running",
+      status: "running",
+      stage: "generating",
+      progress: 0.3,
+    };
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Project 1" },
+            clearJob,
+            createPlaceholderJob: (event) => event.preventDefault(),
+            filteredJobs: [completedJob, runningJob],
+            gpuOptions: ["auto", "0"],
+            jobAction: () => {},
+            jobPrompt: "",
+            projectFilter: "all",
+            projects: [{ id: "project-1", name: "Project 1" }],
+            requestedGpu: "auto",
+            setJobPrompt: () => {},
+            setProjectFilter: () => {},
+            setRequestedGpu: () => {},
+            visibleWorkers: [],
+          },
+          <QueueScreen />,
+        ),
+      );
+    });
+
+    // Exactly one × renders — on the completed card, not the running one.
+    const dismissButtons = [...document.body.querySelectorAll(".worker-progress-card__dismiss")];
+    expect(dismissButtons.length).toBe(1);
+
+    await act(async () => {
+      dismissButtons[0].click();
+    });
+    expect(clearJob).toHaveBeenCalledWith(completedJob);
+  });
+
   it("updates Queue GPU utilization when worker props change", async () => {
     const queueProps = {
       activeProject: { id: "project-1", name: "Project 1" },

--- a/apps/web/src/components/WorkerProgressCard.jsx
+++ b/apps/web/src/components/WorkerProgressCard.jsx
@@ -400,6 +400,7 @@ function ThumbnailsRegion({ variant, finalAssets, interimAssets, thumbnailGroups
 export function WorkerProgressCard({
   job,
   onCancel,
+  onClear,
   onRetry,
   onFreshRetry,
   onDuplicate,
@@ -441,6 +442,10 @@ export function WorkerProgressCard({
   const attempts = job.attempts ?? 1;
   const isModelDownload = job.type === "model_download";
   const canCancel = onCancel && !isTerminal && !job.cancelRequested;
+  // Per-card "×" dismiss (sc-12231, issue #1556): only offered by the Queue, and
+  // only on a terminal job — clearing an in-flight job would resurrect it on the
+  // next SSE tick (cancel it instead).
+  const canClear = !!onClear && isTerminal;
   const canRetryBase = actionStatuses.has(job.status) && attempts < MAX_ATTEMPTS;
   const canRetry = onRetry && canRetryBase && !isModelDownload;
   const canResumeDownload = onRetry && canRetryBase && isModelDownload && job.status !== "completed";
@@ -461,7 +466,20 @@ export function WorkerProgressCard({
     <article className={`worker-progress-card ${job.status}${className ? ` ${className}` : ""}`}>
       <header className="worker-progress-card__header">
         <span className={`worker-progress-card__type chip-${chipModifier(job.type)}`}>{chipLabel}</span>
-        <StatusBadge status={job.status} />
+        <div className="worker-progress-card__header-right">
+          <StatusBadge status={job.status} />
+          {canClear ? (
+            <button
+              className="worker-progress-card__dismiss"
+              onClick={() => onClear(job)}
+              type="button"
+              aria-label="Clear this job from the queue"
+              title="Clear from queue"
+            >
+              ×
+            </button>
+          ) : null}
+        </div>
       </header>
       <div className="worker-progress-card__title-row">
         <h3 className="worker-progress-card__title" title={title}>{title}</h3>

--- a/apps/web/src/components/WorkerProgressCard.test.jsx
+++ b/apps/web/src/components/WorkerProgressCard.test.jsx
@@ -298,6 +298,51 @@ describe("WorkerProgressCard layout", () => {
     expect(onFreshRetry).toHaveBeenCalledWith(resumedJob, { payloadChanges: { downloadAction: "fresh" } });
   });
 
+  it("shows the dismiss × on a terminal job and calls onClear (issue #1556)", () => {
+    const job = {
+      id: "job-done",
+      type: "image_generate",
+      status: "completed",
+      progress: 1,
+      attempts: 1,
+      payload: { prompt: "a fox" },
+    };
+    const onClear = vi.fn();
+    api = render(<WorkerProgressCard job={job} onClear={onClear} />, makeContext([]));
+    const dismiss = api.container.querySelector(".worker-progress-card__dismiss");
+    expect(dismiss).not.toBeNull();
+    act(() => {
+      dismiss.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    });
+    expect(onClear).toHaveBeenCalledWith(job);
+  });
+
+  it("does not show the dismiss × on an active job (would resurrect on SSE)", () => {
+    const job = {
+      id: "job-running",
+      type: "image_generate",
+      status: "running",
+      progress: 0.4,
+      attempts: 1,
+      payload: { prompt: "a fox" },
+    };
+    api = render(<WorkerProgressCard job={job} onClear={vi.fn()} />, makeContext([]));
+    expect(api.container.querySelector(".worker-progress-card__dismiss")).toBeNull();
+  });
+
+  it("omits the dismiss × when no onClear handler is provided", () => {
+    const job = {
+      id: "job-done",
+      type: "image_generate",
+      status: "completed",
+      progress: 1,
+      attempts: 1,
+      payload: { prompt: "a fox" },
+    };
+    api = render(<WorkerProgressCard job={job} />, makeContext([]));
+    expect(api.container.querySelector(".worker-progress-card__dismiss")).toBeNull();
+  });
+
   it("hides View in Queue when hideOpenQueue is true", () => {
     const job = { id: "j", type: "image_generate", status: "running", progress: 0, attempts: 1, payload: {} };
     const onOpenQueue = vi.fn();

--- a/apps/web/src/screens/QueueScreen.jsx
+++ b/apps/web/src/screens/QueueScreen.jsx
@@ -188,6 +188,7 @@ export function QueueScreen() {
     activeProject,
     assets = [],
     clearCompletedJobs,
+    clearJob,
     createPlaceholderJob,
     filteredJobs,
     gpuOptions,
@@ -291,6 +292,7 @@ export function QueueScreen() {
                 thumbnailAssets={thumbnails}
                 onThumbnailClick={setPreviewAsset ? (asset) => setPreviewAsset(asset, thumbnails) : undefined}
                 onCancel={(j) => jobAction(j, "cancel")}
+                onClear={clearJob ? (j) => clearJob(j) : undefined}
                 onRetry={(j, payload) => jobAction(j, "retry", { body: payload ?? {} })}
                 onFreshRetry={(j, payload) => jobAction(j, "retry", { body: payload ?? {} })}
                 onDuplicate={(j) => jobAction(j, "duplicate")}

--- a/apps/web/src/screens/QueueScreen.jsx
+++ b/apps/web/src/screens/QueueScreen.jsx
@@ -187,6 +187,7 @@ export function QueueScreen() {
   const {
     activeProject,
     assets = [],
+    clearCompletedJobs,
     createPlaceholderJob,
     filteredJobs,
     gpuOptions,
@@ -207,6 +208,13 @@ export function QueueScreen() {
   // Prefer the shared index from context (sc-2082); fall back for legacy
   // contexts that may not yet expose it (test harnesses, etc.).
   const gpuWorkers = useMemo(() => workers.filter(isGpuWorker), [workers]);
+  // "Clear completed" (issue #1556): how many of the jobs in view are terminal
+  // (completed / failed / canceled / interrupted) and thus clearable. Gates the
+  // button so it disables when there's nothing to clear.
+  const completedCount = useMemo(
+    () => filteredJobs.filter((job) => terminalStatuses.has(job.status)).length,
+    [filteredJobs],
+  );
   return (
     <section className="page-frame queue-surface">
       <WorkPanel
@@ -239,6 +247,17 @@ export function QueueScreen() {
             </option>
           ))}
         </select>
+        {/* Clear completed items from the queue (issue #1556). Scoped to the
+            current project filter; disabled when nothing in view is terminal. */}
+        <button
+          className="queue-clear-completed"
+          disabled={completedCount === 0 || !clearCompletedJobs}
+          onClick={() => clearCompletedJobs?.(projectFilter)}
+          title="Remove completed, failed, and canceled jobs from the queue"
+          type="button"
+        >
+          Clear completed{completedCount > 0 ? ` (${completedCount})` : ""}
+        </button>
         </div>
       </WorkPanel>
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -10315,6 +10315,31 @@ details[open] > summary.lora-scope-group-heading::before,
   gap: 10px;
 }
 
+/* "Clear completed" (issue #1556) rides at the trailing edge of the queue tools
+   row — a subtle secondary control next to the project filter. */
+.queue-clear-completed {
+  margin-left: auto;
+  min-height: var(--control-h);
+  padding: 0 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.queue-clear-completed:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  background: var(--surface-hover);
+}
+
+.queue-clear-completed:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .job-composer {
   display: grid;
   grid-template-columns: minmax(180px, 1fr) minmax(108px, 140px) auto;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11103,6 +11103,38 @@ details[open] > summary.lora-scope-group-heading::before,
   gap: 8px;
 }
 
+/* Status badge + the optional per-card × dismiss (issue #1556), kept together at
+   the header's trailing edge. */
+.worker-progress-card__header-right {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* Per-card "×" that clears a completed item from the queue (issue #1556). Ghost
+   button that firms up on hover; sits in the card's top-right corner. */
+.worker-progress-card__dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 17px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.worker-progress-card__dismiss:hover {
+  border-color: var(--border);
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
 .worker-progress-card__type {
   display: inline-flex;
   align-items: center;

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -1109,6 +1109,30 @@ pub struct RetryJobRequest {
     pub extra: ExtraFields,
 }
 
+/// Body for `POST /api/v1/jobs/clear` (sc-12231, issue #1556) — the "Clear
+/// completed" queue action. `project_id` scopes the clear to one workspace
+/// (matching the queue's project filter); omitted / null clears every project's
+/// terminal jobs. All fields optional so an empty `{}` body is valid.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ClearJobsRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    #[serde(flatten)]
+    pub extra: ExtraFields,
+}
+
+/// Response for `POST /api/v1/jobs/clear` (sc-12231): how many terminal jobs were
+/// soft-hidden and their ids, so the client can prune them from its live queue.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClearJobsResponse {
+    pub cleared: usize,
+    pub cleared_ids: Vec<String>,
+    #[serde(flatten)]
+    pub extra: ExtraFields,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SidecarPatterns {

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -1050,6 +1050,37 @@ impl JobsStore {
         Ok(cleared_ids)
     }
 
+    /// Soft-hide a single terminal job from the queue (sc-12231, issue #1556) —
+    /// the per-card "×" dismiss, the individual-item twin of
+    /// [`clear_terminal_jobs`]. Stamps `cleared_at` so the row drops out of
+    /// `list_jobs` / `queue_summary` while staying in the table for Generation
+    /// Stats, and returns the updated snapshot.
+    ///
+    /// Only a TERMINAL job can be cleared: an active job would keep emitting
+    /// progress and be re-added to the client's queue on the next SSE tick, and
+    /// "clear" means tidying finished work — cancel an in-flight job instead. A
+    /// non-terminal job is rejected with [`JobsStoreError::InvalidStatus`] (400);
+    /// an already-cleared job is idempotent (the guarded UPDATE no-ops).
+    pub fn clear_job(&self, job_id: &str) -> JobsStoreResult<JobSnapshot> {
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let job = self.get_job_on_connection(&transaction, job_id)?;
+        if !is_terminal_status(job.status.as_str()) {
+            return Err(JobsStoreError::InvalidStatus(format!(
+                "job {job_id} is {} — only completed, failed, canceled, or interrupted jobs can be cleared",
+                job.status.as_str()
+            )));
+        }
+        transaction.execute(
+            "update jobs set cleared_at = ?1 where id = ?2 and cleared_at is null",
+            params![utc_now(), job_id],
+        )?;
+        let job = self.get_job_on_connection(&transaction, job_id)?;
+        transaction.commit()?;
+        Ok(job)
+    }
+
     pub fn register_worker(&self, request: RegisterWorker) -> JobsStoreResult<WorkerSnapshot> {
         let mut guard = self.lock.lock();
         let connection = self.write_connection(&mut guard)?;

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -431,6 +431,13 @@ impl JobsStore {
         // / "cpu"). First-non-null wins so the WorkerProgressCard's arch pill
         // stays stable across the run.
         ensure_column(&transaction, "jobs", "backend", "text")?;
+        // Soft-hide marker for the "Clear completed" queue action (sc-12231, issue #1556).
+        // A cleared job is dropped from the operator's queue list + counts (see
+        // `list_jobs` / `queue_summary`) but the row is deliberately kept: the
+        // Generation Stats feed (epic 10402) inner-joins `generation_metrics` to
+        // `jobs`, so deleting the row would silently wipe that run's stats and
+        // orphan its metrics. Non-null == "cleared from the queue", timestamped.
+        ensure_column(&transaction, "jobs", "cleared_at", "text")?;
         // Structured per-run generation metrics (epic 10402). A companion table
         // keyed 1:1 by job id — kept out of the hot `jobs` row so the queue
         // read path stays lean. Written by the worker on completion and read
@@ -680,7 +687,10 @@ impl JobsStore {
         // progress update. All mutating methods still hold the mutex.
         let connection = self.open_connection()?;
         let limit = limit.clamp(1, 500);
-        let mut conditions: Vec<&str> = Vec::new();
+        // A cleared job (sc-12231, issue #1556) is soft-hidden from every queue
+        // list surface — the operator asked for it gone, so it never comes back
+        // via a status filter either. The row still exists for Generation Stats.
+        let mut conditions: Vec<&str> = vec!["cleared_at is null"];
         let mut bindings: Vec<Box<dyn ToSql>> = Vec::new();
         if let Some(project_id) = project_id {
             conditions.push("project_id = ?");
@@ -978,6 +988,66 @@ impl JobsStore {
         )?;
         transaction.commit()?;
         Ok(job)
+    }
+
+    /// Soft-hide every terminal (completed / failed / canceled / interrupted) job
+    /// from the operator's queue, optionally scoped to one project (sc-12231,
+    /// issue #1556 — "clear completed items from the queue"). Stamps `cleared_at`
+    /// on the matching rows so `list_jobs` and `queue_summary` drop them, and
+    /// returns the cleared ids (newest first) so the caller can prune them from
+    /// live client state.
+    ///
+    /// The rows are deliberately KEPT, not deleted: the Generation Stats feed
+    /// (`list_generation_metrics`, epic 10402) inner-joins `generation_metrics`
+    /// to `jobs`, so a hard delete would silently wipe those runs from the stats
+    /// charts and orphan the metrics rows. Generated assets live in the project
+    /// store independently, so clearing a job never removes its outputs.
+    /// Already-cleared rows and still-active jobs are left untouched.
+    pub fn clear_terminal_jobs(&self, project_id: Option<&str>) -> JobsStoreResult<Vec<String>> {
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+
+        // Collect the ids first so the caller can prune exactly what was cleared
+        // (the set can exceed the client's visible cap). Scoped so the borrowed
+        // statement is dropped before the UPDATE runs on the same transaction.
+        let mut select_sql = format!(
+            "select id from jobs where status in ({terminal}) and cleared_at is null",
+            terminal = terminal_statuses_sql()
+        );
+        let mut bindings: Vec<Box<dyn ToSql>> = Vec::new();
+        if let Some(project_id) = project_id {
+            select_sql.push_str(" and project_id = ?");
+            bindings.push(Box::new(project_id.to_owned()));
+        }
+        select_sql.push_str(" order by created_at desc");
+        let cleared_ids: Vec<String> = {
+            let mut statement = transaction.prepare(&select_sql)?;
+            let rows = statement.query_map(params_from_iter(bindings.iter()), |row| {
+                row.get::<_, String>(0)
+            })?;
+            let mut ids = Vec::new();
+            for row in rows {
+                ids.push(row?);
+            }
+            ids
+        };
+
+        if !cleared_ids.is_empty() {
+            let now = utc_now();
+            let mut update_sql = format!(
+                "update jobs set cleared_at = ? where status in ({terminal}) and cleared_at is null",
+                terminal = terminal_statuses_sql()
+            );
+            let mut update_bindings: Vec<Box<dyn ToSql>> = vec![Box::new(now)];
+            if let Some(project_id) = project_id {
+                update_sql.push_str(" and project_id = ?");
+                update_bindings.push(Box::new(project_id.to_owned()));
+            }
+            transaction.execute(&update_sql, params_from_iter(update_bindings.iter()))?;
+        }
+        transaction.commit()?;
+        Ok(cleared_ids)
     }
 
     pub fn register_worker(&self, request: RegisterWorker) -> JobsStoreResult<WorkerSnapshot> {
@@ -1826,8 +1896,12 @@ impl JobsStore {
             .iter()
             .map(|status| (parse_string_enum::<JobStatus>(status), 0u32))
             .collect::<std::collections::BTreeMap<_, _>>();
-        let mut statement =
-            connection.prepare("select status, count(*) from jobs group by status")?;
+        // Cleared jobs (sc-12231, issue #1556) are excluded from the operator's
+        // status counts too, matching `list_jobs` — a cleared "completed" run must
+        // not keep inflating the completed badge after the user tidied the queue.
+        let mut statement = connection.prepare(
+            "select status, count(*) from jobs where cleared_at is null group by status",
+        )?;
         let rows = statement.query_map([], |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
         })?;

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -325,6 +325,66 @@ fn clear_terminal_jobs_scopes_to_one_project() {
     assert_eq!(b_list[0].id, b.id);
 }
 
+#[test]
+fn clear_job_soft_hides_a_single_terminal_job() {
+    // sc-12231 / issue #1556: the per-card "×" clears one terminal job, leaving
+    // its siblings in the queue and (like the bulk clear) keeping the row so
+    // Generation Stats history survives.
+    let store = store("clear-one");
+
+    let canceled = store
+        .create_job(image_job(object(json!({ "prompt": "stop" }))))
+        .expect("job creates");
+    store.cancel_job(&canceled.id).expect("cancels");
+    let other_terminal = store
+        .create_job(image_job(object(json!({ "prompt": "also done" }))))
+        .expect("job creates");
+    store.cancel_job(&other_terminal.id).expect("cancels other");
+    let queued = store
+        .create_job(image_job(object(json!({ "prompt": "wait" }))))
+        .expect("job creates");
+
+    let cleared = store.clear_job(&canceled.id).expect("clears one job");
+    assert_eq!(cleared.id, canceled.id);
+
+    // Only the one job is gone; the other terminal job and the queued job remain.
+    let remaining: Vec<String> = store
+        .list_jobs(None, None, 100)
+        .expect("list")
+        .into_iter()
+        .map(|job| job.id)
+        .collect();
+    assert!(!remaining.contains(&canceled.id));
+    assert!(remaining.contains(&other_terminal.id));
+    assert!(remaining.contains(&queued.id));
+
+    // Idempotent: clearing an already-cleared job is a no-op success.
+    assert_eq!(
+        store.clear_job(&canceled.id).expect("second clear").id,
+        canceled.id
+    );
+}
+
+#[test]
+fn clear_job_rejects_a_non_terminal_job() {
+    // sc-12231: an active job can't be cleared — it would resurrect on the next
+    // SSE tick and "clear" is for finished work. Rejected with InvalidStatus (400).
+    let store = store("clear-active");
+    let queued = store
+        .create_job(image_job(object(json!({ "prompt": "wait" }))))
+        .expect("job creates");
+
+    let error = store
+        .clear_job(&queued.id)
+        .expect_err("non-terminal is rejected");
+    assert!(matches!(error, JobsStoreError::InvalidStatus(_)));
+
+    // The job is untouched — still listed in the queue.
+    let listed = store.list_jobs(None, None, 100).expect("list");
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].id, queued.id);
+}
+
 /// An Ideogram auto-caption image job (sc-9120). Created NON-claimable in `pending_caption`.
 fn pending_caption_job(payload: Value) -> CreateJob {
     CreateJob {

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -196,6 +196,135 @@ fn job_lifecycle_create_claim_complete() {
     assert_eq!(worker.current_job_id, None);
 }
 
+#[test]
+fn clear_terminal_jobs_soft_hides_from_queue_but_keeps_stats() {
+    // sc-12231 / issue #1556: "Clear completed" drops every terminal job from the
+    // operator's queue list + counts, WITHOUT deleting the rows — the Generation
+    // Stats feed inner-joins metrics to jobs, so a hard delete would wipe history.
+    let store = store("clear-terminal");
+    register_image_worker(&store);
+
+    // A completed run (with recorded generation metrics)...
+    let completed = store
+        .create_job(image_job(object(json!({ "prompt": "done" }))))
+        .expect("job creates");
+    let claimed = store
+        .claim_next_job("worker-1")
+        .expect("claim")
+        .expect("claimed");
+    assert_eq!(claimed.id, completed.id);
+    store
+        .update_job_progress(
+            &completed.id,
+            ProgressUpdate {
+                status: JobStatus::Completed,
+                stage: ProgressStage::Completed,
+                progress: 1.0,
+                message: "Done".to_owned(),
+                error: None,
+                result: Some(object(json!({ "assetIds": ["asset-1"] }))),
+                eta_seconds: None,
+                peak_gpu_memory_pct: None,
+                peak_gpu_load_pct: None,
+                backend: None,
+                worker_id: Some("worker-1".to_owned()),
+            },
+        )
+        .expect("completes");
+    store
+        .upsert_generation_metrics(
+            &completed.id,
+            &GenerationMetrics {
+                model: Some("qwen_image".to_owned()),
+                total_ms: Some(9400),
+                ..Default::default()
+            },
+        )
+        .expect("metrics upsert");
+
+    // ...a canceled job (terminal)...
+    let canceled = store
+        .create_job(image_job(object(json!({ "prompt": "stop" }))))
+        .expect("job creates");
+    store.cancel_job(&canceled.id).expect("cancels");
+
+    // ...and a still-queued job (active).
+    let queued = store
+        .create_job(image_job(object(json!({ "prompt": "wait" }))))
+        .expect("job creates");
+
+    // Before clearing, all three are listed.
+    assert_eq!(store.list_jobs(None, None, 100).expect("list").len(), 3);
+
+    let cleared = store
+        .clear_terminal_jobs(None)
+        .expect("clears terminal jobs");
+    assert_eq!(
+        cleared.len(),
+        2,
+        "completed + canceled cleared, queued kept"
+    );
+    assert!(cleared.contains(&completed.id));
+    assert!(cleared.contains(&canceled.id));
+
+    // The queue now lists only the still-queued job.
+    let remaining = store.list_jobs(None, None, 100).expect("list after clear");
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].id, queued.id);
+
+    // Status counts drop the cleared jobs.
+    let summary = store.queue_summary().expect("summary");
+    assert_eq!(*summary.counts.get(&JobStatus::Completed).unwrap_or(&0), 0);
+    assert_eq!(*summary.counts.get(&JobStatus::Canceled).unwrap_or(&0), 0);
+    assert_eq!(*summary.counts.get(&JobStatus::Queued).unwrap_or(&0), 1);
+
+    // Generation Stats history survives: the completed run's metrics are kept
+    // because the job row is soft-hidden, not deleted, so the join still matches.
+    let metrics = store
+        .list_generation_metrics(None, None, None, 100)
+        .expect("metrics list");
+    assert_eq!(metrics.len(), 1);
+    assert_eq!(metrics[0].job_id, completed.id);
+
+    // A second clear is a no-op — the already-cleared rows are not re-reported.
+    assert!(store
+        .clear_terminal_jobs(None)
+        .expect("second clear")
+        .is_empty());
+}
+
+#[test]
+fn clear_terminal_jobs_scopes_to_one_project() {
+    // sc-12231: the clear honors the queue's project filter — clearing one project
+    // must never touch another project's completed items.
+    let store = store("clear-terminal-scope");
+    let job_in = |project: &str, prompt: &str| CreateJob {
+        project_id: Some(project.to_owned()),
+        ..image_job(object(json!({ "prompt": prompt })))
+    };
+
+    let a = store.create_job(job_in("project-a", "a")).expect("creates");
+    store.cancel_job(&a.id).expect("cancels a");
+    let b = store.create_job(job_in("project-b", "b")).expect("creates");
+    store.cancel_job(&b.id).expect("cancels b");
+
+    let cleared = store
+        .clear_terminal_jobs(Some("project-a"))
+        .expect("clears project-a");
+    assert_eq!(cleared, vec![a.id.clone()]);
+
+    // project-a's queue is empty; project-b's canceled job is untouched.
+    assert!(store
+        .list_jobs(Some("project-a"), None, 100)
+        .expect("list a")
+        .is_empty());
+    let b_list = store
+        .list_jobs(Some("project-b"), None, 100)
+        .expect("list b");
+    assert_eq!(b_list.len(), 1);
+    assert_eq!(b_list[0].id, b.id);
+}
+
 /// An Ideogram auto-caption image job (sc-9120). Created NON-claimable in `pending_caption`.
 fn pending_caption_job(payload: Value) -> CreateJob {
     CreateJob {


### PR DESCRIPTION
Resolves GitHub issue #1556 — the Queue lists every job forever with no way to remove finished ones. Two affordances:

1. **Clear completed** — a button that clears every terminal job in view (scoped to the active project filter).
2. **Per-card ×** — a small dismiss in each finished card's top-right corner to clear that one item.

## Design — soft-hide, not delete
The Generation Stats feed (`list_generation_metrics`, epic 10402) **inner-joins** `generation_metrics` to `jobs`, so hard-deleting a completed job would silently wipe that run from the stats charts and orphan its metrics row. Instead a new nullable `cleared_at` column soft-hides the row:

- `list_jobs` and `queue_summary` exclude cleared jobs (gone from the list + counts; they don't reappear via a status filter).
- The job row is **kept**, so Generation Stats history stays intact.
- Generated assets live in the project store independently, so clearing a job never removes its outputs.

Both affordances only clear **terminal** jobs (completed / failed / canceled / interrupted). The per-card × is intentionally absent on active cards: soft-hiding a running job would just resurrect it on the next SSE tick — cancel an in-flight job instead. The store enforces this too (`clear_job` on a non-terminal job → 400).

A follow-up (**sc-12233**, out of scope) can add age-based **hard purge** of old terminal rows for DB hygiene; that would also drop the joined metrics, which is why it's deliberately separate.

## Changes
- **`sceneworks-core`**: `cleared_at` column; `clear_terminal_jobs(project_id)` (bulk) + `clear_job(job_id)` (single); `list_jobs` / `queue_summary` exclude cleared rows.
- **`sceneworks-rust-api`**: `POST /api/v1/jobs/clear` (bulk) + `POST /api/v1/jobs/:job_id/clear` (single); both republish the queue.
- **web**: `clearCompletedJobs` + `clearJob` actions prune cleared jobs from live state; a `Clear completed (n)` button in the Queue tools row and an `onClear` × on each terminal `WorkerProgressCard`.

## Tests
- Core: bulk + single soft-hide keep Generation Stats and are idempotent; project scoping; non-terminal rejection.
- API: bulk + per-job clear endpoints, project scoping, 400 on a non-terminal job.
- Web: the Clear-completed button (count + scope + disabled state) and the per-card × (renders only on terminal cards, calls the handler).

## Validation
`cargo fmt --check` ✓ · `cargo clippy` (0 warnings) ✓ · core + API tests ✓ · full web vitest suite (1825/1825) ✓ · eslint (0 errors) ✓ · `vite build` ✓ · scaffold check ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)