### PR TITLE
fix(worker): gate Mochi candle video jobs on VRAM before the denoise (sc-12306)

### DIFF
--- a/crates/sceneworks-worker/src/fit_gate.rs
+++ b/crates/sceneworks-worker/src/fit_gate.rs
@@ -1,8 +1,13 @@
-//! Backend-neutral fit-gate outcome and sequential-residency transition (sc-12127).
+//! Backend-neutral fit-gate outcome and sequential-residency transition (sc-12127), plus the
+//! backend-neutral Mochi decode arithmetic (sc-12306).
 //!
 //! MLX and candle derive their predicted resident and sequential peaks differently, but once a
 //! resident fit decision exists they share this state transition exactly. Keeping it here prevents
 //! the two admission gates from drifting while leaving their backend-specific budgeting untouched.
+//!
+//! The Mochi block below is the second thing the two lanes genuinely share: an ARCHITECTURAL formula
+//! (tensor shapes × dtype), not a backend calibration. It lives here so the candle video gate and the
+//! MLX one cannot drift — see [`mochi_decode_peak_gb`].
 
 /// The shared outcome of comparing a predicted resident peak with an available memory budget.
 /// `Unknown` means the backend has no reliable signal and therefore must not reject the job.
@@ -34,5 +39,216 @@ pub(crate) fn resolve_offload(decision: FitDecision, sequential_capable: bool) -
             available_gb,
         },
         other => other,
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Mochi 1: the FRAME-DEPENDENT decode arithmetic, shared by BOTH lanes (epic 1788, sc-12306)
+// ---------------------------------------------------------------------------------------------
+//
+// Originally derived MLX-side (sc-11992) and lifted here when the candle video lane needed the same
+// gate (sc-12306). It sits in the backend-neutral module because every term is a fact about the MODEL
+// — tensor shapes and the dtype the decoder pins — not about MLX or candle. Verified against BOTH
+// providers rather than assumed:
+//
+//                              mlx-gen-mochi              candle-gen-mochi
+//   decode dtype               f32 (vae.rs from_weights)  f32 (vae.rs:260-264, `DType::F32`)
+//   tiled?                     no (`vae.decode(latents)`) no (pipeline.rs:151, one whole-clip call)
+//   decoder_block_out_channels [128, 256, 512, 768]       [128, 256, 512, 768] (config.rs:86)
+//   temporal_expansions        [1, 2, 3] ⇒ ratio 6        [1, 2, 3] ⇒ ratio 6  (config.rs:88)
+//   supports_sequential_offload false                     false (lib.rs:115)
+//
+// candle's own config module calls itself "the candle twin of `mlx-gen-mochi`'s `config` (byte-for-byte
+// the same geometry)", so the shapes are shared by construction. Duplicating the arithmetic per lane
+// would let the two gates disagree about one model's memory profile, which is exactly the drift this
+// module exists to prevent.
+//
+// ## This is a FLOOR, and on candle a slightly loose one
+// candle's VAE inserts `.contiguous()` after every permute — notably the rank-8 depth-to-space in
+// `UpBlock::forward` (vae.rs:170-174), which materializes a full extra copy of the expanded tensor at
+// each up-stage; MLX's `transpose_axes` is lazy and fuses. So candle's REAL peak runs at or above what
+// this predicts. That direction is safe for an admission gate — it refuses the clearly-impossible and
+// never wall-rejects something that would have fit — but it means a MARGINAL candle job can still OOM.
+// On CUDA that surfaces as a catchable allocator error via `classify_engine_error`, not the SIGKILL the
+// MLX lane faces. Inflating these constants with an invented candle fudge factor would be worse than
+// stating the bound: nothing has been measured on-device yet (B5/sc-11995 backfills the real
+// `footprint.peakMemoryBytes`; sc-12291 tiles the decode and should then cut the frame term sharply).
+
+/// Bytes in a GiB. The one definition both gates divide by, so "GB" in a user-facing fit message means
+/// the same thing on both lanes (it is GiB throughout — see [`mochi_decode_peak_gb`]'s note on units).
+pub(crate) const BYTES_PER_GIB: f64 = 1_073_741_824.0;
+
+/// The AsymmVAE decoder's final-stage channel count — `decoder_block_out_channels[0]` (config default
+/// `[128, 256, 512, 768]`). The last `block_out` mid-block runs THIS many channels at FULL output
+/// resolution, which is the decode's peak stage: every earlier stage is either fewer pixels
+/// (pre-upsample) or, at 256/512/768 channels, at 1/4, 1/16, 1/64 of the spatial extent, so their
+/// products are strictly smaller.
+const MOCHI_DECODE_CHANNELS: f64 = 128.0;
+
+/// Bytes per element in the AsymmVAE decode. **f32 (4), NOT bf16 (2)** — BOTH providers pin f32:
+/// mlx-gen-mochi's `MochiVaeDecoder::from_weights` passes `Dtype::Float32`, and candle-gen-mochi's
+/// `load` passes `DType::F32` twice (vae.rs:260-264), its module doc explaining why ("bf16
+/// intermediates reach O(100), outside bf16's range"). Each `decode_denormalized` then casts the
+/// incoming latent to that dtype, so the whole decode flows f32 on both lanes.
+///
+/// ⚠️ This DELIBERATELY disagrees with the sc-12291 / B1-manifest derivation, which assumed **bf16**
+/// (`128 × 156 × 480 × 848 × 2 B`) and therefore under-predicts the real peak by 2×. Surfaced as a
+/// follow-up on sc-12291 — that story's table (19→7, 61→19, 151→45 GiB) and B1's `mlx.minMemoryGb: 96`
+/// are both bf16-derived and want re-deriving against the shipped f32 decode. This gate uses the dtype
+/// the code actually runs.
+const MOCHI_DECODE_BYTES_PER_ELEM: f64 = 4.0;
+
+/// Full-resolution tensors live simultaneously at the decode peak. `MochiResnetBlock3D` is
+/// `GroupNorm → silu → CausalConv3d → GroupNorm → silu → CausalConv3d → + residual`, so the residual
+/// and the in-flight intermediate are both live across the block — the "residual + intermediate live at
+/// once" claim B1's manifest derivation makes. B1 then hedged "2–3×"; 2 is the concrete, defensible
+/// liveness (3 assumes an extra un-freed temporary, which neither allocator need hold). Combined with
+/// the f32 correction above this lands at ~79 GiB for the shipped 5 s / 151-frame default — consistent
+/// with B1's declared `mlx.minMemoryGb: 96` floor.
+const MOCHI_DECODE_LIVE_TENSORS: f64 = 2.0;
+
+/// Extra leading frames the causal decode materializes before `drop_last_temporal_frames` trims them:
+/// `temporal_ratio − 1` = 5 (ratio = ∏`temporal_expansions` = 1×2×3 = 6 on both lanes). The peak is
+/// paid on the UNTRIMMED length, so a 151-frame clip decodes 156 frames wide.
+const MOCHI_DECODE_EXTRA_FRAMES: u32 = 5;
+
+/// Predicted AsymmVAE decode peak (GiB) for a `frames` × `width` × `height` clip.
+///
+/// `live × C × (frames + 5) × H × W × 4 B`. Linear in BOTH clip length and pixel count, because the
+/// peak tensor is `[1, C, T, H, W]` and the decode is untiled on both lanes. This is the term a
+/// per-tier constant (MLX's `HEADROOM_GB`, candle's `candle.vramGbByTier`) structurally cannot
+/// represent: those are calibrated per LOAD, and the load cannot see the request geometry.
+///
+/// DERIVED, not measured. Sanity points at the native 848×480 bucket — all **GiB**, the unit this
+/// function returns (it divides by [`BYTES_PER_GIB`]): 7 frames ⇒ ~4.66, 19 ⇒ ~9.32, 61 ⇒ ~25.62,
+/// 151 ⇒ ~60.56, 163 ⇒ ~65.21.
+///
+/// (These are the constants the whole derivation leans on, so they are stated in ONE unit on purpose:
+/// an earlier revision mixed decimal GB into this list — 5.0/10.1/27.5 are the same three points in
+/// GB — which made the table read as if the peak grew faster than it does.)
+pub(crate) fn mochi_decode_peak_gb(frames: u32, width: u32, height: u32) -> f64 {
+    let decoded_frames = f64::from(frames.saturating_add(MOCHI_DECODE_EXTRA_FRAMES));
+    MOCHI_DECODE_LIVE_TENSORS
+        * MOCHI_DECODE_CHANNELS
+        * decoded_frames
+        * f64::from(width)
+        * f64::from(height)
+        * MOCHI_DECODE_BYTES_PER_ELEM
+        / BYTES_PER_GIB
+}
+
+/// Predicted whole-generation peak (GiB) for a Mochi request: the ALL-RESIDENT weights
+/// (`supports_sequential_offload: false` on BOTH providers ⇒ T5-XXL + AsymmDiT + VAE are held for the
+/// whole run, so nothing drops) + the frame-dependent decode peak + `reserve_gb`.
+///
+/// **`reserve_gb` is passed in, not baked, because the two lanes reserve for DIFFERENT reasons and the
+/// terms only coincidentally agree at 2.0 today.** MLX passes `OS_RESERVE_GB`: on unified memory the OS
+/// draws from the same pool the model does, so the reserve keeps the machine alive. candle passes
+/// `vram_gate::HEADROOM_GB`: the OS does NOT draw from discrete VRAM, so that term instead covers
+/// allocator slack and CUDA context overhead. Baking either constant in would silently move the other
+/// lane's gate the day someone tunes it.
+///
+/// `None` when the weights are unmeasurable (`weight_bytes == 0`) ⇒ no signal ⇒ the gate never blocks,
+/// matching [`FitDecision::Unknown`].
+pub(crate) fn mochi_needed_gb(
+    weight_bytes: u64,
+    frames: u32,
+    width: u32,
+    height: u32,
+    reserve_gb: f64,
+) -> Option<f64> {
+    (weight_bytes > 0).then(|| {
+        weight_bytes as f64 / BYTES_PER_GIB
+            + mochi_decode_peak_gb(frames, width, height)
+            + reserve_gb
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mochi's q4 resident weights (GiB): DiT 9.007 + T5-XXL bf16 8.871 + VAE 0.856 = 18.73 (the exact
+    /// hosted bytes B1's manifest derivation pins).
+    const MOCHI_Q4_RESIDENT_BYTES: u64 = 9_670_883_602 + 9_524_669_250 + 919_551_200;
+
+    /// The decode peak must scale with CLIP LENGTH — the whole reason Mochi cannot ride EITHER lane's
+    /// resolution-blind per-load gate. Pins linearity in frames and in pixels, and the architectural
+    /// anchor. This runs on every lane (the module is ungated), so the windows-candle lane pins the
+    /// same arithmetic its own gate depends on.
+    #[test]
+    fn mochi_decode_peak_scales_with_frames_and_pixels() {
+        // Strictly monotonic in frames.
+        let peaks: Vec<f64> = [7, 19, 61, 151, 163]
+            .iter()
+            .map(|f| mochi_decode_peak_gb(*f, 848, 480))
+            .collect();
+        for pair in peaks.windows(2) {
+            assert!(
+                pair[1] > pair[0],
+                "decode peak must grow with clip length: {peaks:?}"
+            );
+        }
+
+        // The architectural anchor: 2 live × 128 ch × (151+5) frames × 848×480 × 4 B (f32) = 60.56 GiB.
+        // This is the number a bf16 derivation would halve — pin it so the dtype can't silently drift.
+        // BOTH providers pin f32 (mlx-gen-mochi `from_weights`, candle-gen-mochi vae.rs:260-264).
+        let at_151 = mochi_decode_peak_gb(151, 848, 480);
+        assert!(
+            (at_151 - 60.56).abs() < 0.1,
+            "151-frame 848x480 decode peak should be ~60.56 GiB (f32), got {at_151:.2}"
+        );
+
+        // The 5 s default costs ~50 GiB MORE than the engine's 19-frame default on the same machine —
+        // the spread a flat per-load constant cannot express.
+        let at_19 = mochi_decode_peak_gb(19, 848, 480);
+        assert!(
+            at_151 - at_19 > 45.0,
+            "151 vs 19 frames must differ by tens of GiB (got {at_19:.1} → {at_151:.2})"
+        );
+
+        // Linear in pixel count: halving the height halves the peak.
+        let half = mochi_decode_peak_gb(151, 848, 240);
+        assert!(
+            (at_151 / 2.0 - half).abs() < 0.01,
+            "decode peak must be linear in pixels: {at_151:.2} vs {half:.2}"
+        );
+
+        // The causal decode pays for `temporal_ratio − 1` extra leading frames before they're trimmed,
+        // so the 1-frame floor is not free.
+        assert!(mochi_decode_peak_gb(1, 848, 480) > 0.0);
+    }
+
+    /// The reserve is a PARAMETER, not a baked constant — the two lanes reserve for different reasons
+    /// (MLX: the OS shares the unified pool; candle: allocator slack, since the OS does not draw from
+    /// VRAM). They coincide at 2.0 today, so nothing else would catch a re-baking: this test fails if
+    /// someone folds either lane's constant back into the shared formula.
+    #[test]
+    fn mochi_needed_gb_adds_the_callers_reserve_not_a_baked_one() {
+        let at_2 =
+            mochi_needed_gb(MOCHI_Q4_RESIDENT_BYTES, 19, 848, 480, 2.0).expect("weights > 0");
+        let at_5 =
+            mochi_needed_gb(MOCHI_Q4_RESIDENT_BYTES, 19, 848, 480, 5.0).expect("weights > 0");
+        assert!(
+            (at_5 - at_2 - 3.0).abs() < 1e-6,
+            "the reserve must pass straight through: {at_2:.3} vs {at_5:.3}"
+        );
+
+        // And the total is weights + decode + reserve, not one of them alone.
+        let expected = MOCHI_Q4_RESIDENT_BYTES as f64 / BYTES_PER_GIB
+            + mochi_decode_peak_gb(19, 848, 480)
+            + 2.0;
+        assert!(
+            (at_2 - expected).abs() < 1e-6,
+            "got {at_2:.3}, want {expected:.3}"
+        );
+    }
+
+    /// Unmeasurable weights ⇒ no signal ⇒ `None` ⇒ every caller admits. The gate never blocks without
+    /// evidence, on either lane.
+    #[test]
+    fn mochi_needed_gb_has_no_signal_without_weights() {
+        assert!(mochi_needed_gb(0, 151, 848, 480, 2.0).is_none());
+        assert!(mochi_needed_gb(1, 151, 848, 480, 2.0).is_some());
     }
 }

--- a/crates/sceneworks-worker/src/mlx_fit_gate.rs
+++ b/crates/sceneworks-worker/src/mlx_fit_gate.rs
@@ -140,8 +140,9 @@ const HEADROOM_GB: f64 = 18.0;
 const OS_RESERVE_GB: f64 = 2.0;
 
 /// Bytes per binary gigabyte (GiB) — matches `gpu::total_unified_memory_gb`, which divides
-/// `hw.memsize` by 1024³, and the epic's measured on-disk table.
-const BYTES_PER_GIB: f64 = 1_073_741_824.0;
+/// `hw.memsize` by 1024³, and the epic's measured on-disk table. Shared with the candle gate
+/// (sc-12306) so a "GB" in either lane's fit message means the same thing.
+use crate::fit_gate::BYTES_PER_GIB;
 
 /// A usable unified-memory budget for the machine, in GB. Single field (no free/total split): on
 /// unified memory the whole pool is the budget, and current pressure is absorbed by [`HEADROOM_GB`]
@@ -371,80 +372,25 @@ fn sysctl_total_unified_memory_gib() -> Option<f64> {
 // than a calibration constant, because nothing has been measured on-device yet (B5/sc-11995 backfills
 // `footprint.residentMemoryBytes`/`peakMemoryBytes`; sc-12291 tiles the decode and should then cut
 // the frame term sharply).
+//
+// All three points above hold verbatim for the candle lane, which grew the same gate in sc-12306 —
+// except (3), where a CUDA OOM is catchable rather than a SIGKILL, so the pre-flight buys an
+// actionable message and minutes of un-wasted denoise rather than process survival. What remains here
+// is MLX-SPECIFIC: the unified-memory budget probe, the `OS_RESERVE_GB` reserve, and the Mac-worded
+// message. The shared ARITHMETIC lives in `crate::fit_gate` (`mochi_decode_peak_gb` /
+// `mochi_needed_gb`); the candle half is `vram_gate::mochi_fit_error`. The on-disk scan
+// (`mochi_resident_bytes`) is shared too — the hosted tier layout is one repo serving both lanes.
 
-/// The AsymmVAE decoder's final-stage channel count — `decoder_block_out_channels[0]` (config
-/// default `[128, 256, 512, 768]`). The last `block_out` mid-block runs THIS many channels at FULL
-/// output resolution, which is the decode's peak stage: every earlier stage is either fewer pixels
-/// (pre-upsample) or, at 256/512/768 channels, at 1/4/1/16/1/64 of the spatial extent, so their
-/// products are strictly smaller.
-const MOCHI_DECODE_CHANNELS: f64 = 128.0;
-
-/// Bytes per element in the MLX AsymmVAE decode. **f32 (4), NOT bf16 (2)** — `MochiVaeDecoder::
-/// from_weights` pins `Dtype::Float32` and `decode_denormalized` casts the latent to that dtype, so
-/// the whole decode flows f32 ("the reference decode ran bf16 — the parity residual reflects that
-/// bf16 rounding", mlx-gen-mochi/src/vae.rs).
+/// Predicted whole-generation peak (GiB) for an MLX Mochi request, in UNIFIED memory: the shared
+/// backend-neutral arithmetic ([`crate::fit_gate::mochi_needed_gb`]) reserving [`OS_RESERVE_GB`],
+/// because on unified memory the OS draws from the same pool the model does.
 ///
-/// ⚠️ This DELIBERATELY disagrees with the sc-12291 / B1-manifest derivation, which assumed **bf16**
-/// (`128 × 156 × 480 × 848 × 2 B`) and therefore under-predicts the real MLX peak by 2×. Surfaced as
-/// a follow-up on sc-12291 — that story's table (19→7, 61→19, 151→45 GiB) and B1's
-/// `mlx.minMemoryGb: 96` are both bf16-derived and want re-deriving against the shipped f32 decode.
-/// This gate uses the dtype the code actually runs.
-const MOCHI_DECODE_BYTES_PER_ELEM: f64 = 4.0;
-
-/// Full-resolution tensors live simultaneously at the decode peak. `MochiResnetBlock3D` is
-/// `GroupNorm → silu → CausalConv3d → GroupNorm → silu → CausalConv3d → + residual`, so the residual
-/// and the in-flight intermediate are both live across the block — the "residual + intermediate live
-/// at once" claim B1's manifest derivation makes. B1 then hedged "2–3×"; 2 is the concrete,
-/// defensible liveness (3 assumes an extra un-freed temporary, which MLX's allocator need not hold).
-/// Combined with the f32 correction above this lands at ~79 GiB for the shipped 5 s / 151-frame
-/// default — consistent with B1's declared `mlx.minMemoryGb: 96` floor.
-const MOCHI_DECODE_LIVE_TENSORS: f64 = 2.0;
-
-/// Extra leading frames the causal decode materializes before `drop_last_temporal_frames` trims them:
-/// `temporal_ratio − 1` = 5. The peak is paid on the UNTRIMMED length, so a 151-frame clip decodes
-/// 156 frames wide.
-const MOCHI_DECODE_EXTRA_FRAMES: u32 = 5;
-
-/// Predicted AsymmVAE decode peak (GiB) for a `frames` × `width` × `height` clip.
-///
-/// `live × C × (frames + 5) × H × W × 4 B`. Linear in BOTH clip length and pixel count, because the
-/// peak tensor is `[1, C, T, H, W]` and the decode is untiled. This is the term the generic gate's
-/// flat `HEADROOM_GB` structurally cannot represent.
-///
-/// DERIVED, not measured. Sanity points at the native 848×480 bucket — all **GiB**, the unit this
-/// function returns (it divides by [`BYTES_PER_GIB`]): 7 frames ⇒ ~4.66, 19 ⇒ ~9.32, 61 ⇒ ~25.62,
-/// 151 ⇒ ~60.56, 163 ⇒ ~65.21.
-///
-/// (These are the constants the whole derivation leans on, so they are stated in ONE unit on purpose:
-/// an earlier revision mixed decimal GB into this list — 5.0/10.1/27.5 are the same three points in
-/// GB — which made the table read as if the peak grew faster than it does.)
-pub(crate) fn mochi_decode_peak_gb(frames: u32, width: u32, height: u32) -> f64 {
-    let decoded_frames = f64::from(frames.saturating_add(MOCHI_DECODE_EXTRA_FRAMES));
-    MOCHI_DECODE_LIVE_TENSORS
-        * MOCHI_DECODE_CHANNELS
-        * decoded_frames
-        * f64::from(width)
-        * f64::from(height)
-        * MOCHI_DECODE_BYTES_PER_ELEM
-        / BYTES_PER_GIB
-}
-
-/// Predicted whole-generation peak (GiB) for a Mochi request: the ALL-RESIDENT weights
-/// (`supports_sequential_offload: false` ⇒ T5-XXL + AsymmDiT + VAE are held for the whole run, so
-/// nothing drops) + the frame-dependent decode peak + [`OS_RESERVE_GB`]. `None` when the weights are
-/// unmeasurable (`weight_bytes == 0`) ⇒ no signal ⇒ the gate never blocks, matching
-/// [`predicted_peak_gb`].
-pub(crate) fn mochi_needed_gb(
-    weight_bytes: u64,
-    frames: u32,
-    width: u32,
-    height: u32,
-) -> Option<f64> {
-    (weight_bytes > 0).then(|| {
-        weight_bytes as f64 / BYTES_PER_GIB
-            + mochi_decode_peak_gb(frames, width, height)
-            + OS_RESERVE_GB
-    })
+/// The formula itself moved to [`crate::fit_gate`] when the candle video lane needed the identical
+/// arithmetic (sc-12306) — every term in it is a fact about the MODEL (tensor shapes × the f32 dtype
+/// both decoders pin), so duplicating it per lane would let the two gates disagree about one model.
+/// The RESERVE is what stays lane-specific; see that function's note.
+fn mochi_needed_gb(weight_bytes: u64, frames: u32, width: u32, height: u32) -> Option<f64> {
+    crate::fit_gate::mochi_needed_gb(weight_bytes, frames, width, height, OS_RESERVE_GB)
 }
 
 /// The pure Mochi admission decision: `Some(error)` when the predicted peak overflows the budget,
@@ -539,7 +485,16 @@ pub(crate) fn mochi_fit_check(
 /// and `vae/` components resolved from the tier dir's parent (the A6 shared-sibling layout). A
 /// self-contained dir — the raw snapshot, where the components live under the dir itself — is summed
 /// once, never double-counted, because the parent scan only adds SIBLING dirs of `tier_dir`.
-fn mochi_resident_bytes(tier_dir: &Path) -> u64 {
+///
+/// **Shared by both lanes** (sc-12306), despite the module name: this describes the HOSTED REPO LAYOUT,
+/// not MLX. `SceneWorks/mochi-1-mlx` serves candle too — A6's `.scales`-detect seam ingests the same
+/// mlx-affine tiers 1:1 through the same `resolve_mochi_model_dir` — so the resident byte total is
+/// identical off-Mac, and both providers set `supports_sequential_offload: false`, so both hold all
+/// three components for the whole run. It stays here beside its `sum_safetensors_bytes` helper (which
+/// has several other MLX callers) rather than moving to `fit_gate` with the arithmetic; the candle
+/// video gate calls it through this path, exactly as `image_jobs/base.rs` already calls
+/// `mlx_fit_gate::engine_supports_sequential` from the candle image lane (sc-12130).
+pub(crate) fn mochi_resident_bytes(tier_dir: &Path) -> u64 {
     let mut total = sum_safetensors_bytes(tier_dir);
     if let Some(parent) = tier_dir.parent() {
         for component in ["text_encoder", "vae"] {
@@ -1432,49 +1387,10 @@ mod tests {
     /// exact hosted bytes B1's manifest derivation pins). Used as the weight signal in the gate tests.
     const MOCHI_Q4_RESIDENT_BYTES: u64 = 9_670_883_602 + 9_524_669_250 + 919_551_200;
 
-    /// The decode peak must scale with CLIP LENGTH — the whole reason Mochi cannot ride the generic
-    /// resolution-blind gate. Pins linearity in frames and in pixels, and the architectural anchor.
-    #[test]
-    fn mochi_decode_peak_scales_with_frames_and_pixels() {
-        // Strictly monotonic in frames.
-        let peaks: Vec<f64> = [7, 19, 61, 151, 163]
-            .iter()
-            .map(|f| mochi_decode_peak_gb(*f, 848, 480))
-            .collect();
-        for pair in peaks.windows(2) {
-            assert!(
-                pair[1] > pair[0],
-                "decode peak must grow with clip length: {peaks:?}"
-            );
-        }
-
-        // The architectural anchor: 2 live × 128 ch × (151+5) frames × 848×480 × 4 B (f32) = 60.56 GiB.
-        // This is the number a bf16 derivation would halve — pin it so the dtype can't silently drift.
-        let at_151 = mochi_decode_peak_gb(151, 848, 480);
-        assert!(
-            (at_151 - 60.56).abs() < 0.1,
-            "151-frame 848x480 decode peak should be ~60.56 GiB (f32), got {at_151:.2}"
-        );
-
-        // The 5 s default costs ~50 GiB MORE than the engine's 19-frame default on the same machine —
-        // the spread a flat HEADROOM_GB constant cannot express.
-        let at_19 = mochi_decode_peak_gb(19, 848, 480);
-        assert!(
-            at_151 - at_19 > 45.0,
-            "151 vs 19 frames must differ by tens of GiB (got {at_19:.1} → {at_151:.2})"
-        );
-
-        // Linear in pixel count: halving the height halves the peak.
-        let half = mochi_decode_peak_gb(151, 848, 240);
-        assert!(
-            (at_151 / 2.0 - half).abs() < 0.01,
-            "decode peak must be linear in pixels: {at_151:.2} vs {half:.2}"
-        );
-
-        // The causal decode pays for `temporal_ratio − 1` extra leading frames before they're
-        // trimmed, so the 1-frame floor is not free.
-        assert!(mochi_decode_peak_gb(1, 848, 480) > 0.0);
-    }
+    // The pure decode arithmetic (`mochi_decode_peak_gb`: linearity in frames + pixels, the f32
+    // anchor) is pinned in `crate::fit_gate`'s tests alongside the formula, which moved there in
+    // sc-12306 when the candle video lane grew the same gate. What stays here is what is genuinely
+    // MLX: the unified-memory budget shape, the `OS_RESERVE_GB` reserve, and the Mac-worded message.
 
     /// THE gate behavior: on ONE fixed machine, a short Mochi clip is admitted and a long one is
     /// rejected. A frame-blind gate (the plausible wrong implementation — reusing `predicted_peak_gb`

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -5168,10 +5168,95 @@ fn candle_resolve_wan_adapters(
     Ok(specs)
 }
 
+/// The candle Mochi pre-flight's gated result (sc-12306): the tier's baked-in quant marker, obtainable
+/// ONLY by passing the VRAM fit gate.
+///
+/// Bundling the marker into the gated return is deliberate, and mirrors the MLX lane's [`MochiPreflight`]
+/// — which adopted the shape after a review mutation that deleted a free-standing `mochi_fit_check(...)?`
+/// call still compiled and still rendered, silently un-gating the lane. With the marker only obtainable
+/// here, the generation arm cannot reach a quant on a path that skipped the gate.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MochiVramPreflight {
+    quant: Option<Quant>,
+}
+
+/// Live pre-flight Mochi VRAM admission check for the candle lane (sc-12306) — the seam
+/// [`generate_candle_video`] calls before the load + 64-step denoise.
+///
+/// Sums the on-disk bytes the load will hold resident via the SHARED [`crate::mlx_fit_gate::mochi_resident_bytes`]
+/// (the tier dir's AsymmDiT plus the `text_encoder/` + `vae/` siblings from its parent): despite the
+/// module name that scan describes the hosted repo layout, which is one repo serving both lanes, and
+/// summing only the tier dir would miss the ~9.7 GiB T5-XXL + VAE — over half the resident footprint.
+///
+/// `budget` arrives resolved so this stays free of the GPU probe and is unit-testable without CUDA. No
+/// budget signal ⇒ admits. `Err` is the actionable pre-denoise rejection.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn mochi_vram_preflight(
+    model_label: &str,
+    tier_dir: &Path,
+    frames: u32,
+    width: u32,
+    height: u32,
+    gpu_id: &str,
+    budget: Option<crate::vram_gate::VramBudget>,
+) -> WorkerResult<MochiVramPreflight> {
+    match crate::vram_gate::mochi_fit_error(
+        model_label,
+        crate::mlx_fit_gate::mochi_resident_bytes(tier_dir),
+        frames,
+        width,
+        height,
+        gpu_id,
+        budget,
+    ) {
+        Some(error) => Err(error),
+        None => Ok(MochiVramPreflight {
+            quant: mochi_tier_quant(tier_dir),
+        }),
+    }
+}
+
+/// The candle video lane's live VRAM budget: the real `nvidia-smi` reading, the
+/// `SCENEWORKS_CUDA_VRAM_CAP_GB` small-card emulation folded over it, then this process's reclaimable
+/// cudarc pool added back (sc-11023).
+///
+/// The reclaimable fold IS correct here, unlike `krea_control_candle.rs` which deliberately omits it:
+/// video routes through `generator_cache::with_cached_generator` (the `comfyui` in-place MoE is the one
+/// uncached exception, and it is not Mochi), so the single exclusive cache slot evicts its occupant
+/// BEFORE the incoming load and cudarc reuses those pages in-process. Without the fold, a warm re-gate
+/// would be measured against a `free` that still counts the model it is about to replace. Matches
+/// `generate_candle_stream` (image_jobs/base.rs).
+///
+/// The reverse direction is deliberately NOT wired: an admitted Mochi job does not call
+/// [`crate::vram_gate::note_loaded_peak`], so it contributes nothing to the reclaimable high-water the
+/// image lane reads. That keeps today's behavior (the video lane has never recorded a peak) rather than
+/// guessing: Mochi's predicted peak is dominated by a TRANSIENT decode, not by resident weights, and
+/// publishing ~81 GB as "reclaimable" on the strength of a derived floor would relax later image gates
+/// on a number nothing has measured. Under-reporting the pool only ever fails conservative (a spurious
+/// reject, never an OOM). Revisit once B5/sc-11995 backfills real `footprint.peakMemoryBytes`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+async fn candle_video_vram_budget(settings: &Settings) -> Option<crate::vram_gate::VramBudget> {
+    let budget = crate::vram_gate::apply_vram_cap(
+        crate::gpu::nvidia_vram_budget_gb(&settings.gpu_id).await,
+        crate::vram_gate::cuda_vram_cap_gb(),
+    );
+    budget.map(|budget| {
+        crate::vram_gate::with_reclaimable(
+            budget,
+            crate::vram_gate::reclaimable_pool_gb(&settings.gpu_id),
+        )
+    })
+}
+
 /// Windows/CUDA candle video path (sc-5097 txt2video; sc-5175 adds the Wan2.2 14B MoE T2V + I2V).
 /// Resolves the engine + weights, provisions the LTX Gemma encoder, resolves any i2v source-image
 /// conditioning, builds a `VideoGenInput`, and runs it through the shared [`generate_video`] streaming
 /// driver. Returns the decoded clip + the candle adapter label.
+///
+/// Mochi additionally passes a VRAM fit gate before the load (sc-12306); every other engine on this
+/// lane is still ungated (sc-12344 — no candle video model carries the `candle.vramGbByTier` block the
+/// generic `vram_gate` needs, so wiring it here today would admit unconditionally).
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 async fn generate_candle_video(
     api: &ApiClient,
@@ -5208,14 +5293,29 @@ async fn generate_candle_video(
     } else {
         candle_video_snapshot_dir(settings, &repo)?
     };
+    // Coerce the requested frame count onto the engine's temporal stride — the ONE shared ladder both
+    // lanes use (sc-11992), so the candle stride can never drift from the MLX one. Computed HERE, above
+    // the tier binding, because Mochi's fit gate (sc-12306) needs the coerced count: the decode peak is
+    // linear in frames, so gating on the raw request would size the check against a length that never
+    // renders. (The SVD arm below returns before this is read; it derives its own model-fixed burst.)
+    let frames = video_frame_count(&request.model, request.raw_frame_count());
     // Wan quant-matrix tier-select (sc-10027): a candle wan tier repo (`SceneWorks/wan2.2-*-candle`) ships
     // q4/q8/bf16 subdirs — resolve the one matching `advanced.mlxQuantize` (default q4) and load from it
     // (the packed-detect seam reads the baked-in quant). A flat/dense repo (no subdirs, e.g. the
     // `Wan-AI/*-Diffusers` fallback) stays as-is with no quant marker.
     let (model_dir, wan_quant) = if is_mochi {
-        // `resolve_mochi_model_dir` already returned the TIER dir; the quant marker is the tier's own
-        // baked-in level, read from its `split_model.json` (the candle loader asserts it matches).
-        let quant = mochi_tier_quant(&snapshot_dir);
+        // `resolve_mochi_model_dir` already returned the TIER dir. The VRAM fit gate (sc-12306) runs
+        // here, and the quant marker comes back OUT of it — see `mochi_vram_preflight` for why the
+        // marker is bundled into the gated return rather than read alongside a free-standing check.
+        let MochiVramPreflight { quant } = mochi_vram_preflight(
+            engine_id,
+            &snapshot_dir,
+            frames,
+            request.width,
+            request.height,
+            &settings.gpu_id,
+            candle_video_vram_budget(settings).await,
+        )?;
         (snapshot_dir, quant)
     } else {
         match candle_wan_tier_subdir(&snapshot_dir, engine_id, request) {
@@ -5314,9 +5414,6 @@ async fn generate_candle_video(
         let (steps, guidance) = candle_wan_sampling(engine_id, request);
         (steps, guidance, non_empty_negative_prompt(request))
     };
-    // Coerce the requested frame count onto the engine's temporal stride — the ONE shared ladder both
-    // lanes use (sc-11992), so the candle stride can never drift from the MLX one.
-    let frames = video_frame_count(&request.model, request.raw_frame_count());
     let input = VideoGenInput {
         sampler: None,
         scheduler: None,
@@ -10783,21 +10880,37 @@ mod tests {
     /// (which asserts the same total against the pure gate) — the preflight tests need them SPLIT
     /// across the A6 sibling layout so the on-disk scan has to fold the shared components to get the
     /// total right.
-    #[cfg(target_os = "macos")]
+    ///
+    /// On the SUPERSET cfg (sc-12306): both lanes ingest these same hosted tiers, so both gates budget
+    /// against these exact bytes.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
     const MOCHI_Q4_DIT_BYTES: u64 = 9_670_883_602;
-    #[cfg(target_os = "macos")]
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
     const MOCHI_Q4_TE_BYTES: u64 = 9_524_669_250;
-    #[cfg(target_os = "macos")]
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
     const MOCHI_Q4_VAE_BYTES: u64 = 919_551_200;
 
     /// A Mochi A6-layout root (q4 tier + shared `text_encoder`/`vae`/`tokenizer` siblings) whose
-    /// `.safetensors` report the REAL hosted byte sizes, so `mochi_fit_check`'s on-disk scan resolves
-    /// the true ~18.73 GiB resident footprint instead of the 1-byte stubs `mochi_root` writes.
+    /// `.safetensors` report the REAL hosted byte sizes, so the on-disk scan behind either lane's fit
+    /// gate resolves the true ~18.73 GiB resident footprint instead of the 1-byte stubs `mochi_root`
+    /// writes.
     ///
-    /// The files are SPARSE: `set_len` sets the apparent size with zero allocated blocks on APFS, and
-    /// `sum_safetensors_bytes` reads `metadata().len()`. So this is instant and costs no disk —
+    /// The files are SPARSE: `set_len` sets the apparent size with zero allocated blocks on APFS/NTFS,
+    /// and `sum_safetensors_bytes` reads `metadata().len()`. So this is instant and costs no disk —
     /// materializing 18.7 GiB of real zeros per test would not be viable.
-    #[cfg(target_os = "macos")]
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
     fn mochi_root_real_sized(tag: &str) -> PathBuf {
         let root = std::env::temp_dir().join(format!(
             "mochi_preflight_{tag}_{}_{}",
@@ -10920,6 +11033,229 @@ mod tests {
         assert_eq!(
             preflight.frames, 19,
             "19 already sits on the 6k+1 lattice, so the snap is a no-op"
+        );
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Mochi 1 candle/CUDA VRAM fit gate (sc-12306). These run on the windows-candle.yml lane, which
+    // is the ONLY lane that compiles `generate_candle_video` — the macOS lane and the Linux `parity`
+    // job never see this code. `mochi_vram_preflight` takes its budget as a parameter precisely so the
+    // whole decision is exercisable here with no CUDA driver and no GPU.
+    // -----------------------------------------------------------------------------------------
+
+    /// An RTX 5090 — the biggest consumer NVIDIA card, and the machine the story names. 32 GB total,
+    /// all free (a cold card with nothing loaded).
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    fn rtx_5090() -> Option<crate::vram_gate::VramBudget> {
+        crate::vram_gate::apply_vram_cap(None, Some(32.0))
+    }
+
+    /// THE story: the shipped 5 s / 151-frame default is refused BEFORE the load + 64-step denoise, with
+    /// a message naming the clip-length lever. Needs 18.73 GiB weights + 60.56 GiB untiled decode + 2 GiB
+    /// headroom ≈ 81.3 GB against 32 GB — so on consumer hardware this is the DEFAULT path, not an edge
+    /// case.
+    ///
+    /// Kills the mutations that a compile alone would not:
+    ///   * hardcoding the gate's `frames` to a small number (e.g. B2's 7-frame smoke geometry) ⇒ the gate
+    ///     sees 4.66 GiB of decode instead of 60.56, totals ~25 GB, and ADMITS ⇒ `expect_err` fails.
+    ///   * passing `request.raw_frame_count()` instead of the coerced count ⇒ 150 not 151 — caught by
+    ///     `mochi_vram_preflight_coerces_the_frame_count_on_the_candle_lane` below.
+    ///   * dropping the frames term entirely (reusing the resolution-blind `predicted_peak_gb` shape) ⇒
+    ///     admits ⇒ `expect_err` fails.
+    ///   * reusing the MLX message ⇒ the "unified memory" assert fails.
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    #[test]
+    fn mochi_vram_preflight_rejects_the_5s_default_on_an_rtx_5090() {
+        let root = mochi_root_real_sized("candle_reject");
+        let out = mochi_vram_preflight(
+            "mochi_1",
+            &root.join("q4"),
+            video_frame_count("mochi_1", 150),
+            848,
+            480,
+            "0",
+            rtx_5090(),
+        );
+        std::fs::remove_dir_all(&root).ok();
+
+        let message = out
+            .expect_err(
+                "the shipped 5 s default (151 frames) needs ~81 GB and NO consumer NVIDIA GPU has \
+                 that — admitting it burns a full 64-step denoise before a raw CUDA OOM",
+            )
+            .to_string();
+        assert!(message.contains("mochi_1"), "names the model: {message}");
+        assert!(
+            message.contains("151-frame"),
+            "names the clip length that was refused, so the user can act on it: {message}"
+        );
+        assert!(
+            message.contains("Shorten the clip"),
+            "leads with the only lever that moves the dominant term — Mochi has one trained bucket \
+             and the tier delta is ~11 GiB against a ~60 GiB decode: {message}"
+        );
+        assert!(
+            message.contains("VRAM") && !message.contains("unified memory"),
+            "must be CUDA-worded, not the MLX lane's Mac prose: {message}"
+        );
+        assert!(
+            !message.contains("run on a Mac"),
+            "telling a Windows/CUDA user to buy a Mac is the MLX message leaking: {message}"
+        );
+    }
+
+    /// The other half of the contract: on the SAME 32 GB card a short clip is ADMITTED. Without this,
+    /// the reject test above would pass against a gate that blanket-refuses Mochi on every consumer
+    /// card — so this pair is what proves the gate is FRAME-SENSITIVE, which is the whole point of a
+    /// decode peak that scales with clip length.
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    #[test]
+    fn mochi_vram_preflight_admits_a_short_clip_on_the_same_rtx_5090() {
+        let root = mochi_root_real_sized("candle_admit");
+        // 7 frames: 18.73 weights + 4.66 decode + 2 headroom ≈ 25.4 GB, which fits 32 GB.
+        let out = mochi_vram_preflight("mochi_1", &root.join("q4"), 7, 848, 480, "0", rtx_5090());
+        std::fs::remove_dir_all(&root).ok();
+
+        let preflight = out.expect(
+            "a 7-frame clip needs ~25 GB and FITS a 32 GB card — a gate that refuses this has \
+             wall-rejected hardware that works",
+        );
+        assert_eq!(
+            preflight.quant,
+            Some(Quant::Q4),
+            "the tier dir's split_model.json carries the quant the candle loader asserts — and it is \
+             reachable ONLY through the gate"
+        );
+    }
+
+    /// The gate must budget on the COERCED frame count, not the raw request: the decode peak is linear
+    /// in frames, so gating on a length that never renders sizes the check against fiction. 150 raw
+    /// snaps to 151 on Mochi's 6k+1 lattice.
+    ///
+    /// Kills the `wan_frame_count` substitution independently of the MLX lane's copy of this check:
+    /// `wan_frame_count(150) = 149`, and `149 % 6 == 5` is off the lattice the engine accepts.
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    #[test]
+    fn mochi_vram_preflight_coerces_the_frame_count_on_the_candle_lane() {
+        let root = mochi_root_real_sized("candle_lattice");
+        let tier = root.join("q4");
+        // A budget nothing overflows, so ONLY the frame arithmetic is under test.
+        let huge = crate::vram_gate::apply_vram_cap(None, Some(512.0));
+
+        // The seam the generation arm passes: `video_frame_count(&request.model, raw)`.
+        let frames = video_frame_count("mochi_1", 150);
+        assert_eq!(
+            frames, 151,
+            "the shipped 5 s default snaps onto the 6k+1 lattice"
+        );
+        assert_ne!(
+            frames,
+            wan_frame_count(150),
+            "routing the candle lane through the wan stride would gate on 149 — off Mochi's lattice"
+        );
+        assert!(
+            mochi_vram_preflight("mochi_1", &tier, frames, 848, 480, "0", huge).is_ok(),
+            "151 frames fits a 512 GB budget — the gate rejects by BUDGET, never by duration alone"
+        );
+
+        // Frame-sensitivity at the seam: the SAME tier + card, two lengths, two verdicts. A 48 GB card
+        // sits between the 7-frame (~25 GB) and 151-frame (~81 GB) totals.
+        let card_48 = crate::vram_gate::apply_vram_cap(None, Some(48.0));
+        assert!(
+            mochi_vram_preflight("mochi_1", &tier, 7, 848, 480, "0", card_48).is_ok(),
+            "a short clip fits 48 GB"
+        );
+        assert!(
+            mochi_vram_preflight("mochi_1", &tier, frames, 848, 480, "0", card_48).is_err(),
+            "the 5 s default does not fit the SAME 48 GB card — the gate must see the frame count"
+        );
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// The gate NO-OPS without a budget signal (the story's explicit AC) and without a weight signal.
+    /// A worker on a card `nvidia-smi` cannot read, or pointed at a weights dir it cannot scan, must
+    /// keep rendering exactly as it did before this gate existed — a fit gate that blocks on missing
+    /// evidence is a regression, not a safety net (sc-12179: never wall-reject a machine that worked).
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    #[test]
+    fn mochi_vram_preflight_no_ops_without_a_budget_or_weight_signal() {
+        let root = mochi_root_real_sized("candle_nosignal");
+
+        // No budget: `nvidia_vram_budget_gb` → None (non-NVIDIA / unreadable) and no cap set.
+        assert!(
+            mochi_vram_preflight("mochi_1", &root.join("q4"), 151, 848, 480, "0", None).is_ok(),
+            "no budget signal ⇒ admit — the 5 s default is refused ONLY against a real reading"
+        );
+        assert_eq!(
+            crate::vram_gate::apply_vram_cap(None, None),
+            None,
+            "no real reading + no cap ⇒ no budget, so the wiring above really can pass None"
+        );
+
+        // No weights: a dir with no safetensors scans to 0 bytes ⇒ unmeasurable ⇒ admit, even on a
+        // tiny card. The fixture needs its OWN root, for two reasons: `mochi_resident_bytes` folds the
+        // shared `text_encoder/` + `vae/` siblings from the tier dir's PARENT, so (a) an "empty" tier
+        // under `root` above would still scan ~9.7 GiB and be REJECTED — testing the exact opposite of
+        // the intent — and (b) hanging it directly off `temp_dir()` would make the parent scan read
+        // /tmp, so an unrelated `/tmp/text_encoder` would flake it. A private root has neither problem.
+        let bare_root = std::env::temp_dir().join(format!(
+            "mochi_candle_nosignal_bare_{}_{}",
+            std::process::id(),
+            line!()
+        ));
+        let bare = bare_root.join("q4");
+        std::fs::create_dir_all(&bare).unwrap();
+        assert_eq!(
+            crate::mlx_fit_gate::mochi_resident_bytes(&bare),
+            0,
+            "the fixture must really have no weight signal, or the assert below proves nothing"
+        );
+        let out = mochi_vram_preflight(
+            "mochi_1",
+            &bare,
+            151,
+            848,
+            480,
+            "0",
+            crate::vram_gate::apply_vram_cap(None, Some(4.0)),
+        );
+        std::fs::remove_dir_all(&bare_root).ok();
+        std::fs::remove_dir_all(&root).ok();
+        assert!(out.is_ok(), "unmeasurable weights ⇒ no signal ⇒ admit");
+    }
+
+    /// The on-disk scan must fold the SHARED `text_encoder/` + `vae/` siblings from the tier dir's
+    /// PARENT — both providers set `supports_sequential_offload: false`, so all three components are
+    /// held for the whole run. Summing only the tier dir would miss ~9.7 GiB (T5-XXL + VAE), over half
+    /// the resident footprint, and silently under-gate every candle Mochi job.
+    ///
+    /// This pins that the candle lane reuses the SHARED scan rather than growing its own tier-only one.
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    #[test]
+    fn mochi_vram_preflight_folds_the_shared_siblings_on_the_candle_lane() {
+        let root = mochi_root_real_sized("candle_siblings");
+        assert_eq!(
+            crate::mlx_fit_gate::mochi_resident_bytes(&root.join("q4")),
+            MOCHI_Q4_DIT_BYTES + MOCHI_Q4_TE_BYTES + MOCHI_Q4_VAE_BYTES,
+            "the candle gate must budget on DiT + T5 + VAE (~18.73 GiB), not the tier dir alone"
+        );
+
+        // Behavioral consequence: a card sized to fit the DiT alone must still refuse. DiT-only is
+        // 9.01 + 4.66 decode + 2 = ~15.7 GB; the true total is 18.73 + 4.66 + 2 = ~25.4 GB. A 20 GB
+        // card admits the former and must reject the latter.
+        let out = mochi_vram_preflight(
+            "mochi_1",
+            &root.join("q4"),
+            7,
+            848,
+            480,
+            "0",
+            crate::vram_gate::apply_vram_cap(None, Some(20.0)),
+        );
+        std::fs::remove_dir_all(&root).ok();
+        assert!(
+            out.is_err(),
+            "a tier-only scan would admit this job on a 20 GB card and then OOM on the T5 + VAE"
         );
     }
 

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -16859,6 +16859,16 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn ltx_eros_auto_injects_distill_lora_per_pass() {
+        // Hold ENV_LOCK for the whole test. This fixture resolves ONLY while the HF cache-dir env
+        // overrides are unset (`huggingface_hub_cache_dir` reads them BEFORE `data_dir`), and the
+        // check below reads them once, at entry. Without the lock a concurrent `temp_env_var(s)`
+        // caller — e.g. `generate_mochi_using_refuses_before_paying_for_the_tier_download`, which
+        // pins `HF_HUB_CACHE` to its own fixture hub — can set the var AFTER that check passes and
+        // BEFORE `resolve_ltx_adapters` reads it, pointing the resolver at the wrong cache: the
+        // distill LoRA is then "not installed" and this test fails for a reason that has nothing to
+        // do with it. `set_var` is process-global; only the lock makes the read-then-use atomic.
+        // Deterministic (12/12) when the two tests are selected together (sc-12306).
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // The fake HF snapshot only resolves when the cache-dir env overrides are unset (else the real
         // cache is consulted). Skip rather than assert-false in that unusual local config.
         if std::env::var_os("HF_HUB_CACHE").is_some()

--- a/crates/sceneworks-worker/src/vram_gate.rs
+++ b/crates/sceneworks-worker/src/vram_gate.rs
@@ -21,6 +21,7 @@
 use super::*;
 use serde_json::Value;
 
+use crate::fit_gate::BYTES_PER_GIB;
 pub(crate) use crate::fit_gate::{resolve_offload, FitDecision};
 
 /// Emulate a smaller card: cap usable VRAM (GB). Set e.g. `SCENEWORKS_CUDA_VRAM_CAP_GB=10` to make the
@@ -248,6 +249,108 @@ pub(crate) fn sequential_overflow_gb(
 ) -> Option<f64> {
     let (needed_gb, budget) = (sequential_needed_gb?, budget?);
     (budget.free_gb + f64::EPSILON < needed_gb).then_some(needed_gb)
+}
+
+// ---------------------------------------------------------------------------------------------
+// Mochi 1: the FRAME-DEPENDENT decode fit gate, candle/CUDA half (epic 1788 / sc-12306)
+// ---------------------------------------------------------------------------------------------
+//
+// The candle twin of `mlx_fit_gate`'s Mochi gate. Both call the SAME arithmetic
+// (`crate::fit_gate::mochi_needed_gb`); this half supplies the CUDA budget, the CUDA reserve, and the
+// CUDA-worded message.
+//
+// Why Mochi needs its own gate here rather than riding `fit_decision` above:
+//
+//  1. `predicted_peak_gb` is MANIFEST-driven (`candle.vramGbByTier`), and **`mochi_1` has no `candle`
+//     block at all** — it ships `mlx` only (builtin.models.jsonc:7233). So the generic gate returns
+//     `None` ⇒ `Unknown` ⇒ admit. It could not protect Mochi even if the video lane called it. (No
+//     candle VIDEO model has such a block; closing that is sc-12344.)
+//
+//  2. Even given a block, the generic gate is deliberately RESOLUTION-BLIND: a per-tier constant
+//     calibrated at load time, where the seam cannot see the request geometry (the generator is cached
+//     across resolutions). Mochi's AsymmVAE decode is UNTILED (candle-gen-mochi pipeline.rs:151 —
+//     `vae.decode(&latents)` materializes the whole clip; sc-12291), so its peak grows LINEARLY IN CLIP
+//     LENGTH: a 7-frame and a 151-frame request differ by ~55 GiB on the same model and the same tier.
+//     A constant cannot express that.
+//
+//  3. Unlike the MLX lane, a CUDA OOM here is CATCHABLE (`classify_engine_error`) rather than MLX's
+//     unmappable `exit(-1)` (sc-12178/12179). So this gate is not preventing a process kill — it is
+//     preventing a raw allocator error that arrives only AFTER the full 64-step denoise has burned
+//     minutes of GPU time, and that says nothing about the one lever that actually fixes it. At the
+//     shipped 5 s / 151-frame default Mochi needs ~81 GB; an RTX 5090 has 32 GB, so on consumer
+//     hardware this is not an edge case but the DEFAULT path.
+
+/// The pure candle Mochi admission decision: `Some(error)` when the predicted peak overflows the VRAM
+/// budget, `None` to admit. Missing either signal (unmeasurable weights / no budget) admits — the gate
+/// never blocks without evidence, exactly like [`fit_decision`].
+///
+/// Budgets against `free_gb` (what is allocatable now), like [`fit_decision`] and unlike the MLX gate,
+/// which has only a unified `total_gb`. Reserves [`HEADROOM_GB`] rather than the MLX gate's
+/// `OS_RESERVE_GB`: the OS does not draw from discrete VRAM, so the term covers allocator slack and
+/// CUDA context overhead instead. The two constants agree at 2.0 today but mean different things.
+///
+/// Pure (no GPU probe, no env) so the whole decision is unit-testable without CUDA; the caller resolves
+/// the budget.
+pub(crate) fn mochi_fit_error(
+    model_label: &str,
+    weight_bytes: u64,
+    frames: u32,
+    width: u32,
+    height: u32,
+    gpu_id: &str,
+    budget: Option<VramBudget>,
+) -> Option<WorkerError> {
+    let (needed_gb, budget) = (
+        crate::fit_gate::mochi_needed_gb(weight_bytes, frames, width, height, HEADROOM_GB)?,
+        budget?,
+    );
+    (budget.free_gb + f64::EPSILON < needed_gb).then(|| {
+        mochi_too_big_error(
+            model_label,
+            needed_gb,
+            budget.free_gb,
+            frames,
+            width,
+            height,
+            weight_bytes as f64 / BYTES_PER_GIB,
+            gpu_id,
+        )
+    })
+}
+
+/// Build Mochi's actionable over-budget rejection for the candle lane. Follows this module's existing
+/// reject convention — name the model, state what it needs and what the GPU has — and adds the lever
+/// that is UNIQUE to Mochi: the clip length.
+///
+/// The generic candle message's advice ("choose a smaller quant tier, lower the resolution") is nearly
+/// useless here: Mochi has one trained bucket (848×480), and the decode dwarfs the tier delta (q4→bf16
+/// is ~11 GiB against a ~60 GiB decode), so neither lever closes a 49 GB gap. The message therefore
+/// leads with shortening the clip — the only lever that moves the dominant term.
+///
+/// Deliberately does NOT reuse `mlx_fit_gate::mochi_too_big_error`: that one says "unified memory" and
+/// "run on a Mac with more memory", both false on CUDA. The shared thing between the lanes is the
+/// arithmetic, not the prose.
+#[allow(clippy::too_many_arguments)]
+fn mochi_too_big_error(
+    model_label: &str,
+    needed_gb: f64,
+    available_gb: f64,
+    frames: u32,
+    width: u32,
+    height: u32,
+    weights_gb: f64,
+    gpu_id: &str,
+) -> WorkerError {
+    WorkerError::InvalidPayload(format!(
+        "{model_label} needs ~{needed} GB of VRAM to render a {frames}-frame {width}x{height} clip \
+         (~{weights} GB of weights, held resident for the whole run, plus an untiled VAE decode whose \
+         peak grows with clip length) but GPU {gpu_id} has ~{available} GB available. Shorten the \
+         clip — the decode peak scales roughly linearly with duration — or run on a card with more \
+         VRAM.",
+        needed = needed_gb.round() as i64,
+        available = available_gb.round() as i64,
+        weights = weights_gb.round() as i64,
+    ))
 }
 
 /// Parse a JSON uint/int from either a number or a numeric string (mirrors base.rs `quant_int`).


### PR DESCRIPTION
Closes [sc-12306](https://app.shortcut.com/trefry/story/12306). Epic 1788 (Mochi 1).

## The problem

`generate_candle_video` has **no pre-flight memory gate at all**. That was tolerable before Mochi — a CUDA OOM is *catchable* (unlike MLX's `exit(-1)`, sc-12178/12179), so it maps to a job error rather than killing the worker — but Mochi makes it acute:

- Its AsymmVAE decode is **untiled** (sc-12291), so the peak grows **linearly with clip length**.
- At the shipped **5 s / 151-frame default** it needs **~81 GB**: 18.7 GB of resident weights + ~60.6 GB of decode.
- **An RTX 5090 has 32 GB.** On consumer hardware this is the **default path, not an edge case**.

So the user waits out a full 64-step denoise, then gets a raw allocator error that says nothing about the one lever that fixes it: shortening the clip.

## What changed

A Mochi job that cannot fit is refused **before the load**, naming the clip length:

> `mochi_1 needs ~81 GB of VRAM to render a 151-frame 848x480 clip (~19 GB of weights, held resident for the whole run, plus an untiled VAE decode whose peak grows with clip length) but GPU 0 has ~32 GB available. Shorten the clip — the decode peak scales roughly linearly with duration — or run on a card with more VRAM.`

The gate **no-ops without a budget or weight signal** — it never blocks without evidence (sc-12179: never wall-reject a machine that used to work).

## Three decisions worth reviewing

**1. The formula is shared, and that was verified — not assumed.** The story said to factor the pure arithmetic into a backend-neutral seam. Its constants were justified against the *MLX* decoder, so I checked the candle twin before reusing them. candle also pins **f32** (`vae.rs:260-264`), also decodes **untiled** (`pipeline.rs:151`), has the same `[128,256,512,768]` / ratio-6 geometry (`config.rs:86-88`), and also sets `supports_sequential_offload: false` (`lib.rs:115`). So it moves to `fit_gate` (the sc-12127 seam) intact.

What stays lane-specific is the **reserve**, now a parameter: MLX reserves because the OS shares the unified pool; candle reserves for allocator slack, since **the OS does not draw from VRAM**. Both are 2.0 today — which is precisely why baking either in would couple them silently. A test pins the pass-through.

**2. It's a FLOOR on candle, and the PR says so rather than papering over it.** candle's VAE inserts `.contiguous()` after every permute (notably the rank-8 depth-to-space at `vae.rs:170-174`) where MLX's `transpose_axes` is lazy — so the real peak runs **at or above** the prediction. That direction is safe for an admission gate (refuses the clearly-impossible, never wall-rejects something that fits), but a *marginal* job can still OOM — catchably. Inflating the constants with an invented fudge factor would be worse than stating the bound; nothing has been measured on-device yet (B5/sc-11995).

**3. Mochi-specific scope is evidence-based, not convenient.** The story asked whether the generic lane deserves the gate too. The generic `vram_gate` is manifest-driven off `candle.vramGbByTier`, and **no candle video model carries a `candle` block at all** — `mochi_1` ships `mlx` only. Wiring it here today returns `None` → `Unknown` → admit, for every model: dead code that reads as coverage. Wan/LTX/SVD remain ungated; filed as [sc-12344](https://app.shortcut.com/trefry/story/12344) rather than buried in a comment.

## Mutation resistance

The quant marker is returned **out of** the gate (`MochiVramPreflight`), mirroring the MLX lane's `MochiPreflight` — which adopted that shape after a review mutation deleted a free-standing `mochi_fit_check(...)?` and still compiled, silently un-gating the lane.

## Verification

The change is entirely under `cfg(all(not(target_os = "macos"), feature = "backend-candle"))`, which **no macOS build compiles** — so a green local `rust:check` proves nothing about it. I cross-compiled all three configs (stubbing `nvcc` locally, since `cargo check` never links):

| config | clippy `-D warnings` |
|---|---|
| macOS / mlx | ✅ |
| Linux + `backend-candle` (this lane) | ✅ |
| Linux, neither backend (parity — the dead-code trap) | ✅ |

`cargo test -p sceneworks-worker --lib`: **846 passed, 0 failed**, including all 24 MLX Mochi tests — the refactor doesn't move MLX behavior. Every threshold the new assertions depend on was checked arithmetically.

**The candle tests cannot run on a Mac** (they link CUDA), so windows-candle CI is their first real execution. Reviewing that pass before merge.

### One bug this caught in its own tests
The first draft's "no signal" fixture used an empty tier dir *inside* the populated root — but `mochi_resident_bytes` folds shared siblings from the **parent**, so it scanned ~9.7 GiB and would have been **rejected**, asserting the opposite of its intent and failing CI. Fixed to use a private root, with an `assert_eq!(…, 0)` guard so the fixture proves itself. Verified against the real scan on macOS.

## Test coverage (windows-candle lane)
Budget is a parameter, so the whole decision runs with no CUDA driver:
- rejects the 5 s default on a 32 GB card, naming the clip length + CUDA-worded (not the MLX Mac prose)
- **admits a short clip on the SAME card** — proves frame-sensitivity, not a blanket ban
- frame coercion onto the 6k+1 lattice (kills the `wan_frame_count` substitution)
- no-ops without a budget / without weights
- folds the shared `text_encoder/` + `vae/` siblings (a tier-only scan would admit on 20 GB, then OOM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)