### PR TITLE
fix(api): honor each image model's declared defaults.resolution (sc-12427)

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -628,10 +628,17 @@ pub(crate) struct ImageJobRequest {
     pub(crate) count: u32,
     #[serde(default)]
     pub(crate) seed: Option<i64>,
-    #[serde(default = "default_image_size")]
-    pub(crate) width: u32,
-    #[serde(default = "default_image_size")]
-    pub(crate) height: u32,
+    /// Output geometry, or `None` per side when the caller named none — resolved from the model's
+    /// declared `defaults.resolution` in `create_image_job`, not from a blanket 1024 square that 5
+    /// of the 45 image models do not declare (sc-12400). Mirrors `VideoJobRequest::width`.
+    ///
+    /// Only this DTO goes optional: `CharacterTestRequest` and `InterleaveJobRequest` keep the
+    /// blanket because their routes resolve no `modelManifestEntry`, so there is no declared
+    /// default to resolve from.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) width: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) height: Option<u32>,
     #[serde(default = "default_style_preset")]
     pub(crate) style_preset: String,
     #[serde(default)]

--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -42,6 +42,24 @@ pub(crate) async fn create_image_job(
         .unwrap_or(payload.model.as_str())
         .to_owned();
     let model_manifest_entry = resolve_model_manifest_entry(&state, &model_id).await?;
+    // The model's declared `defaults.resolution`, keyed off the post-preset `model_id` for the same
+    // reason the video route's gates are (sc-12300). The image half of the dead-`defaults.*` sweep:
+    // the web honors this key (`ImageStudio.jsx:215`) but Rust did not, so a caller that named no
+    // size rendered a blanket 1024x1024 — HALF the declared 2048x2048 on the four sensenova_u1_8b
+    // variants, the text/infographic family where resolution is the whole point, and 1024 instead of
+    // chroma1_flash's declared 768. Silent: geometry coerces, so nothing ever errored (sc-12400).
+    //
+    // Written back per side only when the caller named none, so a caller's own size is untouched.
+    if let Some(entry) = model_manifest_entry.as_object() {
+        let (default_width, default_height) =
+            image_default_resolution(entry).unwrap_or((1024, 1024));
+        if !job_payload.contains_key("width") {
+            job_payload.insert("width".to_owned(), Value::from(default_width));
+        }
+        if !job_payload.contains_key("height") {
+            job_payload.insert("height".to_owned(), Value::from(default_height));
+        }
+    }
     job_payload.insert("modelManifestEntry".to_owned(), model_manifest_entry);
     validate_job_lora_compatibility_with(
         &state,

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -27,6 +27,7 @@ use sceneworks_core::contracts::{
     WorkerSnapshot, WorkerStatus, WorkerTerminationRequest,
 };
 use sceneworks_core::hf_home::{huggingface_hub_cache_dir, huggingface_repo_cache_path};
+use sceneworks_core::image_request::default_resolution as image_default_resolution;
 use sceneworks_core::jobs_store::{
     candle_supported, mac_capabilities, mac_rust_supported, model_mac_support, CreateJob,
     DuplicateJob, JobsStore, JobsStoreError, MacCapabilities, ProgressUpdate, RegisterWorker,
@@ -2592,8 +2593,15 @@ fn validate_image_job(payload: &ImageJobRequest) -> Result<(), ApiError> {
     if !(1..=8).contains(&payload.count) {
         return Err(ApiError::bad_request("count must be between 1 and 8"));
     }
-    validate_dimension(payload.width, "width", MAX_IMAGE_DIMENSION)?;
-    validate_dimension(payload.height, "height", MAX_IMAGE_DIMENSION)?;
+    // Only a *named* dimension is bounded here: an omitted side is resolved from the model's
+    // declared `defaults.resolution` in `create_image_job` (sc-12400), the same shape as the video
+    // route's duration/fps/size.
+    if let Some(width) = payload.width {
+        validate_dimension(width, "width", MAX_IMAGE_DIMENSION)?;
+    }
+    if let Some(height) = payload.height {
+        validate_dimension(height, "height", MAX_IMAGE_DIMENSION)?;
+    }
     if payload.upscale.enabled {
         if ![2, 4].contains(&payload.upscale.factor) {
             return Err(ApiError::bad_request("upscale.factor must be 2 or 4"));

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -4118,3 +4118,99 @@ async fn real_manifest_mochi_refuses_an_unadvertised_fps_and_defaults_to_its_own
         assert_eq!(body["payload"]["fps"], fps);
     }
 }
+
+/// sc-12400 (image half): a request that names no size renders the MODEL's declared
+/// `defaults.resolution`, not a blanket 1024 square.
+///
+/// The image twin of `a_video_request_naming_no_duration_is_admitted_at_the_models_own_default`,
+/// and against the REAL manifest for the same reason: the bug is precisely that the DTO's blanket
+/// was never compared to what each model declares, so a fixture would let me pick the values that
+/// hide it.
+///
+/// No 400 to observe on this axis — geometry coerces — so the observable IS the enqueued size. The
+/// expectations are transcribed from the manifest, never derived from `default_resolution`: routing
+/// them through the function under test is what made the video half's first cut a tautology that
+/// survived deleting the feature.
+#[tokio::test]
+async fn an_image_request_naming_no_size_renders_the_models_own_declared_resolution() {
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    sceneworks_core::builtin_manifests::seed_builtin_manifests(
+        &settings.config_dir,
+        sceneworks_core::builtin_manifests::SeedMode::Overwrite,
+    )
+    .expect("builtin manifests seed");
+
+    let app = create_app(settings).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Image Default Resolution Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+
+    // The two models the blanket was WRONG for, plus a model it happened to match. Listing the
+    // coincidental match alongside the victims is what keeps this a per-model assertion rather than
+    // "the route returns 1024".
+    for (model, want_w, want_h) in [
+        // 2048x2048 declared: the blanket rendered these at HALF resolution, on the
+        // text/infographic family where pixels are the entire point.
+        ("sensenova_u1_8b", 2048, 2048),
+        ("sensenova_u1_8b_fast", 2048, 2048),
+        // 768x768 declared.
+        ("chroma1_flash", 768, 768),
+        // 1024x1024 declared — the blanket was right here by coincidence, not by design.
+        ("flux1_schnell", 1024, 1024),
+    ] {
+        let (status, body) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/image/jobs",
+            json!({
+                "projectId": project_id,
+                "mode": "text_to_image",
+                "prompt": "a fox",
+                "model": model
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED, "{model}: {body}");
+        assert_eq!(
+            (
+                body["payload"]["width"].as_u64(),
+                body["payload"]["height"].as_u64()
+            ),
+            (Some(want_w), Some(want_h)),
+            "{model}: a size-less request must enqueue the model's declared defaults.resolution: \
+             {body}"
+        );
+    }
+
+    // A NAMED size is honored verbatim — resolution fills a gap, it never overrides.
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/image/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_image",
+            "prompt": "a fox",
+            "model": "sensenova_u1_8b",
+            "width": 512,
+            "height": 512
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{body}");
+    assert_eq!(
+        (
+            body["payload"]["width"].as_u64(),
+            body["payload"]["height"].as_u64()
+        ),
+        (Some(512), Some(512)),
+        "a caller's own size must not be replaced by the model's default: {body}"
+    );
+}

--- a/crates/sceneworks-core/src/image_request.rs
+++ b/crates/sceneworks-core/src/image_request.rs
@@ -11,8 +11,8 @@ use serde_json::Value;
 
 use crate::contracts::{ImageUpscaleRequest, JsonObject};
 use crate::payload_util::{
-    array_or_empty, clamped_u32, int_array, nonempty_string_or, object_or_empty, optional_i64,
-    optional_id, string_list, string_or,
+    array_or_empty, clamped_u32, declared_resolution, int_array, nonempty_string_or,
+    object_or_empty, optional_i64, optional_id, string_list, string_or,
 };
 
 /// Default model when the payload omits one (matches the Python worker).
@@ -23,6 +23,32 @@ const DEFAULT_STYLE_PRESET: &str = "cinematic";
 /// video request (sc-6139) so image- and video-conditioned sources normalize identically.
 pub(crate) const DEFAULT_FIT_MODE: &str = "crop";
 pub(crate) const FIT_MODES: [&str; 4] = ["crop", "pad", "outpaint", "stretch"];
+
+/// The square used when neither the caller nor the model's manifest entry names a size — the
+/// historical blanket, kept for models that declare no `defaults.resolution`.
+const DEFAULT_DIMENSION: u32 = 1024;
+
+/// The payload-sanity bounds on either dimension (the Python `safe_int` clamp). Deliberately wider
+/// than the video lane's 1920 ceiling: image models legitimately render at 2048 (the sensenova U1
+/// family declares `2048x2048`), which is why [`default_resolution`] takes its bounds rather than
+/// sharing one envelope across lanes.
+const MIN_DIMENSION: u32 = 256;
+const MAX_DIMENSION: u32 = 4096;
+
+/// `defaults.resolution` from a resolved manifest entry as `(width, height)`, or `None` for the
+/// blanket [`DEFAULT_DIMENSION`] square.
+///
+/// The image half of the dead-`defaults.*` sweep (sc-12400 closed the video lane's fps / duration /
+/// resolution). The web honors this key (`ImageStudio.jsx:215`); Rust did not, so a raw API / MCP
+/// caller that named no size rendered a blanket 1024x1024 for **5 of the 45** image models that
+/// declare something else — the four `sensenova_u1_8b` variants at `2048x2048` (HALF the declared
+/// resolution, on the text/infographic family where pixels are the point) and `chroma1_flash` at
+/// `768x768`.
+///
+/// Same never-invent-from-a-typo posture as its video twin; see [`declared_resolution`].
+pub fn default_resolution(model_manifest_entry: &JsonObject) -> Option<(u32, u32)> {
+    declared_resolution(model_manifest_entry, MIN_DIMENSION, MAX_DIMENSION)
+}
 
 /// A typed image-generation request, parsed from a job payload.
 #[derive(Debug, Clone, PartialEq)]
@@ -70,6 +96,12 @@ impl ImageRequest {
     /// missing fields fall back to the Python defaults and `project_id` may be empty
     /// — the caller validates it is present (the worker rejects an empty project id).
     pub fn from_payload(payload: &JsonObject) -> Self {
+        // Hoisted above the struct literal because the geometry now depends on it — the same shape
+        // `VideoRequest::from_payload` uses, and the reason the field is read here rather than in
+        // field order below.
+        let model_manifest_entry = object_or_empty(payload, "modelManifestEntry");
+        let (default_width, default_height) = default_resolution(&model_manifest_entry)
+            .unwrap_or((DEFAULT_DIMENSION, DEFAULT_DIMENSION));
         Self {
             project_id: string_or(payload, "projectId", ""),
             mode: nonempty_string_or(payload, "mode", DEFAULT_MODE),
@@ -79,8 +111,18 @@ impl ImageRequest {
             count: clamped_u32(payload.get("count"), 4, 1, 8),
             seed: optional_i64(payload, "seed"),
             seeds: int_array(payload, "seeds"),
-            width: clamped_u32(payload.get("width"), 1024, 256, 4096),
-            height: clamped_u32(payload.get("height"), 1024, 256, 4096),
+            width: clamped_u32(
+                payload.get("width"),
+                default_width,
+                MIN_DIMENSION,
+                MAX_DIMENSION,
+            ),
+            height: clamped_u32(
+                payload.get("height"),
+                default_height,
+                MIN_DIMENSION,
+                MAX_DIMENSION,
+            ),
             style_preset: nonempty_string_or(payload, "stylePreset", DEFAULT_STYLE_PRESET),
             loras: array_or_empty(payload, "loras"),
             character_id: optional_id(payload, "characterId"),
@@ -90,7 +132,7 @@ impl ImageRequest {
             reference_asset_ids: string_list(payload, "referenceAssetIds"),
             mask_asset_id: optional_id(payload, "maskAssetId"),
             fit_mode: normalize_fit_mode(payload.get("fitMode").and_then(Value::as_str)),
-            model_manifest_entry: object_or_empty(payload, "modelManifestEntry"),
+            model_manifest_entry,
             advanced: object_or_empty(payload, "advanced"),
             upscale: parse_upscale(payload),
         }

--- a/crates/sceneworks-core/src/payload_util.rs
+++ b/crates/sceneworks-core/src/payload_util.rs
@@ -86,6 +86,38 @@ pub(crate) fn clamped_u32(value: Option<&Value>, default: u32, min: u32, max: u3
     parse_u32(value).unwrap_or(default).clamp(min, max)
 }
 
+/// A resolved manifest entry's `defaults.resolution` (`"848x480"`) as `(width, height)`, or `None`
+/// when the model declares none or declares one the caller's `[min, max]` cannot honor.
+///
+/// Shared by both lanes because the *parse* is generic while the honorable range is not: video
+/// clamps dimensions to 256..=1920 and images to 256..=4096, so image models legitimately declare
+/// 2048x2048 (the sensenova U1 family) — a value video's bound would reject. Passing the bounds in
+/// keeps one parser without pretending the two lanes share a geometry envelope.
+///
+/// Never-invent-from-a-typo posture, like every other manifest reader: anything that is not
+/// `W x H` with both sides inside `[min, max]` yields `None`, so the caller falls back to its own
+/// blanket rather than emitting a degenerate size. The value is deliberately NOT snapped to any
+/// stride here — each lane's normalization floors declared and blanket geometry alike (sc-12400).
+pub(crate) fn declared_resolution(
+    model_manifest_entry: &JsonObject,
+    min: u32,
+    max: u32,
+) -> Option<(u32, u32)> {
+    let (width, height) = model_manifest_entry
+        .get("defaults")
+        .and_then(Value::as_object)
+        .and_then(|defaults| defaults.get("resolution"))
+        .and_then(Value::as_str)?
+        .split_once(['x', 'X'])?;
+    let honorable = |raw: &str| {
+        raw.trim()
+            .parse::<u32>()
+            .ok()
+            .filter(|side| (min..=max).contains(side))
+    };
+    Some((honorable(width)?, honorable(height)?))
+}
+
 /// Collect a JSON int array (numbers or numeric strings), dropping non-numeric entries.
 /// Absent / non-array → empty.
 pub(crate) fn int_array(payload: &JsonObject, key: &str) -> Vec<i64> {

--- a/crates/sceneworks-core/src/video_request.rs
+++ b/crates/sceneworks-core/src/video_request.rs
@@ -19,8 +19,8 @@ use serde_json::Value;
 
 use crate::contracts::JsonObject;
 use crate::payload_util::{
-    array_or_empty, clamped_u32, nonempty_string_or, object_or_empty, optional_i64, optional_id,
-    parse_u32, string_list,
+    array_or_empty, clamped_u32, declared_resolution, nonempty_string_or, object_or_empty,
+    optional_i64, optional_id, parse_u32, string_list,
 };
 
 /// Defaults matching the Python `video_request_from_job` (`.get(key, default)`).
@@ -498,19 +498,7 @@ const MAX_DIMENSION: u32 = 1920;
 /// [`normalized_dimensions`] does that for declared and blanket geometry alike, so a model whose
 /// advertised default is off its own lattice is floored exactly as a caller's request would be.
 pub fn default_resolution(model_manifest_entry: &JsonObject) -> Option<(u32, u32)> {
-    let (width, height) = model_manifest_entry
-        .get("defaults")
-        .and_then(Value::as_object)
-        .and_then(|defaults| defaults.get("resolution"))
-        .and_then(Value::as_str)?
-        .split_once(['x', 'X'])?;
-    let honorable = |raw: &str| {
-        raw.trim()
-            .parse::<u32>()
-            .ok()
-            .filter(|side| (MIN_DIMENSION..=MAX_DIMENSION).contains(side))
-    };
-    Some((honorable(width)?, honorable(height)?))
+    declared_resolution(model_manifest_entry, MIN_DIMENSION, MAX_DIMENSION)
 }
 
 /// The advertised frame rates as a human list: `30`, `16 or 24`, `6, 7, 8, 10, 12, or 25`.


### PR DESCRIPTION
Closes [sc-12427](https://app.shortcut.com/trefry/story/12427). Epic 12334.

The **image half** of the dead-`defaults.*` sweep. [#1584](https://github.com/SceneWorks/SceneWorks/pull/1584) closed the video lane (fps / duration / resolution); this is the same bug one lane over, found by continuing the pattern rather than stopping at the lane boundary.

## The bug — verified by driving the real route

`POST /api/v1/image/jobs`, real shipped manifest, payload = `{projectId, mode, prompt, model}` and **nothing else**:

```
sensenova_u1_8b: 201 Created | 1024x1024   ← declares 2048x2048
chroma1_flash:   201 Created | 1024x1024   ← declares 768x768
flux1_schnell:   201 Created | 1024x1024   ← declares 1024x1024 (blanket coincides)
```

`dto.rs` defaulted width/height to a blanket **1024** each, and **nothing in Rust read `defaults.resolution`**. The web honors it (`ImageStudio.jsx:215`), so the API and the UI silently disagreed.

## Blast radius: 5 of 45 image models

| model | declares | rendered |
|---|---|---|
| **sensenova_u1_8b** (+ `_fast`, `_infographic_v2`, `_infographic_v2_fast`) | 2048×2048 | **1024×1024** |
| **chroma1_flash** | 768×768 | **1024×1024** |
| the other 40 | 1024×1024 | 1024×1024 — coincidence, not design |

Narrower than the video lane (5/45 vs 7/10), but the **sensenova U1 family *is* the text/infographic model** — it declares 2048 because legible text is the entire point, and a size-less MCP call got **half** that.

**No error at any layer**: geometry *coerces* rather than rejects, which is exactly why this outlived `hardMaxDuration` as a dead key. Silent by construction.

## Fix (the sc-12400 shape)

- **`payload_util::declared_resolution(entry, min, max)`** — the parse is generic, the honorable range is **not**: video clamps 256..=1920, images 256..=4096, so image models legitimately declare **2048×2048**, a value video's bound rejects. Passing the bounds in keeps one parser without pretending the lanes share a geometry envelope. Video's `default_resolution` delegates to it, no behavior change.
- `ImageRequest::from_payload` hoists `model_manifest_entry` above the struct literal so the geometry can consult it — the shape `VideoRequest::from_payload` already uses.
- `ImageJobRequest.width/height` → `Option<u32>`; `create_image_job` resolves per side after manifest resolution, writing back only when the caller named none. `validate_image_job` bounds only a *named* dimension.
- **Deliberately unchanged**: `CharacterTestRequest` / `InterleaveJobRequest` keep the blanket — their routes resolve no `modelManifestEntry`, so there is no declared default to resolve from.

## ⚠️ Behavior change

Raw API / MCP callers that **omit** width/height (UI unaffected — the studio always sends explicit values):

- four sensenova U1 variants: 1024×1024 → **2048×2048**
- chroma1_flash: → 768×768
- the other 40: unchanged

Each adopts the geometry the manifest and the studio already declare. **The sensenova jump doubles each side = 4× the pixels**, so it is a real cost/VRAM change on that family, not only a quality fix — flagging rather than burying it.

## Tests

`an_image_request_naming_no_size_renders_the_models_own_declared_resolution` — real manifest, real route, and it lists the *coincidental* match (`flux1_schnell`) alongside the victims so it stays a per-model assertion rather than "the route returns 1024".

Expectations are **transcribed**, never derived from `default_resolution`: routing them through the function under test is precisely what made the video half's first cut a tautology that survived deleting the feature.

| Mutation | Result |
|---|---|
| `default_resolution` → `None` (= the shipped bug) | **RED** |
| delete the API-side write-back | **RED** |

## Verification

- `npm run rust:check` — exit 0, 21 suites
- core 495 · api 293 · worker 861 · web 1874 — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)