### PR TITLE
fix(worker): fail a LoRA download that fetched nothing (sc-12288)

### DIFF
--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -147,24 +147,12 @@ pub(crate) async fn run_model_download_job(
     // load-side half of that failure is sc-12279, which now falls back to a complete sibling tier;
     // this stops the torn tier being created in the first place.)
     //
-    // Testing each pattern against the RESOLVED files is sound: `snapshot.files` is every remote file
-    // matching ANY pattern, so a pattern with no match among them matched none in the repo.
-    //
     // Safe to hard-fail: swept all 217 `downloads[].files` patterns across the 53 HF repos that
     // declare one (builtin.models.jsonc, comment-stripped through this workspace's own
     // `strip_jsonc_comments`) — every pattern matches at least one file today, so no download that
     // works now begins to fail. A future entry that trips this is a real publishing gap, and failing
     // loudly at download beats a phantom install the user only discovers at generation time.
-    let unmatched = files
-        .iter()
-        .filter(|pattern| {
-            !snapshot
-                .files
-                .iter()
-                .any(|file| pattern_matches(pattern, &file.path))
-        })
-        .cloned()
-        .collect::<Vec<_>>();
+    let unmatched = unmatched_patterns(&files, &snapshot);
     if !unmatched.is_empty() {
         fail_job(
             api,
@@ -246,6 +234,28 @@ pub(crate) async fn run_model_download_job(
     .await
 }
 
+/// The declared `files` patterns that matched ZERO files in `snapshot` (sc-12283).
+///
+/// Testing against the RESOLVED files is sound: `snapshot.files` is every remote file matching ANY
+/// pattern (the filter ORs — see `allow_pattern_matches`), so a pattern with no match among them
+/// matched none in the repo. That OR is exactly why this check is needed: without it a filter is
+/// satisfied as a whole while an individual component of it silently matched nothing.
+///
+/// Empty `files` (a deliberate whole-repo fetch) declares no per-pattern claim, so nothing to check —
+/// the caller's aggregate `snapshot.files.is_empty()` test covers that case.
+fn unmatched_patterns(files: &[String], snapshot: &HuggingFaceSnapshot) -> Vec<String> {
+    files
+        .iter()
+        .filter(|pattern| {
+            !snapshot
+                .files
+                .iter()
+                .any(|file| pattern_matches(pattern, &file.path))
+        })
+        .cloned()
+        .collect()
+}
+
 /// Download a built-in catalog LoRA's Hugging Face repo/file into the shared HF cache
 /// (sc-5944). Mirrors the `run_model_download_job` cache path but skips the model-only
 /// steps (family reconciliation, tokenizer overlay, install marker): a LoRA is a single
@@ -303,6 +313,65 @@ pub(crate) async fn run_lora_download_job(
     })?;
     let snapshot =
         HuggingFaceSnapshot::resolve(http_client, settings, repo, revision, &files).await?;
+    // sc-12288: a LoRA download that fetched NOTHING is not a success. This path had no zero-file
+    // check at all (the sibling `run_model_download_job` got one in sc-9909; this never did), so a
+    // LoRA whose declared `source.file` is absent — renamed upstream, typo'd entry, unpublished —
+    // downloaded nothing and reported the job COMPLETED. The API's install probe
+    // (`lora_huggingface_cached_file`) then finds an empty cache and the catalog still reads "not
+    // installed", so the user got a job that claimed success and a LoRA that never appeared, with no
+    // error anywhere.
+    //
+    // An empty `files` list is NOT an omission here — it deliberately means "fetch the (small) whole
+    // repo" (apps/rust-api `create_lora_download_job`) — but that only widens the filter, so resolving
+    // zero files still means there was nothing to fetch.
+    //
+    // Safe to hard-fail: swept every entry in builtin.loras.jsonc against its repo — 7 entries, all
+    // declaring an explicit `source.file`, all 7 present, no whole-repo entries. Nothing shipping
+    // relies on this silently passing.
+    if snapshot.files.is_empty() {
+        let scope = if files.is_empty() {
+            String::new()
+        } else {
+            format!(" matching {}", files.join(", "))
+        };
+        fail_job(
+            api,
+            &job.id,
+            &format!(
+                "No files to download for LoRA {repo}{scope}. The adapter may have been renamed or \
+                 removed upstream."
+            ),
+            Some(
+                "The Hugging Face repository/revision matched zero files for the requested filter."
+                    .to_owned(),
+            ),
+        )
+        .await?;
+        return Ok(());
+    }
+    // The same per-pattern gap as sc-12283: `create_lora_download_job` accepts an explicit `files`
+    // LIST, and the filter ORs across it, so a multi-file adapter that landed one half and not the
+    // other would pass the aggregate check above and complete as a torn install.
+    let unmatched = unmatched_patterns(&files, &snapshot);
+    if !unmatched.is_empty() {
+        fail_job(
+            api,
+            &job.id,
+            &format!(
+                "Incomplete download for LoRA {repo}: nothing matches {}. Installing it would leave \
+                 a partial adapter.",
+                unmatched.join(", ")
+            ),
+            Some(format!(
+                "{} of the {} declared file patterns matched zero files in the Hugging Face \
+                 repository/revision.",
+                unmatched.len(),
+                files.len()
+            )),
+        )
+        .await?;
+        return Ok(());
+    }
     if let Some(total_bytes) = snapshot.total_bytes() {
         update_job(
             api,

--- a/crates/sceneworks-worker/src/tests/lora_and_downloads.rs
+++ b/crates/sceneworks-worker/src/tests/lora_and_downloads.rs
@@ -1272,6 +1272,98 @@ async fn model_download_fails_when_one_declared_pattern_matches_nothing() {
     assert!(!blames_matched, "only the unmatched pattern should be named");
 }
 
+#[tokio::test]
+async fn lora_download_fails_when_the_declared_adapter_is_absent() {
+    // sc-12288: this path had NO zero-file check. A LoRA whose declared `source.file` is gone from
+    // the repo (renamed upstream / typo'd entry / unpublished) resolved zero files, downloaded
+    // nothing, and reported the job COMPLETED — while the catalog still read "not installed", because
+    // the install probe finds an empty cache. A success post for a fetch of nothing is the bug.
+    let temp = tempdir().expect("tempdir creates");
+    // The repo exists but holds a DIFFERENT adapter than the one declared.
+    let (base_url, posts) =
+        spawn_tree_stub_with_files(vec![("some-other-adapter.safetensors", 8)]).await;
+    let mut settings = test_settings(base_url.clone(), None);
+    settings.api_url = base_url.clone();
+    settings.data_dir = temp.path().to_path_buf();
+    let api = ApiClient::new(&settings);
+    let client = reqwest::Client::new();
+
+    let mut job_json = job_snapshot_json("job-1", false);
+    job_json["type"] = json!("lora_download");
+    job_json["payload"] = json!({
+        "loraId": "ltx_2_3_ic_union_control",
+        "repo": "Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control",
+        "files": ["ltx-2.3-22b-ic-lora-union-control-ref0.5.safetensors"],
+    });
+    let job: JobSnapshot = serde_json::from_value(job_json).expect("job deserializes");
+
+    super::model_jobs::run_lora_download_job(&api, &settings, &client, &job)
+        .await
+        .expect("returns Ok — the failure is reported via a progress post, not an Err");
+
+    let posts = posts.lock().expect("posts lock");
+    let failed = posts.iter().any(|post| {
+        post.get("status").and_then(Value::as_str) == Some("failed")
+            && post
+                .get("message")
+                .and_then(Value::as_str)
+                .is_some_and(|message| message.contains("No files to download for LoRA"))
+    });
+    assert!(failed, "expected a failed progress post, got {posts:?}");
+    // The job must NOT also report success — that is the whole defect.
+    let completed = posts
+        .iter()
+        .any(|post| post.get("status").and_then(Value::as_str) == Some("completed"));
+    assert!(!completed, "a fetch of nothing must never report completed");
+}
+
+#[tokio::test]
+async fn lora_download_fails_when_one_of_several_declared_files_is_absent() {
+    // sc-12288: `create_lora_download_job` accepts an explicit `files` LIST and the filter ORs across
+    // it, so a multi-file adapter that landed one half and not the other passes the aggregate
+    // zero-file check and completes as a torn install. Same gap as sc-12283, LoRA side.
+    let temp = tempdir().expect("tempdir creates");
+    let (base_url, posts) = spawn_tree_stub_with_files(vec![("high_noise.safetensors", 8)]).await;
+    let mut settings = test_settings(base_url.clone(), None);
+    settings.api_url = base_url.clone();
+    settings.data_dir = temp.path().to_path_buf();
+    let api = ApiClient::new(&settings);
+    let client = reqwest::Client::new();
+
+    let mut job_json = job_snapshot_json("job-1", false);
+    job_json["type"] = json!("lora_download");
+    job_json["payload"] = json!({
+        "loraId": "pair",
+        "repo": "owner/pair",
+        "files": ["high_noise.safetensors", "low_noise.safetensors"],
+    });
+    let job: JobSnapshot = serde_json::from_value(job_json).expect("job deserializes");
+
+    super::model_jobs::run_lora_download_job(&api, &settings, &client, &job)
+        .await
+        .expect("returns Ok — the failure is reported via a progress post, not an Err");
+
+    let posts = posts.lock().expect("posts lock");
+    let failed = posts.iter().any(|post| {
+        post.get("status").and_then(Value::as_str) == Some("failed")
+            && post
+                .get("message")
+                .and_then(Value::as_str)
+                .is_some_and(|message| {
+                    message.contains("Incomplete download for LoRA")
+                        && message.contains("low_noise.safetensors")
+                })
+    });
+    assert!(failed, "expected a failed post naming the absent half, got {posts:?}");
+    // The half that DID resolve must not be blamed.
+    let blames_present = posts.iter().any(|post| {
+        post.get("message")
+            .and_then(Value::as_str)
+            .is_some_and(|message| message.contains("nothing matches") && message.contains("high_noise"))
+    });
+    assert!(!blames_present, "only the absent file should be named");
+}
+
 /// A tree stub that paginates: page 1 (no cursor) returns bf16/q4 files plus a `Link: rel="next"`
 /// header pointing at page 2; page 2 (cursor=next) returns the q8 file and no further link.
 async fn spawn_paginated_tree_stub() -> String {

--- a/scripts/check-download-patterns.mjs
+++ b/scripts/check-download-patterns.mjs
@@ -28,8 +28,12 @@
 // gated the worker change: at the time of writing, all 217 patterns across all 53
 // repos matched, which is what made hard-failing safe to ship.
 //
+// Covers builtin.models.jsonc `downloads[].files` AND builtin.loras.jsonc
+// `source.file` / `source.files` — the LoRA download path gained the same hard-fail in
+// sc-12288, so it needs the same pre-flight.
+//
 // USAGE
-//   node scripts/check-download-patterns.mjs            # all HF download entries
+//   node scripts/check-download-patterns.mjs            # all HF model + LoRA entries
 //   node scripts/check-download-patterns.mjs --model krea_2_raw
 //
 // Exits non-zero if any declared pattern matches zero files. Public repos need no
@@ -42,7 +46,8 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const MANIFEST = "config/manifests/builtin.models.jsonc";
+const MODEL_MANIFEST = "config/manifests/builtin.models.jsonc";
+const LORA_MANIFEST = "config/manifests/builtin.loras.jsonc";
 
 // -- JSONC parsing (manifests carry // comments). Mirrors scripts/check-no-nc-weights.mjs. --
 function stripJsoncComments(body) {
@@ -141,32 +146,62 @@ async function main() {
     ? process.argv[process.argv.indexOf("--model") + 1]
     : null;
 
-  const manifest = JSON.parse(stripJsoncComments(await readFile(path.join(root, MANIFEST), "utf8")));
   const failures = [];
   const unreachable = [];
   let repos = 0;
   let patterns = 0;
 
-  for (const model of manifest.models ?? []) {
-    if (only && model.id !== only) continue;
+  // Flatten both manifests to a common shape: { label, repo, declared[] }. A model declares
+  // `downloads[].files`; a LoRA declares `source.file` (one) or `source.files` (a list).
+  const claims = [];
+  const models = JSON.parse(
+    stripJsoncComments(await readFile(path.join(root, MODEL_MANIFEST), "utf8")),
+  );
+  for (const model of models.models ?? []) {
     for (const download of model.downloads ?? []) {
       if (download.provider !== "huggingface") continue;
-      const declared = download.files ?? [];
-      // An empty `files` list is a deliberate whole-repo download, not an omission —
-      // there is no per-pattern claim to verify.
-      if (declared.length === 0) continue;
-      const { files, error } = await repoFiles(download.repo);
-      if (error) {
-        unreachable.push(`${model.id}/${download.variant ?? "-"}  ${download.repo}  (${error})`);
-        continue;
-      }
-      repos += 1;
-      for (const pattern of declared) {
-        patterns += 1;
-        const regexp = patternToRegExp(pattern);
-        if (!files.some((file) => regexp.test(file))) {
-          failures.push(`${model.id}/${download.variant ?? "-"}  ${download.repo}  ${pattern}`);
-        }
+      claims.push({
+        id: model.id,
+        label: `${model.id}/${download.variant ?? "-"}`,
+        repo: download.repo,
+        declared: download.files ?? [],
+      });
+    }
+  }
+  const loras = JSON.parse(
+    stripJsoncComments(await readFile(path.join(root, LORA_MANIFEST), "utf8")),
+  );
+  for (const lora of loras.loras ?? []) {
+    const source = lora.source ?? {};
+    const provider = source.provider ?? lora.provider;
+    const repo = source.repo ?? lora.repo;
+    if (provider !== "huggingface" || !repo) continue;
+    const single = source.file ?? lora.file;
+    claims.push({
+      id: lora.id,
+      label: `lora:${lora.id}`,
+      repo,
+      declared: single ? [single] : (source.files ?? lora.files ?? []),
+    });
+  }
+
+  for (const claim of claims) {
+    if (only && claim.id !== only) continue;
+    // An empty declaration is a deliberate whole-repo fetch, not an omission — there is no
+    // per-pattern claim to verify. (The worker's aggregate zero-file check still covers an
+    // empty repo at download time.)
+    if (claim.declared.length === 0) continue;
+    const { files, error } = await repoFiles(claim.repo);
+    if (error) {
+      unreachable.push(`${claim.label}  ${claim.repo}  (${error})`);
+      continue;
+    }
+    repos += 1;
+    for (const pattern of claim.declared) {
+      patterns += 1;
+      const regexp = patternToRegExp(pattern);
+      if (!files.some((file) => regexp.test(file))) {
+        failures.push(`${claim.label}  ${claim.repo}  ${pattern}`);
       }
     }
   }


### PR DESCRIPTION
Closes sc-12288. Replaces #1564, which reported "merged" but landed nowhere — it was stacked on #1562 and got merged into that branch 12s after it, before GitHub retargeted the base. The commit is identical; this one targets `main`.

## Why

`run_lora_download_job` had **no zero-file check at all**. The sibling `run_model_download_job` got one in sc-9909; this never did.

So a LoRA whose declared `source.file` is absent from the repo — renamed upstream, typo'd entry, unpublished — resolves zero files, downloads nothing, and reports the job **completed**. The API's install probe (`lora_huggingface_cached_file`) then finds an empty cache and the catalog still reads "not installed". The user gets a job that claims success and a LoRA that never appears, with no error anywhere.

## What changed

- **Fail when the resolve yields zero files.** An empty `files` list is *not* an omission here — it deliberately means "fetch the (small) whole repo" (`create_lora_download_job`) — but that only *widens* the filter, so resolving nothing still means there was nothing to fetch.
- **Also check per pattern.** `create_lora_download_job` accepts an explicit `source.files` **list** and the filter ORs across it, so a multi-file adapter that lands one half and not the other passes the aggregate check and completes as a torn install — the sc-12283 gap, LoRA side. No shipping LoRA declares a list today; this guards the case rather than waiting for it. **Happy to cut it back to the literal aggregate check.**
- **Extract `unmatched_patterns`** so the model and LoRA paths share one implementation.
- **`check-download-patterns.mjs` now covers `builtin.loras.jsonc`** (`source.file` / `source.files`) as well as the model manifest.

## Scope — deliberately untouched

**Non-HF LoRAs are unaffected.** `create_lora_download_job` requires a `repo` and only queues this job for a `provider: "huggingface"` source; URL imports and uploads go through the import path.

**`ensure_hf_files_cached` is unchanged, deliberately** — a zero-match filter there is a designed no-op, because its callers keep their own "resolve the tier subdir, else fall back" presence checks.

## Re-validated against current `main`

`main` moved while this was stranded: sc-11991 (#1563) declared **Mochi 1**, adding four download entries against `SceneWorks/mochi-1-mlx` (`q4/*`, `q8/*`, `bf16/*`, plus shared components). Since this change makes a zero-match pattern hard-fail, an unpublished Mochi tier would have turned a working catalog entry into a failed download — a live risk, given the Mochi tier re-host (sc-11990) is still in progress.

Re-ran the sweep on the new base: **230 patterns, up from 224 — exactly Mochi's 6 — all match.** The repo is published and complete, so nothing breaks.

The original LoRA gate still holds: every entry in `builtin.loras.jsonc` swept against its repo — 7 entries, all declaring an explicit `source.file`, all present, zero whole-repo entries.

## Verified

- **641/641** `sceneworks-worker --lib --features backend-candle` on the rebased base; fmt + clippy(candle) clean.
- Cherry-pick is **byte-identical** to the original commit (no rebase drift), and the shared `unmatched_patterns` helper survived #1562 landing as a squash — defined once, called twice.
- Both new tests are real guards: with the checks disabled, each fails on **its own assertion**.
- Script negative control: renaming a LoRA's `file` to one that doesn't exist upstream is caught, named, exit 1.

> Unlike #1564, this targets `main`, so `candle-worker` and `nax-worker` (which filter on `pull_request: branches: [main]`) will actually run — they were silently skipped on the stacked PR and had to be dispatched by hand. Both passed there on the identical commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)