### PR TITLE
fix(worker): download models natively — retire the Python hf CLI (sc-12227, sc-12232)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1544,7 +1544,7 @@ const KREA_MLX_TURNKEY_REPO: &str = "SceneWorks/krea-2-turbo-mlx";
 /// hard-coded const (no manifest/payload override reaches this on-demand ConvRot-base fetch), so pulling
 /// the mutable `main` branch would let an upstream re-push silently swap the bf16 DiT / Qwen3-VL TE /
 /// Qwen-Image VAE we load. Pin the exact commit for defense-in-depth (mirrors the SeedVR2/Real-ESRGAN
-/// pins, sc-8879/sc-9682). The `hf` CLI still verifies each file's own hash on download.
+/// pins, sc-8879/sc-9682). The native downloader still verifies each file's own hash on download.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const KREA_MLX_TURNKEY_REVISION: &str = "d009674080cc1bccf2b629d834c34bf5eccdb723";
 
@@ -1553,8 +1553,8 @@ const KREA_MLX_TURNKEY_REVISION: &str = "d009674080cc1bccf2b629d834c34bf5eccdb72
 /// single-file; the bf16 `bf16/` subdir of the `krea-2-turbo-mlx` turnkey (tokenizer / Qwen3-VL TE /
 /// Qwen-Image VAE / config) is fetched here when the ConvRot tier is selected and it isn't present —
 /// so q4/q8 users are never forced to download the 35 GB bf16 base (it isn't a global co-requisite).
-/// No-op when the request isn't a ConvRot job, the bf16 base is already complete, or the `hf` CLI is
-/// absent (then `resolve_krea_convrot` returns `None` and the job falls back / surfaces a load error).
+/// No-op when the request isn't a ConvRot job or the bf16 base is already complete; a real download
+/// error fails loud (otherwise `resolve_krea_convrot` loads the freshly fetched base).
 /// Fails loud on a real download error — fast, before any compute.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 async fn ensure_krea_convrot_base_present(
@@ -1590,11 +1590,6 @@ async fn fetch_krea_convrot_base(
     settings: &Settings,
     job: &JobSnapshot,
 ) -> WorkerResult<()> {
-    let scratch = settings
-        .data_dir
-        .join("cache")
-        .join(format!(".krea-convrot-base-fetch-{}", job.id));
-    tokio::fs::create_dir_all(&scratch).await?;
     let files = vec![
         "bf16/transformer/*".to_owned(),
         "bf16/text_encoder/*".to_owned(),
@@ -1603,18 +1598,16 @@ async fn fetch_krea_convrot_base(
         "bf16/scheduler/*".to_owned(),
         "bf16/model_index.json".to_owned(),
     ];
-    let result = crate::model_jobs::download_model_with_hf_cli(
+    crate::model_jobs::ensure_hf_files_cached(
         api,
         settings,
         job,
         KREA_MLX_TURNKEY_REPO,
         KREA_MLX_TURNKEY_REVISION,
         &files,
-        &scratch,
     )
-    .await;
-    let _ = tokio::fs::remove_dir_all(&scratch).await;
-    result.map(|_| ())
+    .await
+    .map(|_| ())
 }
 
 /// On-demand fetch of a non-default Boogu tier subfolder (sc-6568 / sc-8513). The catalog download
@@ -1624,7 +1617,7 @@ async fn fetch_krea_convrot_base(
 /// resolves it. No-op when the Q8 default is requested, the model isn't Boogu, the turnkey snapshot
 /// isn't downloaded yet (`boogu_model_subdir` then falls back to Q8 / surfaces the load error), or the
 /// tier subfolder is already complete. Fails loud on a real download error — fast, before any compute;
-/// a missing `hf` CLI leaves the subfolder absent so the request gracefully falls back to Q8. Mirrors
+/// a tier that isn't published yet stays absent so the request falls back to Q8. Mirrors
 /// [`crate::video_jobs::ensure_ltx_q8_present`].
 ///
 /// sc-9607 (epic 9083): also runs on the candle lane (off-Mac) — `generate_candle_stream` calls it
@@ -1671,29 +1664,22 @@ async fn ensure_boogu_tier_present(
     {
         return Ok(());
     }
-    let scratch = settings
-        .data_dir
-        .join("cache")
-        .join(format!(".boogu-tier-fetch-{}", job.id));
-    tokio::fs::create_dir_all(&scratch).await?;
     // The tier subfolder nests transformer/mllm/vae (leaf-dir globs, like the catalog Q8 entry).
     let files = vec![
         format!("{tier}/transformer/*"),
         format!("{tier}/mllm/*"),
         format!("{tier}/vae/*"),
     ];
-    let result = crate::model_jobs::download_model_with_hf_cli(
+    crate::model_jobs::ensure_hf_files_cached(
         api,
         settings,
         job,
         &model_repo(request, &model),
         "main",
         &files,
-        &scratch,
     )
-    .await;
-    let _ = tokio::fs::remove_dir_all(&scratch).await;
-    result.map(|_| ())
+    .await
+    .map(|_| ())
 }
 
 /// On-demand fetch of Ideogram 4's non-default `q8/` tier (sc-9607, epic 9083). The catalog download
@@ -1708,7 +1694,7 @@ async fn ensure_boogu_tier_present(
 /// (and is macOS-only). This is the on-demand `q8/` download the [`ideogram_model_subdir`] docstring
 /// flagged as a follow-up; it runs on BOTH the MLX (`generate_stream`) and candle
 /// (`generate_candle_stream`) lanes, so off-Mac gets the same q4/q8 picker as macOS. Fails loud on a
-/// real download error; a missing `hf` CLI leaves `q8/` absent so the request gracefully falls back to q4.
+/// real download error; a `q8/` tier that isn't published yet stays absent so the request falls back to q4.
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
@@ -1743,24 +1729,17 @@ async fn ensure_ideogram_tier_present(
     {
         return Ok(());
     }
-    let scratch = settings
-        .data_dir
-        .join("cache")
-        .join(format!(".ideogram-tier-fetch-{}", job.id));
-    tokio::fs::create_dir_all(&scratch).await?;
     let files = vec![format!("{tier}/*")];
-    let result = crate::model_jobs::download_model_with_hf_cli(
+    crate::model_jobs::ensure_hf_files_cached(
         api,
         settings,
         job,
         &model_repo(request, &model),
         "main",
         &files,
-        &scratch,
     )
-    .await;
-    let _ = tokio::fs::remove_dir_all(&scratch).await;
-    result.map(|_| ())
+    .await
+    .map(|_| ())
 }
 
 #[cfg(any(

--- a/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
@@ -18,7 +18,7 @@ const KOLORS_IPADAPTER_REPO: &str = "Kwai-Kolors/Kolors-IP-Adapter-Plus";
 /// candle can't read); PR-4 adds `ip_adapter_plus_general.safetensors` + `image_encoder/model.safetensors`.
 /// Pinned to the exact commit at the tip of `refs/pr/4` rather than the mutable `refs/pr/4` ref itself
 /// (sc-11168 / F-007 — completes the sc-9879 rollout): a force-push to the PR could otherwise swap the
-/// adapter/encoder weights we load. The `hf` CLI still verifies each file's own hash on download.
+/// adapter/encoder weights we load. The native downloader still verifies each file's own hash on download.
 const KOLORS_IPADAPTER_REVISION: &str = "5c72aa86cd8d9d23ff406d293c5473820e09e1d9";
 /// The IP-Adapter-Plus bundle file (root of the snapshot).
 const KOLORS_IPADAPTER_BUNDLE: &str = "ip_adapter_plus_general.safetensors";

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -100,24 +100,15 @@ pub(crate) async fn run_model_download_job(
     )
     .await?;
 
-    if let Some(cache_path) =
-        download_model_with_hf_cli(api, settings, job, repo, revision, &files, &target_dir).await?
-    {
-        overlay_derived_tokenizer(api, settings, http_client, &job.id, repo, &cache_path).await?;
-        if !reconcile_downloaded_model_family(api, job, &cache_path).await? {
-            return Ok(());
-        }
-        complete_hf_cache_download(
-            api,
-            job,
-            "modelId",
-            repo,
-            &cache_path,
-            "Model download completed in the Hugging Face cache.",
-        )
-        .await?;
-        return Ok(());
-    }
+    // The model-import download always uses the native Rust downloader below — it is NOT routed
+    // through the Python `hf`/`huggingface-cli` subprocess (sc-12227 / issue #1554). The CLI path
+    // (`download_model_with_hf_cli`) reports progress exactly once (0.12) and never updates it,
+    // and it has no forward-progress watchdog, so on a host with `hf` on PATH a model download
+    // freezes the bar at 12% and a hung HF CDN edge never recovers. The native path streams with
+    // real byte-level progress AND the stall watchdog (sc-11939), resumes via HTTP Range, and
+    // drops a Python dependency from this flow (epic 3482). This mirrors `run_lora_download_job`,
+    // which already downloads natively. (The CLI helper stays for the on-demand generation-time
+    // tier fetches that still rely on it — see `resolve_convert_plan` / base-model tier fetches.)
 
     // Download into the standard Hugging Face hub cache (models--<org>--<name>),
     // not the private app store, so HF-sourced weights dedupe with other tools and

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -100,15 +100,13 @@ pub(crate) async fn run_model_download_job(
     )
     .await?;
 
-    // The model-import download always uses the native Rust downloader below — it is NOT routed
-    // through the Python `hf`/`huggingface-cli` subprocess (sc-12227 / issue #1554). The CLI path
-    // (`download_model_with_hf_cli`) reports progress exactly once (0.12) and never updates it,
-    // and it has no forward-progress watchdog, so on a host with `hf` on PATH a model download
-    // freezes the bar at 12% and a hung HF CDN edge never recovers. The native path streams with
-    // real byte-level progress AND the stall watchdog (sc-11939), resumes via HTTP Range, and
-    // drops a Python dependency from this flow (epic 3482). This mirrors `run_lora_download_job`,
-    // which already downloads natively. (The CLI helper stays for the on-demand generation-time
-    // tier fetches that still rely on it — see `resolve_convert_plan` / base-model tier fetches.)
+    // The model-import download uses the native Rust downloader below. The Python
+    // `hf`/`huggingface-cli` subprocess it used to prefer reported progress exactly once (0.12) and
+    // never updated it, and had no forward-progress watchdog, so on a host with `hf` on PATH a model
+    // download froze the bar at 12% and a hung HF CDN edge never recovered (sc-12227 / sc-12232,
+    // issue #1554). The native path streams with real byte-level progress AND the stall watchdog
+    // (sc-11939), resumes via HTTP Range, and keeps a Python dependency out of this flow (epic 3482).
+    // Mirrors `run_lora_download_job`; the on-demand tier fetches share `ensure_hf_files_cached`.
 
     // Download into the standard Hugging Face hub cache (models--<org>--<name>),
     // not the private app store, so HF-sourced weights dedupe with other tools and
@@ -828,22 +826,8 @@ async fn ensure_ltx_upscaler_cached(
             return Ok(Some(snapshot));
         }
     }
-    let scratch = settings
-        .data_dir
-        .join("cache")
-        .join(format!(".ltx-upscaler-fetch-{}", job.id));
-    tokio::fs::create_dir_all(&scratch).await?;
     let files = vec![file.to_owned()];
-    // Bind-then-remove: the fetch's `?` must not leak the scratch dir under data/cache on the error
-    // path (F-118). Clean the scratch dir whether the download succeeded or failed, then propagate.
-    let fetched =
-        download_model_with_hf_cli(api, settings, job, repo, "main", &files, &scratch).await;
-    let _ = tokio::fs::remove_dir_all(&scratch).await;
-    let fetched = fetched?;
-    let snapshot = match fetched {
-        Some(dir) => Some(dir),
-        None => huggingface_snapshot_dir(&settings.data_dir, repo),
-    };
+    let snapshot = ensure_hf_files_cached(api, settings, job, repo, "main", &files).await?;
     Ok(snapshot.filter(|dir| dir.join(file).exists()))
 }
 
@@ -1621,136 +1605,69 @@ fn converted_dir_backup_path(final_dir: &Path) -> PathBuf {
     }
 }
 
-pub(crate) async fn download_model_with_hf_cli(
+/// Fetch the `files` glob patterns from `repo`@`revision` into the shared Hugging Face hub cache
+/// using the NATIVE downloader — real byte-level progress, the sc-11939 forward-progress stall
+/// watchdog, HTTP-Range resume, and Windows blob hardlinks — and return the repo's snapshot dir.
+/// This is the on-demand generation/convert-time counterpart to `run_model_download_job`'s cache
+/// download; it writes NO install marker (these are cache warm-ups, not user-visible installs).
+///
+/// Replaces the retired Python `hf`/`huggingface-cli` path (sc-12227 / sc-12232, issue #1554): that
+/// subprocess pinned job progress at 12% for the whole transfer, had no stall watchdog, and only ran
+/// when `hf` was on PATH (so a host without it silently couldn't pull these tiers). The native path
+/// also honors a custom `huggingface_base_url`, which the CLI could not. Returns the snapshot dir, or
+/// `None` only when the repo still has no snapshot after the fetch (e.g. the filter matched zero
+/// files) so callers keep their existing "resolve the tier subdir, else fall back" presence checks.
+pub(crate) async fn ensure_hf_files_cached(
     api: &ApiClient,
     settings: &Settings,
     job: &JobSnapshot,
     repo: &str,
     revision: &str,
     files: &[String],
-    marker_dir: &Path,
 ) -> WorkerResult<Option<PathBuf>> {
-    let Some(program) = hf_cli_program().await else {
-        return Ok(None);
-    };
-    if settings.huggingface_base_url.trim_end_matches('/') != DEFAULT_HUGGINGFACE_BASE_URL {
-        return Ok(None);
-    }
-    validate_hf_cli_download_inputs(repo, revision, files)?;
-    let cache_dir = huggingface_hub_cache_dir(&settings.data_dir);
-    tokio::fs::create_dir_all(&cache_dir).await?;
-    update_job(
-        api,
-        &job.id,
-        progress_payload(
-            JobStatus::Downloading,
-            ProgressStage::Downloading,
-            0.12,
-            &format!("Downloading {repo} into the Hugging Face cache."),
-            None,
-            None,
-            None,
-        ),
-    )
-    .await?;
-
-    let mut command = Command::new(program);
-    command
-        .arg("download")
-        .arg(repo)
-        .arg("--repo-type")
-        .arg("model")
-        .arg("--revision")
-        .arg(revision)
-        .arg("--cache-dir")
-        .arg(&cache_dir)
-        .stdout(Stdio::null())
-        .stderr(Stdio::piped());
-    configure_hf_cli_environment(&mut command);
-    // Resolve the HF token lazily (env, or a one-time pull of the recorded
-    // `huggingface.co` keychain credential from the desktop socket on macOS) so the
-    // keychain is read only when a download actually needs it (sc-5891).
-    if let Some(token) = crate::credentials_ipc::resolve_hf_token(settings).await {
-        command.env("HF_TOKEN", token);
-    }
-    for pattern in files {
-        command.arg("--include").arg(pattern);
-    }
-    let fresh_download = optional_payload_string(&job.payload, "downloadAction") == Some("fresh");
-    if fresh_download {
-        command.arg("--force-download");
-    }
-
-    // sc-8804 (F-003): if the heartbeat/cancel `?` in the wait loop below returns early (a transient
-    // POST failure or a 409 stale-sweep reclaim), `child` is dropped without an explicit kill. A
-    // tokio child is not reaped on drop by default, so the `hf` transfer would keep running and
-    // writing partial files into the HF cache. `kill_on_drop` tears it down on any early return.
-    command.kill_on_drop(true);
-    let mut child = command.spawn().map_err(|error| {
-        WorkerError::Engine(format!(
-            "Failed to start Hugging Face CLI. Falling back to direct downloads is only possible when the CLI is absent, not when it fails to launch: {error}"
+    validate_hf_download_inputs(repo, revision, files)?;
+    let repo_dir = huggingface_repo_cache_path(&settings.data_dir, repo).ok_or_else(|| {
+        WorkerError::InvalidPayload(format!(
+            "Unable to resolve Hugging Face cache path for {repo}."
         ))
     })?;
-    let mut stderr = child.stderr.take();
-    let stderr_task = tokio::spawn(async move {
-        let mut bytes = Vec::new();
-        if let Some(stderr) = stderr.as_mut() {
-            let _ = stderr.read_to_end(&mut bytes).await;
-        }
-        bytes
-    });
-    let mut interval = tokio::time::interval(progress_report_interval(settings));
-    interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-    let status = loop {
-        tokio::select! {
-            status = child.wait() => break status?,
-            _ = interval.tick() => {
-                heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
-                if let Err(error) = check_cancel(api, &job.id, "Model download canceled by user.").await {
-                    let _ = child.kill().await;
-                    return Err(error);
-                }
-            }
-        }
-    };
-    let stderr = stderr_task
-        .await
-        .map_err(|error| task_join_error("Hugging Face CLI stderr reader task", error))?;
-    let repo_cache_path =
-        huggingface_repo_cache_path(&settings.data_dir, repo).ok_or_else(|| {
-            WorkerError::InvalidPayload(format!(
-                "Unable to resolve Hugging Face cache path for {repo}."
-            ))
-        })?;
-    if !status.success() {
-        let stderr = String::from_utf8_lossy(&stderr);
-        // Some Windows installs run the Python-based HF CLI with a legacy stdio
-        // codepage. The download can complete, then the process exits non-zero
-        // while printing a Unicode checkmark/progress footer. If the cache now has
-        // a snapshot, keep the completed transfer instead of failing the job.
-        if hf_cli_encoding_failure(&stderr)
-            && huggingface_snapshot_dir(&settings.data_dir, repo).is_some()
-        {
-            let cache_path =
-                huggingface_snapshot_dir(&settings.data_dir, repo).unwrap_or(repo_cache_path);
-            write_model_install_marker(marker_dir, &job.payload, repo, &job.id).await?;
-            return Ok(Some(cache_path));
-        }
-        let detail = bounded_tail(&stderr, 10, 2000);
-        let message = if detail.trim().is_empty() {
-            "Hugging Face CLI download failed without stderr output.".to_owned()
-        } else {
-            format!("Hugging Face CLI download failed:\n{detail}")
-        };
-        return Err(WorkerError::Engine(message));
+    let client = streaming_download_client();
+    let snapshot = HuggingFaceSnapshot::resolve(&client, settings, repo, revision, files).await?;
+    // A filter that matches zero files is a no-op (same net effect as the old `hf download --include`
+    // with no match): don't create an empty transfer, and leave the caller's presence check to fall
+    // back to a smaller complete tier.
+    if !snapshot.files.is_empty() {
+        let mut progress = DownloadProgress::new(
+            repo,
+            directory_size(&repo_dir.join("blobs")).await,
+            snapshot.total_bytes(),
+            progress_report_interval(settings),
+        );
+        download_snapshot_into_cache(
+            &DownloadContext {
+                api,
+                client: &client,
+                settings,
+                job_id: &job.id,
+                cancel_message: "Model download canceled by user.",
+                fresh_download: false,
+            },
+            &repo_dir,
+            revision,
+            &snapshot,
+            &mut progress,
+        )
+        .await?;
     }
-
-    let cache_path = huggingface_snapshot_dir(&settings.data_dir, repo).unwrap_or(repo_cache_path);
-    write_model_install_marker(marker_dir, &job.payload, repo, &job.id).await?;
-    Ok(Some(cache_path))
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
 }
 
-pub(crate) fn validate_hf_cli_download_inputs(
+/// Reject repo / revision / include-pattern inputs that could escape the intended Hugging Face path
+/// before they reach the native downloader's URL builder (`downloads::quote_path`): leading slashes,
+/// `..` traversal, backslashes, control characters, and unsupported characters. Applied by
+/// `ensure_hf_files_cached` to the on-demand tier fetches (the user-facing model/LoRA download jobs
+/// build their URLs the same way).
+pub(crate) fn validate_hf_download_inputs(
     repo: &str,
     revision: &str,
     files: &[String],
@@ -1872,41 +1789,6 @@ fn safe_hf_path_parts<'a>(value: &'a str, label: &str) -> WorkerResult<Vec<&'a s
         )));
     }
     Ok(parts)
-}
-
-pub(crate) const HF_CLI_UTF8_ENV: [(&str, &str); 3] = [
-    ("PYTHONUTF8", "1"),
-    ("PYTHONIOENCODING", "utf-8"),
-    ("HF_HUB_DISABLE_PROGRESS_BARS", "1"),
-];
-
-pub(crate) fn configure_hf_cli_environment(command: &mut Command) {
-    for (key, value) in HF_CLI_UTF8_ENV {
-        command.env(key, value);
-    }
-}
-
-pub(crate) fn hf_cli_encoding_failure(stderr: &str) -> bool {
-    let normalized = stderr.to_ascii_lowercase();
-    normalized.contains("charmap")
-        && (normalized.contains("codec can't encode")
-            || normalized.contains("unicodeencodeerror")
-            || normalized.contains("character maps to <undefined>"))
-}
-
-pub(crate) async fn hf_cli_program() -> Option<&'static str> {
-    for program in ["hf", "huggingface-cli"] {
-        let status = Command::new(program)
-            .arg("--version")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await;
-        if status.is_ok_and(|status| status.success()) {
-            return Some(program);
-        }
-    }
-    None
 }
 
 /// Locates the first `.safetensors` under `dir`, reads its header, and

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -60,8 +60,7 @@ use super::media_jobs::{mask_rollup_state, segment_assembly_frames, SegmentClip,
 use super::model_jobs::{
     check_downloaded_model_family, derived_tokenizer_overlay,
     downloaded_model_detection_io_error_is_inconclusive, finalize_converted_dir,
-    hf_cli_encoding_failure, overlay_derived_tokenizer, validate_hf_cli_download_inputs,
-    DownloadFamilyCheck, HF_CLI_UTF8_ENV,
+    overlay_derived_tokenizer, validate_hf_download_inputs, DownloadFamilyCheck,
 };
 // `terminating_signal` is only exercised by a `#[cfg(unix)]` test (signal-death
 // attribution is uncatchable and only observable on Unix), so gate the import to

--- a/crates/sceneworks-worker/src/tests/cancel_and_heartbeat.rs
+++ b/crates/sceneworks-worker/src/tests/cancel_and_heartbeat.rs
@@ -640,11 +640,11 @@ async fn run_blocking_with_heartbeat_none_cancel_returns_single_shot_value() {
     );
 }
 
-/// sc-8804 (F-003) — the child-process leg: `run_ffmpeg` (media_jobs) and the `hf` CLI download
-/// (model_jobs) build their `tokio::process::Command` with `kill_on_drop(true)` so a
-/// heartbeat/cancel `?` early return reaps the child instead of leaving ffmpeg/`hf` writing partial
-/// files. A tokio child is NOT reaped on drop by default; this test locks the mechanism the fix
-/// relies on — a `kill_on_drop(true)` child is torn down when its handle is dropped.
+/// sc-8804 (F-003) — the child-process leg: `run_ffmpeg` (media_jobs) builds its
+/// `tokio::process::Command` with `kill_on_drop(true)` so a heartbeat/cancel `?` early return reaps
+/// the child instead of leaving ffmpeg writing partial files. A tokio child is NOT reaped on drop by
+/// default; this test locks the mechanism the fix relies on — a `kill_on_drop(true)` child is torn
+/// down when its handle is dropped.
 #[cfg(unix)]
 #[tokio::test]
 async fn kill_on_drop_reaps_a_dropped_child() {

--- a/crates/sceneworks-worker/src/tests/hf_and_family.rs
+++ b/crates/sceneworks-worker/src/tests/hf_and_family.rs
@@ -62,27 +62,8 @@ fn flux1_no_metadata_safetensors_keys() -> Vec<String> {
 }
 
 #[test]
-fn hf_cli_windows_encoding_failures_are_detected() {
-    let stderr = "Fetching 28 files: 100%|##########| 28/28 [00:00<00:00, 14016.05it/s]\n\
-                  Error: Invalid value. 'charmap' codec can't encode character '\\u2713' \
-                  in position 5: character maps to <undefined>";
-
-    assert!(hf_cli_encoding_failure(stderr));
-    assert!(!hf_cli_encoding_failure("Error: Repository not found."));
-}
-
-#[test]
-fn hf_cli_environment_forces_python_utf8_output() {
-    let env: HashMap<_, _> = HF_CLI_UTF8_ENV.into_iter().collect();
-
-    assert_eq!(env.get("PYTHONUTF8"), Some(&"1"));
-    assert_eq!(env.get("PYTHONIOENCODING"), Some(&"utf-8"));
-    assert_eq!(env.get("HF_HUB_DISABLE_PROGRESS_BARS"), Some(&"1"));
-}
-
-#[test]
-fn hf_cli_download_inputs_accept_catalog_values() {
-    validate_hf_cli_download_inputs(
+fn hf_download_inputs_accept_catalog_values() {
+    validate_hf_download_inputs(
         "black-forest-labs/FLUX.1-dev",
         "refs/pr/12",
         &[
@@ -95,14 +76,14 @@ fn hf_cli_download_inputs_accept_catalog_values() {
 }
 
 #[test]
-fn hf_cli_download_inputs_reject_option_injection() {
+fn hf_download_inputs_reject_option_injection() {
     for repo in ["--local-dir=/Users/me/.ssh", "owner/--local-dir=/tmp/out"] {
-        let error = validate_hf_cli_download_inputs(repo, "main", &["*.safetensors".to_owned()])
+        let error = validate_hf_download_inputs(repo, "main", &["*.safetensors".to_owned()])
             .expect_err("malicious repo rejected");
         assert!(matches!(error, WorkerError::InvalidPayload(_)));
     }
 
-    let error = validate_hf_cli_download_inputs(
+    let error = validate_hf_download_inputs(
         "owner/model",
         "--local-dir=/tmp/out",
         &["*.safetensors".to_owned()],
@@ -110,7 +91,7 @@ fn hf_cli_download_inputs_reject_option_injection() {
     .expect_err("malicious revision rejected");
     assert!(matches!(error, WorkerError::InvalidPayload(_)));
 
-    let error = validate_hf_cli_download_inputs(
+    let error = validate_hf_download_inputs(
         "owner/model",
         "main",
         &["--local-dir=/tmp/out".to_owned()],
@@ -120,20 +101,20 @@ fn hf_cli_download_inputs_reject_option_injection() {
 }
 
 #[test]
-fn hf_cli_download_inputs_reject_traversal_and_absolute_patterns() {
+fn hf_download_inputs_reject_traversal_and_absolute_patterns() {
     for pattern in [
         "../model.safetensors",
         "nested/../../model.safetensors",
         "/tmp/model.bin",
     ] {
-        let error = validate_hf_cli_download_inputs("owner/model", "main", &[pattern.to_owned()])
+        let error = validate_hf_download_inputs("owner/model", "main", &[pattern.to_owned()])
             .expect_err("unsafe include pattern rejected");
         assert!(matches!(error, WorkerError::InvalidPayload(_)));
     }
 
     for revision in ["../main", "refs/heads/../main", "/refs/main"] {
         let error =
-            validate_hf_cli_download_inputs("owner/model", revision, &["*.safetensors".to_owned()])
+            validate_hf_download_inputs("owner/model", revision, &["*.safetensors".to_owned()])
                 .expect_err("unsafe revision rejected");
         assert!(matches!(error, WorkerError::InvalidPayload(_)));
     }

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -2854,7 +2854,7 @@ const WAN_T2V_14B_REPO: &str = "SceneWorks/wan2.2-t2v-a14b-mlx";
 /// hard-coded const — no manifest/payload override reaches the on-demand `q8/*` + `bf16/*` fetches —
 /// so pulling the mutable `main` branch would let an upstream re-push silently swap a checkpoint we
 /// load. Pin the exact commit that adds the `q4/`/`q8/`/`bf16/` tier subdirs for defense-in-depth
-/// (the `hf` CLI still verifies each file's own hash on download). This is the commit that added the
+/// (the native downloader still verifies each file's own hash on download). This is the commit that added the
 /// `q4/`/`q8/`/`bf16/` tier subdirs (sc-9942).
 #[cfg(target_os = "macos")]
 const WAN_T2V_14B_REVISION: &str = "991eb255c544bbb2e1f1e07da4355c2f0a5337b7";
@@ -2871,7 +2871,7 @@ const WAN_I2V_14B_REPO: &str = "SceneWorks/wan2.2-i2v-a14b-mlx";
 /// Pinned revision for [`WAN_I2V_14B_REPO`] (mirrors [`WAN_T2V_14B_REVISION`]). The commit that adds
 /// the `q4/`/`q8/`/`bf16/` tier subdirs to the I2V-A14B repo (sc-9943); pinning the exact commit (not
 /// the mutable `main`) stops an upstream re-push from silently swapping a checkpoint the on-demand
-/// `q8/*` + `bf16/*` fetch loads (the `hf` CLI still verifies each file's own hash on download).
+/// `q8/*` + `bf16/*` fetch loads (the native downloader still verifies each file's own hash on download).
 #[cfg(target_os = "macos")]
 const WAN_I2V_14B_REVISION: &str = "c6c786170031eccc3a1fac0f98f1ad4ff988271e";
 
@@ -2887,7 +2887,7 @@ const WAN_TI2V_5B_REPO: &str = "SceneWorks/wan2.2-ti2v-5b-mlx";
 /// Pinned revision for [`WAN_TI2V_5B_REPO`] (mirrors [`WAN_T2V_14B_REVISION`]). The commit that adds
 /// the `q4/`/`q8/`/`bf16/` tier subdirs to the TI2V-5B repo (sc-9941); pinning the exact commit (not
 /// the mutable `main`) stops an upstream re-push from silently swapping a checkpoint the on-demand
-/// `q8/*` + `bf16/*` fetch loads (the `hf` CLI still verifies each file's own hash on download).
+/// `q8/*` + `bf16/*` fetch loads (the native downloader still verifies each file's own hash on download).
 #[cfg(target_os = "macos")]
 const WAN_TI2V_5B_REVISION: &str = "bb1b055249614cf9d7cf4373fbdbc184b77dee88";
 
@@ -2895,7 +2895,7 @@ const WAN_TI2V_5B_REVISION: &str = "bb1b055249614cf9d7cf4373fbdbc184b77dee88";
 /// F-007 — completes the sc-9879 rollout). Both the MLX (`ensure_wan_lightning_present`) and candle
 /// (`candle_ensure_wan_lightning_present`) self-heal fetches were pulling the mutable `main` branch, so an
 /// upstream re-push (or a compromised token) could silently swap the high/low distill weights we load.
-/// Pin the exact commit for defense-in-depth (the `hf` CLI still verifies each file's own hash on
+/// Pin the exact commit for defense-in-depth (the native downloader still verifies each file's own hash on
 /// download). Shared by BOTH lanes so the twins agree. Gated to the lanes that actually fetch it (macOS
 /// MLX or the candle build) so a Linux-non-candle build doesn't flag it dead.
 #[cfg(any(
@@ -3039,7 +3039,7 @@ fn resolve_wan_tier_dir_and_quant(
 /// matrix, a `q4` (default)
 /// job, when the repo snapshot isn't downloaded yet (resolve surfaces the clear error), or when the
 /// tier is already complete. Fails loud on a real download error — fast, before any compute; a
-/// missing `hf` CLI leaves the tier absent so resolve gracefully falls back to a smaller complete
+/// tier that isn't published yet stays absent so resolve falls back to a smaller complete
 /// tier.
 #[cfg(target_os = "macos")]
 async fn ensure_wan_tier_present(
@@ -3063,18 +3063,10 @@ async fn ensure_wan_tier_present(
     if wan_tier_is_complete(&root.join(tier), wan_tier_files(&request.model)) {
         return Ok(());
     }
-    let scratch = settings
-        .data_dir
-        .join("cache")
-        .join(format!(".wan-tier-{tier}-fetch-{}", job.id));
-    tokio::fs::create_dir_all(&scratch).await?;
     let files = vec![format!("{tier}/*")];
-    let result = crate::model_jobs::download_model_with_hf_cli(
-        api, settings, job, repo, revision, &files, &scratch,
-    )
-    .await;
-    let _ = tokio::fs::remove_dir_all(&scratch).await;
-    result.map(|_| ())
+    crate::model_jobs::ensure_hf_files_cached(api, settings, job, repo, revision, &files)
+        .await
+        .map(|_| ())
 }
 
 /// On-demand fetch of the 4-step Lightning distill LoRA pair (`lightx2v/Wan2.2-Lightning`) for the
@@ -3084,8 +3076,8 @@ async fn ensure_wan_tier_present(
 /// self-heals that case: it pulls just the per-architecture high/low pair the first time a gen needs
 /// it (twin of [`ensure_wan_tier_present`] / the candle `ensure_qwen_lightning_lora_cached`). No-op
 /// when the Lightning toggle is off (sc-10047 — the native multi-step recipe needs no LoRA), for a
-/// non-A14B engine, when the pair is already cached, or when the `hf` CLI is absent (resolve then
-/// surfaces the clear "fetch it via the model manager" error). Fails loud on a real download error —
+/// non-A14B engine, or when the pair is already cached. A pair still missing after the fetch makes
+/// resolve surface the clear "fetch it via the model manager" error. Fails loud on a real download error —
 /// fast, before any compute.
 #[cfg(target_os = "macos")]
 async fn ensure_wan_lightning_present(
@@ -3118,27 +3110,20 @@ async fn ensure_wan_lightning_present(
             return Ok(());
         }
     }
-    let scratch = settings
-        .data_dir
-        .join("cache")
-        .join(format!(".wan-lightning-fetch-{}", job.id));
-    tokio::fs::create_dir_all(&scratch).await?;
     let files = vec![
         format!("{subdir}/high_noise_model.safetensors"),
         format!("{subdir}/low_noise_model.safetensors"),
     ];
-    let result = crate::model_jobs::download_model_with_hf_cli(
+    crate::model_jobs::ensure_hf_files_cached(
         api,
         settings,
         job,
         REPO,
         WAN_LIGHTNING_REVISION,
         &files,
-        &scratch,
     )
-    .await;
-    let _ = tokio::fs::remove_dir_all(&scratch).await;
-    result.map(|_| ())
+    .await
+    .map(|_| ())
 }
 
 /// The 4-step Lightning distill LoRA pair (high/low) for an A14B MoE model
@@ -4877,7 +4862,7 @@ fn resolve_candle_video_conditioning(
 // distill through the Lightning toggle and user LoRAs apply on the candle Wan video path. These are
 // candle-lane copies (the macOS lane keeps its own), reusing the backend-neutral helpers `lora_scale` /
 // `resolve_lora_file` / `crate::image_jobs::{lora_path, classify_adapter}` / `MAX_JOB_LORAS` /
-// `advanced_opt_*` / `huggingface_snapshot_dir` / `download_model_with_hf_cli`.
+// `advanced_opt_*` / `huggingface_snapshot_dir` / `ensure_hf_files_cached`.
 // ---------------------------------------------------------------------------
 
 /// (sc-10138) The interim step default for the dense candle TI2V-5B (no distill LoRA exists yet) — the
@@ -4980,8 +4965,8 @@ fn candle_resolve_lightning_loras(
 
 /// (sc-10138) On-demand fetch of the A14B Lightning distill pair for the candle lane — the analog of
 /// `ensure_wan_lightning_present`. Self-heals a worker that installed the tiers before the Lightning
-/// `coRequisite`. No-op when the toggle is off, for a non-A14B engine, when the pair is cached, or when
-/// `hf` is absent (resolve then surfaces the clear "fetch it via the model manager" error).
+/// `coRequisite`. No-op when the toggle is off, for a non-A14B engine, or when the pair is cached. A
+/// pair still missing after the fetch makes resolve surface the clear "fetch it via the model manager" error.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 async fn candle_ensure_wan_lightning_present(
     api: &ApiClient,
@@ -5007,27 +4992,20 @@ async fn candle_ensure_wan_lightning_present(
             return Ok(());
         }
     }
-    let scratch = settings
-        .data_dir
-        .join("cache")
-        .join(format!(".wan-lightning-fetch-{}", job.id));
-    tokio::fs::create_dir_all(&scratch).await?;
     let files = vec![
         format!("{subdir}/high_noise_model.safetensors"),
         format!("{subdir}/low_noise_model.safetensors"),
     ];
-    let result = crate::model_jobs::download_model_with_hf_cli(
+    crate::model_jobs::ensure_hf_files_cached(
         api,
         settings,
         job,
         REPO,
         WAN_LIGHTNING_REVISION,
         &files,
-        &scratch,
     )
-    .await;
-    let _ = tokio::fs::remove_dir_all(&scratch).await;
-    result.map(|_| ())
+    .await
+    .map(|_| ())
 }
 
 /// (sc-10138) Tag an A14B MoE Lightning/user LoRA to a specific expert — the candle analog of
@@ -6298,7 +6276,7 @@ const BERNINI_REPO: &str = "SceneWorks/bernini-mlx";
 
 /// Pinned revision for [`BERNINI_REPO`] — the commit that adds the `q4/`/`q8/`/`bf16/` tier subdirs
 /// (sc-9945). Pinning the exact commit (not the mutable `main`) stops an upstream re-push from silently
-/// swapping a checkpoint the on-demand `q8/*` + `bf16/*` fetch loads (the `hf` CLI still verifies each
+/// swapping a checkpoint the on-demand `q8/*` + `bf16/*` fetch loads (the native downloader still verifies each
 /// file's own hash on download). This is the commit that added the `q4/`/`q8/`/`bf16/` tier subdirs
 /// (sc-9945), with the exact hosted sizes: q4 37,815,703,819 / q8 55,129,270,617 / bf16 87,591,990,679.
 #[cfg(target_os = "macos")]
@@ -6429,7 +6407,7 @@ fn bernini_quant_bits(request: &VideoRequest) -> Option<i64> {
 /// [`BERNINI_REVISION`] the first time it is requested so [`bernini_tier_subdir`] can resolve it. No-op
 /// for a `q4` (default) job, when the repo snapshot isn't downloaded yet (resolve surfaces the clear
 /// error), or when the tier is already complete. Fails loud on a real download error — fast, before any
-/// compute; a missing `hf` CLI leaves the tier absent so resolve falls back to a smaller complete tier.
+/// compute; a tier that isn't published yet stays absent so resolve falls back to a smaller complete tier.
 #[cfg(target_os = "macos")]
 pub(crate) async fn ensure_bernini_tier_present(
     api: &ApiClient,
@@ -6449,24 +6427,17 @@ pub(crate) async fn ensure_bernini_tier_present(
     if bernini_tier_is_complete(&root.join(tier)) {
         return Ok(());
     }
-    let scratch = settings
-        .data_dir
-        .join("cache")
-        .join(format!(".bernini-tier-{tier}-fetch-{}", job.id));
-    tokio::fs::create_dir_all(&scratch).await?;
     let files = vec![format!("{tier}/*")];
-    let result = crate::model_jobs::download_model_with_hf_cli(
+    crate::model_jobs::ensure_hf_files_cached(
         api,
         settings,
         job,
         BERNINI_REPO,
         BERNINI_REVISION,
         &files,
-        &scratch,
     )
-    .await;
-    let _ = tokio::fs::remove_dir_all(&scratch).await;
-    result.map(|_| ())
+    .await
+    .map(|_| ())
 }
 
 /// Raw-settings recorded on a real MLX Bernini asset (mirrors `wan_raw_settings`).
@@ -6948,7 +6919,7 @@ const SCAIL2_REPO: &str = "SceneWorks/scail2-mlx";
 /// Pinned revision for [`SCAIL2_REPO`] (mirrors [`WAN_T2V_14B_REVISION`]). The repo is a hard-coded
 /// const — no manifest/payload override reaches the on-demand `q8/*` + `bf16/*` fetches — so pulling
 /// the mutable `main` branch would let an upstream re-push silently swap a checkpoint we load. This is
-/// the commit that added the `q4/`/`q8/`/`bf16/` tier subdirs (sc-9944); the `hf` CLI still verifies
+/// the commit that added the `q4/`/`q8/`/`bf16/` tier subdirs (sc-9944); the native downloader still verifies
 /// each file's own hash on download.
 #[cfg(target_os = "macos")]
 const SCAIL2_REVISION: &str = "ce88cfdb1008f395e9c820e525e6db7b6695f7b3";
@@ -7044,8 +7015,8 @@ fn resolve_scail2_tier_dir_and_quant(
 /// FIXED [`scail2_tier_repo`] revision the first time it is requested so [`scail2_tier_subdir`] can
 /// resolve it. No-op for a non-SCAIL-2 model, a `q4` (default) job, when the repo snapshot isn't
 /// downloaded yet (resolve surfaces the clear error), or when the tier is already complete. Fails loud
-/// on a real download error — fast, before any compute; a missing `hf` CLI leaves the tier absent so
-/// resolve gracefully falls back to a smaller complete tier.
+/// on a real download error — fast, before any compute; a tier that isn't published yet stays absent so
+/// resolve falls back to a smaller complete tier.
 #[cfg(target_os = "macos")]
 async fn ensure_scail2_tier_present(
     api: &ApiClient,
@@ -7068,18 +7039,10 @@ async fn ensure_scail2_tier_present(
     if scail2_tier_is_complete(&root.join(tier)) {
         return Ok(());
     }
-    let scratch = settings
-        .data_dir
-        .join("cache")
-        .join(format!(".scail2-tier-{tier}-fetch-{}", job.id));
-    tokio::fs::create_dir_all(&scratch).await?;
     let files = vec![format!("{tier}/*")];
-    let result = crate::model_jobs::download_model_with_hf_cli(
-        api, settings, job, repo, revision, &files, &scratch,
-    )
-    .await;
-    let _ = tokio::fs::remove_dir_all(&scratch).await;
-    result.map(|_| ())
+    crate::model_jobs::ensure_hf_files_cached(api, settings, job, repo, revision, &files)
+        .await
+        .map(|_| ())
 }
 
 /// Raw-settings recorded on a real MLX SCAIL-2 asset (mirrors `bernini_raw_settings`). When the
@@ -7509,7 +7472,7 @@ const LTX_BUNDLE_REPO: &str = "SceneWorks/ltx-2.3-mlx";
 /// hard-coded const (no manifest/payload override reaches the on-demand `q8/*` + `bf16/*` fetches), so
 /// pulling the mutable `main` branch would let an upstream re-push silently swap a checkpoint we load.
 /// Pin the exact commit for defense-in-depth (mirrors the SeedVR2/Real-ESRGAN pins, sc-8879/sc-9682).
-/// The `hf` CLI still verifies each file's own hash on download. Bumped to the commit that added the
+/// The native downloader still verifies each file's own hash on download. Bumped to the commit that added the
 /// dense `bf16/` tier (sc-8513) — a superset of the prior commit, so the q8 fetch is unaffected.
 #[cfg(target_os = "macos")]
 const LTX_BUNDLE_REVISION: &str = "01df27d308466533aa09d251e3aebdcc627d07eb";
@@ -7737,7 +7700,7 @@ fn resolve_ltx_eros_gemma_dir(settings: &Settings, model_dir: &Path) -> Option<P
 /// can load it. Base model only (eros has its own single-dir conversion). No-op when Q8 isn't
 /// requested, the bundle snapshot isn't downloaded yet (resolve surfaces the clear "download the
 /// bundle" error), or `q8/` is already present. Fails loud on a real download error — fast, before
-/// any compute; a missing `hf` CLI leaves `q8/` absent so resolve gracefully falls back to Q4.
+/// any compute; a `q8/` tier that isn't published yet stays absent so resolve falls back to Q4.
 /// Mirrors the eros [`ensure_ltx_upscaler_cached`] on-demand fetch.
 #[cfg(target_os = "macos")]
 async fn ensure_ltx_q8_present(
@@ -7755,24 +7718,17 @@ async fn ensure_ltx_q8_present(
     if ltx_dir_is_complete(&root.join("q8")) {
         return Ok(());
     }
-    let scratch = settings
-        .data_dir
-        .join("cache")
-        .join(format!(".ltx-q8-fetch-{}", job.id));
-    tokio::fs::create_dir_all(&scratch).await?;
     let files = vec!["q8/*".to_owned()];
-    let result = crate::model_jobs::download_model_with_hf_cli(
+    crate::model_jobs::ensure_hf_files_cached(
         api,
         settings,
         job,
         LTX_BUNDLE_REPO,
         LTX_BUNDLE_REVISION,
         &files,
-        &scratch,
     )
-    .await;
-    let _ = tokio::fs::remove_dir_all(&scratch).await;
-    result.map(|_| ())
+    .await
+    .map(|_| ())
 }
 
 /// Fetch the SceneWorks LTX bundle's dense `bf16/` subdir on demand (sc-8513, epic 8506). The macOS
@@ -7795,24 +7751,17 @@ async fn ensure_ltx_bf16_present(
     if ltx_dir_is_complete(&root.join("bf16")) {
         return Ok(());
     }
-    let scratch = settings
-        .data_dir
-        .join("cache")
-        .join(format!(".ltx-bf16-fetch-{}", job.id));
-    tokio::fs::create_dir_all(&scratch).await?;
     let files = vec!["bf16/*".to_owned()];
-    let result = crate::model_jobs::download_model_with_hf_cli(
+    crate::model_jobs::ensure_hf_files_cached(
         api,
         settings,
         job,
         LTX_BUNDLE_REPO,
         LTX_BUNDLE_REVISION,
         &files,
-        &scratch,
     )
-    .await;
-    let _ = tokio::fs::remove_dir_all(&scratch).await;
-    result.map(|_| ())
+    .await
+    .map(|_| ())
 }
 
 /// Ensure the Gemma-3 text encoder an **eros** generation needs is on disk (the eros gate over
@@ -7862,24 +7811,17 @@ pub(crate) async fn ensure_ltx_bundle_gemma_present(
             return Ok(());
         }
     }
-    let scratch = settings
-        .data_dir
-        .join("cache")
-        .join(format!(".ltx-gemma-fetch-{}", job.id));
-    tokio::fs::create_dir_all(&scratch).await?;
     let files = vec!["gemma/*".to_owned()];
-    let result = crate::model_jobs::download_model_with_hf_cli(
+    crate::model_jobs::ensure_hf_files_cached(
         api,
         settings,
         job,
         LTX_BUNDLE_REPO,
         LTX_BUNDLE_REVISION,
         &files,
-        &scratch,
     )
-    .await;
-    let _ = tokio::fs::remove_dir_all(&scratch).await;
-    result.map(|_| ())
+    .await
+    .map(|_| ())
 }
 
 /// LoRAs for an LTX generation: the manifest-declared auto distill LoRA (when present) followed by


### PR DESCRIPTION
## Problem

Windows users report model downloads that "begin and then stop" ([#1554](https://github.com/SceneWorks/SceneWorks/issues/1554)) — the screenshot shows a FLUX.2-klein import frozen at 12%.

Root cause: `run_model_download_job` preferred the external Python `hf`/`huggingface-cli` subprocess whenever `hf` was on PATH. That path:
- set job progress **once** to `0.12` and never updated it (stdout `/dev/null`, stderr buffered until exit), so the bar froze at 12% for the entire multi-GB transfer; and
- had **no forward-progress watchdog**, so a hung HF CDN edge never recovered.

The sc-11939 stall watchdog + real byte-progress live only in the **native** downloader, which ran solely as the fallback when `hf` was *absent* — so users **with** a Python HF install got the worse, un-instrumented path. (It also isn't in 0.7.5 at all: the watchdog merged the day after that tag.)

## Fix

**sc-12227** — route `run_model_download_job` straight through the native downloader (`HuggingFaceSnapshot::resolve` + `download_snapshot_into_cache`), matching `run_lora_download_job`. Real byte-level progress, the sc-11939 stall watchdog, HTTP-Range resume, Windows blob hardlinks.

**sc-12232** — retire the CLI **everywhere**. All on-demand generation/convert-time tier fetches now share one native helper, `ensure_hf_files_cached`; `download_model_with_hf_cli` and the `hf_cli_*` helpers are deleted. Repointed: `ensure_ltx_upscaler_cached`; `fetch_krea_convrot_base` / `ensure_boogu_tier_present` / `ensure_ideogram_tier_present`; and the eight video tier fetches (wan / wan-lightning ×2 / bernini / scail2 / ltx q8 / ltx bf16 / ltx gemma). The repo/revision/include-pattern validators are kept (renamed `validate_hf_download_inputs`) and wired into the helper as defense-in-depth.

## Behavior change (sc-12232)

The on-demand fetches used to silently degrade to a smaller tier when `hf` was absent. They now fetch the requested tier natively for everyone (a host without Python is no longer stuck); a real download error fails loud (already the CLI-*present* behavior); an unpublished tier still falls back. Also honors a custom `huggingface_base_url`, which the CLI could not. Removes a Python dependency from every download path (epic 3482).

## Testing

- `cargo test -p sceneworks-worker --lib` — **322 passed / 0 failed** (2 deleted CLI-only tests).
- `cargo check -p sceneworks-worker --lib --features backend-candle` — clean (validates `base.rs` + candle video callers).
- Pre-push **"neither" build** (Linux no-candle dead-code gate) — green.
- The macOS-only video tier fetches use the identical mechanical transform as the validated candle callers, and pass `rustfmt`'s parse; Mac CI GPU-validates.

Fixes #1554.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
