### PR TITLE
feat(web): surface Mochi 1 in Video Studio (sc-11994)

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -730,4 +730,56 @@ export const fallbackModels = [
       promptGuide: { title: "Wan2.2 VACE-Fun Prompt Guide", path: "/prompt-guides/wan-2-2-t2v-14b.md" },
     },
   },
+  {
+    // Mochi 1 (epic 1788 / sc-11994): 10B AsymmDiT, TEXT-TO-VIDEO ONLY. The single capability is
+    // load-bearing — both engine descriptors declare `conditioning: []`, so the studio's mode tabs,
+    // model picker and source band (all keyed off `capabilities`) keep every i2v / first-last-frame /
+    // extend / bridge / reference control off this model by construction.
+    //
+    // NOT Mac-only: the MLX descriptor is `mac_only: true` but the CANDLE one is `mac_only: false`
+    // (VIDEO_MODEL_CAPS `mochi_1` is routed on BOTH lanes), so this entry carries no mac-gating copy —
+    // `macSupport` arrives per-model from the API and leaves Mochi unblocked on either platform.
+    // Claiming Mac exclusivity here would be a false capability.
+    id: "mochi_1",
+    name: "Mochi 1",
+    type: "video",
+    family: "mochi",
+    adapter: "mochi_video",
+    capabilities: ["text_to_video"],
+    // Mirrors the manifest (videoGeometryParity.test.js pins resolutions + defaults.resolution).
+    // `steps: 64` is the AsymmDiT's own default and IS read here — it is the Steps input's
+    // placeholder (`stepsDefaultFromModel`). No `guidanceScale`: no video model declares one, so the
+    // engine's DEFAULT_GUIDANCE (4.5) applies and the Guidance placeholder stays empty.
+    defaults: { duration: 5, fps: 30, resolution: "848x480", quality: "balanced", steps: 64 },
+    limits: {
+      // 5s x 30fps = 150 raw frames, which the worker's `mochi_frame_count` snaps to 151 (the
+      // AsymmVAE is 6x temporal, so the engine only accepts `1 + 6k` — sc-11993).
+      durations: [1, 2, 3, 4, 5],
+      recommendedMaxDuration: 5,
+      // 30 fps only — `frames = duration x fps`, so a second value would change clip length AND play
+      // the 30 fps motion prior off-speed.
+      fps: [30],
+      // 848x480 is Mochi's native — and only — trained bucket. Both axes divide by 16, NOT 32, which is
+      // why the stride travels with them: it is the reason these buckets are legal, and
+      // videoGeometryParity.test.js pins it against the manifest so the pair cannot drift apart. (The
+      // web itself never reads it — sceneworks-core's `dimension_multiple_of` does, off the live
+      // catalog — so the manifest stays authoritative at runtime.)
+      resolutions: ["848x480", "480x848"],
+      requiresDimensionsMultipleOf: 16,
+      // NO `samplers` / `schedulers` key: one fixed flow-match Euler on both descriptors. The studio
+      // hides both pickers when a model offers fewer than 2 options (`samplerOptionsFromModel` falls
+      // back to `["default"]`), so omitting them is what keeps the false axis off the panel.
+    },
+    loraCompatibility: {
+      // Both descriptors set supports_lora/supports_lokr = false. Declare the family anyway so the
+      // picker never offers cross-architecture LoRAs (sc-1927), exactly like SVD.
+      families: ["mochi"],
+      types: [],
+    },
+    ui: {
+      description: "Genmo Mochi 1 — a 10B AsymmDiT text-to-video model with a 6x-temporal AsymmVAE, native on Apple Silicon (MLX) and Windows/Linux (candle/CUDA). Renders 848x480 at 30 fps. Apache-2.0: commercial use free, ungated. Text-to-video only (no image conditioning) and no LoRA support. Needs ample memory — the VAE decode is untiled, so peak scales with clip length.",
+      durationHint: "Native design point is ~5s at 848x480 / 30 fps. Shorter clips cut memory roughly linearly — start at 1-2s if you are memory-constrained.",
+      promptGuide: { title: "Mochi 1 Prompt Guide", path: "/prompt-guides/mochi-1.md" },
+    },
+  },
 ];

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -11,6 +11,7 @@ vi.mock("../api.js", async (importOriginal) => {
 });
 
 import { AppContext } from "../context/AppContext.js";
+import { fallbackModels } from "../constants.js";
 import { VideoStudio } from "./VideoStudio.jsx";
 
 const LTX = {
@@ -1170,5 +1171,204 @@ describe("VideoStudio Lightning toggle (sc-10048)", () => {
     await click(buttonWithText(container, "Render clip"));
     const payload = context.createVideoJob.mock.calls[0][0];
     expect(payload.advanced.lightning).toBeUndefined();
+  });
+});
+
+// Mochi 1 in the Video Studio (epic 1788 / sc-11994 "B4"). Mochi needed no VideoStudio.jsx change:
+// every control here is already driven off the selected model's manifest `capabilities` / `limits` /
+// `defaults`. That is exactly why it needs pinning — "it works because nothing is hardcoded" is a
+// property that silently regresses the moment someone special-cases a model.
+//
+// The fixture is the REAL `fallbackModels` seed row, not a hand-written double. Two reasons: it is the
+// row the picker actually serves before the live catalog loads (the thing this story added), and a
+// hand-written double would happily keep passing after someone deleted the row from constants.js.
+describe("VideoStudio Mochi 1 (epic 1788, sc-11994)", () => {
+  let container;
+  let root;
+
+  const MOCHI = fallbackModels.find((model) => model.id === "mochi_1");
+
+  // The seed row must exist and be a video model before any assertion below means anything — without
+  // this, deleting the row turns `MOCHI` into `undefined` and every test degrades into a vacuous pass
+  // against a model-less studio rather than failing.
+  it("ships a mochi_1 video seed row in fallbackModels", () => {
+    expect(MOCHI, "constants.js must carry the mochi_1 fallback seed row").toBeTruthy();
+    expect(MOCHI.type).toBe("video");
+  });
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <VideoStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  const mochiContext = (overrides = {}) => baseContext({ videoModels: [MOCHI], ...overrides });
+  const modeButton = (label) => buttonWithText(container.querySelector(".mode-control"), label);
+  const modelSelect = () => container.querySelector(".settings-field-model select");
+  const resolutionSelect = () => container.querySelector(".settings-field-aspect select");
+  const durationSelect = () => container.querySelector(".settings-field-count select");
+  const optionValues = (select) => [...select.options].map((option) => option.value);
+  const labelledField = (text) =>
+    [...container.querySelectorAll("label")].find((node) => node.textContent.trim().startsWith(text));
+
+  it("is selectable in the Video Studio picker", async () => {
+    await render(mochiContext());
+
+    expect(optionValues(modelSelect())).toEqual(["mochi_1"]);
+    expect(modelSelect().value).toBe("mochi_1");
+  });
+
+  it("seeds the manifest defaults: 848x480, 5s, 30fps", async () => {
+    await render(mochiContext());
+
+    expect(resolutionSelect().value).toBe("848x480");
+    expect(durationSelect().value).toBe("5");
+    // fps lives in the Advanced disclosure ("Frames").
+    await openAdvanced(container);
+    expect(labelledField("Frames").querySelector("select").value).toBe("30");
+  });
+
+  it("offers exactly the model's advertised geometry — the ÷16 848x480 pair, 1–5s, 30fps only", async () => {
+    await render(mochiContext());
+
+    // 848x480 is Mochi's native (and only) trained bucket. `480x848` is the portrait flip. Neither is
+    // a multiple of 32 — Mochi's engine strides by 16 (see videoGeometryParity.test.js).
+    expect(optionValues(resolutionSelect())).toEqual(["848x480", "480x848"]);
+    expect(optionValues(durationSelect())).toEqual(["1", "2", "3", "4", "5"]);
+
+    await openAdvanced(container);
+    // 30 fps only: `frames = duration x fps`, so a second value would change clip LENGTH and play the
+    // 30 fps motion prior off-speed.
+    expect(optionValues(labelledField("Frames").querySelector("select"))).toEqual(["30"]);
+  });
+
+  it("opens on Text → Video, the only mode it serves", async () => {
+    await render(mochiContext());
+
+    expect(modeButton("Text → Video").className).toContain("active");
+  });
+
+  // Off-Mac the mode TABS are deliberately never disabled (sc-5716: `macModeTabBlocked` is gated on
+  // `macGating`, so tab-disabling is a macOS-only affordance). The cross-platform guard is the submit
+  // summary — and Mochi runs off-Mac on candle, so this is the path a Windows user actually hits.
+  // `conditioning: []` on both descriptors means there is no i2v surface to fall back to.
+  it("refuses to submit an image-conditioned mode it cannot serve", async () => {
+    await render(mochiContext());
+
+    await click(modeButton("Image → Video"));
+    expect(container.textContent).toContain("Mochi 1 does not support this mode.");
+    expect(buttonWithText(container, "Render clip").disabled).toBe(true);
+  });
+
+  it("renders no image-to-video controls (no source band at all)", async () => {
+    const source = { id: "img_src", type: "image", projectId: "project_1", displayName: "Source" };
+    // Even with an image selected in context — the case that would tempt a stray first-frame picker
+    // into rendering — a t2v-only model must show no conditioning slot.
+    await render(mochiContext({ assets: [source], selectedAsset: source }));
+
+    expect(container.querySelector(".studio-source-band")).toBeFalsy();
+    expect(container.querySelector(".fit-mode-field")).toBeFalsy();
+    expect(labelledField("First frame")).toBeFalsy();
+    expect(labelledField("Last frame")).toBeFalsy();
+  });
+
+  it("advertises no sampler/scheduler axis and no Lightning toggle", async () => {
+    await render(mochiContext());
+    await openAdvanced(container);
+
+    // One fixed flow-match Euler integrator — both descriptors advertise `samplers: []`/`schedulers: []`.
+    // Surfacing a menu here would be a false capability.
+    expect(labelledField("Sampler")).toBeFalsy();
+    expect(labelledField("Scheduler")).toBeFalsy();
+    // Lightning is the Wan A14B 4-step distilled recipe — not a Mochi thing.
+    expect(container.querySelector(".lightning-toggle")).toBeFalsy();
+  });
+
+  it("keeps the prompt, negative prompt, seed, steps and guidance controls", async () => {
+    await render(mochiContext());
+
+    // Mochi is text-conditioned (NOT `promptless` like SVD), so the prompt is the primary input.
+    expect(container.querySelector('textarea[aria-label="Prompt"]')).toBeTruthy();
+
+    await openAdvanced(container);
+    expect(labelledField("Seed")).toBeTruthy();
+    expect(labelledField("Negative prompt")).toBeTruthy();
+    // Steps placeholder = the AsymmDiT's own default (64), sourced from `defaults.steps`.
+    expect(labelledField("Steps").querySelector("input").placeholder).toBe("64");
+    // Mochi declares NO `defaults.guidanceScale` — no video model does — so the control is present but
+    // unplaceheld, and the engine's DEFAULT_GUIDANCE (4.5) applies when the request omits it.
+    expect(labelledField("Guidance").querySelector("input")).toBeTruthy();
+    expect(labelledField("Guidance").querySelector("input").placeholder).toBe("");
+  });
+
+  it("submits a text_to_video job carrying the recipe-bearing fields", async () => {
+    const context = mochiContext();
+    await render(context);
+
+    await openAdvanced(container);
+    await act(async () => {
+      setInput(labelledField("Seed").querySelector("input"), "1234");
+    });
+    await click(buttonWithText(container, "Render clip"));
+
+    const payload = context.createVideoJob.mock.calls[0][0];
+    // The fields the Library recipe is rebuilt from (model, prompt, negative, seed, geometry, fps).
+    // Frames are NOT sent: the worker derives them (duration x fps) and snaps to Mochi's 1+6k lattice
+    // (`mochi_frame_count`, sc-11993), so 5s x 30fps = 150 -> 151 frames server-side.
+    expect(payload.model).toBe("mochi_1");
+    expect(payload.mode).toBe("text_to_video");
+    expect(payload.prompt).toBe("Camera slowly pushes in while the scene comes alive");
+    expect(payload.seed).toBe(1234);
+    expect(payload.width).toBe(848);
+    expect(payload.height).toBe(480);
+    expect(payload.duration).toBe(5);
+    expect(payload.fps).toBe(30);
+    // t2v carries no conditioning assets.
+    expect(payload.sourceAssetId).toBeNull();
+    expect(payload.lastFrameAssetId).toBeNull();
+    expect(payload.advanced.lightning).toBeUndefined();
+    expect(payload.advanced.sampler).toBeUndefined();
+    expect(payload.advanced.scheduler).toBeUndefined();
+  });
+
+  // Mochi is NOT Mac-exclusive: the MLX descriptor is `mac_only: true` but the CANDLE one is
+  // `mac_only: false`, and VIDEO_MODEL_CAPS routes `mochi_1` on BOTH lanes ("Mochi must NOT be hard
+  // mac-gated app-side"). So no Mochi-specific gating copy exists to assert — what matters is the
+  // inverse: that active Mac gating leaves Mochi fully usable. A future change that hard-gated Mochi
+  // as Mac-only, or that hid it under gating, fails here.
+  it("stays selectable and t2v-capable under active Mac gating", async () => {
+    const MAC_CAPS = {
+      macGatingActive: true,
+      platform: "darwin",
+      notAvailableLabel: "Not available on Mac (MLX only)",
+      features: {},
+      training: { supportedKernels: [], lokrOnWanSupported: false },
+    };
+    // The API marks Mochi MLX-routed on Mac: supported, with text_to_video served.
+    const macMochi = {
+      ...MOCHI,
+      macSupport: { supported: true, features: { videoModes: { text_to_video: true } } },
+    };
+    await render(baseContext({ videoModels: [macMochi], macCapabilities: MAC_CAPS }));
+
+    expect(optionValues(modelSelect())).toEqual(["mochi_1"]);
+    expect(modeButton("Text → Video").disabled).toBe(false);
+    expect(container.textContent).not.toContain("Not available on Mac");
   });
 });

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -1276,16 +1276,33 @@ describe("VideoStudio Mochi 1 (epic 1788, sc-11994)", () => {
     expect(buttonWithText(container, "Render clip").disabled).toBe(true);
   });
 
-  it("renders no image-to-video controls (no source band at all)", async () => {
+  // MODE-scoped, not capability-scoped — worth stating plainly, because the reverse claim would be
+  // false. The band is gated purely on `mode !== "text_to_video"` (VideoStudio.jsx:1159), so what this
+  // pins is: text_to_video renders no conditioning slot, for ANY video model. Nothing here is specific
+  // to Mochi — swap in a full-i2v model and it passes unchanged.
+  //
+  // The claim it must NOT make is that "a t2v-only model shows no conditioning slot": Mochi's own
+  // "Image → Video" tab renders a complete band (First frame picker + Fit), because mode tabs are not
+  // capability-filtered anywhere in the app (sc-5716 disables them only under Mac gating). What stops
+  // Mochi there is the submit refusal, pinned by the test above — that is the capability guard.
+  //
+  // This still earns its place: it is the suite's only guard against a source-band leak into t2v.
+  it("renders no conditioning slot in text_to_video, even with an image selected", async () => {
     const source = { id: "img_src", type: "image", projectId: "project_1", displayName: "Source" };
-    // Even with an image selected in context — the case that would tempt a stray first-frame picker
-    // into rendering — a t2v-only model must show no conditioning slot.
+    // An image selected in context is the case that would tempt a stray first-frame picker into rendering.
     await render(mochiContext({ assets: [source], selectedAsset: source }));
 
     expect(container.querySelector(".studio-source-band")).toBeFalsy();
     expect(container.querySelector(".fit-mode-field")).toBeFalsy();
-    expect(labelledField("First frame")).toBeFalsy();
-    expect(labelledField("Last frame")).toBeFalsy();
+    // Query the pickers' OWN label nodes. `labelledField` scans <label> elements, but AssetPickerField
+    // renders `<span class="asset-picker-label">` — so `labelledField("First frame")` stays falsy even
+    // when the picker IS on screen (verified against Mochi's i2v tab, which renders exactly that), which
+    // left the two assertions this replaces unable to fail.
+    const pickerLabels = [...container.querySelectorAll(".asset-picker-label")].map((node) =>
+      node.textContent.trim(),
+    );
+    expect(pickerLabels).not.toContain("First frame");
+    expect(pickerLabels).not.toContain("Last frame");
   });
 
   it("advertises no sampler/scheduler axis and no Lightning toggle", async () => {

--- a/apps/web/src/videoGeometryParity.test.js
+++ b/apps/web/src/videoGeometryParity.test.js
@@ -57,37 +57,76 @@ describe("video geometry ↔ manifest parity (sc-12294)", () => {
         fallback.defaults?.resolution,
         `${id} defaults.resolution must mirror the manifest`,
       ).toEqual(manifest.defaults?.resolution);
+      // A mirror that states a stride must state the RIGHT one. The web never reads this field (the
+      // worker resolves it from the live catalog), so nothing else would notice it going stale — but a
+      // wrong stride sitting next to the buckets is worse than none: it is the note a future reader
+      // trusts when deciding whether a new bucket is legal. Only checked when the mirror opts in.
+      if (fallback.limits?.requiresDimensionsMultipleOf !== undefined) {
+        expect(
+          fallback.limits.requiresDimensionsMultipleOf,
+          `${id} limits.requiresDimensionsMultipleOf must mirror the manifest`,
+        ).toEqual(manifest.limits?.requiresDimensionsMultipleOf);
+      }
     },
   );
 
-  it("no video entry advertises a bucket the area cap would floor (sc-12294)", () => {
-    // The direct regression guard, independent of the manifest: every advertised bucket must survive the
-    // model's own maxPixels cap at its stride. This is what makes reintroducing `1280x720` fail loudly
-    // even if someone "fixes" the manifest to match a stale mirror rather than the other way round.
-    const STRIDE = 32;
+  // The dimension stride the ENGINE actually applies to a model: its declared
+  // `limits.requiresDimensionsMultipleOf`, else the blanket 32. This mirrors sceneworks-core's
+  // `dimension_multiple_of` (video_request.rs) exactly, including its validity filter — a declared
+  // multiple is only honored when it is positive and divides 256, because `floor_to_multiple` clamps up
+  // to a hard floor of 256 and that rescue is only on-lattice when the multiple divides 256. Anything
+  // else falls back to `DEFAULT_DIMENSION_MULTIPLE`, so the test agrees with the worker on typo'd input
+  // instead of inventing its own rule.
+  const DEFAULT_STRIDE = 32;
+  const strideFor = (manifest) => {
+    const declared = manifest?.limits?.requiresDimensionsMultipleOf;
+    return Number.isInteger(declared) && declared > 0 && 256 % declared === 0 ? declared : DEFAULT_STRIDE;
+  };
+
+  it("no video entry advertises a bucket its engine would floor (sc-12294, stride fixed in sc-11994)", () => {
+    // The direct regression guard: every advertised bucket must be renderable AS ADVERTISED — on the
+    // model's own stride, and (where the engine caps area) inside its own maxPixels. A bucket that fails
+    // either is a lie the picker tells: the engine floors it and renders something else.
+    //
+    // sc-11994 fixed two defects in this guard, both found while adding Mochi's ÷16 row:
+    //
+    //   1. The stride was hardcoded to 32. That is only the DEFAULT (`DEFAULT_DIMENSION_MULTIPLE`);
+    //      the real floor is per-model, and sc-12294 itself established the floor "is not one number".
+    //      Hardcoding 32 gets ÷16 models BACKWARDS — it would fail `bernini`'s correct native 848x480
+    //      (`848 % 32 == 16`, and bernini declares 16 + carries a cap) the moment the mirror carried it,
+    //      flagging a truthful row as broken. `mochi_1` advertises the same 848x480 bucket.
+    //   2. It `continue`d past every UNCAPPED model, so ltx_2_3 / ltx_2_3_eros / svd / mochi_1 got no
+    //      stride check at all — the cap was doing double duty as the trigger for an orthogonal
+    //      assertion. Verified before the fix: putting `1280x720` back on ltx_2_3 (stride 64, uncapped)
+    //      in BOTH the manifest and the mirror still passed this suite, even though that is precisely
+    //      the regression sc-12294 exists to prevent (720 % 64 == 16 → the engine renders 704).
+    //
+    // Reading the stride per-model fixes both: the check now runs for every video entry, and each is
+    // measured against the stride its own engine uses.
     for (const fallback of fallbackVideo) {
       const manifest = manifestById.get(fallback.id);
+      const stride = strideFor(manifest);
       const maxPixels = manifest?.limits?.maxPixels;
-      if (!maxPixels) {
-        continue; // Uncapped model (ltx/svd/mochi) — nothing to floor against.
-      }
       for (const bucket of fallback.limits?.resolutions ?? []) {
         const [w, h] = bucket.split("x").map(Number);
         expect(
-          w % STRIDE === 0 && h % STRIDE === 0,
-          `${fallback.id} advertises ${bucket}, which is not a multiple of the ${STRIDE}px stride — the engine cannot render it as advertised`,
+          w % stride === 0 && h % stride === 0,
+          `${fallback.id} advertises ${bucket}, which is not a multiple of its ${stride}px stride — the engine cannot render it as advertised`,
         ).toBe(true);
-        expect(
-          w * h <= maxPixels,
-          `${fallback.id} advertises ${bucket} (${w * h}px), which exceeds its ${maxPixels}px cap and would be floored`,
-        ).toBe(true);
+        if (maxPixels) {
+          expect(
+            w * h <= maxPixels,
+            `${fallback.id} advertises ${bucket} (${w * h}px), which exceeds its ${maxPixels}px cap and would be floored`,
+          ).toBe(true);
+        }
       }
     }
   });
 
   it("every manifest video model present in fallbackModels mirrors its geometry", () => {
     // Reverse guard: a manifest video model the mirror DOES carry must not diverge. Models absent from
-    // the seed list (bernini/scail2_14b/mochi_1 load from the live catalog) are intentionally skipped.
+    // the seed list (bernini/scail2_14b load from the live catalog) are intentionally skipped.
+    // `mochi_1` JOINED the seed list in sc-11994, so it is now covered by this guard rather than skipped.
     for (const manifest of manifestModels.filter((model) => model.type === "video")) {
       const fallback = fallbackVideo.find((model) => model.id === manifest.id);
       if (!fallback) {

--- a/apps/web/src/videoGeometryParity.test.js
+++ b/apps/web/src/videoGeometryParity.test.js
@@ -38,6 +38,29 @@ describe("video geometry ↔ manifest parity (sc-12294)", () => {
   const manifestById = new Map(manifestModels.map((model) => [model.id, model]));
   const fallbackVideo = fallbackModels.filter((model) => model.type === "video");
 
+  // The dimension stride the ENGINE actually applies to a model: its declared
+  // `limits.requiresDimensionsMultipleOf`, else the blanket 32. This mirrors sceneworks-core's
+  // `dimension_multiple_of` (video_request.rs) exactly, including its validity filter — a declared
+  // multiple is only honored when it is positive and divides 256, because `floor_to_multiple` clamps up
+  // to a hard floor of 256 and that rescue is only on-lattice when the multiple divides 256. Anything
+  // else falls back to `DEFAULT_DIMENSION_MULTIPLE`, so the test agrees with the worker on typo'd input
+  // instead of inventing its own rule.
+  const DEFAULT_STRIDE = 32;
+  const strideFor = (manifest) => {
+    const declared = manifest?.limits?.requiresDimensionsMultipleOf;
+    return Number.isInteger(declared) && declared > 0 && 256 % declared === 0 ? declared : DEFAULT_STRIDE;
+  };
+
+  // A row's stride declaration is LOAD-BEARING exactly when the row advertises a bucket the default
+  // 32-px stride would not explain: that declaration is the only thing that makes `848x480` a legal
+  // bucket rather than a typo. Rows whose buckets are all on the ÷32 lattice are already explained by
+  // the default, so a stride there is a nicety and stays opt-in.
+  const advertisesOffDefaultLattice = (fallback) =>
+    (fallback.limits?.resolutions ?? []).some((bucket) => {
+      const [w, h] = bucket.split("x").map(Number);
+      return w % DEFAULT_STRIDE !== 0 || h % DEFAULT_STRIDE !== 0;
+    });
+
   it("fallbackModels carries the video entries the picker falls back to", () => {
     // App.jsx:823 serves exactly this set to the Video Studio picker before the catalog loads, so an
     // empty/!video-typed list would silently make the rest of this suite vacuous.
@@ -57,10 +80,22 @@ describe("video geometry ↔ manifest parity (sc-12294)", () => {
         fallback.defaults?.resolution,
         `${id} defaults.resolution must mirror the manifest`,
       ).toEqual(manifest.defaults?.resolution);
+      // Where the stride is load-bearing, pin its PRESENCE — not just its value. Pinning only the
+      // value is how this check first shipped, gated on `if (requiresDimensionsMultipleOf !== undefined)`,
+      // which made it a guard whose trigger was the very field it asserted: DELETING mochi_1's
+      // `requiresDimensionsMultipleOf: 16` passed the whole suite. The pair could drift apart by
+      // deletion — the same defect class this file fixes in the bucket guard below, where a `maxPixels`
+      // trigger was gating an orthogonal stride assertion.
+      if (advertisesOffDefaultLattice(fallback)) {
+        expect(
+          fallback.limits?.requiresDimensionsMultipleOf,
+          `${id} advertises a bucket that is not a multiple of ${DEFAULT_STRIDE}px, so its mirror must declare the stride that makes that bucket legal`,
+        ).toBeDefined();
+      }
       // A mirror that states a stride must state the RIGHT one. The web never reads this field (the
       // worker resolves it from the live catalog), so nothing else would notice it going stale — but a
       // wrong stride sitting next to the buckets is worse than none: it is the note a future reader
-      // trusts when deciding whether a new bucket is legal. Only checked when the mirror opts in.
+      // trusts when deciding whether a new bucket is legal.
       if (fallback.limits?.requiresDimensionsMultipleOf !== undefined) {
         expect(
           fallback.limits.requiresDimensionsMultipleOf,
@@ -69,19 +104,6 @@ describe("video geometry ↔ manifest parity (sc-12294)", () => {
       }
     },
   );
-
-  // The dimension stride the ENGINE actually applies to a model: its declared
-  // `limits.requiresDimensionsMultipleOf`, else the blanket 32. This mirrors sceneworks-core's
-  // `dimension_multiple_of` (video_request.rs) exactly, including its validity filter — a declared
-  // multiple is only honored when it is positive and divides 256, because `floor_to_multiple` clamps up
-  // to a hard floor of 256 and that rescue is only on-lattice when the multiple divides 256. Anything
-  // else falls back to `DEFAULT_DIMENSION_MULTIPLE`, so the test agrees with the worker on typo'd input
-  // instead of inventing its own rule.
-  const DEFAULT_STRIDE = 32;
-  const strideFor = (manifest) => {
-    const declared = manifest?.limits?.requiresDimensionsMultipleOf;
-    return Number.isInteger(declared) && declared > 0 && 256 % declared === 0 ? declared : DEFAULT_STRIDE;
-  };
 
   it("no video entry advertises a bucket its engine would floor (sc-12294, stride fixed in sc-11994)", () => {
     // The direct regression guard: every advertised bucket must be renderable AS ADVERTISED — on the


### PR DESCRIPTION
[sc-11994](https://app.shortcut.com/trefry/story/11994) — B4 of epic 1788 (Mochi 1 text-to-video). Backend landed in B1/B2/B3; this is the UI slice.

## Scope vs each AC

| AC | Status |
|---|---|
| Mochi is selectable in Video Studio | **Done** — `mochi_1` seeded into `fallbackModels` (the pre-catalog mirror). Test: `is selectable in the Video Studio picker`. |
| Controls match its capabilities | **Done, no `VideoStudio.jsx` change needed** — every control already derives from the model's manifest `capabilities`/`limits`/`defaults`. Tests pin geometry (848x480 + 480x848, 1–5s, 30fps only), defaults, steps placeholder 64, and prompt/negative/seed/steps/guidance presence. |
| Unsupported / i2v controls absent | **Done for the controls** — no sampler/scheduler axis (Mochi advertises none; the picker hides a <2-option menu), no Lightning, no source band in t2v. The mode **tabs** are a recorded exception, see below. |
| `VideoStudio.test.jsx` covers selection + control set; vitest green | **Done** — 11 new tests. Full suite **1848/1848, exit 0**. |
| Clip appears in Library with a reproducible recipe | **Delivered as recording parity with every existing video model** — the recorded data is complete; no video model has a re-run affordance (sc-12324). See below. |

## The parity test: Mochi is ÷16, and the guard was wrong

`videoGeometryParity.test.js` (sc-12294) gates `constants.js`. Mochi's `848x480` is **not** a multiple of 32, so I read the guard before adding the row. Two findings:

**Mochi was already exempt — accidentally.** The stride check sits *inside* `if (!maxPixels) continue;`. Mochi declares no `maxPixels`, so the guard never ran on it. The row passes untouched, but with **zero** stride coverage. The exemption came from "no area cap", not from "÷16 is fine".

**The 32px guard is genuinely wrong for ÷16 models, and I did not weaken it — I fixed it:**

1. **Hardcoded 32 is only the *default*.** The real floor is per-model (`requiresDimensionsMultipleOf`); sc-12294's own Rust doc says the floor "is not one number". `bernini` declares 16, carries a cap, and advertises the same `848x480` — the current guard would have **failed that correct row** the moment the mirror carried it.
2. **It skipped every uncapped model.** ltx/svd/mochi got no stride check. **Verified empirically before fixing:** putting `1280x720` back on `ltx_2_3` (stride 64, uncapped) in *both* the manifest and the mirror **still passed** — precisely the regression sc-12294 exists to prevent (720 % 64 = 16 → engine renders 704).

The guard now reads each model's own stride (mirroring `sceneworks-core`'s `dimension_multiple_of`, incl. its divides-256 validity filter) and runs for **every** video entry; the area cap is still checked only where declared. Mochi is measured against its real 16, not exempted. sc-12294's `1280x704` realignments are untouched.

## Mac gating: deliberately none

The story asked for mac-gating copy. **Mochi must not have any.** Its MLX descriptor is `mac_only: true` but its **candle** one is `mac_only: false`, and `VIDEO_MODEL_CAPS::new("mochi_1", true, true, …)` routes both lanes — the catalog comment states *"Mochi must NOT be hard mac-gated app-side"*. Mochi-specific Mac copy would assert an exclusivity that doesn't exist. The test pins the **inverse**: under active Mac gating Mochi stays selectable, t2v-capable, and shows no "Not available on Mac".

## Library / recipe

**The AC is met as recording parity with the existing video lane — stated plainly rather than as a partial.**

**Recorded data: complete, verified.** `video_asset_fact` persists model/mode/adapter/prompt/negativePrompt/seed/width/height/duration/fps/quality, and B2's `mochi_raw_settings` (`crates/sceneworks-worker/src/video_jobs.rs:8958-8976`) adds `frameCount` (the snapped 151), `fps`, `mochiTier` (q4/q8/bf16) plus `advanced` (resolution/steps/guidanceScale). That is every field the AC names, all model-agnostic. `LibraryScreen`/`presetUtils` are model-agnostic too — no change needed. **Mochi records exactly what SVD/LTX/Wan record: it is at full parity with the lane, not behind it.**

**No video model has a recipe re-run affordance.** `apps/web/src/components/assetPanels.jsx:1100` hard-gates the "Use recipe" button to `asset.type === "image"`:

```js
{onUseRecipe && asset.type === "image" && (asset.generationSet?.recipe || asset.recipe) ? (
```

Only `sendAssetRecipeToImage` is wired; there is no video equivalent (`sendAssetToVideo` sends a *source clip*, not a recipe). So "reproducible recipe" is delivered here to the same degree it is delivered for **every** video model that already ships. This is a pre-existing video-lane gap, **not a Mochi gap** — building the video re-run affordance inside B4 would be a cross-cutting lane feature, so it is tracked as **sc-12324**.

If the epic wants the AC met *as literally written* (a clickable re-run), that is sc-12324's scope and should be a **decision**, not a default — flagging it here so B5 (sc-11995) closes the epic on an explicit call. The real end-to-end run is B5's; I am not claiming an e2e verification I did not perform.

## Mode tabs are not capability-filtered (app-wide, recorded decision)

`modeOptions.map()` (`VideoStudio.jsx:1078-1092`) renders **every** mode tab for **every** video model, disabling them only under Mac gating (sc-5716). So Mochi shows i2v/first-last tabs that refuse on submit ("Mochi 1 does not support this mode."), and its i2v tab renders a source band. **This is existing app-wide behavior, identical for SVD/LTX** — not something this PR introduces or regresses.

The AC's "unsupported / i2v controls absent" is met for the **controls**: in the mode Mochi opens in and the only one it can serve (t2v), there is no conditioning slot. Capability-filtering the tabs themselves is a cross-cutting redesign of the video lane, beyond B4's scope. Recorded here as a decision rather than left as an oversight.

## Tests

11 new Mochi tests + 1 auto-generated parity case. Fixture is the **real** `fallbackModels` row, not a hand-written double — a double would keep passing after someone deleted the row.

Mutation-checked with plausible-wrong-implementation mutations (all caught, control green):

| Mutation | Caught by |
|---|---|
| Remove Mochi's row | fixture guard + suite (exit 1) |
| Give it a sampler axis | picker becomes visible **and** `sampler: 'euler'` leaks into the payload |
| Add `image_to_video` capability | "Mochi 1 does not support this mode." guard stops firing |
| Wrong default duration (5→3) | UI default select **and** payload `duration` |
| Source band leaks into t2v (`VideoStudio.jsx` gate) | `.studio-source-band` assertion |
| Mirror stride drifts 16→32 | stride parity pin (value) |
| **Mochi's `requiresDimensionsMultipleOf: 16` deleted** | **presence pin — added in review, see below** |
| **First-frame picker leaks into t2v** | **`.asset-picker-label` assertion — added in review, see below** |
| `1280x720` on uncapped LTX | fixed stride guard (**passed before the fix**) |
| `850x480` on Mochi (off ÷16) | fixed stride guard (**skipped entirely before the fix**) |

**Note on the briefed "~909 pre-existing worktree failures": they don't exist.** They're an artifact of *missing* `node_modules` symlinks. With both symlinked (repo root + `apps/web`), `main` is **1836/1836 green**, so I held the stronger bar — full green, not a matching failure-set. Baseline vs final compared via vitest's JSON reporter: 1836→1848, **0 failures, 0 regressions**. eslint: **0 errors** (53 pre-existing warnings, none in touched files). No Rust touched, so no `rust:check`.

## Review follow-ups (commit 2)

Two findings from adversarial review, both the **same defect class this PR set out to fix** — a guard whose trigger is orthogonal to, or identical with, what it asserts. Fixed by strengthening the assertions, not by softening the claims.

**1. The stride pin was opt-in, so the pair could drift apart by deletion.** The check was gated on `if (fallback.limits?.requiresDimensionsMultipleOf !== undefined)` — it pinned the *value* but not the *presence*. Deleting `requiresDimensionsMultipleOf: 16` from the Mochi row passed **55/55**, while `constants.js` claimed the test "pins it against the manifest so the pair cannot drift apart." A guard triggered by the very field it asserts.

Now the mirror **must** declare a stride whenever its row advertises a bucket the default 32px stride cannot explain — exactly when the declaration is load-bearing (`848x480`). Rows whose buckets are all ÷32 stay opt-in, so **no existing row changes**: `mochi_1` is the only fallback video row off the ÷32 lattice; the other seven pass untouched. Mutation-verified — deleting the stride now fails, and only that row fails:

```
AssertionError: mochi_1 advertises a bucket that is not a multiple of 32px, so its
mirror must declare the stride that makes that bucket legal: expected undefined to be defined
```

**2. A test comment that over-claimed — and two assertions that could not fail.** "renders no image-to-video controls … a t2v-only model must show no conditioning slot" was **mode-scoped, not capability-scoped**: the band is gated purely on `mode !== "text_to_video"` (`VideoStudio.jsx:1159`), so it passes unchanged with a full-i2v model as the fixture. The claim was not just imprecise but **false** — Mochi's own i2v tab renders a complete band (First frame + Fit). Retitled and recommented to what it actually pins. It keeps its place: it is the suite's only guard against a source-band leak into t2v.

While fixing the framing I found the same defect *inside* it: `labelledField` scans `<label>` elements, but `AssetPickerField` renders `<span class="asset-picker-label">` — so `expect(labelledField("First frame")).toBeFalsy()` was falsy **even with the picker on screen**. Two of the four assertions were structurally unfailable. Replaced with a query against the pickers' real label nodes. Proven under an identical picker-leak mutation: the **old** assertions passed green, the **new** ones fail with `expected [ 'First frame' ] to not include 'First frame'`.

Full suite after both fixes: **1848/1848, exit 0**. eslint: **0 errors**, none in touched files. Manifest untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

