### PR TITLE
feat(catalog): declare Mochi 1 to the app — manifest, routing, engine seam (sc-11991)

### DIFF
--- a/apps/web/public/prompt-guides/mochi-1.md
+++ b/apps/web/public/prompt-guides/mochi-1.md
@@ -1,0 +1,69 @@
+# Mochi 1 Prompt Guide
+
+## Best For
+
+Text-to-video clips with strong, coherent motion at 848x480 / 30 fps. Mochi 1 is a 10B AsymmDiT trained for photorealistic motion and prompt adherence.
+
+Mochi 1 is **text-to-video only** — it has no image, reference, or keyframe conditioning. If you need to animate an existing image, use an image-to-video model instead.
+
+## Prompt Shape
+
+Write one flowing, descriptive paragraph rather than a keyword list. Mochi responds to natural prose:
+
+`subject + action + scene + camera + lighting + style`
+
+Mochi supports a negative prompt and true CFG, so you can steer both toward and away from content.
+
+## Build The Prompt
+
+### Subject And Action
+
+Lead with the subject and give it a clear, continuous action. Mochi's strength is motion — a prompt with an explicit verb ("walking", "turning", "pouring") produces far better results than a static description.
+
+### Scene Details
+
+Add location, time of day, weather, and props. Concrete nouns anchor the scene better than abstract mood words.
+
+### Camera
+
+Name the shot and any movement:
+
+- `close-up`, `medium shot`, `wide establishing shot`
+- `slow dolly in`, `tracking shot`, `static camera`, `handheld`
+
+### Lighting And Style
+
+Name the light and the look:
+
+- `golden hour`, `soft overcast light`, `harsh noon sun`, `neon rim light`
+- `photorealistic`, `cinematic 35mm`, `documentary`
+
+## Settings
+
+- **Resolution** — 848x480 (landscape) or 480x848 (portrait). This is Mochi's native and only trained bucket; other sizes are out of distribution.
+- **Frames per second** — 30. Mochi is trained at 30 fps, and fps here sets the generated clip length as well as playback speed.
+- **Duration** — the native design point is about 5 seconds. Shorter clips cut memory use roughly linearly, so start at 1-2 seconds if you are memory-constrained.
+- **Steps** — 64 is the default and a good starting point.
+- **Guidance** — 4.5 by default. Raise it for tighter prompt adherence, lower it for more natural motion.
+
+## Tips
+
+- Describe motion explicitly. Mochi is a motion model first; a prompt with no verb tends to produce a near-still clip.
+- Prefer one connected paragraph over comma-separated tags.
+- Use the negative prompt for artifacts you keep seeing (`blurry, distorted hands, static, watermark`).
+- Keep the subject count low. Crowded scenes dilute motion quality at 480p.
+
+## Limits
+
+- No LoRA support on either backend.
+- No image conditioning, first/last frame, clip extension, or person replacement.
+- One clip per run.
+
+## Licensing
+
+Mochi 1 is Apache-2.0 — commercial use is free and the weights are ungated.
+
+## Sources
+
+- [Mochi 1 model card](https://huggingface.co/genmo/mochi-1-preview)
+- [Genmo Mochi 1 GitHub repo](https://github.com/genmoai/mochi)

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -6984,6 +6984,162 @@
       }
     },
     {
+      "id": "mochi_1",
+      "name": "Mochi 1",
+      // ~53.5 GB for a full install (any one tier + the shared T5-XXL/VAE/tokenizer). Badged but
+      // unchecked in the wizard so the big download stays a deliberate opt-in, like LTX.
+      "autoDownload": false,
+      "family": "mochi",
+      "type": "video",
+      "adapter": "mochi_video",
+      // Text-to-video ONLY. Both descriptors declare `conditioning: []` (no image/reference/clip
+      // conditioning kinds), so there is no i2v / first-last-frame / extend / bridge / replace surface.
+      "capabilities": ["text_to_video"],
+      "licenseUrl": "https://huggingface.co/genmo/mochi-1-preview/blob/main/LICENSE",
+      // ONE repo serves BOTH backends (epic 1788 / A6, sc-11990). This deliberately DEVIATES from the
+      // LTX template, where macOS pulls the MLX rehost and Windows/Linux pull the upstream torch repo:
+      // A6 gave the candle backend a `.scales`-detect seam that ingests the mlx-affine tiers directly
+      // (keys 1:1, no remap), validated end-to-end on Windows/Blackwell by downloading THIS repo
+      // byte-exact. `SceneWorks/mochi-1-candle` was planned but never published. Pointing every
+      // platform here also sidesteps sc-12113: upstream `genmo/mochi-1-preview` ships BOTH a bf16 and
+      // an fp32 `vae/`, and the loader's dir-glob picks fp32 non-deterministically — the rehost ships
+      // bf16 only, so the app stays on the blessed regime by construction.
+      //
+      // No entry carries `platforms`, i.e. every entry is platform-agnostic and always kept
+      // (`retain_downloads_for_os` is a no-op when nothing is tagged) — that IS the "one repo, both
+      // backends" statement.
+      "downloads": [
+        // Shared T5-XXL text encoder + tokenizer + AsymmVAE (~10.4 GB), a `coRequisite` (sc-9696):
+        // fetched alongside whichever tier(s) the user picks, tracked once, excluded from the tier
+        // matrix, and NOT double-counted in the per-tier footprint. The tier dirs hold ONLY the
+        // transformer; the loader reads the tier's `split_model.json` and resolves these shared
+        // components from the tier dir's PARENT, so they must install as siblings of `q4/`/`q8/`/`bf16/`.
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/mochi-1-mlx",
+          "coRequisite": true,
+          "files": ["text_encoder/*", "tokenizer/*", "vae/*"],
+          "estimatedSizeBytes": 10445037860
+        },
+        // Quant matrix (epic 8506 convention): each tier is a SEPARATE user-selectable artifact tagged
+        // with a `variant`; `q4` (default) installs when no tier is chosen. Tiers ship PRE-QUANTIZED —
+        // both descriptors set `supported_quants: &[]`, so `advanced.mlxQuantize` selects a tier DIR and
+        // the loader only ASSERTS the tier's baked-in level (hard-errors on mismatch). There is no
+        // on-the-fly requant. Sizes are the exact hosted subdir bytes (HF API, repo rev 90a87786).
+        // footprint memory is null = NOT yet measured on-device; B5's real e2e run should backfill it.
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/mochi-1-mlx",
+          "variant": "q4",
+          "default": true,
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 9670883602,
+          "footprint": { "diskSizeBytes": 9670883602, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/mochi-1-mlx",
+          "variant": "q8",
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 13282967046,
+          "footprint": { "diskSizeBytes": 13282967046, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/mochi-1-mlx",
+          "variant": "bf16",
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 20055485000,
+          "footprint": { "diskSizeBytes": 20055485000, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/SceneWorks/mochi-1-mlx"
+      },
+      "defaults": {
+        // 5 s x 30 fps = 150 raw frames, which `mochi_frame_count` (B3, sc-11993) snaps to 151 — see
+        // the frame-lattice note under `limits`.
+        "duration": 5,
+        "fps": 30,
+        "resolution": "848x480",
+        "quality": "balanced",
+        // The AsymmDiT's own default (mlx-gen-mochi DEFAULT_STEPS). Guidance is NOT declared here: no
+        // manifest entry carries a `defaults.guidance` and nothing reads one — the engine's
+        // DEFAULT_GUIDANCE (4.5) applies when the request omits it.
+        "steps": 64
+      },
+      "limits": {
+        // Durations stay INTEGER SECONDS like every other video model; the worker snaps the frame count
+        // onto the engine's temporal stride. Mochi's AsymmVAE is 6x temporal, so the engine hard-rejects
+        // any count that is not `1 + 6k` (mlx-gen-mochi `validate_request`). `mochi_frame_count` (B3,
+        // sc-11993) is the snap, the sibling of the existing `ltx_frame_count` (8k+1) / `wan_frame_count`
+        // (4k+1) — the lattice lives in CODE, matching those two, not in a manifest field. At 30 fps every
+        // integer second sits exactly 1 frame below a lattice point (30d is always divisible by 6), so the
+        // snap costs +1 frame (~0.03 s): the 5 s default renders 151 frames.
+        "durations": [1, 2, 3, 4, 5],
+        // Mochi's native design point is 163 frames @ 30 fps (~5.4 s); 5 s is the closest integer second
+        // and the practical ceiling. Longer is both out-of-distribution and memory-infeasible — the
+        // AsymmVAE decode is NOT tiled, so its peak grows linearly in frames (see mlx.minMemoryGb).
+        "recommendedMaxDuration": 5,
+        "hardMaxDuration": 5,
+        // 30 fps only. `frames = duration x fps`, so fps multiplies into the generated LENGTH here — a
+        // second value would silently change clip length AND play a 30 fps motion prior off-speed.
+        // (Wan TI2V-5B is the precedent for a single-fps video model.)
+        "fps": [30],
+        // 848x480 is Mochi's native — and only — trained bucket; it is a 480p model. Both axes divide by
+        // 16, as the engine requires.
+        "resolutions": ["848x480", "480x848"],
+        "requiresDimensionsMultipleOf": 16
+        // NO sampler/scheduler axis: both descriptors advertise `samplers: []` + `schedulers: []` — one
+        // fixed flow-match Euler integrator. Advertising a sampler menu would be a false capability, and
+        // `manifest_menu_is_subset_of_descriptor` enforces that.
+      },
+      "loraCompatibility": {
+        // Both descriptors set supports_lora/supports_lokr = false — there is no Mochi adapter path on
+        // either backend. Declare the family anyway so the picker never offers cross-architecture LoRAs
+        // (per sc-1927), exactly like SVD.
+        "families": ["mochi"],
+        "types": []
+      },
+      "mlx": {
+        // Turnkey pre-converted MLX repo (no requiresConversion); the same repo feeds the candle lane.
+        "repo": "SceneWorks/mochi-1-mlx",
+        "standardTierLayout": true,
+        // DERIVED, NOT MEASURED (no on-device production-bucket run exists yet — A6's parity ran at a
+        // 64x64x7 fixture geometry; B5's real e2e should confirm or correct this). Derivation for the
+        // DEFAULT q4 tier at the default 848x480 / 5 s bucket, the convention this field follows:
+        //   * weights, ALL resident (`supports_sequential_offload: false` — the engine loads T5-XXL, the
+        //     AsymmDiT and the VAE up front and holds them for the whole generation): q4 DiT 9.01 GiB +
+        //     T5-XXL bf16 8.87 GiB + VAE 0.86 GiB = ~18.7 GiB.
+        //   * denoise activations are small (~1.5 GiB): 151 frames -> 44.5k visual tokens x 3072, x2 for
+        //     true CFG, with fused SDPA.
+        //   * the AsymmVAE decode DOMINATES and is NOT tiled — `vae.decode(latents)` materializes the
+        //     whole clip. The final decoder stage runs 128 channels at FULL resolution (T+5, 480, 848),
+        //     i.e. ~16.3 GiB per bf16 tensor, and a resnet holds residual + intermediate live at once, so
+        //     the decode peaks ~33-49 GiB before Metal conv scratch.
+        // ~18.7 + ~49 = ~68 GiB active, and the SCAIL-2 precedent (76 GB measured -> 96 declared) says the
+        // process footprint runs above the active peak. 96 is the floor that fits with headroom. NOTE the
+        // Model Manager SUPPRESSES this blanket badge for tier-matrix models (sc-10042) and drives RAM
+        // guidance off the per-tier `footprint` instead, so this is primarily documentation until those
+        // are measured. Tiling the decode (the sc-11747 / sc-10087 pattern) would cut this sharply.
+        "minMemoryGb": 96
+      },
+      "ui": {
+        "label": "Mochi 1",
+        "description": "Genmo Mochi 1 — a 10B AsymmDiT text-to-video model with a 6x-temporal AsymmVAE, native on Apple Silicon (MLX) and Windows/Linux (candle/CUDA). Renders 848x480 at 30 fps. Apache-2.0: commercial use free, ungated. Text-to-video only (no image conditioning) and no LoRA support. ~53.5 GB installed; needs ample memory — the VAE decode is untiled, so peak scales with clip length.",
+        "recommendedFor": ["text_to_video"],
+        "durationHint": "Native design point is ~5s at 848x480 / 30 fps. Shorter clips cut memory roughly linearly — start at 1-2s if you are memory-constrained.",
+        "promptGuide": {
+          "title": "Mochi 1 Prompt Guide",
+          "path": "/prompt-guides/mochi-1.md",
+          "sources": [
+            { "label": "Mochi 1 model card", "url": "https://huggingface.co/genmo/mochi-1-preview" },
+            { "label": "Genmo Mochi 1 GitHub repo", "url": "https://github.com/genmoai/mochi" }
+          ]
+        }
+      }
+    },
+    {
       "id": "real_esrgan",
       "recommended": true,
       "name": "Real-ESRGAN Upscaler",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -6986,8 +6986,13 @@
     {
       "id": "mochi_1",
       "name": "Mochi 1",
-      // ~53.5 GB for a full install (any one tier + the shared T5-XXL/VAE/tokenizer). Badged but
-      // unchecked in the wizard so the big download stays a deliberate opt-in, like LTX.
+      // ~53.5 GB for ALL THREE tiers + the shared T5-XXL/VAE/tokenizer; the DEFAULT q4 install is
+      // ~20.1 GB (q4 9.67 + shared 10.45). The other single-tier installs: q8 ~23.7, bf16 ~30.5 GB.
+      // Unchecked in the wizard so the big download stays a deliberate opt-in: the wizard LISTS every
+      // downloadable model but pre-checks only `recommended: true` entries (SetupWizard.jsx
+      // `defaultSelection`), and Mochi sets no `recommended` key — like wan_2_2 — so it is neither
+      // badged nor pre-checked. `autoDownload: false` is belt-and-braces: it states the opt-in intent
+      // explicitly, though the `isRecommended` clause already excludes this entry on its own.
       "autoDownload": false,
       "family": "mochi",
       "type": "video",
@@ -7107,26 +7112,37 @@
         "standardTierLayout": true,
         // DERIVED, NOT MEASURED (no on-device production-bucket run exists yet — A6's parity ran at a
         // 64x64x7 fixture geometry; B5's real e2e should confirm or correct this). Derivation for the
-        // DEFAULT q4 tier at the default 848x480 / 5 s bucket, the convention this field follows:
+        // DEFAULT q4 tier at the default 848x480 / 5 s bucket, the convention this field follows.
+        // UNITS: GiB = 1024^3, GB = 1000^3. The app's "GB" is BINARY everywhere (tierSuggestion.js
+        // `BYTES_PER_GB = 1024^3`), so `minMemoryGb: 96` really means 96 GiB and the GiB figures below
+        // — not the GB ones — are what compare against it.
         //   * weights, ALL resident (`supports_sequential_offload: false` — the engine loads T5-XXL, the
-        //     AsymmDiT and the VAE up front and holds them for the whole generation): q4 DiT 9.01 GiB +
-        //     T5-XXL bf16 8.87 GiB + VAE 0.86 GiB = ~18.7 GiB.
+        //     AsymmDiT and the VAE up front and holds them for the whole generation): q4 DiT 9.007 +
+        //     T5-XXL bf16 8.871 + VAE 0.856 = 18.73 GiB. Exact hosted bytes (HF API, repo rev 90a87786):
+        //     9670883602 + 9524669250 + 919551200 = 20115104052 B.
         //   * denoise activations are small (~1.5 GiB): 151 frames -> 44.5k visual tokens x 3072, x2 for
         //     true CFG, with fused SDPA.
         //   * the AsymmVAE decode DOMINATES and is NOT tiled — `vae.decode(latents)` materializes the
-        //     whole clip. The final decoder stage runs 128 channels at FULL resolution (T+5, 480, 848),
-        //     i.e. ~16.3 GiB per bf16 tensor, and a resnet holds residual + intermediate live at once, so
-        //     the decode peaks ~33-49 GiB before Metal conv scratch.
-        // ~18.7 + ~49 = ~68 GiB active, and the SCAIL-2 precedent (76 GB measured -> 96 declared) says the
-        // process footprint runs above the active peak. 96 is the floor that fits with headroom. NOTE the
-        // Model Manager SUPPRESSES this blanket badge for tier-matrix models (sc-10042) and drives RAM
-        // guidance off the per-tier `footprint` instead, so this is primarily documentation until those
-        // are measured. Tiling the decode (the sc-11747 / sc-10087 pattern) would cut this sharply.
+        //     whole clip. The final decoder stage runs 128 channels at FULL resolution (T+5, 480, 848):
+        //     128 x 156 x 480 x 848 x 2 B = 16255549440 B = 16.26 GB = 15.14 GiB per bf16 tensor. A
+        //     resnet holds residual + intermediate live at once (2x = 30.3 GiB), so the decode peaks
+        //     ~30-45 GiB (2-3x that tensor) before Metal conv scratch.
+        // 18.73 + ~45 = ~64 GiB active (~69 GB), and the SCAIL-2 precedent (76 GB measured -> 96
+        // declared) says the process footprint runs above the active peak. 96 is the floor that fits
+        // with headroom. NOTE the Model Manager SUPPRESSES this blanket badge for tier-matrix models
+        // (sc-10042) and drives RAM guidance off the per-tier `footprint` instead, so this is primarily
+        // documentation until those are measured. Tiling the decode (the sc-11747 / sc-10087 pattern)
+        // would cut this sharply.
         "minMemoryGb": 96
       },
       "ui": {
         "label": "Mochi 1",
-        "description": "Genmo Mochi 1 — a 10B AsymmDiT text-to-video model with a 6x-temporal AsymmVAE, native on Apple Silicon (MLX) and Windows/Linux (candle/CUDA). Renders 848x480 at 30 fps. Apache-2.0: commercial use free, ungated. Text-to-video only (no image conditioning) and no LoRA support. ~53.5 GB installed; needs ample memory — the VAE decode is untiled, so peak scales with clip length.",
+        // No install-size figure here, per the tier-matrix house style: LTX, Wan and SCAIL-2 all omit
+        // one because the Model Manager's tier panel already renders the EXACT per-tier size from
+        // `footprint.diskSizeBytes` (`formatTierSize`). A single aggregate would also be wrong for
+        // every individual user — the default q4 install is ~20.1 GB, a quarter of the all-tiers
+        // total. SCAIL-2 is the precedent for the qualitative memory caveat that replaces it.
+        "description": "Genmo Mochi 1 — a 10B AsymmDiT text-to-video model with a 6x-temporal AsymmVAE, native on Apple Silicon (MLX) and Windows/Linux (candle/CUDA). Renders 848x480 at 30 fps. Apache-2.0: commercial use free, ungated. Text-to-video only (no image conditioning) and no LoRA support. Needs ample memory — the VAE decode is untiled, so peak scales with clip length.",
         "recommendedFor": ["text_to_video"],
         "durationHint": "Native design point is ~5s at 848x480 / 30 fps. Shorter clips cut memory roughly linearly — start at 1-2s if you are memory-constrained.",
         "promptGuide": {

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -4899,8 +4899,11 @@ mod candle_routing_tests {
 
     #[test]
     fn candle_routed_video_models_are_eligible_in_their_native_shape() {
-        // txt2video lane: the 5B, ltx, and the 14B T2V (text-only) are eligible for text_to_video.
-        for model in ["wan_2_2", "ltx_2_3", "wan_2_2_t2v_14b"] {
+        // txt2video lane: the 5B, ltx, the 14B T2V (text-only), and Mochi are eligible for
+        // text_to_video. Mochi (sc-11991) is on the candle lane because its CANDLE descriptor is
+        // `mac_only: false` — the off-Mac engine ingests the same hosted mlx-affine tiers, so Mochi
+        // must NOT be hard mac-gated even though its MLX descriptor is `mac_only: true`.
+        for model in ["wan_2_2", "ltx_2_3", "wan_2_2_t2v_14b", "mochi_1"] {
             assert!(
                 video_request_candle_eligible(
                     model,
@@ -4999,6 +5002,22 @@ mod candle_routing_tests {
             ),
             "svd (no candle LoRA slot) must fall back to torch on an i2v+LoRA shape"
         );
+        // Mochi 1 (sc-11991) is txt2video-only with NO candle LoRA slot (both descriptors set
+        // `supports_lora`/`supports_lokr` = false), so every conditioned or LoRA-carrying shape is
+        // refused — there is no torch fallback for it (epic 8283), it simply is not candle-claimed.
+        for case in [
+            json!({ "prompt": "p" }), // no mode → defaults to i2v
+            json!({ "mode": "image_to_video", "sourceAssetId": "a" }),
+            json!({ "mode": "first_last_frame" }),
+            json!({ "mode": "text_to_video", "sourceAssetId": "a" }),
+            json!({ "mode": "text_to_video", "referenceAssetId": "a" }),
+            json!({ "mode": "text_to_video", "loras": [{ "name": "x" }] }),
+        ] {
+            assert!(
+                !video_request_candle_eligible("mochi_1", &object(case.clone())),
+                "mochi_1 non-t2v/conditioned shape must not be candle-claimed: {case}"
+            );
+        }
     }
 
     #[test]
@@ -6843,13 +6862,14 @@ mod mlx_routing_tests {
     #[test]
     fn video_mode_eligibility_admits_flf_only_on_flf_capable_engines() {
         // image_to_video is MLX on every routed model EXCEPT Bernini (text_to_video only — its
-        // renderer is Wan2.2-T2V, no still-image-to-video) and SCAIL-2 (animate_character only);
+        // renderer is Wan2.2-T2V, no still-image-to-video), SCAIL-2 (animate_character only) and
+        // Mochi (text_to_video only — `conditioning: []` on both descriptors, sc-11991);
         // text_to_video on every routed model EXCEPT SVD (image-conditioned only, sc-3523) and
         // SCAIL-2 (animate_character only — sc-5448).
         for model in VIDEO_MLX_ROUTED_MODELS {
             assert_eq!(
                 video_mode_is_mlx_eligible(model, "image_to_video"),
-                *model != "bernini" && *model != "scail2_14b",
+                *model != "bernini" && *model != "scail2_14b" && *model != "mochi_1",
                 "image_to_video eligibility for {model}"
             );
             assert_eq!(
@@ -6948,6 +6968,28 @@ mod mlx_routing_tests {
             assert!(
                 !video_mode_is_mlx_eligible(model, "animate_character"),
                 "animate_character should be SCAIL-2-only, not eligible on {model}"
+            );
+        }
+        // Mochi 1 (sc-11991) serves text_to_video and NOTHING else: both descriptors declare
+        // `conditioning: []`, so the engine has no image/keyframe/clip path — it must not fall
+        // through to the generic `text_to_video | image_to_video => true` arm.
+        assert!(
+            video_mode_is_mlx_eligible("mochi_1", "text_to_video"),
+            "mochi should serve text_to_video"
+        );
+        for mode in [
+            "image_to_video",
+            "first_last_frame",
+            "extend_clip",
+            "video_bridge",
+            "replace_person",
+            "animate_character",
+            "video_to_video",
+            "nonsense",
+        ] {
+            assert!(
+                !video_mode_is_mlx_eligible("mochi_1", mode),
+                "mochi is text_to_video only and should not serve {mode}"
             );
         }
         // first_last_frame: MLX on LTX (base + eros) + Wan TI2V-5B (sc-3055 cutover).

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -751,6 +751,22 @@ pub(crate) const VIDEO_MODEL_CAPS: &[VideoModelCaps] = &[
     // (sc-6837) is a DISTINCT engine gated by its own predicates, NOT Wan-VACE membership — so its
     // candle-video columns are all false (it is deliberately absent from `CANDLE_VIDEO_*`).
     VideoModelCaps::new("scail2_14b", true, false, false, false),
+    // Mochi 1 (epic 1788 / sc-11991): 10B AsymmDiT text-to-video on BOTH backends — `mlx-gen-mochi`
+    // (macOS) and `candle-gen-mochi` (Windows/CUDA + Linux), which ingests the SAME mlx-affine tiers
+    // via the A6 `.scales`-detect seam. Both register the SAME engine id (`mochi_1`), unlike LTX's
+    // `ltx_2_3` + `ltx_2_3_distilled` split.
+    //
+    // `candle_video_routed = true` is load-bearing: the MLX descriptor is `mac_only: true` but the
+    // CANDLE descriptor is `mac_only: false`, so Mochi must NOT be hard mac-gated app-side — the
+    // off-Mac lane is real and CUDA-validated on Blackwell (sc-11990). Per-backend gating is exactly
+    // what this table's two routed columns express, so no new mechanism is needed.
+    //
+    // t2v ONLY (`conditioning: []` on both descriptors): NOT an i2v model and NOT a VACE model, so
+    // those columns stay false — `video_request_candle_eligible`'s non-i2v arm then requires an
+    // explicit `text_to_video` mode and rejects a stray source image, and `video_mode_is_mlx_eligible`
+    // carries the matching t2v-only arm. Absent from `CANDLE_VIDEO_LORA_MODELS` because both
+    // descriptors set `supports_lora`/`supports_lokr` = false, so a LoRA-carrying job is refused.
+    VideoModelCaps::new("mochi_1", true, true, false, false),
 ];
 
 /// Derive a `&'static [&'static str]` list constant from a boolean column of one of the capability
@@ -1127,6 +1143,9 @@ mod tests {
         // Bernini VIDEO lane (sc-10997, epic 6562): the full candle planner+renderer serves t2v + the
         // editing/reference/multi-source modes. Not in the i2v/VACE subsets (a distinct engine).
         "bernini",
+        // Mochi 1 (sc-11991): the candle descriptor is `mac_only: false` and ingests the same hosted
+        // mlx-affine tiers, so the off-Mac t2v lane is real. Not in the i2v/VACE subsets (t2v only).
+        "mochi_1",
     ];
 
     const EXPECTED_CANDLE_VIDEO_I2V_ROUTED_MODELS: &[&str] = &["wan_2_2_i2v_14b", "svd"];
@@ -1143,6 +1162,7 @@ mod tests {
         "svd",
         "bernini",
         "scail2_14b",
+        "mochi_1",
     ];
 
     const EXPECTED_MLX_ROUTED_TRAINING_KERNELS: &[&str] = &[

--- a/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
@@ -629,6 +629,13 @@ pub(crate) fn video_mode_is_mlx_eligible(model: &str, mode: &str) -> bool {
     if model == "scail2_14b" {
         return matches!(mode, "animate_character" | "replace_person");
     }
+    // Mochi 1 (epic 1788 / sc-11991) is TEXT-conditioned only: both descriptors declare
+    // `conditioning: []`, so the engine has no image/keyframe/clip path at all — not even the classic
+    // still-image-to-video the generic arm below would otherwise grant it. Anything but
+    // `text_to_video` is a gap, so it needs its own arm rather than the `svd`-style inversion.
+    if model == "mochi_1" {
+        return mode == "text_to_video";
+    }
     match mode {
         "text_to_video" | "image_to_video" => true,
         "first_last_frame" => matches!(model, "ltx_2_3" | "ltx_2_3_eros" | "wan_2_2"),

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -685,6 +685,10 @@ pub(crate) const VIDEO_ENGINE_IDS: &[&str] = &[
     // ([`registry_capabilities`]) picks up the candle LTX descriptor too (sc-5097).
     "ltx_2_3_distilled",
     "svd_xt",
+    // Mochi 1 (epic 1788 / sc-11991). ONE id covers BOTH backends — unlike LTX above, `mlx-gen-mochi`
+    // and `candle-gen-mochi` both register `MODEL_ID = "mochi_1"`, so a single row is correct and a
+    // `_distilled`-style sibling would resolve to nothing.
+    "mochi_1",
 ];
 
 /// The trainer registry ids this worker serves (the ids `engine_trainer_id` maps TO). Used by
@@ -1226,6 +1230,9 @@ mod tests {
             "wan_2_2_vace_fun_14b" => &["wan2_2_vace_fun_14b"],
             "svd" => &["svd_xt"],
             "ltx_2_3" | "ltx_2_3_eros" => &["ltx_2_3", "ltx_2_3_distilled"],
+            // Mochi 1 (sc-11991): the sceneworks id IS the engine id, and BOTH backends register it,
+            // so one entry resolves the descriptor on either lane.
+            "mochi_1" => &["mochi_1"],
             _ => &[],
         }
     }
@@ -1455,6 +1462,77 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// sc-11991 (epic 1788): `mochi_1` resolves through THIS module to a real gen-core descriptor on
+    /// the active backend — the story's acceptance criterion, asserted directly.
+    ///
+    /// [`manifest_menu_is_subset_of_descriptor`] cannot stand in for this: it `continue`s past any
+    /// model whose descriptor does not resolve, so it stays green whether Mochi is wired or not.
+    /// Mochi also advertises NO sampler/scheduler axis, which makes its subset check vacuous. This
+    /// test fails if the `VIDEO_ENGINE_IDS` row, the `video_engine_ids` mapping, or the runtime pin
+    /// regresses.
+    ///
+    /// It further pins the descriptor facts the manifest entry is derived from, so a runtime bump
+    /// that changes them fails HERE rather than silently making the manifest lie.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn mochi_resolves_one_engine_id_to_the_gen_core_descriptor() {
+        assert!(
+            VIDEO_ENGINE_IDS.contains(&"mochi_1"),
+            "mochi_1 must be in VIDEO_ENGINE_IDS or the registry-derived video_generate \
+             advertisement drops it"
+        );
+        // ONE engine id covers both backends — unlike LTX's `ltx_2_3` + `ltx_2_3_distilled` split,
+        // `mlx-gen-mochi` and `candle-gen-mochi` both register `MODEL_ID = "mochi_1"`.
+        assert_eq!(
+            video_engine_ids("mochi_1"),
+            &["mochi_1"],
+            "mochi maps to exactly one engine id on both backends"
+        );
+
+        let descriptor = video_descriptor("mochi_1")
+            .expect("mochi_1 resolves to a gen-core descriptor on the active backend");
+        assert_eq!(descriptor.id, "mochi_1");
+        assert!(
+            matches!(descriptor.modality, gen_core::Modality::Video),
+            "mochi is a video generator"
+        );
+
+        let caps = &descriptor.capabilities;
+        // The manifest advertises NO sampler/scheduler axis because the engine honors none (one
+        // fixed flow-match Euler integrator). If this ever becomes non-empty, revisit `limits`.
+        assert!(
+            caps.samplers.is_empty() && caps.schedulers.is_empty(),
+            "mochi advertises no sampler/scheduler axis"
+        );
+        // Tiers ship PRE-QUANTIZED as directories; `spec.quantize` only asserts the tier's baked-in
+        // level. An empty `supported_quants` is what makes a tier a DIR rather than a requant toggle.
+        assert!(
+            caps.supported_quants.is_empty(),
+            "mochi tiers are pre-quantized dirs, not an on-the-fly requant toggle"
+        );
+        // t2v only + no adapter path — the two facts the routing rows and `loraCompatibility` encode.
+        assert!(
+            caps.conditioning.is_empty(),
+            "mochi is text-to-video only (no conditioning kinds)"
+        );
+        assert!(
+            !caps.supports_lora && !caps.supports_lokr,
+            "mochi has no LoRA/LoKr path on either backend"
+        );
+        // Everything stays resident: the basis for the manifest's mlx.minMemoryGb derivation.
+        assert!(
+            !caps.supports_sequential_offload,
+            "mochi holds T5 + DiT + VAE resident (the minMemoryGb derivation assumes it)"
+        );
+        assert_eq!(caps.max_count, 1, "mochi renders one clip per run");
+        // The manifest's `requiresDimensionsMultipleOf: 16` + the 848x480 bucket ride these.
+        assert_eq!(caps.min_size, 16);
+        assert_eq!(caps.max_size, 1280);
     }
 
     // Explicit test registrations exercise capability derivation without mutating a process-global

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -1752,3 +1752,288 @@ fn bernini_manifest_ships_the_quant_matrix() {
         assert_eq!(defaults, vec!["q4"], "{id} macOS default tier is q4");
     }
 }
+
+/// sc-11991 (epic 1788): the Mochi 1 builtin entry. Mochi deliberately DIVERGES from every
+/// quant-matrix sibling above in ways a well-meaning "make it consistent with LTX" edit would undo,
+/// so each divergence is pinned here:
+///
+///  * **One repo, BOTH backends.** Every download points at `SceneWorks/mochi-1-mlx` and NO entry
+///    carries `platforms`. A6 (sc-11990) gave candle a `.scales`-detect seam that ingests the
+///    mlx-affine tiers directly, CUDA-validated on Blackwell by downloading this repo byte-exact;
+///    `SceneWorks/mochi-1-candle` was never published. Re-adding an LTX-style
+///    `genmo/mochi-1-preview` Windows entry would also reintroduce sc-12113 (upstream ships bf16 AND
+///    fp32 `vae/`; the loader's dir-glob picks fp32).
+///  * **Tiers hold ONLY the transformer.** T5-XXL / VAE / tokenizer are a shared `coRequisite`
+///    (sc-9696) resolved from the tier dir's PARENT, so they must stay OUT of the tier matrix and out
+///    of the per-tier footprint.
+///  * **No sampler/scheduler axis.** Both descriptors advertise `samplers: []` + `schedulers: []`
+///    (one fixed flow-match Euler integrator) — advertising a menu would be a false capability.
+///  * **t2v only, no LoRA.** `conditioning: []` and `supports_lora`/`supports_lokr` = false.
+#[test]
+fn mochi_manifest_ships_the_one_repo_tier_matrix() {
+    let entry = builtin_model_entry("mochi_1");
+    assert_eq!(
+        entry.get("family").and_then(Value::as_str),
+        Some("mochi"),
+        "mochi family"
+    );
+    assert_eq!(
+        entry.get("type").and_then(Value::as_str),
+        Some("video"),
+        "mochi is a video model"
+    );
+    // t2v ONLY — both descriptors declare `conditioning: []`, so there is no i2v/FLF/extend surface.
+    let capabilities: Vec<&str> = entry
+        .get("capabilities")
+        .and_then(Value::as_array)
+        .map(|c| c.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+    assert_eq!(
+        capabilities,
+        vec!["text_to_video"],
+        "mochi advertises text_to_video and nothing else"
+    );
+    // Apache-2.0 => ungated, no credential host.
+    assert_ne!(
+        entry.get("gated").and_then(Value::as_bool),
+        Some(true),
+        "mochi is Apache-2.0, not gated"
+    );
+    // ~53.5 GB installed — a deliberate opt-in, like LTX.
+    assert_eq!(
+        entry.get("autoDownload").and_then(Value::as_bool),
+        Some(false),
+        "mochi is not auto-downloaded"
+    );
+
+    let downloads = entry
+        .get("downloads")
+        .and_then(Value::as_array)
+        .expect("mochi downloads");
+    // ONE repo, BOTH backends: every entry is the rehost and NONE is platform-tagged, so
+    // `retain_downloads_for_os` keeps them all on macOS, Windows and Linux alike.
+    for download in downloads {
+        assert_eq!(
+            download.get("repo").and_then(Value::as_str),
+            Some("SceneWorks/mochi-1-mlx"),
+            "every mochi download comes from the one rehost repo (candle ingests the mlx tiers)"
+        );
+        assert!(
+            download.get("platforms").is_none(),
+            "mochi downloads stay platform-agnostic — one repo serves both backends"
+        );
+    }
+
+    // The shared T5-XXL / tokenizer / VAE co-requisite: fetched with any tier, excluded from the
+    // tier matrix, and NOT a selectable variant.
+    let corequisites: Vec<&Value> = downloads
+        .iter()
+        .filter(|d| d.get("coRequisite").and_then(Value::as_bool) == Some(true))
+        .collect();
+    assert_eq!(
+        corequisites.len(),
+        1,
+        "exactly one mochi co-requisite (the shared text_encoder/tokenizer/vae)"
+    );
+    let shared_files: Vec<&str> = corequisites[0]
+        .get("files")
+        .and_then(Value::as_array)
+        .map(|f| f.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+    assert_eq!(
+        shared_files,
+        vec!["text_encoder/*", "tokenizer/*", "vae/*"],
+        "the co-requisite carries the shared components the tier dirs resolve from their parent"
+    );
+    assert!(
+        corequisites[0].get("variant").is_none(),
+        "the shared co-requisite is not a selectable quant tier"
+    );
+
+    // The tier matrix: q4 (default) / q8 / bf16, each installing only its own transformer subdir,
+    // with the EXACT hosted subdir byte sizes (HF API, repo rev 90a87786).
+    let tiers: Vec<&Value> = downloads
+        .iter()
+        .filter(|d| d.get("coRequisite").and_then(Value::as_bool) != Some(true))
+        .collect();
+    let variants: Vec<&str> = tiers
+        .iter()
+        .filter_map(|d| d.get("variant").and_then(Value::as_str))
+        .collect();
+    assert_eq!(
+        variants,
+        vec!["q4", "q8", "bf16"],
+        "mochi ships the q4/q8/bf16 tier matrix"
+    );
+    let expected_sizes = [
+        ("q4", 9_670_883_602_u64),
+        ("q8", 13_282_967_046),
+        ("bf16", 20_055_485_000),
+    ];
+    for (tier, expected) in expected_sizes {
+        let entry = tiers
+            .iter()
+            .find(|d| d.get("variant").and_then(Value::as_str) == Some(tier))
+            .unwrap_or_else(|| panic!("mochi {tier} tier"));
+        let files: Vec<String> = entry
+            .get("files")
+            .and_then(Value::as_array)
+            .map(|f| f.iter().filter_map(Value::as_str).map(String::from).collect())
+            .unwrap_or_default();
+        assert_eq!(
+            files,
+            vec![format!("{tier}/*")],
+            "{tier} tier installs only its own subdir (the shared components ride the co-requisite)"
+        );
+        assert_eq!(
+            entry.get("estimatedSizeBytes").and_then(Value::as_u64),
+            Some(expected),
+            "{tier} tier declares the exact hosted subdir size"
+        );
+        assert_eq!(
+            entry
+                .get("footprint")
+                .and_then(|f| f.get("diskSizeBytes"))
+                .and_then(Value::as_u64),
+            Some(expected),
+            "{tier} tier footprint.diskSizeBytes matches its download size"
+        );
+    }
+    let defaults: Vec<&str> = tiers
+        .iter()
+        .filter(|d| d.get("default").and_then(Value::as_bool) == Some(true))
+        .filter_map(|d| d.get("variant").and_then(Value::as_str))
+        .collect();
+    assert_eq!(defaults, vec!["q4"], "the default mochi tier is q4");
+
+    // limits: the engine hard-rejects width/height not divisible by 16, so every advertised bucket
+    // must satisfy it. NO sampler/scheduler axis (both descriptors advertise neither).
+    let limits = entry
+        .get("limits")
+        .and_then(Value::as_object)
+        .expect("mochi limits");
+    assert!(
+        limits.get("samplers").is_none() && limits.get("schedulers").is_none(),
+        "mochi advertises NO sampler/scheduler axis — one fixed flow-match Euler integrator"
+    );
+    assert_eq!(
+        limits.get("requiresDimensionsMultipleOf").and_then(Value::as_u64),
+        Some(16),
+        "mochi requires dimensions divisible by 16"
+    );
+    let resolutions: Vec<&str> = limits
+        .get("resolutions")
+        .and_then(Value::as_array)
+        .map(|r| r.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+    assert_eq!(
+        resolutions,
+        vec!["848x480", "480x848"],
+        "mochi advertises only its native 480p bucket"
+    );
+    for resolution in &resolutions {
+        let (w, h) = resolution.split_once('x').expect("WxH resolution");
+        for axis in [w, h] {
+            let value: u32 = axis.parse().expect("numeric axis");
+            assert_eq!(value % 16, 0, "{resolution} axis {axis} divides by 16");
+        }
+    }
+    // 30 fps only: `frames = duration * fps`, so a second value would silently change clip length.
+    let fps: Vec<u64> = limits
+        .get("fps")
+        .and_then(Value::as_array)
+        .map(|f| f.iter().filter_map(Value::as_u64).collect())
+        .unwrap_or_default();
+    assert_eq!(fps, vec![30], "mochi is a 30 fps model");
+
+    // defaults must be drawn from the advertised menus, or the studio opens on an invalid request.
+    let defaults_block = entry
+        .get("defaults")
+        .and_then(Value::as_object)
+        .expect("mochi defaults");
+    assert_eq!(
+        defaults_block.get("resolution").and_then(Value::as_str),
+        Some("848x480"),
+        "mochi defaults to its native bucket"
+    );
+    assert_eq!(
+        defaults_block.get("fps").and_then(Value::as_u64),
+        Some(30),
+        "mochi defaults to 30 fps"
+    );
+    assert_eq!(
+        defaults_block.get("steps").and_then(Value::as_u64),
+        Some(64),
+        "mochi defaults to the engine's DEFAULT_STEPS"
+    );
+    let durations: Vec<u64> = limits
+        .get("durations")
+        .and_then(Value::as_array)
+        .map(|d| d.iter().filter_map(Value::as_u64).collect())
+        .unwrap_or_default();
+    let default_duration = defaults_block
+        .get("duration")
+        .and_then(Value::as_u64)
+        .expect("mochi default duration");
+    assert!(
+        durations.contains(&default_duration),
+        "the default duration {default_duration} is one of the advertised {durations:?}"
+    );
+
+    // No Mochi adapter path on either backend, but the family is declared so the picker never offers
+    // cross-architecture LoRAs (sc-1927) — the SVD posture.
+    let lora = entry
+        .get("loraCompatibility")
+        .and_then(Value::as_object)
+        .expect("mochi loraCompatibility");
+    assert_eq!(
+        lora.get("families")
+            .and_then(Value::as_array)
+            .map(|f| f.iter().filter_map(Value::as_str).collect::<Vec<_>>()),
+        Some(vec!["mochi"]),
+        "mochi declares its own LoRA family"
+    );
+    assert_eq!(
+        lora.get("types")
+            .and_then(Value::as_array)
+            .map(|t| t.len()),
+        Some(0),
+        "mochi supports no LoRA types (supports_lora/supports_lokr are false on both backends)"
+    );
+
+    let mlx = entry
+        .get("mlx")
+        .and_then(Value::as_object)
+        .expect("mochi mlx block");
+    assert_eq!(
+        mlx.get("repo").and_then(Value::as_str),
+        Some("SceneWorks/mochi-1-mlx"),
+        "mochi mlx repo"
+    );
+    assert_eq!(
+        mlx.get("standardTierLayout").and_then(Value::as_bool),
+        Some(true),
+        "mochi ships the standard q4/q8/bf16 turnkey tier layout"
+    );
+    assert!(
+        mlx.get("minMemoryGb").and_then(Value::as_u64).is_some(),
+        "mochi declares mlx.minMemoryGb"
+    );
+
+    // The prompt guide is served as a static file from apps/web/public; a typo'd path is a silent
+    // 404 in the studio (nothing else in the repo reads `promptGuide`), so pin THIS entry's path.
+    let guide = entry
+        .get("ui")
+        .and_then(|ui| ui.get("promptGuide"))
+        .and_then(|g| g.get("path"))
+        .and_then(Value::as_str)
+        .expect("mochi ui.promptGuide.path");
+    let guide_file = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../apps/web/public")
+        .join(guide.trim_start_matches('/'));
+    assert!(
+        guide_file.is_file(),
+        "mochi prompt guide {guide} resolves to a real file ({})",
+        guide_file.display()
+    );
+}

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -1799,7 +1799,9 @@ fn mochi_manifest_ships_the_one_repo_tier_matrix() {
         Some(true),
         "mochi is Apache-2.0, not gated"
     );
-    // ~53.5 GB installed — a deliberate opt-in, like LTX.
+    // ~20.1 GB for the default q4 install, ~53.5 GB for all three tiers + shared — a deliberate
+    // opt-in. Mochi carries no `recommended: true`, so it is neither badged nor pre-checked in the
+    // wizard; `autoDownload: false` states that intent explicitly.
     assert_eq!(
         entry.get("autoDownload").and_then(Value::as_bool),
         Some(false),


### PR DESCRIPTION
B1 of [epic 1788](https://app.shortcut.com/trefry/epic/1788) — [sc-11991](https://app.shortcut.com/trefry/story/11991).

Track A shipped the native Mochi 1 (`genmo/mochi-1-preview`, Apache-2.0) port in `runtime-2026.07.6`. This is the first app-side story: **declare Mochi to the SceneWorks app**. No worker dispatch (B2), no request contract (B3), no UI (B4).

## What changed

| File | Change |
|---|---|
| `config/manifests/builtin.models.jsonc` | New `mochi_1` entry (+156) |
| `routing/catalog.rs` | `VideoModelCaps::new("mochi_1", true, true, false, false)` + 2 `EXPECTED_*` lists |
| `routing/mlx.rs` | `video_mode_is_mlx_eligible` t2v-only arm |
| `engines.rs` | `VIDEO_ENGINE_IDS` += `mochi_1`; `video_engine_ids` mapping |
| `apps/web/public/prompt-guides/mochi-1.md` | New prompt guide (the manifest points at it) |

Production diff is 5 small edits; the rest is the manifest entry and tests.

## Re-validation: the story text was partly stale

Each item below was verified against app `main` and runtime rev `b2974970`, not taken on trust.

1. **The pin bump was already done — dropped.** `crates/sceneworks-worker/Cargo.toml` already pins all three deps (`sceneworks-gen-core` L31, `runtime-macos` L75, `runtime-cuda` L81) to `runtime-2026.07.6`. **`Cargo.toml` / `Cargo.lock` are untouched in this PR.** The branch name is now a misnomer.
2. **Windows/Linux use `SceneWorks/mochi-1-mlx`, NOT `genmo/mochi-1-preview`** — see "one repo, both backends" below.
3. **No `samplers` in `limits`.** Both descriptors set `samplers: []` + `schedulers: []` — one fixed flow-match Euler integrator. The story text asked for a sampler menu; that would be a false capability, and `manifest_menu_is_subset_of_descriptor` actively rejects it (verified by mutation).
4. **One engine id, and Mochi is NOT mac-only.** Both backends register `MODEL_ID = "mochi_1"` (unlike LTX's `ltx_2_3` + `ltx_2_3_distilled`). MLX is `mac_only: true`, **candle is `mac_only: false`**. The existing `VideoModelCaps` table already expresses per-backend gating via its two routed columns, so `candle_video_routed = true` lights the Windows lane up with **no new mechanism invented**.
5. **Tiers hold only the transformer.** T5-XXL / VAE / tokenizer are a shared `coRequisite` (sc-9696) that the loader resolves from the tier dir's **parent** — kept out of the tier matrix and not double-counted per tier. Sizes are the exact hosted bytes (HF API, rev `90a87786`), independently re-fetched rather than taken from the story: q4 `9,670,883,602` · q8 `13,282,967,046` · bf16 `20,055,485,000` · shared `10,445,037,860`. These sum to the repo total (53.45 GB) minus README/.gitattributes.
6. **Defaults/limits read from the crate**, not the story: `DEFAULT_STEPS = 64`, `DEFAULT_FPS = 30`, width/height ÷ 16, frames ≡ 1 (mod 6), `max_count: 1`, `min_size: 16`, `max_size: 1280`.
7. **`supported_quants: []` ⇒ a tier is a directory**, not a requant toggle. Modelled exactly that way (`standardTierLayout: true`, no `quantize` key).

## Why the manifest deviates from the LTX template on the Windows source

LTX ships macOS from the MLX rehost and Windows/Linux from upstream `Lightricks/LTX-2.3`. Mochi points **every** platform at `SceneWorks/mochi-1-mlx`, and no download entry carries `platforms` (an untagged entry is platform-agnostic; `retain_downloads_for_os` no-ops when nothing is tagged). That is the deliberate encoding of **"one repo, both backends"**:

- A6 gave candle a `.scales`-detect seam that ingests the mlx-affine tiers directly (keys 1:1, no remap), **CUDA-validated on Blackwell by downloading that exact repo byte-exact** (bf16 5.99e-2 = dense, q8 5.10e-2, q4 1.88e-1).
- `SceneWorks/mochi-1-candle` was planned but **never published** — an LTX-style split would point Windows at a repo that does not exist.
- It also sidesteps **sc-12113**: upstream `genmo/mochi-1-preview` ships **both** a bf16 and an fp32 `vae/`, and the loader's dir-glob picks fp32 non-deterministically. The rehost ships bf16 only, so the app stays on the blessed regime by construction.

## `mlx.minMemoryGb: 96` — reasoning

Derived, **not measured** (A6's parity ran at a 64×64×7 fixture geometry; no production-bucket run exists). For the default q4 tier at 848×480 / 5 s, with `supports_sequential_offload: false` (T5 + DiT + VAE all resident):

- **Weights, all resident:** q4 DiT 9.007 + T5-XXL bf16 8.871 + VAE 0.856 = **18.73 GiB** (exact hosted bytes, HF API rev `90a87786`: 9670883602 + 9524669250 + 919551200 = 20115104052 B).
- **Denoise activations:** ~1.5 GiB (44.5k visual tokens × 3072, ×2 for true CFG, fused SDPA).
- **AsymmVAE decode dominates and is NOT tiled** — `vae.decode(latents)` materializes the whole clip. The final decoder stage runs 128 channels at full resolution (T+5, 480, 848): 128 × 156 × 480 × 848 × 2 B = 16255549440 B = 16.26 GB = **15.14 GiB per bf16 tensor**, and a resnet holds residual + intermediate live at once (2× = 30.3 GiB) → **~30-45 GiB** (2-3× that tensor), before Metal conv scratch.

18.73 + ~45 ≈ **64 GiB active** (~69 GB); the SCAIL-2 precedent (76 GB measured → 96 declared) says process footprint runs above active peak. 96 is the floor that fits with headroom.

**Units:** GiB = 1024³, GB = 1000³. The app's "GB" is binary everywhere (`tierSuggestion.js` `BYTES_PER_GB = 1024³`), so `minMemoryGb: 96` really means 96 GiB and the GiB figures are the ones that compare against it.

Note this is **advisory**: the Model Manager suppresses the blanket badge for tier-matrix models (sc-10042) and drives RAM guidance off per-tier `footprint` instead, which I left `null` (unmeasured) rather than invent. See the findings below — this number is the strongest argument for tiling the decode.

## Scope vs acceptance criteria

- ✅ **"Workspace builds against the new runtime tag"** — `npm run rust:check` clean (fmt + clippy `-D warnings` + tests + build), real exit 0.
- ✅ **"`mochi_1` resolves through `engines.rs` to the gen-core descriptor"** — proven directly by `mochi_resolves_one_engine_id_to_the_gen_core_descriptor`. **The obvious candidate for this AC, `manifest_menu_is_subset_of_descriptor`, is a false green**: it `continue`s past any model whose descriptor does not resolve, and Mochi advertises no sampler axis, so its subset check is vacuous. The new test calls `video_descriptor("mochi_1")` and `.expect()`s it.
- ✅ **"Catalog with correct tiers, limits, and mac-gating"** — manifest gate test + routing rows; Mochi is correctly *not* mac-gated (candle lane routed).

## Tests

- `mochi_manifest_ships_the_one_repo_tier_matrix` (`gpu_and_manifest.rs`) — pins every divergence: one repo / no `platforms`, the coRequisite split, exact tier bytes, q4 default, **absence** of samplers/schedulers, 16-divisible resolutions, 30 fps, t2v-only capabilities, empty LoRA types, and that `ui.promptGuide.path` resolves to a real file (nothing else in the repo reads `promptGuide`, so a typo is a silent 404).
- `mochi_resolves_one_engine_id_to_the_gen_core_descriptor` (`engines.rs`) — the AC, plus it pins the descriptor facts the manifest is derived from, so a runtime bump that changes them fails here instead of silently making the manifest lie.
- `video_mode_eligibility_admits_flf_only_on_flf_capable_engines` — extended: Mochi serves `text_to_video` and rejects all 8 other modes (without its own arm it would fall through to the generic `text_to_video | image_to_video => true` and wrongly claim i2v).
- `candle_routed_video_models_are_eligible_in_their_native_shape` / `non_candle_video_models_and_conditioned_shapes_fall_back` — Mochi on the candle t2v lane; every conditioned/LoRA shape refused.
- `routed_model_lists_match_snapshot` — `EXPECTED_*` updated.

**Mutation-checked** (the tests fail when the manifest is wrong, verified, not assumed): perturbing the q4 size by 1 byte → exit 101 "q4 tier declares the exact hosted subdir size"; adding a `samplers` axis → exit 101 "mochi advertises NO sampler/scheduler axis".

## Verification

`npm run rust:check` — **real exit 0** (captured directly, not through a pipe). `npm run rust:check:neither` could not run: Docker daemon is not running locally. The new cfg-gated test uses the same gate verbatim as the `video_engine_ids`/`video_descriptor` fns it calls, so it is correct by construction; CI's parity lane covers it.

## Findings for follow-on stories (not fixed here — out of B1's scope)

1. 🔴 **The untiled VAE decode makes long clips memory-infeasible** (see minMemoryGb above). Peak scales linearly in frames: ~7 GiB at 19 frames → ~49 GiB at 163. The coordinator's "default = 163 frames" was decided on wall-clock grounds; **memory is the more binding constraint**. I capped `durations` at 5 s and documented it. Tiling the decode (the sc-11747 / sc-10087 pattern; SCAIL-2 already tiles temporally) would cut the floor sharply — **worth a story**.
2. 🔴 **`normalized_dimensions` floors to a multiple of 32, so 848 → 832** (`video_request.rs`). Mochi's native 848×480 would be silently rewritten to 832×480. It still passes Mochi's ÷16 check, so it fails *silently* rather than erroring. **B3 (sc-11993) must handle this** or the manifest advertises a bucket the app never generates.
3. ℹ️ **Duration is seconds, not frames.** `raw_frame_count = duration × fps`, and the lattice lives in code (`ltx_frame_count` 8k+1, `wan_frame_count` 4k+1) — not the manifest — so I did **not** invent a `limits` lattice field. At 30 fps no integer second lands on 6k+1 (30d is always ÷6), so B3's `mochi_frame_count` snap costs +1 frame: the 5 s default renders **151** frames, not 163. LTX already behaves this way (6 s @ 25 → 153 frames). Flagging since the coordinator specified 163 exactly; 163 needs a fractional `duration: 5.4`, which no other model uses.
4. ℹ️ `apps/web/src/constants.js` carries a fallback model catalog mirroring the manifest — Mochi likely needs a row there for **B4**.
5. ℹ️ Per-tier `footprint.residentMemoryBytes` / `peakMemoryBytes` are `null` (unmeasured). **B5's real e2e run should backfill them** — they, not `minMemoryGb`, drive the tier-matrix RAM guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Review follow-ups (adversarial review, 4 minor findings — all fixed in `ca3aee07`)

All four were documentation/copy accuracy defects; no functional value changed (tier bytes, `minMemoryGb: 96`, `duration: 5`, capabilities, download entries all untouched; no `recommended` key added).

1. **Entry footprint comment** — "~53.5 GB for a full install (any one tier + shared)" was self-contradictory: 53.45 GB is *all three tiers* + shared; a single-tier install is 20.12 (q4) / 23.73 (q8) / 30.50 (bf16) GB. Restated with both.
2. **`ui.description` (user-facing)** — dropped the "~53.5 GB installed" figure, which overstated the default q4 install (~20.1 GB) by ~2.7× on the model card. Now matches tier-matrix house style: LTX, Wan and SCAIL-2 all omit an install figure because the Model Manager tier panel already renders the exact per-tier size from `footprint.diskSizeBytes` (`formatTierSize`). The qualitative memory caveat (SCAIL-2's precedent) remains.
3. **"Badged but unchecked ... like LTX"** — factually wrong. Badging comes from `recommended: true`; Mochi sets no `recommended` key (like `wan_2_2`), so it is neither badged nor pre-checked. Comment corrected; `recommended` deliberately still omitted.
4. **Decode arithmetic** — "~16.3 GiB" conflated GB with GiB (128×156×480×848×2 B = 16.26 GB = 15.14 GiB), and the slip propagated into "~68 GiB active". Whole block re-derived with consistent units and verified against exact hosted bytes. `minMemoryGb: 96` conclusion unchanged.

The same stale "~53.5 GB installed" copy in the `mochi_manifest_ships_the_one_repo_tier_matrix` test comment was corrected too (comment only, no assertion change).
