### PR TITLE
fix(catalog): land sc-4997's 832x480 fast path as wan_2_2's real default (sc-12319)

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -653,14 +653,12 @@ export const fallbackModels = [
     name: "Wan2.2",
     type: "video",
     capabilities: ["image_to_video", "text_to_video", "first_last_frame", "extend_clip", "video_bridge", "replace_person"],
-    // Mirrors the manifest's 720p default (see videoGeometryParity.test.js). NOTE: sc-4997 set this
-    // mirror to 832x480 for a sane out-of-the-box Mac MLX time (measured 5B @ 832x480/121f/20-step/CFG
-    // = ~5 min vs ~20 min at 720p — the z48 VAE decode dominates at high res), but it only ever changed
-    // this file, never `builtin.models.jsonc`. The live catalog is authoritative once loaded, so that
-    // fast-path default never actually shipped; this mirror was advertising a default the app does not
-    // use. Realigning to the manifest makes the mirror truthful. Whether the manifest itself should
-    // adopt sc-4997's 832x480 fast path is a separate product call, tracked in sc-12319.
-    defaults: { duration: 5, fps: 24, resolution: "1280x704", quality: "balanced" },
+    // Mirrors the manifest's 832x480 fast-path default (see videoGeometryParity.test.js) — sc-12319
+    // adopted it there, so this mirror and the catalog finally agree. sc-4997 measured the reason on
+    // real weights (~5 min at 832x480 vs ~20 min at 720p; the z48 VAE decode dominates at high res
+    // and no quant tier shrinks it), but only ever changed THIS file, so the catalog kept serving
+    // 720p and the fast path never shipped. 720p stays user-selectable via limits.resolutions.
+    defaults: { duration: 5, fps: 24, resolution: "832x480", quality: "balanced" },
     limits: {
       durations: [4, 5, 6, 7, 8],
       recommendedMaxDuration: 7,

--- a/apps/web/src/videoGeometryParity.test.js
+++ b/apps/web/src/videoGeometryParity.test.js
@@ -20,8 +20,9 @@ import { fallbackModels } from "./constants.js";
 //
 // Precedent for the drift being real, not theoretical: sc-4997 set wan_2_2's fast-path default to
 // 832x480 in constants.js ONLY and never touched the manifest, so that default never actually shipped —
-// the catalog kept serving 720p. This test would have caught it. (Whether the manifest should adopt
-// sc-4997's 832x480 fast path is a separate product call, tracked in sc-12319.)
+// the catalog kept serving 720p for a year. This test would have caught it. sc-12319 settled the
+// product question the other way round (the manifest adopted 832x480), so both files now say 480p —
+// but the guard is what keeps them saying it together.
 const HERE = dirname(fileURLToPath(import.meta.url));
 const MANIFEST_PATH = resolve(HERE, "../../../config/manifests/builtin.models.jsonc");
 

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -6003,7 +6003,23 @@
       "defaults": {
         "duration": 5,
         "fps": 24,
-        "resolution": "1280x704",
+        // 832x480, not the 1280x704 this model can also render (sc-12319, adopting sc-4997's
+        // never-landed fast path — it changed only the constants.js mirror, so the catalog kept
+        // serving 720p and every 5B render took the slow path). Measured on real weights at the
+        // dispatched 20-step + CFG recipe (sc-4997, M5 Max, 121f): 1280x720 = 19.7 min (DiT 11.0
+        // + z48 VAE 8.3) vs 832x480 = 5.1 min (DiT 3.5 + VAE 1.5). The bar is <10 min.
+        //
+        // 720p is not reachable by tuning the worker: the z48 vae22 decode alone is ~8.3 min and
+        // is independent of steps/CFG, and the VAE stays dense bf16 in EVERY quant tier (see the
+        // downloads[] note above), so no tier shrinks it. The high-res decode is also mostly
+        // tiling overhead, not compute — `auto_tiling_budgeted` still takes the largest tile under
+        // 0.85 × get_memory_limit() (~99 GB on a 128 GB Mac). That is sc-5089, still OPEN: if it
+        // lands, 720p gets materially cheaper and this default is worth revisiting.
+        //
+        // 832x480 is an advertised bucket, exact on the 32-px stride (26×15), and well under
+        // maxPixels — 720p stays one click away in the picker. Matches scail2_14b/vace_fun_14b,
+        // which already default to 480p despite being the heavier models.
+        "resolution": "832x480",
         "quality": "balanced",
         "sampler": "default",
         "scheduler": "default"


### PR DESCRIPTION
Closes [sc-12319](https://app.shortcut.com/trefry/story/12319).

## The decision

sc-12319 asked a product question rather than describing a patch: should `wan_2_2` (dense TI2V-5B) default to **832x480** or **1280x704**?

**Decision: 832x480.** Michael's stated bar for the 5B is **under 10 minutes**. At the recipe the worker actually dispatches (20-step + CFG), 720p is roughly double that.

| 1280x720, 121f, 20-step | total | load | DiT | z48 VAE |
|---|---|---|---|---|
| CFG on (**the live config**) | **19.7 min** | 28s | 11.0 | **8.3** |
| CFG off | 10.4 min | 15s | 5.7 | 4.4 |
| **832x480** CFG on | **5.1 min** | 10s | 3.5 | 1.5 |

sc-4997 measured this on real weights and concluded 832x480 was right — then set it in `apps/web/src/constants.js` only. The manifest seeds the live catalog, so the catalog kept serving 720p and **the fast path never shipped**. sc-12294 realigned the mirror (making it truthful) and deliberately left the product call open. This lands it where it actually takes effect.

## Re-checked the premise from source

The story said the year-old figures should be re-measured "as the z48 VAE decode cost may have moved." **It hasn't** — verified in the engine rather than by a re-run, which answers that specific question more precisely than a noisy wall-clock:

- The decode path is unchanged since sc-4997. `vae22.rs`/`pipeline.rs` saw only a tree move plus sc-11747 lifting the loop into the shared `mlx_gen::vae_tiling::tiled_decode` (same implementation, de-duplicated with the Qwen VAE).
- `auto_tiling_budgeted` **still** takes the largest tile under `0.85 × get_memory_limit()` — the exact heuristic **sc-5089** identified as the wall-clock bug. sc-5089 is still **open**, so 720p can't reach the bar today.
- The VAE is **dense bf16 in every quant tier**, so no tier shrinks the ~8.3 min that dominates at 720p. Quantization only touches the DiT — which is why the quant-tier work the story flagged doesn't change the answer.

Not a hard floor: sc-5089 has ~2x on the table (the *same* decode ran 8.3 vs 4.4 min depending only on the preceding DiT's memory state). **If sc-5089 lands, 720p is worth revisiting** — noted at the manifest default so the next reader finds it.

## The churn concern is ~nil

The story's main argument for the status quo was that existing recipes would re-run at a different size. Traced it — they won't:

- Every persisted video job payload carries an **explicit** w/h (`generation.rs:489`); the DTO fallbacks are hardcoded 768x512, **not** manifest-derived.
- Retry/duplicate copy the payload **verbatim** (`jobs_store.rs:936,971`).
- Studio-saved presets always pin `resolution`.
- Only an "Any size" preset on a workspace with no snapshot picks up the new default — which is exactly what "Any size" means.

## Why 480p is also the consistent choice

832x480 is already an advertised bucket, exact on the 32-px stride (26x15), and well under `maxPixels` — **no new geometry, and 720p stays one click away**. It also puts the *lightest* Wan in line with `scail2_14b` and `wan_2_2_vace_fun_14b`, which already default to 480p despite being the heavier models.

## Verification

- `videoGeometryParity` enforces manifest + mirror move together — **mutation-checked** that the guard actually fires (reverting the mirror fails with `wan_2_2 defaults.resolution must mirror the manifest`), so the green isn't vacuous.
- `sceneworks-core --lib`: **479 passed / 0 failed** (covers the manifest parse — this adds comments inside `defaults`).
- web suite: **1836 passed / 0 failed** (136 files).

## What I did not do

**No real render was run.** The 5B MLX snapshot isn't on this box (~17 GB) and the conclusion doesn't turn on it — even a *free* DiT leaves 720p at the ~8.3 min VAE, so the direction can't flip. Absolute numbers on the **q4 default tier** are therefore unmeasured; q4 shrinks the DiT only, and its lighter residency might let the VAE run nearer 4.4 than 8.3, so a q4 720p run could land ~10-14 min. Still at/over the bar, still ~3x slower than 480p. Same posture as sc-12294, which derived its strides from engine code and said so. Happy to run the harness (`wan_5b_timing`) for the record if you want the numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)