### PR TITLE
feat(worker): ship Krea sequential residency (sc-12176)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -453,7 +453,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -464,7 +464,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -477,7 +477,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -490,7 +490,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -555,7 +555,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -575,7 +575,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -620,7 +620,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -633,7 +633,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen",
  "image",
@@ -721,7 +721,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -738,7 +738,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -751,7 +751,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -762,7 +762,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -772,7 +772,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -802,7 +802,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -832,7 +832,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -844,7 +844,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -891,7 +891,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1186,7 +1186,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -3645,7 +3645,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3658,7 +3658,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3670,7 +3670,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3683,7 +3683,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3735,7 +3735,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3748,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -3758,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3767,7 +3767,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3776,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3789,7 +3789,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3801,7 +3801,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -3813,7 +3813,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -3834,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3860,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3917,7 +3917,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3946,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3956,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -3967,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3981,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4015,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4025,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4038,7 +4038,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4062,7 +4062,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "core-llm",
  "half",
@@ -4367,7 +4367,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5603,7 +5603,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5613,7 +5613,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "candle-gen-catalog",
  "candle-llm",
@@ -5623,7 +5623,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "mlx-gen-catalog",
  "mlx-llm",
@@ -5901,7 +5901,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.4#358a8d367bdb390bca963be0aec733c07c057e14"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -8313,7 +8313,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2501,11 +2501,12 @@
         "quantize": 8,
         "repo": "SceneWorks/krea-2-turbo-mlx"
       },
-      // candle/CUDA VRAM gate (sc-9094, epic 9083) — MEASURED on an RTX PRO 6000 (Blackwell sm_120) at
-      // 1024²/8-step via the candle-gen nvidia-smi peak monitor: q4 packed overall-peak 26.4 GB (the
-      // single-stream DiT + Qwen3-VL-4B TE + Qwen-Image VAE). minMemoryGb 32 covers it with headroom;
-      // q8/bf16 ESTIMATED (~31 / ~44 GB, consistent with the mlx Q8 ~27 GB / bf16 ~43 GB above) pending
-      // measurement.
+      // candle/CUDA VRAM gate (sc-9094/sc-12131, epic 9083 → epic 10765) — MEASURED on an RTX PRO
+      // 6000 (Blackwell sm_120) at 1024²/8-step with the rendered-device two-process probe. Resident
+      // peaks are q4 26.4, q8 35.9, bf16 55.6 GB. Sequential residency encodes/drops Qwen3-VL before
+      // loading the DiT and peaks at q4 22.7, q8 29.5, bf16 39.8 GB; every resident/sequential pair was
+      // byte-identical. minMemoryGb 32 covers the common q4 resident lane with headroom. INT8-ConvRot
+      // remains an unmeasured non-shipping estimate and defers to resident.
       "candle": {
         "minMemoryGb": 32,
         // sc-9300: the INT8-ConvRot tier's VRAM ceiling. The int8 DiT is ~half the bf16 DiT, but the
@@ -2515,7 +2516,11 @@
         // path as q4/q8/bf16 (the third of the three ConvRot gates; the candle lane + sm_89 compute-cap
         // are the worker's `int8_convrot` capability).
         "vramGbByTier": { "q4": 26.4, "q8": 35.9, "bf16": 55.6, "int8-convrot": 31.0 },
-        "measured": false,
+        // sc-12131 / sc-10856 second-stage gate: measured largest working set after the text phase has
+        // been dropped. INT8-ConvRot is intentionally absent because that lane remains unmeasured and
+        // does not advertise sequential residency.
+        "sequentialPeakGb": { "q4": 22.7, "q8": 29.5, "bf16": 39.8 },
+        "measured": true,
         // Pose-ControlNet lane VRAM fit ladder (sc-11754, epic 8459 → epic 10765). The control lane loads
         // the base at the installed tier PLUS the trained ~6.6 GB bf16 control branch, so its render peak
         // (the end-of-render VAE-decode spike, sc-11744) EXCEEDS the txt2img `vramGbByTier` above — it needs

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2523,10 +2523,14 @@
         // free VRAM and, only when constrained, engages the cheapest sufficient rung. @1024²/8-step/scale 0.6
         // on an RTX PRO 6000 (Blackwell sm_120).
         "control": {
-          // Overall render peak (GB) by BASE tier, bf16 control branch, NO rungs engaged (monolithic VAE
-          // decode). q4 MEASURED 30.9 (sc-11744 GPU timeline, the VAE-decode spike); bf16 MEASURED 46.2
-          // (sc-11743, dense base + bf16 branch); q8 ESTIMATED ~35.5 (between the two) pending measurement.
-          "peakGbByTier": { "q4": 30.9, "q8": 35.5, "bf16": 46.2 },
+          // Trusted two-process rendered-device probe (sc-12176), 1024², bf16 control branch, no deeper
+          // rungs, idle baseline 0.0 GB. Resident peaks: q4 36.2, q8 45.4, bf16 65.8 GB. Sequential
+          // encode/drops Qwen3-VL before the heavy load: q4 32.5, q8 39.6, bf16 50.0 GB. Raw RGB was
+          // byte-identical within every tier; q4/q8 used one denoise step (the working set is step-count
+          // invariant), bf16 used the production 8 steps. The fit gate tries Sequential first and uses
+          // its row for the clean second-stage reject before composing the deeper savings below.
+          "peakGbByTier": { "q4": 36.2, "q8": 45.4, "bf16": 65.8 },
+          "sequentialPeakGbByTier": { "q4": 32.5, "q8": 39.6, "bf16": 50.0 },
           // CHEAPEST rung (sc-11744, candle-gen #492): the peak reduction (GB) from forcing the seam-free
           // tiled VAE decode (`Krea2ControlRequest.tile_vae_decode`) — a SPEED cost, no quality cost. The
           // fit-gate engages it BEFORE branch-quant. GPU-MEASURED on an RTX PRO 6000 (Blackwell sm_120),
@@ -2551,7 +2555,7 @@
           // q8 −8.4 (near-lossless), q4 −10.2 (pose-locked; non-pose details drift). The gate prefers q8
           // before q4, and composes it with the two cheaper (speed-only) rungs above — tiling then chunking.
           "branchQuantSaveGb": { "q8": 8.4, "q4": 10.2 },
-          "measured": false
+          "measured": true
         }
       },
       "licenseUrl": "https://www.krea.ai/krea-2-licensing",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.4" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.6" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.4" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.6" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.4", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.6", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -4953,18 +4953,13 @@ async fn generate_candle_stream(
             )
         }),
     };
-    // The candle FLUX.1 (sc-10769), FLUX.2 txt2img (sc-10868), and Qwen-Image txt2img (sc-10867) lanes
-    // have wired sequential residency (load→encode→drop the text encoder before the DiT); other families
-    // reject-before-OOM. FLUX.2 is the biggest win off-Mac — the 32B `flux2_dev`'s decoder-LM Mistral TE
-    // is multiple GB freed before the DiT loads; Qwen-Image drops the ~8 GB Qwen2.5-VL encoder before the
-    // 20B DiT. The flux2 edit/control and Qwen edit/pose-control/ComfyUI lanes are NOT wired (resident
-    // path) and are diverted before this gate by `resolve_candle_image_route`, so only the plain-txt2img
-    // engine ids appear here. Hoisted so BOTH the capability downtier and the resident/sequential decision
-    // read one capability signal.
-    let sequential_capable = matches!(
-        engine_id,
-        "flux1_dev" | "flux1_schnell" | "flux2_dev" | "flux2_klein_9b" | "qwen_image"
-    );
+    // sc-12130: derive Candle residency support from the provider's weights-free descriptor instead of
+    // maintaining a second engine-id allowlist in the worker. The capability bit is the provider's
+    // contract that every request shape accepted by this id honors Sequential. Bespoke edit/control,
+    // ComfyUI, and strict-control routes are diverted by `resolve_candle_image_route` before this gate;
+    // generic txt2img/img2img reaches this point and uses the same registry-derived signal for both the
+    // capability downtier and the resident/sequential decision.
+    let sequential_capable = crate::mlx_fit_gate::engine_supports_sequential(engine_id);
     // sc-10733 capability downtier: for a DEFAULT job (no explicit per-(screen,model) pick, and not the
     // bespoke ConvRot tier), if the resolved tier won't fit the live budget, step DOWN to the highest
     // installed tier that does — floored at the per-model quality floor — rejecting only when nothing

--- a/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
@@ -305,15 +305,18 @@ struct KreaStrictControl {
     /// peak wouldn't otherwise fit the (possibly emulated) card. Folds the ~6.6 GB dense branch onto the
     /// GPU packed (dequant-on-forward) so it never lands dense in VRAM.
     branch_quant: Option<gen_core::Quant>,
-    /// Force the seam-free tiled VAE decode (sc-11744) — the fit ladder's cheapest rung, engaged only
-    /// when the predicted decode-phase peak exceeds free VRAM. `false` (the big-card default) is the
-    /// monolithic full-speed decode. A *speed* cost, no quality cost.
+    /// Force the seam-free tiled VAE decode (sc-11744) — the fit ladder's first speed-cost rung after
+    /// sequential residency, engaged only when the predicted decode-phase peak exceeds free VRAM.
+    /// `false` (the big-card default) is the monolithic full-speed decode. A *speed* cost, no quality cost.
     tile_vae_decode: bool,
     /// Engage sc-6217-style query-row attention chunking on the composable base stack + control branch
     /// (sc-11745, candle-gen #496) — the fit ladder's rung between VAE-decode tiling and branch quant,
     /// engaged only when the predicted denoise-phase activation peak exceeds free VRAM. `false` (the
     /// big-card default) is the unchunked full-speed forward. A *speed* cost (~+6%), byte-identical output.
     chunk_attention: bool,
+    /// Direct residency selection for this bespoke provider. It is not a registered generator, so the
+    /// control fit gate owns this decision instead of consulting `supports_sequential_offload`.
+    offload_policy: gen_core::OffloadPolicy,
     prompt: String,
     width: u32,
     height: u32,
@@ -358,6 +361,7 @@ impl CandleStrictControl for KreaStrictControl {
             // Unchunked (full speed) by default; the fit ladder (sc-11745) forces query-row attention
             // chunking only to bound the denoise activation peak on a constrained card — byte-identical.
             chunk_attention: self.chunk_attention,
+            offload_policy: self.offload_policy,
         };
         runtime_cuda::providers::krea::Krea2Control::load(&paths).map_err(|error| {
             WorkerError::Engine(format!("Krea 2 strict-pose control load failed: {error}"))
@@ -439,9 +443,9 @@ async fn generate_candle_krea_control_stream(
     // + the ~6.6 GB bf16 control branch + activations + the end-of-render VAE-decode spike) and compare it
     // against the live/capped free VRAM. On a big card the bf16 branch fits — nothing engages, zero speed/
     // quality penalty. On a constrained card (or one emulated via `SCENEWORKS_CUDA_VRAM_CAP_GB`) the ladder
-    // engages the last-resort branch-quant rung (q8 near-lossless, then q4 pose-locked) until it fits, else
-    // rejects-before-OOM. The cheaper rungs (VAE-decode tiling sc-11744, activation chunking / res-cap
-    // sc-11745) slot in ahead of branch-quant here once their candle-gen mechanism lands. NB: this lane uses
+    // first stages the text and heavy phases sequentially (sc-12176), then engages VAE-decode tiling
+    // (sc-11744), activation chunking / res-cap (sc-11745), and finally the last-resort branch-quant rung
+    // (q8 near-lossless, then q4 pose-locked) until it fits, else rejects-before-OOM. NB: this lane uses
     // the UNcached `start_gen_stream` (it doesn't evict the single-slot generator cache), so budget against
     // raw live free VRAM — the cache's pages are NOT reclaimable by this load, unlike the base.rs gate.
     // sc-11042: `base` is the tier dir this lane resolved (`krea_model_subdir`'s output when the user has
@@ -456,8 +460,13 @@ async fn generate_candle_krea_control_stream(
         crate::gpu::nvidia_vram_budget_gb(&settings.gpu_id).await,
         crate::vram_gate::cuda_vram_cap_gb(),
     );
-    let (tile_vae_decode, chunk_attention, branch_quant) = match crate::krea_control_fit::fit_ladder(
+    let (offload_policy, tile_vae_decode, chunk_attention, branch_quant) =
+        match crate::krea_control_fit::fit_ladder(
         crate::krea_control_fit::predicted_control_peak_gb(&request.model_manifest_entry, tier),
+        crate::krea_control_fit::predicted_control_sequential_peak_gb(
+            &request.model_manifest_entry,
+            tier,
+        ),
         budget,
         crate::krea_control_fit::decode_tile_save_gb(&request.model_manifest_entry, tier),
         crate::krea_control_fit::chunk_attn_save_gb(&request.model_manifest_entry),
@@ -467,14 +476,16 @@ async fn generate_candle_krea_control_stream(
         // Big-card fast path (or no signal): monolithic full-speed decode, unchunked attention, bf16 branch.
         crate::krea_control_fit::KreaControlFit::Unknown
         | crate::krea_control_fit::KreaControlFit::Fits {
+            offload_policy: gen_core::OffloadPolicy::Resident,
             tile_vae_decode: false,
             chunk_attention: false,
             branch_quant: None,
-        } => (false, false, None),
-        // Constrained card: the fit ladder engaged the cheapest sufficient set of rungs to fit — the
-        // seam-free tiled VAE decode (sc-11744) and/or query-row attention chunking (sc-11745), both
-        // speed-only, and/or the last-resort branch quant (sc-11743, a quality cost).
+        } => (gen_core::OffloadPolicy::Resident, false, false, None),
+        // Constrained card: the fit ladder engaged the cheapest sufficient set of rungs to fit —
+        // sequential residency (sc-12176), the seam-free tiled VAE decode (sc-11744), query-row attention
+        // chunking (sc-11745), and/or the last-resort branch quant (sc-11743, a quality cost).
         crate::krea_control_fit::KreaControlFit::Fits {
+            offload_policy,
             tile_vae_decode: tile,
             chunk_attention: chunk,
             branch_quant: quant,
@@ -482,13 +493,14 @@ async fn generate_candle_krea_control_stream(
             tracing::info!(
                 model = %request.model,
                 tier,
+                offload_policy = ?offload_policy,
                 tile_vae_decode = tile,
                 chunk_attention = chunk,
                 branch_quant = ?quant,
                 "Krea control VRAM fit ladder: predicted peak exceeds free VRAM — engaging rungs \
-                 (VAE-decode tiling, attention chunking, and/or control-branch quant) to fit"
+                 (sequential residency, VAE-decode tiling, attention chunking, and/or control-branch quant) to fit"
             );
-            (tile, chunk, quant)
+            (offload_policy, tile, chunk, quant)
         }
         // Won't fit even at the last rung ⇒ reject before the reactive CUDA OOM.
         crate::krea_control_fit::KreaControlFit::TooBig {
@@ -497,7 +509,8 @@ async fn generate_candle_krea_control_stream(
         } => {
             return Err(WorkerError::InvalidPayload(format!(
                 "Krea 2 pose-ControlNet at the {tier} base tier needs ~{needed} GB of VRAM (with \
-                 headroom, tiled VAE decode + attention chunking + control branch quantized to q4) but \
+                 headroom, sequential residency + tiled VAE decode + attention chunking + control \
+                 branch quantized to q4) but \
                  GPU {gpu} has ~{available} GB available. Lower the output resolution or run on a card \
                  with more VRAM.",
                 needed = needed_gb.round() as i64,
@@ -514,6 +527,7 @@ async fn generate_candle_krea_control_stream(
         branch_quant,
         tile_vae_decode,
         chunk_attention,
+        offload_policy,
         prompt: request.prompt.clone(),
         width: request.width,
         height: request.height,

--- a/crates/sceneworks-worker/src/krea_control_fit.rs
+++ b/crates/sceneworks-worker/src/krea_control_fit.rs
@@ -14,27 +14,31 @@
 //! stopping as soon as the predicted peak ≤ budget:
 //!  1. **packed base** — default, ~free (candle-gen #480, shipped). Always on; the peak below already
 //!     reflects it.
-//!  2. **VAE-decode tiling** (sc-11744, candle-gen #492) — force the seam-free tiled VAE tail (a *speed*
-//!     cost, no quality cost) to cap the end-of-render decode spike. Engaged first, when the measured
+//!  2. **sequential residency** (sc-12176) — encode/drop Qwen3-VL before loading the heavy phase. The
+//!     cheapest adaptation and no quality cost; its measured per-tier peak enables a clean second-stage
+//!     reject when even the staged working set will not fit.
+//!  3. **VAE-decode tiling** (sc-11744, candle-gen #492) — force the seam-free tiled VAE tail (a *speed*
+//!     cost, no quality cost) to cap the end-of-render decode spike. Engaged after residency, when the measured
 //!     `decodeTileSaveGb` is enough to fit; also stays on underneath the quant rungs (it is cheaper than
 //!     quant and every bit helps).
-//!  3. **activation chunking** (sc-11745, candle-gen #496) — engage sc-6217-style query-row attention
+//!  4. **activation chunking** (sc-11745, candle-gen #496) — engage sc-6217-style query-row attention
 //!     chunking on the composable base stack + control branch when the denoise steady state is the
 //!     overflow. A *speed* cost (~+6%) with byte-identical output; slots between tiling and branch-quant.
 //!     Gated by the presence of the measured scalar `chunkAttnSaveGb`.
-//!  4. **control-branch quant** (sc-11743, candle-gen #483) — bf16 → q8 → q4. A *quality cost* (the
+//!  5. **control-branch quant** (sc-11743, candle-gen #483) — bf16 → q8 → q4. A *quality cost* (the
 //!     residual is precision-sensitive, RMS-clamped at τ), so it is the **last-resort rung**. Composes
 //!     with the cheaper rungs (all reduce the co-resident peak).
 //!
 //! `decodeTileSaveGb` / `chunkAttnSaveGb` absent (unmeasured) ⇒ that rung is skipped exactly like an
 //! unmeasured branch-quant save — the ladder walks the rungs it *can* measure and, if even
-//! (tiling + chunking + q4) won't fit, rejects-before-OOM at the honest best-case peak.
+//! (sequential residency + tiling + chunking + q4) won't fit, rejects-before-OOM at the honest
+//! best-case peak.
 //!
 //! Everything here is pure and unit-tested; the live `nvidia-smi` reading lives in [`crate::gpu`] and the
 //! wiring is in `generate_candle_krea_control_stream` (image_jobs/krea_control_candle.rs).
 
 use super::*;
-use gen_core::Quant;
+use gen_core::{OffloadPolicy, Quant};
 use serde_json::Value;
 
 /// Fixed transient/runtime headroom (GB) added on top of the MEASURED control-lane peak
@@ -49,12 +53,16 @@ pub(crate) enum KreaControlFit {
     /// No measured control peak or no live budget ⇒ don't gate; load the default bf16 branch.
     Unknown,
     /// The predicted peak fits after engaging the minimal sufficient set of rungs. The big-card fast
-    /// path is `{ tile_vae_decode: false, chunk_attention: false, branch_quant: None }` (monolithic
-    /// full-speed decode, unchunked attention, bf16 branch, zero penalty). `tile_vae_decode = true` is the
-    /// cheapest rung (sc-11744 — a *speed* cost only, seam-free); `chunk_attention = true` is the next rung
-    /// (sc-11745 — a *speed* cost only, byte-identical output); `branch_quant = Some(Q8)`/`Some(Q4)` is the
-    /// last-resort *quality* rung, engaged only after both cheaper rungs were insufficient.
+    /// path uses resident components with `{ tile_vae_decode: false, chunk_attention: false,
+    /// branch_quant: None }` (monolithic full-speed decode, unchunked attention, bf16 branch, zero
+    /// penalty). Sequential residency is the first adaptation; `tile_vae_decode = true` is the next rung
+    /// (sc-11744 — a *speed* cost only, seam-free); `chunk_attention = true` follows (sc-11745 — a
+    /// *speed* cost only, byte-identical output); `branch_quant = Some(Q8)`/`Some(Q4)` is the last-resort
+    /// *quality* rung, engaged only after the cheaper rungs were insufficient.
     Fits {
+        /// Component residency selected before any deeper rung. Sequential is the cheapest adaptation:
+        /// it drops Qwen3-VL before loading the DiT + control branch + VAE.
+        offload_policy: OffloadPolicy,
         /// Force the seam-free tiled VAE decode (sc-11744) to cap the end-of-render decode spike. The
         /// worker threads this into `Krea2ControlRequest::tile_vae_decode`.
         tile_vae_decode: bool,
@@ -64,7 +72,8 @@ pub(crate) enum KreaControlFit {
         branch_quant: Option<Quant>,
     },
     /// Won't fit even at the last rung (q4 branch). Reject-before-OOM with an actionable message rather
-    /// than a reactive CUDA OOM mid-render. `needed_gb` is the best-case (q4-branch) predicted peak.
+    /// than a reactive CUDA OOM mid-render. `needed_gb` is the best-case sequential + tiled + chunked +
+    /// q4-branch predicted peak.
     TooBig { needed_gb: f64, available_gb: f64 },
 }
 
@@ -80,6 +89,23 @@ pub(crate) fn predicted_control_peak_gb(
         .get("candle")?
         .get("control")?
         .get("peakGbByTier")
+        .and_then(|tiers| tiers.get(tier_key))
+        .and_then(json_f64)
+        .map(|gb| gb + HEADROOM_GB)
+}
+
+/// Predicted Sequential control-lane peak for `tier_key`:
+/// `candle.control.sequentialPeakGbByTier[tier_key]` + [`HEADROOM_GB`]. This is the measured largest
+/// single working set after Qwen3-VL has been encoded and dropped. `None` preserves best-effort
+/// offload behavior: the lane still stages, but cannot perform an honest second-stage reject.
+pub(crate) fn predicted_control_sequential_peak_gb(
+    manifest_entry: &JsonObject,
+    tier_key: &str,
+) -> Option<f64> {
+    manifest_entry
+        .get("candle")?
+        .get("control")?
+        .get("sequentialPeakGbByTier")
         .and_then(|tiers| tiers.get(tier_key))
         .and_then(json_f64)
         .map(|gb| gb + HEADROOM_GB)
@@ -134,14 +160,16 @@ pub(crate) fn chunk_attn_save_gb(manifest_entry: &JsonObject) -> Option<f64> {
 /// savings, engage the minimal sufficient set of rungs in increasing (Δcost) order and return the
 /// [`KreaControlFit`].
 ///
-/// Walk: if the monolithic peak fits, run untiled/unchunked at the bf16 branch (big-card fast path, no
-/// penalty); else force the seam-free tiled decode (sc-11744 — a *speed* cost only); else — keeping tiling
-/// on — engage query-row attention chunking (sc-11745 — a *speed* cost only, byte-identical); else —
-/// keeping both speed rungs on — quantize the control branch, preferring q8 (near-lossless) then q4
-/// (pose-locked, non-pose drift); else reject-before-OOM. Any unmeasured saving (`None`) skips its rung.
-/// Missing peak or budget ⇒ [`KreaControlFit::Unknown`] (never block).
+/// Walk: if the monolithic peak fits, run resident/untiled/unchunked at the bf16 branch (big-card fast
+/// path, no penalty); else stage text and heavy components sequentially. If the measured sequential peak
+/// still exceeds the budget, force the seam-free tiled decode (sc-11744 — a *speed* cost only); then,
+/// keeping tiling on, engage query-row attention chunking (sc-11745 — a *speed* cost only,
+/// byte-identical); then, keeping both speed rungs on, quantize the control branch, preferring q8
+/// (near-lossless) then q4 (pose-locked, non-pose drift); else reject-before-OOM. Any unmeasured saving
+/// (`None`) skips its rung. Missing resident peak or budget ⇒ [`KreaControlFit::Unknown`] (never block).
 pub(crate) fn fit_ladder(
     peak_bf16_branch_gb: Option<f64>,
+    sequential_peak_bf16_branch_gb: Option<f64>,
     budget: Option<crate::vram_gate::VramBudget>,
     decode_tile_save_gb: Option<f64>,
     chunk_attn_save_gb: Option<f64>,
@@ -158,16 +186,38 @@ pub(crate) fn fit_ladder(
     // so nothing engages: full-speed decode, unchunked attention, zero quality penalty.
     if fits(peak) {
         return KreaControlFit::Fits {
+            offload_policy: OffloadPolicy::Resident,
             tile_vae_decode: false,
             chunk_attention: false,
             branch_quant: None,
         };
     }
-    // Rung 2 (VAE-decode tiling, sc-11744) — cheapest: a *speed* cost, no quality loss (seam-free). An
+
+    // Rung 2 (sequential residency, sc-12176) — the cheapest adaptation. If its measured peak is
+    // absent, preserve the shared gate's best-effort contract: stage anyway and rely on the reactive
+    // CUDA-OOM backstop rather than engaging costlier/quality-affecting rungs from an unknown baseline.
+    let Some(peak) = sequential_peak_bf16_branch_gb else {
+        return KreaControlFit::Fits {
+            offload_policy: OffloadPolicy::Sequential,
+            tile_vae_decode: false,
+            chunk_attention: false,
+            branch_quant: None,
+        };
+    };
+    if fits(peak) {
+        return KreaControlFit::Fits {
+            offload_policy: OffloadPolicy::Sequential,
+            tile_vae_decode: false,
+            chunk_attention: false,
+            branch_quant: None,
+        };
+    }
+    // Rung 3 (VAE-decode tiling, sc-11744) — a *speed* cost, no quality loss (seam-free). An
     // unmeasured tier saving (None) leaves this rung unavailable, degenerating toward the quant-only walk.
     if let Some(tile_save) = decode_tile_save_gb {
         if fits(peak - tile_save) {
             return KreaControlFit::Fits {
+                offload_policy: OffloadPolicy::Sequential,
                 tile_vae_decode: true,
                 chunk_attention: false,
                 branch_quant: None,
@@ -179,12 +229,13 @@ pub(crate) fn fit_ladder(
     let tile_on = decode_tile_save_gb.is_some();
     let peak_after_tile = peak - decode_tile_save_gb.unwrap_or(0.0);
 
-    // Rung 3 (activation chunking, sc-11745, candle-gen #496) — a *speed* cost (~+6%), byte-identical output
+    // Rung 4 (activation chunking, sc-11745, candle-gen #496) — a *speed* cost (~+6%), byte-identical output
     // (the chunked forward is numerically identical). Cheaper than the quality-costing branch quant, so it is
     // engaged BEFORE it. An unmeasured saving (None) leaves this rung unavailable.
     if let Some(chunk_save) = chunk_attn_save_gb {
         if fits(peak_after_tile - chunk_save) {
             return KreaControlFit::Fits {
+                offload_policy: OffloadPolicy::Sequential,
                 tile_vae_decode: tile_on,
                 chunk_attention: true,
                 branch_quant: None,
@@ -196,11 +247,12 @@ pub(crate) fn fit_ladder(
     let chunk_on = chunk_attn_save_gb.is_some();
     let peak_after_chunk = peak_after_tile - chunk_attn_save_gb.unwrap_or(0.0);
 
-    // Rung 4 (control-branch quant, sc-11743) — last resort, a *quality* cost. Prefer q8 (effectively
+    // Rung 5 (control-branch quant, sc-11743) — last resort, a *quality* cost. Prefer q8 (effectively
     // free quality) before q4 (visible non-pose drift). Each save is measured; an unmeasured save skips.
     if let Some(save) = q8_save_gb {
         if fits(peak_after_chunk - save) {
             return KreaControlFit::Fits {
+                offload_policy: OffloadPolicy::Sequential,
                 tile_vae_decode: tile_on,
                 chunk_attention: chunk_on,
                 branch_quant: Some(Quant::Q8),
@@ -210,6 +262,7 @@ pub(crate) fn fit_ladder(
     if let Some(save) = q4_save_gb {
         if fits(peak_after_chunk - save) {
             return KreaControlFit::Fits {
+                offload_policy: OffloadPolicy::Sequential,
                 tile_vae_decode: tile_on,
                 chunk_attention: chunk_on,
                 branch_quant: Some(Quant::Q4),
@@ -250,6 +303,7 @@ mod tests {
                 "control": {
                     // q4 measured (sc-11744), bf16 measured (sc-11743), q8 estimated.
                     "peakGbByTier": { "q4": 30.9, "q8": 35.5, "bf16": 46.2 },
+                    "sequentialPeakGbByTier": { "q4": 25.0, "q8": 30.0, "bf16": 40.0 },
                     // VAE-decode tiling saving (sc-11744); measured only for the constrained q4 tier here
                     // (the decode spike is the peak there). Illustrative test value, not the shipped one.
                     "decodeTileSaveGb": { "q4": 6.9 },
@@ -308,6 +362,76 @@ mod tests {
     }
 
     #[test]
+    fn predicted_control_sequential_peak_reads_the_tier_plus_headroom() {
+        let m = krea_manifest();
+        assert_eq!(predicted_control_sequential_peak_gb(&m, "q4"), Some(27.0));
+        assert_eq!(predicted_control_sequential_peak_gb(&m, "bf16"), Some(42.0));
+        assert_eq!(predicted_control_sequential_peak_gb(&m, "nvfp4"), None);
+        assert_eq!(
+            predicted_control_sequential_peak_gb(&obj(json!({})), "q4"),
+            None
+        );
+    }
+
+    #[test]
+    fn sequential_is_the_first_rung_and_has_a_clean_second_stage_reject() {
+        let resident = Some(40.0);
+        let sequential = Some(30.0);
+
+        assert_eq!(
+            super::fit_ladder(
+                resident,
+                sequential,
+                Some(budget(35.0)),
+                None,
+                None,
+                None,
+                None,
+            ),
+            KreaControlFit::Fits {
+                offload_policy: OffloadPolicy::Sequential,
+                tile_vae_decode: false,
+                chunk_attention: false,
+                branch_quant: None,
+            }
+        );
+        assert_too_big(
+            super::fit_ladder(
+                resident,
+                sequential,
+                Some(budget(29.0)),
+                None,
+                None,
+                None,
+                None,
+            ),
+            30.0,
+            29.0,
+        );
+    }
+
+    #[test]
+    fn missing_sequential_measurement_keeps_best_effort_staging() {
+        assert_eq!(
+            super::fit_ladder(
+                Some(40.0),
+                None,
+                Some(budget(20.0)),
+                Some(5.0),
+                Some(2.0),
+                Some(8.0),
+                Some(10.0),
+            ),
+            KreaControlFit::Fits {
+                offload_policy: OffloadPolicy::Sequential,
+                tile_vae_decode: false,
+                chunk_attention: false,
+                branch_quant: None,
+            }
+        );
+    }
+
+    #[test]
     fn branch_quant_save_reads_the_measured_deltas() {
         let m = krea_manifest();
         assert_eq!(branch_quant_save_gb(&m, "q8"), Some(8.4));
@@ -333,9 +457,23 @@ mod tests {
         }
     }
 
+    /// Keep the pre-sc-12176 rung tests focused on tiling/chunking/branch quant by modeling a staged
+    /// peak equal to the old resident peak. Dedicated tests below cover the residency reduction itself.
+    fn fit_ladder(
+        peak: Option<f64>,
+        budget: Option<VramBudget>,
+        tile: Option<f64>,
+        chunk: Option<f64>,
+        q8: Option<f64>,
+        q4: Option<f64>,
+    ) -> KreaControlFit {
+        super::fit_ladder(peak, peak, budget, tile, chunk, q8, q4)
+    }
+
     /// The big-card fast path: untiled monolithic decode, bf16 branch, no rung engaged.
     fn fits_untiled_bf16() -> KreaControlFit {
         KreaControlFit::Fits {
+            offload_policy: OffloadPolicy::Resident,
             tile_vae_decode: false,
             chunk_attention: false,
             branch_quant: None,
@@ -365,6 +503,7 @@ mod tests {
         assert_eq!(
             fit_ladder(peak, Some(budget(26.0)), tile, chunk, q8, q4),
             KreaControlFit::Fits {
+                offload_policy: OffloadPolicy::Sequential,
                 tile_vae_decode: true,
                 chunk_attention: false,
                 branch_quant: None,
@@ -382,6 +521,7 @@ mod tests {
         assert_eq!(
             fit_ladder(peak, Some(budget(24.0)), tile, chunk, q8, q4),
             KreaControlFit::Fits {
+                offload_policy: OffloadPolicy::Sequential,
                 tile_vae_decode: true,
                 chunk_attention: false,
                 branch_quant: Some(Quant::Q8),
@@ -392,6 +532,7 @@ mod tests {
         assert_eq!(
             fit_ladder(peak, Some(budget(16.0)), tile, chunk, q8, q4),
             KreaControlFit::Fits {
+                offload_policy: OffloadPolicy::Sequential,
                 tile_vae_decode: true,
                 chunk_attention: false,
                 branch_quant: Some(Quant::Q4),
@@ -442,6 +583,7 @@ mod tests {
         assert_eq!(
             fit_ladder(peak, Some(budget(41.0)), tile, chunk, q8, q4),
             KreaControlFit::Fits {
+                offload_policy: OffloadPolicy::Sequential,
                 tile_vae_decode: false,
                 chunk_attention: false,
                 branch_quant: Some(Quant::Q8),
@@ -451,6 +593,7 @@ mod tests {
         assert_eq!(
             fit_ladder(peak, Some(budget(39.0)), tile, chunk, q8, q4),
             KreaControlFit::Fits {
+                offload_policy: OffloadPolicy::Sequential,
                 tile_vae_decode: false,
                 chunk_attention: false,
                 branch_quant: Some(Quant::Q4),
@@ -519,6 +662,7 @@ mod tests {
         assert_eq!(
             fit_ladder(peak, Some(budget(24.0)), tile, chunk, q8, q4),
             KreaControlFit::Fits {
+                offload_policy: OffloadPolicy::Sequential,
                 tile_vae_decode: true,
                 chunk_attention: true,
                 branch_quant: None,
@@ -530,6 +674,7 @@ mod tests {
         assert_eq!(
             fit_ladder(peak, Some(budget(16.0)), tile, chunk, q8, q4),
             KreaControlFit::Fits {
+                offload_policy: OffloadPolicy::Sequential,
                 tile_vae_decode: true,
                 chunk_attention: true,
                 branch_quant: Some(Quant::Q8),
@@ -539,6 +684,7 @@ mod tests {
         assert_eq!(
             fit_ladder(peak, Some(budget(14.0)), tile, chunk, q8, q4),
             KreaControlFit::Fits {
+                offload_policy: OffloadPolicy::Sequential,
                 tile_vae_decode: true,
                 chunk_attention: true,
                 branch_quant: Some(Quant::Q4),
@@ -567,6 +713,7 @@ mod tests {
         assert_eq!(
             fit_ladder(peak, Some(budget(46.0)), tile, chunk, q8, q4),
             KreaControlFit::Fits {
+                offload_policy: OffloadPolicy::Sequential,
                 tile_vae_decode: false,
                 chunk_attention: true,
                 branch_quant: None,

--- a/crates/sceneworks-worker/src/mlx_fit_gate.rs
+++ b/crates/sceneworks-worker/src/mlx_fit_gate.rs
@@ -57,9 +57,10 @@ use crate::{WorkerError, WorkerResult};
 /// query shape the worker already uses for family/guidance/quant capability advertisement and the
 /// analogous `ProviderRegistry::footprint` size seam (sc-10894). An id with no registered generator — or a
 /// registered one that does not advertise the bit — yields `false` (the safe default: never select a
-/// residency policy the provider won't honor). Sees exactly the providers the binary force-links (the
-/// sc-4482 dead-strip rule): on macOS every `mlx_gen_*` provider is anchored in `image_jobs`, so the
-/// live worker resolves them; off-Mac the MLX gate no-ops anyway (no `sysctl` budget).
+/// residency policy the provider won't honor). Sees exactly the providers the selected runtime bundle
+/// carries: MLX providers are explicitly anchored on macOS, while the CUDA bundle exposes its explicit
+/// Candle catalog. The same query is shared by the MLX fit gate (sc-10840) and Candle fit gate
+/// (sc-12130), so adding a truthful provider capability needs no worker allowlist edit.
 pub(crate) fn engine_supports_sequential(engine_id: &str) -> bool {
     crate::inference_runtime::media()
         .generators()
@@ -796,11 +797,34 @@ mod tests {
     }
 
     /// An id with no registered generator is never sequential-capable (the safe default: never select a
-    /// residency policy the provider won't honor) — a cross-platform invariant that holds even off-Mac
-    /// where the image registry is empty.
+    /// residency policy the provider won't honor) — a cross-platform invariant.
     #[test]
     fn engine_supports_sequential_is_false_for_an_unregistered_id() {
         assert!(!engine_supports_sequential("no_such_engine_xyz"));
+    }
+
+    /// Candle's sc-12130 twin of the macOS registry sweep above. These are the generic generator ids that
+    /// reach the Candle fit gate after route diversion. Krea edit is now true because sc-12129 landed;
+    /// the bespoke pose-control provider is not a registered generator and remains outside this gate.
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    #[test]
+    fn candle_sequential_capability_is_derived_from_the_registered_descriptor() {
+        for id in [
+            "flux1_dev",
+            "flux1_schnell",
+            "flux2_dev",
+            "flux2_klein_9b",
+            "qwen_image",
+            "krea_2_turbo",
+            "krea_2_raw",
+            "krea_2_edit",
+        ] {
+            assert!(
+                engine_supports_sequential(id),
+                "{id}: wired Candle provider must advertise sequential residency"
+            );
+        }
+        assert!(!engine_supports_sequential("krea_2_turbo_control"));
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -567,6 +567,60 @@ fn flux2_candle_blocks_drive_the_fit_gate_and_reject() {
     );
 }
 
+/// sc-12130/sc-12131: the shipped Krea base block feeds both stages of the generic Candle gate. This
+/// pins the provider-derived capability handoff and the measured `sequentialPeakGb` values that turn a
+/// small-card staged attempt into a clean reject instead of relying on reactive OOM containment.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn krea_candle_block_drives_the_registry_and_second_stage_gate() {
+    use crate::vram_gate::{
+        apply_vram_cap, fit_decision, predicted_peak_gb, predicted_sequential_peak_gb,
+        resolve_offload, sequential_overflow_gb, FitDecision,
+    };
+
+    let krea = builtin_model_entry("krea_2_turbo");
+    let entry = krea.as_object().expect("krea_2_turbo entry object");
+    assert_eq!(
+        entry
+            .get("candle")
+            .and_then(Value::as_object)
+            .and_then(|candle| candle.get("measured"))
+            .and_then(Value::as_bool),
+        Some(true),
+        "the published Krea base resident + sequential rows are measured"
+    );
+    assert!(
+        crate::mlx_fit_gate::engine_supports_sequential("krea_2_turbo"),
+        "the generic Candle gate must derive Krea support from the registered descriptor"
+    );
+
+    // Manifest values plus the generic gate's fixed 2 GB runtime headroom.
+    let q4_resident = predicted_peak_gb(entry, "q4").expect("q4 resident peak");
+    let q4_sequential =
+        predicted_sequential_peak_gb(entry, "q4").expect("q4 sequential peak");
+    assert!((q4_resident - 28.4).abs() < 1e-6);
+    assert!((q4_sequential - 24.7).abs() < 1e-6);
+    assert!((predicted_sequential_peak_gb(entry, "q8").unwrap() - 31.5).abs() < 1e-6);
+    assert!((predicted_sequential_peak_gb(entry, "bf16").unwrap() - 41.8).abs() < 1e-6);
+    assert_eq!(predicted_sequential_peak_gb(entry, "int8-convrot"), None);
+
+    // A 27 GB card cannot hold resident q4 but can run staged, so the registry bit selects Offload.
+    let card27 = apply_vram_cap(None, Some(27.0));
+    assert!(matches!(
+        resolve_offload(fit_decision(Some(q4_resident), card27), true),
+        FitDecision::Offload { .. }
+    ));
+    assert_eq!(sequential_overflow_gb(Some(q4_sequential), card27), None);
+
+    // A 12 GB card cannot hold even the measured staged working set: carry the honest number into the
+    // worker's second-stage reject-before-load path instead of attempting a process-killing allocation.
+    let card12 = apply_vram_cap(None, Some(12.0));
+    assert_eq!(
+        sequential_overflow_gb(Some(q4_sequential), card12),
+        Some(24.7)
+    );
+}
+
 /// sc-11754 + sc-11744 (epic 8459 → epic 10765): the Krea 2 Turbo `candle.control` block drives the
 /// pose-ControlNet VRAM fit LADDER end-to-end against the SHIPPED manifest bytes. The control-lane sibling
 /// of `flux2_candle_blocks_drive_the_fit_gate_and_reject`: guards the DATA half — dropping the `control`

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -572,9 +572,9 @@ fn flux2_candle_blocks_drive_the_fit_gate_and_reject() {
 /// of `flux2_candle_blocks_drive_the_fit_gate_and_reject`: guards the DATA half — dropping the `control`
 /// block makes `predicted_control_peak_gb` return `None` → the control fit-gate goes INERT (bf16 branch
 /// always, the pre-sc-11754 behavior). Exercises the `SCENEWORKS_CUDA_VRAM_CAP_GB` small-card emulation via
-/// `apply_vram_cap` across the cost-ordered rungs: big card → untiled bf16 branch (no penalty); the
-/// VAE-tiling rung (sc-11744) engaging first (a bf16 branch kept where it would otherwise quantize); then
-/// tiling composing with branch-quant; then reject-before-OOM. Expectations are expressed relative to the
+/// `apply_vram_cap` across the cost-ordered rungs: big card → resident untiled bf16 branch (no penalty);
+/// sequential residency (sc-12176) first; then VAE tiling, chunking, branch quant, and reject-before-OOM.
+/// Expectations are expressed relative to the
 /// SHIPPED deltas (a manifest edit that drifts `decodeTileSaveGb` / `branchQuantSaveGb` fails here) rather
 /// than hard-coded arithmetic.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
@@ -582,10 +582,10 @@ fn flux2_candle_blocks_drive_the_fit_gate_and_reject() {
 fn krea_control_candle_block_drives_the_fit_ladder() {
     use crate::krea_control_fit::{
         branch_quant_save_gb, chunk_attn_save_gb, decode_tile_save_gb, fit_ladder,
-        predicted_control_peak_gb, KreaControlFit,
+        predicted_control_peak_gb, predicted_control_sequential_peak_gb, KreaControlFit,
     };
     use crate::vram_gate::apply_vram_cap;
-    use gen_core::Quant;
+    use gen_core::{OffloadPolicy, Quant};
 
     let krea = builtin_model_entry("krea_2_turbo");
     let entry = krea.as_object().expect("krea_2_turbo entry object");
@@ -610,31 +610,69 @@ fn krea_control_candle_block_drives_the_fit_ladder() {
     let chunk_save = chunk.expect("chunkAttnSaveGb shipped (the sc-11745 chunking rung)");
     assert!(chunk_save > 0.0, "chunking must recover VRAM, got {chunk_save}");
 
-    // The common small-card install: q4 BASE tier. Peak 30.9 (measured sc-11744) + 2 headroom = 32.9,
-    // and the shipped VAE-decode tiling saving (sc-11744) that caps the decode spike.
+    // The common small-card install: q4 BASE tier. Resident and Sequential are both measured; every
+    // deeper rung composes from the Sequential baseline because residency is the cheapest adaptation.
     let q4_peak = predicted_control_peak_gb(entry, "q4");
     let peak = q4_peak.expect("q4 control peak");
-    assert!((peak - 32.9).abs() < 1e-6);
+    assert!((peak - 38.2).abs() < 1e-6);
+    let q4_sequential = predicted_control_sequential_peak_gb(entry, "q4");
+    let sequential_peak = q4_sequential.expect("q4 sequential control peak");
+    assert!((sequential_peak - 34.5).abs() < 1e-6);
     let tile = decode_tile_save_gb(entry, "q4");
     let tile_save = tile.expect("q4 decodeTileSaveGb shipped (the sc-11744 tiling rung)");
     assert!(tile_save > 0.0, "tiling must recover VRAM, got {tile_save}");
-    let tiled_peak = peak - tile_save; // tiling only (bf16 branch, cheapest rung)
-    let chunked_peak = tiled_peak - chunk_save; // + chunking (both speed-only, bf16 branch kept)
+    let tiled_peak = sequential_peak - tile_save;
+    let chunked_peak = tiled_peak - chunk_save;
 
     // 96 GB card: the monolithic peak fits outright — nothing engages, untiled full-speed bf16 branch.
     assert_eq!(
-        fit_ladder(q4_peak, apply_vram_cap(None, Some(96.0)), tile, chunk, q8, q4),
+        fit_ladder(
+            q4_peak,
+            q4_sequential,
+            apply_vram_cap(None, Some(96.0)),
+            tile,
+            chunk,
+            q8,
+            q4,
+        ),
         KreaControlFit::Fits {
+            offload_policy: OffloadPolicy::Resident,
             tile_vae_decode: false,
             chunk_attention: false,
             branch_quant: None,
         }
     );
-    // A card that fits the TILED peak but not the monolithic one ⇒ the cheapest rung: tiling on, bf16
-    // branch kept (no quality penalty). This is sc-11744's win — a card that used to drop to a q8 branch.
+    // A card that fits the measured Sequential peak but not Resident engages residency only.
     assert_eq!(
-        fit_ladder(q4_peak, apply_vram_cap(None, Some(tiled_peak)), tile, chunk, q8, q4),
+        fit_ladder(
+            q4_peak,
+            q4_sequential,
+            apply_vram_cap(None, Some(sequential_peak)),
+            tile,
+            chunk,
+            q8,
+            q4,
+        ),
         KreaControlFit::Fits {
+            offload_policy: OffloadPolicy::Sequential,
+            tile_vae_decode: false,
+            chunk_attention: false,
+            branch_quant: None,
+        }
+    );
+    // A card at the staged+tiled peak engages Sequential then VAE tiling, keeping the bf16 branch.
+    assert_eq!(
+        fit_ladder(
+            q4_peak,
+            q4_sequential,
+            apply_vram_cap(None, Some(tiled_peak)),
+            tile,
+            chunk,
+            q8,
+            q4,
+        ),
+        KreaControlFit::Fits {
+            offload_policy: OffloadPolicy::Sequential,
             tile_vae_decode: true,
             chunk_attention: false,
             branch_quant: None,
@@ -643,8 +681,17 @@ fn krea_control_candle_block_drives_the_fit_ladder() {
     // Just below the tiled peak: tiling alone no longer fits, but the next speed-only rung (chunking) does
     // (chunked_peak fits) ⇒ tiling + chunking, STILL a bf16 branch — sc-11745's win over dropping to q8.
     assert_eq!(
-        fit_ladder(q4_peak, apply_vram_cap(None, Some(tiled_peak - 0.5)), tile, chunk, q8, q4),
+        fit_ladder(
+            q4_peak,
+            q4_sequential,
+            apply_vram_cap(None, Some(tiled_peak - 0.5)),
+            tile,
+            chunk,
+            q8,
+            q4,
+        ),
         KreaControlFit::Fits {
+            offload_policy: OffloadPolicy::Sequential,
             tile_vae_decode: true,
             chunk_attention: true,
             branch_quant: None,
@@ -653,8 +700,17 @@ fn krea_control_candle_block_drives_the_fit_ladder() {
     // Just below the chunked peak: both speed rungs stay on and q8 composes (chunked_peak − 8.4 fits) ⇒
     // tiling + chunking + q8, near-lossless — a shallower quant than the chunk-less ladder would have taken.
     assert_eq!(
-        fit_ladder(q4_peak, apply_vram_cap(None, Some(chunked_peak - 0.5)), tile, chunk, q8, q4),
+        fit_ladder(
+            q4_peak,
+            q4_sequential,
+            apply_vram_cap(None, Some(chunked_peak - 0.5)),
+            tile,
+            chunk,
+            q8,
+            q4,
+        ),
         KreaControlFit::Fits {
+            offload_policy: OffloadPolicy::Sequential,
             tile_vae_decode: true,
             chunk_attention: true,
             branch_quant: Some(Quant::Q8),
@@ -662,15 +718,32 @@ fn krea_control_candle_block_drives_the_fit_ladder() {
     );
     // A card between (…+q8) and (…+q4): tiling + chunking + q4 (chunked_peak − 10.2) fits ⇒ the deepest rung.
     assert_eq!(
-        fit_ladder(q4_peak, apply_vram_cap(None, Some(chunked_peak - 8.9)), tile, chunk, q8, q4),
+        fit_ladder(
+            q4_peak,
+            q4_sequential,
+            apply_vram_cap(None, Some(chunked_peak - 8.9)),
+            tile,
+            chunk,
+            q8,
+            q4,
+        ),
         KreaControlFit::Fits {
+            offload_policy: OffloadPolicy::Sequential,
             tile_vae_decode: true,
             chunk_attention: true,
             branch_quant: Some(Quant::Q4),
         }
     );
     // A card below even (tiling + chunking + q4) ⇒ reject-before-OOM at the best-case peak.
-    match fit_ladder(q4_peak, apply_vram_cap(None, Some(chunked_peak - 11.0)), tile, chunk, q8, q4) {
+    match fit_ladder(
+        q4_peak,
+        q4_sequential,
+        apply_vram_cap(None, Some(chunked_peak - 11.0)),
+        tile,
+        chunk,
+        q8,
+        q4,
+    ) {
         KreaControlFit::TooBig { needed_gb, .. } => {
             assert!(
                 (needed_gb - (chunked_peak - 10.2)).abs() < 1e-6,
@@ -680,23 +753,27 @@ fn krea_control_candle_block_drives_the_fit_ladder() {
         other => panic!("below tiling+chunking+q4 → reject, got {other:?}"),
     }
 
-    // The bf16 BASE tier (peak 46.2 measured sc-11743 + 2 = 48.2) carries NO tiling saving (its denoise
+    // The bf16 BASE tier carries no tiling saving (its denoise
     // steady-state, not the decode, is the peak), but the SCALAR chunking rung applies to every tier: a
     // 41 GB card engages chunking (speed-only) then q8 (48.2 − chunk_save − 8.4 ≤ 41), the near-lossless
     // preference before q4 — a shallower quant than the chunk-less walk (which took bare q8 at 39.8).
     let bf16_peak = predicted_control_peak_gb(entry, "bf16");
-    assert!((bf16_peak.expect("bf16 control peak") - 48.2).abs() < 1e-6);
+    assert!((bf16_peak.expect("bf16 control peak") - 67.8).abs() < 1e-6);
+    let bf16_sequential = predicted_control_sequential_peak_gb(entry, "bf16");
+    assert!((bf16_sequential.expect("bf16 sequential control peak") - 52.0).abs() < 1e-6);
     assert_eq!(decode_tile_save_gb(entry, "bf16"), None);
     assert_eq!(
         fit_ladder(
             bf16_peak,
-            apply_vram_cap(None, Some(41.0)),
+            bf16_sequential,
+            apply_vram_cap(None, Some(42.0)),
             decode_tile_save_gb(entry, "bf16"),
             chunk,
             q8,
             q4
         ),
         KreaControlFit::Fits {
+            offload_policy: OffloadPolicy::Sequential,
             tile_vae_decode: false,
             chunk_attention: true,
             branch_quant: Some(Quant::Q8),
@@ -716,9 +793,10 @@ fn krea_control_candle_block_drives_the_fit_ladder() {
 async fn krea_control_live_ladder_on_a_real_card() {
     use crate::krea_control_fit::{
         branch_quant_save_gb, chunk_attn_save_gb, decode_tile_save_gb, fit_ladder,
-        predicted_control_peak_gb, KreaControlFit,
+        predicted_control_peak_gb, predicted_control_sequential_peak_gb, KreaControlFit,
     };
     use crate::vram_gate::apply_vram_cap;
+    use gen_core::OffloadPolicy;
 
     let krea = builtin_model_entry("krea_2_turbo");
     let entry = krea.as_object().expect("krea_2_turbo entry object");
@@ -728,7 +806,8 @@ async fn krea_control_live_ladder_on_a_real_card() {
     let q4 = branch_quant_save_gb(entry, "q4");
     // The common small-card install: q4 base tier.
     let peak = predicted_control_peak_gb(entry, "q4");
-    let tiled_peak = peak.unwrap() - tile.expect("q4 decodeTileSaveGb shipped");
+    let sequential = predicted_control_sequential_peak_gb(entry, "q4");
+    let tiled_peak = sequential.unwrap() - tile.expect("q4 decodeTileSaveGb shipped");
     let chunked_peak = tiled_peak - chunk.expect("chunkAttnSaveGb shipped");
 
     let real = crate::gpu::nvidia_vram_budget_gb("0")
@@ -738,19 +817,37 @@ async fn krea_control_live_ladder_on_a_real_card() {
 
     // Uncapped real 96 GB card → untiled monolithic decode, unchunked, bf16 branch, no rung engages.
     assert_eq!(
-        fit_ladder(peak, apply_vram_cap(Some(real), None), tile, chunk, q8, q4),
+        fit_ladder(
+            peak,
+            sequential,
+            apply_vram_cap(Some(real), None),
+            tile,
+            chunk,
+            q8,
+            q4,
+        ),
         KreaControlFit::Fits {
+            offload_policy: OffloadPolicy::Resident,
             tile_vae_decode: false,
             chunk_attention: false,
             branch_quant: None,
         },
         "uncapped 96 GB card keeps the untiled bf16 branch"
     );
-    // Cap just at the tiled peak (off the REAL reading) → the cheapest rung engages: tiling on, bf16
-    // branch kept (no quality penalty).
+    // Cap just at the tiled peak (off the REAL reading) → residency and the first speed-cost rung engage:
+    // sequential + tiling, with the bf16 branch kept (no quality penalty).
     assert_eq!(
-        fit_ladder(peak, apply_vram_cap(Some(real), Some(tiled_peak)), tile, chunk, q8, q4),
+        fit_ladder(
+            peak,
+            sequential,
+            apply_vram_cap(Some(real), Some(tiled_peak)),
+            tile,
+            chunk,
+            q8,
+            q4,
+        ),
         KreaControlFit::Fits {
+            offload_policy: OffloadPolicy::Sequential,
             tile_vae_decode: true,
             chunk_attention: false,
             branch_quant: None,
@@ -760,8 +857,17 @@ async fn krea_control_live_ladder_on_a_real_card() {
     // Cap below (tiling + chunking + q8) off the REAL reading → all three cheaper rungs on + q4 to fit,
     // where the old tiling-only ladder rejected-before-OOM.
     assert_eq!(
-        fit_ladder(peak, apply_vram_cap(Some(real), Some(chunked_peak - 8.9)), tile, chunk, q8, q4),
+        fit_ladder(
+            peak,
+            sequential,
+            apply_vram_cap(Some(real), Some(chunked_peak - 8.9)),
+            tile,
+            chunk,
+            q8,
+            q4,
+        ),
         KreaControlFit::Fits {
+            offload_policy: OffloadPolicy::Sequential,
             tile_vae_decode: true,
             chunk_attention: true,
             branch_quant: Some(gen_core::Quant::Q4),

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -243,6 +243,11 @@
                     "description": "Overall control-lane render peak VRAM (GB) at 1024²/8-step, keyed by BASE quant tier, with a bf16 control branch and NO fit-ladder rungs engaged. The peak is the end-of-render VAE-decode spike (sc-11744). The fit-gate compares this + headroom against free VRAM.",
                     "additionalProperties": { "type": "number" }
                   },
+                  "sequentialPeakGbByTier": {
+                    "type": "object",
+                    "description": "Measured pose-control peak after the bespoke provider encodes and drops Qwen3-VL before loading the DiT + control branch + VAE (sc-12176), keyed by BASE quant tier. This is the cheapest fit-ladder rung and the second-stage reject ceiling; deeper tiling/chunking/branch-quant savings compose from this staged baseline.",
+                    "additionalProperties": { "type": "number" }
+                  },
                   "decodeTileSaveGb": {
                     "type": "object",
                     "description": "Measured peak reduction (GB) from the CHEAPEST rung — forcing the seam-free tiled VAE decode (sc-11744, candle-gen #492; Krea2ControlRequest.tile_vae_decode), keyed by BASE quant tier. A SPEED cost, no quality cost. The fit-gate subtracts this from peakGbByTier and engages it BEFORE branch-quant. Measured only for the tier(s) where the end-of-render decode spike IS the render peak (q4); omitted where the denoise steady-state dominates and tiling recovers little.",
@@ -260,7 +265,7 @@
                   },
                   "measured": {
                     "type": "boolean",
-                    "description": "true when peakGbByTier / decodeTileSaveGb / chunkAttnSaveGb / branchQuantSaveGb were MEASURED on a real GPU; false when partially ESTIMATED (e.g. an interpolated q8 base peak) pending measurement."
+                    "description": "true when peakGbByTier / sequentialPeakGbByTier / decodeTileSaveGb / chunkAttnSaveGb / branchQuantSaveGb were MEASURED on a real GPU; false when partially ESTIMATED pending measurement."
                   }
                 }
               },


### PR DESCRIPTION
## What changed

- route the bespoke Candle Krea pose-control lane through explicit resident/sequential fit decisions
- publish measured control peaks for bf16/q8/q4 and base-generator sequential peaks for bf16/q8/q4
- mark the Krea base measurements authoritative while keeping the unsupported int8-convrot sequential tier absent
- replace the hardcoded Candle sequential engine list with the shared runtime capability-registry query
- pin `sceneworks-gen-core`, `runtime-macos`, and `runtime-cuda` together at immutable `runtime-2026.07.6`

## Why

Krea pose control bypasses the normal registered generator route, so it needed its own fit ladder and explicit `OffloadPolicy`. The generic Candle lane also duplicated a hardcoded model list instead of asking the runtime registry. Finally, the second-stage fit gate could not use sequential Krea measurements because the manifest did not publish them.

## Measured peaks

At 1024x1024, resident to sequential Krea pose-control peaks were:

- bf16: 65.8 to 50.0 GB
- q8: 45.4 to 39.6 GB
- q4: 36.2 to 32.5 GB

Each resident/sequential pair produced byte-identical RGB output. The base Krea generator now publishes sequential peaks q4 22.7 GB, q8 29.5 GB, and bf16 39.8 GB.

## Validation

- `cargo fmt --package sceneworks-worker -- --check`
- `cargo test --locked -p sceneworks-worker` (322 passed, 2 ignored)
- `cargo test --locked -p sceneworks-worker --features backend-candle` (633 passed, 35 ignored)
- `cargo clippy --locked -p sceneworks-worker --features backend-candle -- -D warnings`
- gen-core skew self-test, default worker graph, Candle worker graph, and Candle Rust API graph
- all three inference dependencies resolve to one revision: `runtime-2026.07.6#b2974970`

Shortcut: [sc-12176](https://app.shortcut.com/trefry/story/12176), [sc-12130](https://app.shortcut.com/trefry/story/12130), [sc-12131](https://app.shortcut.com/trefry/story/12131)
