### PR TITLE
build: add `npm run rust:check:candle` — reproduce the windows-candle lane locally, no CUDA needed (sc-12356)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,40 @@ optional pre-push hook (installed by `npm run hooks:install`; skip a run with
 > hook, or the CI parity lane. This trap has bitten sc-10404 (`PhaseTimer`) and sc-8390
 > (`run_blocking_with_heartbeat`).
 
+**The "candle" build** — CI's `windows-candle` lane compiles the worker with
+`--features backend-candle` on Windows, i.e. the
+`all(not(target_os = "macos"), feature = "backend-candle")` configuration. That's where
+`vram_gate`, `krea_control_fit`, the candle-control image modules and `generate_candle_video`
+live — and **neither** `npm run rust:check` (macOS pins `target_os`, so the cfg is false
+whatever features you pass) **nor** `rust:check:neither` (candle off) compiles a line of it.
+It carries the most cfg-gated code in the repo. Reproduce it locally with:
+
+```bash
+npm run rust:check:candle
+```
+
+macOS hosts cross-compile to `x86_64-unknown-linux-gnu` (`rustup target add
+x86_64-unknown-linux-gnu` once); Linux/Windows hosts build for the host. **No CUDA toolkit is
+required**: `cudarc` and `candle-kernels` only need `nvcc`/`nvidia-smi` in their *build
+scripts*, and `cargo check`/`clippy` never link or run a kernel, so the script generates a stub
+`nvcc` and sets `CUDA_COMPUTE_CAP`. A real toolkit, if present, is used instead.
+
+So the three Rust configurations each have a local command:
+
+| command | configuration | CI lane |
+| --- | --- | --- |
+| `npm run rust:check` | macOS / mlx | `nax-worker` |
+| `npm run rust:check:neither` | Linux, candle **off** | `parity` |
+| `npm run rust:check:candle` | not-macOS, candle **on** | `windows-candle` |
+
+> **`rust:check:candle` TYPECHECKS — it does not run the candle tests.** `cargo test` links,
+> which needs a real libcuda, so candle-gated `#[test]`s still execute for the first time on
+> CI. Verify their fixtures and thresholds by other means (arithmetic, or by exercising the
+> shared non-gated helper on a Mac): sc-12306 shipped a candle test whose fixture asserted the
+> exact opposite of its intent, and it compiled perfectly. Green here means "it compiles under
+> the cfg CI compiles it under" — which is precisely the class (E0425 from a cfg-gated symbol,
+> dead code under `-D warnings`) that used to cost a full round-trip on a self-hosted runner.
+
 **Web** (from the repo root):
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "rust:build": "cargo build",
     "rust:check": "npm run rust:fmt && npm run rust:lint && npm run rust:test && npm run rust:build",
     "rust:check:neither": "node scripts/check-neither-build.mjs",
+    "rust:check:candle": "node scripts/check-candle-build.mjs",
     "desktop:build": "cargo build -p sceneworks-desktop",
     "desktop:check": "cargo clippy -p sceneworks-desktop --all-targets -- -D warnings",
     "web:build": "npm --prefix apps/web run build",

--- a/scripts/check-candle-build.mjs
+++ b/scripts/check-candle-build.mjs
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+// sc-12356: reproduce the CI `windows-candle` lane's Rust typecheck locally — the
+// `all(not(target_os = "macos"), feature = "backend-candle")` configuration — so a candle-only break
+// is caught before pushing instead of after a full self-hosted-runner round-trip.
+//
+// The sibling of `check-neither-build.mjs` (sc-10463), which covers the OTHER lane a macOS host
+// cannot see. Between them, all three configurations are reachable locally:
+//
+//     npm run rust:check          macOS / mlx          (native here)
+//     npm run rust:check:neither  Linux, candle OFF    (the parity lane)
+//     npm run rust:check:candle   Linux, candle ON     (this script — the windows-candle lane)
+//
+// ## Why this lane needs its own script
+//
+// Everything under `#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]` — `vram_gate`,
+// `krea_control_fit`, the candle-control image modules, `generate_candle_video` and its Mochi fit
+// gates — is compiled by NEITHER a macOS `npm run rust:check` (`target_os` is pinned to `macos`, so
+// the cfg is false whatever features you pass) NOR `rust:check:neither` (candle off). Its only
+// compiler was `windows-candle.yml`. That lane carries the most cfg-gated code in the repo, so it is
+// the one where a local check pays for itself the most — and it was the one with none.
+//
+// ## Why a plain `cargo clippy --target x86_64-unknown-linux-gnu --features backend-candle` fails
+//
+// It dies in DEPENDENCY BUILD SCRIPTS, long before typechecking, on a box with no CUDA toolkit:
+//   1. `cudarc`         → panics "`nvcc --version` failed".
+//   2. `candle-kernels` → `ComputeCapDetectionFailed` (it shells `nvidia-smi`).
+//   3. `candle-kernels` → shells `nvcc --ptx` per kernel, then `include_str!`s the `.ptx` it emitted.
+//
+// `cargo clippy`/`check` NEVER LINK and never run a kernel, so a fake toolkit satisfies all three and
+// the typecheck itself is entirely real. This script generates that stub, points `PATH` at it, and
+// sets `CUDA_COMPUTE_CAP`. A box WITH a real CUDA toolkit uses it instead — the stub is a fallback,
+// not a default.
+//
+// ## What this does NOT do — read this before trusting a green run
+//
+// It TYPECHECKS the candle lane. It cannot RUN the candle tests: `cargo test` links, which needs a
+// real libcuda. So candle-gated `#[test]`s still execute for the first time on CI, and their
+// fixtures/thresholds must be verified by other means (arithmetic, or by exercising the shared
+// non-gated helper on a Mac). sc-12306 shipped a candle test whose fixture asserted the exact
+// opposite of its intent — it compiled cleanly, so this script would have said nothing.
+//
+// Green here means "it compiles under the cfg CI compiles it under", nothing more. That is exactly
+// the class that used to cost a round-trip (E0425 from a cfg-gated symbol, dead code under
+// `-D warnings`), which is why it is worth having.
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// The cfg keys off `target_os`, which a native build cannot change — so a macOS host MUST cross to a
+// non-macOS target. Linux/Windows hosts already satisfy `not(target_os = "macos")` natively, and
+// building for the host avoids needing a cross std at all.
+const CROSS_TARGET = process.env.SCENEWORKS_CANDLE_TARGET || "x86_64-unknown-linux-gnu";
+const needsCross = process.platform === "darwin";
+
+// The version string `cudarc`'s build.rs parses. It reads stdout LINE INDEX 3, splits on ", " and
+// takes [1], then splits on " " and takes [1] — so line 4 must end up as `release 12.9` → `12.9`,
+// and 12.9 must be in its `SUPPORTED_CUDA_VERSIONS` table. Keep those in lockstep if cudarc bumps.
+const STUB_CUDA_VERSION = "12.9";
+
+// candle-kernels shells `nvidia-smi` to detect the compute cap; with no GPU it fails and tells you to
+// set this. Any supported cap works — nothing is executed, only typechecked.
+const DEFAULT_COMPUTE_CAP = "90";
+
+/** The CI lane's own commands, mirrored. `sceneworks-worker` has no `default` feature, so
+ *  `--features backend-candle` is the whole feature set, exactly as windows-candle.yml passes it. */
+const STEPS = [
+  {
+    label: "clippy (candle worker)",
+    args: [
+      "clippy",
+      "-p",
+      "sceneworks-worker",
+      "--features",
+      "backend-candle",
+      "--all-targets",
+      "--",
+      "-D",
+      "warnings",
+    ],
+  },
+  {
+    label: "check (candle sidecar: rust-api)",
+    // `embed-web` is deliberately absent: it gates `WebAssets` via rust-embed's `debug-embed`, which
+    // embeds at COMPILE time even under `cargo check`, and this lane never builds `apps/web/dist`
+    // → `error[E0599]: no function get`. CI omits it for the same reason.
+    args: ["check", "-p", "sceneworks-rust-api", "--features", "backend-candle"],
+  },
+];
+
+function run(cmd, args, env) {
+  return spawnSync(cmd, args, { cwd: repoRoot, env, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+function hasRealNvcc() {
+  const res = spawnSync("nvcc", ["--version"], { stdio: "ignore" });
+  return !res.error && res.status === 0;
+}
+
+function targetInstalled(target) {
+  const res = spawnSync("rustup", ["target", "list", "--installed"], { encoding: "utf8" });
+  if (res.error || res.status !== 0) return null; // no rustup → can't tell; let cargo speak.
+  return res.stdout.split("\n").some((line) => line.trim() === target);
+}
+
+/** Write a fake `nvcc` that satisfies the three build scripts above. Only the two behaviours they
+ *  actually use are implemented; everything else exits 0 having done nothing, which is correct
+ *  because nothing downstream reads it under `cargo check`. */
+function writeStubNvcc() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sceneworks-candle-stub-"));
+  const nvcc = path.join(dir, "nvcc");
+  fs.writeFileSync(
+    nvcc,
+    `#!/bin/sh
+# Generated by scripts/check-candle-build.mjs (sc-12356). NOT a CUDA compiler: it exists so
+# cargo check/clippy can TYPECHECK the candle cfg on a box with no CUDA toolkit. cargo check never
+# links and never runs a kernel, so empty .ptx stand-ins are sufficient. CI compiles for real.
+for a in "$@"; do
+  [ "$a" = "--version" ] && {
+    printf 'nvcc: NVIDIA (R) Cuda compiler driver\\n'
+    printf 'Copyright (c) 2005-2025 NVIDIA Corporation\\n'
+    printf 'Built on stub\\n'
+    printf 'Cuda compilation tools, release ${STUB_CUDA_VERSION}, V${STUB_CUDA_VERSION}.0\\n'
+    printf 'Build stub\\n'
+    exit 0; }
+done
+# cudaforge invokes: nvcc <gencode> --ptx --default-stream per-thread --output-directory DIR ... X.cu
+outdir=""; outfile=""; src=""; prev=""
+for a in "$@"; do
+  case "$prev" in
+    --output-directory) outdir="$a" ;;
+    -o) outfile="$a" ;;
+  esac
+  case "$a" in *.cu) src="$a" ;; esac
+  prev="$a"
+done
+if [ -n "$outfile" ]; then
+  mkdir -p "$(dirname "$outfile")" 2>/dev/null; : > "$outfile"
+elif [ -n "$outdir" ] && [ -n "$src" ]; then
+  base=$(basename "$src" .cu); mkdir -p "$outdir" 2>/dev/null
+  : > "$outdir/$base.ptx"; : > "$outdir/$base.o"
+fi
+exit 0
+`,
+    { mode: 0o755 },
+  );
+  return dir;
+}
+
+/** The gotcha this function exists for: if a candle-kernels build script ever "succeeded" without
+ *  emitting its .ptx (e.g. an earlier run with no stub, or a half-written one), cargo CACHES that
+ *  success and replays `couldn't read .../affine.ptx` forever — without re-invoking nvcc. The stub
+ *  then looks broken when it is fine. Blow the cached build dirs away and the next run re-runs it. */
+function clearCandleKernelsCache() {
+  const roots = [path.join(repoRoot, "target"), path.join(repoRoot, "target", CROSS_TARGET)];
+  let cleared = 0;
+  for (const root of roots) {
+    const buildDir = path.join(root, "debug", "build");
+    if (!fs.existsSync(buildDir)) continue;
+    for (const entry of fs.readdirSync(buildDir)) {
+      if (!entry.startsWith("candle-kernels-")) continue;
+      fs.rmSync(path.join(buildDir, entry), { recursive: true, force: true });
+      cleared += 1;
+    }
+  }
+  return cleared;
+}
+
+const STALE_PTX = /couldn't read .*\.ptx/;
+
+function main() {
+  if (process.argv.includes("--help") || process.argv.includes("-h")) {
+    console.log(
+      "Reproduce the CI 'windows-candle' (not-macOS + backend-candle) Rust typecheck locally.\n\n" +
+        "  node scripts/check-candle-build.mjs      # or: npm run rust:check:candle\n\n" +
+        "macOS hosts cross-compile to a Linux target (the cfg keys off target_os, which a native\n" +
+        "build cannot change); Linux/Windows hosts build for the host. With no CUDA toolkit a stub\n" +
+        "nvcc is generated — cargo check never links, so the typecheck is still real.\n\n" +
+        "This TYPECHECKS only; it cannot RUN candle tests (cargo test links, needing real libcuda).\n\n" +
+        "  --allow-skip   exit 0 (with guidance) instead of 1 when the toolchain for this host is\n" +
+        "                 missing. For the pre-push hook: a dev who never opted into the cross\n" +
+        "                 target should not be blocked from pushing by a check they cannot run.\n\n" +
+        "Env: SCENEWORKS_CANDLE_TARGET overrides the cross target (default x86_64-unknown-linux-gnu).",
+    );
+    return 0;
+  }
+
+  // A missing toolchain is a "cannot run here", not "your code is broken" — the caller decides
+  // whether that blocks. Interactive runs fail loudly (you asked for the check); the pre-push hook
+  // passes --allow-skip so it never turns an un-opted-in dev's push into an error.
+  const unavailable = process.argv.includes("--allow-skip") ? 0 : 1;
+  const env = { ...process.env };
+  const targetArgs = [];
+
+  if (needsCross) {
+    const installed = targetInstalled(CROSS_TARGET);
+    if (installed === false) {
+      const say = unavailable === 0 ? console.log : console.error;
+      say(
+        `[candle] SKIPPED: the cfg keys off target_os, so a macOS host must cross-compile — but the\n` +
+          `         ${CROSS_TARGET} target is not installed. Add it once with:\n\n` +
+          `             rustup target add ${CROSS_TARGET}\n\n` +
+          `         (SCENEWORKS_CANDLE_TARGET overrides the target.)`,
+      );
+      return unavailable;
+    }
+    targetArgs.push("--target", CROSS_TARGET);
+    console.log(
+      `[candle] macOS host: cross-compiling to ${CROSS_TARGET} — a native build pins\n` +
+        `         target_os="macos", so it can never compile this cfg.`,
+    );
+  } else {
+    console.log(
+      `[candle] host is ${process.platform} (not macOS): not(target_os = "macos") already holds, so\n` +
+        `         this builds for the host.`,
+    );
+  }
+
+  if (hasRealNvcc()) {
+    console.log("[candle] using the real nvcc found on PATH.");
+  } else if (process.platform === "win32") {
+    const say = unavailable === 0 ? console.log : console.error;
+    say(
+      "[candle] SKIPPED: no nvcc on PATH. The stub is a POSIX shell script and won't run here; a\n" +
+        "         Windows box running this lane is expected to have the real CUDA Toolkit (as the CI\n" +
+        "         runner does).",
+    );
+    return unavailable;
+  } else {
+    const stubDir = writeStubNvcc();
+    env.PATH = `${stubDir}${path.delimiter}${env.PATH}`;
+    if (!env.CUDA_COMPUTE_CAP) env.CUDA_COMPUTE_CAP = DEFAULT_COMPUTE_CAP;
+    console.log(
+      `[candle] no CUDA toolkit here — generated a stub nvcc in ${stubDir}\n` +
+        `         (CUDA_COMPUTE_CAP=${env.CUDA_COMPUTE_CAP}). cargo check never links, so the\n` +
+        `         typecheck is real; only the kernel objects are fake.`,
+    );
+  }
+
+  for (const step of STEPS) {
+    const args = [step.args[0], ...targetArgs, ...step.args.slice(1)];
+    console.log(`\n[candle] ${step.label}: cargo ${args.join(" ")}`);
+    let res = run("cargo", args, env);
+    if (res.error) {
+      if (res.error.code === "ENOENT") {
+        console.error("[candle] cargo not found on PATH. Install Rust (https://rustup.rs) and retry.");
+        return 1;
+      }
+      throw res.error;
+    }
+
+    // The cached-build-script trap: retry ONCE after clearing, rather than making every run pay for
+    // a candle-kernels rebuild it almost never needs.
+    if (res.status !== 0 && STALE_PTX.test(res.stderr || "")) {
+      const cleared = clearCandleKernelsCache();
+      console.log(
+        `[candle] stale candle-kernels build cache detected (missing .ptx replayed from a cached\n` +
+          `         build-script success). Cleared ${cleared} dir(s); retrying once.`,
+      );
+      res = run("cargo", args, env);
+      if (res.error) throw res.error;
+    }
+
+    process.stdout.write(res.stdout || "");
+    process.stderr.write(res.stderr || "");
+    if (res.status !== 0) {
+      console.error(`\n[candle] FAILED: ${step.label}`);
+      return res.status ?? 1;
+    }
+  }
+
+  console.log(
+    "\n[candle] OK — the candle cfg typechecks, incl. test targets, under -D warnings.\n" +
+      "         Reminder: candle #[test]s still first RUN on the windows-candle CI lane.",
+  );
+  return 0;
+}
+
+process.exit(main());

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,13 +1,13 @@
 #!/bin/sh
-# sc-10463: before pushing Rust changes, run the "neither" build (Linux, no backend-candle) locally
-# so the cfg/dead-code trap that only surfaces in CI's parity lane is caught here instead of after a
-# full CI round-trip. Only runs when the pushed commits touch Rust; skip with SKIP_NEITHER_CHECK=1 or
-# `git push --no-verify`. See CONTRIBUTING.md ("The base.rs / candle cfg rule").
+# sc-10463: before pushing Rust changes, run the configurations a macOS `npm run rust:check` CANNOT
+# compile, so their cfg/dead-code traps are caught here instead of after a full CI round-trip:
+#   * the "neither" build (Linux, no backend-candle)   -> CI's parity lane
+#   * the "candle" build (not-macOS + backend-candle)  -> CI's windows-candle lane   (sc-12356)
+# The candle lane matters most: it is the ONLY compiler of `cfg(all(not(macos), backend-candle))`,
+# and its self-hosted runner can queue for 20+ minutes, so a typo there is expensive to learn about.
+# Only runs when the pushed commits touch Rust. Skip with SKIP_NEITHER_CHECK=1 / SKIP_CANDLE_CHECK=1
+# or `git push --no-verify`. See CONTRIBUTING.md ("The base.rs / candle cfg rule").
 set -eu
-
-if [ "${SKIP_NEITHER_CHECK:-0}" = "1" ]; then
-  exit 0
-fi
 
 zero="0000000000000000000000000000000000000000"
 rust_changed=0
@@ -37,19 +37,38 @@ done
 
 [ "$rust_changed" = "0" ] && exit 0
 
-echo "Running the 'neither' build (Linux, no backend-candle) for pushed Rust changes..."
-echo "(skip with SKIP_NEITHER_CHECK=1 or 'git push --no-verify')"
-
 if ! command -v npm >/dev/null 2>&1; then
-  echo "npm is required to run the neither-build check. Install Node/npm or add it to PATH."
+  echo "npm is required to run the pre-push Rust checks. Install Node/npm or add it to PATH."
   exit 1
 fi
 
-if ! npm run --silent rust:check:neither; then
-  echo
-  echo "The neither build failed: an item used only by base.rs / candle-only code is dead on the"
-  echo "Linux no-candle build. Gate it with the same cfg as base.rs:"
-  echo '  #[cfg(any(target_os = "macos", all(not(target_os = "macos"), feature = "backend-candle")))]'
-  echo "See CONTRIBUTING.md ('The base.rs / candle cfg rule')."
-  exit 1
+if [ "${SKIP_NEITHER_CHECK:-0}" != "1" ]; then
+  echo "Running the 'neither' build (Linux, no backend-candle) for pushed Rust changes..."
+  echo "(skip with SKIP_NEITHER_CHECK=1 or 'git push --no-verify')"
+
+  if ! npm run --silent rust:check:neither; then
+    echo
+    echo "The neither build failed: an item used only by base.rs / candle-only code is dead on the"
+    echo "Linux no-candle build. Gate it with the same cfg as base.rs:"
+    echo '  #[cfg(any(target_os = "macos", all(not(target_os = "macos"), feature = "backend-candle")))]'
+    echo "See CONTRIBUTING.md ('The base.rs / candle cfg rule')."
+    exit 1
+  fi
+fi
+
+if [ "${SKIP_CANDLE_CHECK:-0}" != "1" ]; then
+  echo "Running the 'candle' build (not-macOS + backend-candle) for pushed Rust changes..."
+  echo "(skip with SKIP_CANDLE_CHECK=1 or 'git push --no-verify')"
+
+  # --allow-skip: a missing cross target / CUDA toolkit means "cannot check here", not "broken" —
+  # it must never block a push from a dev who has not opted into the toolchain.
+  if ! npm run --silent rust:check:candle -- --allow-skip; then
+    echo
+    echo "The candle build failed: this is the ONLY lane that compiles"
+    echo '  #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]'
+    echo "so a macOS 'npm run rust:check' cannot see it. Common causes: a pub(crate) symbol defined"
+    echo "under a narrower cfg than its candle-only caller (E0425), or an item that is dead once the"
+    echo "macOS half is excluded. See CONTRIBUTING.md ('The candle build')."
+    exit 1
+  fi
 fi


### PR DESCRIPTION
Closes [sc-12356](https://app.shortcut.com/trefry/story/12356). Follow-on to sc-10463.

## The gap

sc-10463 gave the **"neither"** lane a local repro. The **candle** lane had none — and it's the lane with the most cfg-gated code in the repo.

Everything under `cfg(all(not(target_os = "macos"), feature = "backend-candle"))` — `vram_gate`, `krea_control_fit`, the candle-control image modules, `generate_candle_video` and its Mochi fit gates — is compiled by **neither** a macOS `npm run rust:check` (`target_os` is pinned to `macos`, so the cfg is false *whatever features you pass*) **nor** `rust:check:neither` (candle off). Its only compiler was CI — on a self-hosted runner that queued **20+ minutes** during last night's merge burst.

sc-10463's approach #2 flagged the risk: *"the candle-gen native deps may complicate the cross build — verify."* They do, and it's fixable.

## Why a plain cross-compile fails, and why the fix is sound

It dies in **dependency build scripts**, long before typechecking:
1. `cudarc` → panics ``"`nvcc --version` failed"``
2. `candle-kernels` → `ComputeCapDetectionFailed` (shells `nvidia-smi`)
3. `candle-kernels` → shells `nvcc --ptx` per kernel, then `include_str!`s the output

**`cargo check`/`clippy` never link and never run a kernel**, so a stub `nvcc` satisfies all three and *the typecheck itself is entirely real*. A real toolkit, if present, is used instead — the stub is a fallback, not a default.

All three configurations now have a local command:

| command | configuration | CI lane |
| --- | --- | --- |
| `npm run rust:check` | macOS / mlx | `nax-worker` |
| `npm run rust:check:neither` | Linux, candle **off** | `parity` |
| **`npm run rust:check:candle`** | **not-macOS, candle on** | **`windows-candle`** |

## It earns its place — proven, not asserted

Narrowing `mochi_precheck_dir` to `cfg(target_os = "macos")` while its candle-only caller remains:

| check | result |
|---|---|
| `cargo clippy` on macOS | **EXIT 0** — blind; the break ships |
| `npm run rust:check:candle` | **EXIT 101** — `error[E0425]: cannot find function mochi_precheck_dir` |

And the other trap class — an unused `pub(crate)` fn in `vram_gate.rs` → **EXIT 101**, ``function `sc12356_probe_unused_helper` is never used``.

## Wired into the pre-push hook

A local check nobody runs prevents no round-trips, so it sits beside the neither check. It passes `--allow-skip`: a missing cross target or CUDA toolkit means *"cannot check here"*, not *"your code is broken"* — it must never block a push from a dev who hasn't opted into the toolchain. All three paths verified: interactive → 1, `--allow-skip` → 0, npm flag passthrough → 0.

## Encodes the gotcha that cost ~20 minutes

If a `candle-kernels` build script ever "succeeded" without emitting its `.ptx`, cargo **caches that success** and replays `couldn't read .../affine.ptx` forever without re-invoking nvcc — so the stub looks broken when it's fine. The script detects that signature, clears the cached build dirs, and retries **once**, rather than making every run pay for a rebuild it rarely needs.

## The limit, documented rather than oversold

This **TYPECHECKS**. It cannot **RUN** the candle tests (`cargo test` links, needing real libcuda), so candle-gated `#[test]`s still first execute on CI. **sc-12306 shipped a candle test whose fixture asserted the exact opposite of its intent — it compiled perfectly, and this script would have said nothing.** Green here means "it compiles under the cfg CI compiles it under", which is exactly the class (E0425, dead code under `-D warnings`) that used to cost a full round-trip.

That caveat is in CONTRIBUTING, not just the PR.

## Bonus finding (evaluated, not actioned — see the story)
The same cross-target trick reproduces the **neither** lane on macOS without Docker: a probe item used only by `base.rs` was correctly flagged `never used` by `cargo clippy --target x86_64-unknown-linux-gnu`, proving `base.rs` really is excluded. Whether `check-neither-build.mjs` should drop Docker for it is a real trade-off (Docker has link-level fidelity; cross-check doesn't) and is that script's owner's call — reported on sc-12356 rather than changed here.

## Verification
`npm run rust:check:candle` → **EXIT 0** on this Mac with **no CUDA toolkit**, from a cold `candle-kernels` state, compiling `sceneworks-worker` + test targets and the `rust-api` sidecar. `npm run check` (scaffold) green. `sh -n` on the hook green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)