### PR TITLE
ci: give every main commit its own candle/NAX verdict (sc-12399)

### DIFF
--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -59,9 +59,19 @@ on:
     paths: *desktop_paths
   workflow_dispatch:
 
+# Cancel superseded PR runs, but never cancel a main-push run — same reasoning as
+# windows-candle.yml (sc-12399). `package-windows` below is non-PR-only, so main is
+# the ONLY place the full candle/CUDA desktop package is built before a release tag;
+# cancelling it pushes packaging breaks to release time. It also shares the one
+# `cuda` box with windows-candle.yml, so it is part of the same queue.
+#
+# Main must key on `github.sha`, not `github.ref`: GitHub keeps at most ONE pending
+# run per group and evicts it when a newer run queues, so a shared main group still
+# drops the middle commit of a 3+ merge burst even with cancel-in-progress off.
+# Per-SHA groups cannot evict each other; runs serialize on the box instead.
 concurrency:
-  group: desktop-windows-${{ github.ref }}
-  cancel-in-progress: true
+  group: desktop-windows-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # PR gate — cheap desktop-crate checks on a hosted runner. No candle/CUDA/packaging.

--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -47,9 +47,19 @@ on:
     paths: *mlx_paths
   workflow_dispatch:
 
+# Cancel superseded PR runs, but never cancel a main-push run — same reasoning as
+# windows-candle.yml (sc-12399). This lane is the only thing in CI that runs
+# `nax_guard`, so a main commit whose run is killed carries no NAX verdict at all
+# and a later kernel break is misattributed to the next commit.
+#
+# Main must key on `github.sha`, not `github.ref`: GitHub keeps at most ONE pending
+# run per group and evicts it when a newer run queues, so a shared main group still
+# drops the middle commit of a 3+ merge burst even with cancel-in-progress off.
+# Per-SHA groups cannot evict each other; runs serialize on the self-hosted box
+# instead. Do NOT collapse this back to `group: ...${{ github.ref }}`.
 concurrency:
-  group: macos-mlx-${{ github.ref }}
-  cancel-in-progress: true
+  group: macos-mlx-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   nax-worker:

--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -57,9 +57,27 @@ on:
     paths: *candle_paths
   workflow_dispatch:
 
+# Cancel superseded PR runs, but never cancel a main-push run: this lane is the
+# ONLY thing that compiles the candle-gated worker code, so a main commit whose
+# run is killed carries no candle verdict at all and a later break is misattributed
+# to the next commit (sc-12399 — 8 of 30 main runs cancelled over one 37h window).
+#
+# The group KEY is what does the work here, not just cancel-in-progress. GitHub
+# allows at most ONE pending run per concurrency group and cancels the previously
+# pending run when a new one queues, so keying main on `github.ref` would still
+# drop the middle commit of any 3+ merge burst (A runs, B pends, C evicts B) even
+# with cancel-in-progress off. Keying main on `github.sha` puts every commit in its
+# own group, where nothing can evict it; runs then serialize on the single
+# self-hosted box instead. Do NOT collapse this back to `group: ...${{ github.ref }}`.
+#
+# Cost is bounded and was measured before landing: the lane is ~4.2m median (p90
+# 4.5m) and the box sits ~12% utilized, so restoring the cancelled main runs adds
+# ~34m of box time per ~37h (≈12% -> ≈13% utilization). `queue: max` would be the
+# other way to do this, but it cannot combine with `cancel-in-progress: true`,
+# which the PR side still wants.
 concurrency:
-  group: windows-candle-${{ github.ref }}
-  cancel-in-progress: true
+  group: windows-candle-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   candle-worker:


### PR DESCRIPTION
Fixes [sc-12399](https://app.shortcut.com/trefry/story/12399).

## The bug

`windows-candle.yml`, `macos-mlx.yml` and `desktop-windows.yml` all trigger on `push: main` with `group: <lane>-${{ github.ref }}` + `cancel-in-progress: true`. For a PR that's correct. But `github.ref` is `refs/heads/main` for **every** merge, so each merge cancelled the in-flight run of the previous merge.

**Measured over a 37h window (last 80 runs of windows-candle): 8 of 30 main runs cancelled — 27% of main commits carried no candle verdict.** Two of them (`29543174569`, `29545218408`) executed zero steps.

These lanes are the *sole* compilers of their code paths — candle-gated worker code, `nax_guard`, and the pre-release candle/CUDA package. A killed run means a break is first reported against the **later** commit, and `git bisect` over main is unreliable because many main commits carry no verdict at all.

## Why not the one-liner the story proposed

The story suggested just `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`. That is **not sufficient**: GitHub allows at most **one pending run per concurrency group** and cancels the previously pending run when a newer one queues. With main still keyed on `github.ref`, a 3-merge burst drops the middle commit anyway — A runs, B pends, C evicts B. It fixes a burst of exactly two and silently fails at three, which is the case the story was filed about.

So the **group key** does the work here, not the cancel flag. Keying main on `github.sha` puts every commit in its own group where nothing can evict it; runs then serialize on the runner instead. PRs keep cancelling superseded runs.

`queue: max` is the other route, but it [cannot combine with `cancel-in-progress: true`](https://github.blog/changelog/2026-05-07-github-actions-concurrency-groups-now-allow-larger-queues/), which the PR side still wants.

## Cost — measured, not assumed

The story's follow-up worried this would worsen PR latency on a saturated box. It isn't saturated:

| metric | value |
|---|---|
| run duration | 4.2m median, 4.5m p90 |
| box utilization | **11.9%** (4.4h busy / 37.4h) |
| queue wait | 1.0m median, 12.5m p90, 27.7m max |
| runs arriving while box busy | 41% |

Utilization of ~12% with a p90 wait of 12.5m is **arrival burstiness on a single-concurrency runner, not capacity exhaustion**. Restoring the 8 cancelled main runs costs ~34m of box time per ~37h (≈12% → ≈13%). A queued main run adds a bounded ~4m to a burst.

Worth noting: runner `cuda-windows` (id 2313) is shared with `SceneWorks/inference`, so contention is cross-repo. A companion fix for the same bug lands there (that repo measured **40%** of main commits with no verdict).

## Scope

Also fixes `macos-mlx.yml` (the story explicitly asks to check it — it's the only lane that runs `nax_guard`) and `desktop-windows.yml` (its `package-windows` job is non-PR-only, so main is the only pre-release candle/CUDA package build, and it shares the same box). `release.yml` was already correct; `check.yml` sets no concurrency; `server-candle-linux.yml` is dispatch-only and left alone.

## Verification

YAML parses and anchors still resolve. Per the story's acceptance criterion, the real check is watching a merge burst and confirming no run is cancelled by a successor — that needs a burst on main after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)