### PR TITLE
fix(worker): make the test env seam crate-wide and stop the eros fixture reading ambient env (sc-12380)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -1,6 +1,12 @@
 use super::*;
 use serde_json::json;
 
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+use crate::test_env::EnvVars;
+
 fn request(value: Value) -> ImageRequest {
     ImageRequest::from_payload(&value.as_object().cloned().unwrap())
 }
@@ -5025,7 +5031,7 @@ fn image_route_rejects_wired_pose_when_control_base_absent() {
     let dir = tempfile::tempdir().unwrap();
     // Isolate the HF hub cache to the empty tempdir so the control base is genuinely absent regardless of
     // the machine's real cache (the weight resolvers read the global HF cache in preference to `data_dir`).
-    let _hf = HfHubCacheGuard::isolate_to(dir.path());
+    let _hf = isolate_hf_hub_cache_to(dir.path());
     let mut settings = Settings::from_env();
     // Empty data_dir + isolated HF cache + no `modelPath` → every `…_control_available` weight-gate (and
     // `mlx_available`) resolves nothing, so each wired-family pose job falls through to the reject arm.
@@ -5213,52 +5219,35 @@ fn candle_image_route_sends_krea_img2img_to_txt2img() {
     );
 }
 
-/// RAII guard isolating the HF hub-cache env (`HF_HUB_CACHE` / `HUGGINGFACE_HUB_CACHE` / `HF_HOME`) to an
-/// explicit dir for a test, restoring the previous values on drop. The control-base resolvers (both the
-/// candle lanes and the MLX `resolve_krea_control_base`) read the GLOBAL HF hub cache in preference to
-/// `settings.data_dir` (`hf_home.rs` `huggingface_hub_cache_dir` checks the env vars first), so a test that
-/// wants a controlled base (absent, or a hand-seeded snapshot) must point that cache at its own dir —
-/// otherwise it observes the machine's / CI runner's REAL cache. E.g. when the real cache happens to hold
+/// Isolate the HF hub-cache env (`HF_HUB_CACHE` / `HUGGINGFACE_HUB_CACHE` / `HF_HOME`) to an explicit
+/// dir for as long as the returned guard lives, restoring the previous values on drop. The
+/// control-base resolvers (both the candle lanes and the MLX `resolve_krea_control_base`) read the
+/// GLOBAL HF hub cache in preference to `settings.data_dir` (`hf_home.rs` `huggingface_hub_cache_dir`
+/// checks the env vars first), so a test that wants a controlled base (absent, or a hand-seeded
+/// snapshot) must point that cache at its own dir — otherwise it observes the machine's / CI runner's
+/// REAL cache. E.g. when the real cache happens to hold
 /// `alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1` the candle base is NOT absent and the route flips
 /// `PoseControlBaseMissing` → `ZimageControl`; on the MLX side the real tiered turnkey masks a seeded one.
+///
+/// `HF_HUB_CACHE` is consulted first, so it decides the resolver outright; the lower-priority
+/// fallbacks are cleared anyway so nothing can resolve to the real cache.
+///
+/// Goes through the crate-wide [`EnvVars`] seam so it takes the shared env lock. This used to be an
+/// `HfHubCacheGuard` hand-rolling the same save/set/restore with NO lock at all, which made it an
+/// unsynchronized writer of vars other modules' tests read: it was what still broke
+/// `video_jobs::tests::ltx_eros_auto_injects_distill_lora_per_pass` (6/6) after that test's own
+/// module-local lock was supposed to have fixed it, and the two tests using it also clobbered each
+/// other's `HF_HUB_CACHE` (sc-12380).
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
-struct HfHubCacheGuard {
-    prev: [(&'static str, Option<String>); 3],
-}
-
-#[cfg(any(
-    target_os = "macos",
-    all(not(target_os = "macos"), feature = "backend-candle")
-))]
-impl HfHubCacheGuard {
-    fn isolate_to(hub: &std::path::Path) -> Self {
-        let prev = ["HF_HUB_CACHE", "HUGGINGFACE_HUB_CACHE", "HF_HOME"]
-            .map(|key| (key, std::env::var(key).ok()));
-        // `HF_HUB_CACHE` is consulted first; point it at the isolated dir and clear the lower-priority
-        // fallbacks so nothing resolves to the real cache.
-        std::env::set_var("HF_HUB_CACHE", hub);
-        std::env::remove_var("HUGGINGFACE_HUB_CACHE");
-        std::env::remove_var("HF_HOME");
-        Self { prev }
-    }
-}
-
-#[cfg(any(
-    target_os = "macos",
-    all(not(target_os = "macos"), feature = "backend-candle")
-))]
-impl Drop for HfHubCacheGuard {
-    fn drop(&mut self) {
-        for (key, value) in &self.prev {
-            match value {
-                Some(val) => std::env::set_var(key, val),
-                None => std::env::remove_var(key),
-            }
-        }
-    }
+fn isolate_hf_hub_cache_to(hub: &std::path::Path) -> EnvVars {
+    EnvVars::set(&[
+        ("HF_HUB_CACHE", hub.to_str().expect("utf-8 hub dir")),
+        ("HUGGINGFACE_HUB_CACHE", ""),
+        ("HF_HOME", ""),
+    ])
 }
 
 // sc-11171 (F-008): a strict-pose job on a WIRED candle pose family (e.g. `z_image_turbo`) whose control
@@ -5273,7 +5262,7 @@ fn candle_image_route_rejects_wired_pose_when_control_base_absent() {
     let dir = tempfile::tempdir().unwrap();
     // Isolate the HF hub cache to the empty tempdir so the control base is genuinely absent regardless of
     // the machine's real cache (the resolver reads the global HF cache in preference to `data_dir`).
-    let _hf = HfHubCacheGuard::isolate_to(dir.path());
+    let _hf = isolate_hf_hub_cache_to(dir.path());
     let mut settings = Settings::from_env();
     // A tempdir data_dir + isolated HF cache holds no HF snapshot, so `resolve_zimage_control_base` yields
     // `None` → the Z-Image control lane's weight-gate (`zimage_control_available`) fails and it falls through.
@@ -9587,7 +9576,7 @@ fn krea_control_lora_end_to_end_mlx_smoke() {
     // Point the HF hub-cache env at the REAL cache so `resolve_krea_control_base` / overlay discovery find
     // the installed turnkey + overlay (the resolver reads the env cache before `settings.data_dir`).
     let real_hub = dirs_home().join(".cache/huggingface/hub");
-    let _hf = HfHubCacheGuard::isolate_to(&real_hub);
+    let _hf = isolate_hf_hub_cache_to(&real_hub);
 
     // The LoRA lives under the app data dir; `resolve_adapters` confines it to `settings.data_dir` via
     // `normalize_app_managed_lora_path`, so the data dir must be the real one holding `loras/`.
@@ -9772,7 +9761,7 @@ fn resolve_krea_control_base_descends_turnkey_root_into_tier_with_tokenizer() {
     // (it reads the env cache before `settings.data_dir` — a real cached turnkey would otherwise mask it).
     let hub = dir.path().join("hub");
     std::fs::create_dir_all(&hub).unwrap();
-    let _hf = HfHubCacheGuard::isolate_to(&hub);
+    let _hf = isolate_hf_hub_cache_to(&hub);
 
     // Seed a `SceneWorks/krea-2-turbo-mlx` HF snapshot with a packed q8 tier (transformer + tokenizer) and
     // NOTHING loadable at the root — the exact turnkey shape that triggered the bug.

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -1536,4 +1536,7 @@ fn retry_delay(poll_seconds: u64, attempt: u32) -> u64 {
 }
 
 #[cfg(test)]
+mod test_env;
+
+#[cfg(test)]
 mod tests;

--- a/crates/sceneworks-worker/src/person_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/person_jobs/tests.rs
@@ -741,10 +741,16 @@ fn f011_test_settings(data_dir: PathBuf) -> Settings {
 /// sc-11175/F-011: a set-but-missing `SCENEWORKS_PERSON_DETECTOR_WEIGHTS` pin must fail
 /// loudly (`InvalidPayload`) via `resolve_env_file_pin` instead of silently falling through
 /// to the cache/HF download; an unset pin (with nothing staged) falls through to `Ok(None)`.
-/// `RUST_TEST_THREADS=1` is forced workspace-wide, so the env mutation is serial.
+///
+/// Holds the crate-wide env lock across the whole staged mutation (set → assert → unset → assert),
+/// because `set_var` is process-global and the rest of the crate's tests run as threads in this same
+/// process. This used to claim "`RUST_TEST_THREADS=1` is forced workspace-wide, so the env mutation
+/// is serial" and take no lock — nothing sets that variable anywhere in the repo, so the tests were
+/// in fact fully parallel and the mutation was unsynchronized (sc-12380).
 #[test]
 fn resolve_detector_weights_env_pin_missing_errors_and_unset_falls_through() {
     let key = "SCENEWORKS_PERSON_DETECTOR_WEIGHTS";
+    let _env_guard = crate::test_env::env_lock();
     let dir = tempfile::tempdir().expect("tempdir");
     let settings = f011_test_settings(dir.path().to_path_buf());
     let prior = std::env::var_os(key);

--- a/crates/sceneworks-worker/src/person_segment.rs
+++ b/crates/sceneworks-worker/src/person_segment.rs
@@ -500,10 +500,16 @@ mod tests {
     /// sc-11175/F-011: a set-but-missing `SCENEWORKS_SAM2_WEIGHTS` pin must fail loudly
     /// (`InvalidPayload`) via `resolve_env_file_pin` instead of silently falling through to
     /// the cache/HF download; an unset pin (with nothing staged) falls through to `Ok(None)`.
-    /// `RUST_TEST_THREADS=1` is forced workspace-wide, so the env mutation is serial.
+    ///
+    /// Holds the crate-wide env lock across the whole staged mutation (set → assert → unset →
+    /// assert), because `set_var` is process-global and the rest of the crate's tests run as threads
+    /// in this same process. This used to claim "`RUST_TEST_THREADS=1` is forced workspace-wide, so
+    /// the env mutation is serial" and take no lock — nothing sets that variable anywhere in the
+    /// repo, so the tests were in fact fully parallel and the mutation was unsynchronized (sc-12380).
     #[test]
     fn resolve_segmenter_weights_env_pin_missing_errors_and_unset_falls_through() {
         let key = "SCENEWORKS_SAM2_WEIGHTS";
+        let _env_guard = crate::test_env::env_lock();
         let dir = tempfile::tempdir().expect("tempdir");
         let settings = f011_test_settings(dir.path().to_path_buf());
         let prior = std::env::var_os(key);

--- a/crates/sceneworks-worker/src/person_segment_sam3_common.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3_common.rs
@@ -682,10 +682,16 @@ mod tests {
     /// loudly when set-but-missing OR set to an incomplete dir (missing either file of the
     /// `{model.safetensors, tokenizer.json}` pair), instead of silently falling through to the
     /// cache/HF download. An unset pin (nothing staged) falls through to `Ok(None)`.
-    /// `RUST_TEST_THREADS=1` is forced workspace-wide, so the env mutation is serial.
+    ///
+    /// Holds the crate-wide env lock across the whole staged mutation (set → assert → unset →
+    /// assert), because `set_var` is process-global and the rest of the crate's tests run as threads
+    /// in this same process. This used to claim "`RUST_TEST_THREADS=1` is forced workspace-wide, so
+    /// the env mutation is serial" and take no lock — nothing sets that variable anywhere in the
+    /// repo, so the tests were in fact fully parallel and the mutation was unsynchronized (sc-12380).
     #[test]
     fn resolve_segmenter_weights_env_pin_missing_and_incomplete_error_unset_falls_through() {
         let key = "SCENEWORKS_SAM3_WEIGHTS";
+        let _env_guard = crate::test_env::env_lock();
         let dir = tempfile::tempdir().expect("tempdir");
         let settings = f011_test_settings(dir.path().to_path_buf());
         let prior = std::env::var_os(key);

--- a/crates/sceneworks-worker/src/test_env.rs
+++ b/crates/sceneworks-worker/src/test_env.rs
@@ -1,0 +1,105 @@
+//! The one process-global environment seam for this crate's tests (sc-12380).
+//!
+//! `cargo test -p sceneworks-worker --lib` builds ONE binary and runs every module's tests as
+//! threads in ONE process, so `std::env::set_var` in any test is visible to all the others. Mutual
+//! exclusion therefore has to be crate-wide: a per-module `static Mutex` is a DIFFERENT lock and
+//! serializes nothing against the other modules. That is not hypothetical — `video_jobs` and
+//! `training_jobs` each had their own `ENV_LOCK` while `image_jobs` took none, and all three wrote
+//! `HF_HUB_CACHE`, so `ltx_eros_auto_injects_distill_lora_per_pass` still lost its cache dir to an
+//! `image_jobs` writer (sc-12380 reproduced 6/6 on main AFTER the per-module lock was added).
+//!
+//! Hence: every test that reads OR writes an env var another test may write goes through here.
+//!
+//! Prefer pinning the value you need over branching on what the environment happens to hold. A
+//! `if var_os(..).is_some() { return; }` guard is a silent PASS that asserts nothing on a box where
+//! the var is set — it protects the suite from the environment by not testing at all.
+
+// Not every target/feature combination exercises every helper here.
+#![allow(dead_code)]
+
+use std::sync::{Mutex, MutexGuard};
+
+/// The single lock every env-touching test in this crate serializes on. Crate-level ON PURPOSE —
+/// see the module docs. Do not add a second one.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Take the shared env lock, holding it until the returned guard drops.
+///
+/// Use this directly when a test needs to *read* an env var (or call code that does) and must not
+/// have it changed underneath — the environment is process-global, so only holding the lock across
+/// the whole read-then-use makes that pair atomic. When the test also sets a var, prefer
+/// [`EnvVars::set`], which takes this lock for you.
+///
+/// Poisoning is recovered from: a panic in another env test must not cascade into a spurious
+/// failure here, and there is no guarded data to be left inconsistent — we want the exclusion only.
+///
+/// NOT reentrant. A test holding this must not also call [`temp_env_var`] / [`temp_env_vars`] /
+/// [`EnvVars::set`], which would self-deadlock.
+pub(crate) fn env_lock() -> MutexGuard<'static, ()> {
+    ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner())
+}
+
+/// Env vars pinned for as long as this guard lives, restored on drop. Holds [`env_lock`], so no
+/// other env test can observe or clobber the pinned values.
+///
+/// Restoring on `Drop` (rather than around a closure) means a panicking assertion still puts the
+/// environment back: a leaked `HF_HUB_CACHE` would otherwise silently re-point every later test in
+/// the process at the wrong cache.
+#[must_use = "the vars are restored when this guard drops; `let _ = EnvVars::set(..)` drops it \
+              immediately and pins nothing — bind it to a named `_env`-style local"]
+pub(crate) struct EnvVars {
+    restore: Vec<(String, Option<String>)>,
+    // Dropped after the `Drop` body below has restored the values, so the vars are never visible to
+    // the next lock holder in their pinned state.
+    _guard: MutexGuard<'static, ()>,
+}
+
+impl EnvVars {
+    /// Pin `vars` (an empty value ⇒ the var is REMOVED for the duration) until the guard drops.
+    ///
+    /// NOT reentrant — see [`env_lock`].
+    pub(crate) fn set(vars: &[(&str, &str)]) -> Self {
+        let guard = env_lock();
+        let restore = vars
+            .iter()
+            .map(|(key, value)| {
+                let previous = std::env::var(key).ok();
+                if value.is_empty() {
+                    std::env::remove_var(key);
+                } else {
+                    std::env::set_var(key, value);
+                }
+                ((*key).to_owned(), previous)
+            })
+            .collect();
+        Self {
+            restore,
+            _guard: guard,
+        }
+    }
+}
+
+impl Drop for EnvVars {
+    fn drop(&mut self) {
+        for (key, previous) in &self.restore {
+            match previous {
+                Some(prior) => std::env::set_var(key, prior),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+}
+
+/// Set `key` to `value` (empty ⇒ removed) for the duration of `body`, then restore.
+///
+/// NOT reentrant — nesting these self-deadlocks. A test needing two vars must use
+/// [`temp_env_vars`], which sets them under ONE acquisition.
+pub(crate) fn temp_env_var<T>(key: &str, value: &str, body: impl FnOnce() -> T) -> T {
+    temp_env_vars(&[(key, value)], body)
+}
+
+/// [`temp_env_var`] for several vars set together, under ONE acquisition of the shared lock.
+pub(crate) fn temp_env_vars<T>(vars: &[(&str, &str)], body: impl FnOnce() -> T) -> T {
+    let _vars = EnvVars::set(vars);
+    body()
+}

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -1442,13 +1442,14 @@ async fn run_training_execution(
 mod tests {
     use super::*;
 
-    /// Serializes every test that mutates the process-global `HF_HUB_CACHE` env
-    /// var. Must be a SINGLE module-level mutex: per-function `static`s are
-    /// distinct locks and do not serialize against each other, so under parallel
-    /// test execution one test's `set_var`/`remove_var` races another's
-    /// validation read (the intermittent "must be inside an app-managed
-    /// directory" flake on the macOS nax-worker CI lane).
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // Every test that mutates the process-global `HF_HUB_CACHE` goes through the crate-wide env
+    // seam. This module used to own a module-level mutex, on the reasoning that per-function
+    // `static`s are distinct locks that do not serialize against each other (the intermittent "must
+    // be inside an app-managed directory" flake on the macOS nax-worker lane). That reasoning was
+    // right and simply did not go far enough: the whole crate's tests share ONE process, so a
+    // per-MODULE lock is distinct from `video_jobs`' and `image_jobs`' in exactly the same way, and
+    // those modules write `HF_HUB_CACHE` too (sc-12380).
+    use crate::test_env::EnvVars;
 
     /// sc-9989: only LTX-2.3 gets a trainer `LoadSpec::text_encoder` override, and only from the
     /// bundled sibling `gemma/` (the self-contained turnkey install). Every other family's TE lives
@@ -1820,11 +1821,6 @@ mod tests {
     /// mutation can't race other env-reading tests.
     #[test]
     fn validate_accepts_base_model_in_hf_cache_outside_data_dir() {
-        // Recover from poisoning: a panic in another env-mutating test must not
-        // cascade into a spurious failure here — we only need the mutual
-        // exclusion, not the guarded data.
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-
         let dir = tempfile::tempdir().expect("tempdir");
         let hf_cache = tempfile::tempdir().expect("hf cache tempdir");
         let settings = test_settings(dir.path());
@@ -1849,13 +1845,10 @@ mod tests {
         );
         value["target"]["baseModelPath"] = json!(base_model.display().to_string());
 
-        let prior = std::env::var("HF_HUB_CACHE").ok();
-        std::env::set_var("HF_HUB_CACHE", hf_cache.path());
-        let result = validate_training_plan(&settings, &parse(value));
-        match prior {
-            Some(value) => std::env::set_var("HF_HUB_CACHE", value),
-            None => std::env::remove_var("HF_HUB_CACHE"),
-        }
+        let result = {
+            let _env = EnvVars::set(&[("HF_HUB_CACHE", hf_cache.path().to_str().expect("utf-8"))]);
+            validate_training_plan(&settings, &parse(value))
+        };
 
         assert!(
             result.is_ok(),
@@ -1871,8 +1864,6 @@ mod tests {
     /// real run rejected the same `~/.cache/huggingface` snapshot).
     #[test]
     fn resolve_app_managed_model_dir_accepts_hf_cache_snapshot() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-
         let dir = tempfile::tempdir().expect("tempdir");
         let hf_cache = tempfile::tempdir().expect("hf cache tempdir");
         let settings = test_settings(dir.path());
@@ -1886,17 +1877,14 @@ mod tests {
             .join("abc123");
         std::fs::create_dir_all(&snapshot).expect("snapshot dir");
 
-        let prior = std::env::var("HF_HUB_CACHE").ok();
-        std::env::set_var("HF_HUB_CACHE", hf_cache.path());
-        let resolved = resolve_app_managed_model_dir(
-            &settings,
-            &snapshot.display().to_string(),
-            "Training baseModelPath",
-        );
-        match prior {
-            Some(value) => std::env::set_var("HF_HUB_CACHE", value),
-            None => std::env::remove_var("HF_HUB_CACHE"),
-        }
+        let resolved = {
+            let _env = EnvVars::set(&[("HF_HUB_CACHE", hf_cache.path().to_str().expect("utf-8"))]);
+            resolve_app_managed_model_dir(
+                &settings,
+                &snapshot.display().to_string(),
+                "Training baseModelPath",
+            )
+        };
 
         assert!(
             resolved.is_ok(),

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -12517,10 +12517,24 @@ mod tests {
 
     /// Drive `generate_mochi_using` against `probe` with the Mochi tier at `root` and an MLX budget of
     /// `cap_gb`, from a plain `#[test]` — the env overrides are process-global, so the whole async run
-    /// has to sit inside the [`ENV_LOCK`] the sync `temp_env_vars` holds.
+    /// has to sit inside the crate-wide env lock the sync `temp_env_vars` holds.
     ///
-    /// `api` points at a closed port on purpose: reaching the network would be a bug in this test, and
-    /// an unroutable URL makes that fail loudly rather than depending on a stub's fidelity.
+    /// Both URLs point at a closed port on purpose: reaching the network would be a bug in these tests,
+    /// and an unroutable URL makes that fail loudly rather than depending on a stub's fidelity.
+    /// `api_url` alone is NOT enough — a tier fetch dials `huggingface_base_url`
+    /// (`HuggingFaceSnapshot::resolve` → `{base_url}/api/models/…/tree/…`), which `Settings::from_env()`
+    /// defaults to the real `https://huggingface.co`; `api_url` only carries progress/heartbeat. That is
+    /// exactly the trap #1577 fixed in `generate_mochi_using_refuses_before_paying_for_the_tier_download`
+    /// (see its doc comment), and this helper had it one field over: a caller passing `mlxQuantize: 8`
+    /// reaches `ensure_mochi_q8_present` → `ensure_mochi_tier_present`, and `SceneWorks/mochi-1-mlx` is a
+    /// public repo, so the tree resolve SUCCEEDS against the live hub and a ~13 GiB pull can start
+    /// landing before the heartbeat to the closed `api_url` trips it (sc-12380).
+    ///
+    /// `HF_HUB_CACHE` is pinned for the same reason: `huggingface_hub_cache_dir` reads it (and
+    /// `HUGGINGFACE_HUB_CACHE` / `HF_HOME`) BEFORE `data_dir`, so pinning `data_dir` does NOT make the
+    /// cache lookup hermetic — left ambient, a dev box's real cache decides it, and the desktop injects
+    /// `HF_HOME` as a matter of course. Pointed at a dir with no Mochi repo, so `huggingface_snapshot_dir`
+    /// is `None` and `ensure_mochi_tier_present` early-returns before any network touch.
     #[cfg(target_os = "macos")]
     fn drive_mochi_arm(
         root: &Path,
@@ -12531,12 +12545,18 @@ mod tests {
         let settings = Settings {
             data_dir: root.join("unused-data-dir"),
             api_url: "http://127.0.0.1:0".to_owned(),
+            huggingface_base_url: "http://127.0.0.1:0".to_owned(),
             ..Settings::from_env()
         };
         let job = mochi_job_snapshot();
         let loader = probe.loader();
+        let hf_cache = root.join("unused-hf-cache");
         temp_env_vars(
             &[
+                (
+                    "HF_HUB_CACHE",
+                    hf_cache.to_str().expect("utf-8 fixture hub"),
+                ),
                 (MOCHI_DIR_ENV, root.to_str().expect("utf-8 fixture root")),
                 (crate::mlx_fit_gate::MLX_MEMORY_CAP_ENV, cap_gb),
             ],
@@ -13374,57 +13394,22 @@ mod tests {
         assert_eq!(mochi_raw_settings(&req, None)["mochiTier"], json!("bf16"));
     }
 
-    /// Set `key` to `value` (empty ⇒ removed) for the duration of `body`, then restore. The Mochi
-    /// resolver reads an operator override from the environment, and `std::env::set_var` is
-    /// process-global, so the tests that use it are serialized behind one mutex.
+    // The env seam is crate-wide (`crate::test_env`), not per-module: this binary runs every
+    // module's tests in ONE process, so a lock private to `video_jobs` serializes nothing against
+    // the `image_jobs` / `training_jobs` tests that write the same vars (sc-12380).
+    //
+    // Gated to match the consumers exactly. The parity lane builds this crate with NEITHER backend
+    // and runs `clippy -D warnings` over the test target, so an import held under a wider cfg than
+    // its users is an `unused_imports` error there rather than a warning.
     #[cfg(any(
         target_os = "macos",
         all(not(target_os = "macos"), feature = "backend-candle")
     ))]
-    fn temp_env_var<T>(key: &str, value: &str, body: impl FnOnce() -> T) -> T {
-        temp_env_vars(&[(key, value)], body)
-    }
+    use crate::test_env::{temp_env_var, temp_env_vars};
 
-    /// The single lock every env-scoped test serializes on. Shared by [`temp_env_var`] and
-    /// [`temp_env_vars`] so a one-var and a multi-var test can never interleave their mutations of the
-    /// process-global environment.
-    #[cfg(any(
-        target_os = "macos",
-        all(not(target_os = "macos"), feature = "backend-candle")
-    ))]
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    /// [`temp_env_var`] for several vars set together, under ONE acquisition of the shared
-    /// [`ENV_LOCK`]. Nesting the single-var helper to get a second var would self-deadlock — the lock
-    /// is not reentrant — so a test needing e.g. both the Mochi dir override and the MLX memory cap
-    /// must come through here.
-    #[cfg(any(
-        target_os = "macos",
-        all(not(target_os = "macos"), feature = "backend-candle")
-    ))]
-    fn temp_env_vars<T>(vars: &[(&str, &str)], body: impl FnOnce() -> T) -> T {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let restore: Vec<(String, Option<String>)> = vars
-            .iter()
-            .map(|(key, value)| {
-                let previous = std::env::var(key).ok();
-                if value.is_empty() {
-                    std::env::remove_var(key);
-                } else {
-                    std::env::set_var(key, value);
-                }
-                ((*key).to_owned(), previous)
-            })
-            .collect();
-        let out = body();
-        for (key, previous) in restore {
-            match previous {
-                Some(prior) => std::env::set_var(&key, prior),
-                None => std::env::remove_var(&key),
-            }
-        }
-        out
-    }
+    // Only the macOS-gated eros fixture pins a var for a whole test body — see the cfg note above.
+    #[cfg(target_os = "macos")]
+    use crate::test_env::EnvVars;
 
     /// sc-10418: the resolved video quant maps to the same normalized tier labels the
     /// image lane uses, so the Stats charts group video + image runs on one axis.
@@ -17917,15 +17902,21 @@ mod tests {
         assert!(none.is_empty());
     }
 
+    /// The fixture's own HF hub cache: the path `huggingface_hub_cache_dir` falls back to for this
+    /// `data_dir`. Pin `HF_HUB_CACHE` here (see [`ltx_eros_auto_injects_distill_lora_per_pass`]) and
+    /// the resolver returns this dir outright rather than by fallback, so the fixture no longer
+    /// depends on the ambient environment being unset.
+    #[cfg(target_os = "macos")]
+    fn fake_hf_hub_dir(data_dir: &Path) -> PathBuf {
+        data_dir.join("cache").join("huggingface").join("hub")
+    }
+
     /// Lay down a fake HF snapshot file under `data_dir`
     /// (`cache/huggingface/hub/models--<org>--<name>/snapshots/<rev>/<file>`) and return its path, so
     /// [`resolve_ltx_distill_adapter`] resolves hermetically (mirrors `write_fake_wan_lightning`).
     #[cfg(target_os = "macos")]
     fn write_fake_hf_lora(data_dir: &Path, repo: &str, file: &str) -> PathBuf {
-        let snapshot = data_dir
-            .join("cache")
-            .join("huggingface")
-            .join("hub")
+        let snapshot = fake_hf_hub_dir(data_dir)
             .join(format!("models--{}", repo.replace('/', "--")))
             .join("snapshots")
             .join("deadbeef");
@@ -17953,26 +17944,23 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn ltx_eros_auto_injects_distill_lora_per_pass() {
-        // Hold ENV_LOCK for the whole test. This fixture resolves ONLY while the HF cache-dir env
-        // overrides are unset (`huggingface_hub_cache_dir` reads them BEFORE `data_dir`), and the
-        // check below reads them once, at entry. Without the lock a concurrent `temp_env_var(s)`
-        // caller — e.g. `generate_mochi_using_refuses_before_paying_for_the_tier_download`, which
-        // pins `HF_HUB_CACHE` to its own fixture hub — can set the var AFTER that check passes and
-        // BEFORE `resolve_ltx_adapters` reads it, pointing the resolver at the wrong cache: the
-        // distill LoRA is then "not installed" and this test fails for a reason that has nothing to
-        // do with it. `set_var` is process-global; only the lock makes the read-then-use atomic.
-        // Deterministic (12/12) when the two tests are selected together (sc-12306).
-        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        // The fake HF snapshot only resolves when the cache-dir env overrides are unset (else the real
-        // cache is consulted). Skip rather than assert-false in that unusual local config.
-        if std::env::var_os("HF_HUB_CACHE").is_some()
-            || std::env::var_os("HUGGINGFACE_HUB_CACHE").is_some()
-            || std::env::var_os("HF_HOME").is_some()
-        {
-            return;
-        }
         let dir = std::env::temp_dir().join(format!("sw_eros_distill_{}", Uuid::new_v4().simple()));
         std::fs::create_dir_all(&dir).unwrap();
+        // PIN the hub cache at this fixture's own dir for the whole test, rather than depending on
+        // the ambient environment. `huggingface_hub_cache_dir` reads `HF_HUB_CACHE` FIRST and returns
+        // it outright, so this alone decides the resolver — whatever the host or a concurrent test
+        // holds in the lower-priority `HUGGINGFACE_HUB_CACHE` / `HF_HOME`.
+        //
+        // This replaces a read-then-use ("skip if any HF var is set", then resolve) that was wrong
+        // twice over: process-global `set_var` from another test could land between the check and the
+        // use (sc-12380), AND on any box with an ambient HF cache the guard turned "env is set" into
+        // a silent PASS that asserted nothing. Pinning removes both — there is no window to race and
+        // no configuration in which this test quietly stops testing. `EnvVars` holds the crate-wide
+        // env lock until it drops at end of test, so no concurrent writer can retarget the resolver.
+        let _env = EnvVars::set(&[(
+            "HF_HUB_CACHE",
+            fake_hf_hub_dir(&dir).to_str().expect("utf-8 fixture hub"),
+        )]);
         let repo = "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments";
         let file = "ltx-2.3-22b-distilled-lora-1.1_fro90_ceil72_condsafe.safetensors";
         let distill = write_fake_hf_lora(&dir, repo, file);


### PR DESCRIPTION
Closes the wider surface [sc-12380](https://app.shortcut.com/trefry/story/12380) left open. **The one-line `ENV_LOCK` fix that shipped for this flake did not actually fix it** — it still reproduced 6/6 on main’s HEAD.

## 1. The lock excluded one of three writer domains

`cargo test --lib` builds ONE binary and runs every module’s tests as threads in ONE process. Three modules write `HF_HUB_CACHE`:

| writer | lock held |
|---|---|
| `video_jobs::tests::temp_env_vars` | `video_jobs::tests::ENV_LOCK` |
| `training_jobs::tests` ×2 | `training_jobs::tests::ENV_LOCK` ← **a different mutex** |
| `image_jobs::tests::HfHubCacheGuard` ×2 (not `#[ignore]`d) | **none at all** |

The eros guard took `video_jobs`’ lock, so `image_jobs` walked through it:

```
cargo test -p sceneworks-worker --lib -- \
  ltx_eros_auto_injects_distill_lora_per_pass \
  image_route_rejects_wired_pose_when_control_base_absent \
  resolve_krea_control_base_descends_turnkey_root_into_tier_with_tokenizer
```
Each alone **ok**; together **6/6 FAIL** on main. The two `image_jobs` tests also clobbered *each other’s* `HF_HUB_CACHE`.

`training_jobs`’ own comment had the reasoning — *“per-function `static`s are distinct locks and do not serialize against each other”* — and stopped one scope short: **per-MODULE statics are distinct too.** Now one crate-wide seam, `crates/sceneworks-worker/src/test_env.rs`. Restoring on `Drop` also fixes a latent bug: the old closure helper leaked the var into every later test when an assertion panicked.

## 2. `RUST_TEST_THREADS=1` is a phantom

Three tests mutated env with no lock, justified by *“`RUST_TEST_THREADS=1` is forced workspace-wide.”* **Nothing sets it anywhere in the repo** — `.cargo/config.toml`’s `[env]` has only `MACOSX_DEPLOYMENT_TARGET`. It traces to `docs/sc-6537/alignment-handoff.md:182`, never implemented, then hardened into “forced workspace-wide”. They now take the lock; the false claim is deleted.

## 3. The skip-guard false green — proven by mutation

Breaking the resolver (`stage2` reading `stage1Strength`):

| code | ambient env | result |
|---|---|---|
| main | clean | **FAIL** ✅ works |
| main | `HF_HUB_CACHE` set | **PASS** ❌ false green |
| main | `HF_HOME` set | **PASS** ❌ false green |
| this PR | `HF_HUB_CACHE` set | **FAIL** ✅ catches it |

`hf_home.rs` notes *“The desktop and Docker Compose already inject `HF_HOME`”* — so that is the normal box, where the test asserted nothing and reported green. Now pins `HF_HUB_CACHE` at its own fixture hub (read first, returned outright) and the guard is gone: no read-then-use to race, no config where it stops testing.

## 4. A test that really dialed the internet

`drive_mochi_arm` had #1577’s trap one field over: it pinned `api_url` but not `huggingface_base_url`, and pinned `data_dir` — which does **not** make the cache lookup hermetic, because `huggingface_hub_cache_dir` reads the env first. With Mochi in an ambient cache, a `mlxQuantize: 8` caller dialed the live hub. Proven with a sentinel:

```
error sending request for url (http://sentinel-proves-the-dial.invalid/api/models/
  SceneWorks/mochi-1-mlx/tree/90a87786...?recursive=1&expand=1)
```

On main that host is `https://huggingface.co`; the repo is public ⇒ the tree resolve succeeds and a ~13 GiB q8 pull can start landing before the heartbeat to the closed `api_url` trips it.

## Verified
- Both repros **6/6 fail → 6/6 pass**; eros green under hostile ambient `HF_HUB_CACHE` / `HF_HOME` / all three.
- macOS **861 passed / 0 failed**; `clippy -D warnings` clean on **macOS**, **parity** (linux, neither backend) and **candle-worker** (linux, `backend-candle`); `fmt` clean. Merged `origin/main` before verifying.
- Scoped out with reasoning (see the story comment): remaining lock-free writers are all `#[ignore]`d, with a *real* justification (run one-per-process) — unlike the phantom. Say the word if you want them migrated; the seam is there and it is mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)