### PR TITLE
fix(video): enforce each model's declared limits.fps, and honor its defaults.fps (sc-12347)

### DIFF
--- a/apps/rust-api/src/defaults.rs
+++ b/apps/rust-api/src/defaults.rs
@@ -132,9 +132,10 @@ pub(crate) fn default_video_duration() -> ContractNumber {
     ContractNumber::from(6)
 }
 
-pub(crate) fn default_video_fps() -> u32 {
-    25
-}
+// No `default_video_fps`: an omitted fps resolves to the model's declared `defaults.fps` (core's
+// `resolve_fps`, applied in `create_video_job` once the manifest entry is resolved), not to a
+// blanket this layer invents. The blanket 25 that used to live here was off-menu for 7 of the 10
+// shipped video models — see `VideoJobRequest::fps` (sc-12347).
 
 pub(crate) fn default_video_width() -> u32 {
     768

--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -765,8 +765,18 @@ pub(crate) struct VideoJobRequest {
     pub(crate) model: String,
     #[serde(default = "default_video_duration")]
     pub(crate) duration: ContractNumber,
-    #[serde(default = "default_video_fps")]
-    pub(crate) fps: u32,
+    /// Frames per second, or `None` when the caller named none — which the MCP server does whenever
+    /// *its* caller does (`server.rs` omits the key entirely rather than sending a default).
+    ///
+    /// Deliberately optional rather than `#[serde(default = …)]` = 25: that blanket is off-menu for
+    /// 7 of the 10 shipped video models, so it silently rendered them at a rate they do not declare
+    /// (mochi_1 at 25 instead of 30 — a 30 fps prior played 20% slow), and it is not a value any
+    /// model chose. `create_video_job` resolves `None` from the model's declared `defaults.fps` once
+    /// the manifest entry is in hand, then writes the resolved rate back into the payload. Keeping
+    /// the blanket here would also make `limits.fps` unenforceable: the gate would reject a payload
+    /// this route constructed itself (sc-12347).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) fps: Option<u32>,
     #[serde(default = "default_video_width")]
     pub(crate) width: u32,
     #[serde(default = "default_video_height")]

--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -535,6 +535,30 @@ pub(crate) async fn create_video_job(
     }) {
         return Err(ApiError::bad_request(message));
     }
+    // The model's declared `defaults.fps` + `limits.fps`, the other half of `frames = duration ×
+    // fps` (sc-12347). The cap above closes the *duration* axis only: a legally-5s mochi_1 request
+    // (cap 5 ✓) at 60 fps is 301 frames — double the shipped default's 151 — and `301 % 6 == 1`
+    // clears the engine's own check, so nothing downstream refuses it.
+    //
+    // Resolving the omission is what makes the menu enforceable, not a separate nicety. The DTO
+    // used to default fps to a blanket 25, which is off-menu for 7 of the 10 shipped video models,
+    // so gating alone would 400 a payload this route constructed itself — and the MCP server omits
+    // `fps` whenever its caller does, making that the likeliest non-UI call shape. It was already
+    // silently wrong: `generate_video(model = "mochi_1", duration = 5)` rendered at 25 fps, not
+    // mochi's declared 30, playing a 30 fps motion prior 20% slow. The web never had this bug —
+    // `VideoStudio.jsx:223` reads `defaults.fps` — so this is the API converging on the UI.
+    //
+    // Same placement rationale as the duration cap: keyed off the post-preset `model_id` and the
+    // resolved entry (reading either from the DTO is sc-12300). The RESOLVED rate is written back so
+    // the enqueued payload records what was actually rendered — the worker re-resolves identically
+    // from the same entry, but a recipe replay reads this row.
+    if let Some(entry) = model_manifest_entry.as_object() {
+        let fps = resolve_fps(job_payload.get("fps"), entry);
+        if let Some(message) = fps_limit_error(&model_id, fps, entry) {
+            return Err(ApiError::bad_request(message));
+        }
+        job_payload.insert("fps".to_owned(), Value::from(fps));
+    }
     job_payload.insert("modelManifestEntry".to_owned(), model_manifest_entry);
     validate_job_lora_compatibility_with(
         &state,

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -56,7 +56,7 @@ use sceneworks_core::training_store::{
     TrainingDatasetCaptionSidecarsInput, TrainingDatasetCreateInput, TrainingDatasetMutationResult,
     TrainingDatasetSummary, TrainingDatasetUpdateInput,
 };
-use sceneworks_core::video_request::duration_limit_error;
+use sceneworks_core::video_request::{duration_limit_error, fps_limit_error, resolve_fps};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -2683,8 +2683,14 @@ fn validate_video_job(payload: &VideoJobRequest) -> Result<(), ApiError> {
     if !duration.is_finite() || !(1.0..=30.0).contains(&duration) {
         return Err(ApiError::bad_request("duration must be between 1 and 30"));
     }
-    if !(1..=60).contains(&payload.fps) {
-        return Err(ApiError::bad_request("fps must be between 1 and 60"));
+    // Only a *named* fps is bounded here: an omitted one is resolved from the model's declared
+    // `defaults.fps` in `create_video_job`, which is the first point that knows the model (this
+    // runs before preset expansion, so the model here may be stale — sc-12300). This blanket stays
+    // a payload-sanity check; the model's own `limits.fps` menu is enforced there (sc-12347).
+    if let Some(fps) = payload.fps {
+        if !(1..=60).contains(&fps) {
+            return Err(ApiError::bad_request("fps must be between 1 and 60"));
+        }
     }
     validate_dimension(payload.width, "width", MAX_VIDEO_DIMENSION)?;
     validate_dimension(payload.height, "height", MAX_VIDEO_DIMENSION)?;

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -3594,3 +3594,371 @@ async fn video_duration_past_the_post_preset_models_hard_cap_is_rejected() {
         "10s is within the default model's 15s cap: {body}"
     );
 }
+
+/// sc-12347: `limits.fps` is enforced at enqueue against the POST-PRESET model's menu, and an
+/// OMITTED fps resolves to that model's declared `defaults.fps` rather than a blanket.
+///
+/// The fixture makes both halves load-bearing by having the two models' menus disagree:
+///   * default video model — `[24, 25, 30]`, default 25 (permissive)
+///   * `preset-vid`        — `[30]`, default 30 (strict, the mochi_1 shape)
+///
+/// `fps: 25` is the discriminator. It is on the default's menu and off `preset-vid`'s, so a gate
+/// reading the DTO's stale `payload.model` — i.e. inside `validate_video_job`, before
+/// `apply_recipe_preset_to_video_payload` — admits it and enqueues a job the strict model does not
+/// advertise. 25 is also the blanket the DTO used to default to, which is why the omitted-fps case
+/// below is the regression this story nearly shipped rather than a nicety.
+#[tokio::test]
+async fn video_fps_outside_the_post_preset_models_menu_is_rejected() {
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    let default_video_model = crate::defaults::default_video_model();
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "models": [
+            {
+              "id": "__DEFAULT_VIDEO_MODEL__",
+              "name": "Default Vid",
+              "family": "ltx-video",
+              "type": "video",
+              "adapter": "ltx_video",
+              "capabilities": ["text_to_video"],
+              "downloads": [
+                { "provider": "huggingface", "repo": "owner/default-vid", "files": ["*.safetensors"], "default": true }
+              ],
+              "paths": {},
+              "defaults": { "fps": 25 },
+              "limits": { "fps": [24, 25, 30] },
+              "ui": { "label": "Default Vid" }
+            },
+            {
+              "id": "preset-vid",
+              "name": "Preset Vid",
+              "family": "mochi",
+              "type": "video",
+              "adapter": "mochi_video",
+              "capabilities": ["text_to_video"],
+              "downloads": [
+                { "provider": "huggingface", "repo": "owner/preset-vid", "files": ["*.safetensors"], "default": true }
+              ],
+              "paths": {},
+              "defaults": { "fps": 30 },
+              "limits": { "fps": [30] },
+              "ui": { "label": "Preset Vid" }
+            }
+          ]
+        }
+        "#
+        .replace("__DEFAULT_VIDEO_MODEL__", &default_video_model),
+    )
+    .expect("builtin models writes");
+    std::fs::write(
+        config_dir.join("user.models.jsonc"),
+        r#"{ "schemaVersion": 1, "models": [] }"#,
+    )
+    .expect("user models writes");
+    std::fs::write(
+        config_dir.join("builtin.recipe-presets.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "presets": [
+            {
+              "id": "preset_override",
+              "name": "Preset Override",
+              "workflow": "text_to_video",
+              "model": "preset-vid",
+              "defaults": {},
+              "prompt": { "prefix": "cinematic", "suffix": "smooth" }
+            }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin recipe presets writes");
+    std::fs::write(
+        config_dir.join("user.recipe-presets.jsonc"),
+        r#"{ "schemaVersion": 1, "presets": [] }"#,
+    )
+    .expect("user recipe presets writes");
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Fps Menu Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+
+    // 25fps: on the DEFAULT's menu, off the preset-resolved model's. `model` omitted so the preset's
+    // model wins — the sc-12300 shape. A gate reading the stale DTO model admits this.
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_video",
+            "prompt": "a fox runs",
+            "fps": 25,
+            "recipePresetId": "preset_override"
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "25fps is off preset-vid's [30] menu and must be refused at enqueue, not snapped: {body}"
+    );
+    let detail = body["detail"].as_str().unwrap_or_default();
+    assert!(
+        detail.contains("preset-vid"),
+        "names the model whose menu applied — NOT the default's: {detail}"
+    );
+    assert!(
+        detail.contains("30 fps"),
+        "states what is allowed: {detail}"
+    );
+    assert!(detail.contains("25 fps"), "states what was asked: {detail}");
+
+    // THE REGRESSION THIS STORY NEARLY SHIPPED: omitting fps must be ADMITTED, and must resolve to
+    // the post-preset model's declared 30 — not the blanket 25 (which the assertion above proves is
+    // rejected), and not the DEFAULT model's 25. Both wrong answers are 25, so this pins the
+    // resolution AND that it is keyed off the post-preset model.
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_video",
+            "prompt": "a fox runs",
+            "recipePresetId": "preset_override"
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "a request naming no fps must not be refused by the menu: {body}"
+    );
+    assert_eq!(body["payload"]["model"], "preset-vid");
+    assert_eq!(
+        body["payload"]["fps"], 30,
+        "the enqueued payload records the model's declared rate, not the blanket 25: {body}"
+    );
+
+    // An advertised rate admits — keeps the rejection above from passing for a gate that refuses
+    // everything.
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_video",
+            "prompt": "a fox runs",
+            "fps": 30,
+            "recipePresetId": "preset_override"
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "30 is what preset-vid advertises: {body}"
+    );
+    assert_eq!(body["payload"]["fps"], 30);
+
+    // ...and the SAME 25fps request against the default model IS admitted, proving the rejection
+    // came from the per-model menu rather than a blanket fps bound.
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_video",
+            "prompt": "a fox runs",
+            "fps": 25,
+            "model": default_video_model
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "25 is on the default model's [24, 25, 30] menu: {body}"
+    );
+    assert_eq!(body["payload"]["fps"], 25);
+
+    // The blanket payload-sanity bound still applies to a NAMED fps, and still comes from
+    // `validate_video_job` — a different message than the per-model menu's.
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_video",
+            "prompt": "a fox runs",
+            "fps": 240,
+            "model": default_video_model
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "240 is past the sanity bound: {body}"
+    );
+    assert!(body["detail"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("fps must be between 1 and 60"));
+}
+
+/// sc-12347 END TO END, against the **REAL shipped manifest** rather than a fixture — the route the
+/// app actually serves, the bytes the app actually ships, the model the story is about.
+///
+/// The fixture test above pins the gate's PLACEMENT (post-preset, post-resolution). This one pins
+/// that the placement is wired to the real `mochi_1` entry: a fixture proves the wiring, not the
+/// values, and `limits.fps` spent its whole existence declared-but-unread precisely because nothing
+/// ever connected the two. Both are needed — reverting mochi's manifest `fps` to `[24, 25, 30]`
+/// leaves the fixture test green and turns this one red.
+#[tokio::test]
+async fn real_manifest_mochi_refuses_an_unadvertised_fps_and_defaults_to_its_own_30() {
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    // The real binary seeds these at startup (`server.rs`); `create_app` does not, so a test that
+    // skipped this would resolve mochi_1 to `{}` — no menu, everything admitted — and assert nothing.
+    sceneworks_core::builtin_manifests::seed_builtin_manifests(
+        &settings.config_dir,
+        sceneworks_core::builtin_manifests::SeedMode::Overwrite,
+    )
+    .expect("builtin manifests seed");
+
+    let app = create_app(settings).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Real Manifest Fps Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+
+    // The story's headline case: a LEGALLY 5-second request — sc-12297's cap admits it — that still
+    // asks for 301 frames because fps multiplies into length.
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_video",
+            "prompt": "a fox runs",
+            "model": "mochi_1",
+            "duration": 5,
+            "fps": 60
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "mochi_1 advertises 30 fps only; 5s @ 60fps is 301 frames from a legal 5s request: {body}"
+    );
+    let detail = body["detail"].as_str().unwrap_or_default();
+    assert!(detail.contains("mochi_1"), "names the model: {detail}");
+    // `renders at 30 fps` in full, NOT `contains("30 fps")` — the latter is also a substring of
+    // "24, 25, or 30 fps", so it would pass against a mochi entry advertising three rates and pin
+    // nothing about the shipped `[30]`.
+    assert!(
+        detail.contains("renders at 30 fps"),
+        "states mochi's real menu — exactly one rate: {detail}"
+    );
+    assert!(detail.contains("60 fps"), "states what was asked: {detail}");
+
+    // THE DISCRIMINATOR for the shipped bytes: 25 fps. It is the blanket the DTO used to apply, and
+    // it is off mochi's real `[30]` menu — so this is red both if mochi's manifest ever re-advertises
+    // 25 and if the blanket ever comes back. `fps: 60` above cannot pin either: it is off-menu under
+    // any plausible mochi menu.
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_video",
+            "prompt": "a fox runs",
+            "model": "mochi_1",
+            "duration": 5,
+            "fps": 25
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "mochi_1 renders at 30 only; 25 is the old blanket and must be refused, not snapped: {body}"
+    );
+
+    // THE LIVE BUG THIS CLOSES: `generate_video(model = "mochi_1", duration = 5)` — the natural MCP
+    // call, which omits fps entirely. It used to enqueue 25 fps (the blanket), rendering a 30 fps
+    // motion prior 20% slow at 127 frames. It must now record mochi's own declared 30.
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_video",
+            "prompt": "a fox runs",
+            "model": "mochi_1",
+            "duration": 5
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "omitting fps is an ordinary request and must be admitted: {body}"
+    );
+    assert_eq!(
+        body["payload"]["fps"], 30,
+        "the enqueued payload records mochi's declared 30, not the old blanket 25: {body}"
+    );
+
+    // And every rate the real manifest advertises for a model with a real CHOICE is admitted, so
+    // the gate matches the shipped dropdown rather than merely rejecting things.
+    for fps in [24, 25, 30] {
+        let (status, body) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/video/jobs",
+            json!({
+                "projectId": project_id,
+                "mode": "text_to_video",
+                "prompt": "a fox runs",
+                "model": "ltx_2_3",
+                "duration": 4,
+                "fps": fps
+            }),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::CREATED,
+            "ltx_2_3 advertises {fps} fps in the shipped manifest: {body}"
+        );
+        assert_eq!(body["payload"]["fps"], fps);
+    }
+}

--- a/crates/sceneworks-core/src/payload_util.rs
+++ b/crates/sceneworks-core/src/payload_util.rs
@@ -63,11 +63,12 @@ pub(crate) fn optional_i64(payload: &JsonObject, key: &str) -> Option<i64> {
     })
 }
 
-/// Parse an int (JSON number or numeric string), clamp to `[min, max]`, default when
-/// absent/unparseable — the `safe_int` contract. Takes the raw `Option<&Value>` so both
-/// the `payload.get(key)` (image) and pre-fetched `payload.get("width")` (video) call
-/// sites share one primitive.
-pub(crate) fn clamped_u32(value: Option<&Value>, default: u32, min: u32, max: u32) -> u32 {
+/// The `safe_int` READ with no default applied: a JSON number or a numeric string, `None` when
+/// absent or unparseable. Split out of [`clamped_u32`] so a caller whose default is not a constant
+/// can tell "the caller named nothing" from "the caller named a value" — video's fps resolves an
+/// omission from the model's declared `defaults.fps`, which [`clamped_u32`]'s eager `unwrap_or`
+/// collapses (sc-12347).
+pub(crate) fn parse_u32(value: Option<&Value>) -> Option<u32> {
     value
         .and_then(|value| {
             value
@@ -75,8 +76,14 @@ pub(crate) fn clamped_u32(value: Option<&Value>, default: u32, min: u32, max: u3
                 .or_else(|| value.as_str()?.trim().parse().ok())
         })
         .and_then(|value| u32::try_from(value).ok())
-        .unwrap_or(default)
-        .clamp(min, max)
+}
+
+/// Parse an int (JSON number or numeric string), clamp to `[min, max]`, default when
+/// absent/unparseable — the `safe_int` contract. Takes the raw `Option<&Value>` so both
+/// the `payload.get(key)` (image) and pre-fetched `payload.get("width")` (video) call
+/// sites share one primitive.
+pub(crate) fn clamped_u32(value: Option<&Value>, default: u32, min: u32, max: u32) -> u32 {
+    parse_u32(value).unwrap_or(default).clamp(min, max)
 }
 
 /// Collect a JSON int array (numbers or numeric strings), dropping non-numeric entries.

--- a/crates/sceneworks-core/src/video_request.rs
+++ b/crates/sceneworks-core/src/video_request.rs
@@ -20,7 +20,7 @@ use serde_json::Value;
 use crate::contracts::JsonObject;
 use crate::payload_util::{
     array_or_empty, clamped_u32, nonempty_string_or, object_or_empty, optional_i64, optional_id,
-    string_list,
+    parse_u32, string_list,
 };
 
 /// Defaults matching the Python `video_request_from_job` (`.get(key, default)`).
@@ -46,6 +46,16 @@ pub struct VideoRequest {
     /// that function for why this parse is the wrong home for it (sc-12297).
     pub duration: f32,
     /// Frames per second, clamped to 1..=60 (Python `safe_int`).
+    ///
+    /// An **omitted** fps resolves to the model's declared `defaults.fps` rather than the blanket
+    /// 25 — see [`resolve_fps`]. That blanket is out of menu for 7 of the 10 shipped video models,
+    /// so it silently rendered them off-spec (mochi at 25 instead of 30 plays a 30 fps prior 20%
+    /// slow) and would make [`fps_limit_error`] reject requests that name no fps at all.
+    ///
+    /// A value the caller *did* name is clamped here but never rewritten onto the model's menu:
+    /// `limits.fps` is enforced as a *rejection* by [`fps_limit_error`] at the API and worker
+    /// gates, because fps multiplies into `frames = duration × fps` and snapping it would silently
+    /// change the clip length asked for (sc-12347).
     pub fps: u32,
     /// Output dimensions: clamped to 256..=1920, floored to the model's dimension
     /// granularity — `model_manifest_entry.limits.requiresDimensionsMultipleOf`, default
@@ -119,7 +129,7 @@ impl VideoRequest {
             negative_prompt: nonempty_string_or(payload, "negativePrompt", ""),
             model: nonempty_string_or(payload, "model", DEFAULT_MODEL),
             duration: safe_float(payload.get("duration"), 6.0, 1.0, 30.0),
-            fps: clamped_u32(payload.get("fps"), 25, 1, 60),
+            fps: resolve_fps(payload.get("fps"), &model_manifest_entry),
             width,
             height,
             quality: nonempty_string_or(payload, "quality", DEFAULT_QUALITY),
@@ -286,6 +296,148 @@ pub fn duration_limit_error(
         format!(
             "{model} renders clips up to {cap}s, but this request asks for {duration}s. Shorten \
              the clip to {cap}s or less, or choose a model that renders longer clips."
+        )
+    })
+}
+
+/// The frame rate used when neither the caller nor the model's manifest entry names one — the
+/// historical blanket default, kept for models that declare no `defaults.fps` so an undeclared
+/// model is byte-identical to before [`default_fps`] had a reader.
+const DEFAULT_FPS: u32 = 25;
+
+/// The payload-sanity bounds on fps (the Python `safe_int`). NOT a model's limit: that is
+/// [`allowed_fps`]. Values outside this are a nonsense payload rather than an off-menu request,
+/// so they clamp here and the model's menu judges the result.
+const MIN_FPS: u32 = 1;
+const MAX_FPS: u32 = 60;
+
+/// `defaults.fps` from a resolved manifest entry, or `None` when the model declares none.
+///
+/// The third dead manifest key epic 12334 revives, and the one that makes [`fps_limit_error`]
+/// shippable at all. `dto.rs`'s `default_video_fps` is a blanket **25** that no model chose, and
+/// the MCP server omits `fps` entirely when its caller does — so "the caller said nothing" has
+/// always resolved to 25 regardless of what the model declares. That is out of menu for **7 of 10**
+/// shipped video models (every `[16]` model, `wan_2_2`'s `[16, 24]`, and mochi's `[30]`), which
+/// means an fps allowlist alone would reject the API's *own default* on a request that merely
+/// omits the field (sc-12347).
+///
+/// It is also a live bug on its own, with no odd input required: an MCP `generate_video(model =
+/// "mochi_1", duration = 5)` resolves to 25 fps, not mochi's declared 30, so `5 × 25 = 125` snaps
+/// to 127 frames — `127 % 6 == 1`, so the engine accepts it — and a 30 fps motion prior plays back
+/// 20% slow. Exactly the harm mochi's own manifest comment predicts. The web never had this
+/// problem because `VideoStudio.jsx:223` reads `defaults.fps`; only the backend ignored it.
+///
+/// Same never-invent-a-constraint-from-a-typo posture as [`hard_max_duration`] / [`max_pixels_of`]:
+/// a default outside [`MIN_FPS`]`..=`[`MAX_FPS`] is not a frame rate anyone could have meant, so it
+/// falls back to [`DEFAULT_FPS`] rather than propagating a degenerate value into the frame count.
+pub fn default_fps(model_manifest_entry: &JsonObject) -> Option<u32> {
+    model_manifest_entry
+        .get("defaults")
+        .and_then(Value::as_object)
+        .and_then(|defaults| defaults.get("fps"))
+        .and_then(Value::as_u64)
+        .filter(|fps| (u64::from(MIN_FPS)..=u64::from(MAX_FPS)).contains(fps))
+        .map(|fps| fps as u32)
+}
+
+/// `limits.fps` — the discrete set of frame rates a model advertises — or `None` for **no menu**,
+/// meaning any fps the blanket [`MIN_FPS`]`..=`[`MAX_FPS`] bound allows.
+///
+/// Unlike [`hard_max_duration`]'s scalar ceiling this is an **allowlist**, so the comparison is
+/// membership rather than `>`. It had ten declarations and zero *Rust* readers (sc-12347) while
+/// the web bounded the picker with it at `VideoStudio.jsx:599/912` and `PresetManagerScreen.jsx`
+/// already refused to *save* an off-menu fps via `checkInMenu` — so the product treated this key as
+/// binding everywhere except the backend that actually renders.
+///
+/// Absent ⇒ no menu, so a model that declares nothing is byte-identical to before this key had a
+/// reader. An array with no usable entry (empty, or every value non-integer / out of the sanity
+/// bounds) is likewise **no menu**: a menu nothing can satisfy would reject every request including
+/// the model's own `defaults.fps`, which is a typo'd manifest bricking a model rather than a
+/// constraint. Same fallback as an unhonorable `hardMaxDuration` or `maxPixels`.
+pub fn allowed_fps(model_manifest_entry: &JsonObject) -> Option<Vec<u32>> {
+    let menu: Vec<u32> = model_manifest_entry
+        .get("limits")
+        .and_then(Value::as_object)
+        .and_then(|limits| limits.get("fps"))
+        .and_then(Value::as_array)?
+        .iter()
+        .filter_map(Value::as_u64)
+        .filter(|fps| (u64::from(MIN_FPS)..=u64::from(MAX_FPS)).contains(fps))
+        .map(|fps| fps as u32)
+        .collect();
+    (!menu.is_empty()).then_some(menu)
+}
+
+/// The fps a payload actually renders at: the caller's value clamped to the sanity bounds, or —
+/// when the caller named none — the model's declared [`default_fps`], falling back to the blanket
+/// [`DEFAULT_FPS`].
+///
+/// **Resolution, not rejection**, which is why it belongs in [`VideoRequest::from_payload`] (whose
+/// infallibility [`fps_limit_error`] must not disturb) next to [`normalized_dimensions`] — the
+/// established precedent for consulting the manifest entry during the parse. Filling an omitted
+/// field from the model's own declaration is not coercion: nothing the caller asked for is being
+/// overridden, and the alternative is the blanket 25 that silently renders 7 of 10 models off-spec.
+/// A value the caller *did* name is never rewritten — it is clamped and then judged by
+/// [`fps_limit_error`], so an off-menu fps is refused rather than quietly snapped onto the menu
+/// (the reject-never-clamp rule [`duration_limit_error`] states).
+///
+/// Reads through [`parse_u32`], so the `safe_int` contract is unchanged: a numeric **string**
+/// (`"30"`) is a value the caller named, not an omission. An unparseable / `null` fps IS treated as
+/// absent — a value core cannot read is not a value the caller named. The API never produces one
+/// (serde types the field), so that only governs hand-written worker payloads.
+pub fn resolve_fps(requested: Option<&Value>, model_manifest_entry: &JsonObject) -> u32 {
+    parse_u32(requested)
+        .unwrap_or_else(|| default_fps(model_manifest_entry).unwrap_or(DEFAULT_FPS))
+        .clamp(MIN_FPS, MAX_FPS)
+}
+
+/// The advertised frame rates as a human list: `30`, `16 or 24`, `6, 7, 8, 10, 12, or 25`.
+fn humanized_fps_menu(menu: &[u32]) -> String {
+    match menu {
+        [only] => only.to_string(),
+        [first, second] => format!("{first} or {second}"),
+        [rest @ .., last] => format!(
+            "{}, or {last}",
+            rest.iter()
+                .map(u32::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        [] => String::new(),
+    }
+}
+
+/// The actionable rejection for an `fps` outside the model's declared [`allowed_fps`], or `None` to
+/// admit. The pure decision, so both enqueue gates assert on one message (sc-12347).
+///
+/// **Reject, never clamp**, for [`duration_limit_error`]'s reason and one of its own: fps is the
+/// other multiplier in `frames = duration × fps`, so silently snapping 60 onto mochi's 30 would
+/// halve the clip the caller asked for. sc-12297's duration cap does not bound frames — a *legally
+/// 5-second* mochi request at 60 fps is 301 frames, double the shipped default's 151, and
+/// `301 % 6 == 1` clears the engine's own check.
+///
+/// The gate is **uniform**, deliberately. svd's fps is pacing-only (its manifest says duration only
+/// sets playback pacing), so an off-menu fps there does not multiply into length and is a weaker
+/// harm than mochi's. Keying the gate on "does fps drive frame count" would hardcode family
+/// knowledge into the gate — the exact anti-pattern epic 12334 exists to remove. The manifest is
+/// the seam: a model that renders at more rates declares them, and one that renders at any rate
+/// omits the key.
+///
+/// ⚠️ This bounds frames only as far as the *contract* goes — with sc-12297 it pins mochi at
+/// `hardMaxDuration × max(limits.fps) = 5 × 30 → 151` frames, which is still ~4× past the ~36-frame
+/// correctness ceiling MLX's `i32::MAX` element limit imposes (sc-12349). Honoring what a model
+/// advertises is not a safety gate; do not read it as one.
+///
+/// Message follows the house convention (`mlx_fit_gate::too_big_error`): name the model, state what
+/// was asked and what is allowed, and give the lever. Pinned by
+/// `fps_limit_error_names_the_model_the_request_and_the_menu`.
+pub fn fps_limit_error(model: &str, fps: u32, model_manifest_entry: &JsonObject) -> Option<String> {
+    let menu = allowed_fps(model_manifest_entry)?;
+    (!menu.contains(&fps)).then(|| {
+        let allowed = humanized_fps_menu(&menu);
+        format!(
+            "{model} renders at {allowed} fps, but this request asks for {fps} fps. Set fps to \
+             {allowed}, or choose a model that renders at {fps} fps."
         )
     })
 }
@@ -1081,6 +1233,401 @@ mod tests {
         assert_eq!(hard_max_duration(&fractional), Some(2.5));
         assert!(duration_limit_error("m", 3.0, &fractional).is_some());
         assert_eq!(duration_limit_error("m", 2.5, &fractional), None);
+    }
+
+    /// sc-12347 — the fps axis of the same invariant, derived from the shipped `limits.fps` menus
+    /// and the `defaults.fps` each model declares. `THE_BLANKET_FPS` is the value `dto.rs` used to
+    /// default to; it is listed here so assertion 5 can prove *why* [`resolve_fps`] must consult
+    /// the manifest, rather than that claim living only in a comment.
+    const FPS_MENUS: &[(&str, &[u32], u32)] = &[
+        ("ltx_2_3", &[24, 25, 30], 25),
+        ("ltx_2_3_eros", &[24, 25, 30], 25),
+        ("svd", &[6, 7, 8, 10, 12, 25], 7),
+        ("mochi_1", &[30], 30),
+        ("wan_2_2", &[16, 24], 24),
+        ("wan_2_2_t2v_14b", &[16], 16),
+        ("wan_2_2_i2v_14b", &[16], 16),
+        ("wan_2_2_vace_fun_14b", &[16], 16),
+        ("bernini", &[16], 16),
+        ("scail2_14b", &[16], 16),
+    ];
+
+    /// The fps the API blanket-defaulted to before sc-12347, kept as a named constant because the
+    /// point of assertion 5 is that this number is *wrong for most models* — deleting the constant
+    /// would delete the regression guard.
+    const THE_BLANKET_FPS: u32 = 25;
+
+    /// sc-12347 — the temporal invariant's other half: **what a video model advertises is what it
+    /// renders**, on the axis that actually multiplies into frame count.
+    ///
+    /// Same four-part skeleton as `shipped_manifest_duration_caps_admit_everything_they_advertise`,
+    /// against the REAL manifest bytes for the same reason: `limits.fps` spent its whole existence
+    /// with ten declarations and zero Rust readers, so a suite that hardcoded the menus it claims to
+    /// check would re-test `Vec::contains` and notice nothing.
+    #[test]
+    fn shipped_manifest_fps_menus_admit_everything_they_advertise() {
+        let models = builtin_video_models();
+        assert_eq!(
+            models.len(),
+            FPS_MENUS.len(),
+            "a video model was added/removed; declare its limits.fps + defaults.fps and add it to \
+             FPS_MENUS — an undeclared menu is silently NO menu"
+        );
+
+        for (id, want_menu, want_default) in FPS_MENUS {
+            let entry = models
+                .iter()
+                .find(|m| m.get("id").and_then(Value::as_str) == Some(*id))
+                .unwrap_or_else(|| panic!("{id} present in builtin.models.jsonc"))
+                .as_object()
+                .expect("model entry object");
+
+            // 1. Every video model DECLARES a menu, and core reads exactly it. `None` here is the
+            //    sc-12347 bug itself — an absent menu means "any fps", which is how a 60 fps
+            //    request reached a model that advertises only 30.
+            assert_eq!(
+                allowed_fps(entry),
+                Some(want_menu.to_vec()),
+                "{id}: effective fps menu"
+            );
+
+            // 2. FIXED POINT: the model's own declared default is on its own menu. This is the
+            //    assertion the story asks for, and it is what makes `resolve_fps` safe — resolving
+            //    an omitted fps from `defaults.fps` must never produce a value this gate refuses.
+            assert_eq!(
+                default_fps(entry),
+                Some(*want_default),
+                "{id}: effective default fps"
+            );
+            assert!(
+                want_menu.contains(want_default),
+                "{id}: defaults.fps {want_default} must be on its own limits.fps menu {want_menu:?}"
+            );
+
+            // 3. Every advertised rate is ADMITTED — the menu IS the web's dropdown source
+            //    (`VideoStudio.jsx:912`), so anything the picker can emit must pass the gate.
+            for advertised in want_menu.iter().copied().chain([*want_default]) {
+                assert_eq!(
+                    fps_limit_error(id, advertised, entry),
+                    None,
+                    "{id} advertises {advertised} fps; the menu must admit it"
+                );
+            }
+
+            // 4. MUTATION CHECK: the menu actually rejects something. Assertions 1-3 all pass if
+            //    `allowed_fps` returns `None` (the shipped bug) or the membership test is neutered.
+            //    61 is past the blanket sanity bound, so it is off EVERY shipped menu.
+            let off_menu = 61;
+            assert!(
+                !want_menu.contains(&off_menu),
+                "{id}: fixture assumes {off_menu} is off-menu"
+            );
+            let message = fps_limit_error(id, off_menu, entry)
+                .unwrap_or_else(|| panic!("{id}: {off_menu} fps is off-menu and must be rejected"));
+            assert!(message.contains(id), "{id}: names the model: {message}");
+
+            // 5. THE REASON `resolve_fps` READS THE MANIFEST: a payload that names NO fps must
+            //    resolve to a rate this model's own menu admits. Enforcing `limits.fps` while
+            //    defaulting to a blanket the menu rejects would 400 the API's own default — which
+            //    is exactly what the pre-sc-12347 blanket did on 7 of these 10 models.
+            let resolved = resolve_fps(None, entry);
+            assert_eq!(
+                resolved, *want_default,
+                "{id}: omitted fps takes the model's default"
+            );
+            assert_eq!(
+                fps_limit_error(id, resolved, entry),
+                None,
+                "{id}: an fps-less payload must be ADMITTED, not rejected"
+            );
+        }
+
+        // The blanket the DTO used to apply is off-menu for a MAJORITY of shipped models — the
+        // finding that made "enforce limits.fps" unshippable on its own. Pinned as a number rather
+        // than prose so re-introducing a blanket default fails here.
+        let rejecting_the_blanket: Vec<&str> = FPS_MENUS
+            .iter()
+            .filter(|(_, menu, _)| !menu.contains(&THE_BLANKET_FPS))
+            .map(|(id, _, _)| *id)
+            .collect();
+        assert_eq!(
+            rejecting_the_blanket.len(),
+            7,
+            "the blanket {THE_BLANKET_FPS} fps is off-menu for these models: {rejecting_the_blanket:?} \
+             — if this count moved, re-read why resolve_fps consults defaults.fps before changing it"
+        );
+    }
+
+    /// sc-12347 + sc-12297 together — **the frame ceiling the story's Option B would have built
+    /// explicitly, obtained for free as a derived property.**
+    ///
+    /// Neither gate bounds frames alone: the duration cap admits 5s @ 60fps (301 mochi frames), and
+    /// the fps menu admits 30fps @ 30s (901). Together they pin `frames ≤ hardMaxDuration ×
+    /// max(limits.fps)` for every shipped model, which is exactly B's ceiling — so A subsumes B
+    /// rather than trading against it.
+    ///
+    /// ⚠️ This is a CONTRACT bound, NOT a safety gate. Mochi's 151 is still ~4× past the ~36-frame
+    /// correctness ceiling that MLX's `i32::MAX` element limit imposes (sc-12349), and no amount of
+    /// honoring the manifest closes that — see `mlx-gen-mochi`'s `MAX_TENSOR_ELEMS`.
+    #[test]
+    fn the_two_gates_together_bound_frames_at_the_advertised_ceiling() {
+        let models = builtin_video_models();
+
+        for (id, menu, _) in FPS_MENUS {
+            let entry = models
+                .iter()
+                .find(|m| m.get("id").and_then(Value::as_str) == Some(*id))
+                .unwrap_or_else(|| panic!("{id} present"))
+                .as_object()
+                .expect("model entry object");
+            let cap = hard_max_duration(entry).unwrap_or_else(|| panic!("{id} declares a cap"));
+            let fastest = menu.iter().copied().max().expect("non-empty menu");
+            let ceiling = (cap * fastest as f32).round() as u32;
+
+            // Anything BOTH gates admit lands at or under the derived ceiling.
+            for fps in menu.iter() {
+                let request = VideoRequest::from_payload(&payload(json!({
+                    "projectId": "p", "model": id, "duration": cap, "fps": fps,
+                    "modelManifestEntry": Value::Object(entry.clone()),
+                })));
+                assert_eq!(duration_limit_error(id, request.duration, entry), None);
+                assert_eq!(fps_limit_error(id, request.fps, entry), None);
+                assert!(
+                    request.raw_frame_count() <= ceiling,
+                    "{id}: {cap}s @ {fps}fps = {} raw frames, past the advertised ceiling {ceiling}",
+                    request.raw_frame_count()
+                );
+            }
+
+            // MUTATION CHECK: the ceiling binds because BOTH gates hold. Drop either one and the
+            // frame count blows past it — which is the whole argument for this story existing
+            // alongside sc-12297.
+            let over_fps = VideoRequest::from_payload(&payload(json!({
+                "projectId": "p", "model": id, "duration": cap, "fps": 60,
+                "modelManifestEntry": Value::Object(entry.clone()),
+            })));
+            if fastest < 60 {
+                assert!(
+                    over_fps.raw_frame_count() > ceiling,
+                    "{id}: 60fps must exceed the ceiling for this test to mean anything"
+                );
+                assert!(
+                    fps_limit_error(id, over_fps.fps, entry).is_some(),
+                    "{id}: only the FPS gate refuses {cap}s @ 60fps — the duration cap admits it"
+                );
+                assert_eq!(
+                    duration_limit_error(id, over_fps.duration, entry),
+                    None,
+                    "{id}: the duration cap admits this request; it is legally {cap}s"
+                );
+            }
+        }
+
+        // The concrete case from the story: mochi_1, a *legally 5-second* request at 60fps.
+        let mochi = payload(json!({
+            "limits": { "hardMaxDuration": 5, "fps": [30] }, "defaults": { "fps": 30 }
+        }));
+        let request = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "model": "mochi_1", "duration": 5, "fps": 60,
+            "modelManifestEntry": Value::Object(mochi.clone()),
+        })));
+        assert_eq!(request.raw_frame_count(), 300);
+        assert_eq!(
+            request.frame_count(),
+            301,
+            "301 % 6 == 1, so the engine accepts it"
+        );
+        assert_eq!(
+            duration_limit_error("mochi_1", request.duration, &mochi),
+            None,
+            "the request IS 5 seconds — sc-12297's cap is doing exactly what it says"
+        );
+        assert!(
+            fps_limit_error("mochi_1", request.fps, &mochi).is_some(),
+            "301 frames from a legal 5s request is refused only by the fps menu"
+        );
+
+        // …and the shipped default is the documented 151.
+        let default_request = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "model": "mochi_1", "duration": 5,
+            "modelManifestEntry": Value::Object(mochi),
+        })));
+        assert_eq!(
+            default_request.fps, 30,
+            "omitted fps takes mochi's declared 30"
+        );
+        assert_eq!(default_request.frame_count(), 151);
+    }
+
+    /// The house message convention: name the model, state what was asked and what is allowed, and
+    /// give the lever. A caller that hits this has no other signal — the request simply stops.
+    #[test]
+    fn fps_limit_error_names_the_model_the_request_and_the_menu() {
+        let mochi = payload(json!({ "limits": { "fps": [30] } }));
+        let message = fps_limit_error("mochi_1", 60, &mochi).expect("60 is off mochi's [30] menu");
+        assert!(message.contains("mochi_1"), "names the model: {message}");
+        assert!(
+            message.contains("30 fps"),
+            "states what is allowed: {message}"
+        );
+        assert!(
+            message.contains("60 fps"),
+            "states what was asked: {message}"
+        );
+        assert!(message.contains("Set fps to"), "gives the lever: {message}");
+
+        // Every advertised rate admits; anything else is refused — membership, not a range. 24 and
+        // 30 bracket 25, so a `>=`/`<=` mutation of the check cannot pass this.
+        let ltx = payload(json!({ "limits": { "fps": [24, 25, 30] } }));
+        for advertised in [24, 25, 30] {
+            assert_eq!(fps_limit_error("ltx_2_3", advertised, &ltx), None);
+        }
+        for off_menu in [23, 26, 29, 31] {
+            assert!(
+                fps_limit_error("ltx_2_3", off_menu, &ltx).is_some(),
+                "{off_menu} is between/around advertised rates but is not one of them"
+            );
+        }
+
+        // The menu is humanized per arity: one value, two values, and a long list each read as
+        // English rather than as a debug-printed Vec.
+        assert!(
+            fps_limit_error("m", 1, &payload(json!({ "limits": { "fps": [30] } })))
+                .expect("off-menu")
+                .contains("renders at 30 fps")
+        );
+        assert!(
+            fps_limit_error("m", 1, &payload(json!({ "limits": { "fps": [16, 24] } })))
+                .expect("off-menu")
+                .contains("renders at 16 or 24 fps")
+        );
+        assert!(fps_limit_error(
+            "m",
+            1,
+            &payload(json!({ "limits": { "fps": [6, 7, 8, 10, 12, 25] } }))
+        )
+        .expect("off-menu")
+        .contains("renders at 6, 7, 8, 10, 12, or 25 fps"));
+    }
+
+    /// A model that declares no menu is UNCONSTRAINED — the default-absent behavior that keeps
+    /// every non-declaring model (a user-manifest entry, the stub lane, an uncatalogued id whose
+    /// entry resolves to `{}`) byte-identical to before the key had a reader.
+    ///
+    /// Also the infallibility contract: a menu nobody could satisfy falls back to NO menu rather
+    /// than bricking the model. An empty array, or one whose every entry is unusable, would
+    /// otherwise reject every request the model has — including its own `defaults.fps`.
+    #[test]
+    fn absent_or_unhonorable_limits_fps_means_no_menu() {
+        for empty in [json!({}), json!({ "limits": {} })] {
+            let entry = payload(empty.clone());
+            assert_eq!(allowed_fps(&entry), None, "no menu declared: {empty}");
+            assert_eq!(fps_limit_error("any_model", 60, &entry), None);
+        }
+
+        for bad in [
+            json!([]),
+            json!(30),
+            json!("30"),
+            json!(null),
+            json!({ "min": 30 }),
+        ] {
+            let entry = payload(json!({ "limits": { "fps": bad } }));
+            assert_eq!(allowed_fps(&entry), None, "unhonorable menu {bad}");
+            assert_eq!(
+                fps_limit_error("any_model", 60, &entry),
+                None,
+                "an unsatisfiable menu must not brick the model: {bad}"
+            );
+        }
+
+        // A menu whose every entry is out of the sanity bounds is no menu at all — but a menu with
+        // ONE usable entry keeps that entry and drops the junk, rather than falling back to
+        // unconstrained. Dropping junk is not the same decision as having no menu.
+        let all_junk = payload(json!({ "limits": { "fps": [0, 61, "30", null] } }));
+        assert_eq!(allowed_fps(&all_junk), None);
+        assert_eq!(fps_limit_error("m", 60, &all_junk), None);
+
+        let partly_junk = payload(json!({ "limits": { "fps": [0, 30, 999] } }));
+        assert_eq!(allowed_fps(&partly_junk), Some(vec![30]));
+        assert_eq!(fps_limit_error("m", 30, &partly_junk), None);
+        assert!(fps_limit_error("m", 24, &partly_junk).is_some());
+    }
+
+    /// [`resolve_fps`] — resolution, not coercion. An omitted fps takes the model's declared
+    /// default; a NAMED fps is never rewritten onto the menu, only clamped to the sanity bounds and
+    /// then judged by [`fps_limit_error`].
+    ///
+    /// The named-value half is the reject-never-clamp rule: silently snapping a 60 fps request onto
+    /// mochi's 30 would halve the clip the caller asked for, which is the same silent-coercion class
+    /// as the 848→832 rewrite.
+    #[test]
+    fn omitted_fps_resolves_to_the_models_declared_default() {
+        let mochi = payload(json!({ "limits": { "fps": [30] }, "defaults": { "fps": 30 } }));
+
+        // Omitted / unreadable ⇒ the model's declared default, NOT the blanket 25. Asserted
+        // against a menu whose default (30) differs from the blanket, so a `resolve_fps` that
+        // ignored the manifest would be RED here rather than coincidentally right.
+        assert_eq!(resolve_fps(None, &mochi), 30);
+        assert_eq!(resolve_fps(Some(&json!(null)), &mochi), 30);
+        assert_eq!(resolve_fps(Some(&json!("nonsense")), &mochi), 30);
+
+        // A numeric STRING is a value the caller NAMED, not an omission — the pre-existing
+        // `safe_int` contract (`reads_numeric_strings_and_carries_advanced_fields`). Pinned with 24,
+        // which is neither the blanket nor this model's default, so falling back to either is RED.
+        assert_eq!(resolve_fps(Some(&json!("24")), &mochi), 24);
+        assert!(
+            fps_limit_error("mochi_1", 24, &mochi).is_some(),
+            "and it is then judged by the menu like any named value"
+        );
+
+        // Named ⇒ honored verbatim, even when off-menu. The gate refuses it; resolution does not
+        // quietly fix it up.
+        assert_eq!(resolve_fps(Some(&json!(60)), &mochi), 60);
+        assert!(fps_limit_error("mochi_1", 60, &mochi).is_some());
+
+        // Named-but-nonsense clamps to the sanity bounds (unchanged behavior), then the menu judges.
+        assert_eq!(resolve_fps(Some(&json!(999)), &mochi), 60);
+        assert_eq!(resolve_fps(Some(&json!(0)), &mochi), 1);
+
+        // No declared default ⇒ the blanket, so a model that declares nothing is unchanged.
+        let bare = payload(json!({}));
+        assert_eq!(resolve_fps(None, &bare), THE_BLANKET_FPS);
+        assert_eq!(default_fps(&bare), None);
+
+        // An unhonorable default is not a rate anyone meant ⇒ the blanket, rather than propagating
+        // a degenerate value into `frames = duration × fps`.
+        for bad in [json!(0), json!(61), json!(-1), json!("30"), json!(null)] {
+            let entry = payload(json!({ "defaults": { "fps": bad } }));
+            assert_eq!(default_fps(&entry), None, "unhonorable default {bad}");
+            assert_eq!(resolve_fps(None, &entry), THE_BLANKET_FPS);
+        }
+
+        // The live bug this closes, end to end: mochi at the blanket renders a 30fps prior 20% slow.
+        let before = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "model": "mochi_1", "duration": 5,
+            "modelManifestEntry": json!({ "limits": { "fps": [30] } }),
+        })));
+        assert_eq!(
+            before.fps, THE_BLANKET_FPS,
+            "no declared default ⇒ the old behavior"
+        );
+        assert_eq!(
+            before.frame_count(),
+            127,
+            "5 × 25 = 125 → 127, and 127 % 6 == 1"
+        );
+
+        let after = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p", "model": "mochi_1", "duration": 5,
+            "modelManifestEntry": Value::Object(mochi),
+        })));
+        assert_eq!(after.fps, 30, "the declared default is honored");
+        assert_eq!(
+            after.frame_count(),
+            151,
+            "the frame count the manifest documents"
+        );
     }
 
     /// sc-12294 BLOCKER — the case the dropdown never produces but every raw path does.

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -20,7 +20,9 @@
 use std::f32::consts::PI;
 use std::path::Path;
 
-use sceneworks_core::video_request::{duration_limit_error, is_ltx_model, VideoRequest};
+use sceneworks_core::video_request::{
+    duration_limit_error, fps_limit_error, is_ltx_model, VideoRequest,
+};
 
 // Used only by the video generation metrics builders below, which are themselves
 // gated to the macOS / backend-candle lanes (the shared `generate_video` funnel) —
@@ -320,6 +322,21 @@ fn video_preflight(request: &VideoRequest) -> WorkerResult<()> {
         request.duration,
         &request.model_manifest_entry,
     ) {
+        return Err(WorkerError::InvalidPayload(message));
+    }
+    // The model's declared `limits.fps`. NOT redundant with the duration cap above — they bound
+    // different axes, and the cost/quality axis is `frames = duration × fps`, which only both
+    // together bound. A *legally 5-second* mochi_1 request (cap 5 ✓) at 60 fps is 301 frames,
+    // double the shipped 5s default's 151, and `301 % 6 == 1` clears the engine's own check, so
+    // nothing downstream says no (sc-12347).
+    //
+    // `request.fps` is already resolved against the model's `defaults.fps` by `from_payload`, so a
+    // payload that names no fps is judged on the value the model itself declares — not the blanket
+    // 25, which is off-menu for 7 of the 10 shipped video models and would make this gate reject
+    // every fps-less payload.
+    if let Some(message) =
+        fps_limit_error(&request.model, request.fps, &request.model_manifest_entry)
+    {
         return Err(WorkerError::InvalidPayload(message));
     }
     Ok(())
@@ -10796,6 +10813,100 @@ mod tests {
             video_preflight(&no_project),
             Err(WorkerError::InvalidPayload(m)) if m.contains("projectId")
         ));
+    }
+
+    /// sc-12347: the same backstop on the fps axis — refuses a rate the model does not advertise,
+    /// and admits a payload that names no rate at all.
+    ///
+    /// Kills the same class of mutation: deleting the `fps_limit_error` call from `video_preflight`
+    /// leaves every core test green, because the core function is still correct — just not CALLED.
+    ///
+    /// Ungated for the same reason as the duration test: `mochi_preflight`'s fit gate is macOS-only
+    /// AND is a *memory* test, so it cannot refuse an off-spec-but-affordable rate on any lane.
+    #[test]
+    fn video_preflight_refuses_an_fps_the_model_does_not_advertise() {
+        let mochi_entry = json!({
+            "limits": { "hardMaxDuration": 5, "fps": [30] }, "defaults": { "fps": 30 }
+        });
+
+        // The story's shape: a request that is LEGALLY 5 seconds — sc-12297's cap admits it — but
+        // asks for 60fps. 5 x 60 = 300 raw frames snapping to 301, double the shipped default's
+        // 151, and `301 % 6 == 1` so the engine's own validate_request ACCEPTS it. The duration gate
+        // cannot see this; only the fps menu refuses it.
+        let off_menu = request(json!({
+            "projectId": "p", "model": "mochi_1", "mode": "text_to_video", "prompt": "p",
+            "duration": 5, "fps": 60, "modelManifestEntry": mochi_entry
+        }));
+        assert_eq!(off_menu.raw_frame_count(), 300);
+        assert_eq!(
+            off_menu.frame_count(),
+            301,
+            "on-lattice, and the engine would accept it"
+        );
+        assert_eq!(
+            duration_limit_error(
+                &off_menu.model,
+                off_menu.duration,
+                &off_menu.model_manifest_entry
+            ),
+            None,
+            "the duration cap ADMITS this request — it is legally 5 seconds"
+        );
+        let Err(WorkerError::InvalidPayload(message)) = video_preflight(&off_menu) else {
+            panic!("60fps on a model that advertises only 30 must be refused before the load");
+        };
+        assert!(message.contains("mochi_1"), "names the model: {message}");
+        assert!(
+            message.contains("30 fps"),
+            "states what is allowed: {message}"
+        );
+        assert!(
+            message.contains("60 fps"),
+            "states what was asked: {message}"
+        );
+
+        // The model's own advertised rate admits — the shipped default must still run.
+        let on_menu = request(json!({
+            "projectId": "p", "model": "mochi_1", "mode": "text_to_video", "prompt": "p",
+            "duration": 5, "fps": 30, "modelManifestEntry": mochi_entry
+        }));
+        assert!(
+            video_preflight(&on_menu).is_ok(),
+            "30 is what mochi advertises"
+        );
+        assert_eq!(on_menu.frame_count(), 151);
+
+        // THE REGRESSION THIS STORY NEARLY SHIPPED: a payload naming NO fps must be ADMITTED. It
+        // resolves to the model's declared 30, not the blanket 25 — which is off mochi's menu and
+        // would make this gate refuse a perfectly ordinary job (7 of the 10 shipped video models
+        // are in that position, so this is the common case, not an edge).
+        let no_fps = request(json!({
+            "projectId": "p", "model": "mochi_1", "mode": "text_to_video", "prompt": "p",
+            "duration": 5, "modelManifestEntry": mochi_entry
+        }));
+        assert_eq!(
+            no_fps.fps, 30,
+            "resolved from the model's declared defaults.fps"
+        );
+        assert!(
+            video_preflight(&no_fps).is_ok(),
+            "an fps-less payload must not be refused by the menu"
+        );
+        assert_eq!(
+            no_fps.frame_count(),
+            151,
+            "the frame count the manifest documents"
+        );
+
+        // A job carrying no manifest entry is UNCONSTRAINED — never block without a declared menu.
+        let no_entry = request(json!({
+            "projectId": "p", "model": "stub-model", "mode": "text_to_video", "prompt": "p",
+            "duration": 5, "fps": 60
+        }));
+        assert!(
+            video_preflight(&no_entry).is_ok(),
+            "no menu declared => no menu"
+        );
     }
 
     // -----------------------------------------------------------------------------------------


### PR DESCRIPTION
Closes [sc-12347](https://app.shortcut.com/trefry/story/12347). Epic 12334.

## The gap

`limits.fps` had **10 declarations and 0 Rust readers**. The web bounded its picker with it (`VideoStudio.jsx:599/912`) and `PresetManagerScreen.jsx` already refused to *save* an off-menu rate (`checkInMenu`) — so the product treated the key as binding everywhere except the backend that actually renders.

sc-12297 closed the *duration* axis. It does not bound **frames**, and `frames = duration × fps`:

| | |
|---|---|
| `mochi_1` declares | `limits.fps: [30]`, `hardMaxDuration: 5` |
| payload | `duration: 5, fps: 60` |
| `validate_video_job` | ✅ 5 ≤ 30, 60 ≤ 60 |
| sc-12297's cap | ✅ the request **is** 5s |
| result | `5 × 60 = 300` → **301** frames — 2× the default's 151 |
| engine `validate_request` | ✅ `301 % 6 == 1` |

Nothing said no.

## Decision: option A (binding allowlist) + honor `defaults.fps`

Enforced at the two seams sc-12297 established — `create_video_job` → `ApiError::bad_request`, `video_preflight` → `WorkerError::InvalidPayload` — with the pure decision in `sceneworks-core::video_request` beside `duration_limit_error`. **Reject, never clamp**: snapping 60 onto mochi's 30 halves the clip asked for.

**Uniform gate, no per-family branch.** svd's fps is pacing-only, so its harm is weaker — but keying the gate on "does fps drive frame count" would hardcode family knowledge into the gate, the exact anti-pattern epic 12334 exists to remove. The manifest is the seam: a model that renders at more rates declares them; one that renders at any rate omits the key (⇒ uncapped).

## 🔴 Why the story's "zero UI blast radius" was wrong — and why the gate needs a second half

The story argued A is safe because `limits.fps` **is** the dropdown. True for the web. But it never considered **the API's own default**: `dto.rs` defaulted fps to a blanket **25**, and the MCP server **omits the key entirely** when its caller does. 25 is **off-menu for 7 of the 10** shipped video models:

| model | `limits.fps` | `defaults.fps` | blanket 25 admitted? |
|---|---|---|---|
| ltx_2_3 / ltx_2_3_eros | `[24,25,30]` | 25 | yes |
| svd | `[6,7,8,10,12,25]` | 7 | yes |
| **wan_2_2** | `[16,24]` | 24 | **NO → 400** |
| **wan_2_2_{t2v,i2v,vace_fun}_14b** | `[16]` | 16 | **NO → 400** |
| **bernini / scail2_14b** | `[16]` | 16 | **NO → 400** |
| **mochi_1** | `[30]` | 30 | **NO → 400** |

Gating alone would make `create_video_job` **400 a payload it constructed itself**, on the likeliest non-UI call shape.

## 🆕 `defaults.fps` was dead too — and already silently wrong

No Rust read it. So **today, no odd input required**, `generate_video(model="mochi_1", duration=5)`:

- fps ⇒ 25 (the blanket), **not** mochi's declared 30
- `5 × 25 = 125` → snaps to **127** frames; `127 % 6 == 1` ✓ so the engine accepts
- ⇒ a 30 fps motion prior played back **20% slow**, silently

Exactly the harm mochi's own manifest comment at `:7214` predicts — on the **default path**, a likelier harm than the `fps: 60` hypothetical. The web was immune only because `VideoStudio.jsx:223` reads `defaults.fps`.

An omitted fps now resolves from the model's `defaults.fps` (`resolve_fps`, sitting beside `normalized_dimensions` — the established precedent for consulting the manifest entry inside an infallible parse). Resolution ≠ rejection; a value the caller *named* is never rewritten.

**⚠️ Behavior change** — raw API / MCP callers that **omit** fps (UI unaffected): svd 25→7, wan_2_2 25→24, the `[16]` models 25→16, mochi 25→30. Each is the API adopting the value the manifest and dropdown already declare.

## Tests — every one mutation-checked

| Mutation | Result |
|---|---|
| `allowed_fps` → always `None` (the shipped bug) | **5 core tests RED** |
| `resolve_fps` ignores the manifest (old blanket) | **3 core + worker seam RED** |
| delete `fps_limit_error` call from `video_preflight` | core **stays green** (fn still correct, just not *called*), worker **RED** — the sc-11992 dropped-gate shape |
| delete the API gate | API test **RED** |
| gate the **stale DTO model** instead of post-preset | API test **RED** — pins the sc-12300 placement |
| revert mochi's manifest `fps` → `[24,25,30]` | real-manifest test **RED**, fixture test green |

That last mutation caught a **false claim in my own doc comment** on the first pass: `fps: 60` is off-menu under *any* plausible mochi menu, and `"30 fps"` is a substring of `"24, 25, or 30 fps"`, so the test pinned nothing about the shipped `[30]`. The discriminator is **`fps: 25`** — the blanket itself.

Notable tests:
- `shipped_manifest_fps_menus_admit_everything_they_advertise` — real manifest bytes; pins the fixed point (every `defaults.fps` on its own menu) and that the blanket is off-menu for **exactly 7** models.
- `the_two_gates_together_bound_frames_at_the_advertised_ceiling` — A + sc-12297 derive option **B's** `hardMaxDuration × max(limits.fps)` ceiling **for free**, so A subsumes B rather than trading against it.
- `real_manifest_mochi_...` — real bytes through the real route (fixtures prove wiring, not values; the two are complementary).

## ⚠️ NOT a safety gate

Both gates pin mochi's frames at `5 × 30 → 151`. Per [sc-12349](https://app.shortcut.com/trefry/story/12349) the **correctness** ceiling is **~36 frames** (MLX silently wrong above `i32::MAX` elements/tensor). 151 is still **~4× past it**. This honors the *contract*; `MAX_TENSOR_ELEMS` is sc-12349's job.

## Verification

- `npm run rust:check` — exit 0, 21 suites
- **parity lane** (Linux, default features): `cargo clippy --all-targets -D warnings` — exit 0
- **candle-worker lane** (Linux, `backend-candle`, via the fake-nvcc recipe) — exit 0
- Full suites: core 488 · api 292 · worker 854 · mcp — all green

No manifest change, no web change: this commit only adds readers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)