### PR TITLE
fix(api): video requests that name no duration/fps/size are admitted at the model's own declared defaults (sc-12400)

### DIFF
--- a/apps/rust-api/src/defaults.rs
+++ b/apps/rust-api/src/defaults.rs
@@ -137,13 +137,10 @@ pub(crate) fn default_video_model() -> String {
 // blanket this layer invents. The blanket 25 that used to live here was off-menu for 7 of the 10
 // shipped video models — see `VideoJobRequest::fps` (sc-12347).
 
-pub(crate) fn default_video_width() -> u32 {
-    768
-}
-
-pub(crate) fn default_video_height() -> u32 {
-    512
-}
+// No `default_video_width` / `default_video_height` either: an omitted side resolves to the model's
+// declared `defaults.resolution` (core's `default_resolution`). The blanket 768x512 that used to
+// live here is not in `limits.resolutions` for 8 of the 10 shipped video models — mochi_1 rendered
+// at 768x512 instead of its native, only-trained 848x480 (sc-12400). See `VideoJobRequest::width`.
 
 pub(crate) fn default_video_quality() -> String {
     "balanced".to_owned()

--- a/apps/rust-api/src/defaults.rs
+++ b/apps/rust-api/src/defaults.rs
@@ -8,8 +8,6 @@
 //! `#[serde(default = "default_x")]` string path and sibling call site
 //! resolving unchanged.
 
-use sceneworks_core::contracts::ContractNumber;
-
 pub(crate) fn default_timeline_name() -> String {
     "Main timeline".to_owned()
 }
@@ -128,9 +126,11 @@ pub(crate) fn default_video_model() -> String {
     "ltx_2_3".to_owned()
 }
 
-pub(crate) fn default_video_duration() -> ContractNumber {
-    ContractNumber::from(6)
-}
+// No `default_video_duration` either, and for a sharper reason than fps: the blanket 6.0 that used
+// to live here is past the `hardMaxDuration` of 7 of the 10 shipped video models, so once sc-12297
+// began enforcing that cap, this default made the API reject its own duration-less requests
+// (sc-12400). An omitted duration resolves to the model's declared `defaults.duration` via core's
+// `resolve_duration` — see `VideoJobRequest::duration`.
 
 // No `default_video_fps`: an omitted fps resolves to the model's declared `defaults.fps` (core's
 // `resolve_fps`, applied in `create_video_job` once the manifest entry is resolved), not to a

--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -785,10 +785,14 @@ pub(crate) struct VideoJobRequest {
     /// this route constructed itself (sc-12347).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) fps: Option<u32>,
-    #[serde(default = "default_video_width")]
-    pub(crate) width: u32,
-    #[serde(default = "default_video_height")]
-    pub(crate) height: u32,
+    /// Output geometry, or `None` per side when the caller named none — resolved from the model's
+    /// declared `defaults.resolution` in `create_video_job`, not from a blanket 768×512 that 8 of
+    /// the 10 shipped video models do not advertise anywhere (sc-12400). See
+    /// [`VideoJobRequest::fps`] for the pattern.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) width: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) height: Option<u32>,
     #[serde(default = "default_video_quality")]
     pub(crate) quality: String,
     #[serde(default)]

--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -763,8 +763,16 @@ pub(crate) struct VideoJobRequest {
     pub(crate) negative_prompt: String,
     #[serde(default = "default_video_model")]
     pub(crate) model: String,
-    #[serde(default = "default_video_duration")]
-    pub(crate) duration: ContractNumber,
+    /// Clip length in seconds, or `None` when the caller named none — which the MCP server does
+    /// whenever *its* caller does (`server.rs` omits the key rather than sending a default).
+    ///
+    /// Optional for the same reason as [`VideoJobRequest::fps`], and with a sharper edge: the
+    /// blanket 6.0 that used to live here is past the `hardMaxDuration` of 7 of the 10 shipped video
+    /// models, and sc-12297's cap reads whatever lands in the payload — so a request that named NO
+    /// duration was rejected for "asking for 6s". `create_video_job` resolves `None` from the
+    /// model's declared `defaults.duration` once the manifest entry is in hand (sc-12400).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) duration: Option<ContractNumber>,
     /// Frames per second, or `None` when the caller named none — which the MCP server does whenever
     /// *its* caller does (`server.rs` omits the key entirely rather than sending a default).
     ///

--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -572,6 +572,26 @@ pub(crate) async fn create_video_job(
             return Err(ApiError::bad_request(message));
         }
         job_payload.insert("fps".to_owned(), Value::from(fps));
+
+        // The model's declared `defaults.resolution` — the third dead `defaults.*` key, and the one
+        // with no error surface: dimensions COERCE rather than reject, so this was silent by
+        // construction. The blanket 768×512 is not in `limits.resolutions` for 8 of the 10 shipped
+        // video models, so an MCP `generate_video(model = "mochi_1", prompt = …)` naming no size
+        // rendered at 768×512 — a geometry mochi was never trained on — while the web rendered its
+        // declared 848×480 from the identical request (`VideoStudio.jsx:234`). Same convergence as
+        // fps and duration: the API adopts what the manifest and the dropdown already say.
+        //
+        // Written back per side only when the caller named none, so a caller's own size is untouched
+        // and each side still falls back independently. The stride/area normalization stays in
+        // core's `normalized_dimensions` — this records the RESOLVED request, not the final
+        // geometry, exactly as it did when the blanket lived in the DTO.
+        let (default_width, default_height) = default_resolution(entry).unwrap_or((768, 512));
+        if !job_payload.contains_key("width") {
+            job_payload.insert("width".to_owned(), Value::from(default_width));
+        }
+        if !job_payload.contains_key("height") {
+            job_payload.insert("height".to_owned(), Value::from(default_height));
+        }
     }
     job_payload.insert("modelManifestEntry".to_owned(), model_manifest_entry);
     validate_job_lora_compatibility_with(

--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -527,13 +527,27 @@ pub(crate) async fn create_video_job(
     // Duration comes off `job_payload` for the same reason: gate the value actually enqueued.
     // (Presets deliberately do not patch duration today — see `apply_recipe_preset_to_video_payload`
     // — so this reads the DTO's value; it just stops being a latent bug if that ever changes.)
-    if let Some(message) = model_manifest_entry.as_object().and_then(|entry| {
-        job_payload
-            .get("duration")
-            .and_then(Value::as_f64)
-            .and_then(|duration| duration_limit_error(&model_id, duration as f32, entry))
-    }) {
-        return Err(ApiError::bad_request(message));
+    //
+    // The duration is RESOLVED against the model's declared `defaults.duration` first, for the same
+    // reason the fps menu is below — and sc-12297 shipped without it, which is the bug sc-12400
+    // fixes. The DTO blanket was 6.0, serialized unconditionally, and 6.0 is past the cap of 7 of
+    // the 10 shipped video models: a payload that named NO duration was rejected for "asking for
+    // 6s", a value the caller never set, with a lever ("shorten the clip") for a field they never
+    // touched. Enforcing a manifest constraint requires the layer's own default to be
+    // manifest-aware first, or the gate refuses a payload this route constructed itself.
+    if let Some(entry) = model_manifest_entry.as_object() {
+        let duration = resolve_duration(job_payload.get("duration"), entry);
+        if let Some(message) = duration_limit_error(&model_id, duration, entry) {
+            return Err(ApiError::bad_request(message));
+        }
+        // Write back ONLY the resolved default. A duration the caller named is already in the
+        // payload verbatim — `validate_video_job` bounded it to 1..=30, so it needs no clamp — and
+        // rewriting it would flatten its JSON shape: `duration` is a `ContractNumber`
+        // (= `serde_json::Number`), which carries int-vs-float across the wire, so a caller's `10`
+        // must not become `10.0`.
+        if !job_payload.contains_key("duration") {
+            job_payload.insert("duration".to_owned(), contract_number(duration));
+        }
     }
     // The model's declared `defaults.fps` + `limits.fps`, the other half of `frames = duration ×
     // fps` (sc-12347). The cap above closes the *duration* axis only: a legally-5s mochi_1 request
@@ -578,6 +592,21 @@ pub(crate) async fn create_video_job(
     )
     .await?;
     Ok((StatusCode::CREATED, Json(job)))
+}
+
+/// A resolved `duration` in the payload's `ContractNumber` (= `serde_json::Number`) shape: an
+/// integral value stays integral.
+///
+/// The wire has always carried `"duration": 5`, not `5.0` — `ContractNumber` preserves whatever the
+/// caller sent, and every shipped `defaults.duration` is a whole number. Writing an `f32` straight
+/// in flattens that (`Value::from(5.0_f32)` is `5.0`), a gratuitous contract change that the
+/// payload-normalization tests correctly catch.
+fn contract_number(value: f32) -> Value {
+    if value.fract() == 0.0 {
+        Value::from(value as i64)
+    } else {
+        Value::from(value)
+    }
 }
 
 /// The typed route that owns `job_type`, or `None` for every job type the generic

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -56,7 +56,9 @@ use sceneworks_core::training_store::{
     TrainingDatasetCaptionSidecarsInput, TrainingDatasetCreateInput, TrainingDatasetMutationResult,
     TrainingDatasetSummary, TrainingDatasetUpdateInput,
 };
-use sceneworks_core::video_request::{duration_limit_error, fps_limit_error, resolve_fps};
+use sceneworks_core::video_request::{
+    duration_limit_error, fps_limit_error, resolve_duration, resolve_fps,
+};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -2676,12 +2678,17 @@ fn validate_video_job(payload: &VideoJobRequest) -> Result<(), ApiError> {
             "sourceClipAssetIds must contain at most {MAX_VIDEO_SOURCE_CLIP_ASSET_IDS} ids"
         )));
     }
-    let duration = payload
-        .duration
-        .as_f64()
-        .ok_or_else(|| ApiError::bad_request("duration must be a number between 1 and 30"))?;
-    if !duration.is_finite() || !(1.0..=30.0).contains(&duration) {
-        return Err(ApiError::bad_request("duration must be between 1 and 30"));
+    // Only a *named* duration is bounded here, for the same reason as fps below: an omitted one is
+    // resolved from the model's declared `defaults.duration` in `create_video_job`. This blanket
+    // stays a payload-sanity check; the model's own `limits.hardMaxDuration` is enforced there
+    // (sc-12297 / sc-12400).
+    if let Some(duration) = payload.duration.as_ref() {
+        let duration = duration
+            .as_f64()
+            .ok_or_else(|| ApiError::bad_request("duration must be a number between 1 and 30"))?;
+        if !duration.is_finite() || !(1.0..=30.0).contains(&duration) {
+            return Err(ApiError::bad_request("duration must be between 1 and 30"));
+        }
     }
     // Only a *named* fps is bounded here: an omitted one is resolved from the model's declared
     // `defaults.fps` in `create_video_job`, which is the first point that knows the model (this

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -57,7 +57,7 @@ use sceneworks_core::training_store::{
     TrainingDatasetSummary, TrainingDatasetUpdateInput,
 };
 use sceneworks_core::video_request::{
-    duration_limit_error, fps_limit_error, resolve_duration, resolve_fps,
+    default_resolution, duration_limit_error, fps_limit_error, resolve_duration, resolve_fps,
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -2699,8 +2699,14 @@ fn validate_video_job(payload: &VideoJobRequest) -> Result<(), ApiError> {
             return Err(ApiError::bad_request("fps must be between 1 and 60"));
         }
     }
-    validate_dimension(payload.width, "width", MAX_VIDEO_DIMENSION)?;
-    validate_dimension(payload.height, "height", MAX_VIDEO_DIMENSION)?;
+    // Only a *named* dimension is bounded here, like duration and fps above: an omitted side is
+    // resolved from the model's declared `defaults.resolution` in `create_video_job` (sc-12400).
+    if let Some(width) = payload.width {
+        validate_dimension(width, "width", MAX_VIDEO_DIMENSION)?;
+    }
+    if let Some(height) = payload.height {
+        validate_dimension(height, "height", MAX_VIDEO_DIMENSION)?;
+    }
     match payload.mode.as_str() {
         "image_to_video" if payload.source_asset_id.is_none() => Err(ApiError::bad_request(
             "Image to Video requires a source image.",

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -3926,7 +3926,8 @@ async fn a_video_request_naming_no_duration_is_admitted_at_the_models_own_defaul
     for (model, want_w, want_h) in [
         ("mochi_1", 848, 480),
         ("bernini", 848, 480),
-        ("wan_2_2_t2v_14b", 1280, 704),
+        // True 720p since sc-12308 (#1581) lifted the A14B area cap to its real 921,600.
+        ("wan_2_2_t2v_14b", 1280, 720),
         ("ltx_2_3", 768, 512),
     ] {
         let (status, body) = request(

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -3917,6 +3917,66 @@ async fn a_video_request_naming_no_duration_is_admitted_at_the_models_own_defaul
         .as_str()
         .unwrap_or_default()
         .contains("asks for 30s"));
+
+    // The GEOMETRY axis of the same bug — the third dead `defaults.*` key. No 400 to observe here
+    // (dimensions coerce), so the observable is the enqueued size itself: mochi_1 must take its
+    // declared 848x480 native bucket, NOT the blanket 768x512 it is never trained on and never
+    // advertises. `bernini` (848x480, stride 16) and `wan_2_2_t2v_14b` (1280x704) come along to
+    // prove this reads the per-model value rather than one hardcoded pair.
+    for (model, want_w, want_h) in [
+        ("mochi_1", 848, 480),
+        ("bernini", 848, 480),
+        ("wan_2_2_t2v_14b", 1280, 704),
+        ("ltx_2_3", 768, 512),
+    ] {
+        let (status, body) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/video/jobs",
+            json!({
+                "projectId": project_id,
+                "mode": "text_to_video",
+                "prompt": "a fox runs",
+                "model": model
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED, "{model}: {body}");
+        assert_eq!(
+            (
+                body["payload"]["width"].as_u64(),
+                body["payload"]["height"].as_u64()
+            ),
+            (Some(want_w), Some(want_h)),
+            "{model}: a size-less request must enqueue the model's declared defaults.resolution: \
+             {body}"
+        );
+    }
+
+    // A NAMED size is still honored verbatim — resolution fills a gap, it does not override.
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_video",
+            "prompt": "a fox runs",
+            "model": "mochi_1",
+            "width": 640,
+            "height": 384
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{body}");
+    assert_eq!(
+        (
+            body["payload"]["width"].as_u64(),
+            body["payload"]["height"].as_u64()
+        ),
+        (Some(640), Some(384)),
+        "a caller's own size must not be replaced by the model's default: {body}"
+    );
 }
 
 /// sc-12347 END TO END, against the **REAL shipped manifest** rather than a fixture — the route the

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -3824,6 +3824,101 @@ async fn video_fps_outside_the_post_preset_models_menu_is_rejected() {
         .contains("fps must be between 1 and 60"));
 }
 
+/// sc-12400 — the regression sc-12297 shipped: a request that names **no duration at all** was
+/// rejected for "asking for 6s", on 7 of the 10 shipped video models.
+///
+/// Against the REAL manifest, because the whole bug is that the DTO's blanket 6.0 was never compared
+/// to the caps sc-12297 began enforcing — a fixture would let me pick a cap that hides it.
+///
+/// This is the exact payload the MCP `generate_video` tool sends when its caller names only a model
+/// and a prompt (`server.rs` omits every `None` optional), so it is the natural non-UI call, not an
+/// edge case. Before the fix: `400 mochi_1 renders clips up to 5s, but this request asks for 6s` —
+/// naming a value the caller never set, with a lever for a field they never touched.
+#[tokio::test]
+async fn a_video_request_naming_no_duration_is_admitted_at_the_models_own_default() {
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    sceneworks_core::builtin_manifests::seed_builtin_manifests(
+        &settings.config_dir,
+        sceneworks_core::builtin_manifests::SeedMode::Overwrite,
+    )
+    .expect("builtin manifests seed");
+
+    let app = create_app(settings).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Duration Default Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+
+    // Every shipped video model whose cap is UNDER the old blanket 6.0 — i.e. every model this
+    // regression bricked — plus ltx_2_3, whose cap of 15 admitted 6.0 and which therefore stayed
+    // green throughout. Listing the survivor alongside the victims is what makes this a per-model
+    // assertion rather than "the route works".
+    for (model, want_duration) in [
+        ("mochi_1", 5.0),
+        ("bernini", 5.0),
+        ("scail2_14b", 5.0),
+        ("wan_2_2_t2v_14b", 5.0),
+        ("wan_2_2_i2v_14b", 5.0),
+        ("wan_2_2_vace_fun_14b", 5.0),
+        ("svd", 4.0),
+        ("ltx_2_3", 6.0),
+    ] {
+        let (status, body) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/video/jobs",
+            json!({
+                "projectId": project_id,
+                "mode": "text_to_video",
+                "prompt": "a fox runs",
+                "model": model
+            }),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::CREATED,
+            "{model}: a request naming no duration must be admitted, not 400'd for a value it \
+             never set: {body}"
+        );
+        assert_eq!(
+            body["payload"]["duration"], want_duration,
+            "{model}: the enqueued payload records the model's declared defaults.duration, not the \
+             blanket 6.0: {body}"
+        );
+    }
+
+    // A NAMED over-cap duration is still refused — the cap is intact; only the phantom 6.0 is gone.
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_video",
+            "prompt": "a fox runs",
+            "model": "mochi_1",
+            "duration": 30
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "sc-12297's cap must still refuse a duration the caller actually asked for: {body}"
+    );
+    assert!(body["detail"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("asks for 30s"));
+}
+
 /// sc-12347 END TO END, against the **REAL shipped manifest** rather than a fixture — the route the
 /// app actually serves, the bytes the app actually ships, the model the story is about.
 ///

--- a/crates/sceneworks-core/src/video_request.rs
+++ b/crates/sceneworks-core/src/video_request.rs
@@ -128,7 +128,7 @@ impl VideoRequest {
             prompt: nonempty_string_or(payload, "prompt", ""),
             negative_prompt: nonempty_string_or(payload, "negativePrompt", ""),
             model: nonempty_string_or(payload, "model", DEFAULT_MODEL),
-            duration: safe_float(payload.get("duration"), 6.0, 1.0, 30.0),
+            duration: resolve_duration(payload.get("duration"), &model_manifest_entry),
             fps: resolve_fps(payload.get("fps"), &model_manifest_entry),
             width,
             height,
@@ -298,6 +298,54 @@ pub fn duration_limit_error(
              the clip to {cap}s or less, or choose a model that renders longer clips."
         )
     })
+}
+
+/// The clip length used when neither the caller nor the model's manifest entry names one — the
+/// historical blanket, kept for models that declare no `defaults.duration`.
+const DEFAULT_DURATION: f32 = 6.0;
+
+/// The payload-sanity bounds on duration (the Python `safe_float`). NOT a model's limit: that is
+/// [`hard_max_duration`].
+const MIN_DURATION: f32 = 1.0;
+const MAX_DURATION: f32 = 30.0;
+
+/// `defaults.duration` (seconds) from a resolved manifest entry, or `None` when the model declares
+/// none.
+///
+/// Dead in exactly the way [`default_fps`] was, with a worse consequence: sc-12297 began enforcing
+/// [`hard_max_duration`] without ever comparing the API's **own** blanket [`DEFAULT_DURATION`] to
+/// the caps it was now enforcing. 6.0 is past the cap of **7 of the 10** shipped video models, and
+/// the DTO serializes it unconditionally, so a payload that named NO duration was rejected with
+/// "this request asks for 6s" — naming a value the caller never set, and offering a lever
+/// ("shorten the clip") for a field they never touched (sc-12400).
+///
+/// Same posture as [`default_fps`]: a default outside [`MIN_DURATION`]`..=`[`MAX_DURATION`], or
+/// non-finite, is not a length anyone meant, so it falls back to the blanket rather than
+/// propagating a degenerate value into `frames = duration × fps`.
+pub fn default_duration(model_manifest_entry: &JsonObject) -> Option<f32> {
+    model_manifest_entry
+        .get("defaults")
+        .and_then(Value::as_object)
+        .and_then(|defaults| defaults.get("duration"))
+        .and_then(Value::as_f64)
+        .map(|duration| duration as f32)
+        .filter(|duration| duration.is_finite() && (MIN_DURATION..=MAX_DURATION).contains(duration))
+}
+
+/// The clip length a payload actually renders at: the caller's value clamped to the sanity bounds,
+/// or — when the caller named none — the model's declared [`default_duration`], falling back to
+/// [`DEFAULT_DURATION`].
+///
+/// The duration twin of [`resolve_fps`], and the fix for the regression [`default_duration`]
+/// documents. **Resolution, not rejection**: a value the caller *did* name is clamped and then
+/// judged by [`duration_limit_error`], never quietly shortened onto the cap.
+///
+/// Reads through [`safe_float`], so the `safe_float` contract is unchanged: a numeric **string**
+/// (`"4.5"`) is a value the caller named. An unreadable / `null` duration is treated as absent — a
+/// value core cannot read is not a value the caller named.
+pub fn resolve_duration(requested: Option<&Value>, model_manifest_entry: &JsonObject) -> f32 {
+    let fallback = default_duration(model_manifest_entry).unwrap_or(DEFAULT_DURATION);
+    safe_float(requested, fallback, MIN_DURATION, MAX_DURATION)
 }
 
 /// The frame rate used when neither the caller nor the model's manifest entry names one — the
@@ -1233,6 +1281,139 @@ mod tests {
         assert_eq!(hard_max_duration(&fractional), Some(2.5));
         assert!(duration_limit_error("m", 3.0, &fractional).is_some());
         assert_eq!(duration_limit_error("m", 2.5, &fractional), None);
+    }
+
+    /// sc-12400 — **the invariant whose absence let sc-12297 ship a regression**, stated in the
+    /// general form so it covers every axis at once: *the value the API resolves for an OMITTED
+    /// field must be admitted by the gate the API then applies to it.*
+    ///
+    /// sc-12297's own conformance test asserts `duration_limit_error(id, defaults.duration) == None`
+    /// — the manifest's internal fixed point — and that passed. What nothing checked was the
+    /// **DTO's blanket** against the caps: 6.0 is past the cap of 7 of the 10 shipped models, and
+    /// the DTO serialized it unconditionally, so a payload naming NO duration was refused for
+    /// "asking for 6s". The manifest was self-consistent; the API's default simply was not part of
+    /// the test.
+    ///
+    /// So this asserts the resolution ITSELF (`resolve_*(None, entry)`), not a manifest value — the
+    /// only form that catches a blanket the model rejects.
+    #[test]
+    fn what_the_api_resolves_for_an_omitted_field_is_admitted_by_that_models_own_gate() {
+        let models = builtin_video_models();
+
+        for (id, ..) in FPS_MENUS {
+            let entry = models
+                .iter()
+                .find(|m| m.get("id").and_then(Value::as_str) == Some(*id))
+                .unwrap_or_else(|| panic!("{id} present"))
+                .as_object()
+                .expect("model entry object");
+
+            // A payload naming NOTHING — the MCP `generate_video(model, prompt)` shape.
+            let bare = VideoRequest::from_payload(&payload(json!({
+                "projectId": "p", "model": id,
+                "modelManifestEntry": Value::Object(entry.clone()),
+            })));
+
+            assert_eq!(
+                duration_limit_error(id, bare.duration, entry),
+                None,
+                "{id}: the duration resolved for an omitted field ({}s) must be admitted by the \
+                 model's own cap — this is sc-12400: the blanket {DEFAULT_DURATION}s was past 7 of \
+                 10 caps, so the API rejected requests that named no duration at all",
+                bare.duration
+            );
+            assert_eq!(
+                fps_limit_error(id, bare.fps, entry),
+                None,
+                "{id}: the fps resolved for an omitted field ({}) must be on the model's own menu",
+                bare.fps
+            );
+
+            // MUTATION CHECK: the assertions above are only meaningful where the blanket would have
+            // FAILED. Pin that this model is one of those, or that it is a known survivor.
+            let cap = hard_max_duration(entry).unwrap_or_else(|| panic!("{id} declares a cap"));
+            if DEFAULT_DURATION > cap {
+                assert!(
+                    duration_limit_error(id, DEFAULT_DURATION, entry).is_some(),
+                    "{id}: fixture assumes the blanket is over-cap here"
+                );
+                assert!(
+                    bare.duration < DEFAULT_DURATION,
+                    "{id}: resolution must have MOVED off the blanket, not merely passed"
+                );
+            }
+        }
+
+        // The blanket duration was over-cap for a MAJORITY of shipped models — the same 7-of-10
+        // shape as the fps blanket, and the reason this is a generalized invariant rather than two
+        // coincidences. Pinned as a number so reintroducing a blanket default fails here.
+        let over_cap: Vec<&str> = FPS_MENUS
+            .iter()
+            .filter_map(|(id, ..)| {
+                let entry = models
+                    .iter()
+                    .find(|m| m.get("id").and_then(Value::as_str) == Some(*id))?
+                    .as_object()?;
+                (hard_max_duration(entry)? < DEFAULT_DURATION).then_some(*id)
+            })
+            .collect();
+        assert_eq!(
+            over_cap.len(),
+            7,
+            "the blanket {DEFAULT_DURATION}s is past the cap of these models: {over_cap:?} — if this \
+             count moved, re-read why resolve_duration consults defaults.duration before changing it"
+        );
+    }
+
+    /// [`resolve_duration`] — the duration twin of
+    /// `omitted_fps_resolves_to_the_models_declared_default`.
+    #[test]
+    fn omitted_duration_resolves_to_the_models_declared_default() {
+        let mochi = payload(json!({
+            "limits": { "hardMaxDuration": 5 }, "defaults": { "duration": 5 }
+        }));
+
+        // Omitted / unreadable ⇒ the model's declared default, NOT the blanket 6.0 — which this
+        // model's own cap REJECTS, which is the entire bug.
+        assert_eq!(resolve_duration(None, &mochi), 5.0);
+        assert_eq!(resolve_duration(Some(&json!(null)), &mochi), 5.0);
+        assert_eq!(resolve_duration(Some(&json!("nonsense")), &mochi), 5.0);
+        assert_eq!(
+            duration_limit_error("mochi_1", resolve_duration(None, &mochi), &mochi),
+            None,
+            "the resolved default must be admitted by the cap that resolved it"
+        );
+        assert!(
+            duration_limit_error("mochi_1", DEFAULT_DURATION, &mochi).is_some(),
+            "…and the blanket would NOT have been — sc-12400"
+        );
+
+        // A numeric STRING is a value the caller NAMED (the `safe_float` contract). Pinned with 3,
+        // which is neither the blanket (6) nor this model's default (5), so falling back to either
+        // is RED.
+        assert_eq!(resolve_duration(Some(&json!("3")), &mochi), 3.0);
+        assert_eq!(resolve_duration(Some(&json!(4.5)), &mochi), 4.5);
+
+        // Named ⇒ honored verbatim, even past the cap. The gate refuses it; resolution does not
+        // quietly shorten it — reject, never clamp.
+        assert_eq!(resolve_duration(Some(&json!(30)), &mochi), 30.0);
+        assert!(duration_limit_error("mochi_1", 30.0, &mochi).is_some());
+
+        // Named-but-nonsense clamps to the sanity bounds (unchanged), then the cap judges.
+        assert_eq!(resolve_duration(Some(&json!(999)), &mochi), MAX_DURATION);
+        assert_eq!(resolve_duration(Some(&json!(0)), &mochi), MIN_DURATION);
+
+        // No declared default ⇒ the blanket, so a model that declares nothing is unchanged.
+        let bare = payload(json!({}));
+        assert_eq!(resolve_duration(None, &bare), DEFAULT_DURATION);
+        assert_eq!(default_duration(&bare), None);
+
+        // An unhonorable default is not a length anyone meant ⇒ the blanket.
+        for bad in [json!(0), json!(-1), json!(31), json!("5"), json!(null)] {
+            let entry = payload(json!({ "defaults": { "duration": bad } }));
+            assert_eq!(default_duration(&entry), None, "unhonorable default {bad}");
+            assert_eq!(resolve_duration(None, &entry), DEFAULT_DURATION);
+        }
     }
 
     /// sc-12347 — the fps axis of the same invariant, derived from the shipped `limits.fps` menus

--- a/crates/sceneworks-core/src/video_request.rs
+++ b/crates/sceneworks-core/src/video_request.rs
@@ -1590,8 +1590,13 @@ mod tests {
         ("svd", 1024, 576),
         ("mochi_1", 848, 480),
         ("wan_2_2", 832, 480),
-        ("wan_2_2_t2v_14b", 1280, 704),
-        ("wan_2_2_i2v_14b", 1280, 704),
+        // 720, not 704: sc-12308 (#1581) restored TRUE 720p to the A14B pair by lifting maxPixels
+        // to the 14B's real 921,600 (sc-12294 had walked the manifest down to the 5B's 901,120).
+        // This table caught that drift in CI when main moved under this branch — which is the
+        // table's whole purpose: transcribed from the manifest, so a manifest change forces a
+        // conscious update here instead of passing silently.
+        ("wan_2_2_t2v_14b", 1280, 720),
+        ("wan_2_2_i2v_14b", 1280, 720),
         ("wan_2_2_vace_fun_14b", 832, 480),
         ("bernini", 848, 480),
         ("scail2_14b", 832, 480),

--- a/crates/sceneworks-core/src/video_request.rs
+++ b/crates/sceneworks-core/src/video_request.rs
@@ -439,6 +439,52 @@ pub fn resolve_fps(requested: Option<&Value>, model_manifest_entry: &JsonObject)
         .clamp(MIN_FPS, MAX_FPS)
 }
 
+/// The geometry used when neither the caller nor the model's manifest entry names one — the
+/// historical blanket, kept for models that declare no `defaults.resolution`.
+const DEFAULT_WIDTH: u32 = 768;
+const DEFAULT_HEIGHT: u32 = 512;
+
+/// The payload-sanity bounds on either dimension (the Python `normalized_dimensions` clamp). NOT a
+/// model's limit: the stride is [`dimension_multiple_of`] and the area cap is [`max_pixels_of`].
+const MIN_DIMENSION: u32 = 256;
+const MAX_DIMENSION: u32 = 1920;
+
+/// `defaults.resolution` (`"848x480"`) from a resolved manifest entry as `(width, height)`, or
+/// `None` when the model declares none or declares one this parse cannot honor.
+///
+/// The **third** instance of the dead-`defaults.*` key [`default_fps`] and [`default_duration`]
+/// document, and the one with no error surface at all: dimensions are *coerced* by
+/// [`normalized_dimensions`], never rejected, so this failure is silent by construction rather than
+/// a 400 someone eventually reports.
+///
+/// The blanket 768×512 is not merely un-declared for **8 of the 10** shipped video models — it is
+/// not even in their `limits.resolutions`, i.e. it is a geometry the model never advertised at any
+/// point. mochi_1 is the sharp case: its declared (and only trained) bucket is 848×480, so an MCP
+/// `generate_video(model = "mochi_1", prompt = …)` that names no size rendered at 768×512 — a
+/// geometry the model was never trained on — while the web, which reads `defaults.resolution` at
+/// `VideoStudio.jsx:234`, rendered 848×480 from the same request (sc-12400).
+///
+/// Same never-invent-from-a-typo posture as its siblings: anything that is not `W x H` with both
+/// dimensions inside the clamp range falls back to the blanket rather than emitting a degenerate
+/// size. The value is deliberately NOT snapped to the model's stride here —
+/// [`normalized_dimensions`] does that for declared and blanket geometry alike, so a model whose
+/// advertised default is off its own lattice is floored exactly as a caller's request would be.
+pub fn default_resolution(model_manifest_entry: &JsonObject) -> Option<(u32, u32)> {
+    let (width, height) = model_manifest_entry
+        .get("defaults")
+        .and_then(Value::as_object)
+        .and_then(|defaults| defaults.get("resolution"))
+        .and_then(Value::as_str)?
+        .split_once(['x', 'X'])?;
+    let honorable = |raw: &str| {
+        raw.trim()
+            .parse::<u32>()
+            .ok()
+            .filter(|side| (MIN_DIMENSION..=MAX_DIMENSION).contains(side))
+    };
+    Some((honorable(width)?, honorable(height)?))
+}
+
 /// The advertised frame rates as a human list: `30`, `16 or 24`, `6, 7, 8, 10, 12, or 25`.
 fn humanized_fps_menu(menu: &[u32]) -> String {
     match menu {
@@ -540,8 +586,20 @@ fn normalized_dimensions(
     model_manifest_entry: &JsonObject,
 ) -> (u32, u32) {
     let multiple = dimension_multiple_of(model_manifest_entry);
-    let w = floor_to_multiple(clamped_u32(width, 768, 256, 1920), multiple);
-    let h = floor_to_multiple(clamped_u32(height, 512, 256, 1920), multiple);
+    // An omitted side takes the model's declared `defaults.resolution`, not the blanket 768×512 —
+    // which 8 of the 10 shipped video models do not advertise anywhere, mochi_1's 848×480 native
+    // bucket being the case that matters (sc-12400). Each side falls back independently, exactly as
+    // the two blanket constants did, so a caller naming only one dimension is unchanged in shape.
+    let (default_width, default_height) =
+        default_resolution(model_manifest_entry).unwrap_or((DEFAULT_WIDTH, DEFAULT_HEIGHT));
+    let w = floor_to_multiple(
+        clamped_u32(width, default_width, MIN_DIMENSION, MAX_DIMENSION),
+        multiple,
+    );
+    let h = floor_to_multiple(
+        clamped_u32(height, default_height, MIN_DIMENSION, MAX_DIMENSION),
+        multiple,
+    );
     match max_pixels_of(model_manifest_entry) {
         Some(cap) if (w as u64) * (h as u64) > cap => fit_to_max_pixels(w, h, multiple, cap),
         _ => (w, h),
@@ -1329,6 +1387,44 @@ mod tests {
                 bare.fps
             );
 
+            // The geometry axis has no gate to be admitted BY — dimensions coerce rather than
+            // reject — so the invariant takes its strongest available form: what a size-less
+            // request renders must be the model's own advertised default, snapped to its own
+            // stride. That is what the web produces from the same request (`VideoStudio.jsx:234`),
+            // and the blanket 768x512 is not even in `limits.resolutions` for 8 of these 10.
+            //
+            // The expectation comes from DEFAULT_RESOLUTIONS, NOT from `default_resolution` — see
+            // that table's comment: deriving it from the function under test made this green
+            // through the very bug it checks.
+            let &(_, declared_w, declared_h) = DEFAULT_RESOLUTIONS
+                .iter()
+                .find(|(model, ..)| model == id)
+                .unwrap_or_else(|| panic!("{id} listed in DEFAULT_RESOLUTIONS"));
+            assert_eq!(
+                default_resolution(entry),
+                Some((declared_w, declared_h)),
+                "{id}: core must read the resolution the manifest actually declares"
+            );
+
+            let (want_w, want_h) = (declared_w, declared_h);
+            let multiple = dimension_multiple_of(entry);
+            let (want_w, want_h) = (
+                floor_to_multiple(want_w, multiple),
+                floor_to_multiple(want_h, multiple),
+            );
+            let (want_w, want_h) = match max_pixels_of(entry) {
+                Some(cap) if u64::from(want_w) * u64::from(want_h) > cap => {
+                    fit_to_max_pixels(want_w, want_h, multiple, cap)
+                }
+                _ => (want_w, want_h),
+            };
+            assert_eq!(
+                (bare.width, bare.height),
+                (want_w, want_h),
+                "{id}: a size-less request must render the model's declared defaults.resolution, \
+                 not the blanket {DEFAULT_WIDTH}x{DEFAULT_HEIGHT}"
+            );
+
             // MUTATION CHECK: the assertions above are only meaningful where the blanket would have
             // FAILED. Pin that this model is one of those, or that it is a known survivor.
             let cap = hard_max_duration(entry).unwrap_or_else(|| panic!("{id} declares a cap"));
@@ -1362,6 +1458,34 @@ mod tests {
             7,
             "the blanket {DEFAULT_DURATION}s is past the cap of these models: {over_cap:?} — if this \
              count moved, re-read why resolve_duration consults defaults.duration before changing it"
+        );
+
+        // …and the geometry blanket is UNADVERTISED — not merely un-declared — for 8 of the 10:
+        // 768x512 is absent from their `limits.resolutions` entirely, so the API was rendering a
+        // size the model never offered anywhere. Pinned so reintroducing a blanket fails here.
+        let unadvertised: Vec<&str> = FPS_MENUS
+            .iter()
+            .filter_map(|(id, ..)| {
+                let entry = models
+                    .iter()
+                    .find(|m| m.get("id").and_then(Value::as_str) == Some(*id))?
+                    .as_object()?;
+                let blanket = format!("{DEFAULT_WIDTH}x{DEFAULT_HEIGHT}");
+                let advertises = entry
+                    .get("limits")?
+                    .as_object()?
+                    .get("resolutions")?
+                    .as_array()?
+                    .iter()
+                    .any(|r| r.as_str() == Some(blanket.as_str()));
+                (!advertises).then_some(*id)
+            })
+            .collect();
+        assert_eq!(
+            unadvertised.len(),
+            8,
+            "the blanket {DEFAULT_WIDTH}x{DEFAULT_HEIGHT} is not advertised by these models: \
+             {unadvertised:?}"
         );
     }
 
@@ -1437,6 +1561,27 @@ mod tests {
     /// point of assertion 5 is that this number is *wrong for most models* — deleting the constant
     /// would delete the regression guard.
     const THE_BLANKET_FPS: u32 = 25;
+
+    /// Each shipped model's declared `defaults.resolution`, TRANSCRIBED from the manifest — and
+    /// deliberately independent of [`default_resolution`], which is the function under test.
+    ///
+    /// Deriving the expectation by calling `default_resolution` instead made the geometry assertion
+    /// a tautology (`f(x) == f(x)`): stubbing the function to `None` moved the expected value AND
+    /// the actual value to the blanket together, so the test stayed GREEN through the exact bug it
+    /// exists to catch. Only the API's end-to-end test — which hardcodes 848x480 — was red. This
+    /// table is what makes the core half a real check.
+    const DEFAULT_RESOLUTIONS: &[(&str, u32, u32)] = &[
+        ("ltx_2_3", 768, 512),
+        ("ltx_2_3_eros", 768, 512),
+        ("svd", 1024, 576),
+        ("mochi_1", 848, 480),
+        ("wan_2_2", 832, 480),
+        ("wan_2_2_t2v_14b", 1280, 704),
+        ("wan_2_2_i2v_14b", 1280, 704),
+        ("wan_2_2_vace_fun_14b", 832, 480),
+        ("bernini", 848, 480),
+        ("scail2_14b", 832, 480),
+    ];
 
     /// sc-12347 — the temporal invariant's other half: **what a video model advertises is what it
     /// renders**, on the axis that actually multiplies into frame count.


### PR DESCRIPTION
Closes [sc-12400](https://app.shortcut.com/trefry/story/12400). Epic 12334. **Fixes a regression live on `main`** (`e9277420`), and closes the two remaining instances of the same pattern.

Found immediately after [#1579](https://github.com/SceneWorks/SceneWorks/pull/1579) merged, by applying that PR's own finding to the sibling keys.

## Commit 1 — the live regression: a duration-less request is 400'd on 7 of 10 models

Verified by driving the real route against the real manifest. Payload = `{projectId, mode, prompt, model}` and **nothing else**:

```
mochi_1: 400 | mochi_1 renders clips up to 5s, but this request asks for 6s. Shorten the clip to 5s or less...
bernini: 400 | bernini renders clips up to 5s, but this request asks for 6s...
svd:     400 | svd renders clips up to 4s, but this request asks for 6s...
ltx_2_3: 201 Created
```

**The caller asked for nothing, and is told it "asks for 6s"** — a value they never set, with a lever ("Shorten the clip") for a field they never touched.

sc-12297 enforced `limits.hardMaxDuration` but never compared **the API's own default** to the caps it was enforcing. The DTO blanket was 6.0, serialized unconditionally; 6.0 is past the cap of svd (4) and the six cap-5 models. The MCP server omits `duration` when its caller does, so `generate_video(model="mochi_1", prompt="…")` was **refused**. Before sc-12297 that path rendered a 6s clip — so this is a **regression**, and 7 of 10 video models have been ungenerable from MCP/raw API without an explicit duration.

## Commit 2 — the third dead key: `defaults.resolution`

Same bug, no error surface: dimensions **coerce** rather than reject, so it was silent by construction. Zero production Rust readers (the only hit is inside `#[cfg(test)]`); the web reads it at `VideoStudio.jsx:234`.

The blanket 768×512 is not merely un-declared for **8 of 10** models — it is **absent from their `limits.resolutions`**, a geometry the model never advertised anywhere. mochi_1: 848×480 is its declared and **only trained** bucket, so an MCP call rendered at 768×512 — never trained on — while the web produced 848×480 from the identical request.

## The pattern, now closed on all three axes

> Enforcing a manifest constraint requires the layer's own default to be **manifest-aware first**, or the gate refuses a payload the route constructed itself.

| axis | blanket | wrong for | symptom | fixed |
|---|---|---|---|---|
| `fps` | 25 | 7/10 | silent off-speed (30fps prior at 25) | #1579 |
| `duration` | 6.0 | 7/10 | **hard 400 on a request naming nothing** | commit 1 |
| `resolution` | 768×512 | 8/10 | silent untrained geometry | commit 2 |

**Precondition verified** for each: every shipped model's `defaults.*` is admitted by its own gate, so honoring it admits all 10. **Reject-never-clamp intact** — a value the caller *named* is still refused if it violates a limit.

## The durable fix: the invariant sc-12297 lacked

`what_the_api_resolves_for_an_omitted_field_is_admitted_by_that_models_own_gate`:

> *The value the API resolves for an omitted field must be admitted by the gate the API then applies to it.*

It asserts the **resolution itself** (`resolve_*(None, entry)`), not a manifest value — the only form that catches a blanket the model rejects — across all three axes.

**Why stated this way:** sc-12297's own conformance test asserts `duration_limit_error(id, defaults.duration) == None`, the manifest's *internal* fixed point, and **passes through the mutation that reproduces the shipped bug**. The manifest was self-consistent all along; the DTO blanket was simply never part of any test.

## Contract shape — two things the existing suite and mutation testing caught

1. **A payload-shape regression I introduced.** My first cut rewrote duration unconditionally with `Value::from(f32)`, flattening a caller's `10` → `10.0` (`ContractNumber` is `serde_json::Number`, which carries int-vs-float). Two existing payload-normalization tests failed — **they were right and I was wrong**. Now only the resolved *default* is written back, via `contract_number()`.
2. **A false green in my own new test.** The geometry assertion derived its expectation by *calling `default_resolution`* — the function under test — so stubbing it to `None` moved expected and actual to the blanket together and it stayed **green through the exact bug it checks** (`f(x) == f(x)`). Only the e2e test (hardcoding 848×480) was red. Fixed with `DEFAULT_RESOLUTIONS`, transcribed from the manifest and independent of the function.

| Mutation | Result |
|---|---|
| `resolve_duration` ignores the manifest (= shipped bug) | 3 tests **RED**; sc-12297's conformance test **stays GREEN** |
| `default_resolution` → `None` | core + e2e **RED** (was a false green before the fix above) |
| `normalized_dimensions` ignores the resolved default | core **RED** |

## ⚠️ Behavior change

Raw API / MCP callers that **omit** these fields (UI unaffected — the studio always sends explicit values, and its 1874 tests pass):

- **duration**: svd 6→4, wan_2_2 6→5, cap-5 models 6→5, mochi 6→5; ltx keeps 6 *(each currently **400s**)*
- **resolution**: mochi/bernini 768×512→848×480, A14B pair→1280×704, wan_2_2/vace/scail2→832×480, svd→1024×576; ltx keeps 768×512

Commit 2 is the only part that **changes rendered pixels** rather than un-breaking a 400 — happy to split it into its own PR if that warrants separate review.

## Verification

- `npm run rust:check` — exit 0, 21 suites
- **parity lane** (Linux, default features, `clippy --all-targets -D warnings`) — exit 0
- core 491 · api 292 · web 1874 — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)