### PR TITLE
fix(worker): fail a download when a declared file pattern matches nothing (sc-12283)

### DIFF
--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -140,6 +140,50 @@ pub(crate) async fn run_model_download_job(
         .await?;
         return Ok(());
     }
+    // sc-12283: the same must hold PER PATTERN, not just in aggregate. `allow_pattern_matches` ORs
+    // across the filter, so a tier whose `q8/transformer/*` matched but whose `q8/tokenizer/*`
+    // matched NOTHING passed the check above, downloaded, completed, and wrote an install marker —
+    // leaving a tier that is "installed" by every marker we keep and unloadable in practice. (The
+    // load-side half of that failure is sc-12279, which now falls back to a complete sibling tier;
+    // this stops the torn tier being created in the first place.)
+    //
+    // Testing each pattern against the RESOLVED files is sound: `snapshot.files` is every remote file
+    // matching ANY pattern, so a pattern with no match among them matched none in the repo.
+    //
+    // Safe to hard-fail: swept all 217 `downloads[].files` patterns across the 53 HF repos that
+    // declare one (builtin.models.jsonc, comment-stripped through this workspace's own
+    // `strip_jsonc_comments`) — every pattern matches at least one file today, so no download that
+    // works now begins to fail. A future entry that trips this is a real publishing gap, and failing
+    // loudly at download beats a phantom install the user only discovers at generation time.
+    let unmatched = files
+        .iter()
+        .filter(|pattern| {
+            !snapshot
+                .files
+                .iter()
+                .any(|file| pattern_matches(pattern, &file.path))
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    if !unmatched.is_empty() {
+        fail_job(
+            api,
+            &job.id,
+            &format!(
+                "Incomplete download for {repo}: nothing matches {}. Installing it would leave a \
+                 partial model that fails to load.",
+                unmatched.join(", ")
+            ),
+            Some(format!(
+                "{} of the {} declared file patterns matched zero files in the Hugging Face \
+                 repository/revision.",
+                unmatched.len(),
+                files.len()
+            )),
+        )
+        .await?;
+        return Ok(());
+    }
     if let Some(total_bytes) = snapshot.total_bytes() {
         update_job(
             api,

--- a/crates/sceneworks-worker/src/tests/lora_and_downloads.rs
+++ b/crates/sceneworks-worker/src/tests/lora_and_downloads.rs
@@ -1077,12 +1077,55 @@ async fn download_progress_tick_cancels_from_progress_post_snapshot() {
 /// A stub whose HF tree resolve returns an EMPTY file list, plus the job/progress/heartbeat routes a
 /// download job touches. Progress POSTs are recorded so the test can assert the job was FAILED.
 async fn spawn_empty_tree_stub() -> (String, std::sync::Arc<std::sync::Mutex<Vec<Value>>>) {
+    // No files at this revision under any filter — the unpublished-tier case.
+    spawn_tree_stub_with_files(Vec::new()).await
+}
+
+/// [`spawn_empty_tree_stub`], but the tree resolve serves `files` (path, size) — so a test can model a
+/// repo that satisfies SOME declared patterns and not others (sc-12283, the torn-tier case).
+async fn spawn_tree_stub_with_files(
+    files: Vec<(&'static str, u64)>,
+) -> (String, std::sync::Arc<std::sync::Mutex<Vec<Value>>>) {
     use std::sync::{Arc, Mutex};
     type Posts = Arc<Mutex<Vec<Value>>>;
-    async fn tree_route() -> Response {
-        // No files at this revision under any filter — the unpublished-tier case.
-        Json(json!([])).into_response()
-    }
+    let sizes: Arc<std::collections::HashMap<String, u64>> = Arc::new(
+        files
+            .iter()
+            .map(|(path, size)| ((*path).to_owned(), *size))
+            .collect(),
+    );
+    let tree = Arc::new(Value::Array(
+        files
+            .into_iter()
+            .map(|(path, size)| json!({ "type": "file", "path": path, "size": size }))
+            .collect(),
+    ));
+    let tree_route = {
+        let tree = tree.clone();
+        move || {
+            let tree = tree.clone();
+            async move { Json((*tree).clone()).into_response() }
+        }
+    };
+    // Serve exactly the byte count the tree declared for this path, so the transfer isn't rejected as
+    // truncated (see `download_snapshot_rejects_truncated_file`).
+    let blob_route = {
+        let sizes = sizes.clone();
+        move |axum::extract::Path((_owner, _repo, _revision, path)): axum::extract::Path<(
+            String,
+            String,
+            String,
+            String,
+        )>| {
+            let sizes = sizes.clone();
+            async move {
+                match sizes.get(&path) {
+                    Some(size) => vec![b'x'; *size as usize].into_response(),
+                    None => axum::http::StatusCode::NOT_FOUND.into_response(),
+                }
+            }
+        }
+    };
     async fn job_route(axum::extract::Path(job_id): axum::extract::Path<String>) -> Response {
         Json(job_snapshot_json(&job_id, false)).into_response()
     }
@@ -1102,6 +1145,11 @@ async fn spawn_empty_tree_stub() -> (String, std::sync::Arc<std::sync::Mutex<Vec
     let posts: Posts = Arc::new(Mutex::new(Vec::new()));
     let app = Router::new()
         .route("/api/models/:owner/:repo/tree/:revision", get(tree_route))
+        // Serve the blobs too, so a test that DISABLES the pattern check fails on its own assertions
+        // (a torn tier installed + a completion marker written) rather than on an unrelated 404 from a
+        // stub that simply can't serve the download. Without this the test would pass for the wrong
+        // reason and would not actually guard the regression.
+        .route("/:owner/:repo/resolve/:revision/*path", get(blob_route))
         .route("/api/v1/jobs/:job_id", get(job_route))
         .route("/api/v1/jobs/:job_id/progress", post(progress_route))
         .route("/api/v1/workers/:worker_id/heartbeat", post(heartbeat_route))
@@ -1160,6 +1208,68 @@ async fn model_download_fails_when_the_tier_resolves_no_files() {
                 .is_some_and(|message| message.contains("No files to download"))
     });
     assert!(failed, "expected a failed progress post, got {posts:?}");
+}
+
+#[tokio::test]
+async fn model_download_fails_when_one_declared_pattern_matches_nothing() {
+    // sc-12283: `allow_pattern_matches` ORs across the filter, so a tier whose transformer matched but
+    // whose `tokenizer/*` matched NOTHING passed the aggregate zero-file check, downloaded, completed
+    // and wrote an install marker — an "installed" tier that cannot load. This is the #850 shape.
+    let temp = tempdir().expect("tempdir creates");
+    // The repo satisfies q8/transformer/* and q8/vae/* but has NO q8/tokenizer/* at all. Sizes are
+    // token — the stub serves them verbatim, and this test is about the filter, not the transfer.
+    let (base_url, posts) = spawn_tree_stub_with_files(vec![
+        ("q8/transformer/diffusion_pytorch_model.safetensors", 8),
+        ("q8/vae/diffusion_pytorch_model.safetensors", 4),
+    ])
+    .await;
+    let mut settings = test_settings(base_url.clone(), None);
+    settings.api_url = base_url.clone();
+    settings.data_dir = temp.path().to_path_buf();
+    let api = ApiClient::new(&settings);
+    let client = reqwest::Client::new();
+
+    let mut job_json = job_snapshot_json("job-1", false);
+    job_json["type"] = json!("model_download");
+    job_json["payload"] = json!({
+        "modelId": "krea_2_raw",
+        "repo": "SceneWorks/krea-2-raw-mlx",
+        "files": ["q8/transformer/*", "q8/vae/*", "q8/tokenizer/*"],
+    });
+    let job: JobSnapshot = serde_json::from_value(job_json).expect("job deserializes");
+
+    super::model_jobs::run_model_download_job(&api, &settings, &client, &job)
+        .await
+        .expect("returns Ok — the failure is reported via a progress post, not an Err");
+
+    // No completion marker: a torn tier must never read as installed.
+    let marker = temp
+        .path()
+        .join("models")
+        .join(safe_download_dir("SceneWorks/krea-2-raw-mlx"))
+        .join(INSTALL_MARKER);
+    assert!(!marker.exists(), "no completion marker for a partial download");
+
+    let posts = posts.lock().expect("posts lock");
+    let failed = posts.iter().any(|post| {
+        post.get("status").and_then(Value::as_str) == Some("failed")
+            && post
+                .get("message")
+                .and_then(Value::as_str)
+                .is_some_and(|message| {
+                    // The message must NAME the pattern that matched nothing — "something is missing"
+                    // is not actionable, "q8/tokenizer/* matched nothing" is.
+                    message.contains("Incomplete download") && message.contains("q8/tokenizer/*")
+                })
+    });
+    assert!(failed, "expected a failed post naming the unmatched pattern, got {posts:?}");
+    // The patterns that DID match must not be blamed.
+    let blames_matched = posts.iter().any(|post| {
+        post.get("message")
+            .and_then(Value::as_str)
+            .is_some_and(|message| message.contains("q8/transformer/*"))
+    });
+    assert!(!blames_matched, "only the unmatched pattern should be named");
 }
 
 /// A tree stub that paginates: page 1 (no cursor) returns bf16/q4 files plus a `Link: rel="next"`

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "check:compose": "node scripts/check-compose-config.mjs",
     "check:health": "node scripts/check-health.mjs",
     "check:nc-weights": "node scripts/check-no-nc-weights.mjs",
+    "check:download-patterns": "node scripts/check-download-patterns.mjs",
     "hooks:install": "git config core.hooksPath scripts/git-hooks",
     "check:docker:rust-api": "node scripts/check-docker-api-runtime.mjs",
     "rust:fmt": "cargo fmt --all -- --check",

--- a/scripts/check-download-patterns.mjs
+++ b/scripts/check-download-patterns.mjs
@@ -1,0 +1,194 @@
+// SceneWorks catalog guard: every declared download pattern must match a real file
+// (sc-12283, epic 8506 "Catalog-wide quant matrix").
+//
+// WHY THIS EXISTS
+// ---------------
+// A manifest `downloads[]` entry scopes what to fetch with a `files` glob list, e.g.
+//
+//   "files": ["q8/transformer/*", "q8/text_encoder/*", "q8/vae/*", "q8/tokenizer/*", ...]
+//
+// The worker's filter ORs across that list (`allow_pattern_matches`), so a pattern
+// matching NOTHING used to be invisible: the tier downloaded, the job completed, and
+// an install marker was written for a tier missing a whole component — "installed" by
+// every marker we keep, and unloadable in practice. That is the shape behind
+// SceneWorks#850's "tokenizer: No such file or directory (os error 2)".
+//
+// As of sc-12283 the worker HARD-FAILS a download when any single declared pattern
+// matches zero files. That is the right behavior — a partial install is worse than a
+// clear error — but it moves the cost of a bad entry onto the USER, who sees a failed
+// download. This script moves it back to authoring time: run it after editing a
+// `downloads[]` entry, or after publishing/re-hosting a tier, and a typo'd glob or an
+// unpublished tier surfaces here instead of in someone's download queue.
+//
+// WHY IT IS NOT IN CI
+// -------------------
+// It talks to the Hugging Face API — one request per repo (~53 today). That is too
+// slow and too flaky a dependency for the parity lane, which must stay hermetic and
+// fast. It is a deliberate manual pre-flight, in the spirit of the sc-12283 sweep that
+// gated the worker change: at the time of writing, all 217 patterns across all 53
+// repos matched, which is what made hard-failing safe to ship.
+//
+// USAGE
+//   node scripts/check-download-patterns.mjs            # all HF download entries
+//   node scripts/check-download-patterns.mjs --model krea_2_raw
+//
+// Exits non-zero if any declared pattern matches zero files. Public repos need no
+// auth; a token is picked up from $HF_TOKEN / $HUGGING_FACE_HUB_TOKEN if set, so a
+// repo that is later gated still resolves.
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const MANIFEST = "config/manifests/builtin.models.jsonc";
+
+// -- JSONC parsing (manifests carry // comments). Mirrors scripts/check-no-nc-weights.mjs. --
+function stripJsoncComments(body) {
+  let result = "";
+  let inString = false;
+  let escaped = false;
+  for (let index = 0; index < body.length; index += 1) {
+    const char = body[index];
+    const next = body[index + 1];
+    if (inString) {
+      result += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      result += char;
+      continue;
+    }
+    if (char === "/" && next === "/") {
+      while (index < body.length && body[index] !== "\n") {
+        index += 1;
+      }
+      result += "\n";
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      index += 2;
+      while (index < body.length && !(body[index] === "*" && body[index + 1] === "/")) {
+        index += 1;
+      }
+      index += 1;
+      continue;
+    }
+    result += char;
+  }
+  return result;
+}
+
+// Glob semantics must mirror the worker's `pattern_matches` (imports.rs), which uses the
+// Rust `glob` crate with default MatchOptions — `*` and `?` DO cross `/` there
+// (require_literal_separator is false), so a `q8/*` pattern legitimately matches
+// `q8/vae/config.json`. Translating to a regex without that behavior would under-report
+// matches and produce false failures here that the worker would never raise.
+function patternToRegExp(pattern) {
+  let out = "";
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+    if (char === "*") {
+      out += "[\\s\\S]*";
+    } else if (char === "?") {
+      out += "[\\s\\S]";
+    } else if (char === "[") {
+      const close = pattern.indexOf("]", index + 1);
+      if (close === -1) {
+        out += "\\[";
+      } else {
+        let body = pattern.slice(index + 1, close);
+        if (body.startsWith("!")) body = `^${body.slice(1)}`;
+        out += `[${body}]`;
+        index = close;
+      }
+    } else {
+      out += char.replace(/[.+^${}()|\\]/g, "\\$&");
+    }
+  }
+  return new RegExp(`^${out}$`);
+}
+
+const fileCache = new Map();
+
+async function repoFiles(repo) {
+  if (fileCache.has(repo)) return fileCache.get(repo);
+  const token = process.env.HF_TOKEN || process.env.HUGGING_FACE_HUB_TOKEN;
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const response = await fetch(`https://huggingface.co/api/models/${repo}?blobs=false`, { headers });
+  if (!response.ok) {
+    const result = { error: `HTTP ${response.status}` };
+    fileCache.set(repo, result);
+    return result;
+  }
+  const body = await response.json();
+  const result = { files: (body.siblings ?? []).map((sibling) => sibling.rfilename) };
+  fileCache.set(repo, result);
+  return result;
+}
+
+async function main() {
+  const only = process.argv.includes("--model")
+    ? process.argv[process.argv.indexOf("--model") + 1]
+    : null;
+
+  const manifest = JSON.parse(stripJsoncComments(await readFile(path.join(root, MANIFEST), "utf8")));
+  const failures = [];
+  const unreachable = [];
+  let repos = 0;
+  let patterns = 0;
+
+  for (const model of manifest.models ?? []) {
+    if (only && model.id !== only) continue;
+    for (const download of model.downloads ?? []) {
+      if (download.provider !== "huggingface") continue;
+      const declared = download.files ?? [];
+      // An empty `files` list is a deliberate whole-repo download, not an omission —
+      // there is no per-pattern claim to verify.
+      if (declared.length === 0) continue;
+      const { files, error } = await repoFiles(download.repo);
+      if (error) {
+        unreachable.push(`${model.id}/${download.variant ?? "-"}  ${download.repo}  (${error})`);
+        continue;
+      }
+      repos += 1;
+      for (const pattern of declared) {
+        patterns += 1;
+        const regexp = patternToRegExp(pattern);
+        if (!files.some((file) => regexp.test(file))) {
+          failures.push(`${model.id}/${download.variant ?? "-"}  ${download.repo}  ${pattern}`);
+        }
+      }
+    }
+  }
+
+  console.log(`checked ${patterns} pattern(s) across ${repos} download entr(ies)`);
+  if (unreachable.length > 0) {
+    console.log(`\nUNREACHABLE (could not verify — set $HF_TOKEN if these are gated):`);
+    for (const line of unreachable) console.log(`  ${line}`);
+  }
+  if (failures.length > 0) {
+    console.error(`\nZERO-MATCH PATTERNS (${failures.length}) — the worker will hard-fail these downloads:`);
+    for (const line of failures) console.error(`  ${line}`);
+    console.error(`\nEither the glob is wrong, or the tier is not published yet.`);
+    process.exitCode = 1;
+    return;
+  }
+  // An unreachable repo is not a pass: we made no claim about it either way.
+  if (unreachable.length > 0) {
+    process.exitCode = 1;
+    return;
+  }
+  console.log("\nEvery declared download pattern matches at least one file.");
+}
+
+await main();


### PR DESCRIPTION
Closes sc-12283. The ingest-side half of the torn-tier failure whose load-side half was #1561 (sc-12279) — this stops a torn tier being **created**, that one stops it being **loaded**.

## Why

`run_model_download_job` failed only when the filter matched zero files **in aggregate**. But `allow_pattern_matches` ORs across the pattern list:

```rust
patterns.iter().any(|pattern| pattern_matches(pattern, path))
```

So a tier whose `q8/transformer/*` matched while its `q8/tokenizer/*` matched **nothing** downloaded, completed, and wrote an install marker — a tier "installed" by every marker we keep, and unloadable in practice. That's the shape behind #850's `tokenizer: No such file or directory (os error 2)`.

## What changed

- **`model_jobs.rs`** — after resolve, every declared pattern must match ≥1 resolved file, else fail **naming the patterns that matched nothing**. Checking against `snapshot.files` is sound: that's every remote file matching *any* pattern, so a pattern with no match there matched none in the repo. The existing aggregate-zero error still fires first and is unchanged, so its message and test stay put.
- **`scripts/check-download-patterns.mjs`** (+ `npm run check:download-patterns`) — the authoring-time pre-flight. Hard-failing is correct, but it moves the cost of a bad manifest entry onto the *user* as a failed download. This surfaces a typo'd glob or an unpublished tier at authoring time instead. **Deliberately not in CI**: one HF request per repo (~53) is too slow and too flaky for the hermetic parity lane.

## Why hard-failing is safe — the evidence

Swept **all 217 `downloads[].files` patterns across the 53 HF repos** that declare one, reading the manifest through this workspace's own `strip_jsonc_comments` rather than re-implementing JSONC. **Every pattern matches at least one file today**, so no download that works now begins to fail. Cross-checked by two independent implementations — a throwaway Python `fnmatch` sweep and the committed JS regex script — agreeing on 217/217.

A future entry that trips this is a real publishing gap, and failing loudly at download beats a phantom install the user only discovers at generation time.

### Glob semantics

The worker's `pattern_matches` uses the Rust `glob` crate with **default** `MatchOptions`, where `*` **does** cross `/` (`require_literal_separator: false`) — so `q8/*` legitimately matches `q8/vae/config.json`. The script mirrors that. A stricter translation would under-report matches and fail entries the worker accepts.

## Correcting the record

sc-12279 deferred this on the premise that several `SceneWorks/*` turnkeys are private and so couldn't be swept without a token. **That was wrong** — all 53 repos with patterns resolve anonymously; no token was needed. The sweep was the right gate; I should have just run it.

## Verified

- **637/637** `sceneworks-worker --lib --features backend-candle`; fmt + clippy(candle) clean.
- The new test is a real guard, not a passing decoration: with the check disabled it fails on **its own assertion** — `no completion marker for a partial download` — which is exactly the regression. The tree stub now serves blobs so that failure is the assertion rather than an unrelated 404 from a stub that couldn't serve the download.
- Script negative control: injecting `q8/DOES_NOT_EXIST/*` is caught, named, exit 1.

## Not covered

`run_lora_download_job` has no zero-file check at all, and `ensure_hf_files_cached` treats a zero-match filter as a deliberate no-op (its callers fall back on their own presence checks). Both are out of scope here — say the word and I'll file them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)