### PR TITLE
fix(api): resolve the manifest entry from the preset-overridden model (sc-12300)

### DIFF
--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -32,7 +32,16 @@ pub(crate) async fn create_image_job(
     // `queued` create) for every other model, an already-structured caption, or an image-conditioned
     // edit. The worker's format-guard + reseed net remains the fallback if the expansion is unavailable.
     let caption_request = crate::ideogram::caption_request_for_ideogram(&job_payload);
-    let model_manifest_entry = resolve_model_manifest_entry(&state, &payload.model).await?;
+    // Keyed off the POST-preset job_payload["model"], NOT the DTO's payload.model — see the
+    // matching note in create_video_job (sc-12300). apply_recipe_preset_to_image_payload above
+    // may have replaced the model with the preset's own when the caller omitted one, which
+    // leaves payload.model stale and would resolve the DEFAULT model's entry.
+    let model_id = job_payload
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or(payload.model.as_str())
+        .to_owned();
+    let model_manifest_entry = resolve_model_manifest_entry(&state, &model_id).await?;
     job_payload.insert("modelManifestEntry".to_owned(), model_manifest_entry);
     validate_job_lora_compatibility_with(
         &state,
@@ -490,7 +499,20 @@ pub(crate) async fn create_video_job(
     // builtin/user.models.jsonc itself — Rust owns manifest parsing/merging
     // (story 1653). An unknown model resolves to {}, matching the worker's
     // existing fallback to the model's default repo.
-    let model_manifest_entry = resolve_model_manifest_entry(&state, &payload.model).await?;
+    //
+    // Keyed off the POST-preset job_payload["model"], NOT the DTO's payload.model:
+    // apply_recipe_preset_to_video_payload above may have replaced the model with the
+    // preset's own when the caller omitted one, which leaves payload.model stale (sc-12300).
+    // Resolving from the stale id enqueued the overridden model id alongside the DEFAULT
+    // model's entry — wrong repo/paths/quant, and wrong `limits`, which normalized_dimensions
+    // honors for the dimension floor (sc-11993). Mirrors how validate_job_lora_compatibility_with
+    // below already reads the model from job_payload.
+    let model_id = job_payload
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or(payload.model.as_str())
+        .to_owned();
+    let model_manifest_entry = resolve_model_manifest_entry(&state, &model_id).await?;
     job_payload.insert("modelManifestEntry".to_owned(), model_manifest_entry);
     validate_job_lora_compatibility_with(
         &state,

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -2305,9 +2305,13 @@ async fn preset_overridden_video_model_carries_its_own_manifest_entry() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");
     std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
-    // `default-vid` uses the real default_video_model() id, because that literal is what the
-    // preset-override gate compares against. Its 32 / owner/default mirror ltx_2_3's real
-    // manifest; `preset-vid` mirrors mochi_1's 16 / distinct repo.
+    // `default-vid` is BUILT FROM default_video_model() rather than hardcoding its id. That
+    // literal is what the preset-override gate compares against, so a hardcoded fixture would
+    // quietly stop modelling *the default's* entry if the default ever changed: the pre-fix
+    // failure would degrade from "carries the DEFAULT's entry" to "carries {}" — still red,
+    // but no longer demonstrating the documented defect. Its 32 / owner/default mirror the
+    // real default video manifest; `preset-vid` mirrors mochi_1's 16 / distinct repo.
+    let default_video_model = crate::defaults::default_video_model();
     std::fs::write(
         config_dir.join("builtin.models.jsonc"),
         r#"
@@ -2315,7 +2319,7 @@ async fn preset_overridden_video_model_carries_its_own_manifest_entry() {
           "schemaVersion": 1,
           "models": [
             {
-              "id": "ltx_2_3",
+              "id": "__DEFAULT_VIDEO_MODEL__",
               "name": "Default Vid",
               "family": "ltx-video",
               "type": "video",
@@ -2346,7 +2350,8 @@ async fn preset_overridden_video_model_carries_its_own_manifest_entry() {
             }
           ]
         }
-        "#,
+        "#
+        .replace("__DEFAULT_VIDEO_MODEL__", &default_video_model),
     )
     .expect("builtin models writes");
     std::fs::write(
@@ -2432,7 +2437,9 @@ async fn preset_overridden_image_model_carries_its_own_manifest_entry() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");
     std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
-    // `z_image_turbo` is the real default_image_model() id the override gate compares against.
+    // Built FROM default_image_model() — the id the override gate compares against — for the
+    // same durability reason as the video fixture above.
+    let default_image_model = crate::defaults::default_image_model();
     std::fs::write(
         config_dir.join("builtin.models.jsonc"),
         r#"
@@ -2440,7 +2447,7 @@ async fn preset_overridden_image_model_carries_its_own_manifest_entry() {
           "schemaVersion": 1,
           "models": [
             {
-              "id": "z_image_turbo",
+              "id": "__DEFAULT_IMAGE_MODEL__",
               "name": "Default Img",
               "family": "z-image",
               "type": "image",
@@ -2471,7 +2478,8 @@ async fn preset_overridden_image_model_carries_its_own_manifest_entry() {
             }
           ]
         }
-        "#,
+        "#
+        .replace("__DEFAULT_IMAGE_MODEL__", &default_image_model),
     )
     .expect("builtin models writes");
     std::fs::write(

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -2287,6 +2287,264 @@ async fn video_jobs_expand_recipe_presets_server_side() {
 }
 
 #[tokio::test]
+async fn preset_overridden_video_model_carries_its_own_manifest_entry() {
+    // sc-12300: a client that OMITS `model` (MCP's submit_video_job documents its `model`
+    // param as "Omit for the server default") gets `default_video_model()` from serde, which
+    // is exactly the gate `apply_recipe_preset_to_video_payload` uses to let the preset's
+    // model win. The preset then overwrites job_payload["model"] — but the manifest entry
+    // used to be resolved from the DTO's pre-override `payload.model`, so the job was
+    // enqueued carrying the OVERRIDDEN model id alongside the DEFAULT model's entry.
+    //
+    // Both halves of that mismatch are asserted, because they fail in opposite ways:
+    //   - `repo`   — the LOUD failure: the worker reaches for the wrong model's weights.
+    //   - `limits.requiresDimensionsMultipleOf` — the SILENT one: sceneworks-core's
+    //     normalized_dimensions honors this (sc-11993). A 16-multiple model handed a
+    //     32-declaring entry silently renders off-bucket (Mochi's native 848x480 -> 832x480).
+    // Pinning only `repo` would let the silent geometry bug regress undetected.
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    // `default-vid` uses the real default_video_model() id, because that literal is what the
+    // preset-override gate compares against. Its 32 / owner/default mirror ltx_2_3's real
+    // manifest; `preset-vid` mirrors mochi_1's 16 / distinct repo.
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "models": [
+            {
+              "id": "ltx_2_3",
+              "name": "Default Vid",
+              "family": "ltx-video",
+              "type": "video",
+              "adapter": "ltx_video",
+              "capabilities": ["text_to_video"],
+              "downloads": [
+                { "provider": "huggingface", "repo": "owner/default-vid", "files": ["*.safetensors"], "default": true }
+              ],
+              "paths": {},
+              "defaults": {},
+              "limits": { "requiresDimensionsMultipleOf": 32 },
+              "ui": { "label": "Default Vid" }
+            },
+            {
+              "id": "preset-vid",
+              "name": "Preset Vid",
+              "family": "mochi",
+              "type": "video",
+              "adapter": "mochi_video",
+              "capabilities": ["text_to_video"],
+              "downloads": [
+                { "provider": "huggingface", "repo": "owner/preset-vid", "files": ["*.safetensors"], "default": true }
+              ],
+              "paths": {},
+              "defaults": {},
+              "limits": { "requiresDimensionsMultipleOf": 16 },
+              "ui": { "label": "Preset Vid" }
+            }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin models writes");
+    std::fs::write(
+        config_dir.join("user.models.jsonc"),
+        r#"{ "schemaVersion": 1, "models": [] }"#,
+    )
+    .expect("user models writes");
+    std::fs::write(
+        config_dir.join("builtin.recipe-presets.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "presets": [
+            {
+              "id": "preset_override",
+              "name": "Preset Override",
+              "workflow": "text_to_video",
+              "model": "preset-vid",
+              "defaults": {},
+              "prompt": { "prefix": "cinematic", "suffix": "smooth" }
+            }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin recipe presets writes");
+    std::fs::write(
+        config_dir.join("user.recipe-presets.jsonc"),
+        r#"{ "schemaVersion": 1, "presets": [] }"#,
+    )
+    .expect("user recipe presets writes");
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Preset Override Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+
+    let (status, video_job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_video",
+            "prompt": "a fox runs",
+            // `model` deliberately OMITTED — this is the trigger. Sending it explicitly
+            // closes the gate and the bug never fires.
+            "recipePresetId": "preset_override"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    // The preset's model won over the omitted-model default...
+    assert_eq!(video_job["payload"]["model"], "preset-vid");
+    // ...and the entry travelling with it must describe THAT model, not the default's.
+    let entry = &video_job["payload"]["modelManifestEntry"];
+    assert_eq!(
+        entry["id"], "preset-vid",
+        "manifest entry should be resolved from the post-override model"
+    );
+    assert_eq!(
+        entry["downloads"][0]["repo"], "owner/preset-vid",
+        "wrong repo => the worker fetches the wrong model's weights (loud failure)"
+    );
+    assert_eq!(
+        entry["limits"]["requiresDimensionsMultipleOf"], 16,
+        "wrong dimension floor => silently renders off-bucket geometry (sc-11993)"
+    );
+}
+
+#[tokio::test]
+async fn preset_overridden_image_model_carries_its_own_manifest_entry() {
+    // sc-12300: create_image_job has the identical ordering shape as create_video_job —
+    // apply_recipe_preset_to_image_payload may overwrite job_payload["model"] (gated on the
+    // omitted-model default_image_model()), and the entry was likewise resolved from the
+    // pre-override DTO. Same defect, same function family, so it is pinned the same way.
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    // `z_image_turbo` is the real default_image_model() id the override gate compares against.
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "models": [
+            {
+              "id": "z_image_turbo",
+              "name": "Default Img",
+              "family": "z-image",
+              "type": "image",
+              "adapter": "z_image",
+              "capabilities": ["text_to_image"],
+              "downloads": [
+                { "provider": "huggingface", "repo": "owner/default-img", "files": ["*.safetensors"], "default": true }
+              ],
+              "paths": {},
+              "defaults": {},
+              "limits": { "requiresDimensionsMultipleOf": 32 },
+              "ui": { "label": "Default Img" }
+            },
+            {
+              "id": "preset-img",
+              "name": "Preset Img",
+              "family": "flux",
+              "type": "image",
+              "adapter": "flux",
+              "capabilities": ["text_to_image"],
+              "downloads": [
+                { "provider": "huggingface", "repo": "owner/preset-img", "files": ["*.safetensors"], "default": true }
+              ],
+              "paths": {},
+              "defaults": {},
+              "limits": { "requiresDimensionsMultipleOf": 16 },
+              "ui": { "label": "Preset Img" }
+            }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin models writes");
+    std::fs::write(
+        config_dir.join("user.models.jsonc"),
+        r#"{ "schemaVersion": 1, "models": [] }"#,
+    )
+    .expect("user models writes");
+    std::fs::write(
+        config_dir.join("builtin.recipe-presets.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "presets": [
+            {
+              "id": "img_override",
+              "name": "Img Override",
+              "workflow": "text_to_image",
+              "model": "preset-img",
+              "defaults": {},
+              "prompt": { "prefix": "cinematic", "suffix": "smooth" }
+            }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin recipe presets writes");
+    std::fs::write(
+        config_dir.join("user.recipe-presets.jsonc"),
+        r#"{ "schemaVersion": 1, "presets": [] }"#,
+    )
+    .expect("user recipe presets writes");
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Img Override Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+
+    let (status, image_job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/image/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_image",
+            "prompt": "a fox runs",
+            // `model` deliberately OMITTED — the trigger.
+            "recipePresetId": "img_override"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(image_job["payload"]["model"], "preset-img");
+    let entry = &image_job["payload"]["modelManifestEntry"];
+    assert_eq!(
+        entry["id"], "preset-img",
+        "manifest entry should be resolved from the post-override model"
+    );
+    assert_eq!(
+        entry["downloads"][0]["repo"], "owner/preset-img",
+        "wrong repo => the worker fetches the wrong model's weights (loud failure)"
+    );
+    assert_eq!(
+        entry["limits"]["requiresDimensionsMultipleOf"], 16,
+        "wrong dimension floor => silently renders off-bucket geometry"
+    );
+}
+
+#[tokio::test]
 async fn preset_image_job_builds_each_catalog_once() {
     // sc-8819 (F-017): a preset-backed POST /image/jobs fans out into recipe_preset_catalog,
     // merge_preset_loras_into_payload, and validate_job_lora_compatibility. Before the fix


### PR DESCRIPTION
Fixes [sc-12300](https://app.shortcut.com/trefry/story/12300).

## The ordering defect

In `apps/rust-api/src/generation.rs`, `create_video_job` did two things in the wrong relationship:

1. `apply_recipe_preset_to_video_payload` may **overwrite** `job_payload["model"]` with the recipe preset's model. The gate is `payload.model == default_video_model()` (`"ltx_2_3"`) — i.e. it fires when the caller did **not** explicitly pick a model.
2. The model manifest entry was then resolved from **`payload.model` (the DTO)** — the *pre-override* value.

So the enqueued job could carry `model: "preset-model"` alongside **`ltx_2_3`'s manifest entry**. The model id is overridden; the entry travelling with it was not.

## Trigger

A client that **omits `model`** and passes a video `recipePresetId` whose preset names a different model. `model` is `#[serde(default = "default_video_model")]`, so omitting it yields exactly the value the override gate tests for. MCP's `submit_video_job` explicitly invites this — its `model` param is documented *"Omit for the server default."*

**Status: latent.** No Mochi recipe preset exists today, so the dangerous case is currently unreachable. B4 (sc-11994) adds Video Studio presets — if it ships one for a non-default model, this goes live. The bug is **generic**, not Mochi-specific: any preset whose model differs from the default hits it.

## Why both assertions

The mismatched entry fails in two opposite ways, and the tests pin **both**:

- **`repo`** — the **loud** failure: the worker reaches for the wrong model's weights. Fails obviously, which is likely why this was never noticed in practice.
- **`limits.requiresDimensionsMultipleOf`** — the **silent** one. sc-11993 made `limits` load-bearing for correctness: `normalized_dimensions` honors it (default 32). Mochi declares **16** so its native `848×480` survives the ÷32 floor. On this path Mochi would carry ltx_2_3's entry (declares 32) → **silently renders 832×480** — precisely the bug sc-11993 exists to fix — **while sc-11993's own tests still pass**, because they exercise the correct entry.

Pinning only `repo` would let the silent geometry bug regress undetected.

## The fix

Key the resolution off the post-preset `job_payload["model"]` rather than the stale DTO field.

I checked the ordering rather than just moving a line: the resolve call **already sits after** preset expansion on both paths, and nothing between the two points reads the model from the DTO (the image path's `caption_request_for_ideogram` already reads `job_payload`). So only the *source of the id* changes — no call is reordered. This also mirrors `validate_job_lora_compatibility_with`, which already reads `job_payload.get("model")`; `resolve_model_manifest_entry` was the lone consumer still reading the stale DTO value. `model` has no `skip_serializing_if`, so `job_payload["model"]` is always present and the `unwrap_or` fallback is purely defensive.

## Other modalities

`create_image_job` had the **identical defect in the same function family** — `apply_recipe_preset_to_image_payload` overwrites `job_payload["model"]` (gated on `default_image_model()`), and the entry was likewise resolved from the pre-override DTO. Same defect, same shape, so it is **fixed here too** and pinned with its own test.

## Verification

- Both regression tests confirmed **RED before the fix** (exit 101): entry resolved to `ltx_2_3`/`z_image_turbo` where `preset-vid`/`preset-img` was required.
- **Mutation-check**: reverting only the fix (keeping the tests) returns both to RED (exit 101).
- Additionally verified the `limits` assertion is **independently load-bearing** — with the `id`/`repo` asserts temporarily removed so it could not be masked by short-circuiting, it fails on its own with `left: Number(32), right: 16`, i.e. it genuinely catches the silent geometry bug.
- `cargo test -p sceneworks-rust-api`: **286 passed, 0 failed** (exit 0).
- `npm run rust:check`: **exit 0** (clippy `--all-targets -D warnings` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)