### PR TITLE
fix(catalog): declare each video model's real dimension stride (sc-12294)

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -602,7 +602,7 @@ export const fallbackModels = [
       durations: [4, 6, 8, 10, 12, 15],
       recommendedMaxDuration: 10,
       fps: [24, 25, 30],
-      resolutions: ["768x512", "512x768", "640x640", "1280x720", "720x1280"],
+      resolutions: ["768x512", "512x768", "640x640", "1280x704", "704x1280"],
     },
     ui: {
       description: "First-class short-shot video target.",
@@ -620,7 +620,7 @@ export const fallbackModels = [
       durations: [4, 6, 8, 10, 12, 15],
       recommendedMaxDuration: 10,
       fps: [24, 25, 30],
-      resolutions: ["768x512", "512x768", "640x640", "1280x720", "720x1280"],
+      resolutions: ["768x512", "512x768", "640x640", "1280x704", "704x1280"],
     },
     ui: {
       description: "Community LTX-2.3 merge tuned for image-to-video; uses LTX-video LoRAs.",
@@ -653,15 +653,19 @@ export const fallbackModels = [
     name: "Wan2.2",
     type: "video",
     capabilities: ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge", "replace_person"],
-    // Default to 832x480 for a sane out-of-the-box time on the Mac MLX path (sc-4997): measured
-    // 5B @ 832x480/121f/20-step/CFG = ~5 min vs ~20 min at 1280x720 (the z48 VAE decode dominates
-    // at high res). 1280x720 stays user-selectable via `limits.resolutions` for those who accept it.
-    defaults: { duration: 5, fps: 24, resolution: "832x480", quality: "balanced" },
+    // Mirrors the manifest's 720p default (see videoGeometryParity.test.js). NOTE: sc-4997 set this
+    // mirror to 832x480 for a sane out-of-the-box Mac MLX time (measured 5B @ 832x480/121f/20-step/CFG
+    // = ~5 min vs ~20 min at 720p — the z48 VAE decode dominates at high res), but it only ever changed
+    // this file, never `builtin.models.jsonc`. The live catalog is authoritative once loaded, so that
+    // fast-path default never actually shipped; this mirror was advertising a default the app does not
+    // use. Realigning to the manifest makes the mirror truthful. Whether the manifest itself should
+    // adopt sc-4997's 832x480 fast path is a separate product call, tracked in sc-12319.
+    defaults: { duration: 5, fps: 24, resolution: "1280x704", quality: "balanced" },
     limits: {
       durations: [4, 5, 6, 7, 8],
       recommendedMaxDuration: 7,
       fps: [16, 24],
-      resolutions: ["832x480", "1280x720", "720x1280"],
+      resolutions: ["832x480", "1280x704", "704x1280"],
     },
     ui: {
       description: "Fallback video family.",
@@ -674,12 +678,12 @@ export const fallbackModels = [
     name: "Wan2.2 14B (T2V)",
     type: "video",
     capabilities: ["text_to_video"],
-    defaults: { duration: 5, fps: 16, resolution: "1280x720", quality: "balanced" },
+    defaults: { duration: 5, fps: 16, resolution: "1280x704", quality: "balanced" },
     limits: {
       durations: [3, 4, 5],
       recommendedMaxDuration: 5,
       fps: [16],
-      resolutions: ["832x480", "480x832", "1280x720", "720x1280"],
+      resolutions: ["832x480", "480x832", "1280x704", "704x1280"],
     },
     ui: {
       description: "Wan2.2 A14B text-to-video (high/low-noise mixture-of-experts).",
@@ -692,12 +696,12 @@ export const fallbackModels = [
     name: "Wan2.2 14B (I2V)",
     type: "video",
     capabilities: ["image_to_video", "first_last_frame", "extend_clip", "video_bridge"],
-    defaults: { duration: 5, fps: 16, resolution: "1280x720", quality: "balanced" },
+    defaults: { duration: 5, fps: 16, resolution: "1280x704", quality: "balanced" },
     limits: {
       durations: [3, 4, 5],
       recommendedMaxDuration: 5,
       fps: [16],
-      resolutions: ["832x480", "480x832", "1280x720", "720x1280"],
+      resolutions: ["832x480", "480x832", "1280x704", "704x1280"],
     },
     ui: {
       description: "Wan2.2 A14B image-to-video (high/low-noise mixture-of-experts).",
@@ -718,7 +722,7 @@ export const fallbackModels = [
       durations: [3, 4, 5],
       recommendedMaxDuration: 5,
       fps: [16],
-      resolutions: ["832x480", "480x832", "1280x720", "720x1280"],
+      resolutions: ["832x480", "480x832", "1280x704", "704x1280"],
     },
     ui: {
       description: "Wan2.2 A14B VACE control model (high/low-noise mixture-of-experts) for person replacement and controllable video.",

--- a/apps/web/src/videoGeometryParity.test.js
+++ b/apps/web/src/videoGeometryParity.test.js
@@ -1,0 +1,104 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import JSON5 from "json5";
+import { describe, expect, it } from "vitest";
+import { fallbackModels } from "./constants.js";
+
+// Manifest ↔ constants parity for VIDEO geometry (sc-12294), a sibling of controlModesParity.test.js.
+//
+// The Video Studio picker offers `limits.resolutions` and preselects `defaults.resolution`. At runtime
+// those come from the live catalog — seeded from `config/manifests/builtin.models.jsonc` — but
+// `apps/web/src/constants.js` (`fallbackModels`) carries a HAND-MIRRORED copy that App.jsx serves to the
+// real picker whenever the catalog hasn't loaded yet. Nothing stops that mirror from silently drifting.
+//
+// That drift is not cosmetic here. sc-12294 retired the A14B/LTX `1280x720` buckets in favour of
+// `1280x704`, because 720 is not a multiple of the models' 32-px dimension stride and the 901120 area cap
+// floors it: the engine advertised 720 and rendered 704. A stale mirror reintroduces exactly that lie —
+// the picker advertises a bucket the engine will not render. The manifest-side test added by sc-12294 is
+// manifest-only and structurally cannot see this file, so this test is the guard for the mirror.
+//
+// Precedent for the drift being real, not theoretical: sc-4997 set wan_2_2's fast-path default to
+// 832x480 in constants.js ONLY and never touched the manifest, so that default never actually shipped —
+// the catalog kept serving 720p. This test would have caught it. (Whether the manifest should adopt
+// sc-4997's 832x480 fast path is a separate product call, tracked in sc-12319.)
+const HERE = dirname(fileURLToPath(import.meta.url));
+const MANIFEST_PATH = resolve(HERE, "../../../config/manifests/builtin.models.jsonc");
+
+function loadManifestModels() {
+  const raw = readFileSync(MANIFEST_PATH, "utf8");
+  const parsed = JSON5.parse(raw);
+  const models = Array.isArray(parsed) ? parsed : parsed.models;
+  expect(Array.isArray(models), "manifest must expose a models array").toBe(true);
+  return models;
+}
+
+describe("video geometry ↔ manifest parity (sc-12294)", () => {
+  const manifestModels = loadManifestModels();
+  const manifestById = new Map(manifestModels.map((model) => [model.id, model]));
+  const fallbackVideo = fallbackModels.filter((model) => model.type === "video");
+
+  it("fallbackModels carries the video entries the picker falls back to", () => {
+    // App.jsx:823 serves exactly this set to the Video Studio picker before the catalog loads, so an
+    // empty/!video-typed list would silently make the rest of this suite vacuous.
+    expect(fallbackVideo.length).toBeGreaterThan(0);
+  });
+
+  it.each(fallbackVideo.map((model) => [model.id, model]))(
+    "constants.js %s mirrors the manifest resolutions + default resolution",
+    (id, fallback) => {
+      const manifest = manifestById.get(id);
+      expect(manifest, `${id} must exist in the manifest`).toBeTruthy();
+      // Order matters — the picker renders the buckets in this order.
+      expect(fallback.limits?.resolutions, `${id} limits.resolutions must mirror the manifest`).toEqual(
+        manifest.limits?.resolutions,
+      );
+      expect(
+        fallback.defaults?.resolution,
+        `${id} defaults.resolution must mirror the manifest`,
+      ).toEqual(manifest.defaults?.resolution);
+    },
+  );
+
+  it("no video entry advertises a bucket the area cap would floor (sc-12294)", () => {
+    // The direct regression guard, independent of the manifest: every advertised bucket must survive the
+    // model's own maxPixels cap at its stride. This is what makes reintroducing `1280x720` fail loudly
+    // even if someone "fixes" the manifest to match a stale mirror rather than the other way round.
+    const STRIDE = 32;
+    for (const fallback of fallbackVideo) {
+      const manifest = manifestById.get(fallback.id);
+      const maxPixels = manifest?.limits?.maxPixels;
+      if (!maxPixels) {
+        continue; // Uncapped model (ltx/svd/mochi) — nothing to floor against.
+      }
+      for (const bucket of fallback.limits?.resolutions ?? []) {
+        const [w, h] = bucket.split("x").map(Number);
+        expect(
+          w % STRIDE === 0 && h % STRIDE === 0,
+          `${fallback.id} advertises ${bucket}, which is not a multiple of the ${STRIDE}px stride — the engine cannot render it as advertised`,
+        ).toBe(true);
+        expect(
+          w * h <= maxPixels,
+          `${fallback.id} advertises ${bucket} (${w * h}px), which exceeds its ${maxPixels}px cap and would be floored`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("every manifest video model present in fallbackModels mirrors its geometry", () => {
+    // Reverse guard: a manifest video model the mirror DOES carry must not diverge. Models absent from
+    // the seed list (bernini/scail2_14b/mochi_1 load from the live catalog) are intentionally skipped.
+    for (const manifest of manifestModels.filter((model) => model.type === "video")) {
+      const fallback = fallbackVideo.find((model) => model.id === manifest.id);
+      if (!fallback) {
+        continue;
+      }
+      expect(fallback.limits?.resolutions, `${manifest.id} resolutions must be mirrored`).toEqual(
+        manifest.limits?.resolutions,
+      );
+      expect(fallback.defaults?.resolution, `${manifest.id} default resolution must be mirrored`).toEqual(
+        manifest.defaults?.resolution,
+      );
+    }
+  });
+});

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -5670,8 +5670,15 @@
         // fall outside the training distribution and produce black frames. Keep
         // the square option at 640x640 even though normalized_dimensions would
         // accept larger.
-        "resolutions": ["768x512", "512x768", "640x640", "1280x720", "720x1280"],
-        "requiresDimensionsMultipleOf": 32,
+        //
+        // The engine requires W×H divisible by **64**, not 32: `validate_request`
+        // hard-errors otherwise (mlx-gen-ltx/src/model.rs:1047) because stage-1 runs
+        // at `//2//32`. The previously declared 32 was too loose — it let a request
+        // floor onto a ÷32-but-not-÷64 size (e.g. 736) that the engine then rejects.
+        // `720` is not on the ÷64 lattice, so the 720p buckets are advertised at their
+        // real geometry (704 = 64·11), the way scail2_14b already does (sc-12294).
+        "resolutions": ["768x512", "512x768", "640x640", "1280x704", "704x1280"],
+        "requiresDimensionsMultipleOf": 64,
         // Epic 7114 curated sampler menu (sc-7296): both backends' LTX engine advertises the full
         // curated set (candle also keeps the legacy `rectified-flow` alias). No scheduler axis.
         "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"]
@@ -5782,9 +5789,10 @@
         "hardMaxDuration": 15,
         "fps": [24, 25, 30],
         // See LTX-2.3 note above: squares above 640x640 are out-of-distribution
-        // and render black.
-        "resolutions": ["768x512", "512x768", "640x640", "1280x720", "720x1280"],
-        "requiresDimensionsMultipleOf": 32,
+        // and render black; same engine, so the same ÷64 requirement and the same
+        // 704 (= 64·11) 720p buckets apply (sc-12294).
+        "resolutions": ["768x512", "512x768", "640x640", "1280x704", "704x1280"],
+        "requiresDimensionsMultipleOf": 64,
         // Epic 7114 curated sampler menu (sc-7296): shares LTX's curated set (same engine id as
         // base LTX-2.3 per backend). No scheduler axis.
         "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"]
@@ -5868,6 +5876,13 @@
         "recommendedMaxDuration": 4,
         "hardMaxDuration": 4,
         "fps": [6, 7, 8, 10, 12, 25],
+        // The SVD UNet needs W×H divisible by **64** (VAE 8× spatial, then the UNet's 3
+        // stride-2 downsamples = another 8×): `SIZE_ALIGN = VAE_SCALE * 8`
+        // (mlx-gen-svd/src/model.rs:57 + validate at :175; candle-gen-svd/src/config.rs:128
+        // agrees). Both advertised buckets are already ÷64 (576 = 64·9, 1024 = 64·16), so
+        // this changes no shipped geometry — it stops core's looser default-32 floor from
+        // handing the engine a ÷32-but-not-÷64 custom size, which SVD hard-rejects (sc-12294).
+        "requiresDimensionsMultipleOf": 64,
         "resolutions": ["1024x576", "576x1024"],
         // Epic 7114 curated sampler menu (sc-7296): both backends' SVD engine advertises the
         // full curated set. No scheduler axis. Same menu both backends (no per-backend override).
@@ -5988,17 +6003,24 @@
       "defaults": {
         "duration": 5,
         "fps": 24,
-        "resolution": "1280x720",
+        "resolution": "1280x704",
         "quality": "balanced",
         "sampler": "default",
         "scheduler": "default"
       },
       "limits": {
+        // The dense TI2V-5B is the one Wan that genuinely needs **32**: its z48 vae22 has
+        // `vae_stride (4,16,16)`, so patch 2 × 16 = 32 (mlx-gen-wan/src/config.rs:286,
+        // descriptor min_size 32 at model.rs:112; candle-gen-wan/src/config.rs:38
+        // SIZE_MULTIPLE = 32 agrees — and the engine's own `max_area` is 704×1280).
+        // 720 is off that lattice, so the 720p buckets are advertised at the geometry they
+        // actually render (704 = 32·22), the way scail2_14b already does. Core's default
+        // floor is 32, so this entry declares nothing (sc-12294).
         "durations": [4, 5, 6, 7, 8],
         "recommendedMaxDuration": 7,
         "hardMaxDuration": 8,
         "fps": [16, 24],
-        "resolutions": ["832x480", "1280x720", "720x1280"],
+        "resolutions": ["832x480", "1280x704", "704x1280"],
         // Epic 7114 curated sampler menu (sc-7296). Base = the candle (Windows) Wan engine's
         // curated set, run over Wan's native flow σ schedule; the macOS mlx override below adds
         // `dpmpp_2m` (mlx Wan's native FLOW-SNR DPM++2M). No scheduler axis — the flow shift is
@@ -6192,6 +6214,13 @@
         "recommendedMaxDuration": 5,
         "hardMaxDuration": 5,
         "fps": [16],
+        // A14B rides the z16 Wan2.1 VAE: `patch (1,2,2)` × `vae_stride (4,8,8)` = **16**
+        // (mlx-gen-wan/src/config.rs:169 + align_dim at pipeline.rs:36; descriptor min_size
+        // 16 at model.rs:601; candle-gen-wan/src/wan14b.rs:717 agrees). Only the dense
+        // TI2V-5B needs 32 (its z48 VAE has vae_stride 16). Declaring 16 stops core's
+        // default-32 floor from silently rendering the advertised 1280x720 at 1280x704
+        // (sc-12294).
+        "requiresDimensionsMultipleOf": 16,
         "resolutions": ["832x480", "480x832", "1280x720", "720x1280"],
         // Epic 7114 curated menu (sc-7296). Base = the candle (Windows) A14B engine's curated
         // set (native `uni_pc`/`euler`); the macOS mlx override below exposes the full curated
@@ -6386,6 +6415,10 @@
         "hardMaxDuration": 5,
         "fps": [16],
         "resolutions": ["832x480", "480x832", "1280x720", "720x1280"],
+        // Same z16 A14B geometry as the T2V entry above: patch 2 × vae_stride 8 = **16**
+        // (mlx-gen-wan/src/config.rs:169; candle-gen-wan/src/wan14b.rs:717). Keeps the
+        // advertised 1280x720 from silently rendering at 1280x704 (sc-12294).
+        "requiresDimensionsMultipleOf": 16,
         // Epic 7114 curated menu (sc-7296). Base = the candle (Windows) A14B engine's curated
         // set (native `uni_pc`/`euler`); the macOS mlx override below exposes the full curated
         // fold-in. No scheduler axis (flow shift = `scheduler_shift`).
@@ -6522,10 +6555,15 @@
         // Upstream trained at 81 frames / 16 fps / multi-res 512·768·1024. Keep clips short
         // (dual 14B is heavy); the VACE control clip resolution must match the generation
         // resolution (the engine errors otherwise).
+        //
+        // VACE-Fun is A14B/z16: `VAE_S = 8` × patch 2 = **16** (mlx-gen-wan/src/model_vace.rs:56
+        // + align at :108; descriptor min_size 16 at :243; candle-gen-wan/src/model_vace.rs:380
+        // agrees). Declaring it keeps the advertised 1280x720 real (sc-12294).
         "durations": [3, 4, 5],
         "recommendedMaxDuration": 5,
         "hardMaxDuration": 5,
         "fps": [16],
+        "requiresDimensionsMultipleOf": 16,
         "resolutions": ["832x480", "480x832", "1280x720", "720x1280"],
         // Epic 7114 curated menu (sc-7296). mlx-only model (no candle/Torch backend) — the native
         // dual-expert VACE-Fun engine over Wan's flow σ schedule exposes the native curated set.
@@ -6672,6 +6710,12 @@
         "hardMaxDuration": 5,
         "fps": [16],
         // Renderer aligns W×H to the patch stride (16); engine max_size 1280.
+        // The renderer is a Wan2.2-T2V-A14B snapshot: `align_dim(patch.2 = 2,
+        // vae_stride.2 = 8)` = 16 (mlx-gen-bernini/src/bernini.rs:646, descriptor
+        // min_size 16 at :541; candle-gen-bernini agrees at pipeline.rs:96). Declaring
+        // it stops core's default-32 floor from silently rewriting THIS model's own
+        // default 848x480 → 832x480 and 1280x720 → 1280x704 (sc-12294).
+        "requiresDimensionsMultipleOf": 16,
         "resolutions": ["848x480", "480x848", "1280x720", "720x1280"],
         // MLX path is default-only (UniPC flow). Sampler/scheduler menus are
         // pinned on mlx.limits to mirror the other native-MLX video models.

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -6204,7 +6204,7 @@
       "defaults": {
         "duration": 5,
         "fps": 16,
-        "resolution": "1280x720",
+        "resolution": "1280x704",
         "quality": "balanced",
         "sampler": "default",
         "scheduler": "default"
@@ -6217,11 +6217,15 @@
         // A14B rides the z16 Wan2.1 VAE: `patch (1,2,2)` × `vae_stride (4,8,8)` = **16**
         // (mlx-gen-wan/src/config.rs:169 + align_dim at pipeline.rs:36; descriptor min_size
         // 16 at model.rs:601; candle-gen-wan/src/wan14b.rs:717 agrees). Only the dense
-        // TI2V-5B needs 32 (its z48 VAE has vae_stride 16). Declaring 16 stops core's
-        // default-32 floor from silently rendering the advertised 1280x720 at 1280x704
-        // (sc-12294).
+        // TI2V-5B needs 32 (its z48 VAE has vae_stride 16). Declaring 16 is the engine's
+        // truth and keeps custom dims honest (sc-12294).
+        //
+        // The 720p buckets are 704 for a SEPARATE reason — the A14B **area** cap, not the
+        // stride: candle-gen-wan/src/wan14b.rs:645 hard-errors above MAX_AREA_14B
+        // (704×1280 = 901,120 px) and 1280×720 = 921,600 exceeds it. 1280x704 is exactly
+        // AT the cap (`>` check) so it passes; mlx T2V has max_area 0 and never caps.
         "requiresDimensionsMultipleOf": 16,
-        "resolutions": ["832x480", "480x832", "1280x720", "720x1280"],
+        "resolutions": ["832x480", "480x832", "1280x704", "704x1280"],
         // Epic 7114 curated menu (sc-7296). Base = the candle (Windows) A14B engine's curated
         // set (native `uni_pc`/`euler`); the macOS mlx override below exposes the full curated
         // fold-in. No scheduler axis (flow shift = `scheduler_shift`).
@@ -6404,7 +6408,7 @@
       "defaults": {
         "duration": 5,
         "fps": 16,
-        "resolution": "1280x720",
+        "resolution": "1280x704",
         "quality": "balanced",
         "sampler": "default",
         "scheduler": "default"
@@ -6414,11 +6418,16 @@
         "recommendedMaxDuration": 5,
         "hardMaxDuration": 5,
         "fps": [16],
-        "resolutions": ["832x480", "480x832", "1280x720", "720x1280"],
         // Same z16 A14B geometry as the T2V entry above: patch 2 × vae_stride 8 = **16**
-        // (mlx-gen-wan/src/config.rs:169; candle-gen-wan/src/wan14b.rs:717). Keeps the
-        // advertised 1280x720 from silently rendering at 1280x704 (sc-12294).
+        // (mlx-gen-wan/src/config.rs:169; candle-gen-wan/src/wan14b.rs:717) (sc-12294).
+        //
+        // I2V is the strictest of the trio on area: BOTH backends enforce the 704×1280 =
+        // 901,120 px cap, and they disagree on how — candle hard-errors (wan14b.rs:645)
+        // while mlx silently RESCALES via `best_output_size` (model.rs:1074), which its own
+        // test pins at 1280×720 → 1264×704 (pipeline.rs:1510). So 1280x720 is unreachable
+        // here either way; 1280x704 is exactly AT the cap and renders as advertised on both.
         "requiresDimensionsMultipleOf": 16,
+        "resolutions": ["832x480", "480x832", "1280x704", "704x1280"],
         // Epic 7114 curated menu (sc-7296). Base = the candle (Windows) A14B engine's curated
         // set (native `uni_pc`/`euler`); the macOS mlx override below exposes the full curated
         // fold-in. No scheduler axis (flow shift = `scheduler_shift`).
@@ -6558,13 +6567,18 @@
         //
         // VACE-Fun is A14B/z16: `VAE_S = 8` × patch 2 = **16** (mlx-gen-wan/src/model_vace.rs:56
         // + align at :108; descriptor min_size 16 at :243; candle-gen-wan/src/model_vace.rs:380
-        // agrees). Declaring it keeps the advertised 1280x720 real (sc-12294).
+        // agrees) (sc-12294).
+        //
+        // The 720p buckets are 704 on the **area** cap, not the stride: mlx VACE is uncapped
+        // (model_vace.rs:107 — "no max-area cap"), but candle VACE hard-errors above
+        // MAX_AREA_14B = 901,120 px (model_vace.rs:298) and 1280×720 = 921,600 exceeds it.
+        // 1280x704 is exactly AT the cap, so it renders as advertised on both backends.
         "durations": [3, 4, 5],
         "recommendedMaxDuration": 5,
         "hardMaxDuration": 5,
         "fps": [16],
         "requiresDimensionsMultipleOf": 16,
-        "resolutions": ["832x480", "480x832", "1280x720", "720x1280"],
+        "resolutions": ["832x480", "480x832", "1280x704", "704x1280"],
         // Epic 7114 curated menu (sc-7296). mlx-only model (no candle/Torch backend) — the native
         // dual-expert VACE-Fun engine over Wan's flow σ schedule exposes the native curated set.
         // No scheduler axis (flow shift = `scheduler_shift`).
@@ -6714,9 +6728,15 @@
         // vae_stride.2 = 8)` = 16 (mlx-gen-bernini/src/bernini.rs:646, descriptor
         // min_size 16 at :541; candle-gen-bernini agrees at pipeline.rs:96). Declaring
         // it stops core's default-32 floor from silently rewriting THIS model's own
-        // default 848x480 → 832x480 and 1280x720 → 1280x704 (sc-12294).
+        // default 848x480 → 832x480 (sc-12294).
+        //
+        // Separately, the 720p buckets are 704 — NOT a stride effect but the A14B
+        // **area** cap: candle-gen-bernini/src/config.rs:164 hard-errors above
+        // MAX_AREA_14B (704×1280 = 901,120 px), and 1280×720 = 921,600 exceeds it.
+        // 1280x704 sits exactly AT the cap (the check is `>`), so it passes on candle
+        // and is uncapped on mlx. 848x480 (407,040) is far under the cap.
         "requiresDimensionsMultipleOf": 16,
-        "resolutions": ["848x480", "480x848", "1280x720", "720x1280"],
+        "resolutions": ["848x480", "480x848", "1280x704", "704x1280"],
         // MLX path is default-only (UniPC flow). Sampler/scheduler menus are
         // pinned on mlx.limits to mirror the other native-MLX video models.
         "samplers": ["default"],

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -6010,12 +6010,19 @@
       },
       "limits": {
         // The dense TI2V-5B is the one Wan that genuinely needs **32**: its z48 vae22 has
-        // `vae_stride (4,16,16)`, so patch 2 × 16 = 32 (mlx-gen-wan/src/config.rs:286,
-        // descriptor min_size 32 at model.rs:112; candle-gen-wan/src/config.rs:38
-        // SIZE_MULTIPLE = 32 agrees — and the engine's own `max_area` is 704×1280).
-        // 720 is off that lattice, so the 720p buckets are advertised at the geometry they
-        // actually render (704 = 32·22), the way scail2_14b already does. Core's default
-        // floor is 32, so this entry declares nothing (sc-12294).
+        // `vae_stride (4,16,16)`, so patch 2 × 16 = 32 — candle `SIZE_MULTIPLE = 32`
+        // (config.rs:38) enforced via `is_multiple_of` (lib.rs:338), and mlx `align_dim`
+        // over the same patch × stride (config.rs:286). (`min_size` corroborates but is only
+        // a lower bound.) 720 is off that lattice, so the 720p buckets are advertised at the
+        // geometry they actually render (704 = 32·22), the way scail2_14b already does.
+        // Core's default floor is 32, so this entry declares no stride (sc-12294).
+        //
+        // It DOES declare the area cap. The backends disagree in the opposite direction
+        // from the A14B trio: mlx `wan22_ti2v_5b()` sets `max_area: 704*1280` and silently
+        // rescales (config.rs:293 → resolve_capped_dims at model.rs:1074), while candle's
+        // 5B `validate` (lib.rs:328) checks only the multiple and has NO area check. The
+        // stricter truth is mlx's, so `maxPixels` carries it and both backends now agree.
+        "maxPixels": 901120,
         "durations": [4, 5, 6, 7, 8],
         "recommendedMaxDuration": 7,
         "hardMaxDuration": 8,
@@ -6214,17 +6221,28 @@
         "recommendedMaxDuration": 5,
         "hardMaxDuration": 5,
         "fps": [16],
-        // A14B rides the z16 Wan2.1 VAE: `patch (1,2,2)` × `vae_stride (4,8,8)` = **16**
-        // (mlx-gen-wan/src/config.rs:169 + align_dim at pipeline.rs:36; descriptor min_size
-        // 16 at model.rs:601; candle-gen-wan/src/wan14b.rs:717 agrees). Only the dense
-        // TI2V-5B needs 32 (its z48 VAE has vae_stride 16). Declaring 16 is the engine's
-        // truth and keeps custom dims honest (sc-12294).
+        // A14B rides the z16 Wan2.1 VAE: `patch (1,2,2)` × `vae_stride (4,8,8)` = **16**.
+        // The constraint is the engines' own divisibility check — candle
+        // `SIZE_MULTIPLE_14B = 16` enforced via `is_multiple_of`
+        // (candle-gen-wan/src/config.rs:209, checked at wan14b.rs:635), and mlx's
+        // `align_dim(patch, vae_stride)` (mlx-gen-wan/src/pipeline.rs:36, config.rs:169).
+        // (The descriptor `min_size` agrees by convention, but it is only a lower BOUND —
+        // gen-core checks `req.width < min_size` — not a lattice.) Only the dense TI2V-5B
+        // needs 32 (its z48 VAE has vae_stride 16). Declaring 16 is the engine's truth and
+        // keeps custom dims honest (sc-12294).
         //
         // The 720p buckets are 704 for a SEPARATE reason — the A14B **area** cap, not the
         // stride: candle-gen-wan/src/wan14b.rs:645 hard-errors above MAX_AREA_14B
         // (704×1280 = 901,120 px) and 1280×720 = 921,600 exceeds it. 1280x704 is exactly
-        // AT the cap (`>` check) so it passes; mlx T2V has max_area 0 and never caps.
+        // AT the cap (`>` check) so it passes.
+        //
+        // `maxPixels` makes that cap ENFORCED rather than merely advertised: nothing in the
+        // app validates against `resolutions`, so a raw over-cap request (job retry, MCP,
+        // preset replay) reaches the engine untouched. The backends DISAGREE here — candle
+        // hard-errors, while mlx T2V has `max_area: 0` and never caps — so the manifest
+        // carries the STRICTER truth (candle's), which one geometry can serve to both.
         "requiresDimensionsMultipleOf": 16,
+        "maxPixels": 901120,
         "resolutions": ["832x480", "480x832", "1280x704", "704x1280"],
         // Epic 7114 curated menu (sc-7296). Base = the candle (Windows) A14B engine's curated
         // set (native `uni_pc`/`euler`); the macOS mlx override below exposes the full curated
@@ -6419,14 +6437,18 @@
         "hardMaxDuration": 5,
         "fps": [16],
         // Same z16 A14B geometry as the T2V entry above: patch 2 × vae_stride 8 = **16**
-        // (mlx-gen-wan/src/config.rs:169; candle-gen-wan/src/wan14b.rs:717) (sc-12294).
+        // (candle `SIZE_MULTIPLE_14B` at config.rs:209 via `is_multiple_of`; mlx `align_dim`
+        // at pipeline.rs:36) (sc-12294).
         //
-        // I2V is the strictest of the trio on area: BOTH backends enforce the 704×1280 =
-        // 901,120 px cap, and they disagree on how — candle hard-errors (wan14b.rs:645)
-        // while mlx silently RESCALES via `best_output_size` (model.rs:1074), which its own
-        // test pins at 1280×720 → 1264×704 (pipeline.rs:1510). So 1280x720 is unreachable
-        // here either way; 1280x704 is exactly AT the cap and renders as advertised on both.
+        // I2V is the one model where BOTH backends enforce the 704×1280 = 901,120 px cap —
+        // but they disagree on HOW: candle hard-errors (wan14b.rs:645) while mlx silently
+        // RESCALES via `best_output_size` (model.rs:1074), whose own test pins
+        // 1280×720 → 1264×704 (pipeline.rs:1510). `maxPixels` resolves that split in ONE
+        // place: core fits to the cap with a port of mlx's `best_output_size`, so a request
+        // that used to hard-error on candle and silently rescale on mlx now arrives already
+        // at the geometry mlx would have produced — legal on candle, a no-op on mlx.
         "requiresDimensionsMultipleOf": 16,
+        "maxPixels": 901120,
         "resolutions": ["832x480", "480x832", "1280x704", "704x1280"],
         // Epic 7114 curated menu (sc-7296). Base = the candle (Windows) A14B engine's curated
         // set (native `uni_pc`/`euler`); the macOS mlx override below exposes the full curated
@@ -6565,19 +6587,25 @@
         // (dual 14B is heavy); the VACE control clip resolution must match the generation
         // resolution (the engine errors otherwise).
         //
-        // VACE-Fun is A14B/z16: `VAE_S = 8` × patch 2 = **16** (mlx-gen-wan/src/model_vace.rs:56
-        // + align at :108; descriptor min_size 16 at :243; candle-gen-wan/src/model_vace.rs:380
-        // agrees) (sc-12294).
+        // VACE-Fun is A14B/z16: `VAE_S = 8` × patch 2 = **16** — mlx aligns via `align_dim`
+        // (model_vace.rs:108) and candle enforces `SIZE_MULTIPLE_14B` via `is_multiple_of`
+        // (model_vace.rs:380). (`min_size` agrees by convention but is only a lower bound.)
+        // (sc-12294)
         //
         // The 720p buckets are 704 on the **area** cap, not the stride: mlx VACE is uncapped
         // (model_vace.rs:107 — "no max-area cap"), but candle VACE hard-errors above
         // MAX_AREA_14B = 901,120 px (model_vace.rs:298) and 1280×720 = 921,600 exceeds it.
         // 1280x704 is exactly AT the cap, so it renders as advertised on both backends.
+        //
+        // Backends DISAGREE (mlx uncapped, candle errors) → the manifest carries the
+        // STRICTER truth so one geometry serves both. `maxPixels` enforces it: advertising
+        // 704 does not stop a raw request (retry / MCP / preset replay) asking for 720.
         "durations": [3, 4, 5],
         "recommendedMaxDuration": 5,
         "hardMaxDuration": 5,
-        "fps": [16],
         "requiresDimensionsMultipleOf": 16,
+        "maxPixels": 901120,
+        "fps": [16],
         "resolutions": ["832x480", "480x832", "1280x704", "704x1280"],
         // Epic 7114 curated menu (sc-7296). mlx-only model (no candle/Torch backend) — the native
         // dual-expert VACE-Fun engine over Wan's flow σ schedule exposes the native curated set.
@@ -6724,18 +6752,25 @@
         "hardMaxDuration": 5,
         "fps": [16],
         // Renderer aligns W×H to the patch stride (16); engine max_size 1280.
-        // The renderer is a Wan2.2-T2V-A14B snapshot: `align_dim(patch.2 = 2,
-        // vae_stride.2 = 8)` = 16 (mlx-gen-bernini/src/bernini.rs:646, descriptor
-        // min_size 16 at :541; candle-gen-bernini agrees at pipeline.rs:96). Declaring
-        // it stops core's default-32 floor from silently rewriting THIS model's own
-        // default 848x480 → 832x480 (sc-12294).
+        // The renderer is a Wan2.2-T2V-A14B snapshot: mlx aligns via `align_dim(patch.2 = 2,
+        // vae_stride.2 = 8)` = 16 (mlx-gen-bernini/src/bernini.rs:646) and candle enforces
+        // `SIZE_MULTIPLE_14B = 16` via `is_multiple_of` (candle-gen-bernini/src/config.rs:155).
+        // (The descriptor `min_size` agrees by convention, but it is a lower BOUND, not a
+        // lattice.) Declaring it stops core's default-32 floor from silently rewriting THIS
+        // model's own default 848x480 → 832x480 (sc-12294).
         //
         // Separately, the 720p buckets are 704 — NOT a stride effect but the A14B
         // **area** cap: candle-gen-bernini/src/config.rs:164 hard-errors above
         // MAX_AREA_14B (704×1280 = 901,120 px), and 1280×720 = 921,600 exceeds it.
-        // 1280x704 sits exactly AT the cap (the check is `>`), so it passes on candle
-        // and is uncapped on mlx. 848x480 (407,040) is far under the cap.
+        // 1280x704 sits exactly AT the cap (the check is `>`), so it passes on candle.
+        // 848x480 (407,040) is far under the cap.
+        //
+        // Backends DISAGREE — mlx bernini calls `align_dim` directly and never caps area —
+        // so the manifest carries the STRICTER truth (candle's). `maxPixels` is what makes
+        // it real: declaring 16 REMOVES the accidental ÷32 protection that used to floor a
+        // stored 1280x720 to 1280x704, so the cap has to be enforced, not just advertised.
         "requiresDimensionsMultipleOf": 16,
+        "maxPixels": 901120,
         "resolutions": ["848x480", "480x848", "1280x704", "704x1280"],
         // MLX path is default-only (UniPC flow). Sampler/scheduler menus are
         // pinned on mlx.limits to mirror the other native-MLX video models.
@@ -6991,12 +7026,21 @@
       "limits": {
         // One 81-frame driving segment ≈ 5s at 16fps (longer clips stitch segments —
         // each is a full 14B denoise, so keep clips short). Core aligns W×H to a
-        // multiple of 32; engine max_size 1280. The output bucket should match the
-        // driving clip's aspect (the clip sets the motion + framing).
+        // multiple of 32 — mlx's hardcoded `DIM_ALIGN = 32` (mlx-gen-scail2/src/generate.rs:73),
+        // which core's default floor already matches, so no stride is declared. Engine
+        // max_size 1280. The output bucket should match the driving clip's aspect (the
+        // clip sets the motion + framing).
+        //
+        // Area: candle shares the A14B envelope — `reject_over_area` hard-errors above
+        // MAX_AREA_14B = 901,120 px (candle-gen-scail2/src/pipeline.rs:294), added because
+        // `max_size` alone only bounds each EDGE, so 1280×1280 slipped through. mlx scail2
+        // has no area check, so the backends disagree and the manifest carries the stricter
+        // (candle's) truth (sc-12294).
         "durations": [3, 4, 5],
         "recommendedMaxDuration": 5,
         "hardMaxDuration": 5,
         "fps": [16],
+        "maxPixels": 901120,
         "resolutions": ["832x480", "480x832", "1280x704", "704x1280"],
         "samplers": ["default"],
         "schedulers": ["default"]

--- a/crates/sceneworks-core/src/video_request.rs
+++ b/crates/sceneworks-core/src/video_request.rs
@@ -44,8 +44,9 @@ pub struct VideoRequest {
     pub fps: u32,
     /// Output dimensions: clamped to 256..=1920, then floored to the model's dimension
     /// granularity — `model_manifest_entry.limits.requiresDimensionsMultipleOf`, default
-    /// 32 (Python `normalized_dimensions`). Defaults 768x512. Mochi declares 16 so its
-    /// native 848x480 bucket survives the floor (sc-11993).
+    /// 32 (Python `normalized_dimensions`). Defaults 768x512. Each video model declares the
+    /// stride its engine actually needs, so the advertised buckets survive the floor: 16 for
+    /// mochi (sc-11993) and for bernini / the Wan A14B trio, 64 for ltx and svd (sc-12294).
     pub width: u32,
     pub height: u32,
     pub quality: String,
@@ -243,9 +244,23 @@ const DEFAULT_DIMENSION_MULTIPLE: u32 = 32;
 /// A blanket 32 silently rewrote Mochi's native (and only trained) 848x480 bucket to
 /// 832x480 — `848 % 32 == 16` — and the rewrite was invisible because `832 % 16 == 0`
 /// satisfies the engine's own ÷16 check (sc-11993). Models opt in by *declaring* the
-/// limit; the rest keep 32 (sc-12294 tracks the shipped 848/720 buckets that still
-/// floor, pending a decision — changing them retroactively would move the geometry of
-/// already-reproducible recipes).
+/// limit; the rest keep 32.
+///
+/// sc-12294 then swept every video model against its engine's real constraint, and the
+/// answer differed per model — the floor is not one number:
+///
+/// * **16** — bernini and the Wan A14B trio (t2v / i2v / vace-fun) ride a z16 VAE:
+///   `patch 2 × vae_stride 8`. They now declare it, so bernini's own default 848x480 and
+///   the advertised 1280x720 stop silently rendering as 832x480 / 1280x704.
+/// * **32** — the dense Wan TI2V-5B (z48 vae22, `vae_stride 16`) and scail2 (hardcoded
+///   `DIM_ALIGN`) genuinely need it. There the *advertisement* was wrong, so their 720p
+///   buckets were corrected to the 704 they always rendered; both keep this default.
+/// * **64** — ltx (`validate_request` hard-errors below it: stage-1 runs at `//2//32`) and
+///   svd (VAE 8× then the UNet's 8×). A declared 32 was too *loose* for these: it could
+///   floor onto a ÷32-but-not-÷64 size the engine then rejects.
+///
+/// So a declared value can be looser OR stricter than the default — it is the engine's
+/// truth, not a blanket policy.
 fn normalized_dimensions(
     width: Option<&Value>,
     height: Option<&Value>,
@@ -379,16 +394,15 @@ mod tests {
         assert_eq!(request.width, 992);
         assert_eq!(request.height, 512);
 
-        // A manifest entry that does NOT declare the limit keeps the 32 default — the
-        // shipped case for every video model except ltx (declares 32) and mochi (16).
-        // sc-12294 tracks bernini's own 848x480 bucket still flooring to 832x480 pending
-        // a product decision; B3 deliberately does NOT change it. Only models that
-        // *declare* `requiresDimensionsMultipleOf` opt out of the 32 floor.
-        let bernini = VideoRequest::from_payload(&payload(json!({
-            "projectId": "p", "model": "bernini", "width": 848, "height": 480,
-            "modelManifestEntry": { "family": "bernini", "limits": { "resolutions": ["848x480"] } }
+        // A manifest entry that does NOT declare the limit keeps the 32 default. This is
+        // still the shipped case for the two models whose engines genuinely need 32 —
+        // wan_2_2 (TI2V-5B) and scail2_14b — so the default path stays live and covered.
+        // Only models that *declare* `requiresDimensionsMultipleOf` move off it.
+        let undeclared = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "model": "wan_2_2", "width": 848, "height": 480,
+            "modelManifestEntry": { "family": "wan-video", "limits": { "resolutions": ["832x480"] } }
         })));
-        assert_eq!((bernini.width, bernini.height), (832, 480));
+        assert_eq!((undeclared.width, undeclared.height), (832, 480));
     }
 
     #[test]
@@ -410,12 +424,12 @@ mod tests {
         })));
         assert_eq!((portrait.width, portrait.height), (480, 848));
 
-        // A declared 32 (ltx) is identical to the default path.
-        let ltx = VideoRequest::from_payload(&payload(json!({
-            "projectId": "p", "model": "ltx_2_3", "width": 1000, "height": 543,
+        // An explicitly declared 32 is identical to the default path.
+        let declared_32 = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "model": "scail2_14b", "width": 1000, "height": 543,
             "modelManifestEntry": { "limits": { "requiresDimensionsMultipleOf": 32 } }
         })));
-        assert_eq!((ltx.width, ltx.height), (992, 512));
+        assert_eq!((declared_32.width, declared_32.height), (992, 512));
 
         // 16 is a smaller floor, not a bypass: off-lattice input still floors.
         let odd = VideoRequest::from_payload(&payload(json!({
@@ -423,6 +437,96 @@ mod tests {
             "modelManifestEntry": { "limits": { "requiresDimensionsMultipleOf": 16 } }
         })));
         assert_eq!((odd.width, odd.height), (848, 480));
+    }
+
+    /// sc-12294: the floor is per-engine, and a declared value can be looser OR stricter
+    /// than the 32 default. Each case below mirrors the stride derived from that engine's
+    /// own constraint, so the advertised bucket is what actually renders.
+    #[test]
+    fn declared_multiple_honors_each_engines_true_stride() {
+        // --- 16: bernini renders through a Wan2.2-T2V-A14B snapshot (patch 2 × vae_stride
+        // 8). Its OWN default bucket, 848x480, used to floor to 832x480 under the blanket
+        // 32 — silently, because 832 % 16 == 0 passed the engine's own check.
+        let bernini = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "model": "bernini", "width": 848, "height": 480,
+            "modelManifestEntry": { "family": "bernini", "limits": { "requiresDimensionsMultipleOf": 16 } }
+        })));
+        assert_eq!((bernini.width, bernini.height), (848, 480));
+
+        // The 720p bucket is real for every ÷16 model (720 = 16·45): bernini + the Wan A14B
+        // trio all advertised 1280x720 while rendering 1280x704.
+        for model in [
+            "bernini",
+            "wan_2_2_t2v_14b",
+            "wan_2_2_i2v_14b",
+            "wan_2_2_vace_fun_14b",
+        ] {
+            let req = VideoRequest::from_payload(&payload(json!({
+                "projectId": "p", "model": model, "width": 1280, "height": 720,
+                "modelManifestEntry": { "limits": { "requiresDimensionsMultipleOf": 16 } }
+            })));
+            assert_eq!(
+                (req.width, req.height),
+                (1280, 720),
+                "{model} must keep 1280x720"
+            );
+        }
+
+        // --- 64: ltx hard-errors below ÷64 (stage-1 runs at //2//32) and svd's UNet needs
+        // VAE 8× × 8×. A declared 32 was too LOOSE — 736 is ÷32 but the engine rejects it.
+        // 64 floors it onto the lattice the engine actually accepts.
+        for model in ["ltx_2_3", "ltx_2_3_eros", "svd"] {
+            let req = VideoRequest::from_payload(&payload(json!({
+                "projectId": "p", "model": model, "width": 1280, "height": 736,
+                "modelManifestEntry": { "limits": { "requiresDimensionsMultipleOf": 64 } }
+            })));
+            assert_eq!(
+                (req.width, req.height),
+                (1280, 704),
+                "{model} must floor 736 -> 704"
+            );
+            assert_eq!(req.height % 64, 0, "{model} must land on the ÷64 lattice");
+        }
+
+        // Each model's advertised buckets are fixed points under its own stride — that is
+        // the whole invariant sc-12294 restores: what is advertised is what renders.
+        for (model, multiple, buckets) in [
+            (
+                "bernini",
+                16,
+                vec![(848, 480), (480, 848), (1280, 720), (720, 1280)],
+            ),
+            (
+                "wan_2_2_t2v_14b",
+                16,
+                vec![(832, 480), (480, 832), (1280, 720), (720, 1280)],
+            ),
+            (
+                "ltx_2_3",
+                64,
+                vec![(768, 512), (512, 768), (640, 640), (1280, 704), (704, 1280)],
+            ),
+            ("svd", 64, vec![(1024, 576), (576, 1024)]),
+            // Genuinely-32 engines: the advertisement was corrected to the 704 they render.
+            ("wan_2_2", 32, vec![(832, 480), (1280, 704), (704, 1280)]),
+            (
+                "scail2_14b",
+                32,
+                vec![(832, 480), (480, 832), (1280, 704), (704, 1280)],
+            ),
+        ] {
+            for (w, h) in buckets {
+                let req = VideoRequest::from_payload(&payload(json!({
+                    "projectId": "p", "model": model, "width": w, "height": h,
+                    "modelManifestEntry": { "limits": { "requiresDimensionsMultipleOf": multiple } }
+                })));
+                assert_eq!(
+                    (req.width, req.height),
+                    (w, h),
+                    "{model} advertises {w}x{h}; it must render {w}x{h}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/sceneworks-core/src/video_request.rs
+++ b/crates/sceneworks-core/src/video_request.rs
@@ -332,8 +332,19 @@ fn max_pixels_of(model_manifest_entry: &JsonObject) -> Option<u64> {
 /// cap that the candle backend hard-errors on. One geometry, both backends (sc-12294).
 ///
 /// The `.max(d)` clamps mirror the engine's own F-030 guard against a degenerate area flooring a
-/// dimension to 0 (and a subsequent `area / 0` → NaN ratio). They cannot fire here — a cap below
-/// 256×256 is rejected by [`max_pixels_of`] — but the port is kept faithful rather than trimmed.
+/// dimension to 0 (and a subsequent `area / 0` → NaN ratio). They cannot fire for any *shipped*
+/// cap, and the port is kept faithful rather than trimmed.
+///
+/// The bound comes from the shipped caps, NOT from [`max_pixels_of`]'s filter — that distinction
+/// matters if a future cap is added. [`MIN_HONORABLE_MAX_PIXELS`] only guarantees a *square*
+/// 256×256 fits; it says nothing about a non-square fit, which drives the minor dimension well
+/// below 256 (a cap of exactly 65,536 — which passes the filter — fits 1920×256 to `(688, 80)` at
+/// stride 16, violating [`normalized_dimensions`]'s own 256 floor and every engine's `min_size`).
+/// What actually rules the clamps out is the reachable minimum: [`normalized_dimensions`] clamps
+/// both inputs to `[256, 1920]`, so the aspect ratio cannot exceed `1920/256 = 7.5`, and at the
+/// only cap the manifest declares (901,120) the smaller ideal dimension is `√(901120/7.5) ≈ 346`
+/// — comfortably above every stride, so nothing floors to 0. A cap below ~491,520 would put an
+/// extreme-ratio request back into clamp territory; the manifest's caps are test-pinned.
 fn fit_to_max_pixels(width: u32, height: u32, multiple: u32, max_pixels: u64) -> (u32, u32) {
     let (w, h, d) = (width as f64, height as f64, multiple as f64);
     let area = max_pixels as f64;
@@ -670,7 +681,17 @@ mod tests {
     ///   (`config.rs:293`); candle's 5B `validate` (`lib.rs:328`) has NO area check.
     /// * `wan_2_2_i2v_14b` — the only agreement, and even there candle errors while mlx
     ///   rescales.
-    /// * `ltx_2_3` / `ltx_2_3_eros` / `svd` / `mochi_1` — zero area checks in either backend.
+    /// * `ltx_2_3` / `ltx_2_3_eros` / `svd` / `mochi_1` — no `maxPixels`-expressible area cap in
+    ///   either backend, so no cap is declared. Not literally "no checks": candle-LTX caps
+    ///   **latent tokens** (`candle-gen-ltx/src/lib.rs:454`: `t_lat·h_lat·w_lat > 131_072`), which
+    ///   is proportional to `frames × w × h`. That is a frames×area constraint and therefore
+    ///   outside `maxPixels`' scope — `maxPixels` is a pure per-frame area budget with no frame
+    ///   term, so no value of it could express this cap without either under- or over-constraining
+    ///   at some duration. It is also unreachable within the advertised duration/fps limits (the
+    ///   worst advertised case, 15s at 30fps and 1280×704, is ~25k of the 131,072 tokens), and
+    ///   candle-LTX registers `ltx_2_3_distilled` — a different id from these entries. Frame-count
+    ///   shaping is the sibling lever (cf. mochi's 6k+1 rule, sc-11993); if an LTX request ever
+    ///   needs to honor this cap it belongs there, not in `maxPixels`.
     const ENGINE_GEOMETRY: &[(&str, Option<u32>, Option<u64>)] = &[
         ("ltx_2_3", Some(64), None),
         ("ltx_2_3_eros", Some(64), None),

--- a/crates/sceneworks-core/src/video_request.rs
+++ b/crates/sceneworks-core/src/video_request.rs
@@ -42,11 +42,16 @@ pub struct VideoRequest {
     pub duration: f32,
     /// Frames per second, clamped to 1..=60 (Python `safe_int`).
     pub fps: u32,
-    /// Output dimensions: clamped to 256..=1920, then floored to the model's dimension
+    /// Output dimensions: clamped to 256..=1920, floored to the model's dimension
     /// granularity — `model_manifest_entry.limits.requiresDimensionsMultipleOf`, default
-    /// 32 (Python `normalized_dimensions`). Defaults 768x512. Each video model declares the
-    /// stride its engine actually needs, so the advertised buckets survive the floor: 16 for
-    /// mochi (sc-11993) and for bernini / the Wan A14B trio, 64 for ltx and svd (sc-12294).
+    /// 32 (Python `normalized_dimensions`) — then fitted into the model's area cap,
+    /// `limits.maxPixels`, if it declares one (no cap when absent). Defaults 768x512.
+    ///
+    /// Each video model declares the stride its engine actually needs, so the advertised
+    /// buckets survive the floor: 16 for mochi (sc-11993) and for bernini / the Wan A14B
+    /// trio, 64 for ltx and svd. The A14B-family engines additionally cap area at 901,120
+    /// px; `maxPixels` is what keeps a raw over-cap request (retry / MCP / preset replay,
+    /// none of which pass through the UI dropdown) from reaching them (sc-12294).
     pub width: u32,
     pub height: u32,
     pub quality: String,
@@ -250,19 +255,31 @@ const DEFAULT_DIMENSION_MULTIPLE: u32 = 32;
 /// answer differed per model — the floor is not one number:
 ///
 /// * **16** — bernini and the Wan A14B trio (t2v / i2v / vace-fun) ride a z16 VAE:
-///   `patch 2 × vae_stride 8`. They now declare it, so bernini's own default 848x480 stops
-///   silently rendering as 832x480. Their 720p buckets still move to 704, but for a
-///   different reason: the A14B **area** cap (704×1280 = 901,120 px), which candle
+///   `patch 2 × vae_stride 8`. The constraint is the engines' own divisibility check —
+///   candle `SIZE_MULTIPLE_14B = 16`, enforced via `is_multiple_of`, and mlx's `align_dim`
+///   rounding to `patch · vae_stride`. They now declare it, so bernini's own default
+///   848x480 stops silently rendering as 832x480. Their 720p buckets still move to 704, but
+///   for a different reason: the A14B **area** cap (704×1280 = 901,120 px), which candle
 ///   hard-errors on and mlx i2v silently rescales for — not the stride.
-/// * **32** — the dense Wan TI2V-5B (z48 vae22, `vae_stride 16`) and scail2 (hardcoded
-///   `DIM_ALIGN`) genuinely need it. There the *advertisement* was wrong, so their 720p
-///   buckets were corrected to the 704 they always rendered; both keep this default.
+/// * **32** — the dense Wan TI2V-5B (z48 vae22, `vae_stride 16` → candle `SIZE_MULTIPLE =
+///   32`) and scail2 (hardcoded `DIM_ALIGN`) genuinely need it. There the *advertisement*
+///   was wrong, so their 720p buckets were corrected to the 704 they always rendered; both
+///   keep this default.
 /// * **64** — ltx (`validate_request` hard-errors below it: stage-1 runs at `//2//32`) and
-///   svd (VAE 8× then the UNet's 8×). A declared 32 was too *loose* for these: it could
+///   svd (`SIZE_ALIGN = VAE_SCALE * 8`). A declared 32 was too *loose* for these: it could
 ///   floor onto a ÷32-but-not-÷64 size the engine then rejects.
+///
+/// (The descriptors' `min_size` corroborates each stride by convention, but it is NOT the
+/// evidence: gen-core checks `req.width < self.min_size` — a lower *bound*, not a lattice.
+/// The divisibility constants above are the actual constraint.)
 ///
 /// So a declared value can be looser OR stricter than the default — it is the engine's
 /// truth, not a blanket policy.
+///
+/// The stride is only half the geometry. Some engines also cap **area**, and the stride
+/// floor does not imply the cap: a finer stride makes MORE over-cap sizes reachable, not
+/// fewer. Models whose engine caps declare `limits.maxPixels`, and the result is fitted
+/// into it by [`fit_to_max_pixels`]. A model that declares nothing is uncapped (sc-12294).
 fn normalized_dimensions(
     width: Option<&Value>,
     height: Option<&Value>,
@@ -271,7 +288,76 @@ fn normalized_dimensions(
     let multiple = dimension_multiple_of(model_manifest_entry);
     let w = floor_to_multiple(clamped_u32(width, 768, 256, 1920), multiple);
     let h = floor_to_multiple(clamped_u32(height, 512, 256, 1920), multiple);
-    (w, h)
+    match max_pixels_of(model_manifest_entry) {
+        Some(cap) if (w as u64) * (h as u64) > cap => fit_to_max_pixels(w, h, multiple, cap),
+        _ => (w, h),
+    }
+}
+
+/// The lower bound a [`max_pixels_of`] cap must clear to be honorable: [`floor_to_multiple`]
+/// hard-floors every dimension at 256, so a cap under 256×256 could never be satisfied.
+const MIN_HONORABLE_MAX_PIXELS: u64 = 256 * 256;
+
+/// `limits.maxPixels` from a resolved manifest entry, or `None` for **no cap** — the
+/// default-absent behavior, so every model that does not declare one is byte-identical to
+/// before this key existed (sc-12294).
+///
+/// A cap is declared only where the *engine* enforces one, and it is deliberately not a
+/// blanket: ltx / svd / mochi have no area check in either backend, so they get no key.
+/// Where the two backends disagree the manifest carries the STRICTER truth, because one
+/// manifest serves both — see the per-model notes in `builtin.models.jsonc`.
+///
+/// Same infallibility posture as [`dimension_multiple_of`]: `from_payload` must survive a
+/// typo'd manifest, so a cap the geometry could never honor (zero / negative / non-integer /
+/// below the 256×256 floor) falls back to *no cap* rather than emitting a degenerate size.
+/// That matches the default-absent behavior instead of inventing a constraint from a typo.
+fn max_pixels_of(model_manifest_entry: &JsonObject) -> Option<u64> {
+    model_manifest_entry
+        .get("limits")
+        .and_then(Value::as_object)
+        .and_then(|limits| limits.get("maxPixels"))
+        .and_then(Value::as_u64)
+        .filter(|cap| *cap >= MIN_HONORABLE_MAX_PIXELS)
+}
+
+/// The largest `(width, height)` inside `max_pixels` that preserves the input aspect ratio and
+/// stays on the `multiple` lattice.
+///
+/// A direct port of the mlx engine's `best_output_size` (`mlx-gen-wan/src/pipeline.rs:94`,
+/// itself a port of `generate_wan.py`'s `_best_output_size`): derive the ideal `(ow, oh)` from
+/// `√(max_area·ratio)`, then try width-first and height-first alignment and keep whichever
+/// distorts the ratio less. Porting it rather than inventing a fit is the point of the story —
+/// mlx I2V/TI2V silently rescale through this exact function, so matching it is what makes the
+/// app's normalization agree with the backend that rescales, while keeping the result inside the
+/// cap that the candle backend hard-errors on. One geometry, both backends (sc-12294).
+///
+/// The `.max(d)` clamps mirror the engine's own F-030 guard against a degenerate area flooring a
+/// dimension to 0 (and a subsequent `area / 0` → NaN ratio). They cannot fire here — a cap below
+/// 256×256 is rejected by [`max_pixels_of`] — but the port is kept faithful rather than trimmed.
+fn fit_to_max_pixels(width: u32, height: u32, multiple: u32, max_pixels: u64) -> (u32, u32) {
+    let (w, h, d) = (width as f64, height as f64, multiple as f64);
+    let area = max_pixels as f64;
+    let ratio = w / h;
+    let ow = (area * ratio).sqrt();
+    let oh = area / ow;
+
+    // Option 1: align width first, derive height from the remaining area.
+    let ow1 = ((ow / d).floor() * d).max(d);
+    let oh1 = ((area / ow1 / d).floor() * d).max(d);
+    let ratio1 = ow1 / oh1;
+
+    // Option 2: align height first, derive width.
+    let oh2 = ((oh / d).floor() * d).max(d);
+    let ow2 = ((area / oh2 / d).floor() * d).max(d);
+    let ratio2 = ow2 / oh2;
+
+    let dist1 = (ratio / ratio1).max(ratio1 / ratio);
+    let dist2 = (ratio / ratio2).max(ratio2 / ratio);
+    if dist1 < dist2 {
+        (ow1 as u32, oh1 as u32)
+    } else {
+        (ow2 as u32, oh2 as u32)
+    }
 }
 
 /// `limits.requiresDimensionsMultipleOf` from a resolved manifest entry, else
@@ -560,6 +646,283 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Every video model in the SHIPPED `builtin.models.jsonc`, keyed by id, with the geometry
+    /// its ENGINE actually enforces — derived from the runtime source, NOT read back from the
+    /// manifest. That independence is the whole point: this table is the expectation, the
+    /// manifest is the thing under test, so a manifest edit that drifts from engine truth
+    /// fails here instead of shipping.
+    ///
+    /// `multiple` — the divisibility the engine checks (`is_multiple_of` on candle,
+    /// `align_dim` rounding on mlx). `None` = declares nothing, inherits the 32 default.
+    /// `max_pixels` — the engine's area cap; `None` = neither backend caps, so the manifest
+    /// must NOT invent one.
+    ///
+    /// Where the backends disagree the table carries the STRICTER side, because one manifest
+    /// serves both:
+    /// * `wan_2_2_t2v_14b`  — candle errors (`wan14b.rs:645`); mlx `max_area: 0`, uncapped.
+    /// * `wan_2_2_vace_fun_14b` — candle errors (`model_vace.rs:298`); mlx uncapped (`:107`).
+    /// * `bernini`  — candle errors (`candle-gen-bernini/src/config.rs:164`); mlx calls
+    ///   `align_dim` directly and never caps.
+    /// * `scail2_14b` — candle errors (`candle-gen-scail2/src/pipeline.rs:294`); mlx uncapped.
+    /// * `wan_2_2` (TI2V-5B) — the reverse: mlx caps + silently rescales
+    ///   (`config.rs:293`); candle's 5B `validate` (`lib.rs:328`) has NO area check.
+    /// * `wan_2_2_i2v_14b` — the only agreement, and even there candle errors while mlx
+    ///   rescales.
+    /// * `ltx_2_3` / `ltx_2_3_eros` / `svd` / `mochi_1` — zero area checks in either backend.
+    const ENGINE_GEOMETRY: &[(&str, Option<u32>, Option<u64>)] = &[
+        ("ltx_2_3", Some(64), None),
+        ("ltx_2_3_eros", Some(64), None),
+        ("svd", Some(64), None),
+        ("mochi_1", Some(16), None),
+        ("wan_2_2", None, Some(901_120)),
+        ("wan_2_2_t2v_14b", Some(16), Some(901_120)),
+        ("wan_2_2_i2v_14b", Some(16), Some(901_120)),
+        ("wan_2_2_vace_fun_14b", Some(16), Some(901_120)),
+        ("bernini", Some(16), Some(901_120)),
+        ("scail2_14b", None, Some(901_120)),
+    ];
+
+    /// The `models` array of the SHIPPED manifest — the exact bytes the app embeds and seeds.
+    fn builtin_video_models() -> Vec<Value> {
+        let raw = crate::builtin_manifests::BUILTIN_MANIFESTS
+            .iter()
+            .find(|(name, _)| *name == "builtin.models.jsonc")
+            .map(|(_, contents)| *contents)
+            .expect("builtin.models.jsonc present");
+        let manifest: Value =
+            serde_json::from_str(&crate::jsonc::strip_jsonc_comments(raw)).expect("parses as JSON");
+        manifest
+            .get("models")
+            .and_then(Value::as_array)
+            .expect("models array")
+            .iter()
+            .filter(|m| m.get("type").and_then(Value::as_str) == Some("video"))
+            .cloned()
+            .collect()
+    }
+
+    /// sc-12294 — the invariant this story exists to establish, asserted against the REAL
+    /// manifest bytes rather than inline literals: **what a video model advertises is what it
+    /// renders, and everything it advertises is legal on its engine.**
+    ///
+    /// The earlier revision of this suite hardcoded the manifest values it claimed to verify
+    /// (`"limits": { "requiresDimensionsMultipleOf": 16 }` written straight into the payload),
+    /// so it only re-tested `normalized_dimensions`' arithmetic — reverting bernini's manifest
+    /// declaration to 32 (restoring the original sc-12294 bug) left the whole suite GREEN.
+    /// This test loads the shipped manifest and checks it against [`ENGINE_GEOMETRY`], so that
+    /// mutation is RED.
+    #[test]
+    fn shipped_manifest_matches_each_engines_real_geometry() {
+        let models = builtin_video_models();
+        assert_eq!(
+            models.len(),
+            ENGINE_GEOMETRY.len(),
+            "a video model was added/removed; derive its stride + area cap from its engine \
+             source and add it to ENGINE_GEOMETRY — do not blanket-apply"
+        );
+
+        for (id, want_multiple, want_max_pixels) in ENGINE_GEOMETRY {
+            let entry = models
+                .iter()
+                .find(|m| m.get("id").and_then(Value::as_str) == Some(*id))
+                .unwrap_or_else(|| panic!("{id} present in builtin.models.jsonc"))
+                .as_object()
+                .expect("model entry object");
+            let limits = entry
+                .get("limits")
+                .and_then(Value::as_object)
+                .unwrap_or_else(|| panic!("{id} has limits"));
+
+            // 1. The manifest declares exactly the stride the engine enforces.
+            let declared = limits
+                .get("requiresDimensionsMultipleOf")
+                .and_then(Value::as_u64)
+                .map(|m| m as u32);
+            assert_eq!(
+                declared, *want_multiple,
+                "{id}: manifest stride disagrees with its engine's divisibility check"
+            );
+            // ...and the effective floor is what the geometry will actually apply.
+            assert_eq!(
+                dimension_multiple_of(entry),
+                want_multiple.unwrap_or(DEFAULT_DIMENSION_MULTIPLE),
+                "{id}: effective dimension multiple"
+            );
+
+            // 2. The manifest declares an area cap exactly where an engine has one. A model
+            //    with no engine cap must not invent one.
+            assert_eq!(
+                limits.get("maxPixels").and_then(Value::as_u64),
+                *want_max_pixels,
+                "{id}: manifest area cap disagrees with its engine's max-area check"
+            );
+            assert_eq!(
+                max_pixels_of(entry),
+                *want_max_pixels,
+                "{id}: effective max pixels"
+            );
+
+            // 3. Every advertised bucket AND the shipped default is a FIXED POINT of the
+            //    geometry — advertise 848x480 and 848x480 is what renders — and fits the cap.
+            let buckets = limits
+                .get("resolutions")
+                .and_then(Value::as_array)
+                .unwrap_or_else(|| panic!("{id} advertises resolutions"));
+            let default_res = entry
+                .get("defaults")
+                .and_then(Value::as_object)
+                .and_then(|d| d.get("resolution"))
+                .and_then(Value::as_str)
+                .unwrap_or_else(|| panic!("{id} has a default resolution"));
+            assert!(
+                buckets.iter().any(|b| b.as_str() == Some(default_res)),
+                "{id}: default {default_res} is not one of its advertised buckets"
+            );
+
+            for advertised in buckets
+                .iter()
+                .map(|b| b.as_str().expect("resolution is a string"))
+                .chain(std::iter::once(default_res))
+            {
+                let (w, h) = advertised
+                    .split_once('x')
+                    .map(|(w, h)| (w.parse::<u32>().unwrap(), h.parse::<u32>().unwrap()))
+                    .unwrap_or_else(|| panic!("{id}: malformed resolution {advertised}"));
+
+                let request = VideoRequest::from_payload(&payload(json!({
+                    "projectId": "p", "model": *id, "width": w, "height": h,
+                    "modelManifestEntry": Value::Object(entry.clone()),
+                })));
+                assert_eq!(
+                    (request.width, request.height),
+                    (w, h),
+                    "{id} advertises {advertised}; it must render {advertised}"
+                );
+                if let Some(cap) = want_max_pixels {
+                    assert!(
+                        (w as u64) * (h as u64) <= *cap,
+                        "{id}: advertised {advertised} exceeds its engine's area cap {cap}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// sc-12294 BLOCKER — the case the dropdown never produces but every raw path does.
+    ///
+    /// `1280x720` was the shipped `defaults.resolution` of the A14B T2V/I2V entries, so it is
+    /// the single most common stored value. On `main` a blanket ÷32 floored it to 1280x704 (=
+    /// the cap exactly) by accident. Declaring ÷16 removes that accidental protection — so the
+    /// cap must be enforced, or job retry / MCP / `POST /api/v1/jobs` / preset replay would
+    /// hand candle a hard error and mlx a silent rescale.
+    ///
+    /// Driven through the REAL manifest entries, but judged against [`ENGINE_GEOMETRY`] — the
+    /// engine's truth, never the manifest's own claim. Reading the cap back out of the entry
+    /// would make this vacuous exactly when it matters: delete a `maxPixels` and the area
+    /// assertion would simply stop running. Judged independently, a deleted cap is RED here.
+    #[test]
+    fn stored_720p_is_legal_on_every_video_model() {
+        for model in builtin_video_models() {
+            let entry = model.as_object().expect("model entry object");
+            let id = entry.get("id").and_then(Value::as_str).expect("id");
+            let (_, want_multiple, want_max_pixels) = ENGINE_GEOMETRY
+                .iter()
+                .find(|(known, _, _)| known == &id)
+                .unwrap_or_else(|| panic!("{id} covered by ENGINE_GEOMETRY"));
+
+            let request = VideoRequest::from_payload(&payload(json!({
+                "projectId": "p", "model": id, "width": 1280, "height": 720,
+                "modelManifestEntry": model.clone(),
+            })));
+
+            let multiple = want_multiple.unwrap_or(DEFAULT_DIMENSION_MULTIPLE);
+            assert_eq!(
+                (request.width % multiple, request.height % multiple),
+                (0, 0),
+                "{id}: stored 1280x720 -> {}x{} is off the ÷{multiple} lattice its engine checks",
+                request.width,
+                request.height
+            );
+            if let Some(cap) = want_max_pixels {
+                assert!(
+                    (request.width as u64) * (request.height as u64) <= *cap,
+                    "{id}: stored 1280x720 -> {}x{} = {} px exceeds the engine cap {cap} — \
+                     candle would hard-error and mlx would silently rescale",
+                    request.width,
+                    request.height,
+                    (request.width as u64) * (request.height as u64)
+                );
+            }
+        }
+    }
+
+    /// The fit is a port of mlx's `best_output_size`, and this pins it to the value the
+    /// engine's OWN test pins (`mlx-gen-wan/src/pipeline.rs:1510`): `best_output_size(1280,
+    /// 720, 16, 16, 704*1280) == (1264, 704)`. If the two ever diverge, the app stops agreeing
+    /// with the backend that silently rescales — which is the whole reason to port rather than
+    /// invent a fit.
+    #[test]
+    fn area_fit_matches_the_mlx_engines_own_pinned_value() {
+        assert_eq!(fit_to_max_pixels(1280, 720, 16, 901_120), (1264, 704));
+
+        // Aspect-preserving and grid-aligned, and it only ever shrinks.
+        let (w, h) = fit_to_max_pixels(1280, 720, 16, 901_120);
+        assert!((w as u64) * (h as u64) <= 901_120, "fits the cap");
+        assert_eq!((w % 16, h % 16), (0, 0), "lands on the declared lattice");
+        assert!(w <= 1280 && h <= 720, "never upscales");
+        let (orig, fitted) = (1280.0 / 720.0, w as f64 / h as f64);
+        assert!(
+            (orig - fitted).abs() / orig < 0.05,
+            "aspect preserved within 5%: {orig} vs {fitted}"
+        );
+
+        // An at-cap request is untouched: the engines check `>`, so 901,120 exactly passes.
+        assert_eq!(1280 * 704, 901_120);
+        let at_cap = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "model": "wan_2_2_i2v_14b", "width": 1280, "height": 704,
+            "modelManifestEntry": { "limits": { "requiresDimensionsMultipleOf": 16, "maxPixels": 901_120 } }
+        })));
+        assert_eq!((at_cap.width, at_cap.height), (1280, 704));
+    }
+
+    /// A model that declares no `maxPixels` is UNCONSTRAINED — the default-absent behavior that
+    /// keeps every non-declaring model byte-identical to before the key existed. Also covers the
+    /// infallibility contract: a typo'd cap the geometry could never honor falls back to no cap
+    /// rather than emitting a degenerate size.
+    #[test]
+    fn absent_or_unhonorable_max_pixels_means_no_cap() {
+        // No `maxPixels` → 1280x720 floors on stride alone and is NOT area-fitted.
+        let uncapped = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "model": "mochi_1", "width": 1280, "height": 720,
+            "modelManifestEntry": { "limits": { "requiresDimensionsMultipleOf": 16 } }
+        })));
+        assert_eq!((uncapped.width, uncapped.height), (1280, 720));
+        assert!((uncapped.width as u64) * (uncapped.height as u64) > 901_120);
+
+        // Same entry + a cap → fitted. This is what makes the assertion above meaningful.
+        let capped = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "model": "mochi_1", "width": 1280, "height": 720,
+            "modelManifestEntry": { "limits": { "requiresDimensionsMultipleOf": 16, "maxPixels": 901_120 } }
+        })));
+        assert_eq!((capped.width, capped.height), (1264, 704));
+
+        // Unhonorable caps fall back to NO cap (never a degenerate size): the 256 floor means
+        // nothing under 256×256 is satisfiable.
+        for bad in [
+            json!(0),
+            json!(-1),
+            json!(1.5),
+            json!("901120"),
+            json!(65_535),
+        ] {
+            let entry = payload(json!({ "limits": { "maxPixels": bad } }));
+            assert_eq!(max_pixels_of(&entry), None, "unhonorable maxPixels {bad}");
+        }
+        // The smallest honorable cap is exactly the 256x256 floor.
+        let floor = payload(json!({ "limits": { "maxPixels": 65_536 } }));
+        assert_eq!(max_pixels_of(&floor), Some(65_536));
     }
 
     #[test]

--- a/crates/sceneworks-core/src/video_request.rs
+++ b/crates/sceneworks-core/src/video_request.rs
@@ -250,8 +250,10 @@ const DEFAULT_DIMENSION_MULTIPLE: u32 = 32;
 /// answer differed per model — the floor is not one number:
 ///
 /// * **16** — bernini and the Wan A14B trio (t2v / i2v / vace-fun) ride a z16 VAE:
-///   `patch 2 × vae_stride 8`. They now declare it, so bernini's own default 848x480 and
-///   the advertised 1280x720 stop silently rendering as 832x480 / 1280x704.
+///   `patch 2 × vae_stride 8`. They now declare it, so bernini's own default 848x480 stops
+///   silently rendering as 832x480. Their 720p buckets still move to 704, but for a
+///   different reason: the A14B **area** cap (704×1280 = 901,120 px), which candle
+///   hard-errors on and mlx i2v silently rescales for — not the stride.
 /// * **32** — the dense Wan TI2V-5B (z48 vae22, `vae_stride 16`) and scail2 (hardcoded
 ///   `DIM_ALIGN`) genuinely need it. There the *advertisement* was wrong, so their 720p
 ///   buckets were corrected to the 704 they always rendered; both keep this default.
@@ -453,8 +455,11 @@ mod tests {
         })));
         assert_eq!((bernini.width, bernini.height), (848, 480));
 
-        // The 720p bucket is real for every ÷16 model (720 = 16·45): bernini + the Wan A14B
-        // trio all advertised 1280x720 while rendering 1280x704.
+        // A finer floor is NOT a licence to advertise 720p. The A14B family (bernini + the
+        // Wan trio) is capped by AREA, not stride: candle hard-errors above MAX_AREA_14B
+        // (704×1280 = 901,120 px) and mlx i2v silently rescales 1280×720 → 1264×704. So
+        // 1280x704 — exactly AT the cap — is the real 1280-wide bucket, and it must survive
+        // the ÷16 floor untouched.
         for model in [
             "bernini",
             "wan_2_2_t2v_14b",
@@ -462,13 +467,31 @@ mod tests {
             "wan_2_2_vace_fun_14b",
         ] {
             let req = VideoRequest::from_payload(&payload(json!({
-                "projectId": "p", "model": model, "width": 1280, "height": 720,
+                "projectId": "p", "model": model, "width": 1280, "height": 704,
                 "modelManifestEntry": { "limits": { "requiresDimensionsMultipleOf": 16 } }
             })));
             assert_eq!(
                 (req.width, req.height),
-                (1280, 720),
-                "{model} must keep 1280x720"
+                (1280, 704),
+                "{model} must keep its at-cap 1280x704 bucket"
+            );
+            assert!(
+                (req.width as usize) * (req.height as usize) <= 704 * 1280,
+                "{model} bucket must fit MAX_AREA_14B"
+            );
+
+            // Every A14B advertised bucket is ÷32, so the at-cap check above holds under
+            // either floor. What the declared 16 actually buys is a CUSTOM dim below the
+            // cap: 848 survives at ÷16 and would be cut to 832 at ÷32. This is the
+            // assertion that makes the declaration load-bearing for the Wan trio.
+            let custom = VideoRequest::from_payload(&payload(json!({
+                "projectId": "p", "model": model, "width": 848, "height": 480,
+                "modelManifestEntry": { "limits": { "requiresDimensionsMultipleOf": 16 } }
+            })));
+            assert_eq!(
+                (custom.width, custom.height),
+                (848, 480),
+                "{model} declares 16, so a custom 848x480 must not be cut to 832"
             );
         }
 
@@ -494,12 +517,22 @@ mod tests {
             (
                 "bernini",
                 16,
-                vec![(848, 480), (480, 848), (1280, 720), (720, 1280)],
+                vec![(848, 480), (480, 848), (1280, 704), (704, 1280)],
             ),
             (
                 "wan_2_2_t2v_14b",
                 16,
-                vec![(832, 480), (480, 832), (1280, 720), (720, 1280)],
+                vec![(832, 480), (480, 832), (1280, 704), (704, 1280)],
+            ),
+            (
+                "wan_2_2_i2v_14b",
+                16,
+                vec![(832, 480), (480, 832), (1280, 704), (704, 1280)],
+            ),
+            (
+                "wan_2_2_vace_fun_14b",
+                16,
+                vec![(832, 480), (480, 832), (1280, 704), (704, 1280)],
             ),
             (
                 "ltx_2_3",


### PR DESCRIPTION
## sc-12294 — what a video model advertises is what it renders, and what it renders is legal

Every video model's dimension stride was swept against its engine's real constraint. The answer differs per model — the floor is not one number — and two of the story's premises turned out to be false.

### The strides

| model | stride | engine evidence |
|---|---|---|
| `bernini`, `wan_2_2_t2v_14b`, `wan_2_2_i2v_14b`, `wan_2_2_vace_fun_14b` | **16** | z16 VAE, `patch 2 × vae_stride 8`. candle `SIZE_MULTIPLE_14B = 16` via `is_multiple_of`; mlx `align_dim(patch, vae_stride)` |
| `wan_2_2` (TI2V-5B), `scail2_14b` | **32** (default, undeclared) | 5B z48 vae22 `vae_stride 16` → candle `SIZE_MULTIPLE = 32`; scail2 mlx `DIM_ALIGN = 32` |
| `ltx_2_3`, `ltx_2_3_eros`, `svd` | **64** | ltx `validate_request` hard-errors below ÷64 (stage-1 runs at `//2//32`); svd `SIZE_ALIGN = VAE_SCALE * 8` |
| `mochi_1` | **16** | unchanged (sc-11993) |

A declared value can be **looser or stricter** than the 32 default — it is the engine's truth, not a policy. The declared 32 on ltx was too *loose*: it could floor onto a ÷32-but-not-÷64 size the engine then rejects.

`848x480` on bernini — its own default — was silently rendering as `832x480`, invisibly, because `832 % 16 == 0` satisfies the engine's own check. That is the original bug.

### Declaring the stride removes a protection — so this PR replaces it

Declaring ÷16 is correct, but on its own it would have **regressed shipping users**. Nothing in the app validates a resolution against `limits.resolutions`; `validate_dimension` is a bare `256..=1920` range check. The blanket ÷32 floor was the *only* thing keeping a stored `1280x720` under the engines' 901,120 px area cap — it floored to `1280x704`, the cap exactly, by accident.

`1280x720` was the shipped `defaults.resolution` of `wan_2_2_t2v_14b`, `wan_2_2_i2v_14b` and `wan_2_2` until this PR, making it the single most common stored value. Paths that supply raw dims and never touch the dropdown are all live: job **retry/duplicate** (replays the payload verbatim), **MCP** `submit_video_job`, `POST /api/v1/jobs`, and **recipe-preset** replay.

So this PR adds **`limits.maxPixels`** and fits into it in `normalized_dimensions` — aspect-preserving and grid-aligned, a direct port of the mlx engine's `best_output_size`, pinned to the value the engine's own test pins: `best_output_size(1280, 720, 16, 16, 704*1280) == (1264, 704)`. The app now hands both backends the geometry mlx would have produced: legal on candle, a no-op on mlx.

### Which models get a cap, and why

Derived per model from the runtime source — **not blanket-applied**. Where the backends disagree the manifest carries the **stricter** side, so one manifest serves both:

| model | candle | mlx | `maxPixels` |
|---|---|---|---|
| `wan_2_2_t2v_14b` | errors `> MAX_AREA_14B` | `max_area: 0`, never caps | 901120 (candle) |
| `wan_2_2_i2v_14b` | errors | caps + silently rescales | 901120 (both, disagree on *how*) |
| `wan_2_2_vace_fun_14b` | errors | explicitly uncapped | 901120 (candle) |
| `bernini` | errors | calls `align_dim` directly, bypasses the cap | 901120 (candle) |
| `scail2_14b` | errors (`reject_over_area`) | no area check | 901120 (candle) |
| `wan_2_2` (TI2V-5B) | **no area check at all** | caps + rescales | 901120 (**mlx** — the reverse case) |
| `ltx_2_3`, `ltx_2_3_eros`, `svd`, `mochi_1` | none | none | **none** — no engine cap, so none invented |

The check is `>`, so `1280x704 = 901,120` passes exactly. **Default-absent is no cap**: a model that declares nothing is unconstrained.

### Stored `1280x720`, per model, per backend

| | on `main` | this PR |
|---|---|---|
| `ltx_2_3` / `ltx_2_3_eros` / `svd` | 1280x704 | 1280x704 — uncapped, ÷64 |
| `wan_2_2` / `scail2_14b` | 1280x704 | 1280x704 — 901,120 px = cap exactly |
| `wan_2_2_t2v_14b` / `i2v_14b` / `vace_fun_14b` / `bernini` | 1280x704 | **1264x704** — 889,856 px, fitted |
| `mochi_1` | 1280x720 | 1280x720 — uncapped |

Legal on every model on both backends. Without `maxPixels` these four would have shipped `1280x720` = 921,600 px: a **hard error on candle** (all four ship `windows`/`linux` downloads) and a **silent rescale on mlx**.

⚠️ **One deliberate behavior change worth a look:** for those four models a stored `1280x720` now yields `1264x704` where `main` gave `1280x704`. Both are legal; `1264x704` is what mlx's `best_output_size` produces (better aspect fidelity to the 16:9 request — 1.795 vs 1.818), and matching it is what makes the two backends agree. But it is slightly smaller than `main` and is **not** one of the advertised buckets. Bucket-snapping to `1280x704` instead would also be legal on both and would preserve `main`'s exact output — happy to switch if that is preferred. The dropdown path is unaffected either way; only legacy replay of a stored `1280x720` is touched.

### Tests

The previous revision of this suite **hardcoded the manifest values it claimed to verify**, so it only re-tested `normalized_dimensions`' arithmetic — reverting bernini's declaration to 32 (restoring the original bug) left it green. Replaced with a test that loads the **real** `builtin.models.jsonc` and checks it against a table of engine truth (`ENGINE_GEOMETRY`), derived from the runtime source and independent of the manifest. Per video model it asserts the declared stride, the declared cap, and that every advertised bucket **and the shipped default** is a fixed point that fits the cap.

**Manifest mutations (not test literals) — both RED:**

| mutation | result |
|---|---|
| bernini stride `16 → 32` (restores the sc-12294 bug) | 🔴 `bernini: manifest stride disagrees with its engine's divisibility check — left: Some(32), right: Some(16)` |
| remove a `maxPixels` | 🔴 **two** tests: `manifest area cap disagrees with its engine's max-area check` and `stored 1280x720 -> 1280x720 = 921600 px exceeds the engine cap 901120` |

The `DEFAULT_DIMENSION_MULTIPLE` 32→16 mutation remains genuine (`left: 528 right: 512`), so the default-32 path stays pinned.

### Verification — derived, not rendered

**No render validation was performed.** These are 14B models; real weights and GPU time were out of reach. Everything below is derived from the runtime source and exercised through the real code and the real manifest. No claim here rests on an observed render.

- **Exhaustive differential sweep** — 10 models × `0..=2200` × `0..=2200` = **48.4M inputs**, `main` vs this PR. The "before" side is exact rather than a replication: this PR leaves `clamped_u32` / `floor_to_multiple` / `dimension_multiple_of` byte-identical, so main's geometry is those same helpers fed main's manifest entry.

| model | swept | changed | before ILLEGAL | after ILLEGAL |
|---|---|---|---|---|
| `ltx_2_3` | 4844401 | 2970240 | 2970240 | **0** |
| `ltx_2_3_eros` | 4844401 | 2970240 | 2970240 | **0** |
| `svd` | 4844401 | 2970240 | 2970240 | **0** |
| `wan_2_2` | 4844401 | 2356657 | 2356657 | **0** |
| `wan_2_2_t2v_14b` | 4844401 | 3812753 | 2356657 | **0** |
| `wan_2_2_i2v_14b` | 4844401 | 3812753 | 2356657 | **0** |
| `wan_2_2_vace_fun_14b` | 4844401 | 3812753 | 2356657 | **0** |
| `bernini` | 4844401 | 3812753 | 2356657 | **0** |
| `scail2_14b` | 4844401 | 2356657 | 2356657 | **0** |
| `mochi_1` | 4844401 | 0 | 0 | **0** |
| **total** | **48,444,010** | 28,875,046 | **23,050,662** | **0** |

  Legality is judged against engine truth (stride + cap), independent of both manifests. `main` produced 23M engine-illegal results; this PR produces none. `mochi_1` is untouched.

- **Default-absent byte-identity** — the new code run against **main's** manifest (which declares no `maxPixels` anywhere) drifts on **0 of 48,444,010** inputs. This isolates the code change from the manifest change and proves the cap step can never fire on a non-declaring model.

- **`cargo test -p sceneworks-core`** 479 passed / 0 failed · **`cargo test -p sceneworks-worker --lib`** 820 passed / 0 failed · **`npm run rust:check`** clean.

### Also

`min_size` was cited as stride evidence throughout the doc comments, but gen-core checks `req.width < self.min_size` — a lower **bound**, not a lattice. Every stride conclusion is independently corroborated and unchanged; the citations now point at `SIZE_MULTIPLE_14B` / `align_dim` / `is_multiple_of` and demote `min_size` to corroborating convention. Comments only.

Deferred: `sc-12308` tracks the candle-vs-mlx reconciliation (candle hard-errors where mlx silently rescales). This PR does not depend on it — `maxPixels` means neither backend's cap is reached.


---

## Review round 3 — the fallback catalog (`ad1c3b8f`)

**Major: the hand-mirrored `fallbackModels` catalog still advertised the retired `1280x720`.** The manifest and `video_request.rs` were fixed, but `apps/web/src/constants.js` is a hand-mirrored copy and was left stale — and it is **live, not dead code**: `App.jsx:823` serves it to the real Video Studio picker whenever the catalog has not loaded. Geometry stayed legal (`maxPixels` doing its job), but the picker advertised `1280x720` while the engine rendered `1264x704` — a milder instance of the precise bug this story exists to kill. The earlier manifest test is manifest-only and structurally cannot see this file.

### Fixed — six video entries realigned to the manifest

| Entry | `resolutions` | `defaults.resolution` |
|---|---|---|
| `ltx_2_3` | `1280x720`/`720x1280` → `1280x704`/`704x1280` | unchanged (`768x512`) |
| `ltx_2_3_eros` | `1280x720`/`720x1280` → `1280x704`/`704x1280` | unchanged (`768x512`) |
| `wan_2_2` | `1280x720`/`720x1280` → `1280x704`/`704x1280` | `832x480` → **`1280x704`** (see below) |
| `wan_2_2_t2v_14b` | `1280x720`/`720x1280` → `1280x704`/`704x1280` | `1280x720` → **`1280x704`** |
| `wan_2_2_i2v_14b` | `1280x720`/`720x1280` → `1280x704`/`704x1280` | `1280x720` → **`1280x704`** |
| `wan_2_2_vace_fun_14b` | `1280x720`/`720x1280` → `1280x704`/`704x1280` | unchanged (`832x480`) |

`svd` already matched. All **7** video entries (incl. `svd`) now match the manifest exactly, verified programmatically. The one remaining `1280x720` in `constants.js` is `chroma1_hd` — an **image** model, no video area cap, correctly untouched.

### The durable part — `apps/web/src/videoGeometryParity.test.js`

A sibling of `controlModesParity.test.js` (the existing precedent guarding this same mirror, which notes *"Nothing stops that mirror from silently drifting from the manifest"*). It reads the **real** manifest via JSON5 and pins:

1. **Forward parity** — every `fallbackModels` video entry's `resolutions` + `defaults.resolution` match the manifest (order included; the picker renders in order).
2. **Reverse parity** — a manifest video model the mirror carries must not diverge (models absent from the seed list are skipped, per the sibling's convention).
3. **A manifest-independent guard** — every advertised bucket must be on the 32px stride and inside the model's own `maxPixels`. This fails loudly even if someone "fixes" the manifest to match a stale mirror rather than the other way round.
4. A non-vacuity check that the fallback video list is non-empty.

**Mutation-proven.** Reintroducing `1280x720` into `wan_2_2_t2v_14b` → **exit 1, 3/10 tests fail**:

```
× constants.js wan_2_2_t2v_14b mirrors the manifest resolutions + default resolution
× no video entry advertises a bucket the area cap would floor (sc-12294)
× every manifest video model present in fallbackModels mirrors its geometry

AssertionError: wan_2_2_t2v_14b advertises 1280x720, which is not a multiple of the
32px stride — the engine cannot render it as advertised
```
Reverted → 10/10 pass, exit 0.

### 🔎 Found in passing: sc-4997's fast-path default never shipped (filed as sc-12319)

The parity test immediately earned its keep. `wan_2_2`'s mirror said `832x480` (citing sc-4997's measured *~5 min vs ~20 min*) while the manifest said 720p. Cause: **sc-4997 (`580436a7`) changed only `constants.js` + `video_jobs.rs` and never touched `builtin.models.jsonc`.** The manifest is authoritative once the catalog loads, so **that fast-path default has never actually applied** — every real `wan_2_2` render has defaulted to 720p. This test would have caught it at merge time.

This PR realigns the mirror to what the app **actually does** (truthful mirror = this PR's remit) and does **not** decide the product question. Whether the manifest should adopt sc-4997's 832x480 is filed as **sc-12319**, with the rationale preserved in a comment.

### Doc fixes (comments only — zero behavior delta)

- **`fit_to_max_pixels`** — the claim that the `.max(d)` clamps "cannot fire — a cap below 256×256 is rejected by `max_pixels_of`" was **not sound**. `MIN_HONORABLE_MAX_PIXELS = 65536` only guarantees a *square* 256×256 fits; a cap of exactly 65,536 **passes the filter** yet fits 1920×256 to **(688, 80)** at stride 16 (**(640, 64)** at stride 64) — violating the 256 floor and every engine's `min_size`. Reworded to "cannot fire for any **shipped** cap", with the actual reason: `normalized_dimensions` clamps inputs to `[256, 1920]`, so the ratio cannot exceed 7.5, and at the only declared cap (901,120) the smaller ideal dimension is `√(901120/7.5) ≈ 346`. The guarantee comes from the shipped caps, **not** the filter — noted explicitly since it matters if a cap below ~491,520 is ever added.
- **`ENGINE_GEOMETRY`** — "zero area checks in either backend" was wrong for LTX. Verified at the **pinned** rev (`runtime-2026.07.6`, `b2974970`): `candle-gen-ltx/src/lib.rs:454` caps `t_lat·h_lat·w_lat > 131_072`. The decision stands — it is a **frames×area** constraint, outside `maxPixels`' scope (a pure per-frame area budget with no frame term), unreachable within the advertised limits (~25k of 131,072 worst case), and candle-LTX registers `ltx_2_3_distilled`, a different id. Reworded to say that accurately.

### Verification

- **Sweep unchanged** — `config/manifests/builtin.models.jsonc` is **byte-identical** to the previous round (`git diff 26c6923d` empty), and the Rust diff is **comment-only** (verified: zero non-comment lines changed), so the differential sweep is provably identical. `constants.js` is web-only.
- **`cargo test -p sceneworks-core`** 675 passed / 0 failed (incl. all 20 `video_request` tests) · **`npm run rust:check`** exit 0 · **eslint** exit 0.
- **New web test isolated by name**: 10/10 pass, exit 0. The `apps/web` full suite shows 909 pre-existing failures from the known worktree `node_modules` artifact — the failure set is **byte-identical to clean `main`** (same 82 files by name, 909 failed on both); passing tests go **917 → 927**, exactly the 10 added. Nothing else perturbed; no unrelated failures touched.
