### PR TITLE
fix(worker): refuse an over-budget Mochi job before paying for the tier download (sc-12322)

### DIFF
--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -8812,6 +8812,81 @@ fn mochi_tier_quant(tier_dir: &Path) -> Option<Quant> {
     }
 }
 
+/// The dir the PRE-DOWNLOAD fit gate measures: the REQUESTED tier's path, whether or not it has been
+/// downloaded yet. `None` when no model root is locatable at all ⇒ no signal ⇒ [`mochi_precheck`]
+/// skips (never blocks without evidence, matching the gate's own fail-open rule).
+///
+/// Deliberately NOT [`resolve_mochi_model_dir`]: that one requires a COMPLETE tier and falls back to a
+/// smaller installed one, and it hard-errors when nothing is installed — which is correct AFTER the
+/// download and wrong before it (a first-ever q8 job would be rejected as "not downloaded" instead of
+/// downloading). This returns a bare path and lets the gate's on-disk scan decide.
+///
+/// Naming the REQUESTED tier (not the fallback) is what keeps the weights term a strict lower bound on
+/// what THIS job will hold resident: the scan finds the shared co-requisites plus this tier's own bytes
+/// if present, never a different tier's.
+#[cfg(target_os = "macos")]
+fn mochi_precheck_dir(settings: &Settings, request: &VideoRequest) -> Option<PathBuf> {
+    // The preferred tier — `mochi_tier_order`'s head is the one the request actually asked for; the
+    // rest of the order is fallback, which the pre-check must not measure.
+    let requested = mochi_tier_order(request).first().copied()?;
+    let root = match std::env::var(MOCHI_DIR_ENV) {
+        Ok(override_dir) => {
+            let root = PathBuf::from(override_dir.trim());
+            // A self-contained dir that IS one tier — the components live under it, so it is already
+            // the thing to measure (and no download can change it).
+            if mochi_tier_dir_is_complete(&root) && mochi_shared_is_complete(&root) {
+                return Some(root);
+            }
+            root
+        }
+        Err(_) => huggingface_snapshot_dir(&settings.data_dir, MOCHI_REPO)?,
+    };
+    Some(root.join(requested))
+}
+
+/// PRE-DOWNLOAD Mochi admission check (sc-12322) — the same gate as [`mochi_preflight`], run BEFORE
+/// `ensure_mochi_*_present` fetches a ~13-20 GiB tier, so a job that cannot fit is refused without
+/// paying for the download first.
+///
+/// This is sound because the weights term is a conservative FLOOR here, not zero. Mochi's
+/// `text_encoder/` + `tokenizer/` + `vae/` are a `coRequisite: true` download (~9.7 GiB) that is
+/// already on disk before an on-demand `<tier>/*` fetch, and `mochi_resident_bytes` sums those shared
+/// siblings from the tier dir's PARENT even when the tier dir itself is absent. So:
+///
+/// ```text
+/// floor = shared co-requisites + (requested tier, if already downloaded)  ≤  actual resident weights
+/// ⇒ needed(floor) ≤ needed(actual) ⇒ {pre-check refuses} ⊆ {full gate refuses}
+/// ```
+///
+/// i.e. it can only refuse when refusal is CERTAIN — a config that fits is never rejected early, which
+/// is the property that makes an early gate safe at all. Anything it admits still faces the unchanged
+/// full check after the download.
+///
+/// The floor is what makes this bite on the machine the story is named for: at the shipped 151-frame
+/// default the shared components alone give 9.73 + 60.56 decode + 2 OS = 72.29 GiB > 64. A
+/// WEIGHTS-FREE pre-check (decode + OS only) would total 62.56 and ADMIT on a 64 GB Mac — downloading
+/// the tier just to refuse it, which is the whole bug.
+///
+/// Lives beside [`mochi_preflight`] and for the same reason: `generate_mochi` is `async` and needs a
+/// live `ApiClient`/`JobSnapshot`, so any decision left inside it is unpinned by tests.
+#[cfg(target_os = "macos")]
+fn mochi_precheck(
+    model: &str,
+    engine_id: &str,
+    tier_dir: Option<&Path>,
+    raw_frames: u32,
+    width: u32,
+    height: u32,
+) -> WorkerResult<()> {
+    let Some(tier_dir) = tier_dir else {
+        return Ok(());
+    };
+    // The COERCED count — the frames the decode will really pay for, exactly as `mochi_preflight`
+    // computes it. Pre-checking the raw request would gate on a length the engine never renders.
+    let frames = video_frame_count(model, raw_frames);
+    crate::mlx_fit_gate::mochi_fit_check(engine_id, tier_dir, frames, width, height)
+}
+
 /// Resolve the Mochi tier dir to load: the `$SCENEWORKS_MLX_MOCHI_DIR` override (accepted as either a
 /// model root carrying tier subdirs or a single self-contained tier dir), then the turnkey
 /// [`MOCHI_REPO`] snapshot's tier subdir. Only a COMPLETE tier + its shared co-requisite counts.
@@ -9046,8 +9121,10 @@ fn mochi_preflight(
 /// [`generate_video`] funnel — the same one Wan/LTX/SVD use — so Mochi inherits the "no background
 /// heartbeat during a job, the progress callback IS the keepalive" contract without re-implementing it.
 ///
-/// Deliberately thin: every pre-load decision lives in [`mochi_preflight`], which is reachable from a
-/// unit test where this `async` arm is not.
+/// Deliberately thin: every pre-load decision lives in [`mochi_precheck`] (before the download) or
+/// [`mochi_preflight`] (after it), both reachable from a unit test where this `async` arm is not. The
+/// ORDER of those two against the `ensure_mochi_*_present` fetches is the one decision this arm still
+/// owns, and it is the point of sc-12322 — the pre-check must precede the download to be worth having.
 #[cfg(target_os = "macos")]
 async fn generate_mochi(
     api: &ApiClient,
@@ -9057,6 +9134,17 @@ async fn generate_mochi(
     engine_id: &'static str,
     backend: &str,
 ) -> WorkerResult<(DecodedVideo, Value)> {
+    // Refuse a job that cannot possibly fit BEFORE paying for its tier download (sc-12322). Runs on a
+    // weights FLOOR (the already-present shared co-requisites), so it only ever refuses when the full
+    // gate below would too — see `mochi_precheck`.
+    mochi_precheck(
+        &request.model,
+        engine_id,
+        mochi_precheck_dir(settings, request).as_deref(),
+        request.raw_frame_count(),
+        request.width,
+        request.height,
+    )?;
     // A tier the job toggled but never downloaded is fetched before any compute (no-op otherwise).
     ensure_mochi_q8_present(api, settings, job, request).await?;
     ensure_mochi_bf16_present(api, settings, job, request).await?;
@@ -10920,6 +11008,187 @@ mod tests {
         assert_eq!(
             preflight.frames, 19,
             "19 already sits on the 6k+1 lattice, so the snap is a no-op"
+        );
+    }
+
+    /// The PRE-DOWNLOAD disk state (sc-12322): the shared `coRequisite` components at their REAL
+    /// hosted sizes, and NO tier dir — exactly what a machine looks like when a job has toggled q8/bf16
+    /// but `ensure_mochi_*_present` has not run yet. Sparse, like [`mochi_root_real_sized`].
+    #[cfg(target_os = "macos")]
+    fn mochi_root_shared_only(tag: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "mochi_precheck_{tag}_{}_{}",
+            std::process::id(),
+            line!()
+        ));
+        for (relative, len) in [
+            ("text_encoder/model.safetensors", MOCHI_Q4_TE_BYTES),
+            ("vae/model.safetensors", MOCHI_Q4_VAE_BYTES),
+        ] {
+            let path = root.join(relative);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::File::create(&path).unwrap().set_len(len).unwrap();
+        }
+        std::fs::create_dir_all(root.join("tokenizer")).unwrap();
+        root
+    }
+
+    /// THE sc-12322 behavior: the 5 s default is refused on a 64 GB Mac with NO tier on disk — i.e.
+    /// before the ~13-20 GiB download the old ordering charged for the same answer.
+    ///
+    /// The fixture's premise — the decision is reached with NO tier dir on disk — is what makes this a
+    /// PRE-download test rather than a second copy of the `mochi_preflight` pair.
+    ///
+    /// The three mutations, MEASURED not assumed (`generate_mochi` is `async` and needs a live
+    /// `ApiClient`/`JobSnapshot`, so no unit test reaches the call site — only the seam):
+    ///   * pre-check unconditionally admits ⇒ **RED here** (this test + the floor test). This is the
+    ///     story's required mutation-check.
+    ///   * `mochi_precheck(...)?` deleted from `generate_mochi` ⇒ every mochi test stays GREEN, but
+    ///     **CI goes RED**: `clippy -p sceneworks-worker --all-targets -- -D warnings` (macos-mlx.yml)
+    ///     reports `mochi_precheck` + `mochi_precheck_dir` "never used", since only `cfg(test)` would
+    ///     still call them. The same dead-code pin `mochi_preflight` leans on (sc-12318).
+    ///   * pre-check MOVED to after `ensure_mochi_*_present` ⇒ **survives everything**. It stays a
+    ///     correct gate, just a worthless one — the download it exists to avoid has already been paid.
+    ///     That residual is structural to the untestable `async` arm; **sc-12318** tracks it.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn mochi_precheck_refuses_the_5s_default_before_any_tier_is_downloaded() {
+        let root = mochi_root_shared_only("reject");
+        // The requested tier does NOT exist yet — the pre-check must still decide.
+        let tier_dir = root.join("bf16");
+        assert!(
+            !tier_dir.exists(),
+            "the fixture must model the pre-download state"
+        );
+        let out = temp_env_var(crate::mlx_fit_gate::MLX_MEMORY_CAP_ENV, "64", || {
+            mochi_precheck("mochi_1", "mochi_1", Some(&tier_dir), 150, 848, 480)
+        });
+        std::fs::remove_dir_all(&root).ok();
+
+        let message = out
+            .expect_err(
+                "the shipped 5 s default (151 frames) needs 9.73 GiB of already-present shared \
+                 components + 60.56 GiB untiled decode + 2 GiB OS reserve = 72.29 GiB, which does NOT \
+                 fit a 64 GB Mac — so the answer is knowable BEFORE the ~20 GiB bf16 download",
+            )
+            .to_string();
+        assert!(message.contains("mochi_1"), "names the model: {message}");
+        assert!(
+            message.contains("Shorten the clip"),
+            "the early refusal must carry the same actionable lever as the full gate: {message}"
+        );
+    }
+
+    /// Why the pre-check measures the WEIGHTS FLOOR and not just the decode term (sc-12322's own
+    /// description proposed decode-only). On a 64 GB Mac the decode + OS reserve for the shipped
+    /// default is 62.56 GiB — it FITS, by 1.44 GiB. So a weights-free pre-check admits exactly the job
+    /// in this story's title, downloads ~20 GiB, and only then refuses: the bug, unfixed.
+    ///
+    /// The already-present shared co-requisites are what push the floor over the line. This test fails
+    /// the moment someone "simplifies" the pre-check to decode-only.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn mochi_precheck_needs_the_shared_weights_floor_to_catch_the_64gb_default() {
+        // Decode + OS alone does NOT bust a 64 GB budget at the shipped default …
+        let decode_only = crate::mlx_fit_gate::mochi_decode_peak_gb(151, 848, 480) + 2.0;
+        assert!(
+            decode_only < 64.0,
+            "a weights-free pre-check would ADMIT the titled case ({decode_only:.2} < 64) — which is \
+             precisely why the floor is load-bearing"
+        );
+
+        // … but the floor the shared components already put on disk does.
+        let root = mochi_root_shared_only("floor");
+        let out = temp_env_var(crate::mlx_fit_gate::MLX_MEMORY_CAP_ENV, "64", || {
+            mochi_precheck(
+                "mochi_1",
+                "mochi_1",
+                Some(&root.join("bf16")),
+                150,
+                848,
+                480,
+            )
+        });
+        std::fs::remove_dir_all(&root).ok();
+        assert!(
+            out.is_err(),
+            "the shared co-requisites (~9.73 GiB) are already on disk before any tier fetch, and \
+             {decode_only:.2} + 9.73 > 64 — the pre-check must use them"
+        );
+    }
+
+    /// The other direction, and the property that makes an early gate SAFE: a clip that fits is NOT
+    /// refused early. Without this the pre-check could blanket-reject and still pass the test above —
+    /// and a pre-check that refuses a fitting config is strictly worse than the late refusal it
+    /// replaces, because no download can ever redeem it.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn mochi_precheck_admits_a_short_clip_on_the_same_64gb_mac() {
+        let root = mochi_root_shared_only("admit");
+        let out = temp_env_var(crate::mlx_fit_gate::MLX_MEMORY_CAP_ENV, "64", || {
+            mochi_precheck("mochi_1", "mochi_1", Some(&root.join("bf16")), 19, 848, 480)
+        });
+        std::fs::remove_dir_all(&root).ok();
+
+        out.expect(
+            "19 frames needs 9.73 floor + 9.32 decode + 2 OS = 21.1 GiB — it fits, so the pre-check \
+             must let the download proceed",
+        );
+    }
+
+    /// Fail-open, twice over: no locatable root (`None`) and a root with nothing measurable on disk
+    /// both ADMIT. The pre-check never blocks without evidence — same rule as the gate it calls
+    /// (`weight_bytes == 0` ⇒ no signal). A first-ever Mochi job must reach the download, not be
+    /// refused for not having downloaded yet.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn mochi_precheck_admits_without_a_signal() {
+        // No root at all ⇒ nothing to measure.
+        temp_env_var(crate::mlx_fit_gate::MLX_MEMORY_CAP_ENV, "64", || {
+            mochi_precheck("mochi_1", "mochi_1", None, 150, 848, 480)
+        })
+        .expect("no locatable model root ⇒ no signal ⇒ admit, never a phantom refusal");
+
+        // An empty root ⇒ the scan sums 0 bytes ⇒ still no signal, even though the clip is huge.
+        let root =
+            std::env::temp_dir().join(format!("mochi_precheck_empty_{}", std::process::id()));
+        std::fs::create_dir_all(root.join("bf16")).unwrap();
+        let out = temp_env_var(crate::mlx_fit_gate::MLX_MEMORY_CAP_ENV, "64", || {
+            mochi_precheck(
+                "mochi_1",
+                "mochi_1",
+                Some(&root.join("bf16")),
+                150,
+                848,
+                480,
+            )
+        });
+        std::fs::remove_dir_all(&root).ok();
+        out.expect("unmeasurable weights ⇒ no signal ⇒ admit and let the full gate decide later");
+    }
+
+    /// The pre-check must measure the tier the job ASKED for, not the smaller one already installed.
+    /// `resolve_mochi_model_dir` deliberately falls back to a smaller complete tier — reusing it here
+    /// would measure q4's bytes for a bf16 job and, worse, hard-error when nothing is installed at all.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn mochi_precheck_dir_names_the_requested_tier_not_the_installed_fallback() {
+        let root = mochi_root("precheck_dir", &["q4"], true);
+        let settings = Settings {
+            data_dir: root.join("unused-data-dir"),
+            ..Settings::from_env()
+        };
+        let dir = temp_env_var(MOCHI_DIR_ENV, root.to_str().unwrap(), || {
+            // bf16 requested; only q4 is on disk.
+            mochi_precheck_dir(&settings, &mochi_request(json!({ "mlxQuantize": 16 })))
+        });
+        std::fs::remove_dir_all(&root).ok();
+
+        assert_eq!(
+            dir.as_deref(),
+            Some(root.join("bf16").as_path()),
+            "the requested tier's path, existence NOT required — measuring the q4 fallback would \
+             under-count a bf16 job's weights against a budget it must clear"
         );
     }
 


### PR DESCRIPTION
Closes [sc-12322](https://app.shortcut.com/trefry/story/12322).

`generate_mochi` ran `ensure_mochi_{q8,bf16}_present` **before** the fit gate, so a Mac that could not possibly fit the job downloaded ~13–20 GiB and *only then* got refused. The refusal was correct — it just arrived after a download the answer never depended on.

## The fix

`mochi_precheck` runs the **existing, unchanged** `mochi_fit_check` before the download, against the requested tier's path. `mochi_precheck_dir` names that path without requiring it to exist — `resolve_mochi_model_dir` can't serve here: it demands a COMPLETE tier, falls back to a smaller installed one, and hard-errors when nothing is installed. Correct after the download, wrong before it.

No new gate math. The post-download gate is untouched.

## Why an early gate is safe here

The weights term is a conservative **floor**, not zero. Mochi's `text_encoder/` + `tokenizer/` + `vae/` are a `coRequisite: true` download (~9.7 GiB) already on disk before an on-demand `<tier>/*` fetch, and `mochi_resident_bytes` already sums those shared siblings from the tier dir's **parent** even when the tier dir is absent.

```
floor ≤ actual  ⇒  needed(floor) ≤ needed(actual)  ⇒  {pre-check refuses} ⊆ {full gate refuses}
```

So it can only refuse when refusal is **certain** — a fitting config is never rejected early, which is the property that makes an early gate worth having. No signal (`weight_bytes == 0`) still admits, so a first-ever job reaches its download.

## ⚠️ Scope delta — the story's spec misses its own headline case

sc-12322 specified a **weights-free** pre-check, on the premise that a 64 GB Mac's budget is *"~42.7 GiB at MLX's ~RAM/1.5 wired ceiling"*. The gate does not budget that way — `resolve_budget` = `cap.or(real_total_gb)` over `sysctl hw.memsize`, **no division**. Gating on full RAM is exactly what sc-12178/12179 settled: wired ≠ usage cap.

Redone with the real budget, at the shipped 151-frame / 848×480 default:

| pre-check | needed | vs 64.0 budget | outcome |
|---|---|---|---|
| decode-only (as specified) | 60.56 + 2 = **62.56** | fits by 1.44 | **admits** → downloads ~20 GiB → refused. The bug, unfixed. |
| **+ shared floor (this PR)** | 9.73 + 60.56 + 2 = **72.29** | busts | **refused, no download** ✅ |

A decode-only pre-check would first refuse at **157** frames on a 64 GB Mac; the default is 151. It would help 32/48 GB Macs but not the machine the story is named for. The description's *"the weights half cannot run before the download"* is the load-bearing error: the **tier** half can't, but the **co-requisite** half is already there. Full analysis on the story.

`mlx.minMemoryGb: 96` untouched.

## Mutation-checks — measured, not assumed

- pre-check unconditionally admits ⇒ **RED** (2 tests). The story's required check. ✅
- call site deleted ⇒ tests stay **green**, but **CI clippy goes red** — dead-code cascade (`mochi_precheck`/`mochi_precheck_dir` "never used"). The same pin `mochi_preflight` leans on (sc-12318).
- pre-check moved *after* the fetches ⇒ **survives everything**. Still a correct gate, just a worthless one. Structural to the untestable `async` arm — tracked by **sc-12318**, and recorded in the test's docs rather than claimed as covered.

`mochi_precheck_needs_the_shared_weights_floor_to_catch_the_64gb_default` asserts *both* halves (decode-only fits 64; the floor busts it), so it fails the moment someone "simplifies" this back to the spec.

## Verification

`npm run rust:check` (fmt + lint + test + build) — exit **0**, **849 passed / 0 failed**. `clippy --all-targets -- -D warnings` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)