### PR TITLE
fix(api): close the generic POST /api/v1/jobs door on generation jobs (sc-12305)

### DIFF
--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -533,3 +533,40 @@ pub(crate) async fn create_video_job(
     .await?;
     Ok((StatusCode::CREATED, Json(job)))
 }
+
+/// The typed route that owns `job_type`, or `None` for every job type the generic
+/// `POST /api/v1/jobs` legitimately serves (`image_upscale`, `image_detail`,
+/// `model_download`, …). The guard list for `create_job` (sc-12305).
+///
+/// This is exactly the set of job types produced by [`create_image_job`] /
+/// [`create_video_job`] — the only two routes in the tree that resolve a model's merged
+/// manifest entry and inject it as `modelManifestEntry`. Enqueued raw through the generic
+/// route, such a job carries no entry at all: the worker falls back to the model's default
+/// repo/knobs, and on the video lane `VideoRequest::from_payload` misses
+/// `limits.requiresDimensionsMultipleOf` and falls back to ÷32 — silently rendering
+/// Mochi's native (and only trained) 848x480 as 832x480, a rewrite the engine's own ÷16
+/// check cannot catch because `832 % 16 == 0`. The video geometry is the *silent* failure
+/// (see `mochi_without_manifest_entry_silently_loses_its_native_bucket`); the image lane
+/// reads the same entry for its family/repo knobs, where a miss surfaces sooner.
+///
+/// Rejecting is deliberate over resolving the entry here. The manifest entry is one of
+/// several things these routes do: they also validate the request (`validate_video_job` —
+/// projectId, model id, prompt bounds, mode allowlist), expand recipe presets (which can
+/// *replace* the model — sc-12300), check LoRA compatibility, and map `mode` to the job
+/// type. Filling in only the entry would leave a path that renders at the right geometry
+/// while skipping every one of those, which is a subtler trap than the one being closed.
+/// One door per generation job type.
+///
+/// Keep in step with [`create_image_job`] / [`create_video_job`]: a new generation route
+/// that injects a `modelManifestEntry` belongs here too. (`image_vqa` / `image_interleave`
+/// have typed routes but resolve no manifest entry, so they are deliberately absent.)
+pub(crate) fn typed_generation_route(job_type: &JobType) -> Option<&'static str> {
+    match job_type {
+        JobType::ImageGenerate | JobType::ImageEdit => Some("/api/v1/image/jobs"),
+        JobType::VideoGenerate
+        | JobType::VideoExtend
+        | JobType::VideoBridge
+        | JobType::PersonReplace => Some("/api/v1/video/jobs"),
+        _ => None,
+    }
+}

--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -76,6 +76,20 @@ pub(crate) async fn create_job(
     State(state): State<AppState>,
     ApiJson(payload): ApiJson<JobCreateRequest>,
 ) -> Result<(StatusCode, Json<JobSnapshot>), ApiError> {
+    // A generation job type must be created through its typed route, which resolves the
+    // model's merged manifest entry into the payload (and validates the request). This
+    // route is the raw queue primitive: it enqueues `job_type` + payload verbatim, so a
+    // generation job through this door carries no `modelManifestEntry` and renders at the
+    // wrong geometry with no error (sc-12305). See `typed_generation_route`.
+    if let Some(route) = typed_generation_route(&payload.job_type) {
+        return Err(ApiError::bad_request(format!(
+            "{} jobs must be created via POST {route}. That route resolves the model's \
+             manifest entry — its repo, quant and geometry limits — and validates the \
+             request; POST /api/v1/jobs enqueues the payload verbatim, so the job would run \
+             with none of it.",
+            payload.job_type.as_str()
+        )));
+    }
     let job = store_call(state.clone(), move |store, _timeout| {
         store.create_job(CreateJob {
             job_type: payload.job_type,

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -118,7 +118,7 @@ use training::{
 mod generation;
 use generation::{
     create_image_job, create_interleave_job, create_video_job, create_vqa_job,
-    parse_recipe_preset_resolution, JobCatalogSnapshot,
+    parse_recipe_preset_resolution, typed_generation_route, JobCatalogSnapshot,
 };
 #[cfg(test)]
 use generation::{validate_interleave_job, validate_vqa_job};

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -38,6 +38,78 @@ async fn image_and_video_jobs_reject_path_unsafe_model_id() {
     }
 }
 
+/// sc-12305: the generic `POST /api/v1/jobs` enqueues `type` + payload verbatim — no
+/// manifest resolution — so a generation job through that door carries no
+/// `modelManifestEntry` and silently renders off-bucket (see the
+/// `mochi_without_manifest_entry_*` test in `video_request.rs` for the exact geometry).
+/// Every job type whose typed route injects an entry must be rejected here, pointed at
+/// that route. Covers image as well as video: `image_request.rs` reads the entry the same way.
+#[tokio::test]
+async fn generic_jobs_route_rejects_generation_types_with_their_typed_route() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    for (job_type, typed_route) in [
+        ("image_generate", "/api/v1/image/jobs"),
+        ("image_edit", "/api/v1/image/jobs"),
+        ("video_generate", "/api/v1/video/jobs"),
+        ("video_extend", "/api/v1/video/jobs"),
+        ("video_bridge", "/api/v1/video/jobs"),
+        ("person_replace", "/api/v1/video/jobs"),
+    ] {
+        let (status, body) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/jobs",
+            json!({
+                "type": job_type,
+                "projectId": "project-1",
+                "requestedGpu": "auto",
+                "payload": { "model": "mochi_1", "prompt": "a fox", "width": 848, "height": 480 },
+            }),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "{job_type} must be rejected"
+        );
+        let detail = body["detail"].as_str().unwrap_or_default();
+        assert!(
+            detail.contains(typed_route),
+            "{job_type}: error must name {typed_route}, got {body}"
+        );
+    }
+}
+
+/// The other half of the guard: the job types the generic route legitimately serves keep
+/// working. `image_upscale` / `image_detail` are the real web callers (batch ops), and
+/// neither has a typed door — so the sc-12305 rejection must not touch them.
+#[tokio::test]
+async fn generic_jobs_route_still_serves_non_generation_types() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    for job_type in ["image_upscale", "image_detail"] {
+        let (status, body) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/jobs",
+            json!({
+                "type": job_type,
+                "requestedGpu": "auto",
+                "payload": { "sourceAssetId": "asset-1" },
+            }),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::CREATED,
+            "{job_type} must still enqueue: {body}"
+        );
+    }
+}
+
 #[test]
 fn serialize_job_lora_carries_network_type_to_payload() {
     // A trained LoKr adapter records networkType (epic 2193); the generation
@@ -167,6 +239,13 @@ async fn create_video_job_rejects_over_length_negative_prompt() {
         .is_some_and(|detail| detail.contains("negativePrompt")));
 }
 
+// The queue-lifecycle tests below drive `POST /api/v1/jobs` — claim, cancel, retry,
+// progress, clear, stale sweep. They need *a* GPU-routed claimable job and do not care
+// which; they use `image_detail` (a real caller of this route — the web batch ops post it)
+// rather than `image_generate`, which sc-12305 moved behind its typed route so the model's
+// manifest entry is always resolved. The worker `capabilities` match by job type
+// (`required_capability`), so the two move together.
+
 #[tokio::test]
 async fn worker_can_register_claim_and_complete_job_through_http() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
@@ -180,7 +259,7 @@ async fn worker_can_register_claim_and_complete_job_through_http() {
             "workerId": "worker-1",
             "gpuId": "gpu-0",
             "gpuName": "GPU 0",
-            "capabilities": ["image_generate"],
+            "capabilities": ["image_detail"],
             "loadedModels": []
         }),
     )
@@ -192,7 +271,7 @@ async fn worker_can_register_claim_and_complete_job_through_http() {
         "POST",
         "/api/v1/jobs",
         json!({
-            "type": "image_generate",
+            "type": "image_detail",
             "projectId": "project-1",
             "projectName": "Project 1",
             "payload": { "prompt": "mist over hills" },
@@ -253,7 +332,7 @@ async fn progress_ticks_only_republish_queue_on_status_change() {
             "workerId": "worker-1",
             "gpuId": "gpu-0",
             "gpuName": "GPU 0",
-            "capabilities": ["image_generate"],
+            "capabilities": ["image_detail"],
             "loadedModels": []
         }),
     )
@@ -263,7 +342,7 @@ async fn progress_ticks_only_republish_queue_on_status_change() {
         "POST",
         "/api/v1/jobs",
         json!({
-            "type": "image_generate",
+            "type": "image_detail",
             "projectId": "project-1",
             "projectName": "Project 1",
             "payload": { "prompt": "mist" },
@@ -334,7 +413,7 @@ async fn canceling_queued_job_finishes_without_worker_acknowledgement() {
         "POST",
         "/api/v1/jobs",
         json!({
-            "type": "image_generate",
+            "type": "image_detail",
             "projectId": "project-1",
             "projectName": "Project 1",
             "payload": { "prompt": "mist over hills" },
@@ -375,7 +454,7 @@ async fn canceling_queued_job_finishes_without_worker_acknowledgement() {
             "workerId": "worker-1",
             "gpuId": "gpu-0",
             "gpuName": "GPU 0",
-            "capabilities": ["image_generate"],
+            "capabilities": ["image_detail"],
             "loadedModels": []
         }),
     )
@@ -406,7 +485,7 @@ async fn clear_jobs_soft_hides_terminal_items_from_the_queue() {
         "POST",
         "/api/v1/jobs",
         json!({
-            "type": "image_generate",
+            "type": "image_detail",
             "projectId": "project-1",
             "projectName": "Project 1",
             "payload": { "prompt": "done" },
@@ -428,7 +507,7 @@ async fn clear_jobs_soft_hides_terminal_items_from_the_queue() {
         "POST",
         "/api/v1/jobs",
         json!({
-            "type": "image_generate",
+            "type": "image_detail",
             "projectId": "project-1",
             "projectName": "Project 1",
             "payload": { "prompt": "wait" },
@@ -478,7 +557,7 @@ async fn clear_jobs_scopes_to_the_requested_project() {
             "POST",
             "/api/v1/jobs",
             json!({
-                "type": "image_generate",
+                "type": "image_detail",
                 "projectId": project,
                 "projectName": project,
                 "payload": { "prompt": "done" },
@@ -542,7 +621,7 @@ async fn clear_single_job_soft_hides_only_that_terminal_job() {
             "POST",
             "/api/v1/jobs",
             json!({
-                "type": "image_generate",
+                "type": "image_detail",
                 "projectId": "project-1",
                 "projectName": "Project 1",
                 "payload": { "prompt": prompt },
@@ -595,7 +674,7 @@ async fn clear_single_job_rejects_a_non_terminal_job() {
         "POST",
         "/api/v1/jobs",
         json!({
-            "type": "image_generate",
+            "type": "image_detail",
             "projectId": "project-1",
             "projectName": "Project 1",
             "payload": { "prompt": "wait" },
@@ -3132,7 +3211,7 @@ async fn worker_heartbeat_interrupts_previous_active_job_through_http() {
             "workerId": "worker-1",
             "gpuId": "gpu-0",
             "gpuName": null,
-            "capabilities": ["image_generate"],
+            "capabilities": ["image_detail"],
             "loadedModels": []
         }),
     )
@@ -3141,7 +3220,7 @@ async fn worker_heartbeat_interrupts_previous_active_job_through_http() {
         app.clone(),
         "POST",
         "/api/v1/jobs",
-        json!({ "type": "image_generate", "payload": {}, "requestedGpu": "auto" }),
+        json!({ "type": "image_detail", "payload": {}, "requestedGpu": "auto" }),
     )
     .await;
     request(
@@ -3200,7 +3279,7 @@ async fn stale_sweep_broadcasts_job_updated_for_interrupted_jobs() {
             "workerId": "worker-1",
             "gpuId": "gpu-0",
             "gpuName": null,
-            "capabilities": ["image_generate"],
+            "capabilities": ["image_detail"],
             "loadedModels": []
         }),
     )
@@ -3209,7 +3288,7 @@ async fn stale_sweep_broadcasts_job_updated_for_interrupted_jobs() {
         app.clone(),
         "POST",
         "/api/v1/jobs",
-        json!({ "type": "image_generate", "payload": {}, "requestedGpu": "auto" }),
+        json!({ "type": "image_detail", "payload": {}, "requestedGpu": "auto" }),
     )
     .await;
     let job_id = created["id"].as_str().expect("job id is string").to_owned();
@@ -3264,7 +3343,7 @@ async fn claim_sweeps_stale_jobs_once_and_still_refreshes_the_queue() {
             "workerId": "worker-1",
             "gpuId": "gpu-0",
             "gpuName": null,
-            "capabilities": ["image_generate"],
+            "capabilities": ["image_detail"],
             "loadedModels": []
         }),
     )
@@ -3273,7 +3352,7 @@ async fn claim_sweeps_stale_jobs_once_and_still_refreshes_the_queue() {
         app.clone(),
         "POST",
         "/api/v1/jobs",
-        json!({ "type": "image_generate", "payload": {}, "requestedGpu": "auto" }),
+        json!({ "type": "image_detail", "payload": {}, "requestedGpu": "auto" }),
     )
     .await;
     let stale_job_id = created["id"].as_str().expect("job id is string").to_owned();
@@ -3296,7 +3375,7 @@ async fn claim_sweeps_stale_jobs_once_and_still_refreshes_the_queue() {
             "workerId": "worker-2",
             "gpuId": "gpu-1",
             "gpuName": null,
-            "capabilities": ["image_generate"],
+            "capabilities": ["image_detail"],
             "loadedModels": []
         }),
     )
@@ -3305,7 +3384,7 @@ async fn claim_sweeps_stale_jobs_once_and_still_refreshes_the_queue() {
         app.clone(),
         "POST",
         "/api/v1/jobs",
-        json!({ "type": "image_generate", "payload": {}, "requestedGpu": "auto" }),
+        json!({ "type": "image_detail", "payload": {}, "requestedGpu": "auto" }),
     )
     .await;
     tokio::time::sleep(Duration::from_millis(2_100)).await;

--- a/crates/sceneworks-core/src/video_request.rs
+++ b/crates/sceneworks-core/src/video_request.rs
@@ -504,6 +504,42 @@ mod tests {
         assert_eq!((undeclared.width, undeclared.height), (832, 480));
     }
 
+    /// sc-12305 — the silent failure that justifies rejecting a generation job on the
+    /// generic `POST /api/v1/jobs`.
+    ///
+    /// That route enqueues `type` + payload verbatim, resolving no manifest entry (only the
+    /// typed `/api/v1/video/jobs` and `/api/v1/image/jobs` do). With the entry absent,
+    /// `dimension_multiple_of` misses `requiresDimensionsMultipleOf` and falls back to 32,
+    /// so Mochi's native — and only trained — 848x480 bucket renders as 832x480. The engine
+    /// never catches it: `832 % 16 == 0` satisfies its own ÷16 check, so there is no error,
+    /// just off-bucket inference.
+    ///
+    /// This pins the *reason* the API guard exists. It is deliberately asserted here, at the
+    /// geometry, rather than only at the route: if a future change ever makes an absent entry
+    /// safe (a distinguishable absent-vs-unknown signal — sc-12304), this test goes RED and
+    /// the guard can be revisited on evidence instead of belief.
+    #[test]
+    fn mochi_without_manifest_entry_silently_loses_its_native_bucket() {
+        let no_entry = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "model": "mochi_1", "width": 848, "height": 480,
+        })));
+        assert_eq!(
+            (no_entry.width, no_entry.height),
+            (832, 480),
+            "an absent modelManifestEntry must still be the ÷32 fallback — if this changed, \
+             the sc-12305 API guard's premise changed with it"
+        );
+        // Silent, not loud: the engine's own divisibility check passes on the rewritten size.
+        assert_eq!(no_entry.width % 16, 0);
+
+        // The same payload through a typed route — which resolves the entry — keeps 848.
+        let with_entry = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "model": "mochi_1", "width": 848, "height": 480,
+            "modelManifestEntry": { "family": "mochi", "limits": { "requiresDimensionsMultipleOf": 16 } }
+        })));
+        assert_eq!((with_entry.width, with_entry.height), (848, 480));
+    }
+
     #[test]
     fn honors_manifest_dimension_multiple_so_mochi_keeps_848() {
         // 848 % 32 == 16, so the blanket 32 floor silently rewrote Mochi's ONLY trained

--- a/tests/fixtures/rust_api_contract_snapshots/snapshots.json
+++ b/tests/fixtures/rust_api_contract_snapshots/snapshots.json
@@ -1567,8 +1567,7 @@
         "stage": "preparing",
         "startedAt": "<timestamp>",
         "status": "preparing",
-        "title": "Generate Image \u2014 (no prompt)",
-        "type": "image_generate",
+        "type": "image_detail",
         "updatedAt": "<timestamp>",
         "workerId": "claim-worker-fixture"
       }

--- a/tests/test_rust_api_contract_snapshots.py
+++ b/tests/test_rust_api_contract_snapshots.py
@@ -1497,17 +1497,22 @@ def test_job_state_transition_contracts(contract_runtimes):
 
 
 def concurrent_claim_result(runtime: ContractRuntime) -> list[Any]:
+    # `image_detail` (not `image_generate`) is the claim-race fixture: this test needs *a*
+    # GPU-routed claimable job, and sc-12305 made the generic POST /api/v1/jobs reject the
+    # generation job types, whose typed routes resolve a model manifest entry the generic
+    # route cannot. image_detail is a real caller of this route (the web batch ops post it)
+    # and is GPU-routed, so the two-workers-one-gpu race below is unchanged.
     runtime.request(
         "POST",
         "/api/v1/workers/register",
-        json_payload={"workerId": "claim-worker-a", "gpuId": "gpu-0", "capabilities": ["image_generate"], "loadedModels": []},
+        json_payload={"workerId": "claim-worker-a", "gpuId": "gpu-0", "capabilities": ["image_detail"], "loadedModels": []},
     )
     runtime.request(
         "POST",
         "/api/v1/workers/register",
-        json_payload={"workerId": "claim-worker-b", "gpuId": "gpu-0", "capabilities": ["image_generate"], "loadedModels": []},
+        json_payload={"workerId": "claim-worker-b", "gpuId": "gpu-0", "capabilities": ["image_detail"], "loadedModels": []},
     )
-    runtime.request("POST", "/api/v1/jobs", json_payload={"type": "image_generate", "payload": {}, "requestedGpu": "auto"})
+    runtime.request("POST", "/api/v1/jobs", json_payload={"type": "image_detail", "payload": {}, "requestedGpu": "auto"})
     with ThreadPoolExecutor(max_workers=2) as executor:
         futures = [
             executor.submit(runtime.request, "POST", "/api/v1/jobs/claim", json_payload={"workerId": worker_id})


### PR DESCRIPTION
Closes the latent trap in [sc-12305](https://app.shortcut.com/trefry/story/12305). Pre-existing; surfaced twice during epic 1788 Phase B.

## The defect
`create_job` ([jobs.rs:75](apps/rust-api/src/jobs.rs)) enqueues `type` + payload **verbatim, resolving no model manifest entry** — only the typed `/api/v1/image/jobs` and `/api/v1/video/jobs` do that (`generation.rs:44-45`, `515-516`; confirmed by grep to be the only two injection sites in the tree).

So a video job through the generic door carries no `modelManifestEntry` → `normalized_dimensions` misses `limits.requiresDimensionsMultipleOf` → falls back to **÷32** → **Mochi's native (and only trained) 848x480 renders as 832x480**. Silently: `832 % 16 == 0` satisfies the engine's own ÷16 check, so there is no error, just off-bucket inference. Same outcome as sc-12300, different cause — that one supplies the *wrong* entry, this one supplies *none*.

## Decision: reject (the story's option 2), not resolve
The full reasoning is [on the story](https://app.shortcut.com/trefry/story/12305). In short:

- **Option 1 (resolve the entry in `create_job`) is incomplete by construction.** The manifest entry is one of several things the typed routes do — they also validate the request (`validate_video_job`: projectId, model id, prompt bounds, mode allowlist), expand recipe presets (which can *replace* the model — sc-12300), and check LoRA compatibility. Filling in only the entry leaves a path that renders at the right geometry while skipping all of that: a *subtler* trap, because the entry looks right so the path looks blessed.
- **Option 3 (make absence loud in `sceneworks-core`) is not implementable as written.** `resolve_model_manifest_entry` *deliberately* returns `{}` for an unknown model, so "absent because the route skipped resolution" and "empty because the model is unknown" are **the same value** at `VideoRequest::from_payload` — which is deliberately infallible. Distinguishing them needs a new signal; that belongs to **sc-12304**, and is recorded there rather than smuggled in here.

## Scope — the full door, not just video
The rejected set is exactly the job types whose typed route injects an entry, which is an evidence-derived boundary rather than a hand-picked list:

| job type | typed route |
|---|---|
| `image_generate`, `image_edit` | `POST /api/v1/image/jobs` |
| `video_generate`, `video_extend`, `video_bridge`, `person_replace` | `POST /api/v1/video/jobs` |

Image has the identical defect (`image_request.rs:93` reads the entry the same way), so fixing only video would leave half the door open. `image_vqa`/`image_interleave` have typed routes but resolve no entry — deliberately absent.

**Nothing this route actually serves is affected.** `image_upscale`/`image_detail` (the web batch-ops callers, `batchOps.js:15-16`) have no typed door and keep working; MCP already uses the typed route. No shipped script posts a generation job here.

## Verification
- `npm run rust:check` green (fmt + clippy `-D warnings` + full `cargo test` + build).
- Full Python parity suite green (`pytest -m parity`) — 12 passed. One golden updated (`concurrent claim response set`), scoped regen, 2-line diff.
- **Driven end-to-end against the real binary** (sandboxed `HOME`): `video_generate` and `image_generate` → 400 naming their typed route; `image_detail` → 201 queued.

```
$ curl -X POST /api/v1/jobs -d '{"type":"video_generate",...}'
video_generate jobs must be created via POST /api/v1/video/jobs. That route resolves the
model's manifest entry — its repo, quant and geometry limits — and validates the request;
POST /api/v1/jobs enqueues the payload verbatim, so the job would run with none of it.
```

## Tests
- `mochi_without_manifest_entry_silently_loses_its_native_bucket` (`video_request.rs`) — pins **why**: an entry-less Mochi payload silently yields 832x480, and `832 % 16 == 0` so nothing catches it. This is the geometry assertion the AC asks for; if an absent entry ever becomes safe (sc-12304), it goes RED and the guard gets revisited on evidence.
- `generic_jobs_route_rejects_generation_types_with_their_typed_route` — all 6 types, each error naming its route.
- `generic_jobs_route_still_serves_non_generation_types` — the other half of the guard.

**Fixture note:** 12 queue-lifecycle fixtures posted `image_generate` to this route only because they needed *a* claimable job. They move to `image_detail` (a real caller of the route, GPU-routed, so the claim-race semantics are unchanged). No product code posts generation types here — the blast radius was tests only, which is itself evidence the route was a trap rather than a used path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)