### PR TITLE
feat(core): shape Mochi video requests — 6k+1 frames, manifest-driven dimension floor (sc-11993)

### DIFF
--- a/crates/sceneworks-core/src/video_request.rs
+++ b/crates/sceneworks-core/src/video_request.rs
@@ -42,8 +42,10 @@ pub struct VideoRequest {
     pub duration: f32,
     /// Frames per second, clamped to 1..=60 (Python `safe_int`).
     pub fps: u32,
-    /// Output dimensions: clamped to 256..=1920, then floored to a multiple of 32
-    /// (Python `normalized_dimensions`). Defaults 768x512.
+    /// Output dimensions: clamped to 256..=1920, then floored to the model's dimension
+    /// granularity — `model_manifest_entry.limits.requiresDimensionsMultipleOf`, default
+    /// 32 (Python `normalized_dimensions`). Defaults 768x512. Mochi declares 16 so its
+    /// native 848x480 bucket survives the floor (sc-11993).
     pub width: u32,
     pub height: u32,
     pub quality: String,
@@ -93,7 +95,12 @@ impl VideoRequest {
     /// missing fields fall back to the Python defaults and `project_id` may be empty
     /// — the caller validates it is present (the worker rejects an empty project id).
     pub fn from_payload(payload: &JsonObject) -> Self {
-        let (width, height) = normalized_dimensions(payload.get("width"), payload.get("height"));
+        let model_manifest_entry = object_or_empty(payload, "modelManifestEntry");
+        let (width, height) = normalized_dimensions(
+            payload.get("width"),
+            payload.get("height"),
+            &model_manifest_entry,
+        );
         Self {
             project_id: nonempty_string_or(payload, "projectId", ""),
             mode: nonempty_string_or(payload, "mode", DEFAULT_MODE),
@@ -126,7 +133,7 @@ impl VideoRequest {
             reference_asset_ids: string_list(payload, "referenceAssetIds"),
             reference_clip_asset_id: optional_id(payload, "referenceClipAssetId"),
             advanced: object_or_empty(payload, "advanced"),
-            model_manifest_entry: object_or_empty(payload, "modelManifestEntry"),
+            model_manifest_entry,
         }
     }
 
@@ -138,16 +145,19 @@ impl VideoRequest {
     }
 
     /// The frame count the model will actually produce: the raw `duration * fps`
-    /// snapped to the model's temporal constraint (LTX `8k + 1`, Wan `4n + 1`).
-    /// Unknown / stub models keep the raw count. The engine's `validate()` is
-    /// authoritative for the real models (sc-3034 / sc-3035); this mirrors the
-    /// Python worker's pre-snap so the stub clip length and the UI estimate agree.
+    /// snapped to the model's temporal constraint (LTX `8k + 1`, Wan `4n + 1`,
+    /// Mochi `6k + 1`). Unknown / stub models keep the raw count. The engine's
+    /// `validate()` is authoritative for the real models (sc-3034 / sc-3035); this
+    /// mirrors the Python worker's pre-snap so the stub clip length and the UI
+    /// estimate agree.
     pub fn frame_count(&self) -> u32 {
         let raw = self.raw_frame_count();
         if is_ltx_model(&self.model) {
             ltx_frame_count(raw)
         } else if is_wan_model(&self.model) {
             wan_frame_count(raw)
+        } else if is_mochi_model(&self.model) {
+            mochi_frame_count(raw)
         } else {
             raw
         }
@@ -181,6 +191,30 @@ pub fn wan_frame_count(raw_frames: u32) -> u32 {
     (raw - ((raw - 1) % 4)).max(5)
 }
 
+/// Mochi's 7-frame floor: `6·1 + 1`, the smallest on-lattice count that yields more than
+/// one latent frame (`lf = 1 + (frames − 1) / 6`). Mirrors LTX's 9 (`8·1 + 1`) and Wan's
+/// 5 (`4·1 + 1`) — one temporal stride above a single still frame.
+const MOCHI_MIN_FRAMES: u32 = 7;
+
+/// Mochi 1 temporal stride: the AsymmVAE's 6× temporal ratio makes `t_lat` equal to
+/// `1 + (frames − 1) / 6`, so the engine's `validate_request` hard-rejects anything but
+/// `frames ≡ 1 (mod 6)`. Frames snap to the NEAREST `6k + 1` (ties → lower), minimum
+/// [`MOCHI_MIN_FRAMES`] — the LTX rule, deliberately NOT Wan's floor: flooring the shipped
+/// 5s @ 30fps default (150) would give 145, which the runtime happily accepts
+/// (`145 % 6 == 1`) while silently rendering 4.83s instead of the requested 5s. Nearest
+/// gives 151 (`1 + 6·25`), the frame count the manifest documents for the 5s default.
+pub fn mochi_frame_count(raw_frames: u32) -> u32 {
+    let frame_count = raw_frames.max(MOCHI_MIN_FRAMES);
+    // `frame_count >= 7` ⇒ `lower >= 7`, so the floor needs no second guard.
+    let lower = frame_count - ((frame_count - 1) % 6);
+    let upper = lower + 6;
+    if frame_count - lower <= upper - frame_count {
+        lower
+    } else {
+        upper
+    }
+}
+
 /// Whether `model` is an LTX-2.3 family id (`ltx_2_3`, `ltx_2_3_eros`, …).
 pub fn is_ltx_model(model: &str) -> bool {
     model.starts_with("ltx")
@@ -191,16 +225,56 @@ pub fn is_wan_model(model: &str) -> bool {
     model.starts_with("wan")
 }
 
-/// Clamp + floor dimensions exactly like the Python `normalized_dimensions`: parse
-/// (default 768x512), clamp to 256..=1920, floor to a multiple of 32, floor of 256.
-fn normalized_dimensions(width: Option<&Value>, height: Option<&Value>) -> (u32, u32) {
-    let w = floor_to_32(clamped_u32(width, 768, 256, 1920));
-    let h = floor_to_32(clamped_u32(height, 512, 256, 1920));
+/// Whether `model` is a Mochi 1 family id (`mochi_1`, …). Epic 1788 / sc-11993.
+pub fn is_mochi_model(model: &str) -> bool {
+    model.starts_with("mochi")
+}
+
+/// The dimension granularity applied when a model's manifest entry does not declare
+/// `limits.requiresDimensionsMultipleOf` — the historical blanket floor, kept as the
+/// default so every already-shipped model's geometry is byte-for-byte unchanged.
+const DEFAULT_DIMENSION_MULTIPLE: u32 = 32;
+
+/// Clamp + floor dimensions like the Python `normalized_dimensions`: parse (default
+/// 768x512), clamp to 256..=1920, floor to the model's dimension multiple, floor of 256.
+///
+/// The multiple comes from the resolved manifest entry's
+/// `limits.requiresDimensionsMultipleOf`, defaulting to [`DEFAULT_DIMENSION_MULTIPLE`].
+/// A blanket 32 silently rewrote Mochi's native (and only trained) 848x480 bucket to
+/// 832x480 — `848 % 32 == 16` — and the rewrite was invisible because `832 % 16 == 0`
+/// satisfies the engine's own ÷16 check (sc-11993). Models opt in by *declaring* the
+/// limit; the rest keep 32 (sc-12294 tracks the shipped 848/720 buckets that still
+/// floor, pending a decision — changing them retroactively would move the geometry of
+/// already-reproducible recipes).
+fn normalized_dimensions(
+    width: Option<&Value>,
+    height: Option<&Value>,
+    model_manifest_entry: &JsonObject,
+) -> (u32, u32) {
+    let multiple = dimension_multiple_of(model_manifest_entry);
+    let w = floor_to_multiple(clamped_u32(width, 768, 256, 1920), multiple);
+    let h = floor_to_multiple(clamped_u32(height, 512, 256, 1920), multiple);
     (w, h)
 }
 
-fn floor_to_32(value: u32) -> u32 {
-    (value - (value % 32)).max(256)
+/// `limits.requiresDimensionsMultipleOf` from a resolved manifest entry, else
+/// [`DEFAULT_DIMENSION_MULTIPLE`]. Read as a plain `u64` (the manifest is machine-authored
+/// — same reader as the `engines.rs` manifest checks). A zero / negative / non-integer
+/// declaration falls back rather than panicking on `% 0`: `from_payload` is infallible and
+/// must survive a typo'd manifest entry.
+fn dimension_multiple_of(model_manifest_entry: &JsonObject) -> u32 {
+    model_manifest_entry
+        .get("limits")
+        .and_then(Value::as_object)
+        .and_then(|limits| limits.get("requiresDimensionsMultipleOf"))
+        .and_then(Value::as_u64)
+        .and_then(|multiple| u32::try_from(multiple).ok())
+        .filter(|multiple| *multiple > 0)
+        .unwrap_or(DEFAULT_DIMENSION_MULTIPLE)
+}
+
+fn floor_to_multiple(value: u32, multiple: u32) -> u32 {
+    (value - (value % multiple)).max(256)
 }
 
 /// Parse a float (JSON number or numeric string), clamp to `[min, max]`, default
@@ -287,13 +361,85 @@ mod tests {
     }
 
     #[test]
-    fn floors_dimensions_to_multiple_of_32() {
+    fn floors_dimensions_to_multiple_of_32_by_default() {
         let request = VideoRequest::from_payload(&payload(json!({
             "projectId": "p", "width": 1000, "height": 543
         })));
         // 1000 -> 992 (31*32), 543 -> 512 (16*32).
         assert_eq!(request.width, 992);
         assert_eq!(request.height, 512);
+
+        // A manifest entry that does NOT declare the limit keeps the 32 default — the
+        // shipped case for every video model except ltx (declares 32) and mochi (16).
+        // sc-12294 tracks bernini's own 848x480 bucket still flooring to 832x480 pending
+        // a product decision; B3 deliberately does NOT change it. Only models that
+        // *declare* `requiresDimensionsMultipleOf` opt out of the 32 floor.
+        let bernini = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "model": "bernini", "width": 848, "height": 480,
+            "modelManifestEntry": { "family": "bernini", "limits": { "resolutions": ["848x480"] } }
+        })));
+        assert_eq!((bernini.width, bernini.height), (832, 480));
+    }
+
+    #[test]
+    fn honors_manifest_dimension_multiple_so_mochi_keeps_848() {
+        // 848 % 32 == 16, so the blanket 32 floor silently rewrote Mochi's ONLY trained
+        // bucket to 832x480 — and 832 % 16 == 0, so the engine's ÷16 check passed and the
+        // off-bucket render went unnoticed. The manifest's `requiresDimensionsMultipleOf: 16`
+        // now preserves it.
+        let mochi = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "model": "mochi_1", "width": 848, "height": 480,
+            "modelManifestEntry": { "family": "mochi", "limits": { "requiresDimensionsMultipleOf": 16 } }
+        })));
+        assert_eq!((mochi.width, mochi.height), (848, 480));
+
+        // The portrait bucket too.
+        let portrait = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "model": "mochi_1", "width": 480, "height": 848,
+            "modelManifestEntry": { "limits": { "requiresDimensionsMultipleOf": 16 } }
+        })));
+        assert_eq!((portrait.width, portrait.height), (480, 848));
+
+        // A declared 32 (ltx) is identical to the default path.
+        let ltx = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "model": "ltx_2_3", "width": 1000, "height": 543,
+            "modelManifestEntry": { "limits": { "requiresDimensionsMultipleOf": 32 } }
+        })));
+        assert_eq!((ltx.width, ltx.height), (992, 512));
+
+        // 16 is a smaller floor, not a bypass: off-lattice input still floors.
+        let odd = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "model": "mochi_1", "width": 855, "height": 489,
+            "modelManifestEntry": { "limits": { "requiresDimensionsMultipleOf": 16 } }
+        })));
+        assert_eq!((odd.width, odd.height), (848, 480));
+    }
+
+    #[test]
+    fn malformed_dimension_multiple_falls_back_to_32_without_panicking() {
+        // `value % 0` panics; `from_payload` is infallible and must never crash on a
+        // typo'd/hostile manifest entry. Non-`u64` shapes fall back to the 32 default
+        // (the manifest is machine-authored — `as_u64`, matching the engines.rs reader).
+        for bogus in [
+            json!(0),
+            json!(-16),
+            json!("16"),
+            json!(null),
+            json!({}),
+            json!(1.5),
+        ] {
+            let request = VideoRequest::from_payload(&payload(json!({
+                "projectId": "p", "width": 1000, "height": 543,
+                "modelManifestEntry": { "limits": { "requiresDimensionsMultipleOf": bogus } }
+            })));
+            assert_eq!((request.width, request.height), (992, 512), "bogus={bogus}");
+        }
+
+        // `limits` present but not an object → default.
+        let odd = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "width": 1000, "modelManifestEntry": { "limits": 7 }
+        })));
+        assert_eq!(odd.width, 992);
     }
 
     #[test]
@@ -410,6 +556,36 @@ mod tests {
     }
 
     #[test]
+    fn mochi_frame_count_snaps_to_6k_plus_1_min_7() {
+        // Exact 6k+1 values >= 7 are unchanged.
+        assert_eq!(mochi_frame_count(7), 7);
+        assert_eq!(mochi_frame_count(19), 19);
+        assert_eq!(mochi_frame_count(151), 151);
+        // Below the floor snaps up to 7 (6·1+1 — the smallest on-lattice count with more
+        // than one latent frame, mirroring LTX's 9 = 8·1+1 and Wan's 5 = 4·1+1).
+        assert_eq!(mochi_frame_count(1), 7);
+        assert_eq!(mochi_frame_count(6), 7);
+        // Nearest wins; ties go to the lower 6k+1 (the LTX rule).
+        assert_eq!(mochi_frame_count(10), 7); // |10-7|=3 == |13-10|=3 -> lower
+        assert_eq!(mochi_frame_count(11), 13); // closer to 13
+                                               // The shipped default: 5s * 30fps = 150 -> 151 (1 + 6·25). Wan's FLOOR rule would
+                                               // give 145 — accepted by the runtime (145 % 6 == 1) but silently 4.83s, not 5s.
+        assert_eq!(mochi_frame_count(150), 151);
+        assert_ne!(mochi_frame_count(150), wan_frame_count(150));
+        // Every output lands on the runtime's lattice (`validate_request`: frames % 6 == 1)
+        // and never rounds down below the 7-frame floor.
+        for raw in 1..=400 {
+            let frames = mochi_frame_count(raw);
+            assert_eq!(
+                frames % 6,
+                1,
+                "raw={raw} -> {frames} is off the 6k+1 lattice"
+            );
+            assert!(frames >= 7, "raw={raw} -> {frames} below the floor");
+        }
+    }
+
+    #[test]
     fn frame_count_dispatches_by_model_family() {
         let ltx = VideoRequest::from_payload(&payload(json!({
             "projectId": "p", "model": "ltx_2_3", "duration": 6.0, "fps": 25
@@ -421,8 +597,21 @@ mod tests {
         })));
         assert_eq!(wan.frame_count(), wan_frame_count(48));
 
+        // Mochi's shipped default (5s @ 30fps, the manifest's only fps): 150 -> 151.
+        let mochi = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "model": "mochi_1", "duration": 5.0, "fps": 30
+        })));
+        assert_eq!(mochi.raw_frame_count(), 150);
+        assert_eq!(mochi.frame_count(), 151);
+        assert_eq!(mochi.frame_count(), mochi_frame_count(150));
+
         assert!(is_ltx_model("ltx_2_3_eros"));
         assert!(is_wan_model("wan_2_2"));
         assert!(!is_ltx_model("wan_2_2"));
+        // Mochi is its own family — it must not fall through to the Wan floor.
+        assert!(is_mochi_model("mochi_1"));
+        assert!(!is_mochi_model("wan_2_2"));
+        assert!(!is_wan_model("mochi_1"));
+        assert!(!is_ltx_model("mochi_1"));
     }
 }

--- a/crates/sceneworks-core/src/video_request.rs
+++ b/crates/sceneworks-core/src/video_request.rs
@@ -259,9 +259,19 @@ fn normalized_dimensions(
 
 /// `limits.requiresDimensionsMultipleOf` from a resolved manifest entry, else
 /// [`DEFAULT_DIMENSION_MULTIPLE`]. Read as a plain `u64` (the manifest is machine-authored
-/// — same reader as the `engines.rs` manifest checks). A zero / negative / non-integer
-/// declaration falls back rather than panicking on `% 0`: `from_payload` is infallible and
-/// must survive a typo'd manifest entry.
+/// — same reader as the `engines.rs` manifest checks). `from_payload` is infallible and
+/// must survive a typo'd manifest entry, so anything the geometry can't honor falls back
+/// to the 32 default rather than panicking or silently emitting an off-lattice dimension.
+///
+/// Accepted: a positive power of two that divides 256 (1/2/4/8/16/32/64/128/256 — Mochi's
+/// declared 16 and every shipped model's 32 are both in the set). Everything else falls
+/// back: zero / negative / non-integer (which would panic on `% 0` or fail `as_u64`), and
+/// — less obviously — any multiple that does not divide 256. [`floor_to_multiple`] clamps
+/// its result up to a hard floor of 256, and that `.max(256)` rescue is only on-lattice
+/// when the multiple divides 256. A typo'd `1024` would otherwise yield 256x256 with
+/// `256 % 1024 == 256 != 0`, breaking the multiple invariant with no fallback firing; so
+/// would an in-range-looking `96` (`256 % 96 == 64`). Divisibility is the real constraint
+/// here, not magnitude — a bare upper bound would let `96` through.
 fn dimension_multiple_of(model_manifest_entry: &JsonObject) -> u32 {
     model_manifest_entry
         .get("limits")
@@ -269,7 +279,7 @@ fn dimension_multiple_of(model_manifest_entry: &JsonObject) -> u32 {
         .and_then(|limits| limits.get("requiresDimensionsMultipleOf"))
         .and_then(Value::as_u64)
         .and_then(|multiple| u32::try_from(multiple).ok())
-        .filter(|multiple| *multiple > 0)
+        .filter(|multiple| *multiple > 0 && 256 % *multiple == 0)
         .unwrap_or(DEFAULT_DIMENSION_MULTIPLE)
 }
 
@@ -443,6 +453,44 @@ mod tests {
     }
 
     #[test]
+    fn dimension_multiple_that_cannot_divide_256_falls_back_to_32() {
+        // `floor_to_multiple` clamps up to a hard floor of 256, so a multiple that does
+        // not divide 256 breaks the very invariant it declares: without this guard,
+        // `1024` yielded 256x256 (`256 % 1024 == 256`) and nothing fell back. Magnitude
+        // is not the tell — `96` is small and still off-lattice (`256 % 96 == 64`).
+        for bogus in [
+            json!(1024),
+            json!(4096),
+            json!(100_000),
+            json!(96),
+            json!(48),
+        ] {
+            let request = VideoRequest::from_payload(&payload(json!({
+                "projectId": "p", "width": 1000, "height": 543,
+                "modelManifestEntry": { "limits": { "requiresDimensionsMultipleOf": bogus } }
+            })));
+            assert_eq!(
+                (request.width, request.height),
+                (992, 512),
+                "bogus={bogus} must fall back to the 32 default"
+            );
+        }
+
+        // The accepted set — every power of two dividing 256 — is honored, and the
+        // resulting geometry is always on-lattice.
+        for good in [1u32, 2, 4, 8, 16, 32, 64, 128, 256] {
+            let request = VideoRequest::from_payload(&payload(json!({
+                "projectId": "p", "width": 1000, "height": 543,
+                "modelManifestEntry": {
+                    "limits": { "requiresDimensionsMultipleOf": good }
+                }
+            })));
+            assert_eq!(request.width % good, 0, "width off-lattice for {good}");
+            assert_eq!(request.height % good, 0, "height off-lattice for {good}");
+        }
+    }
+
+    #[test]
     fn reads_numeric_strings_and_carries_advanced_fields() {
         let request = VideoRequest::from_payload(&payload(json!({
             "projectId": "p",
@@ -610,6 +658,11 @@ mod tests {
         assert!(!is_ltx_model("wan_2_2"));
         // Mochi is its own family — it must not fall through to the Wan floor.
         assert!(is_mochi_model("mochi_1"));
+        // Prefix, not an exact id: a future `mochi_1_preview`/`mochi_2` must keep hitting
+        // the 6k+1 lattice. Exact-matching `mochi_1` would drop it into `frame_count`'s
+        // `else { raw }` arm -> off-lattice frames -> engine hard-reject.
+        assert!(is_mochi_model("mochi_1_preview"));
+        assert!(is_mochi_model("mochi_2"));
         assert!(!is_mochi_model("wan_2_2"));
         assert!(!is_wan_model("mochi_1"));
         assert!(!is_ltx_model("mochi_1"));


### PR DESCRIPTION
Epic 1788 · B3. Story: https://app.shortcut.com/trefry/story/11993

Adds Mochi request shaping to `crates/sceneworks-core/src/video_request.rs`, on top of B1 (`a59cada7`, #1563).

## What changed

**1. Frame coercion — `is_mochi_model` + `mochi_frame_count`**

Snaps to the **NEAREST** `6k + 1` (ties → lower, min 7) — the AsymmVAE's 6× temporal ratio, which the engine's `validate_request` hard-rejects otherwise.

Deliberately the **LTX rule, not Wan's floor**. Wan's `raw - ((raw-1) % 6)` on the shipped 5 s @ 30 fps default gives **145**, which the runtime *accepts* (`145 % 6 == 1`) while silently rendering **4.83 s instead of 5 s**. Nearest gives **151** (`1 + 6·25`) — the count B1's manifest documents.

Min **7** (`6·1 + 1`) mirrors LTX's 9 (`8·1+1`) and Wan's 5 (`4·1+1`): one temporal stride above a single still frame — the smallest on-lattice count with more than one latent frame. Not an arbitrary pick; 13 would have no precedent.

**2. The real fix — the ÷32 floor silently rewrote Mochi's 848 → 832**

`normalized_dimensions` floored **every** model to a multiple of 32, model-blind, before `model` was even read:

```rust
fn floor_to_32(value: u32) -> u32 { (value - (value % 32)).max(256) }
```

`848 % 32 == 16 → 832`. The rewrite was **invisible** because `832 % 16 == 0` satisfies the engine's own ÷16 check, so the job ran clean — just off Mochi's native and *only* trained bucket. A quality regression on a 480p-only model, not a 16 px crop.

It now honors the resolved manifest entry's `limits.requiresDimensionsMultipleOf`, **defaulting to 32**. The entry was already in hand at parse time (`video_request.rs:88`) and simply never inspected. Verified the producer forwards it intact: `apps/rust-api/src/generation.rs:493` inserts the whole merged entry at enqueue — `limits` is an explicit deep-merge key (`models.rs:1993`) — so this is not a no-op in production.

`from_payload` **stays infallible**: a malformed declaration falls back to 32 rather than panicking on `% 0`. The accepted set is **the multiples that divide 256** (i.e. the powers of two `1..=256`) — everything else falls back, including an oversized/typo'd value.

Divisibility, not a bare upper bound, is the real constraint: `floor_to_multiple` clamps its result up to a hard floor of 256, and that `.max(256)` rescue is on-lattice exactly when the multiple divides 256. A typo'd `1024` would otherwise yield **256x256** with `256 % 1024 == 256 != 0` — the declared invariant broken with no fallback firing — and an in-range-looking `96` fails the same way (`256 % 96 == 64`), so an `<= 256` bound would not have been enough.

## Review follow-ups (2nd commit)

- **Oversized `requiresDimensionsMultipleOf` broke the invariant silently.** The guard only rejected non-positive values, so `1024` produced 256x256 and no fallback fired. Now filtered to multiples dividing 256; doc comment corrected (it had overstated the guard). Pinned by `dimension_multiple_that_cannot_divide_256_falls_back_to_32`.
- **`is_mochi_model`'s prefix behavior was unpinned.** The tests asserted only `mochi_1` / `!wan_2_2`, so mutating the fn to `model == "mochi_1"` left all 14 green. Inert today, but a future `mochi_1_preview` / `mochi_2` would fall through `frame_count`'s `else { raw }` arm to an off-lattice count the engine rejects. Now asserted, mirroring the existing `is_ltx_model("ltx_2_3_eros")` assertion.

Both fixes mutation-checked (mutation applied → a test fails → restored → green). The no-regression sweep below was re-run over frames **and** dimensions and still changes exactly one model. Neither LTX's declared 32 nor Mochi's 16 is affected by the new bound.

## No-regression proof — only Mochi changes

Swept the shipped `config/manifests/builtin.models.jsonc`, every model × every input in `0..2200`, old `floor_to_32` vs new:

```
Total manifest models swept : 66
UNCHANGED (byte-for-byte)   : 65
CHANGED                     : 1 -> ['mochi_1']
```

Exactly three entries declare `requiresDimensionsMultipleOf`: `ltx_2_3`=32, `ltx_2_3_eros`=32 (both == the default → identical), `mochi_1`=16. Everything else declares nothing → 32. **Models opt in only by declaring the limit.**

### sc-12294 boundary — deliberately untouched

bernini's `848x480` still renders `832x480`, and `1280x720 → 1280x704` across the video models, exactly as today:

```
mochi_1          multOf=16   848->848   720->720
bernini          multOf=32   848->832   720->704
wan_2_2_t2v_14b  multOf=32   848->832   720->704
scail2_14b       multOf=32   848->832   720->704
```

That broader bug is pre-existing and tracked as **sc-12294**, pending a product decision — retroactively moving shipped geometry would invalidate reproducible recipes. `floors_dimensions_to_multiple_of_32_by_default` now pins the bernini case so the boundary can't erode silently.

## Scope vs. the story's AC — three bullets overridden

The story text was stale; corrections re-verified against the code and runtime rev `b2974970`:

- ❌ **"clamp to the model's max"** — no such thing exists. Neither `ltx_frame_count` nor `wan_frame_count` has a max clamp; the only ceiling is `duration.clamp(1.0, 30.0)`. **No Mochi frame ceiling added** — see below.
- ❌ **"Resolution/fps/duration validation with actionable errors (surface `error`, hide `requirement`)"** — that's a *web form* convention (epic 10644); no `requirement` field exists in Rust, and `from_payload` is documented **Infallible**. Not made fallible. The house convention for actionable rejections is `WorkerError::InvalidPayload` / `ApiError::bad_request`, which belong where a rejection can happen — not in a parser. See follow-ups.
- ✅ **"pass negative prompt + guidance"** — already generic and satisfied (`negative_prompt` `:39`, `advanced` `:86`, `non_empty_negative_prompt`, `advanced_opt_f32`). Notably `mlx-gen-mochi::generate_impl` reads `req.guidance` + `req.negative_prompt` and **never** `req.true_cfg` — "supports true CFG" is a capability floor, not a field to wire.
- ✅ **"omits i2v-only conditioning fields"** — B1's, already done at routing (`video_mode_is_mlx_eligible`). `VideoRequest` is a dumb parser and cannot omit fields.

### No frame ceiling — explicit decision

`hardMaxDuration: 5` is read by **nothing** in Rust, so `duration:30 × fps:30 = 900 → 901` frames sails through today. I did **not** add a Mochi-only ceiling:

1. **No precedent** — no family helper has one; `ltx_2_3` declares `hardMaxDuration: 15` and it's equally unenforced.
2. **It would be another silent coercion** — quietly rewriting 901 → 151 is the same class of bug this PR fixes.
3. **It would mask a generic gap** behind a one-model band-aid: `hardMaxDuration` is unenforced for *all 9* video models, and the correct home is an actionable rejection at the API boundary, not a silent clamp in an infallible parser.

Filed as a follow-up rather than smuggled in — it changes accepted inputs for shipped models, the same risk class as sc-12294.

## Tests

Inline `#[cfg(test)] mod tests`, matching the file's existing pattern.

- **`mochi_frame_count_snaps_to_6k_plus_1_min_7`** (new) — lattice table, tie→lower, `150 → 151`, `assert_ne!` vs `wan_frame_count(150)`, plus an exhaustive `1..=400` sweep asserting every output satisfies `% 6 == 1` and `>= 7`.
- **`honors_manifest_dimension_multiple_so_mochi_keeps_848`** (new) — 848×480 + 480×848 survive; declared 32 == default; 16 is a *floor*, not a bypass (855×489 → 848×480).
- **`malformed_dimension_multiple_falls_back_to_32_without_panicking`** (new) — `0` / `-16` / `"16"` / `null` / `{}` / `1.5` / non-object `limits` → 32, no `% 0` panic.
- **`floors_dimensions_to_multiple_of_32_by_default`** (updated from `floors_dimensions_to_multiple_of_32`) — still pins `1000 → 992`, and now pins the bernini sc-12294 boundary.
- **`frame_count_dispatches_by_model_family`** (updated) — `mochi_1 @ 5 s / 30 fps → 151`; asserts Mochi doesn't fall through to Wan/LTX.

**Mutation-checked** — each behavior broken, failure confirmed, restored:

| Mutation | Caught by |
|---|---|
| `mochi_frame_count` floors (150→145) | `mochi_frame_count_snaps…`, `frame_count_dispatches…` |
| dimension multiple hardcoded to 32 | `honors_manifest_dimension_multiple…` |
| zero-guard removed | `malformed_dimension_multiple…` (`% 0` panic) |
| `is_mochi_model` always false | `frame_count_dispatches…` |

`npm run rust:check` (fmt + clippy `-D warnings` + test + build): **exit 0**, 21 suites, **1859 tests**. AC-named guards green: `jobs_store` 148 passed (exit 0), MCP `video_job_tools` 8 passed (exit 0).

## Known seam — B3 alone does not deliver `duration:5 → 151` end-to-end

Coercion has two consumers. This PR fixes `VideoRequest::frame_count()` (the stub/metadata path). The real engine paths bypass it and re-call the free fns on `raw_frame_count()` — **`video_jobs.rs:5216-5218` is a binary `if is_ltx { ltx_frame_count } else { wan_frame_count }`** that silently claims every non-LTX model, `mochi_1` included → 145. That arm is **B2 (sc-11992)** scope and is recorded there. Not fixed here; not claimed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
