### PR TITLE
fix(video): gate NVFP4 from MLX tier picker (sc-12173)

### DIFF
--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -394,11 +394,11 @@ export function VideoStudio() {
   const activeBackend = macGating ? "mlx" : "candle";
   // MLX tier installs and the torch/GGUF quantization variants can coexist on one catalog model,
   // but they target different worker lanes. Only derive an MLX tier while the MLX lane is active;
-  // the existing quantization picker owns the non-MLX lane. `convRotEligible: false` keeps the
-  // candle-only INT8-ConvRot image tier out of this MLX video control.
+  // the existing quantization picker owns the non-MLX lane. The explicit false gates keep the
+  // candle-only INT8-ConvRot and NVFP4 image tiers out of this MLX video control.
   const mlxTierLane = activeBackend === "mlx";
   const tierOptions = useMemo(
-    () => ({ convRotEligible: false, defaultQuality: VIDEO_DEFAULT_TIER }),
+    () => ({ convRotEligible: false, nvfp4Eligible: false, defaultQuality: VIDEO_DEFAULT_TIER }),
     [],
   );
   const availableTiers = useMemo(

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -880,7 +880,7 @@ describe("VideoStudio MLX quant-tier picker (sc-12165)", () => {
     loraCompatibility: {},
     ui: {},
     hasVariantMatrix: true,
-    variants: ["q4", "q8", "bf16"].map((tier) => ({
+    variants: ["q4", "q8", "bf16", "nvfp4"].map((tier) => ({
       variant: tier,
       installState: installed.includes(tier) ? "installed" : "missing",
     })),
@@ -948,6 +948,20 @@ describe("VideoStudio MLX quant-tier picker (sc-12165)", () => {
     expect(tierPicker()).toBeNull();
     await click(buttonWithText(container, "Render clip"));
     expect(context.createVideoJob.mock.calls[0][0].advanced.mlxQuantize).toBe(4);
+  });
+
+  it("keeps the candle-only NVFP4 tier out of the MLX video picker", async () => {
+    const context = baseContext({
+      videoModels: [tieredVideoModel(["q4", "nvfp4"])],
+      macCapabilities: MAC_CAPS,
+    });
+    await render(context);
+    await openAdvanced();
+
+    expect(tierPicker()).toBeNull();
+    await click(buttonWithText(container, "Render clip"));
+    expect(context.createVideoJob.mock.calls[0][0].advanced).toMatchObject({ mlxQuantize: 4 });
+    expect(context.createVideoJob.mock.calls[0][0].advanced).not.toHaveProperty("quantTier");
   });
 
   it("emits a selected high tier, warns about memory, and restores the video/model sticky", async () => {


### PR DESCRIPTION
## Summary

- explicitly mark NVFP4 ineligible for VideoStudio's MLX quant-tier picker
- keep the existing candle-only ConvRot and NVFP4 gates symmetric
- add a regression test covering an installed NVFP4 tier and the submitted video payload

## Why

VideoStudio opted out of the candle-only INT8-ConvRot tier but omitted the equivalent NVFP4 gate. Because the shared tier helper defaults eligibility flags to `true`, an installed NVFP4 tier could appear selectable on the MLX video lane. NVFP4 has no bits-valued `mlxQuantize` mapping, so selecting it could leave the UI claiming NVFP4 while the worker received no corresponding selection signal.

This change explicitly hides NVFP4 from that lane so the displayed tier and submitted render settings stay aligned.

Shortcut: https://app.shortcut.com/trefry/story/12173

## Validation

- `npm.cmd test` — 138 test files passed, 1,875 tests passed
- `npm.cmd exec -- eslint src/screens/VideoStudio.jsx src/screens/VideoStudio.test.jsx` — no errors (five pre-existing hook warnings in `VideoStudio.jsx`)
- `git diff --check`
