### PR TITLE
test(worker): keep the Mochi pre-download pin hermetic — pin huggingface_base_url, not just api_url (sc-12318)

### DIFF
--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -11609,10 +11609,19 @@ mod tests {
     ///
     /// How it discriminates. The job asks for **q8**, and the staged cache has the shared components
     /// but no q8 tier — so `ensure_mochi_q8_present` is past its `!mochi_wants_q8` early-out and MUST
-    /// attempt a real `ensure_hf_files_cached` fetch. `api` points at a closed port, so the two orders
-    /// give different errors:
+    /// attempt a real `ensure_hf_files_cached` fetch. The two orders then give different errors:
     ///   * pre-check first (correct) ⇒ the gate's actionable "Shorten the clip", no network touched.
-    ///   * pre-check after the fetches ⇒ a `WorkerError::Http` from the download instead ⇒ RED.
+    ///   * pre-check after the fetches ⇒ a transport error from the download instead ⇒ RED.
+    ///
+    /// **`huggingface_base_url` is what makes that hermetic, and it is NOT `api_url`.** The fetch dials
+    /// `settings.huggingface_base_url` (`HuggingFaceSnapshot::resolve` → `{base_url}/api/models/…/tree/…`);
+    /// `api_url` only carries progress/heartbeat. `Settings::from_env()` defaults the former to the real
+    /// `https://huggingface.co`, so overriding only `api_url` would send this test's FAILURE path to the
+    /// live internet: it still goes red (the download's `report_download_progress` hard-`?`s on a
+    /// heartbeat to the closed `api_url`), but only after really resolving the tree — and the tier is a
+    /// public ungated repo, so that resolve succeeds and bytes can start landing before the heartbeat
+    /// trips. Pinning BOTH at a closed port keeps the whole thing offline and instant. Verified by
+    /// pointing the base at a sentinel host and reading it back out of the mutation's error.
     ///
     /// `HF_HUB_CACHE` is pinned at the fixture because `huggingface_hub_cache_dir` reads it (and
     /// `HF_HOME`) BEFORE `data_dir` — left ambient, a dev box's real cache would decide this test.
@@ -11627,6 +11636,9 @@ mod tests {
         let settings = Settings {
             data_dir: hub.join("unused-data-dir"),
             api_url: "http://127.0.0.1:0".to_owned(),
+            // The URL the tier fetch actually dials — see above. Unroutable ⇒ the failure path can
+            // never reach the real hub.
+            huggingface_base_url: "http://127.0.0.1:0".to_owned(),
             ..Settings::from_env()
         };
         let job = mochi_job_snapshot();


### PR DESCRIPTION
**Rewritten.** This PR originally added an ordering pin for sc-12318's bypass #7. **#1575 landed that first**, independently and better (loader-injection `_using` arms + the candle lane). I dropped my duplicate entirely and reset onto main — what's left is one real gap I found in the landed test.

## The gap

`generate_mochi_using_refuses_before_paying_for_the_tier_download` builds its Settings as `api_url: 127.0.0.1:0, ..Settings::from_env()`, and its doc explains:

> "`api` points at a closed port, so the two orders give different errors"

**That mechanism is wrong.** The tier fetch dials `settings.huggingface_base_url` — `HuggingFaceSnapshot::resolve` → `{base_url}/api/models/…/tree/…` (`downloads.rs:421`). `api_url` only carries progress/heartbeat. And `Settings::from_env()` defaults `huggingface_base_url` to `DEFAULT_HUGGINGFACE_BASE_URL` = **the real `https://huggingface.co`**.

So overriding only `api_url` left the test's *failure* path pointed at the live hub.

## Proven, not argued

Reordering the pre-check with a sentinel base URL set:

```
error sending request for url
(http://sentinel-proves-real-hf-was-dialed.invalid/api/models/SceneWorks/mochi-1-mlx/tree/90a87786…)
```

The sentinel comes back in the error — that's the tree API dialing `huggingface_base_url`, not `api_url`.

## Severity: real, but not a false green

The test **does** still go red under the mutation: the download's `report_download_progress` hard-`?`s on a heartbeat to the closed `api_url`. I checked that specifically, because a best-effort heartbeat would have made this a false green — the reordered code would have downloaded ~13 GiB, then refused, and passed.

So this is hygiene, not correctness: the regression path really resolved the tree against the public hub first, and mochi-1-mlx is public and ungated — so that resolve *succeeds* and bytes can start landing before the heartbeat trips. A test whose entire point is *"no download happened"* shouldn't be able to start one.

## The fix

One field — pin `huggingface_base_url` at the same closed port — plus a doc correction so the stated mechanism is true.

Verified after the fix:

| check | result |
|---|---|
| normal run | **green**, 0.01s, no network |
| reorder mutation | **still red** |
| sentinel dialed? | **0 occurrences** — the override beats ambient env |
| URL actually dialed | `http://127.0.0.1:0/api/models/…` |

Only this test needs it: the sibling `_using` tests stage complete tiers (`mochi_root_real_sized` / `mochi_root`), so `ensure_mochi_tier_present` early-returns before any fetch. This one uses `mochi_hf_cache_shared_only` — a deliberately missing tier — which is exactly why its fetch is reachable.

## Verification

`npm run rust:check` (fmt + lint + test + build) — exit **0**. **854 passed / 0 failed**.

15 lines. Credit to #1575 for the harness and for closing #7 — this just seals its failure path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)