### PR TITLE
fix(video): enforce each model's declared limits.hardMaxDuration (sc-12297)

### DIFF
--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -513,6 +513,28 @@ pub(crate) async fn create_video_job(
         .unwrap_or(payload.model.as_str())
         .to_owned();
     let model_manifest_entry = resolve_model_manifest_entry(&state, &model_id).await?;
+    // The model's declared `limits.hardMaxDuration`, enforced at enqueue (sc-12297). It had ten
+    // declarations and zero readers, so `validate_video_job`'s blanket `1..=30` was the ONLY
+    // ceiling: a raw API/MCP/preset-replay caller could ask mochi_1 (cap 5) for 30s @ 30fps, and
+    // the resulting 901 frames clear the engine's own `frames % 6 == 1` check — nothing downstream
+    // says no. Rejected, never clamped: silently rendering 5s of a 30s request is the same
+    // silent-coercion class as the 848→832 rewrite (sc-11993/sc-12294).
+    //
+    // It lives HERE, not in `validate_video_job`, because this is the first point that holds BOTH
+    // halves of the decision: the resolved manifest entry (the cap) and the post-preset `model_id`
+    // (whose cap). Reading either from the DTO is precisely sc-12300 — a preset may have replaced
+    // the model, leaving `payload.model` stale, which would gate against the DEFAULT model's cap.
+    // Duration comes off `job_payload` for the same reason: gate the value actually enqueued.
+    // (Presets deliberately do not patch duration today — see `apply_recipe_preset_to_video_payload`
+    // — so this reads the DTO's value; it just stops being a latent bug if that ever changes.)
+    if let Some(message) = model_manifest_entry.as_object().and_then(|entry| {
+        job_payload
+            .get("duration")
+            .and_then(Value::as_f64)
+            .and_then(|duration| duration_limit_error(&model_id, duration as f32, entry))
+    }) {
+        return Err(ApiError::bad_request(message));
+    }
     job_payload.insert("modelManifestEntry".to_owned(), model_manifest_entry);
     validate_job_lora_compatibility_with(
         &state,

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -56,6 +56,7 @@ use sceneworks_core::training_store::{
     TrainingDatasetCaptionSidecarsInput, TrainingDatasetCreateInput, TrainingDatasetMutationResult,
     TrainingDatasetSummary, TrainingDatasetUpdateInput,
 };
+use sceneworks_core::video_request::duration_limit_error;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -3345,3 +3345,173 @@ async fn claim_sweeps_stale_jobs_once_and_still_refreshes_the_queue() {
     assert_eq!(job["status"], "interrupted");
     assert_eq!(job["workerId"], Value::Null);
 }
+
+/// sc-12297: `limits.hardMaxDuration` is enforced at enqueue, and — the part that makes WHERE it
+/// lives load-bearing — against the POST-PRESET model's cap.
+///
+/// The fixture is built so the two plausible homes for this check disagree:
+///   * default video model — cap 15 (generous)
+///   * `preset-vid`        — cap  5 (strict)
+///
+/// The request omits `model` (so the preset's model wins, per sc-12300) and asks for 10s. Gating
+/// on the DTO's `payload.model` — i.e. inside `validate_video_job`, the intuitive home, which runs
+/// BEFORE `apply_recipe_preset_to_video_payload` — reads the DEFAULT's cap of 15, admits 10s, and
+/// enqueues a job the strict model can't render. Only a gate placed after preset expansion AND
+/// manifest resolution sees the 5 that actually applies. That is the whole reason this check is not
+/// in `validate_video_job`, and this test is what pins it there.
+#[tokio::test]
+async fn video_duration_past_the_post_preset_models_hard_cap_is_rejected() {
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    let default_video_model = crate::defaults::default_video_model();
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "models": [
+            {
+              "id": "__DEFAULT_VIDEO_MODEL__",
+              "name": "Default Vid",
+              "family": "ltx-video",
+              "type": "video",
+              "adapter": "ltx_video",
+              "capabilities": ["text_to_video"],
+              "downloads": [
+                { "provider": "huggingface", "repo": "owner/default-vid", "files": ["*.safetensors"], "default": true }
+              ],
+              "paths": {},
+              "defaults": {},
+              "limits": { "hardMaxDuration": 15 },
+              "ui": { "label": "Default Vid" }
+            },
+            {
+              "id": "preset-vid",
+              "name": "Preset Vid",
+              "family": "mochi",
+              "type": "video",
+              "adapter": "mochi_video",
+              "capabilities": ["text_to_video"],
+              "downloads": [
+                { "provider": "huggingface", "repo": "owner/preset-vid", "files": ["*.safetensors"], "default": true }
+              ],
+              "paths": {},
+              "defaults": {},
+              "limits": { "hardMaxDuration": 5 },
+              "ui": { "label": "Preset Vid" }
+            }
+          ]
+        }
+        "#
+        .replace("__DEFAULT_VIDEO_MODEL__", &default_video_model),
+    )
+    .expect("builtin models writes");
+    std::fs::write(
+        config_dir.join("user.models.jsonc"),
+        r#"{ "schemaVersion": 1, "models": [] }"#,
+    )
+    .expect("user models writes");
+    std::fs::write(
+        config_dir.join("builtin.recipe-presets.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "presets": [
+            {
+              "id": "preset_override",
+              "name": "Preset Override",
+              "workflow": "text_to_video",
+              "model": "preset-vid",
+              "defaults": {},
+              "prompt": { "prefix": "cinematic", "suffix": "smooth" }
+            }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin recipe presets writes");
+    std::fs::write(
+        config_dir.join("user.recipe-presets.jsonc"),
+        r#"{ "schemaVersion": 1, "presets": [] }"#,
+    )
+    .expect("user recipe presets writes");
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Duration Cap Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+
+    // 10s: legal for the default (15) but past the preset-resolved model's 5. `model` omitted so
+    // the preset's model wins — the sc-12300 shape.
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_video",
+            "prompt": "a fox runs",
+            "duration": 10,
+            "recipePresetId": "preset_override"
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "10s past preset-vid's 5s cap must be refused at enqueue, not silently clamped: {body}"
+    );
+    let detail = body["detail"].as_str().unwrap_or_default();
+    assert!(
+        detail.contains("preset-vid"),
+        "names the model whose cap applied — NOT the default's: {detail}"
+    );
+    assert!(detail.contains("5s"), "states the cap: {detail}");
+    assert!(detail.contains("10s"), "states what was asked: {detail}");
+
+    // At-cap admits: 5s is exactly the cap, and the bound is `>`. This is what keeps the
+    // assertion above from passing for a gate that simply rejects everything.
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_video",
+            "prompt": "a fox runs",
+            "duration": 5,
+            "recipePresetId": "preset_override"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "5s is at the cap: {body}");
+    assert_eq!(body["payload"]["model"], "preset-vid");
+
+    // ...and the SAME 10s request against the default model (cap 15) is admitted, proving the
+    // rejection above came from the per-model cap rather than a blanket duration bound.
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_video",
+            "prompt": "a fox runs",
+            "duration": 10,
+            "model": default_video_model
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "10s is within the default model's 15s cap: {body}"
+    );
+}

--- a/crates/sceneworks-core/src/video_request.rs
+++ b/crates/sceneworks-core/src/video_request.rs
@@ -39,6 +39,11 @@ pub struct VideoRequest {
     pub negative_prompt: String,
     pub model: String,
     /// Clip length in seconds, clamped to 1.0..=30.0 (Python `safe_float`).
+    ///
+    /// That blanket 30 is a payload-sanity bound, NOT the model's limit: each video model
+    /// declares its own `limits.hardMaxDuration` (4–15 s), enforced as a *rejection* by
+    /// [`duration_limit_error`] at the API and worker gates rather than clamped here — see
+    /// that function for why this parse is the wrong home for it (sc-12297).
     pub duration: f32,
     /// Frames per second, clamped to 1..=60 (Python `safe_int`).
     pub fps: u32,
@@ -234,6 +239,55 @@ pub fn is_wan_model(model: &str) -> bool {
 /// Whether `model` is a Mochi 1 family id (`mochi_1`, …). Epic 1788 / sc-11993.
 pub fn is_mochi_model(model: &str) -> bool {
     model.starts_with("mochi")
+}
+
+/// `limits.hardMaxDuration` (seconds) from a resolved manifest entry, or `None` for **no cap**.
+///
+/// The second constraint key core reads, after B3's [`dimension_multiple_of`] (sc-11993). It had
+/// ten declarations and zero readers — in Rust *and* in the web — for as long as it has existed
+/// (sc-12297): the word "hard" promised an enforcement that was never written, so every video
+/// model accepted any duration the blanket `1..=30` clamp allowed.
+///
+/// Absent ⇒ no cap, so a model that declares nothing is byte-identical to before this key had a
+/// reader. Same never-block-without-evidence posture as `mlx_fit_gate`'s `fit_decision`, and the
+/// same typo'd-manifest tolerance as [`max_pixels_of`]: a non-positive or non-finite cap is not a
+/// constraint anyone could satisfy (it would reject *every* request, including the model's own
+/// `defaults.duration`), so it falls back to no cap rather than bricking the model.
+pub fn hard_max_duration(model_manifest_entry: &JsonObject) -> Option<f32> {
+    model_manifest_entry
+        .get("limits")
+        .and_then(Value::as_object)
+        .and_then(|limits| limits.get("hardMaxDuration"))
+        .and_then(Value::as_f64)
+        .map(|cap| cap as f32)
+        .filter(|cap| cap.is_finite() && *cap > 0.0)
+}
+
+/// The actionable rejection for a `duration` past the model's declared [`hard_max_duration`], or
+/// `None` to admit. The pure decision, so both enqueue gates assert on one message (sc-12297).
+///
+/// **Reject, never clamp.** Quietly rewriting a 30 s request into a 5 s render is the same
+/// silent-coercion bug class B3 exists to fix (the invisible 848→832 dimension rewrite, sc-11993 /
+/// sc-12294): duration is a creative choice, and returning a sixth of the clip the caller asked for
+/// — with no error — is worse than refusing. This is also why the cap has no home in
+/// [`VideoRequest::from_payload`], which is infallible by contract and has no error surface; the
+/// rejection lives where a rejection can actually happen.
+///
+/// Message follows the house convention (`mlx_fit_gate::too_big_error`): name the model, state
+/// what was asked and what the cap is, and give the lever. Pinned by
+/// `duration_limit_error_names_the_model_the_request_and_the_cap`.
+pub fn duration_limit_error(
+    model: &str,
+    duration: f32,
+    model_manifest_entry: &JsonObject,
+) -> Option<String> {
+    let cap = hard_max_duration(model_manifest_entry)?;
+    (duration > cap).then(|| {
+        format!(
+            "{model} renders clips up to {cap}s, but this request asks for {duration}s. Shorten \
+             the clip to {cap}s or less, or choose a model that renders longer clips."
+        )
+    })
 }
 
 /// The dimension granularity applied when a model's manifest entry does not declare
@@ -829,6 +883,168 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// sc-12297 — the same invariant as [`shipped_manifest_matches_each_engines_real_geometry`],
+    /// on the temporal axis: **what a video model advertises is what it will render.** Asserted
+    /// against the REAL manifest bytes, because `hardMaxDuration` spent its whole existence with
+    /// ten declarations and zero readers — a suite that hardcoded the caps it claimed to check
+    /// would re-test `duration_limit_error`'s `>` and notice nothing.
+    ///
+    /// The table is derived from the shipped `limits.durations` dropdown, not copied from
+    /// `hardMaxDuration` — that independence is what makes the `cap == max(durations)` assertion
+    /// below a real check rather than a tautology.
+    const DURATION_LIMITS: &[(&str, f32)] = &[
+        ("ltx_2_3", 15.0),
+        ("ltx_2_3_eros", 15.0),
+        ("svd", 4.0),
+        ("mochi_1", 5.0),
+        ("wan_2_2", 8.0),
+        ("wan_2_2_t2v_14b", 5.0),
+        ("wan_2_2_i2v_14b", 5.0),
+        ("wan_2_2_vace_fun_14b", 5.0),
+        ("bernini", 5.0),
+        ("scail2_14b", 5.0),
+    ];
+
+    #[test]
+    fn shipped_manifest_duration_caps_admit_everything_they_advertise() {
+        let models = builtin_video_models();
+        assert_eq!(
+            models.len(),
+            DURATION_LIMITS.len(),
+            "a video model was added/removed; declare its hardMaxDuration and add it to \
+             DURATION_LIMITS — an undeclared cap is silently NO cap"
+        );
+
+        for (id, want_cap) in DURATION_LIMITS {
+            let entry = models
+                .iter()
+                .find(|m| m.get("id").and_then(Value::as_str) == Some(*id))
+                .unwrap_or_else(|| panic!("{id} present in builtin.models.jsonc"))
+                .as_object()
+                .expect("model entry object");
+            let limits = entry
+                .get("limits")
+                .and_then(Value::as_object)
+                .unwrap_or_else(|| panic!("{id} has limits"));
+
+            // 1. Every video model DECLARES a cap, and core reads exactly it. `None` here is the
+            //    sc-12297 bug itself — an absent key means "no cap", which is how a 30 s request
+            //    reached every one of these models.
+            assert_eq!(
+                hard_max_duration(entry),
+                Some(*want_cap),
+                "{id}: effective hard max duration"
+            );
+
+            let buckets: Vec<f64> = limits
+                .get("durations")
+                .and_then(Value::as_array)
+                .unwrap_or_else(|| panic!("{id} advertises durations"))
+                .iter()
+                .map(|d| {
+                    d.as_f64()
+                        .unwrap_or_else(|| panic!("{id}: non-numeric duration"))
+                })
+                .collect();
+            let default_duration = entry
+                .get("defaults")
+                .and_then(Value::as_object)
+                .and_then(|d| d.get("duration"))
+                .and_then(Value::as_f64)
+                .unwrap_or_else(|| panic!("{id} has a default duration"));
+
+            // 2. THE UI-PARITY INVARIANT, and the reason this change is safe to ship: the cap is
+            //    exactly the top of the advertised dropdown, for all ten models. The web UI bounds
+            //    duration via `limits.durations` (VideoStudio.jsx:894), so enforcing the cap cannot
+            //    reject a single request the studio is capable of sending — it rejects only what
+            //    the raw API / MCP / preset-replay paths send past the advertisement. A model whose
+            //    cap sat BELOW its own dropdown would start rejecting its own UI, which is what
+            //    this assertion exists to catch before it ships.
+            let advertised_max = buckets.iter().copied().fold(f64::MIN, f64::max);
+            assert_eq!(
+                f64::from(*want_cap),
+                advertised_max,
+                "{id}: hardMaxDuration must equal the top of its advertised durations — a lower \
+                 cap rejects the model's own dropdown; a higher one advertises less than it allows"
+            );
+
+            // 3. FIXED POINT: every advertised bucket and the shipped default are ADMITTED.
+            //    Advertise 5s and 5s renders — the cap is `>`, so an at-cap request passes.
+            for advertised in buckets
+                .iter()
+                .copied()
+                .chain(std::iter::once(default_duration))
+            {
+                assert_eq!(
+                    duration_limit_error(id, advertised as f32, entry),
+                    None,
+                    "{id} advertises {advertised}s; the cap must admit it"
+                );
+            }
+
+            // 4. MUTATION CHECK: the cap actually rejects something. Without this, a cap read as
+            //    `None` (the shipped bug) or a neutered `>` passes every assertion above.
+            let over = *want_cap + 0.5;
+            let message = duration_limit_error(id, over, entry).unwrap_or_else(|| {
+                panic!("{id}: {over}s is past the {want_cap}s cap and must be rejected")
+            });
+            assert!(message.contains(id), "{id}: names the model: {message}");
+        }
+    }
+
+    /// The house message convention (`mlx_fit_gate::too_big_error_names_model_budget_and_optional_staged`):
+    /// name the model, state what was asked and what the limit is, and give the lever. A caller
+    /// that hits this has no other signal — the request simply stops — so the message IS the UX.
+    #[test]
+    fn duration_limit_error_names_the_model_the_request_and_the_cap() {
+        let mochi = payload(json!({ "limits": { "hardMaxDuration": 5 } }));
+        let message =
+            duration_limit_error("mochi_1", 30.0, &mochi).expect("30s is past the 5s cap");
+        assert!(message.contains("mochi_1"), "names the model: {message}");
+        assert!(message.contains("5s"), "states the cap: {message}");
+        assert!(message.contains("30s"), "states what was asked: {message}");
+        assert!(message.contains("Shorten"), "gives the lever: {message}");
+
+        // At-cap and under-cap admit: the bound is `>`, matching every advertised bucket being a
+        // legal request (`shipped_manifest_duration_caps_admit_everything_they_advertise`).
+        assert_eq!(duration_limit_error("mochi_1", 5.0, &mochi), None);
+        assert_eq!(duration_limit_error("mochi_1", 1.0, &mochi), None);
+        assert!(duration_limit_error("mochi_1", 5.5, &mochi).is_some());
+    }
+
+    /// A model that declares no cap is UNCONSTRAINED — the default-absent behavior that keeps
+    /// every non-declaring model (a user-manifest entry, the stub lane, an uncatalogued id whose
+    /// entry resolves to `{}`) byte-identical to before the key had a reader.
+    ///
+    /// Also the infallibility contract: a cap nobody could satisfy falls back to NO cap rather
+    /// than bricking the model. A typo'd `0` or `-1` would otherwise reject every request the
+    /// model has — including its own `defaults.duration` — turning a manifest typo into a
+    /// completely dead model instead of an unenforced limit.
+    #[test]
+    fn absent_or_unhonorable_hard_max_duration_means_no_cap() {
+        for empty in [json!({}), json!({ "limits": {} })] {
+            let entry = payload(empty.clone());
+            assert_eq!(hard_max_duration(&entry), None, "no cap declared: {empty}");
+            assert_eq!(duration_limit_error("any_model", 30.0, &entry), None);
+        }
+
+        for bad in [json!(0), json!(-1), json!("5"), json!(null), json!([5])] {
+            let entry = payload(json!({ "limits": { "hardMaxDuration": bad } }));
+            assert_eq!(hard_max_duration(&entry), None, "unhonorable cap {bad}");
+            assert_eq!(
+                duration_limit_error("any_model", 30.0, &entry),
+                None,
+                "an unsatisfiable cap must not brick the model: {bad}"
+            );
+        }
+
+        // A fractional cap IS honorable — nothing about the key requires an integer.
+        let fractional = payload(json!({ "limits": { "hardMaxDuration": 2.5 } }));
+        assert_eq!(hard_max_duration(&fractional), Some(2.5));
+        assert!(duration_limit_error("m", 3.0, &fractional).is_some());
+        assert_eq!(duration_limit_error("m", 2.5, &fractional), None);
     }
 
     /// sc-12294 BLOCKER — the case the dropdown never produces but every raw path does.

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -20,7 +20,7 @@
 use std::f32::consts::PI;
 use std::path::Path;
 
-use sceneworks_core::video_request::{is_ltx_model, VideoRequest};
+use sceneworks_core::video_request::{duration_limit_error, is_ltx_model, VideoRequest};
 
 // Used only by the video generation metrics builders below, which are themselves
 // gated to the macOS / backend-candle lanes (the shared `generate_video` funnel) —
@@ -283,6 +283,41 @@ fn resolve_candle_video_route(request: &VideoRequest, settings: &Settings) -> Ca
     }
 }
 
+/// The payload invariants every video job must satisfy before the worker does anything expensive —
+/// the pure, synchronously testable seam [`run_video_generate_job`] delegates them to (sc-12297).
+///
+/// It exists as its own function for the reason `mochi_preflight` does: `run_video_generate_job` is
+/// `async` and needs a live `ApiClient`/`JobSnapshot`, so any decision left INSIDE it is in practice
+/// unpinned — the sc-11992 review caught exactly that, a dropped gate surviving 835 green tests.
+/// Both checks here are refusals whose absence is invisible until a render is already underway.
+///
+/// EVERY video job funnels through this: `VideoGenerate` / `VideoExtend` / `VideoBridge` /
+/// `PersonReplace` all dispatch to `run_video_generate_job` (lib.rs). That is what makes it the
+/// backstop for the API's `create_video_job` gate — which is the one that returns a caller a 400,
+/// but only covers what IT enqueues, not a job replayed from a pre-sc-12297 row or produced by any
+/// future non-HTTP path.
+fn video_preflight(request: &VideoRequest) -> WorkerResult<()> {
+    if request.project_id.trim().is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "Missing payload.projectId".to_owned(),
+        ));
+    }
+    // The model's declared `limits.hardMaxDuration`. NOT redundant with `mochi_preflight`'s fit
+    // gate (sc-11992) — the closest thing that already existed: that one is macOS-only (so the
+    // candle lane has no duration ceiling but this), Mochi-only, and answers a DIFFERENT question
+    // — "does this fit THIS machine's RAM", not "is this within what the model can do". Memory is
+    // not capability: a machine with the headroom to decode a 30s Mochi clip would render 30s off
+    // a model trained for 5. Neither gate subsumes the other.
+    if let Some(message) = duration_limit_error(
+        &request.model,
+        request.duration,
+        &request.model_manifest_entry,
+    ) {
+        return Err(WorkerError::InvalidPayload(message));
+    }
+    Ok(())
+}
+
 /// Dispatch handler for `JobType::VideoGenerate`: generate, encode, and stream a
 /// single video asset through the Rust GPU worker.
 pub(crate) async fn run_video_generate_job(
@@ -291,11 +326,7 @@ pub(crate) async fn run_video_generate_job(
     job: &JobSnapshot,
 ) -> WorkerResult<()> {
     let request = VideoRequest::from_payload(&job.payload);
-    if request.project_id.trim().is_empty() {
-        return Err(WorkerError::InvalidPayload(
-            "Missing payload.projectId".to_owned(),
-        ));
-    }
+    video_preflight(&request)?;
     let project =
         ProjectStore::new(settings.data_dir.clone(), "worker").get_project(&request.project_id)?;
     let project_path = PathBuf::from(project.path);
@@ -10458,6 +10489,72 @@ mod tests {
 
     fn request(value: Value) -> VideoRequest {
         VideoRequest::from_payload(&value.as_object().cloned().unwrap())
+    }
+
+    /// sc-12297: the worker's backstop refuses a clip past the model's declared
+    /// `limits.hardMaxDuration` BEFORE any weights load — pinned at the seam
+    /// `run_video_generate_job` actually calls, not just as a sceneworks-core free function.
+    ///
+    /// Kills the mutation that matters: deleting the `duration_limit_error` call from
+    /// `video_preflight`. Every core test stays green through that — the core function is still
+    /// correct, it is simply no longer CALLED — which is the precise shape of the dropped-gate bug
+    /// the sc-11992 review caught surviving 835 green tests.
+    ///
+    /// Ungated on purpose. `mochi_preflight`'s fit gate is macOS-only, so the candle lane's ONLY
+    /// duration ceiling is this one; a `#[cfg(target_os = "macos")]` here would leave the platform
+    /// that has no other protection untested.
+    #[test]
+    fn video_preflight_refuses_a_clip_past_the_models_declared_hard_max_duration() {
+        // The story's mochi_1 shape: cap 5s, asked for 30s. 30 x 30fps = 900 raw frames, which snap
+        // to 901 on Mochi's 6k+1 lattice — and `901 % 6 == 1`, so the engine's own validate_request
+        // ACCEPTS it. On the candle lane nothing else says no, which is what makes this gate the
+        // whole defense rather than a nicety.
+        let over = request(json!({
+            "projectId": "p", "model": "mochi_1", "mode": "text_to_video", "prompt": "p",
+            "duration": 30, "fps": 30,
+            "modelManifestEntry": { "limits": { "hardMaxDuration": 5 } }
+        }));
+        assert_eq!(over.raw_frame_count(), 900);
+        assert_eq!(
+            over.frame_count(),
+            901,
+            "on-lattice, and the engine would accept it"
+        );
+        let Err(WorkerError::InvalidPayload(message)) = video_preflight(&over) else {
+            panic!("a 30s clip on a 5s-capped model must be refused before the load");
+        };
+        assert!(message.contains("mochi_1"), "names the model: {message}");
+        assert!(message.contains("5s"), "states the cap: {message}");
+        assert!(message.contains("30s"), "states what was asked: {message}");
+
+        // At-cap admits — the shipped 5s default must still run, or the gate has bricked the model.
+        let at_cap = request(json!({
+            "projectId": "p", "model": "mochi_1", "mode": "text_to_video", "prompt": "p",
+            "duration": 5, "fps": 30,
+            "modelManifestEntry": { "limits": { "hardMaxDuration": 5 } }
+        }));
+        assert!(
+            video_preflight(&at_cap).is_ok(),
+            "5s is exactly the cap and is the model's own shipped default"
+        );
+
+        // A job carrying no manifest entry (the stub lane, an uncatalogued id whose entry resolves
+        // to {}) is UNCONSTRAINED — the gate never blocks without a declared cap.
+        let no_entry = request(json!({
+            "projectId": "p", "model": "stub-model", "mode": "text_to_video", "prompt": "p",
+            "duration": 30
+        }));
+        assert!(
+            video_preflight(&no_entry).is_ok(),
+            "no cap declared => no cap"
+        );
+
+        // The pre-existing projectId invariant still holds at this seam.
+        let no_project = request(json!({ "model": "mochi_1", "mode": "text_to_video" }));
+        assert!(matches!(
+            video_preflight(&no_project),
+            Err(WorkerError::InvalidPayload(m)) if m.contains("projectId")
+        ));
     }
 
     // -----------------------------------------------------------------------------------------


### PR DESCRIPTION
Closes [sc-12297](https://app.shortcut.com/trefry/story/12297). Epic [12334 — Manifest contract](https://app.shortcut.com/trefry/epic/12334).

## The bug

`limits.hardMaxDuration` shipped with **10 declarations and zero readers** — in Rust *and* in the web. The word "hard" promised an enforcement nobody ever wrote.

So the only ceiling on any video model was `validate_video_job`'s blanket `1..=30`. A raw API / MCP / preset-replay caller could ask `mochi_1` (cap 5) for `duration: 30, fps: 30` → **901 frames**, which clears the engine's own `frames % 6 == 1` check. Nothing downstream says no.

## Decision: reject, never clamp

Silently rendering 5s of a 30s request is the same silent-coercion class as the 848→832 dimension rewrite (sc-11993 / sc-12294). Duration is a creative choice.

## What's here

| Piece | Gate |
|---|---|
| `sceneworks-core::video_request` — `hard_max_duration()` + `duration_limit_error()` | the pure decision + message |
| `create_video_job` | `ApiError::bad_request` (400 at enqueue) |
| `video_preflight` (worker) | `WorkerError::InvalidPayload` (backstop) |

**`from_payload` stays infallible and untouched** — it has no error surface, so the cap lives in a separate pure seam beside B3's `dimension_multiple_of`. Absent or unsatisfiable cap ⇒ **no cap**: never block without evidence (the `mlx_fit_gate` posture), and a typo'd `0` must not brick a model.

**The API gate's placement is load-bearing.** It sits *after* preset expansion + manifest resolution and keys off the post-preset `model_id`. `validate_video_job` is the intuitive home but runs *before* `apply_recipe_preset_to_video_payload` — a gate there reads the stale DTO model, which is precisely sc-12300. Pinned by a test where the default model's cap (15) and the preset-resolved model's cap (5) disagree.

**`video_preflight` is extracted, not inlined**, for the reason sc-11992's review documented: a gate left inside that `async` arm is unreachable from a unit test, and one survived 835 green tests when silently dropped. It's ungated — the candle lane's only duration ceiling.

## Blast radius: zero for the UI — verified, not assumed

The story flagged this as a decision gate ("tightens accepted inputs for 9 shipped models"). I derived each model's advertised `limits.durations` independently:

| model | `hardMaxDuration` | `max(durations)` |
|---|---|---|
| ltx_2_3 / ltx_2_3_eros | 15 | 15 |
| svd | 4 | 4 |
| wan_2_2 | 8 | 8 |
| wan_2_2_t2v_14b / i2v_14b / vace_fun_14b / bernini / scail2_14b | 5 | 5 |
| mochi_1 | 5 | 5 |

**For all 10, the cap IS the top of the advertised dropdown** — and the dropdown (`VideoStudio.jsx:894`), not `hardMaxDuration`, is what bounds the studio. So this cannot reject anything the web app can send; it rejects only raw traffic that asks past the advertisement. That invariant is now test-pinned.

## Not a `mochi_fit_check` duplicate

sc-11992's fit gate is the closest existing thing, and it does **not** subsume this: it's `#[cfg(target_os = "macos")]` and Mochi-only, and asks *"does this fit THIS machine's RAM"* — not *"is this within what the model can do."* Memory is not capability. (Worth noting: because that gate exists, the story's "MLX `exit(-1)` hard worker kill" rationale is stale on macOS — details in the story comment. The real reasons are the unguarded candle lane and the manifest lying.)

## Tests — every one mutation-verified

- `shipped_manifest_duration_caps_admit_everything_they_advertise` — reads the **real manifest bytes** (the sc-12294 lesson: the earlier suite hardcoded the values it "verified" and stayed green through the bug). Pins cap == max(durations), every advertised bucket + `defaults.duration` admitted, plus a mutation check that the cap rejects *something*.
- `duration_limit_error_names_the_model_the_request_and_the_cap` — house message convention.
- `absent_or_unhonorable_hard_max_duration_means_no_cap` — infallibility.
- `video_duration_past_the_post_preset_models_hard_cap_is_rejected` (API) — the sc-12300 interaction.
- `video_preflight_refuses_a_clip_past_the_models_declared_hard_max_duration` (worker).

Mutations confirmed RED before green: manifest cap 5→4 · cap key deleted · `>` neutered · `>`→`>=` · gate dropped from `video_preflight` · API gate resolving the entry from the pre-preset DTO model.

`cargo test` 1811 passed / 0 failed · `npm run rust:check` exit 0.

## Known gap — filed, not buried

This closes the **duration** axis, not the **frames** axis. `frames = duration × fps`, and `limits.fps` has 2 web readers and **0 Rust readers** — the same bug, one key over. A `duration: 5, fps: 60` payload on `mochi_1` (declares `fps: [30]`) is legally 5 seconds, passes this new cap, and still yields 301 frames — 2× the shipped default.

Filed as **[sc-12347](https://app.shortcut.com/trefry/story/12347)** rather than absorbed: `limits.fps` is a discrete *allowlist*, not a scalar ceiling, and enforcing it would refuse engine-valid values (no video engine validates fps at all). That's a product decision belonging with sc-12304's binding-vs-advisory classification.

## Reviewer note

**[sc-12305](https://app.shortcut.com/trefry/story/12305) is In Progress and also touches `video_request.rs`** — sequence or expect a small conflict. It's complementary: it closes the generic `POST /api/v1/jobs` door, which currently resolves no manifest entry at all (so this gate correctly no-ops there — no entry, no declared cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)