### PR TITLE
feat(worker): run Mochi 1 video jobs — both backends, tier dirs, fit gate (sc-11992)

### DIFF
--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -330,6 +330,15 @@ mod pid_tier_mlx_smoke;
 // the already-packed weights (packed-detected) and bf16 loads dense (Quant::None).
 #[cfg(all(test, target_os = "macos"))]
 mod sana_mlx_smoke;
+// Real-weight MLX smoke for the Mochi 1 quant-matrix video lane (epic 1788, sc-11992). macOS-only;
+// drives `crate::inference_runtime::load("mochi_1")` with a per-tier LoadSpec against the
+// pre-quantized q4/q8 + dense bf16 tier subdirs of the SceneWorks/mochi-1-mlx turnkey. On-device
+// evidence that the worker tier path loads (`WeightsSource::Dir` = the TIER dir, with the shared
+// T5-XXL/tokenizer/AsymmVAE resolved from that dir's PARENT — the A6 sibling layout) and renders a
+// non-degenerate, MOVING clip at every downloaded tier, with monotonic progress that reaches decode
+// (the video job lane has no background heartbeat during a generation).
+#[cfg(all(test, target_os = "macos"))]
+mod mochi_mlx_smoke;
 // On-device per-tier memory-footprint measurement harness (sc-8516, epic 8506). Test-only + macOS-only;
 // #[ignore]d real-weight smokes that drive `crate::inference_runtime::load(id)` + ONE generation while sampling the MLX
 // process-global memory counters (mlx_rs::memory::{reset_peak_memory, get_active_memory, get_peak_memory})

--- a/crates/sceneworks-worker/src/mlx_fit_gate.rs
+++ b/crates/sceneworks-worker/src/mlx_fit_gate.rs
@@ -341,6 +341,214 @@ fn sysctl_total_unified_memory_gib() -> Option<f64> {
     None
 }
 
+// ---------------------------------------------------------------------------------------------
+// Mochi 1: the FRAME-DEPENDENT decode fit gate (epic 1788 / sc-11992)
+// ---------------------------------------------------------------------------------------------
+//
+// Why Mochi needs its own gate rather than riding the generic one above:
+//
+//  1. The generic gate is deliberately RESOLUTION-BLIND. `predicted_peak_gb` = Σweights +
+//     HEADROOM_GB, where HEADROOM_GB is a 1024²-calibrated CONSTANT — the load-time seam cannot see
+//     the request geometry (the generator is cached across resolutions, see the HEADROOM_GB note).
+//     That structure is right for image models, whose transient is roughly request-independent once
+//     calibrated. It is WRONG for Mochi: its AsymmVAE decode is UNTILED (`vae.decode(latents)`
+//     materializes the whole clip — sc-12291), so the peak grows LINEARLY IN CLIP LENGTH. A 7-frame
+//     and a 151-frame request differ by ~55 GiB on the same model. A constant cannot express that.
+//
+//  2. Mochi's `supports_sequential_offload: false` ⇒ `weights_fit_floor` admits on WEIGHTS ALONE
+//     (18.73 GiB fits almost any Mac), so the generic gate would happily admit a 151-frame job that
+//     then needs ~79 GiB. The floor is correct for its own purpose (sc-12179: never wall-reject a
+//     machine that used to work) but it is precisely what makes the generic gate unable to protect
+//     Mochi.
+//
+//  3. This MUST be a pre-flight rejection, not a caught error. MLX's default error handler is
+//     `exit(-1)` — a hard process kill (sc-12178/12179, GitHub #1544). An `exit(-1)` cannot be
+//     mapped to a job error after the fact, so the only place to honor the epic's "actionable error,
+//     not a crash" AC is BEFORE the decode allocates.
+//
+// The gate is therefore a per-REQUEST admission check (it sees frames + geometry), layered beside —
+// not inside — the generic per-LOAD one, and it budgets on a DERIVED architectural formula rather
+// than a calibration constant, because nothing has been measured on-device yet (B5/sc-11995 backfills
+// `footprint.residentMemoryBytes`/`peakMemoryBytes`; sc-12291 tiles the decode and should then cut
+// the frame term sharply).
+
+/// The AsymmVAE decoder's final-stage channel count — `decoder_block_out_channels[0]` (config
+/// default `[128, 256, 512, 768]`). The last `block_out` mid-block runs THIS many channels at FULL
+/// output resolution, which is the decode's peak stage: every earlier stage is either fewer pixels
+/// (pre-upsample) or, at 256/512/768 channels, at 1/4/1/16/1/64 of the spatial extent, so their
+/// products are strictly smaller.
+const MOCHI_DECODE_CHANNELS: f64 = 128.0;
+
+/// Bytes per element in the MLX AsymmVAE decode. **f32 (4), NOT bf16 (2)** — `MochiVaeDecoder::
+/// from_weights` pins `Dtype::Float32` and `decode_denormalized` casts the latent to that dtype, so
+/// the whole decode flows f32 ("the reference decode ran bf16 — the parity residual reflects that
+/// bf16 rounding", mlx-gen-mochi/src/vae.rs).
+///
+/// ⚠️ This DELIBERATELY disagrees with the sc-12291 / B1-manifest derivation, which assumed **bf16**
+/// (`128 × 156 × 480 × 848 × 2 B`) and therefore under-predicts the real MLX peak by 2×. Surfaced as
+/// a follow-up on sc-12291 — that story's table (19→7, 61→19, 151→45 GiB) and B1's
+/// `mlx.minMemoryGb: 96` are both bf16-derived and want re-deriving against the shipped f32 decode.
+/// This gate uses the dtype the code actually runs.
+const MOCHI_DECODE_BYTES_PER_ELEM: f64 = 4.0;
+
+/// Full-resolution tensors live simultaneously at the decode peak. `MochiResnetBlock3D` is
+/// `GroupNorm → silu → CausalConv3d → GroupNorm → silu → CausalConv3d → + residual`, so the residual
+/// and the in-flight intermediate are both live across the block — the "residual + intermediate live
+/// at once" claim B1's manifest derivation makes. B1 then hedged "2–3×"; 2 is the concrete,
+/// defensible liveness (3 assumes an extra un-freed temporary, which MLX's allocator need not hold).
+/// Combined with the f32 correction above this lands at ~79 GiB for the shipped 5 s / 151-frame
+/// default — consistent with B1's declared `mlx.minMemoryGb: 96` floor.
+const MOCHI_DECODE_LIVE_TENSORS: f64 = 2.0;
+
+/// Extra leading frames the causal decode materializes before `drop_last_temporal_frames` trims them:
+/// `temporal_ratio − 1` = 5. The peak is paid on the UNTRIMMED length, so a 151-frame clip decodes
+/// 156 frames wide.
+const MOCHI_DECODE_EXTRA_FRAMES: u32 = 5;
+
+/// Predicted AsymmVAE decode peak (GiB) for a `frames` × `width` × `height` clip.
+///
+/// `live × C × (frames + 5) × H × W × 4 B`. Linear in BOTH clip length and pixel count, because the
+/// peak tensor is `[1, C, T, H, W]` and the decode is untiled. This is the term the generic gate's
+/// flat `HEADROOM_GB` structurally cannot represent.
+///
+/// DERIVED, not measured. Sanity points at the native 848×480 bucket: 7 frames ⇒ ~5.0 GiB, 19 ⇒
+/// ~10.1, 61 ⇒ ~27.5, 151 ⇒ ~60.6, 163 ⇒ ~65.2 GiB.
+pub(crate) fn mochi_decode_peak_gb(frames: u32, width: u32, height: u32) -> f64 {
+    let decoded_frames = f64::from(frames.saturating_add(MOCHI_DECODE_EXTRA_FRAMES));
+    MOCHI_DECODE_LIVE_TENSORS
+        * MOCHI_DECODE_CHANNELS
+        * decoded_frames
+        * f64::from(width)
+        * f64::from(height)
+        * MOCHI_DECODE_BYTES_PER_ELEM
+        / BYTES_PER_GIB
+}
+
+/// Predicted whole-generation peak (GiB) for a Mochi request: the ALL-RESIDENT weights
+/// (`supports_sequential_offload: false` ⇒ T5-XXL + AsymmDiT + VAE are held for the whole run, so
+/// nothing drops) + the frame-dependent decode peak + [`OS_RESERVE_GB`]. `None` when the weights are
+/// unmeasurable (`weight_bytes == 0`) ⇒ no signal ⇒ the gate never blocks, matching
+/// [`predicted_peak_gb`].
+pub(crate) fn mochi_needed_gb(
+    weight_bytes: u64,
+    frames: u32,
+    width: u32,
+    height: u32,
+) -> Option<f64> {
+    (weight_bytes > 0).then(|| {
+        weight_bytes as f64 / BYTES_PER_GIB
+            + mochi_decode_peak_gb(frames, width, height)
+            + OS_RESERVE_GB
+    })
+}
+
+/// The pure Mochi admission decision: `Some(error)` when the predicted peak overflows the budget,
+/// `None` to admit. Missing either signal (unmeasurable weights / no budget) admits — the gate never
+/// blocks without evidence, exactly like [`fit_decision`].
+pub(crate) fn mochi_fit_error(
+    model_label: &str,
+    weight_bytes: u64,
+    frames: u32,
+    width: u32,
+    height: u32,
+    budget: Option<MemoryBudget>,
+) -> Option<WorkerError> {
+    let (needed_gb, budget) = (
+        mochi_needed_gb(weight_bytes, frames, width, height)?,
+        budget?,
+    );
+    (budget.total_gb + f64::EPSILON < needed_gb).then(|| {
+        mochi_too_big_error(
+            model_label,
+            needed_gb,
+            budget.total_gb,
+            frames,
+            width,
+            height,
+            weight_bytes as f64 / BYTES_PER_GIB,
+        )
+    })
+}
+
+/// Build Mochi's actionable over-budget rejection. Follows the [`too_big_error`] convention — name
+/// the model, explain the constraint ("unified memory"), state what it needs and what the machine
+/// has — and adds the lever that is UNIQUE to Mochi: the clip length. The generic message's advice
+/// ("choose a smaller quant tier, lower the resolution") is nearly useless here — Mochi has one
+/// trained bucket (848×480) and the decode dwarfs the tier delta (q4→bf16 is ~11 GiB against a
+/// ~60 GiB decode) — so the message leads with shortening the clip, which is the only lever that
+/// moves the dominant term.
+#[allow(clippy::too_many_arguments)]
+fn mochi_too_big_error(
+    model_label: &str,
+    needed_gb: f64,
+    available_gb: f64,
+    frames: u32,
+    width: u32,
+    height: u32,
+    weights_gb: f64,
+) -> WorkerError {
+    WorkerError::InvalidPayload(format!(
+        "{model_label} needs ~{needed} GB of unified memory to render a {frames}-frame \
+         {width}x{height} clip (~{weights} GB of weights, held resident for the whole run, plus an \
+         untiled VAE decode whose peak grows with clip length) but this machine has ~{available} \
+         GB. Shorten the clip — the decode peak scales roughly linearly with duration — or run on a \
+         Mac with more memory.",
+        needed = needed_gb.round() as i64,
+        available = available_gb.round() as i64,
+        weights = weights_gb.round() as i64,
+    ))
+}
+
+/// Live pre-flight Mochi admission check (the seam the worker's Mochi generation arm calls before
+/// loading). Resolves the same budget the generic gate uses — the real `sysctl hw.memsize` total,
+/// overridable by [`MLX_MEMORY_CAP_ENV`] so a small Mac can be emulated in tests — and sums the
+/// on-disk bytes the load will actually hold resident: the TIER dir (the AsymmDiT) plus the SHARED
+/// `text_encoder/` + `vae/` siblings, which the provider resolves from the tier dir's PARENT
+/// (`resolve_component_root`, mlx-gen-mochi/src/model.rs). Summing only the tier dir would miss the
+/// ~9.7 GiB T5-XXL + VAE — over half the resident footprint.
+///
+/// `Ok(())` admits (including whenever there is no signal); `Err` is the actionable pre-crash
+/// rejection.
+pub(crate) fn mochi_fit_check(
+    model_label: &str,
+    tier_dir: &Path,
+    frames: u32,
+    width: u32,
+    height: u32,
+) -> WorkerResult<()> {
+    let budget = resolve_budget(probe_total_unified_memory_gib(), mlx_memory_cap_gb());
+    match mochi_fit_error(
+        model_label,
+        mochi_resident_bytes(tier_dir),
+        frames,
+        width,
+        height,
+        budget,
+    ) {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
+}
+
+/// The on-disk bytes a Mochi load holds resident: the tier dir (AsymmDiT) + the shared `text_encoder/`
+/// and `vae/` components resolved from the tier dir's parent (the A6 shared-sibling layout). A
+/// self-contained dir — the raw snapshot, where the components live under the dir itself — is summed
+/// once, never double-counted, because the parent scan only adds SIBLING dirs of `tier_dir`.
+fn mochi_resident_bytes(tier_dir: &Path) -> u64 {
+    let mut total = sum_safetensors_bytes(tier_dir);
+    if let Some(parent) = tier_dir.parent() {
+        for component in ["text_encoder", "vae"] {
+            let dir = parent.join(component);
+            // Only count a shared sibling — a self-contained tier dir already summed its own
+            // components above (`sum_safetensors_bytes` recurses).
+            if dir.is_dir() && !tier_dir.join(component).is_dir() {
+                total += sum_safetensors_bytes(&dir);
+            }
+        }
+    }
+    total
+}
+
 /// The residency-selection outcome (sc-10839) — the pure decision, split from the [`LoadSpec`]/IO so
 /// the whole three-way selection is deterministically unit-testable without the live probe or the
 /// `MLX_MEMORY_CAP_ENV` global. See [`decide_residency`].
@@ -1209,5 +1417,182 @@ mod tests {
             decide_residency(total, te_footprint, budget, true),
             ResidencyOutcome::Sequential
         );
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Mochi 1 frame-aware decode gate (epic 1788 / sc-11992)
+    // -----------------------------------------------------------------------------------------
+
+    /// Mochi's q4 resident weights (GiB): DiT 9.007 + T5-XXL bf16 8.871 + VAE 0.856 = 18.73 (the
+    /// exact hosted bytes B1's manifest derivation pins). Used as the weight signal in the gate tests.
+    const MOCHI_Q4_RESIDENT_BYTES: u64 = 9_670_883_602 + 9_524_669_250 + 919_551_200;
+
+    /// The decode peak must scale with CLIP LENGTH — the whole reason Mochi cannot ride the generic
+    /// resolution-blind gate. Pins linearity in frames and in pixels, and the architectural anchor.
+    #[test]
+    fn mochi_decode_peak_scales_with_frames_and_pixels() {
+        // Strictly monotonic in frames.
+        let peaks: Vec<f64> = [7, 19, 61, 151, 163]
+            .iter()
+            .map(|f| mochi_decode_peak_gb(*f, 848, 480))
+            .collect();
+        for pair in peaks.windows(2) {
+            assert!(
+                pair[1] > pair[0],
+                "decode peak must grow with clip length: {peaks:?}"
+            );
+        }
+
+        // The architectural anchor: 2 live × 128 ch × (151+5) frames × 848×480 × 4 B (f32) = 60.55 GiB.
+        // This is the number a bf16 derivation would halve — pin it so the dtype can't silently drift.
+        let at_151 = mochi_decode_peak_gb(151, 848, 480);
+        assert!(
+            (at_151 - 60.55).abs() < 0.1,
+            "151-frame 848x480 decode peak should be ~60.6 GiB (f32), got {at_151:.2}"
+        );
+
+        // The 5 s default costs ~50 GiB MORE than the engine's 19-frame default on the same machine —
+        // the spread a flat HEADROOM_GB constant cannot express.
+        let at_19 = mochi_decode_peak_gb(19, 848, 480);
+        assert!(
+            at_151 - at_19 > 45.0,
+            "151 vs 19 frames must differ by tens of GiB (got {at_19:.1} → {at_151:.2})"
+        );
+
+        // Linear in pixel count: halving the height halves the peak.
+        let half = mochi_decode_peak_gb(151, 848, 240);
+        assert!(
+            (at_151 / 2.0 - half).abs() < 0.01,
+            "decode peak must be linear in pixels: {at_151:.2} vs {half:.2}"
+        );
+
+        // The causal decode pays for `temporal_ratio − 1` extra leading frames before they're
+        // trimmed, so the 1-frame floor is not free.
+        assert!(mochi_decode_peak_gb(1, 848, 480) > 0.0);
+    }
+
+    /// THE gate behavior: on ONE fixed machine, a short Mochi clip is admitted and a long one is
+    /// rejected. A frame-blind gate (the plausible wrong implementation — reusing `predicted_peak_gb`
+    /// or dropping the frames term) cannot pass this: it would give both clips the same verdict.
+    #[test]
+    fn mochi_gate_admits_a_short_clip_and_rejects_a_long_one_on_the_same_mac() {
+        // A 64 GB Mac — the machine B1's `mlx.minMemoryGb: 96` says is under-provisioned, and the one
+        // the epic's crash report names.
+        let mac_64 = Some(MemoryBudget { total_gb: 64.0 });
+
+        // 19 frames (the engine's own DEFAULT_FRAMES, ~0.6 s): 18.73 weights + 10.1 decode + 2 OS
+        // ≈ 30.8 GiB ⇒ admitted.
+        assert!(
+            mochi_fit_error("mochi_1", MOCHI_Q4_RESIDENT_BYTES, 19, 848, 480, mac_64).is_none(),
+            "a 19-frame clip fits a 64 GB Mac and must NOT be rejected"
+        );
+
+        // 151 frames (the shipped 5 s default): 18.73 + 60.6 + 2 ≈ 81.3 GiB ⇒ rejected BEFORE the
+        // untiled decode can trip MLX's `exit(-1)`.
+        assert!(
+            mochi_fit_error("mochi_1", MOCHI_Q4_RESIDENT_BYTES, 151, 848, 480, mac_64).is_some(),
+            "a 151-frame clip needs ~81 GB and MUST be rejected on a 64 GB Mac — this is the \
+             unmappable exit(-1) the gate exists to prevent"
+        );
+
+        // The same 151-frame clip is admitted on a 128 GB Mac — the gate rejects by BUDGET, it does
+        // not blanket-ban the default duration.
+        let mac_128 = Some(MemoryBudget { total_gb: 128.0 });
+        assert!(
+            mochi_fit_error("mochi_1", MOCHI_Q4_RESIDENT_BYTES, 151, 848, 480, mac_128).is_none(),
+            "a 151-frame clip fits a 128 GB Mac"
+        );
+    }
+
+    /// The rejection message must be self-contained + actionable, following the `too_big_error`
+    /// convention (name the model, explain the constraint, state need vs budget) and additionally
+    /// naming Mochi's one real lever: clip length.
+    #[test]
+    fn mochi_too_big_error_names_model_budget_and_the_clip_length_lever() {
+        let mac_64 = Some(MemoryBudget { total_gb: 64.0 });
+        let Some(WorkerError::InvalidPayload(message)) =
+            mochi_fit_error("mochi_1", MOCHI_Q4_RESIDENT_BYTES, 151, 848, 480, mac_64)
+        else {
+            panic!("expected an InvalidPayload rejection");
+        };
+        assert!(message.contains("mochi_1"), "names the model: {message}");
+        assert!(
+            message.contains("unified memory"),
+            "explains the constraint: {message}"
+        );
+        assert!(
+            message.contains("81"),
+            "states what it needs (~81 GB): {message}"
+        );
+        assert!(message.contains("64"), "states the budget: {message}");
+        assert!(
+            message.contains("151"),
+            "names the clip length that drove it: {message}"
+        );
+        assert!(message.contains("848x480"), "names the geometry: {message}");
+        assert!(
+            message.contains("Shorten the clip"),
+            "gives the actionable lever: {message}"
+        );
+    }
+
+    /// No signal ⇒ never block, matching `fit_decision`/`predicted_peak_gb`. An unmeasurable model
+    /// dir or a machine with no probe must not wall off generation.
+    #[test]
+    fn mochi_gate_never_blocks_without_a_signal() {
+        let mac_64 = Some(MemoryBudget { total_gb: 64.0 });
+        // Weights unmeasurable (empty/missing dir ⇒ 0 bytes) ⇒ admit.
+        assert!(mochi_fit_error("mochi_1", 0, 151, 848, 480, mac_64).is_none());
+        assert!(mochi_needed_gb(0, 151, 848, 480).is_none());
+        // No budget (off-Mac / probe failed) ⇒ admit.
+        assert!(mochi_fit_error("mochi_1", MOCHI_Q4_RESIDENT_BYTES, 151, 848, 480, None).is_none());
+    }
+
+    /// `mochi_resident_bytes` must fold the SHARED `text_encoder/` + `vae/` siblings resolved from the
+    /// tier dir's PARENT — they are over half the resident footprint, and summing only the tier dir
+    /// would under-count by ~9.7 GiB and admit a job that then dies.
+    #[test]
+    fn mochi_resident_bytes_folds_the_shared_parent_siblings() {
+        let root =
+            std::env::temp_dir().join(format!("mochi_resident_{}_{}", std::process::id(), line!()));
+        // The A6 installed layout: tier dirs as siblings of the shared components.
+        for (sub, bytes) in [
+            ("q4/transformer", 400_usize),
+            ("text_encoder", 300),
+            ("vae", 200),
+            // A sibling tier that must NOT be counted into the q4 load.
+            ("q8/transformer", 999),
+        ] {
+            let dir = root.join(sub);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("model.safetensors"), vec![0u8; bytes]).unwrap();
+        }
+
+        let tier_dir = root.join("q4");
+        assert_eq!(
+            mochi_resident_bytes(&tier_dir),
+            400 + 300 + 200,
+            "tier transformer + the shared text_encoder/vae siblings, and NOT the q8 tier"
+        );
+
+        // A self-contained dir (the raw snapshot: components UNDER the dir) is summed once, not
+        // double-counted via the parent scan.
+        let flat = root.join("flat");
+        for (sub, bytes) in [
+            ("transformer", 400_usize),
+            ("text_encoder", 300),
+            ("vae", 200),
+        ] {
+            let dir = flat.join(sub);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("model.safetensors"), vec![0u8; bytes]).unwrap();
+        }
+        assert_eq!(
+            mochi_resident_bytes(&flat),
+            900,
+            "a self-contained snapshot counts its own components exactly once"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
     }
 }

--- a/crates/sceneworks-worker/src/mlx_fit_gate.rs
+++ b/crates/sceneworks-worker/src/mlx_fit_gate.rs
@@ -411,8 +411,13 @@ const MOCHI_DECODE_EXTRA_FRAMES: u32 = 5;
 /// peak tensor is `[1, C, T, H, W]` and the decode is untiled. This is the term the generic gate's
 /// flat `HEADROOM_GB` structurally cannot represent.
 ///
-/// DERIVED, not measured. Sanity points at the native 848×480 bucket: 7 frames ⇒ ~5.0 GiB, 19 ⇒
-/// ~10.1, 61 ⇒ ~27.5, 151 ⇒ ~60.6, 163 ⇒ ~65.2 GiB.
+/// DERIVED, not measured. Sanity points at the native 848×480 bucket — all **GiB**, the unit this
+/// function returns (it divides by [`BYTES_PER_GIB`]): 7 frames ⇒ ~4.66, 19 ⇒ ~9.32, 61 ⇒ ~25.62,
+/// 151 ⇒ ~60.56, 163 ⇒ ~65.21.
+///
+/// (These are the constants the whole derivation leans on, so they are stated in ONE unit on purpose:
+/// an earlier revision mixed decimal GB into this list — 5.0/10.1/27.5 are the same three points in
+/// GB — which made the table read as if the peak grew faster than it does.)
 pub(crate) fn mochi_decode_peak_gb(frames: u32, width: u32, height: u32) -> f64 {
     let decoded_frames = f64::from(frames.saturating_add(MOCHI_DECODE_EXTRA_FRAMES));
     MOCHI_DECODE_LIVE_TENSORS
@@ -1443,12 +1448,12 @@ mod tests {
             );
         }
 
-        // The architectural anchor: 2 live × 128 ch × (151+5) frames × 848×480 × 4 B (f32) = 60.55 GiB.
+        // The architectural anchor: 2 live × 128 ch × (151+5) frames × 848×480 × 4 B (f32) = 60.56 GiB.
         // This is the number a bf16 derivation would halve — pin it so the dtype can't silently drift.
         let at_151 = mochi_decode_peak_gb(151, 848, 480);
         assert!(
-            (at_151 - 60.55).abs() < 0.1,
-            "151-frame 848x480 decode peak should be ~60.6 GiB (f32), got {at_151:.2}"
+            (at_151 - 60.56).abs() < 0.1,
+            "151-frame 848x480 decode peak should be ~60.56 GiB (f32), got {at_151:.2}"
         );
 
         // The 5 s default costs ~50 GiB MORE than the engine's 19-frame default on the same machine —
@@ -1480,14 +1485,14 @@ mod tests {
         // the epic's crash report names.
         let mac_64 = Some(MemoryBudget { total_gb: 64.0 });
 
-        // 19 frames (the engine's own DEFAULT_FRAMES, ~0.6 s): 18.73 weights + 10.1 decode + 2 OS
-        // ≈ 30.8 GiB ⇒ admitted.
+        // 19 frames (the engine's own DEFAULT_FRAMES, ~0.6 s): 18.73 weights + 9.32 decode + 2 OS
+        // ≈ 30.1 GiB ⇒ admitted. (All GiB — see `mochi_decode_peak_gb`.)
         assert!(
             mochi_fit_error("mochi_1", MOCHI_Q4_RESIDENT_BYTES, 19, 848, 480, mac_64).is_none(),
             "a 19-frame clip fits a 64 GB Mac and must NOT be rejected"
         );
 
-        // 151 frames (the shipped 5 s default): 18.73 + 60.6 + 2 ≈ 81.3 GiB ⇒ rejected BEFORE the
+        // 151 frames (the shipped 5 s default): 18.73 + 60.56 + 2 ≈ 81.3 GiB ⇒ rejected BEFORE the
         // untiled decode can trip MLX's `exit(-1)`.
         assert!(
             mochi_fit_error("mochi_1", MOCHI_Q4_RESIDENT_BYTES, 151, 848, 480, mac_64).is_some(),

--- a/crates/sceneworks-worker/src/mochi_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/mochi_mlx_smoke.rs
@@ -34,7 +34,8 @@ use std::path::{Path, PathBuf};
 use gen_core::{GenerationOutput, GenerationRequest, LoadSpec, Progress, Quant, WeightsSource};
 
 use super::smoke_support::{
-    env_or, image_mean, image_std, is_all_zero, save_png, DEGENERATE_STD_FLOOR_DEFAULT,
+    env_or, image_mean, image_std, is_all_zero, mean_abs_frame_delta, save_png,
+    DEGENERATE_STD_FLOOR_DEFAULT,
 };
 
 /// The engine id BOTH backends register (no `_distilled`-style split).
@@ -52,6 +53,31 @@ const TIERS: &[(&str, Option<Quant>)] = &[
 
 /// The shared components the provider resolves from the tier dir's PARENT (the A6 sibling layout).
 const SHARED_COMPONENTS: &[&str] = &["text_encoder", "tokenizer", "vae"];
+
+/// Motion floor: the minimum [`mean_abs_frame_delta`] (0–255 scale) every CONSECUTIVE frame pair of a
+/// live Mochi clip must clear (sc-11992 review).
+///
+/// Why this exists: a FROZEN clip — the 6× temporal path collapsed to N copies of one still — scores
+/// exactly 0.0 here yet passes every other assertion this smoke makes (frame count, dimensions,
+/// non-all-zero, per-pixel std), because each individual frame is a perfectly good image. The temporal
+/// path IS Mochi's distinguishing feature, so a smoke that cannot tell a moving clip from a frozen one
+/// is not evidence the lane works.
+///
+/// Why the per-PAIR minimum and not just `first` vs `last`: the pair minimum is strictly stronger. A
+/// clip that moves once and then freezes for the rest of the run still shows a large first→last span,
+/// but its frozen stretch drives a consecutive pair to ~0. Requiring EVERY adjacent pair to clear the
+/// floor asserts the temporal path stayed alive for the whole clip, not just at its ends.
+///
+/// Calibration — the observed 848×480 × 7f @ 4-step run on this Mac (seed 42), per-pair deltas:
+///   q4   [7.58, 5.58, 3.60, 3.41, 2.60, 5.21]  → min 2.597 (first→last span 14.65)
+///   q8   [30.04, 6.11, 2.57, 7.23, 14.93, 11.89] → min 2.573 (span 20.41)
+///   bf16 [30.87, 6.47, 2.75, 7.19, 16.24, 12.67] → min 2.752 (span 19.90)
+/// The tightest real observation across all three tiers is 2.573. 1.0 sits ~2.6× below it — enough
+/// margin that a different prompt/step count/seed (all env-overridable here) will not flake — while a
+/// frozen or near-frozen pair (0.0, or a sub-1/255 average pixel change) cannot reach it. This is a
+/// structural liveness floor, deliberately NOT a motion-quality bar: the saved-PNG eyeball remains the
+/// quality call, exactly like `DEGENERATE_STD_FLOOR_DEFAULT`.
+const MOTION_MIN_PAIR_DELTA_FLOOR: f64 = 1.0;
 
 /// Whether `root` is a Mochi model root: the shared co-requisite plus at least one complete tier.
 fn is_model_root(root: &Path) -> bool {
@@ -218,15 +244,38 @@ fn mochi_mlx_gpu_smoke() {
                  all-black / flat decode"
             );
         }
-        let first = image_mean(&rendered[0]);
-        let last = image_mean(&rendered[rendered.len() - 1]);
+        // The clip must actually MOVE. Every per-frame check above is structurally blind to a frozen
+        // clip (N copies of one good still), and the 6× temporal path is the thing this lane exists to
+        // prove — so assert a real motion floor on EVERY consecutive pair, not just the ends. A frozen
+        // pair scores exactly 0.0. See `MOTION_MIN_PAIR_DELTA_FLOOR` for the calibration.
+        let pair_deltas: Vec<f64> = rendered
+            .windows(2)
+            .map(|pair| mean_abs_frame_delta(&pair[0], &pair[1]))
+            .collect();
+        let span = mean_abs_frame_delta(&rendered[0], &rendered[rendered.len() - 1]);
         println!(
             "[smoke] mochi_1 {tier} {w}x{h} x{} frames, mean {:.2} -> {:.2}, std {:.2}",
             rendered.len(),
-            first,
-            last,
+            image_mean(&rendered[0]),
+            image_mean(&rendered[rendered.len() - 1]),
             image_std(&rendered[0])
         );
+        println!(
+            "[smoke-motion] mochi_1 {tier} pair_deltas={:?} span={span:.3}",
+            pair_deltas
+                .iter()
+                .map(|d| format!("{d:.3}"))
+                .collect::<Vec<_>>()
+        );
+        for (index, delta) in pair_deltas.iter().enumerate() {
+            assert!(
+                *delta > MOTION_MIN_PAIR_DELTA_FLOOR,
+                "mochi_1 {tier} frames {index}->{} are FROZEN (mean abs delta {delta:.3} <= floor \
+                 {MOTION_MIN_PAIR_DELTA_FLOOR}) — the temporal path is broken; per-pair deltas \
+                 {pair_deltas:?}",
+                index + 1
+            );
+        }
 
         for (index, frame) in rendered.iter().enumerate() {
             save_png(

--- a/crates/sceneworks-worker/src/mochi_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/mochi_mlx_smoke.rs
@@ -1,0 +1,249 @@
+//! Local real-weight MLX smoke for the Mochi 1 **quant-matrix** worker lane (epic 1788 / sc-11992).
+//! `#[ignore]`d — run by hand on an Apple-Silicon Mac. It drives the real native-MLX `mochi_1` engine
+//! via `crate::inference_runtime::load(id)` with a per-tier `LoadSpec` pointed at the tier subdir —
+//! the exact runtime seam `generate_mochi` uses (minus the API/job plumbing).
+//!
+//! Purpose: on-device evidence that the `SceneWorks/mochi-1-mlx` pre-quantized turnkey loads through
+//! the worker tier path and renders a non-degenerate CLIP at every downloaded tier. Mochi ships its
+//! AsymmDiT pre-quantized per tier (`q4/`/`q8/`/`bf16/`), with the T5-XXL text encoder + AsymmVAE
+//! SHARED as siblings of the tier dir — so this also covers the thing most likely to break in the
+//! worker: that `WeightsSource::Dir` points at the TIER dir while the provider resolves the shared
+//! components from that dir's PARENT (`resolve_component_root`).
+//!
+//! It additionally asserts the three worker-owned facts the unit tests can only assert in the
+//! abstract: the tier dir the resolver picks really loads, `mochi_frame_count`'s `6k+1` lattice is
+//! what the engine's `validate_request` accepts (the Wan stride lands OFF that lattice for the
+//! shipped 5 s default and is hard-rejected — see `frames_are_the_mochi_lattice_not_wans`), and that
+//! progress is monotonic, reaches the decode, and terminates.
+//!
+//! Setup — point at the published turnkey (the worker default) or a local staging dir:
+//! ```text
+//! hf download SceneWorks/mochi-1-mlx --include 'q4/*' 'text_encoder/*' 'tokenizer/*' 'vae/*'
+//! # or point at any model root laid out as <root>/{q4,q8,bf16}/ + {text_encoder,tokenizer,vae}/
+//! export MOCHI_MODEL_DIR=/path/to/mochi-root
+//! cargo test -p sceneworks-worker --release mochi_mlx_gpu_smoke -- --ignored --nocapture
+//! ```
+//! Optional overrides: `MOCHI_W`/`MOCHI_H` (default 848x480 — Mochi's only trained bucket; both axes
+//! must divide by 16), `MOCHI_FRAMES` (default 7 = `6·1+1`, the cheapest on-lattice clip — the
+//! untiled AsymmVAE decode peak grows LINEARLY in frames, ~60 GiB at the shipped 151-frame default,
+//! so the smoke deliberately renders the shortest legal clip), `MOCHI_STEPS` (default 4 — this is a
+//! load/decode smoke, not a quality bar), `MOCHI_OUT_DIR` (default `/tmp/mochi_mlx_smoke`).
+
+use std::path::{Path, PathBuf};
+
+use gen_core::{GenerationOutput, GenerationRequest, LoadSpec, Progress, Quant, WeightsSource};
+
+use super::smoke_support::{
+    env_or, image_mean, image_std, is_all_zero, save_png, DEGENERATE_STD_FLOOR_DEFAULT,
+};
+
+/// The engine id BOTH backends register (no `_distilled`-style split).
+const MOCHI_ENGINE_ID: &str = "mochi_1";
+
+/// The three matrix tiers + the load `Quant` each asserts. Mirrors `video_jobs::mochi_tier_quant`,
+/// which derives this from the tier's `split_model.json`: q4→Q4, q8→Q8, bf16→dense/None. The provider
+/// only ASSERTS this against the tier's manifest (a mismatch is a hard load error) — it never
+/// re-quantizes, so a wrong value here fails loud rather than silently rendering the wrong tier.
+const TIERS: &[(&str, Option<Quant>)] = &[
+    ("q4", Some(Quant::Q4)),
+    ("q8", Some(Quant::Q8)),
+    ("bf16", None),
+];
+
+/// The shared components the provider resolves from the tier dir's PARENT (the A6 sibling layout).
+const SHARED_COMPONENTS: &[&str] = &["text_encoder", "tokenizer", "vae"];
+
+/// Whether `root` is a Mochi model root: the shared co-requisite plus at least one complete tier.
+fn is_model_root(root: &Path) -> bool {
+    SHARED_COMPONENTS
+        .iter()
+        .all(|component| root.join(component).is_dir())
+        && TIERS
+            .iter()
+            .any(|(tier, _)| tier_is_complete(&root.join(tier)))
+}
+
+/// Whether `dir` is a loadable tier dir (mirrors `video_jobs::mochi_tier_dir_is_complete`).
+fn tier_is_complete(dir: &Path) -> bool {
+    dir.join("split_model.json").is_file()
+        && dir.join("transformer").join("model.safetensors").is_file()
+}
+
+/// The Mochi model root: `$MOCHI_MODEL_DIR`, else the cached `SceneWorks/mochi-1-mlx` snapshot.
+fn model_root() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("MOCHI_MODEL_DIR") {
+        let root = PathBuf::from(dir.trim());
+        if is_model_root(&root) {
+            return Some(root);
+        }
+        println!(
+            "[smoke] $MOCHI_MODEL_DIR={} is not a complete Mochi model root; falling back to the HF cache",
+            root.display()
+        );
+    }
+    let home = std::env::var("HOME").ok()?;
+    let snapshots = PathBuf::from(home)
+        .join(".cache/huggingface/hub/models--SceneWorks--mochi-1-mlx/snapshots");
+    std::fs::read_dir(&snapshots)
+        .ok()?
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .find(|dir| is_model_root(dir))
+}
+
+#[test]
+#[ignore = "real-weight MLX smoke; needs the SceneWorks/mochi-1-mlx tiers cached + an Apple-Silicon Mac"]
+fn mochi_mlx_gpu_smoke() {
+    let out_dir = PathBuf::from(env_or("MOCHI_OUT_DIR", "/tmp/mochi_mlx_smoke"));
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+    let w: u32 = env_or("MOCHI_W", "848").parse().expect("MOCHI_W");
+    let h: u32 = env_or("MOCHI_H", "480").parse().expect("MOCHI_H");
+    let frames: u32 = env_or("MOCHI_FRAMES", "7").parse().expect("MOCHI_FRAMES");
+    let steps: u32 = env_or("MOCHI_STEPS", "4").parse().expect("MOCHI_STEPS");
+    let prompt = "a calico kitten padding through tall sunlit grass, shallow depth of field";
+
+    assert_eq!(
+        frames % 6,
+        1,
+        "MOCHI_FRAMES must sit on the 6k+1 lattice the engine's validate_request enforces \
+         (mochi_frame_count snaps to this); got {frames}"
+    );
+    assert!(
+        w % 16 == 0 && h % 16 == 0,
+        "Mochi requires width/height divisible by 16; got {w}x{h}"
+    );
+
+    let Some(root) = model_root() else {
+        panic!(
+            "no Mochi model root found — set $MOCHI_MODEL_DIR to a dir laid out as \
+             <root>/{{q4,q8,bf16}}/ + {{text_encoder,tokenizer,vae}}/, or pull the turnkey: \
+             hf download SceneWorks/mochi-1-mlx --include 'q4/*' 'text_encoder/*' 'tokenizer/*' 'vae/*'"
+        );
+    };
+    println!("[smoke] Mochi model root: {}", root.display());
+
+    let mut verified: Vec<String> = Vec::new();
+    for (tier, quant) in TIERS {
+        let tier_dir = root.join(tier);
+        if !tier_is_complete(&tier_dir) {
+            println!("[smoke] mochi_1 {tier} not downloaded — skipping");
+            continue;
+        }
+
+        // The worker seam: `WeightsSource::Dir` points at the TIER dir, and the provider resolves the
+        // shared T5/tokenizer/VAE from its PARENT. `with_quant` mirrors `mochi_tier_quant` — advisory
+        // in the sense that the tier dir dictates the real precision, but ASSERTED by the loader.
+        let mut spec = LoadSpec::new(WeightsSource::Dir(tier_dir.clone()));
+        if let Some(q) = quant {
+            spec = spec.with_quant(*q);
+        }
+        println!(
+            "[smoke] loading mochi_1 ({tier}) from {} ...",
+            tier_dir.display()
+        );
+        let generator = crate::inference_runtime::load(MOCHI_ENGINE_ID, &spec)
+            .expect("load mlx mochi generator for tier");
+
+        let req = GenerationRequest {
+            prompt: prompt.to_owned(),
+            width: w,
+            height: h,
+            count: 1,
+            frames: Some(frames),
+            fps: Some(30),
+            seed: Some(42),
+            steps: Some(steps),
+            guidance: Some(4.5),
+            ..Default::default()
+        };
+        println!("[smoke] rendering {w}x{h} x {frames}f @ {steps} steps (mochi_1 {tier}) ...");
+
+        // Progress must be MONOTONIC and reach the decode — the job lane has NO background heartbeat
+        // during a generation, so this callback IS the keepalive; a silent engine would stall the job.
+        let mut last_step = 0_u32;
+        let mut saw_decoding = false;
+        let output = generator
+            .generate(&req, &mut |progress| match progress {
+                Progress::Step { current, total } => {
+                    assert!(
+                        current >= last_step,
+                        "progress went BACKWARDS: {current} after {last_step}"
+                    );
+                    assert!(current <= total, "step {current} exceeds total {total}");
+                    last_step = current;
+                }
+                Progress::Decoding => saw_decoding = true,
+                Progress::Loading(_) => {}
+            })
+            .expect("mochi generate");
+        assert!(last_step > 0, "engine emitted no denoise Step progress");
+        assert!(saw_decoding, "engine never reported the Decoding phase");
+
+        let GenerationOutput::Video {
+            frames: rendered,
+            fps,
+            audio,
+        } = output
+        else {
+            panic!("expected Video output from a video generator");
+        };
+        assert!(
+            audio.is_none(),
+            "mochi has no audio branch — a Some(audio) means the wrong engine answered"
+        );
+        assert_eq!(
+            rendered.len(),
+            frames as usize,
+            "mochi_1 {tier} returned {} frames for a {frames}-frame request",
+            rendered.len()
+        );
+        assert_eq!(fps, 30, "mochi renders ~30 fps");
+
+        // Every frame must be a real decode, and the clip must actually MOVE — a frozen clip would
+        // pass a per-frame std check while proving the temporal path is broken.
+        for (index, frame) in rendered.iter().enumerate() {
+            assert_eq!(
+                (frame.width, frame.height),
+                (w, h),
+                "mochi_1 {tier} frame {index} has the wrong dimensions"
+            );
+            assert!(
+                !is_all_zero(frame),
+                "mochi_1 {tier} frame {index} is ALL-ZERO — a broken tier load or decode"
+            );
+            let std = image_std(frame);
+            assert!(
+                std > DEGENERATE_STD_FLOOR_DEFAULT,
+                "mochi_1 {tier} frame {index} looks degenerate (std {std:.2}) — possible NaN / \
+                 all-black / flat decode"
+            );
+        }
+        let first = image_mean(&rendered[0]);
+        let last = image_mean(&rendered[rendered.len() - 1]);
+        println!(
+            "[smoke] mochi_1 {tier} {w}x{h} x{} frames, mean {:.2} -> {:.2}, std {:.2}",
+            rendered.len(),
+            first,
+            last,
+            image_std(&rendered[0])
+        );
+
+        for (index, frame) in rendered.iter().enumerate() {
+            save_png(
+                frame,
+                &out_dir.join(format!("mochi_1_{tier}_{index:03}.png")),
+            );
+        }
+        verified.push(format!("mochi_1:{tier}"));
+    }
+
+    assert!(
+        !verified.is_empty(),
+        "no Mochi tiers were verified — download at least one tier plus the shared components \
+         (hf download SceneWorks/mochi-1-mlx --include 'q4/*' 'text_encoder/*' 'tokenizer/*' 'vae/*')"
+    );
+    println!(
+        "[smoke] DONE: Mochi renders a coherent clip through the worker tier lane for [{}]",
+        verified.join(", ")
+    );
+}

--- a/crates/sceneworks-worker/src/smoke_support.rs
+++ b/crates/sceneworks-worker/src/smoke_support.rs
@@ -88,6 +88,41 @@ pub(crate) fn image_std(img: &Image) -> f64 {
     var.sqrt()
 }
 
+/// Mean absolute per-pixel difference between two same-sized RGB8 frames, on the native 0–255 scale
+/// (sc-11992). The video lanes' "did the clip actually MOVE?" metric.
+///
+/// A FROZEN clip — the temporal path collapsed to N copies of one still — scores EXACTLY 0.0 here,
+/// while passing every per-frame check a smoke makes (dimensions, non-all-zero, per-pixel std): each
+/// individual frame is a perfectly good image, so the per-frame floors are structurally blind to it.
+/// That is the same blind spot [`ghost_cepstrum_score`] exists for on the spatial axis.
+///
+/// Why the mean ABSOLUTE delta and not the difference of the two frames' [`image_mean`]s (the first
+/// thing sc-11992 reached for): `image_mean` collapses a frame to ONE scalar, and motion routinely
+/// preserves it — a pan, or any subject moving across a roughly uniform background, leaves the frame
+/// mean essentially unchanged while every pixel moved. So `|mean(a) − mean(b)|` can read ~0 on a
+/// perfectly live clip (false alarm) and, worse, is trivially cleared by a global brightness drift on
+/// a frozen-geometry clip (false pass). The per-pixel mean-abs delta is 0 if and only if the frames
+/// are bit-identical, which is exactly the property the guard needs.
+///
+/// Mismatched dimensions (or an empty frame) return 0.0 — no comparable signal. That fails SAFE for
+/// the intended use: callers assert the delta is ABOVE a floor, so a mismatch trips the assertion
+/// loudly instead of silently admitting.
+pub(crate) fn mean_abs_frame_delta(a: &Image, b: &Image) -> f64 {
+    if a.width != b.width || a.height != b.height || a.pixels.len() != b.pixels.len() {
+        return 0.0;
+    }
+    let n = a.pixels.len() as f64;
+    if n == 0.0 {
+        return 0.0;
+    }
+    a.pixels
+        .iter()
+        .zip(b.pixels.iter())
+        .map(|(&x, &y)| (x as f64 - y as f64).abs())
+        .sum::<f64>()
+        / n
+}
+
 /// Ceiling on the ghost/double-exposure cepstral score (sc-10852). See [`ghost_cepstrum_score`].
 ///
 /// A coherent render leaves the score (a robust z-score of the strongest off-origin **cepstral** peak)
@@ -369,6 +404,94 @@ pub(crate) fn save_png(img: &Image, path: &Path) {
         .expect("rgb buffer")
         .save(path)
         .unwrap_or_else(|e| panic!("save {}: {e}", path.display()));
+}
+
+/// GPU-free structural coverage for the video-lane motion metric (sc-11992). The smoke that consumes
+/// [`mean_abs_frame_delta`] is `#[ignore]`d and needs ~50 GB of weights, so these tests pin the
+/// metric's two load-bearing properties against synthetic frames: a frozen pair scores EXACTLY 0
+/// (the failure the floor exists to catch), and a moved subject scores well clear of it — including
+/// the case where the frame MEAN is preserved, which is precisely where the `image_mean`-difference
+/// check the smoke used to print would have read ~0 on a live clip.
+#[cfg(test)]
+mod motion_metric_tests {
+    use super::*;
+
+    /// A `w`×`h` RGB8 frame: mid-gray with one white `size`×`size` square at (`x`, `y`). Moving the
+    /// square translates content without changing how many white pixels exist — so the frame MEAN is
+    /// identical between two positions, while every pixel under the square changed.
+    fn frame_with_square(w: u32, h: u32, x: u32, y: u32, size: u32) -> Image {
+        let mut pixels = vec![128u8; (w * h * 3) as usize];
+        for row in y..(y + size).min(h) {
+            for col in x..(x + size).min(w) {
+                let i = ((row * w + col) * 3) as usize;
+                pixels[i] = 255;
+                pixels[i + 1] = 255;
+                pixels[i + 2] = 255;
+            }
+        }
+        Image {
+            width: w,
+            height: h,
+            pixels,
+        }
+    }
+
+    #[test]
+    fn a_frozen_pair_scores_exactly_zero() {
+        // The whole point: N copies of one good still. Every per-frame smoke check passes; this is the
+        // only signal that separates it from a live clip.
+        let frame = frame_with_square(64, 64, 8, 8, 16);
+        assert_eq!(mean_abs_frame_delta(&frame, &frame), 0.0);
+        let identical = frame_with_square(64, 64, 8, 8, 16);
+        assert_eq!(mean_abs_frame_delta(&frame, &identical), 0.0);
+    }
+
+    #[test]
+    fn a_moved_subject_scores_above_zero_even_when_the_frame_mean_is_unchanged() {
+        // Translating the square leaves `image_mean` bit-identical (same pixel population), so the
+        // old `|mean(first) − mean(last)|` check reads ~0 here — a live clip it would call frozen.
+        // The per-pixel metric sees the motion.
+        let a = frame_with_square(64, 64, 8, 8, 16);
+        let b = frame_with_square(64, 64, 32, 32, 16);
+        assert_eq!(
+            image_mean(&a),
+            image_mean(&b),
+            "fixture invariant: translation preserves the frame mean"
+        );
+        let delta = mean_abs_frame_delta(&a, &b);
+        assert!(
+            delta > 1.0,
+            "a fully displaced subject must score well above the liveness floor, got {delta:.3}"
+        );
+    }
+
+    #[test]
+    fn the_metric_scales_with_how_much_moved() {
+        // Monotone in the amount of changed content — a partial overlap moves less than a full
+        // displacement. Guards against a metric that saturates (e.g. any-pixel-changed booleans).
+        let base = frame_with_square(64, 64, 8, 8, 16);
+        let small = mean_abs_frame_delta(&base, &frame_with_square(64, 64, 12, 12, 16));
+        let large = mean_abs_frame_delta(&base, &frame_with_square(64, 64, 40, 40, 16));
+        assert!(
+            large > small && small > 0.0,
+            "expected 0 < small ({small:.3}) < large ({large:.3})"
+        );
+    }
+
+    #[test]
+    fn mismatched_or_empty_frames_score_zero_and_fail_safe() {
+        // No comparable signal ⇒ 0.0, which is BELOW any motion floor ⇒ the caller's assertion trips
+        // loudly rather than silently admitting an unverifiable clip.
+        let a = frame_with_square(64, 64, 8, 8, 16);
+        let smaller = frame_with_square(32, 32, 4, 4, 8);
+        assert_eq!(mean_abs_frame_delta(&a, &smaller), 0.0);
+        let empty = Image {
+            width: 0,
+            height: 0,
+            pixels: Vec::new(),
+        };
+        assert_eq!(mean_abs_frame_delta(&empty, &empty), 0.0);
+    }
 }
 
 /// GPU-free structural coverage for the ghost/double-exposure guard (sc-10852). The `*_gpu_smoke`

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -5192,7 +5192,11 @@ async fn generate_candle_video(
     // co-requisite are identical off-Mac. It must NOT fall through to the wan tier-select below: the
     // Mochi tier layout is `<root>/{q4|q8|bf16}/transformer/` with the T5/VAE/tokenizer as siblings of
     // the tier dir, which `candle_wan_tier_subdir` does not understand.
-    let is_mochi = is_mochi_model(&request.model);
+    //
+    // Keyed off the RESOLVED engine id, mirroring the `is_ltx` binding below — the id is already
+    // resolved through `candle_video_engine_id`, so re-deriving the family from the model string here
+    // would be a second, drift-prone source of truth.
+    let is_mochi = engine_id == "mochi_1";
     if is_mochi {
         ensure_mochi_q8_present(api, settings, job, request).await?;
         ensure_mochi_bf16_present(api, settings, job, request).await?;
@@ -8641,14 +8645,16 @@ const MOCHI_REVISION: &str = "90a87786d9b5b592c3b3c083e5fcdf130007b1de";
 ))]
 const MOCHI_DIR_ENV: &str = "SCENEWORKS_MLX_MOCHI_DIR";
 
-/// SceneWorks Mochi model id → the gen-core registry id, or `None` if not a Mochi family id. ONE id
-/// covers BOTH backends (both providers register `MODEL_ID = "mochi_1"`), so this is lane-agnostic —
-/// contrast [`ltx_engine_id`], which folds two sceneworks ids onto one engine, and the candle LTX
-/// arm, which maps to a DIFFERENT `ltx_2_3_distilled` id.
-#[cfg(any(
-    target_os = "macos",
-    all(not(target_os = "macos"), feature = "backend-candle")
-))]
+/// SceneWorks Mochi model id → the gen-core registry id, or `None` if not a Mochi family id.
+///
+/// ONE id covers BOTH backends (both providers register `MODEL_ID = "mochi_1"`) — contrast
+/// [`ltx_engine_id`], which folds two sceneworks ids onto one engine, and the candle LTX arm, which
+/// maps to a DIFFERENT `ltx_2_3_distilled` id. Despite that, this is the **MLX lane's** resolver: it
+/// is the `resolve_video_route` / `mochi_available` / `ensure_video_engine_weights` key. The candle
+/// lane resolves the same id through its own [`candle_video_engine_id`] table and then keys off the
+/// resolved `engine_id` (mirroring its local `is_ltx`), so it never calls this — hence the macOS gate
+/// rather than the superset one the shared tier helpers below carry.
+#[cfg(target_os = "macos")]
 fn mochi_engine_id(model: &str) -> Option<&'static str> {
     (model == "mochi_1").then_some("mochi_1")
 }
@@ -10604,11 +10610,9 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
-    /// `mochi_1` is the engine id on BOTH backends — no `_distilled`-style split, unlike LTX.
-    #[cfg(any(
-        target_os = "macos",
-        all(not(target_os = "macos"), feature = "backend-candle")
-    ))]
+    /// `mochi_1` is the engine id on BOTH backends — no `_distilled`-style split, unlike LTX. (The
+    /// candle lane's equivalent is pinned by `candle_mochi_resolves_the_engine_and_never_falls_to_the_stub`.)
+    #[cfg(target_os = "macos")]
     #[test]
     fn mochi_engine_id_is_the_model_id_and_matches_nothing_else() {
         assert_eq!(mochi_engine_id("mochi_1"), Some("mochi_1"));

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -8982,6 +8982,69 @@ fn mochi_raw_settings(request: &VideoRequest, quant: Option<Quant>) -> Value {
 /// forward-progress stall watchdog and the completion metrics all come from the shared
 /// [`generate_video`] funnel — the same one Wan/LTX/SVD use — so Mochi inherits the "no background
 /// heartbeat during a job, the progress callback IS the keepalive" contract without re-implementing it.
+/// Everything a Mochi generation must settle BEFORE the load, resolved as ONE unit by
+/// [`mochi_preflight`] (sc-11992).
+///
+/// These travel together on purpose. Both fields are things [`generate_mochi`] cannot build its
+/// [`VideoGenInput`] without, and [`mochi_preflight`] is the only thing that produces them — so the
+/// generation arm cannot obtain a frame count or a quant marker on a path that skipped the fit gate.
+/// Splitting them back into free-standing calls in the caller is what let the gate be silently dropped
+/// (the mutation that survived the first round of this story's review).
+#[cfg(target_os = "macos")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MochiPreflight {
+    /// The requested frame count coerced onto Mochi's `6k+1` lattice.
+    frames: u32,
+    /// The tier dir's quant marker (`None` = the dense bf16 tier).
+    quant: Option<Quant>,
+}
+
+/// The Mochi pre-flight: coerce the clip length onto the engine's lattice, refuse a job that cannot
+/// fit this machine, and report the tier's quant — the whole "before we load anything" decision, as a
+/// pure, synchronously testable seam (sc-11992).
+///
+/// This exists as its own function because [`generate_mochi`] is `async` and needs a live
+/// `ApiClient`/`JobSnapshot`, which makes it unreachable from a unit test — so any decision left
+/// INSIDE it is, in practice, unpinned. Both decisions here are ones this story exists to get right,
+/// and both are invisible in the output when wrong (a mis-coerced frame count is a hard engine reject;
+/// a skipped gate is a `SIGKILL`), so they live here where `mochi_preflight_*` can assert them by
+/// model id, budget, and clip length.
+///
+/// `Ok(MochiPreflight)` admits; `Err` is the actionable pre-crash rejection.
+#[cfg(target_os = "macos")]
+fn mochi_preflight(
+    model: &str,
+    engine_id: &str,
+    tier_dir: &Path,
+    raw_frames: u32,
+    width: u32,
+    height: u32,
+) -> WorkerResult<MochiPreflight> {
+    // The shared stride ladder, dispatched BY MODEL — so Mochi lands on `mochi_frame_count`'s 6k+1
+    // lattice and never on Wan's 4k+1 stride. NOT `wan_frame_count` (see `video_frame_count`): the
+    // shipped 5 s @ 30 fps default takes `wan_frame_count(150) = 149`, and `149 % 6 == 5` is OFF the
+    // lattice, which the engine's `validate_request` hard-rejects.
+    let frames = video_frame_count(model, raw_frames);
+
+    // PRE-FLIGHT FIT GATE (epic AC: "an unsupported environment shows an actionable error, not a
+    // crash"). This MUST run before the load: Mochi holds ~18.7 GiB of weights resident for the whole
+    // run (`supports_sequential_offload: false`) and its AsymmVAE decode is UNTILED, so the peak grows
+    // linearly with clip length (sc-12291) — ~60 GiB of decode alone at the shipped 5 s default. MLX's
+    // default error handler is `exit(-1)`, a hard process kill that CANNOT be mapped to a job error
+    // after the fact, so an over-budget job has to be refused here or it takes the worker down with
+    // it. The generic `mlx_fit_gate` cannot cover this: it is resolution-blind by construction and its
+    // weights-fit floor would admit on the 18.7 GiB weights alone.
+    //
+    // It takes the COERCED `frames` — the count the decode will actually pay for — not the raw
+    // request, and not a constant.
+    crate::mlx_fit_gate::mochi_fit_check(engine_id, tier_dir, frames, width, height)?;
+
+    Ok(MochiPreflight {
+        frames,
+        quant: mochi_tier_quant(tier_dir),
+    })
+}
+
 #[cfg(target_os = "macos")]
 async fn generate_mochi(
     api: &ApiClient,
@@ -8995,22 +9058,12 @@ async fn generate_mochi(
     ensure_mochi_q8_present(api, settings, job, request).await?;
     ensure_mochi_bf16_present(api, settings, job, request).await?;
     let model_dir = resolve_mochi_model_dir(settings, request)?;
-    let quant = mochi_tier_quant(&model_dir);
-    // The shared stride ladder — NOT `wan_frame_count` (see `video_frame_count`).
-    let frames = video_frame_count(&request.model, request.raw_frame_count());
-
-    // PRE-FLIGHT FIT GATE (epic AC: "an unsupported environment shows an actionable error, not a
-    // crash"). This MUST run before the load: Mochi holds ~18.7 GiB of weights resident for the whole
-    // run (`supports_sequential_offload: false`) and its AsymmVAE decode is UNTILED, so the peak grows
-    // linearly with clip length (sc-12291) — ~60 GiB of decode alone at the shipped 5 s default. MLX's
-    // default error handler is `exit(-1)`, a hard process kill that CANNOT be mapped to a job error
-    // after the fact, so an over-budget job has to be refused here or it takes the worker down with
-    // it. The generic `mlx_fit_gate` cannot cover this: it is resolution-blind by construction and its
-    // weights-fit floor would admit on the 18.7 GiB weights alone.
-    crate::mlx_fit_gate::mochi_fit_check(
+    // Frame lattice + fit gate + tier quant, as one gated unit — see `mochi_preflight`.
+    let MochiPreflight { frames, quant } = mochi_preflight(
+        &request.model,
         engine_id,
         &model_dir,
-        frames,
+        request.raw_frame_count(),
         request.width,
         request.height,
     )?;
@@ -10720,6 +10773,151 @@ mod tests {
             }
         }
         assert!(accepted > 0, "the invariant must be exercised, not vacuous");
+    }
+
+    /// Mochi's REAL hosted q4 resident footprint, split by component: AsymmDiT 9.007 GiB + T5-XXL
+    /// bf16 8.871 + AsymmVAE 0.856 = 18.73 GiB. Mirrors `mlx_fit_gate`'s `MOCHI_Q4_RESIDENT_BYTES`
+    /// (which asserts the same total against the pure gate) — the preflight tests need them SPLIT
+    /// across the A6 sibling layout so the on-disk scan has to fold the shared components to get the
+    /// total right.
+    #[cfg(target_os = "macos")]
+    const MOCHI_Q4_DIT_BYTES: u64 = 9_670_883_602;
+    #[cfg(target_os = "macos")]
+    const MOCHI_Q4_TE_BYTES: u64 = 9_524_669_250;
+    #[cfg(target_os = "macos")]
+    const MOCHI_Q4_VAE_BYTES: u64 = 919_551_200;
+
+    /// A Mochi A6-layout root (q4 tier + shared `text_encoder`/`vae`/`tokenizer` siblings) whose
+    /// `.safetensors` report the REAL hosted byte sizes, so `mochi_fit_check`'s on-disk scan resolves
+    /// the true ~18.73 GiB resident footprint instead of the 1-byte stubs `mochi_root` writes.
+    ///
+    /// The files are SPARSE: `set_len` sets the apparent size with zero allocated blocks on APFS, and
+    /// `sum_safetensors_bytes` reads `metadata().len()`. So this is instant and costs no disk —
+    /// materializing 18.7 GiB of real zeros per test would not be viable.
+    #[cfg(target_os = "macos")]
+    fn mochi_root_real_sized(tag: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "mochi_preflight_{tag}_{}_{}",
+            std::process::id(),
+            line!()
+        ));
+        for (relative, len) in [
+            ("q4/transformer/model.safetensors", MOCHI_Q4_DIT_BYTES),
+            ("text_encoder/model.safetensors", MOCHI_Q4_TE_BYTES),
+            ("vae/model.safetensors", MOCHI_Q4_VAE_BYTES),
+        ] {
+            let path = root.join(relative);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::File::create(&path).unwrap().set_len(len).unwrap();
+        }
+        std::fs::create_dir_all(root.join("tokenizer")).unwrap();
+        std::fs::write(
+            root.join("q4").join("split_model.json"),
+            serde_json::to_string(
+                &json!({ "quantized": true, "quantization_bits": 4, "quantization_group_size": 64 }),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        root
+    }
+
+    /// sc-11992 review: pin the frame lattice AT THE SEAM THE GENERATION ARM CALLS, not just as a free
+    /// function. `generate_mochi` is `async` and needs a live `ApiClient`/`JobSnapshot`, so it is
+    /// unreachable from a unit test — `mochi_preflight` is the pure seam it delegates the decision to.
+    ///
+    /// Kills the review mutation `video_frame_count(...)` → `wan_frame_count(...)`, which survived
+    /// 835/0 green when this logic sat inline in `generate_mochi`: the wan stride answers 149 for the
+    /// shipped 5 s default, and `149 % 6 == 5` is off the lattice the engine accepts.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn mochi_preflight_coerces_the_frame_count_on_mochis_lattice_by_model_id() {
+        let root = mochi_root_real_sized("lattice");
+        // A budget no clip can overflow, so ONLY the lattice is under test here.
+        let out = temp_env_var(crate::mlx_fit_gate::MLX_MEMORY_CAP_ENV, "512", || {
+            mochi_preflight("mochi_1", "mochi_1", &root.join("q4"), 150, 848, 480)
+        });
+        std::fs::remove_dir_all(&root).ok();
+
+        let preflight = out.expect("a 151-frame clip fits a 512 GB budget");
+        assert_eq!(
+            preflight.frames, 151,
+            "the seam must snap the shipped 5 s default onto the 6k+1 lattice"
+        );
+        assert_eq!(
+            preflight.frames,
+            mochi_frame_count(150),
+            "the seam's mochi arm must BE mochi_frame_count"
+        );
+        assert_ne!(
+            preflight.frames,
+            wan_frame_count(150),
+            "routing the seam through the wan stride is the bug this story exists to fix"
+        );
+        assert_eq!(
+            preflight.quant,
+            Some(Quant::Q4),
+            "the tier dir's split_model.json carries the quant the load asserts"
+        );
+    }
+
+    /// sc-11992 review / epic AC "a missing-weights or unsupported environment shows an ACTIONABLE
+    /// ERROR, not a crash": the fit gate must run on the generation seam, with the REAL coerced frame
+    /// count. MLX's default error handler is `exit(-1)` — a hard process kill that cannot be mapped to
+    /// a job error after the fact — so an over-budget job must be refused here or it takes the worker
+    /// down with it.
+    ///
+    /// Kills BOTH remaining review mutations, each of which survived 835/0 green:
+    ///   * hardcoding the gate's `frames` argument to `7` ⇒ the gate sees 4.66 GiB of decode instead
+    ///     of 60.56, totals ~25 GiB, and ADMITS this job ⇒ `expect_err` fails.
+    ///   * deleting the `mochi_fit_check(...)?` call ⇒ nothing rejects ⇒ `expect_err` fails.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn mochi_preflight_rejects_the_5s_default_on_a_64gb_mac() {
+        let root = mochi_root_real_sized("reject");
+        // A 64 GB Mac — the machine the epic's crash report names.
+        let out = temp_env_var(crate::mlx_fit_gate::MLX_MEMORY_CAP_ENV, "64", || {
+            mochi_preflight("mochi_1", "mochi_1", &root.join("q4"), 150, 848, 480)
+        });
+        std::fs::remove_dir_all(&root).ok();
+
+        let message = out
+            .expect_err(
+                "the shipped 5 s default (151 frames) needs 18.73 GiB weights + 60.56 GiB untiled \
+                 decode + 2 GiB OS reserve = 81.3 GiB, which does NOT fit a 64 GB Mac — admitting it \
+                 is exactly the SIGKILL this gate exists to prevent",
+            )
+            .to_string();
+        assert!(message.contains("mochi_1"), "names the model: {message}");
+        assert!(
+            message.contains("Shorten the clip"),
+            "leads with the only lever that moves the dominant term: {message}"
+        );
+    }
+
+    /// The other half of the gate's contract: on the SAME 64 GB Mac a short clip is ADMITTED. Without
+    /// this, `mochi_preflight_rejects_the_5s_default_on_a_64gb_mac` would still pass against a gate
+    /// that blanket-refuses everything — so this is what makes the pair prove the gate is
+    /// FRAME-SENSITIVE, which is the whole point of a decode peak that scales with clip length.
+    ///
+    /// Also independently kills the `wan_frame_count` substitution: `wan_frame_count(19) = 17`.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn mochi_preflight_admits_a_short_clip_on_the_same_64gb_mac() {
+        let root = mochi_root_real_sized("admit");
+        let out = temp_env_var(crate::mlx_fit_gate::MLX_MEMORY_CAP_ENV, "64", || {
+            mochi_preflight("mochi_1", "mochi_1", &root.join("q4"), 19, 848, 480)
+        });
+        std::fs::remove_dir_all(&root).ok();
+
+        let preflight = out.expect(
+            "19 frames (the engine's own DEFAULT_FRAMES) needs 18.73 + 9.32 + 2 = 30.1 GiB, which \
+             fits a 64 GB Mac and must NOT be rejected",
+        );
+        assert_eq!(
+            preflight.frames, 19,
+            "19 already sits on the 6k+1 lattice, so the snap is a no-op"
+        );
     }
 
     /// Mochi is text-to-video ONLY (`conditioning: []` on both descriptors). `VideoRequest`'s mode

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -69,13 +69,21 @@ use gen_core::{Image, ReplacementMode};
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 use sceneworks_core::character_store::CharacterStore;
-// Frame-count stride coercion (Wan needs frames ≡ 1 mod 4; LTX snaps to 8k+1) — used by the MLX path
-// and the candle entry (sc-5097).
+// Frame-count stride coercion (Wan needs frames ≡ 1 mod 4; LTX snaps to 8k+1; Mochi snaps to 6k+1)
+// — used by the MLX path and the candle entry (sc-5097).
+//
+// Mochi's stride is NOT interchangeable with Wan's (sc-11992, epic 1788): `wan_frame_count(150)` is
+// 149, `149 % 6 == 5`, and the Mochi runtime's `validate_request` hard-rejects anything but `1 + 6k`
+// — so the shipped 5 s @ 30 fps default (150 raw) fails outright on the Wan stride. `mochi_frame_count`
+// (B3/sc-11993) snaps to the NEAREST 6k+1 (151), the count the manifest documents for that default.
+// See `frames_are_the_mochi_lattice_not_wans` for the exact failure mode.
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
-use sceneworks_core::video_request::{ltx_frame_count, wan_frame_count};
+use sceneworks_core::video_request::{
+    is_mochi_model, ltx_frame_count, mochi_frame_count, wan_frame_count,
+};
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
@@ -144,6 +152,9 @@ enum VideoRoute {
     Bernini(&'static str),
     /// SCAIL-2 standalone character animation (epic 5439). Carries the resolved engine id.
     Scail2(&'static str),
+    /// Mochi 1 text-to-video (epic 1788 / sc-11992). Carries the resolved engine id. t2v ONLY —
+    /// [`mochi_available`] gates the mode, since `conditioning: []` means there is no other shape.
+    Mochi(&'static str),
     /// No native engine matched (or weights unresolved) → the procedural stub, after
     /// `ensure_video_engine_weights` fails a known-but-unprovisioned engine loudly (sc-4176).
     Stub,
@@ -189,6 +200,13 @@ fn resolve_video_route(request: &VideoRequest, settings: &Settings) -> VideoRout
         scail2_engine_id(&request.model).filter(|_| scail2_available(request, settings))
     {
         VideoRoute::Scail2(engine_id)
+    } else if let Some(engine_id) =
+        mochi_engine_id(&request.model).filter(|_| mochi_available(request, settings))
+    {
+        // Mochi 1 (epic 1788 / sc-11992). Appended at the TAIL of the ladder: `mochi_engine_id`
+        // matches only `mochi_1`, and no earlier predicate can match that id, so routing for every
+        // pre-existing model stays byte-identical. `mochi_available` folds in the t2v-only mode gate.
+        VideoRoute::Mochi(engine_id)
     } else {
         VideoRoute::Stub
     }
@@ -529,6 +547,17 @@ pub(crate) async fn run_video_generate_job(
                     scail2_raw_settings(&request, lightning),
                     None,
                 )
+            }
+            VideoRoute::Mochi(engine_id) => {
+                // Mochi 1 (epic 1788 / sc-11992): 10B AsymmDiT text-to-video, true CFG, pre-quantized
+                // tier dirs. `generate_mochi` fetches an opted-into tier on demand, resolves the tier
+                // dir + its shared T5/VAE co-requisite, runs the pre-flight memory fit gate (the
+                // untiled AsymmVAE decode scales with clip length and MLX's OOM handler is an
+                // unmappable `exit(-1)`), then drives the shared `generate_video` funnel. It returns
+                // its own `rawSettings` so the record names the tier that was actually loaded.
+                let (decoded, raw_settings) =
+                    generate_mochi(api, settings, job, &request, engine_id, backend).await?;
+                (decoded, MOCHI_ADAPTER, raw_settings, None)
             }
             VideoRoute::Stub => {
                 // An MLX-routed video model whose snapshot didn't resolve must fail
@@ -2757,6 +2786,13 @@ pub(crate) fn ensure_video_engine_weights(
     if scail2_engine_id(&request.model).is_some() {
         resolve_scail2_model_dir(settings)?;
     }
+    // Mochi 1 (epic 1788 / sc-11992). Without this arm a Mochi job whose weights don't resolve falls
+    // to `VideoRoute::Stub` and the user is handed a PROCEDURAL FAKE VIDEO instead of the resolver's
+    // precise "download the tier" / "the shared components are missing" error — exactly the silent
+    // degradation sc-4176 added this gate to prevent.
+    if mochi_engine_id(&request.model).is_some() {
+        resolve_mochi_model_dir(settings, request)?;
+    }
     Ok(())
 }
 
@@ -4540,6 +4576,11 @@ const CANDLE_WAN_ADAPTER: &str = "candle_wan";
 const CANDLE_LTX_ADAPTER: &str = "candle_ltx";
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const CANDLE_SVD_ADAPTER: &str = "candle_svd";
+/// Adapter id recorded on a candle Mochi 1 asset (epic 1788 / sc-11992). Distinct from the MLX
+/// [`MOCHI_ADAPTER`] so the sidecar records which backend rendered the clip, matching the
+/// `candle_wan`/`mlx_wan` and `candle_ltx`/`mlx_ltx` pairs.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const CANDLE_MOCHI_ADAPTER: &str = "candle_mochi";
 
 /// Default HuggingFace repos the candle video providers load (overridable via the manifest `repo`).
 /// The candle wan providers read a Wan2.2 diffusers snapshot — the TI2V-5B, or the T2V-A14B /
@@ -4590,6 +4631,16 @@ fn candle_video_engine_id(model: &str) -> Option<&'static str> {
         "ltx_2_3" | "ltx_2_3_eros" => Some("ltx_2_3_distilled"),
         // SVD-XT image→video (sc-5493 / epic 5481): the candle-gen-svd provider's `svd_xt` engine.
         "svd" => Some("svd_xt"),
+        // Mochi 1 (epic 1788 / sc-11992). The sceneworks id IS the engine id: `candle-gen-mochi`
+        // registers the SAME `MODEL_ID = "mochi_1"` as `mlx-gen-mochi` (no `_distilled`-style split),
+        // and its descriptor is `mac_only: false` — the off-Mac lane is real and CUDA-validated on
+        // Blackwell (sc-11990), ingesting the same hosted mlx-affine tiers.
+        //
+        // Load-bearing: without this arm `is_candle_video_engine` is false, `resolve_candle_video_route`
+        // never reaches the generic arm, and a Windows Mochi job falls to `CandleVideoRoute::Stub` —
+        // handing the user a PROCEDURAL FAKE VIDEO instead of an error. B1 already routed Windows
+        // (`candle_video_routed = true`), so that promise must be served here.
+        "mochi_1" => Some("mochi_1"),
         _ => None,
     }
 }
@@ -4600,17 +4651,24 @@ fn is_candle_video_engine(model: &str) -> bool {
     candle_video_engine_id(model).is_some()
 }
 
+/// The adapter id recorded on a candle video asset. Every engine that is NOT wan MUST have an
+/// explicit arm: the `_` fall-through is the Wan default, so a missing arm silently stamps a
+/// different model's provenance onto the asset sidecar + telemetry (sc-11992 — `mochi_1` landed in
+/// `_` and was labelled a Wan adapter).
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 fn candle_video_adapter_label(engine_id: &str) -> &'static str {
     match engine_id {
         "ltx_2_3_distilled" => CANDLE_LTX_ADAPTER,
         "svd_xt" => CANDLE_SVD_ADAPTER,
+        "mochi_1" => CANDLE_MOCHI_ADAPTER,
         _ => CANDLE_WAN_ADAPTER,
     }
 }
 
 /// The candle default weights repo for a video engine id (the per-variant Wan2.2 diffusers snapshot,
-/// or the LTX-2.3 checkpoint). Used when the manifest entry omits `repo`.
+/// or the LTX-2.3 checkpoint). Used when the manifest entry omits `repo`. Like
+/// [`candle_video_adapter_label`], the `_` arm is the Wan default — a non-wan engine without an
+/// explicit arm inherits Wan's repo (sc-11992).
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 fn candle_video_default_repo(engine_id: &str) -> &'static str {
     match engine_id {
@@ -4618,6 +4676,11 @@ fn candle_video_default_repo(engine_id: &str) -> &'static str {
         "svd_xt" => SVD_REPO,
         "wan2_2_t2v_14b" => CANDLE_WAN_T2V_14B_REPO,
         "wan2_2_i2v_14b" => CANDLE_WAN_I2V_14B_REPO,
+        // Mochi 1 (epic 1788 / sc-11992): ONE repo serves BOTH backends — candle ingests the same
+        // mlx-affine tiers via A6's `.scales`-detect seam, and `SceneWorks/mochi-1-candle` was never
+        // published. No manifest entry carries a top-level `repo`, so this default is what the candle
+        // lane actually resolves.
+        "mochi_1" => MOCHI_REPO,
         // `wan2_2_ti2v_5b` (and any other wan id) → the 5B TI2V snapshot.
         _ => CANDLE_WAN_5B_REPO,
     }
@@ -5123,14 +5186,38 @@ async fn generate_candle_video(
     })?;
     let adapter = candle_video_adapter_label(engine_id);
     let repo = candle_video_repo(request, engine_id);
-    let snapshot_dir = candle_video_snapshot_dir(settings, &repo)?;
+    // Mochi (epic 1788 / sc-11992) resolves its tier dir through the SHARED resolver both lanes use —
+    // `SceneWorks/mochi-1-mlx` serves candle too (A6's `.scales`-detect seam ingests the mlx-affine
+    // tiers 1:1), so the tier-dir semantics, the on-demand q8/bf16 fetch and the shared-parent
+    // co-requisite are identical off-Mac. It must NOT fall through to the wan tier-select below: the
+    // Mochi tier layout is `<root>/{q4|q8|bf16}/transformer/` with the T5/VAE/tokenizer as siblings of
+    // the tier dir, which `candle_wan_tier_subdir` does not understand.
+    let is_mochi = is_mochi_model(&request.model);
+    if is_mochi {
+        ensure_mochi_q8_present(api, settings, job, request).await?;
+        ensure_mochi_bf16_present(api, settings, job, request).await?;
+    }
+    let snapshot_dir = if is_mochi {
+        // Resolve-or-error; never a stub (the candle generic arm has no stub fallback once
+        // `candle_video_engine_id` resolves the id).
+        resolve_mochi_model_dir(settings, request)?
+    } else {
+        candle_video_snapshot_dir(settings, &repo)?
+    };
     // Wan quant-matrix tier-select (sc-10027): a candle wan tier repo (`SceneWorks/wan2.2-*-candle`) ships
     // q4/q8/bf16 subdirs — resolve the one matching `advanced.mlxQuantize` (default q4) and load from it
     // (the packed-detect seam reads the baked-in quant). A flat/dense repo (no subdirs, e.g. the
     // `Wan-AI/*-Diffusers` fallback) stays as-is with no quant marker.
-    let (model_dir, wan_quant) = match candle_wan_tier_subdir(&snapshot_dir, engine_id, request) {
-        Some((tier_dir, quant)) => (tier_dir, quant),
-        None => (snapshot_dir, None),
+    let (model_dir, wan_quant) = if is_mochi {
+        // `resolve_mochi_model_dir` already returned the TIER dir; the quant marker is the tier's own
+        // baked-in level, read from its `split_model.json` (the candle loader asserts it matches).
+        let quant = mochi_tier_quant(&snapshot_dir);
+        (snapshot_dir, quant)
+    } else {
+        match candle_wan_tier_subdir(&snapshot_dir, engine_id, request) {
+            Some((tier_dir, quant)) => (tier_dir, quant),
+            None => (snapshot_dir, None),
+        }
     };
     // ltx needs the separate Gemma-3-12B encoder (its only conditioning input). Resolve its snapshot
     // dir here and thread it onto the LoadSpec below (sc-8827) instead of mutating `$LTX_GEMMA_DIR`.
@@ -5205,18 +5292,27 @@ async fn generate_candle_video(
     // distilled ltx takes neither (single-stage, no CFG). Wan uses the Lightning-aware recipe
     // ([`candle_wan_sampling`]: 4-step/CFG-off when the toggle is on, else native multi-step + CFG);
     // ltx keeps its own step default and no CFG.
+    //
+    // Mochi needs its OWN arm (sc-11992) — it is not distilled, so it takes true CFG (negative prompt
+    // + guidance), but it is also not a Wan model: falling through to `candle_wan_sampling` would hit
+    // that function's dense-5B tail and force `CANDLE_WAN5B_INTERIM_STEPS` (20) on it, silently
+    // overriding the AsymmDiT's own 64-step default with a Wan tuning constant. `None` ⇒ the engine's
+    // DEFAULT_STEPS (64) / DEFAULT_GUIDANCE (4.5) stand.
     let (steps, guidance, negative_prompt) = if is_ltx {
         (advanced_opt_u32(request, "steps"), None, None)
+    } else if is_mochi {
+        (
+            advanced_opt_u32(request, "steps"),
+            advanced_opt_f32(request, "guidanceScale"),
+            non_empty_negative_prompt(request),
+        )
     } else {
         let (steps, guidance) = candle_wan_sampling(engine_id, request);
         (steps, guidance, non_empty_negative_prompt(request))
     };
-    // Coerce the requested frame count onto each engine's temporal stride (wan: ≡1 mod 4; ltx: 8k+1).
-    let frames = if is_ltx {
-        ltx_frame_count(request.raw_frame_count())
-    } else {
-        wan_frame_count(request.raw_frame_count())
-    };
+    // Coerce the requested frame count onto the engine's temporal stride — the ONE shared ladder both
+    // lanes use (sc-11992), so the candle stride can never drift from the MLX one.
+    let frames = video_frame_count(&request.model, request.raw_frame_count());
     let input = VideoGenInput {
         sampler: None,
         scheduler: None,
@@ -8485,6 +8581,464 @@ async fn generate_ltx(
 }
 
 // ---------------------------------------------------------------------------
+// Mochi 1 (epic 1788 / sc-11992): a 10B AsymmDiT text-to-video model with a 6×-temporal AsymmVAE,
+// served natively on BOTH backends — `mlx-gen-mochi` (macOS) and `candle-gen-mochi` (Windows/Linux
+// CUDA). Two facts shape this whole block, and both DEVIATE from the LTX template it otherwise
+// mirrors:
+//
+//  1. ONE engine id, TWO backends. Both providers register `MODEL_ID = "mochi_1"` (unlike LTX's
+//     `ltx_2_3` + `ltx_2_3_distilled` split), so `mochi_engine_id` is lane-agnostic.
+//  2. ONE repo, TWO backends. Every tier lives in `SceneWorks/mochi-1-mlx` with no `platforms` tag,
+//     because A6's `.scales`-detect seam lets candle ingest the mlx-affine tiers 1:1 (CUDA-validated
+//     on Blackwell, sc-11990). So the tier resolver + the on-demand fetches below are compiled for
+//     the SUPERSET of both lanes and serve candle exactly as they serve MLX.
+//
+// A tier IS a directory, not a requant toggle: both descriptors advertise `supported_quants: &[]`, so
+// `advanced.mlxQuantize` selects WHICH DIR to load and the provider only ASSERTS the tier's baked-in
+// level from its `split_model.json` (a mismatch is a hard load error, never a silent bf16 run).
+// Installed layout — the tier dirs are SIBLINGS of the shared components, which the provider resolves
+// from the tier dir's PARENT (`resolve_component_root`):
+//
+//     <model_dir>/{q4,q8,bf16}/{split_model.json, transformer/}
+//     <model_dir>/{text_encoder,tokenizer,vae}/          <- the shared coRequisite (~10.4 GB)
+//
+// Text-to-video ONLY (`conditioning: []` on both descriptors), no LoRA/LoKr, no sampler/scheduler
+// axis (one fixed flow-match Euler integrator), `max_count: 1`.
+// ---------------------------------------------------------------------------
+
+/// Adapter id recorded on a real MLX Mochi asset (the candle sibling is [`CANDLE_MOCHI_ADAPTER`]).
+#[cfg(target_os = "macos")]
+const MOCHI_ADAPTER: &str = "mlx_mochi";
+
+/// The ONE turnkey repo serving BOTH backends (epic 1788 / A6 sc-11990). Deliberately NOT the LTX
+/// shape (MLX rehost for macOS + upstream torch repo off-Mac): candle ingests these mlx-affine tiers
+/// directly, `SceneWorks/mochi-1-candle` was never published, and pointing every platform here also
+/// sidesteps sc-12113 (upstream `genmo/mochi-1-preview` ships both a bf16 and an fp32 `vae/` and the
+/// loader's dir-glob picks fp32 non-deterministically — this rehost ships bf16 only).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+const MOCHI_REPO: &str = "SceneWorks/mochi-1-mlx";
+
+/// Pinned revision for the fixed [`MOCHI_REPO`]. The repo is a hard-coded const (no manifest/payload
+/// override reaches the on-demand `q8/*` + `bf16/*` fetches below), so pulling the mutable `main`
+/// branch would let an upstream re-push silently swap a checkpoint we load. Pin the exact commit for
+/// defense-in-depth, mirroring [`LTX_BUNDLE_REVISION`] / the SeedVR2 + Real-ESRGAN pins. This is the
+/// same revision B1's manifest sizes were read from (HF API rev `90a87786`); the native downloader
+/// still verifies each file's own hash on download.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+const MOCHI_REVISION: &str = "90a87786d9b5b592c3b3c083e5fcdf130007b1de";
+
+/// Operator override for the Mochi model root (or a single tier dir) — the smoke's seam and the
+/// escape hatch for a hand-staged conversion, mirroring `$SCENEWORKS_MLX_LTX_DIR`.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+const MOCHI_DIR_ENV: &str = "SCENEWORKS_MLX_MOCHI_DIR";
+
+/// SceneWorks Mochi model id → the gen-core registry id, or `None` if not a Mochi family id. ONE id
+/// covers BOTH backends (both providers register `MODEL_ID = "mochi_1"`), so this is lane-agnostic —
+/// contrast [`ltx_engine_id`], which folds two sceneworks ids onto one engine, and the candle LTX
+/// arm, which maps to a DIFFERENT `ltx_2_3_distilled` id.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn mochi_engine_id(model: &str) -> Option<&'static str> {
+    (model == "mochi_1").then_some("mochi_1")
+}
+
+/// Whether `dir` is a loadable Mochi TIER dir: the `split_model.json` the provider reads to resolve
+/// the tier's baked-in quant, plus the AsymmDiT weights themselves. A tier dir mid-download (manifest
+/// written, `transformer/` absent, or vice versa) fails this, so it never half-loads.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn mochi_tier_dir_is_complete(dir: &Path) -> bool {
+    dir.join("split_model.json").is_file()
+        && dir.join("transformer").join("model.safetensors").is_file()
+}
+
+/// Whether `root` carries the SHARED T5-XXL text encoder + tokenizer + AsymmVAE the provider resolves
+/// from the tier dir's PARENT. These ship as a `coRequisite` (sc-9696) — a separate ~10.4 GB download
+/// tracked once and excluded from the tier matrix — so a user can genuinely have a complete `q4/` and
+/// no `text_encoder/`. Checking the tier dir alone would then resolve "successfully" and dead-end
+/// inside the provider on a missing-file error.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn mochi_shared_is_complete(root: &Path) -> bool {
+    ["text_encoder", "tokenizer", "vae"]
+        .iter()
+        .all(|component| root.join(component).is_dir())
+}
+
+/// The frame count `model` will actually render for `raw` requested frames, coerced onto that
+/// engine's temporal stride: LTX `8k+1`, **Mochi `6k+1`**, everything else (Wan and the families
+/// built on it) `4k+1`.
+///
+/// THE POINT OF THIS FUNCTION (sc-11992): the stride choice used to be an inline
+/// `if is_ltx { ltx } else { wan }` binary in each generation path, so every non-LTX model — Mochi
+/// included — silently inherited the WAN stride. That is not a benign default. Mochi's AsymmVAE is 6×
+/// temporal and its `validate_request` hard-rejects anything but `1 + 6k`; the Wan stride lands off
+/// that lattice for most inputs (the shipped 5 s @ 30 fps default → `wan_frame_count(150) = 149`,
+/// `149 % 6 == 5`), so EVERY default-duration Mochi job would die on engine validation.
+///
+/// Centralizing the ladder here — rather than repeating it per lane — is what makes the mapping
+/// unit-testable by model id and keeps the MLX and candle lanes from drifting apart. Both call it.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn video_frame_count(model: &str, raw_frames: u32) -> u32 {
+    if is_ltx_model(model) {
+        ltx_frame_count(raw_frames)
+    } else if is_mochi_model(model) {
+        mochi_frame_count(raw_frames)
+    } else {
+        wan_frame_count(raw_frames)
+    }
+}
+
+/// Parse `advanced.mlxQuantize` (int or numeric string) → the requested bit width, if present.
+/// Mirrors [`ltx_quant_bits`].
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn mochi_quant_bits(request: &VideoRequest) -> Option<i64> {
+    request
+        .advanced
+        .get("mlxQuantize")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()))
+}
+
+/// Whether the request opts into the Q8 tier (`advanced.mlxQuantize >= 8`, int or string).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn mochi_wants_q8(request: &VideoRequest) -> bool {
+    mochi_quant_bits(request).is_some_and(|bits| (8..=15).contains(&bits))
+}
+
+/// Whether the request opts into the dense **bf16** tier (`advanced.mlxQuantize <= 0`, or an explicit
+/// `>= 16`). Never the default: absent ⇒ q4, so the ~20 GB dense tier is a deliberate opt-in
+/// (mirrors [`ltx_wants_bf16`] / [`resolve_mlx_dense_quant`]'s `<= 0` rule, and additionally accepts
+/// a literal `16` since bf16 IS 16-bit and a caller may say so).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn mochi_wants_bf16(request: &VideoRequest) -> bool {
+    mochi_quant_bits(request).is_some_and(|bits| bits <= 0 || bits >= 16)
+}
+
+/// The Mochi tier search order — preferred tier first, then the always-SMALLER fallback tiers so a
+/// partially-installed model still loads: `mlxQuantize <= 0`/`>= 16` ⇒ bf16, `8..=15` ⇒ q8, and — with
+/// an explicit `1..=4` OR no explicit pick — the **q4** default (q4-first).
+///
+/// bf16 stays OUT of the default order so a default job never loads the dense tier by accident, and
+/// the video lane keeps the pre-sc-10726 q4-first default (sc-10859) rather than epic 10721's app-wide
+/// Q8 — see [`wan_tier_order`] / [`ltx_bundle_tier_order`] for that carve-out's rationale. For Mochi
+/// the argument is sharper still: the untiled decode already dominates the footprint, so a silent Q8
+/// buys quality the machine may not have the memory to spend.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn mochi_tier_order(request: &VideoRequest) -> &'static [&'static str] {
+    if mochi_wants_bf16(request) {
+        &["bf16", "q8", "q4"]
+    } else if mochi_wants_q8(request) {
+        &["q8", "q4"]
+    } else {
+        &["q4", "q8"]
+    }
+}
+
+/// Pick the first COMPLETE tier subdir of a Mochi model `root`, trying `order` (preferred first).
+/// Requires the shared co-requisite at `root` too — a tier dir without the T5/VAE siblings is not
+/// loadable, so it must not resolve.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn mochi_tier_subdir(root: &Path, order: &[&str]) -> Option<PathBuf> {
+    if !mochi_shared_is_complete(root) {
+        return None;
+    }
+    order
+        .iter()
+        .map(|tier| root.join(tier))
+        .find(|dir| mochi_tier_dir_is_complete(dir))
+}
+
+/// The tier's baked-in quant level, read from the resolved tier dir's `split_model.json` — the same
+/// manifest the provider reads. `Some(Q4)`/`Some(Q8)` for a packed tier, `None` for dense bf16.
+///
+/// Threaded onto the `LoadSpec` so (a) the asset record + metrics report the tier that was actually
+/// loaded rather than the tier that was asked for, and (b) the provider's assert becomes a real
+/// cross-check that our tier selection and its manifest read agree. Deriving this from the RESOLVED
+/// dir rather than from `advanced.mlxQuantize` is what keeps a fallback (requested q8, only q4
+/// installed) from turning into the provider's hard "spec.quantize disagrees with the tier" error.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn mochi_tier_quant(tier_dir: &Path) -> Option<Quant> {
+    let raw = std::fs::read_to_string(tier_dir.join("split_model.json")).ok()?;
+    let manifest: Value = serde_json::from_str(&raw).ok()?;
+    if !manifest.get("quantized").and_then(Value::as_bool)? {
+        return None;
+    }
+    match manifest.get("quantization_bits").and_then(Value::as_i64)? {
+        4 => Some(Quant::Q4),
+        8 => Some(Quant::Q8),
+        _ => None,
+    }
+}
+
+/// Resolve the Mochi tier dir to load: the `$SCENEWORKS_MLX_MOCHI_DIR` override (accepted as either a
+/// model root carrying tier subdirs or a single self-contained tier dir), then the turnkey
+/// [`MOCHI_REPO`] snapshot's tier subdir. Only a COMPLETE tier + its shared co-requisite counts.
+///
+/// Shared by BOTH lanes (one repo, both backends), so the candle generation arm calls this instead of
+/// `candle_video_snapshot_dir` — the flat-snapshot resolver has no notion of the tier layout.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn resolve_mochi_model_dir(settings: &Settings, request: &VideoRequest) -> WorkerResult<PathBuf> {
+    let order = mochi_tier_order(request);
+    if let Ok(override_dir) = std::env::var(MOCHI_DIR_ENV) {
+        let root = PathBuf::from(override_dir.trim());
+        // A model root with `q4/`/`q8/`/`bf16/` subdirs …
+        if let Some(dir) = mochi_tier_subdir(&root, order) {
+            return Ok(dir);
+        }
+        // … or a self-contained dir that IS one tier (components under it, the provider's
+        // `resolve_component_root` self-resolution case).
+        if mochi_tier_dir_is_complete(&root) && mochi_shared_is_complete(&root) {
+            return Ok(root);
+        }
+    }
+    if let Some(root) = huggingface_snapshot_dir(&settings.data_dir, MOCHI_REPO) {
+        if let Some(dir) = mochi_tier_subdir(&root, order) {
+            return Ok(dir);
+        }
+        // The snapshot exists but nothing loadable resolved — say WHICH half is missing rather than a
+        // blanket "not found", since the tiers and the shared components are separate downloads.
+        if !mochi_shared_is_complete(&root) {
+            return Err(WorkerError::InvalidPayload(format!(
+                "{}: the shared Mochi text encoder / tokenizer / VAE are not installed (expected \
+                 text_encoder/, tokenizer/ and vae/ beside the tier dirs under {}). Re-download \
+                 Mochi 1 in the Model Manager — the shared components install alongside whichever \
+                 tier you pick.",
+                request.model,
+                root.display()
+            )));
+        }
+        return Err(WorkerError::InvalidPayload(format!(
+            "{}: no complete Mochi tier found under {} (looked for {order:?}). Download the tier you \
+             selected in the Model Manager, or set ${MOCHI_DIR_ENV} to a model dir.",
+            request.model,
+            root.display()
+        )));
+    }
+    Err(WorkerError::InvalidPayload(format!(
+        "{}: Mochi 1 is not downloaded (no {MOCHI_REPO} snapshot under {}). Install it from the \
+         Model Manager, or set ${MOCHI_DIR_ENV} to a model dir.",
+        request.model,
+        settings.data_dir.display()
+    )))
+}
+
+/// Whether the linked Mochi engine can serve this request now: a Mochi model id, in the ONE mode it
+/// supports, with resolvable weights.
+///
+/// **text_to_video only** — both descriptors declare `conditioning: []`, so there is no i2v /
+/// first-last / extend / bridge / replace surface. This gate matters because `VideoRequest`'s mode
+/// DEFAULTS to `image_to_video` when the payload omits one, so a mode check is what keeps a
+/// conditioning-shaped Mochi job out of the route rather than letting it reach the engine's
+/// `validate_request` (or, worse, an unrelated arm of the ladder).
+#[cfg(target_os = "macos")]
+fn mochi_available(request: &VideoRequest, settings: &Settings) -> bool {
+    mochi_engine_id(&request.model).is_some()
+        && request.mode == "text_to_video"
+        && resolve_mochi_model_dir(settings, request).is_ok()
+}
+
+/// Fetch the `q8/` tier on demand (mirrors [`ensure_ltx_q8_present`]). The default install is the lean
+/// q4 tier + the shared co-requisite; a job that toggles `advanced.mlxQuantize: 8` without a
+/// pre-installed q8 pulls just `q8/*` from the FIXED [`MOCHI_REVISION`] before any compute. No-op when
+/// q8 isn't requested, when the snapshot isn't downloaded at all (resolve surfaces the clear
+/// "not downloaded" error), or when `q8/` is already complete. Fails loud on a real download error.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+async fn ensure_mochi_q8_present(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+) -> WorkerResult<()> {
+    if !mochi_wants_q8(request) {
+        return Ok(());
+    }
+    ensure_mochi_tier_present(api, settings, job, "q8").await
+}
+
+/// Fetch the dense `bf16/` tier on demand (~20 GB) — the [`ensure_mochi_q8_present`] sibling for the
+/// power-user tier ([`mochi_wants_bf16`]).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+async fn ensure_mochi_bf16_present(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+) -> WorkerResult<()> {
+    if !mochi_wants_bf16(request) {
+        return Ok(());
+    }
+    ensure_mochi_tier_present(api, settings, job, "bf16").await
+}
+
+/// The shared body behind the two on-demand tier fetches: pull `<tier>/*` from the pinned
+/// [`MOCHI_REVISION`] when the snapshot exists but that tier doesn't.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+async fn ensure_mochi_tier_present(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    tier: &str,
+) -> WorkerResult<()> {
+    let Some(root) = huggingface_snapshot_dir(&settings.data_dir, MOCHI_REPO) else {
+        return Ok(());
+    };
+    if mochi_tier_dir_is_complete(&root.join(tier)) {
+        return Ok(());
+    }
+    crate::model_jobs::ensure_hf_files_cached(
+        api,
+        settings,
+        job,
+        MOCHI_REPO,
+        MOCHI_REVISION,
+        &[format!("{tier}/*")],
+    )
+    .await
+    .map(|_| ())
+}
+
+/// The `rawSettings` recorded on a Mochi asset. `mochiTier` names the tier that was actually LOADED
+/// (from the resolved dir's `split_model.json`), not the one the request asked for — those differ
+/// when a requested tier isn't installed and the order falls back.
+#[cfg(target_os = "macos")]
+fn mochi_raw_settings(request: &VideoRequest, quant: Option<Quant>) -> Value {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("model".to_owned(), Value::String(request.model.clone()));
+    raw.insert("frameCount".to_owned(), json!(request.frame_count()));
+    raw.insert("fps".to_owned(), json!(request.fps));
+    raw.insert(
+        "mochiTier".to_owned(),
+        Value::String(
+            match quant {
+                Some(Quant::Q4) => "q4",
+                Some(Quant::Q8) => "q8",
+                _ => "bf16",
+            }
+            .to_owned(),
+        ),
+    );
+    Value::Object(raw)
+}
+
+/// Resolve a Mochi request into a [`VideoGenInput`] and run it (epic 1788 / sc-11992) — the MLX lane.
+///
+/// Text-to-video only, true CFG (not distilled, so negative prompt + guidance are real), frames snap
+/// to `6k+1`, and the tier dir carries the quant. Progress/heartbeat bridging, cooperative cancel, the
+/// forward-progress stall watchdog and the completion metrics all come from the shared
+/// [`generate_video`] funnel — the same one Wan/LTX/SVD use — so Mochi inherits the "no background
+/// heartbeat during a job, the progress callback IS the keepalive" contract without re-implementing it.
+#[cfg(target_os = "macos")]
+async fn generate_mochi(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    engine_id: &'static str,
+    backend: &str,
+) -> WorkerResult<(DecodedVideo, Value)> {
+    // A tier the job toggled but never downloaded is fetched before any compute (no-op otherwise).
+    ensure_mochi_q8_present(api, settings, job, request).await?;
+    ensure_mochi_bf16_present(api, settings, job, request).await?;
+    let model_dir = resolve_mochi_model_dir(settings, request)?;
+    let quant = mochi_tier_quant(&model_dir);
+    // The shared stride ladder — NOT `wan_frame_count` (see `video_frame_count`).
+    let frames = video_frame_count(&request.model, request.raw_frame_count());
+
+    // PRE-FLIGHT FIT GATE (epic AC: "an unsupported environment shows an actionable error, not a
+    // crash"). This MUST run before the load: Mochi holds ~18.7 GiB of weights resident for the whole
+    // run (`supports_sequential_offload: false`) and its AsymmVAE decode is UNTILED, so the peak grows
+    // linearly with clip length (sc-12291) — ~60 GiB of decode alone at the shipped 5 s default. MLX's
+    // default error handler is `exit(-1)`, a hard process kill that CANNOT be mapped to a job error
+    // after the fact, so an over-budget job has to be refused here or it takes the worker down with
+    // it. The generic `mlx_fit_gate` cannot cover this: it is resolution-blind by construction and its
+    // weights-fit floor would admit on the 18.7 GiB weights alone.
+    crate::mlx_fit_gate::mochi_fit_check(
+        engine_id,
+        &model_dir,
+        frames,
+        request.width,
+        request.height,
+    )?;
+
+    let input = VideoGenInput {
+        sampler: None,
+        scheduler: None,
+        engine_id,
+        model_dir,
+        quant,
+        // No adapter path on either backend (`supports_lora`/`supports_lokr` = false).
+        adapters: Vec::new(),
+        // t2v only — `conditioning: []` on the descriptor.
+        conditioning: Vec::new(),
+        prompt: request.prompt.clone(),
+        // Not distilled ⇒ true CFG, so a negative prompt is real conditioning here (contrast the
+        // distilled LTX path, which passes `None`).
+        negative_prompt: non_empty_negative_prompt(request),
+        width: request.width,
+        height: request.height,
+        frames,
+        fps: request.fps,
+        // `None` ⇒ the engine's own DEFAULT_STEPS (64) / DEFAULT_GUIDANCE (4.5).
+        steps: advanced_opt_u32(request, "steps"),
+        guidance: advanced_opt_f32(request, "guidanceScale"),
+        seed: resolve_video_seed(request) as u64,
+        ..VideoGenInput::default()
+    };
+    let raw_settings = mochi_raw_settings(request, quant);
+    let decoded = generate_video(api, settings, job, backend, &request.advanced, input).await?;
+    Ok((decoded, raw_settings))
+}
+
+// ---------------------------------------------------------------------------
 // Real MLX Stable Video Diffusion (SVD-XT) generation (macOS, via mlx-gen-svd, sc-3523):
 // image→video ONLY — animates one source image into a fixed ~25-frame burst (no text prompt,
 // no audio) via the `motion_bucket_id` / `noise_aug_strength` / conditioning-fps
@@ -9842,6 +10396,515 @@ mod tests {
 
     fn request(value: Value) -> VideoRequest {
         VideoRequest::from_payload(&value.as_object().cloned().unwrap())
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Mochi 1 (epic 1788 / sc-11992). These sit on the SUPERSET cfg because the tier resolver, the
+    // stride and the on-demand fetches are SHARED by both lanes (one repo, both backends) — so they
+    // run on the macOS lane AND on the windows-candle lane, which is what makes the candle half
+    // genuinely covered rather than asserted.
+    // -----------------------------------------------------------------------------------------
+
+    /// Build a Mochi model root in the A6 installed layout: tier dirs as SIBLINGS of the shared
+    /// T5/tokenizer/VAE co-requisite. `tiers` lists the tier dirs to materialize.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    fn mochi_root(tag: &str, tiers: &[&str], shared: bool) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "mochi_root_{tag}_{}_{}",
+            std::process::id(),
+            line!()
+        ));
+        for tier in tiers {
+            let transformer = root.join(tier).join("transformer");
+            std::fs::create_dir_all(&transformer).unwrap();
+            std::fs::write(transformer.join("model.safetensors"), b"w").unwrap();
+            let (quantized, bits) = match *tier {
+                "q4" => (true, 4),
+                "q8" => (true, 8),
+                _ => (false, 0),
+            };
+            let manifest = if quantized {
+                json!({ "quantized": true, "quantization_bits": bits, "quantization_group_size": 64 })
+            } else {
+                json!({ "quantized": false })
+            };
+            std::fs::write(
+                root.join(tier).join("split_model.json"),
+                serde_json::to_string(&manifest).unwrap(),
+            )
+            .unwrap();
+        }
+        if shared {
+            for component in ["text_encoder", "tokenizer", "vae"] {
+                std::fs::create_dir_all(root.join(component)).unwrap();
+            }
+        }
+        root
+    }
+
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    fn mochi_request(advanced: Value) -> VideoRequest {
+        request(json!({
+            "projectId": "p",
+            "model": "mochi_1",
+            "mode": "text_to_video",
+            "prompt": "a calico kitten",
+            "advanced": advanced,
+        }))
+    }
+
+    /// `advanced.mlxQuantize` selects WHICH TIER DIR to load — the story's "selecting q4/q8/bf16
+    /// loads the right tier" AC. A tier is a DIRECTORY, not a requant toggle (`supported_quants: &[]`
+    /// on both descriptors), so this mapping is the entire quant mechanism.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn mochi_tier_order_maps_mlx_quantize_to_a_tier_dir() {
+        // No explicit pick ⇒ q4-first (the video lane's sc-10859 carve-out; bf16 never a default).
+        assert_eq!(mochi_tier_order(&mochi_request(json!({}))), &["q4", "q8"]);
+        assert!(!mochi_tier_order(&mochi_request(json!({}))).contains(&"bf16"));
+        // Explicit small ⇒ still q4-first.
+        assert_eq!(
+            mochi_tier_order(&mochi_request(json!({ "mlxQuantize": 4 }))),
+            &["q4", "q8"]
+        );
+        // q8 ⇒ q8-first. Accepted as int OR string (the manifest/UI can send either).
+        assert_eq!(
+            mochi_tier_order(&mochi_request(json!({ "mlxQuantize": 8 }))),
+            &["q8", "q4"]
+        );
+        assert_eq!(
+            mochi_tier_order(&mochi_request(json!({ "mlxQuantize": "8" }))),
+            &["q8", "q4"]
+        );
+        // Dense bf16 ⇒ the `<= 0` opt-in rule, and a literal 16 (bf16 IS 16-bit).
+        for dense in [json!({ "mlxQuantize": 0 }), json!({ "mlxQuantize": -1 })] {
+            assert_eq!(
+                mochi_tier_order(&mochi_request(dense)),
+                &["bf16", "q8", "q4"]
+            );
+        }
+        assert_eq!(
+            mochi_tier_order(&mochi_request(json!({ "mlxQuantize": 16 }))),
+            &["bf16", "q8", "q4"]
+        );
+    }
+
+    /// The resolver returns the TIER DIR (not the model root), honors the requested tier, and folds
+    /// in the shared co-requisite gate. Pins the `WeightsSource::Dir` = tier-dir contract the
+    /// provider's parent-resolution (`resolve_component_root`) depends on.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn resolve_mochi_model_dir_picks_the_requested_tier_dir() {
+        let root = mochi_root("resolve", &["q4", "q8", "bf16"], true);
+        let settings = Settings {
+            data_dir: root.join("unused-data-dir"),
+            ..Settings::from_env()
+        };
+        // Route the resolver at the fixture via the operator override.
+        temp_env_var(MOCHI_DIR_ENV, root.to_str().unwrap(), || {
+            for (advanced, want) in [
+                (json!({}), "q4"),
+                (json!({ "mlxQuantize": 4 }), "q4"),
+                (json!({ "mlxQuantize": 8 }), "q8"),
+                (json!({ "mlxQuantize": 0 }), "bf16"),
+            ] {
+                let dir = resolve_mochi_model_dir(&settings, &mochi_request(advanced.clone()))
+                    .unwrap_or_else(|e| panic!("resolve {advanced} failed: {e:?}"));
+                assert_eq!(
+                    dir,
+                    root.join(want),
+                    "advanced {advanced} must resolve the {want} TIER dir"
+                );
+                // The tier dir's parent is the model root — where the provider finds the shared
+                // T5/VAE. If the resolver ever returned the root itself this breaks.
+                assert_eq!(dir.parent().unwrap(), root);
+            }
+        });
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// A complete tier with NO shared co-requisite must NOT resolve. The T5/tokenizer/VAE are a
+    /// SEPARATE download (`coRequisite`, sc-9696), so "q4 present, text_encoder absent" is a real
+    /// user state — and resolving it would dead-end inside the provider on a missing-file error
+    /// instead of telling the user what to re-download.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn resolve_mochi_model_dir_requires_the_shared_corequisite() {
+        let root = mochi_root("noshared", &["q4"], false);
+        let settings = Settings {
+            data_dir: root.join("unused-data-dir"),
+            ..Settings::from_env()
+        };
+        temp_env_var(MOCHI_DIR_ENV, root.to_str().unwrap(), || {
+            assert!(
+                mochi_tier_subdir(&root, &["q4"]).is_none(),
+                "a tier without the shared T5/VAE siblings is not loadable"
+            );
+            assert!(
+                resolve_mochi_model_dir(&settings, &mochi_request(json!({}))).is_err(),
+                "must error rather than resolve an unloadable tier"
+            );
+        });
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// A half-downloaded tier (manifest without weights, or weights without the manifest) must fall
+    /// THROUGH to the next tier in the order rather than half-loading.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn mochi_tier_subdir_skips_an_incomplete_tier() {
+        let root = mochi_root("partial", &["q4"], true);
+        // A `q8/` that carries only the manifest — the shape a mid-flight download leaves on disk.
+        std::fs::create_dir_all(root.join("q8")).unwrap();
+        std::fs::write(root.join("q8").join("split_model.json"), b"{}").unwrap();
+
+        assert!(!mochi_tier_dir_is_complete(&root.join("q8")));
+        assert_eq!(
+            mochi_tier_subdir(&root, &["q8", "q4"]),
+            Some(root.join("q4")),
+            "a torn q8 must fall through to the complete q4, never half-load"
+        );
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// The quant marker rides the RESOLVED tier's own `split_model.json` — the same manifest the
+    /// provider asserts against — so the spec can never disagree with the dir we picked (which would
+    /// be a hard load error), and the asset record names the tier actually loaded.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn mochi_tier_quant_reads_the_tier_manifest() {
+        let root = mochi_root("quant", &["q4", "q8", "bf16"], true);
+        assert_eq!(mochi_tier_quant(&root.join("q4")), Some(Quant::Q4));
+        assert_eq!(mochi_tier_quant(&root.join("q8")), Some(Quant::Q8));
+        // Dense tier ⇒ no quant assertion (the provider loads it dense).
+        assert_eq!(mochi_tier_quant(&root.join("bf16")), None);
+        // A manifest-less dir is dense-by-absence, never a guess.
+        assert_eq!(mochi_tier_quant(&root.join("nope")), None);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// `mochi_1` is the engine id on BOTH backends — no `_distilled`-style split, unlike LTX.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn mochi_engine_id_is_the_model_id_and_matches_nothing_else() {
+        assert_eq!(mochi_engine_id("mochi_1"), Some("mochi_1"));
+        for other in [
+            "wan_2_2",
+            "ltx_2_3",
+            "svd",
+            "scail2_14b",
+            "bernini",
+            "mochi",
+        ] {
+            assert!(mochi_engine_id(other).is_none(), "{other} is not mochi_1");
+        }
+    }
+
+    /// **The frame-stride seam** (sc-11992): Mochi must use its own `6k+1` snap, not the
+    /// `wan_frame_count` else-arm every non-LTX model used to fall into.
+    ///
+    /// The failure mode is worth stating precisely, because the story brief mis-stated it. It claimed
+    /// `wan_frame_count(150) = 145`, that `145 % 6 == 1` makes the runtime ACCEPT it, and that a 5 s
+    /// request would therefore silently render 4.83 s. The arithmetic does not hold:
+    /// `wan_frame_count(150)` is **149** (`150 − ((150−1) % 4)` = 150 − 1), and `149 % 6 == 5`, so the
+    /// engine's `validate_request` **hard-rejects** it. The real bug is a LOUD failure — every
+    /// default-duration Mochi job dies on "num_frames must be 1 + 6·k (got 149)" — not a silent
+    /// wrong-length clip.
+    ///
+    /// Stronger still, a silent wrong length is IMPOSSIBLE on this pairing, and the test pins that:
+    /// whenever the Wan stride's answer happens to land on Mochi's lattice it is provably EQUAL to
+    /// Mochi's snap, so the substitution either agrees or errors — it never lies. (Why: if
+    /// `wan(raw) = W` is `≡ 1 mod 6` then `raw − W ∈ 0..=3`, so `W` is Mochi's `lower` and
+    /// `raw − W ≤ 3 ≤ 6 − (raw − W)` makes Mochi's nearest-with-ties-low pick `W` too.)
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn frames_are_the_mochi_lattice_not_wans() {
+        // THE WIRING (not just the functions): the shared ladder BOTH generation lanes call must map
+        // the mochi_1 MODEL ID onto the 6k+1 stride. This is what fails if a lane is (re-)pointed at
+        // `wan_frame_count` — asserting `mochi_frame_count` vs `wan_frame_count` in isolation would
+        // NOT, since both functions stay correct while the caller picks the wrong one.
+        assert_eq!(
+            video_frame_count("mochi_1", 150),
+            151,
+            "mochi_1 must resolve the 6k+1 stride through the shared ladder"
+        );
+        assert_eq!(
+            video_frame_count("mochi_1", 150),
+            mochi_frame_count(150),
+            "the mochi arm must BE mochi_frame_count"
+        );
+        assert_ne!(
+            video_frame_count("mochi_1", 150),
+            wan_frame_count(150),
+            "routing mochi through the wan stride is the bug this pins"
+        );
+        // The other families keep their own strides — adding Mochi must not perturb them.
+        assert_eq!(video_frame_count("ltx_2_3", 150), ltx_frame_count(150));
+        assert_eq!(video_frame_count("ltx_2_3_eros", 150), ltx_frame_count(150));
+        assert_eq!(video_frame_count("wan_2_2", 150), wan_frame_count(150));
+        assert_eq!(video_frame_count("scail2_14b", 150), wan_frame_count(150));
+        assert_eq!(video_frame_count("bernini", 150), wan_frame_count(150));
+
+        // The shipped default: 5 s x 30 fps = 150 raw frames.
+        assert_eq!(
+            mochi_frame_count(150),
+            151,
+            "the manifest's documented 5 s count"
+        );
+        assert_eq!(
+            wan_frame_count(150),
+            149,
+            "NOT 145 — the brief's arithmetic was wrong"
+        );
+        assert_ne!(mochi_frame_count(150), wan_frame_count(150));
+        // The default job's real failure on the wan arm: OFF-lattice ⇒ the engine rejects.
+        assert_eq!(
+            wan_frame_count(150) % 6,
+            5,
+            "149 is off Mochi's 6k+1 lattice, so validate_request hard-rejects the 5 s default"
+        );
+
+        // Mochi's own snap is always ON-lattice — the engine accepts every value we can produce.
+        for raw in [1_u32, 6, 7, 30, 90, 150, 151, 163, 900] {
+            assert_eq!(
+                mochi_frame_count(raw) % 6,
+                1,
+                "mochi_frame_count({raw}) must sit on the 6k+1 lattice"
+            );
+        }
+
+        // The invariant: the wan stride can never SILENTLY render a wrong length — over the whole
+        // supported duration range it either equals mochi's snap or is rejected by the engine.
+        let mut accepted = 0;
+        for raw in 1_u32..=1_800 {
+            let wan = wan_frame_count(raw);
+            if wan % 6 == 1 {
+                accepted += 1;
+                assert_eq!(
+                    wan,
+                    mochi_frame_count(raw),
+                    "raw {raw}: a wan value the mochi runtime ACCEPTS must equal mochi's own snap, \
+                     or the substitution would silently change clip length"
+                );
+            }
+        }
+        assert!(accepted > 0, "the invariant must be exercised, not vacuous");
+    }
+
+    /// Mochi is text-to-video ONLY (`conditioning: []` on both descriptors). `VideoRequest`'s mode
+    /// DEFAULTS to `image_to_video` when the payload omits one, so the mode gate is what keeps a
+    /// conditioning-shaped job out of the Mochi route — without it an unmoded payload would route to
+    /// Mochi and fail deep in the engine.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn mochi_available_is_text_to_video_only() {
+        let root = mochi_root("mode", &["q4"], true);
+        let settings = Settings {
+            data_dir: root.join("unused-data-dir"),
+            ..Settings::from_env()
+        };
+        temp_env_var(MOCHI_DIR_ENV, root.to_str().unwrap(), || {
+            let t2v = request(json!({
+                "projectId": "p", "model": "mochi_1", "mode": "text_to_video", "prompt": "p"
+            }));
+            assert!(
+                mochi_available(&t2v, &settings),
+                "a t2v mochi job with resolvable weights must route to the Mochi engine"
+            );
+            // Every non-t2v mode — including the DEFAULT the DTO applies when `mode` is absent.
+            for mode in [
+                "image_to_video",
+                "first_last_frame",
+                "extend_clip",
+                "video_bridge",
+                "replace_person",
+                "animate_character",
+            ] {
+                let req = request(json!({
+                    "projectId": "p", "model": "mochi_1", "mode": mode, "prompt": "p"
+                }));
+                assert!(
+                    !mochi_available(&req, &settings),
+                    "mochi has no {mode} surface (conditioning: [])"
+                );
+            }
+            let unmoded = request(json!({ "projectId": "p", "model": "mochi_1", "prompt": "p" }));
+            assert_eq!(unmoded.mode, "image_to_video", "the DTO's default mode");
+            assert!(
+                !mochi_available(&unmoded, &settings),
+                "a payload with no mode defaults to i2v and must NOT reach the t2v-only engine"
+            );
+        });
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// A Mochi t2v job with resolvable weights routes to `VideoRoute::Mochi` — and, critically, a
+    /// Mochi job whose weights DON'T resolve must NOT silently become `VideoRoute::Stub` output:
+    /// `ensure_video_engine_weights` (the sc-4176 fail-loud gate the Stub arm calls) must error.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn mochi_routes_to_the_mochi_engine_and_never_degrades_to_a_fake_video() {
+        let root = mochi_root("route", &["q4"], true);
+        let settings = Settings {
+            data_dir: root.join("unused-data-dir"),
+            ..Settings::from_env()
+        };
+        let req = request(json!({
+            "projectId": "p", "model": "mochi_1", "mode": "text_to_video", "prompt": "p"
+        }));
+        temp_env_var(MOCHI_DIR_ENV, root.to_str().unwrap(), || {
+            assert_eq!(
+                resolve_video_route(&req, &settings),
+                VideoRoute::Mochi("mochi_1")
+            );
+            // Adding Mochi must not perturb any pre-existing route.
+            let wan = request(json!({
+                "projectId": "p", "model": "wan_2_2", "mode": "text_to_video", "prompt": "p"
+            }));
+            assert!(!matches!(
+                resolve_video_route(&wan, &settings),
+                VideoRoute::Mochi(_)
+            ));
+        });
+
+        // Weights absent (no override, empty data dir) ⇒ the route falls to Stub, BUT the Stub arm's
+        // fail-loud gate must refuse rather than hand back a procedural fake video.
+        let empty = std::env::temp_dir().join(format!("mochi_empty_{}", std::process::id()));
+        std::fs::create_dir_all(&empty).unwrap();
+        let bare = Settings {
+            data_dir: empty.clone(),
+            ..Settings::from_env()
+        };
+        temp_env_var(MOCHI_DIR_ENV, "", || {
+            assert_eq!(resolve_video_route(&req, &bare), VideoRoute::Stub);
+            let err = ensure_video_engine_weights(&req, &bare)
+                .expect_err("an unprovisioned mochi MUST fail loudly, never render a fake video");
+            let WorkerError::InvalidPayload(message) = err else {
+                panic!("expected an actionable InvalidPayload");
+            };
+            assert!(
+                message.contains("mochi_1") && message.contains("Model Manager"),
+                "the error must name the model and tell the user what to do: {message}"
+            );
+        });
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&empty).ok();
+    }
+
+    /// The on-demand tier fetches are gated on the request's tier toggle — the "fetched on demand if
+    /// toggled but not downloaded" AC. Pins that a default (q4) job asks for NEITHER extra tier, so
+    /// no job accidentally pulls the ~13 GB q8 / ~20 GB bf16.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn mochi_on_demand_tier_fetch_is_gated_on_the_toggle() {
+        // Default ⇒ neither on-demand tier is wanted.
+        assert!(!mochi_wants_q8(&mochi_request(json!({}))));
+        assert!(!mochi_wants_bf16(&mochi_request(json!({}))));
+        // q8 toggle ⇒ q8 only.
+        assert!(mochi_wants_q8(&mochi_request(json!({ "mlxQuantize": 8 }))));
+        assert!(!mochi_wants_bf16(&mochi_request(
+            json!({ "mlxQuantize": 8 })
+        )));
+        // bf16 toggle ⇒ bf16 only (the two must be mutually exclusive, or a bf16 job would also drag
+        // the q8 tier down).
+        assert!(mochi_wants_bf16(&mochi_request(
+            json!({ "mlxQuantize": 0 })
+        )));
+        assert!(!mochi_wants_q8(&mochi_request(json!({ "mlxQuantize": 0 }))));
+        // An explicit q4 pick pulls nothing extra.
+        assert!(!mochi_wants_q8(&mochi_request(json!({ "mlxQuantize": 4 }))));
+        assert!(!mochi_wants_bf16(&mochi_request(
+            json!({ "mlxQuantize": 4 })
+        )));
+    }
+
+    /// The pinned revision must be a full 40-char commit, not a mutable branch: the repo is a
+    /// hard-coded const, so `main` would let an upstream re-push swap a checkpoint we load.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn mochi_repo_revision_is_pinned_to_a_commit() {
+        assert_eq!(MOCHI_REPO, "SceneWorks/mochi-1-mlx");
+        assert_eq!(MOCHI_REVISION.len(), 40, "a full commit sha, not a branch");
+        assert!(MOCHI_REVISION.chars().all(|c| c.is_ascii_hexdigit()));
+        // The revision B1's manifest sizes were read from.
+        assert!(MOCHI_REVISION.starts_with("90a87786"));
+    }
+
+    /// The MLX asset record names the tier that was actually LOADED, so provenance can't drift from
+    /// the tier the resolver picked when a requested tier isn't installed.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn mochi_raw_settings_record_the_loaded_tier() {
+        let req = mochi_request(json!({ "mlxQuantize": 8 }));
+        // Requested q8 but q4 was what resolved ⇒ the record says q4, not q8.
+        let raw = mochi_raw_settings(&req, Some(Quant::Q4));
+        assert_eq!(raw["mochiTier"], json!("q4"));
+        assert_eq!(raw["realModelInference"], json!(true));
+        assert_eq!(raw["model"], json!("mochi_1"));
+        assert_eq!(raw["frameCount"], json!(req.frame_count()));
+        assert_eq!(
+            mochi_raw_settings(&req, Some(Quant::Q8))["mochiTier"],
+            json!("q8")
+        );
+        assert_eq!(mochi_raw_settings(&req, None)["mochiTier"], json!("bf16"));
+    }
+
+    /// Set `key` to `value` (empty ⇒ removed) for the duration of `body`, then restore. The Mochi
+    /// resolver reads an operator override from the environment, and `std::env::set_var` is
+    /// process-global, so the tests that use it are serialized behind one mutex.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    fn temp_env_var<T>(key: &str, value: &str, body: impl FnOnce() -> T) -> T {
+        use std::sync::Mutex;
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let previous = std::env::var(key).ok();
+        if value.is_empty() {
+            std::env::remove_var(key);
+        } else {
+            std::env::set_var(key, value);
+        }
+        let out = body();
+        match previous {
+            Some(prior) => std::env::set_var(key, prior),
+            None => std::env::remove_var(key),
+        }
+        out
     }
 
     /// sc-10418: the resolved video quant maps to the same normalized tier labels the
@@ -14882,6 +15945,74 @@ mod candle_video_label_tests {
             "candle_ltx"
         );
         assert_eq!(candle_video_adapter_label("svd_xt"), "candle_svd");
+        // Mochi (sc-11992) must have its OWN arm. The `_` fall-through is the Wan default, so a
+        // missing arm silently stamps `candle_wan` onto a Mochi asset's sidecar + telemetry — wrong
+        // provenance with no error anywhere.
+        assert_eq!(candle_video_adapter_label("mochi_1"), "candle_mochi");
+        assert_ne!(
+            candle_video_adapter_label("mochi_1"),
+            CANDLE_WAN_ADAPTER,
+            "mochi_1 must not fall through to the Wan adapter label"
+        );
+    }
+
+    /// **The candle-lane routing trap** (sc-11992). B1 declared Windows served
+    /// (`VideoModelCaps::new("mochi_1", true, true, false, false)` ⇒ `candle_video_routed`), and A6
+    /// validated the lane on Blackwell against the very same hosted tiers. If `candle_video_engine_id`
+    /// does not resolve `mochi_1`, `is_candle_video_engine` is false, `resolve_candle_video_route`
+    /// never reaches its generic arm, and the job lands on `CandleVideoRoute::Stub` — handing the user
+    /// a PROCEDURAL FAKE VIDEO rather than an error. That is a silent wrong-output bug, so it is
+    /// pinned here rather than left to the descriptor.
+    #[test]
+    fn candle_mochi_resolves_the_engine_and_never_falls_to_the_stub() {
+        // ONE engine id on BOTH backends — no `_distilled`-style split (contrast ltx above).
+        assert_eq!(candle_video_engine_id("mochi_1"), Some("mochi_1"));
+        assert!(
+            is_candle_video_engine("mochi_1"),
+            "mochi_1 MUST be a candle video engine or Windows silently renders a procedural stub"
+        );
+
+        // The generic candle arm is reached for a t2v mochi job (the shape B1's router allows
+        // through: text_to_video, no source asset, no LoRA).
+        let settings = Settings {
+            backend_candle_enabled: true,
+            ..Settings::from_env()
+        };
+        let payload = json!({
+            "projectId": "p", "model": "mochi_1", "mode": "text_to_video", "prompt": "p"
+        });
+        let req = VideoRequest::from_payload(payload.as_object().expect("object"));
+        assert_eq!(
+            resolve_candle_video_route(&req, &settings),
+            CandleVideoRoute::CandleVideo,
+            "a t2v mochi job must route to the candle video engine, NOT the stub"
+        );
+    }
+
+    /// The candle default repo must be Mochi's own. No Mochi manifest entry carries a top-level
+    /// `repo`, so `candle_video_repo` falls through to this default — and the `_` arm is Wan's, which
+    /// would send the loader at a Wan diffusers snapshot.
+    #[test]
+    fn candle_mochi_default_repo_is_the_shared_mochi_turnkey() {
+        assert_eq!(
+            candle_video_default_repo("mochi_1"),
+            "SceneWorks/mochi-1-mlx"
+        );
+        assert_ne!(
+            candle_video_default_repo("mochi_1"),
+            CANDLE_WAN_5B_REPO,
+            "mochi_1 must not inherit Wan's default repo"
+        );
+        // ONE repo serves BOTH backends — the candle default IS the MLX repo (A6's `.scales`-detect
+        // seam ingests the mlx-affine tiers 1:1; `SceneWorks/mochi-1-candle` was never published).
+        assert_eq!(candle_video_default_repo("mochi_1"), MOCHI_REPO);
+
+        // With no manifest `repo` (the shipped Mochi entry), the resolved repo is that default.
+        let payload = json!({
+            "projectId": "p", "model": "mochi_1", "mode": "text_to_video", "prompt": "p"
+        });
+        let req = VideoRequest::from_payload(payload.as_object().expect("object"));
+        assert_eq!(candle_video_repo(&req, "mochi_1"), "SceneWorks/mochi-1-mlx");
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -8975,13 +8975,6 @@ fn mochi_raw_settings(request: &VideoRequest, quant: Option<Quant>) -> Value {
     Value::Object(raw)
 }
 
-/// Resolve a Mochi request into a [`VideoGenInput`] and run it (epic 1788 / sc-11992) — the MLX lane.
-///
-/// Text-to-video only, true CFG (not distilled, so negative prompt + guidance are real), frames snap
-/// to `6k+1`, and the tier dir carries the quant. Progress/heartbeat bridging, cooperative cancel, the
-/// forward-progress stall watchdog and the completion metrics all come from the shared
-/// [`generate_video`] funnel — the same one Wan/LTX/SVD use — so Mochi inherits the "no background
-/// heartbeat during a job, the progress callback IS the keepalive" contract without re-implementing it.
 /// Everything a Mochi generation must settle BEFORE the load, resolved as ONE unit by
 /// [`mochi_preflight`] (sc-11992).
 ///
@@ -9045,6 +9038,16 @@ fn mochi_preflight(
     })
 }
 
+/// Resolve a Mochi request into a [`VideoGenInput`] and run it (epic 1788 / sc-11992) — the MLX lane.
+///
+/// Text-to-video only, true CFG (not distilled, so negative prompt + guidance are real), frames snap
+/// to `6k+1`, and the tier dir carries the quant. Progress/heartbeat bridging, cooperative cancel, the
+/// forward-progress stall watchdog and the completion metrics all come from the shared
+/// [`generate_video`] funnel — the same one Wan/LTX/SVD use — so Mochi inherits the "no background
+/// heartbeat during a job, the progress callback IS the keepalive" contract without re-implementing it.
+///
+/// Deliberately thin: every pre-load decision lives in [`mochi_preflight`], which is reachable from a
+/// unit test where this `async` arm is not.
 #[cfg(target_os = "macos")]
 async fn generate_mochi(
     api: &ApiClient,


### PR DESCRIPTION
B2 of [epic 1788](https://app.shortcut.com/trefry/epic/1788) — [sc-11992](https://app.shortcut.com/trefry/story/11992). B1 (`a59cada7`) declared Mochi to the app; B3 (`0c9061df`) shaped the request. **This wires the worker so a Mochi text-to-video job actually runs.**

## Scope vs each AC

| AC | Status |
|---|---|
| A Mochi t2v job produces frames | ✅ **GPU smoke run on real weights** — all 3 tiers render 848×480 × 7 frames; at the engine's full 64 steps q4 renders a recognizable subject |
| …reports monotonic progress | ✅ Smoke asserts monotonicity + that `Decoding` is reached; the shared `generate_video` funnel bridges it to job progress/heartbeat |
| …cancels promptly | ✅ Inherited from `generate_video` (`CancelFlag` threaded, stall watchdog, abandon deadline) — not re-implemented |
| Selecting q4/q8/bf16 loads the right tier | ✅ `mochi_tier_order` + `resolve_mochi_model_dir`; **all three tiers load in the smoke** |
| …fetched on demand if toggled but not downloaded | ✅ `ensure_mochi_{q8,bf16}_present` off the pinned revision |
| gpu smoke test passes on macOS | ✅ `mochi_mlx_smoke.rs` — **actually run**, exit 0, all 3 tiers, incl. a real **motion floor** (a frozen clip now fails it) |
| 🔴 Candle lane | ✅ All three traps fixed + a fourth found |
| 🔴 Fit gate | ✅ `mlx_fit_gate::mochi_fit_check`, frame-aware — **called via the `mochi_preflight` seam and pinned there** (reject@151 / admit@19 on a 64 GB Mac) |
| 🔴 Frame seam | ✅ Centralized as `video_frame_count`, and pinned **at the caller** via `mochi_preflight` |

## The candle lane

The story text is MLX-only, but B1 already routed Windows (`VideoModelCaps::new("mochi_1", true, true, false, false)`) and A6 CUDA-validated the lane against the *same* hosted tiers (the manifest carries no `platforms` tag). Shipping the MLX half alone would leave Windows **routed but unserved**. Three traps, each now pinned by a test:

1. **`candle_video_engine_id` didn't resolve `mochi_1`** → `resolve_candle_video_route` never reached the generic arm → `CandleVideoRoute::Stub` → a **procedural fake video**, not an error. The worst failure mode of the three.
2. **`candle_video_adapter_label`'s `_` arm is the Wan default** → `mochi_1` labelled a Wan adapter. Wrong provenance, no error.
3. **`candle_video_default_repo`** — same fall-through shape.

**A fourth, not in the brief:** the same else-arm routed Mochi into `candle_wan_sampling`, whose dense-5B tail forces `CANDLE_WAN5B_INTERIM_STEPS` (**20**) — silently overriding the AsymmDiT's own **64**-step default with a Wan tuning constant. Mochi gets its own sampling arm (true CFG: negative prompt + guidance, `None` ⇒ engine defaults).

**Tier dirs serve both lanes.** `resolve_mochi_model_dir` + `ensure_mochi_{q8,bf16}_present` + `mochi_tier_quant` are compiled for the **superset** cfg, so `advanced.mlxQuantize` works off-Mac and the candle arm calls them instead of `candle_video_snapshot_dir` (which has no notion of the tier layout).

**Does Windows actually work end-to-end?** Routing/labelling/tier-resolution: yes, and covered. **But** see sc-12306 — the candle video lane has **no VRAM gate at all**, and Mochi's untiled decode needs ~60 GiB at the 5 s default, which no consumer GPU has. Short clips will work; the default duration will CUDA-OOM (a catchable error, so it maps to a job error rather than a crash — the epic AC holds, but the UX is poor). A6 validated candle at a 64×64×7 fixture geometry, so the lane has never been exercised at a production bucket either.

**I could not compile the candle lane locally** — it is `cfg`'d out on macOS and cross-compiling needs `nvcc`. `windows-candle.yml` runs `cargo check`, `cargo clippy -D warnings` **and** `cargo test --features backend-candle` on every same-repo PR, so the arms + the candle-gated tests (**2 new** — `candle_mochi_resolves_the_engine_and_never_falls_to_the_stub`, `candle_mochi_default_repo_is_the_shared_mochi_turnkey` — plus `candle_video_adapter_labels_are_per_family`, which is **pre-existing and extended** here, not new) are genuinely gated there.

## The fit gate

Mochi holds **~18.7 GiB resident** for the whole run (`supports_sequential_offload: false` ⇒ nothing drops) and its AsymmVAE decode is **untiled**, so the peak grows **linearly with clip length**.

**Why the generic `mlx_fit_gate` cannot cover it** — two independent reasons:
- `predicted_peak_gb` = Σweights + a **1024²-calibrated constant**. It is resolution-blind *by construction* (the generator is cached across resolutions), so a 7-frame and a 151-frame request are indistinguishable to it. A constant cannot express a term that spans ~55 GiB.
- `supports_sequential_offload: false` ⇒ `weights_fit_floor` (sc-12179) admits on the **weights alone** (18.7 GiB fits almost any Mac). That floor is correct for its own purpose but is exactly what makes the generic gate unable to protect Mochi.

**It must be pre-flight.** MLX's default error handler is `exit(-1)` (sc-12178/12179, #1544) — a hard process kill that **cannot be mapped** to a job error afterwards.

**Formula** (`mochi_decode_peak_gb`), derived from the architecture with every constant named:
```
decode_peak = live(2) × C(128) × (frames + 5) × W × H × 4 B
needed      = resident_weights + decode_peak + OS_RESERVE_GB
```
- `C = 128` = `decoder_block_out_channels[0]` — the final `block_out` stage runs 128 ch at **full** output resolution; every earlier stage is strictly smaller.
- `+5` = the causal decode's extra leading frames, paid before `drop_last_temporal_frames` trims them.
- **`4 B` = f32, NOT bf16** — 🔴 this **deliberately disagrees with sc-12291 and B1's manifest**, which both derived `× 2 B`. The port pins `Dtype::Float32` (`mlx-gen-mochi/src/vae.rs:270`) and the crate says so: *"the reference decode ran bf16 — the parity residual reflects that bf16 rounding."* **sc-12291's decode table is ~2× low** (19→7, 61→19, 151→45 GiB). Corrected table filed there.

  **`mlx.minMemoryGb: 96` is wrong in its DERIVATION only — the value itself survives, so the manifest is unchanged.** B1 reached 96 from the bf16 (halved) peak, so the reasoning is void; but re-derived against the shipped f32 decode the requirement still clears 96 on every tier. Measured against the real hosted weights (`.safetensors` byte sums), + the 60.56 GiB decode at the 151-frame default + 2 GiB `OS_RESERVE_GB`:

  | tier | resident | total needed | vs 96 |
  |---|---|---|---|
  | q4 | 18.73 GiB | **81.29 GiB** | clears |
  | q8 | 22.10 GiB | **84.66 GiB** | clears |
  | bf16 (worst case) | 28.41 GiB | **90.97 GiB** | clears |

  So 96 remains a correct advisory floor and needs no change. An earlier revision of this PR body claimed "96 inherits" the 2× error — that overstated it and contradicted this PR's own `MOCHI_DECODE_LIVE_TENSORS` doc, which says 96 is consistent. The doc was the accurate one.
- `live = 2` = B1's own concrete "residual + intermediate live at once" (it then hedged 2–3×; 2 is the defensible claim).

Sanity, all in **GiB** (an earlier revision of this list mixed in decimal GB — the code was always correct, it divides by `BYTES_PER_GIB`): 7 frames ⇒ ~4.66 decode; 19 ⇒ ~9.32; 61 ⇒ ~25.62; 151 ⇒ ~60.56; 163 ⇒ ~65.21. The 5 s default needs **~79 GiB active** (18.73 weights + 60.56 decode) — consistent with B1's declared 96 GiB floor.

**Message** follows the `too_big_error` convention (names the model, "unified memory", need vs budget) and adds the lever unique to Mochi — the generic advice ("smaller tier, lower resolution") is near-useless here, since Mochi has one trained bucket and q4→bf16 is ~11 GiB against a ~60 GiB decode:
> `mochi_1 needs ~81 GB of unified memory to render a 151-frame 848x480 clip (~19 GB of weights, held resident for the whole run, plus an untiled VAE decode whose peak grows with clip length) but this machine has ~64 GB. Shorten the clip — the decode peak scales roughly linearly with duration — or run on a Mac with more memory.`

**Tested**: same machine, 19 frames admitted / 151 rejected (a frame-blind gate cannot pass this); message shape; linearity in frames *and* pixels; no-signal ⇒ never block; and that the shared parent T5/VAE are folded in (summing only the tier dir would under-count by ~9.7 GiB and admit a job that then dies).

## The frame seam — and a correction

`video_jobs.rs:5216` was a binary `if is_ltx { ltx } else { wan }`, so **every non-LTX model including `mochi_1`** inherited Wan's stride. Rather than add a third inline branch, the ladder is centralized as **`video_frame_count(model, raw)`**, called by **both** lanes — which is what makes the mapping unit-testable *by model id* and keeps the lanes from drifting.

The other `wan_frame_count` sites (`~5445, 5671, 5771, 5818, 5939, 5990, 6058, 6193`) are all inside **family-specific** functions (scail2 / bernini / wan-vace / comfyui) that Mochi never reaches — verified; left alone.

🔴 **The brief's characterization was arithmetically wrong**, and the error originates in B1's analysis (it propagated to sc-11992's comment and sc-11993's). The claim: *"`wan_frame_count(150) = 145`. And `145 % 6 == 1`, so the runtime accepts it → a 5 s request silently renders 4.83 s."*

- `wan_frame_count(150)` is **149**, not 145 — `150 − ((150−1) % 4)` = 150 − 1. (145 is unreachable: it needs `149 % 4 == 5`.)
- `149 % 6 == 5`, so the engine **hard-rejects** it.

The bug is real but **loud**: every default-duration Mochi job would die on *"num_frames must be 1 + 6·k (got 149)"*. Stronger — a silent wrong length is **provably impossible** on this pairing: whenever Wan's answer lands on Mochi's lattice it *equals* Mochi's snap (if `wan(raw) = W ≡ 1 mod 6` then `raw − W ∈ 0..=3`, so `W` is Mochi's `lower` and nearest-with-ties-low picks it). Verified exhaustively over raw 1..1999 (0 silent-wrong cases) and pinned as an invariant in the test.

## Tests

**27 added** (counted as `#[test]` attributes in the diff vs `origin/main`): **17** in `video_jobs` — incl. the 3 `mochi_preflight` seam tests and **2 new** candle-gated ones (`candle_mochi_resolves_the_engine_and_never_falls_to_the_stub`, `candle_mochi_default_repo_is_the_shared_mochi_turnkey`) — **5** fit-gate, **4** `smoke_support` motion-metric, **1** GPU smoke (`#[ignore]`d). `candle_video_adapter_labels_are_per_family` is **pre-existing and extended** here, so it is not counted as new. Deliberately placed on the **superset** cfg where the code is shared, so the tier resolver / stride / fetch gating run on the macOS lane **and** the windows-candle lane.

**Mutation-checked** (real exit codes; each restored after).

🔴 **Correction — an earlier revision of this section claimed every mutation was caught. That was not accurate.** A review round found **three more that survived 835/0 green**, all at the *production seam* rather than in the pure functions: the tests pinned the FUNCTIONS, not the CALL SITE. `generate_mochi` is `async` and needs a live `ApiClient`/`JobSnapshot`, so every decision left inline in it was unreachable from a unit test — which left the epic AC *"an unsupported environment shows an actionable error, not a crash"* **unenforced by any test**. Fixed by extracting `mochi_preflight` (below); all three are now RED, re-run and pasted.

| Mutation | Before | Now |
|---|---|---|
| `video_frame_count(...)` → `wan_frame_count(...)` **at the caller** | 🔴 **survived** 835/0 | **caught** — 2 tests, exit 101 |
| Fit gate's `frames` argument **hardcoded to `7`** | 🔴 **survived** 835/0 | **caught** — 1 test, exit 101 |
| **`mochi_fit_check(...)?` call deleted** | 🔴 **survived** 835/0 | **caught** — 1 test, exit 101 |
| **Frozen clip** (temporal path → N copies of one still) | 🔴 **passed the whole smoke** | **caught** — smoke fails, exit 101 |
| Route Mochi to `wan_frame_count` (function-level) | survived first → drove the `video_frame_count` extraction | caught |
| Fit gate ignores frame count (function-level) | — | caught (3 tests) |
| Candle adapter arm removed → Wan | — | caught |
| Candle default-repo arm removed → Wan | — | caught |
| Candle `engine_id` arm removed → Stub | — | caught |
| `mochi_available` drops the t2v mode gate | — | caught |
| `resolve_mochi_model_dir` ignores the tier order | — | caught |
| `ensure_video_engine_weights` loses the fail-loud arm | — | caught |
| Fit gate misses the shared T5/VAE | — | caught |

### The `mochi_preflight` seam

The fix for the first three. The frame lattice, the fit gate, and the tier quant move out of `generate_mochi` into a **pure, synchronously testable** seam:

```rust
fn mochi_preflight(model, engine_id, tier_dir, raw_frames, width, height)
    -> WorkerResult<MochiPreflight>   // { frames, quant }
```

`generate_mochi` becomes a thin caller. `frames` and `quant` are returned as **one unit** on purpose: both are things the generation arm cannot build its `VideoGenInput` without, and `mochi_preflight` is the only thing that produces them — so it cannot obtain a frame count or a quant marker on a path that skipped the gate. The three tests assert **by model id**, through the real on-disk weight scan (sparse fixtures at the true hosted byte sizes) and the live `SCENEWORKS_MLX_MEMORY_CAP_GB` budget:

- `mochi_preflight_coerces_the_frame_count_on_mochis_lattice_by_model_id` — 150 ⇒ **151**, `== mochi_frame_count(150)`, `!= wan_frame_count(150)`.
- `mochi_preflight_rejects_the_5s_default_on_a_64gb_mac` — 151 frames ⇒ 81.29 GiB ⇒ **Err**, message names the model + the clip-length lever.
- `mochi_preflight_admits_a_short_clip_on_the_same_64gb_mac` — 19 frames ⇒ 30.05 GiB ⇒ **Ok**. Without this the reject test would pass against a gate that blanket-refuses; the pair is what proves the gate is **frame-sensitive**.

**Residual, disclosed and tracked as [sc-12318](https://app.shortcut.com/trefry/story/12318):** a unit test still cannot reach `generate_mochi` itself, so a deliberate multi-line rewrite of its single `mochi_preflight` call could still bypass the gate. The seam raises that from a one-line slip (what actually happened) to an obvious rewrite, but it does not make it impossible — closing it fully needs integration coverage of the async arm. The candle lane's `video_frame_count` call in `generate_candle_video` has the same shape and the same residual.

### The smoke's motion floor

The smoke's comment promised *"the clip must actually MOVE"* — then only **printed** the means. **A fully frozen clip passed every assertion**, and the 6× temporal path is Mochi's distinguishing feature. Now asserted with `mean_abs_frame_delta` (0 **iff** bit-identical; unlike an `image_mean` delta, which a pan preserves — so the old print-only metric could read ~0 on a live clip and be cleared by brightness drift on a frozen one), on **every consecutive pair** (strictly stronger than first-vs-last: it also catches a clip that moves once then freezes).

ε = **1.0**, from the observed run — not invented. Real per-pair deltas at 848×480 × 7f @ 4 steps, seed 42:

| tier | per-pair deltas | min |
|---|---|---|
| q4 | 7.58, 5.58, 3.60, 3.41, 2.60, 5.21 | 2.597 |
| q8 | 30.04, 6.11, 2.57, 7.23, 14.93, 11.89 | **2.573** |
| bf16 | 30.87, 6.47, 2.75, 7.19, 16.24, 12.67 | 2.752 |

Tightest real observation **2.573**; 1.0 sits ~2.6× below it (margin against a different prompt/steps/seed) while a frozen pair scores **exactly 0.0**. Proven load-bearing: freezing the clip fails the smoke with *"frames 0->1 are FROZEN (mean abs delta 0.000 <= floor 1)"*, exit 101. Backed by 4 GPU-free unit tests on the metric.

The candle mutations were run against verbatim copies of the real match statements in a scratch harness (the arms can't execute on macOS); the pre-B2 state fails 7 assertions.

`npm run rust:check` **exit 0** (fmt + `clippy -D warnings` + test + build, 0 warnings); worker lib suite **844 passed / 0 failed**; GPU smoke **exit 0** on real weights, all 3 tiers, now including the motion floor.

## Not the stub

`ensure_video_engine_weights` (the sc-4176 fail-loud gate) gets a Mochi arm — without it, unresolvable weights hand the user a **procedural fake video** instead of the resolver's precise error. Tested.

## Follow-ups filed (not buried)

- **[sc-12318](https://app.shortcut.com/trefry/story/12318)** — the async video generation arms are unreachable from a unit test, which is what let 3 mutations survive here. `mochi_preflight` closes the Mochi case as far as a unit test can; this tracks the remaining residual.
- **[sc-12306](https://app.shortcut.com/trefry/story/12306)** — the candle video lane has **no VRAM gate at all** (for any model); Mochi at the 5 s default will OOM every consumer GPU.
- **[sc-12291 comment](https://app.shortcut.com/trefry/story/12291)** — the bf16-vs-f32 correction: its decode table and B1's `mlx.minMemoryGb: 96` are ~2× low. Also flags a possibly cheaper lever than tiling (the decoder already takes a dtype; the reference *was* bf16 — the question is whether the `vae_parity` golden holds).

## Known limitations (disclosed)

- The fit-gate constants are **derived, not measured**. The dtype is read from shipped code (a clean 2×); the liveness multiplier (2 vs 3) is ~1.5× uncertainty. B5/sc-12291 settle it — `mochi_decode_peak_gb` is the one place to update.
- Candle **not compiled locally** (no `nvcc`); relies on `windows-candle.yml`'s PR gate.
- The smoke renders **7 frames** by default — the untiled decode is why (~60 GiB at 151).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


