### PR TITLE
fix(worker): gate candle Wan video jobs on the MEASURED per-tier peak, not the weights floor (sc-12402)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -6097,6 +6097,51 @@
           "schedulers": ["default"]
         }
       },
+      // candle/CUDA VRAM gate (sc-12402, epic 1788) — MEASURED on an idle RTX PRO 6000 (Blackwell
+      // sm_120) via the candle-gen-wan VramProbe harness (candle-gen-wan/tests/vram_probe.rs, the Wan
+      // sibling of the sc-9094 harness behind the flux2/qwen blocks), at this model's OWN shipped
+      // default — 832x480, 121 frames (5s @ 24fps), 20 steps, CFG on — i.e. the schema's "video =
+      // default frames", not 1024². Each tier measured in its own process (cudarc's caching allocator
+      // never returns pages, so a second tier in-process re-reports the first one's high-water).
+      //
+      // THE PEAK IS THE DENOISE, NOT THE DECODE — which is why a per-tier CONSTANT is honest here.
+      // candle-gen-wan's sdpa (transformer.rs:46) materializes the full [B,H,S,S] attention plus an f32
+      // softmax copy (the sc-6217 query-row chunking Qwen/Krea got was never ported to Wan), so at this
+      // geometry S = 12,090 tokens x 24 heads x CFG batch-2 ≈ 55 GB of transient — dwarfing the ~29 GiB
+      // of weights. The z48 vae22 decode contributes **0.0 GB**: it reuses the pool the denoise just
+      // freed. Instrumented at the Progress::Decoding boundary: `pre-decode 88.8 GB | decode adds 0.0`.
+      //
+      // That the decode is free also means these numbers are CARD-INDEPENDENT, which is not obvious:
+      // `auto_tiling_budgeted_wan22` budgets 0.85 x TOTAL VRAM, so the decode tiles to whatever card it
+      // is on. A/B with the tiler's budget forced 81.3 -> 12 GiB left the peak IDENTICAL at 86.3 GB and
+      // only made it slower (358s -> 401s) — the tiling engaged and never touched the ceiling. So this
+      // is a property of the model, not of the measuring GPU.
+      //
+      // Coherence check — the ladder is the DiT delta and nothing else: q8 - q4 = 2.5 GB = exactly the
+      // q8-vs-q4 DiT delta (5.25 - 2.92 GiB); bf16 - q4 = 7.8 GB against the 6.9 GB the dense DiT
+      // predicts (its shards are **fp32** — `index.json` total_size 19,999,150,848 = 4.0 bytes/param for
+      // a 5B — so it HALVES to ~9.31 GiB on load, it does not land at its 18.63 GiB on-disk size). Every
+      // other term is tier-independent: the UMT5 TE loads **f32** (10.58 GiB on disk -> 21.16 GiB
+      // resident), the z48 VAE loads f32, and the attention is tier-blind. That is why the whole quant
+      // ladder spans only ~8 GB and no tier brings this model near a consumer card.
+      //
+      // minMemoryGb 88 gates the DEFAULT/lightest (q4) tier (86.3 + the gate's 2 GB headroom), matching
+      // the qwen convention. NOTE the resolver actually prefers **q8** when installed (sc-10726 /
+      // epic 10721 made q8 the app-wide default, clamping to q4) even though downloads[] marks q4
+      // `"default": true`; the two tiers differ by 2.5 GB, so gating the lighter one is the safe read.
+      //
+      // ⚠️ These numbers say a 480p 5s clip on the 5B needs an ~88 GB card. That is real, and it is the
+      // unchunked attention, not the weights (weights are ~29 GiB of an 86 GB peak; the sc-12344 floor
+      // reads 18.13 GiB — a 4.4x UNDER-count, which is exactly why a 32 GB 5090 was admitted and then
+      // OOM'd mid-denoise). Porting sc-6217 chunking to candle-gen-wan (sc-12434) is what would collapse
+      // these; re-measure when it lands. No `sequentialPeakGb`: every candle video engine declares
+      // `supports_sequential_offload: false` (candle-gen-wan lib.rs:417), so `resolve_offload` is a
+      // no-op here and that key would be dead data.
+      "candle": {
+        "minMemoryGb": 88,
+        "vramGbByTier": { "q4": 86.3, "q8": 88.8, "bf16": 94.1 },
+        "measured": true
+      },
       "ui": {
         "label": "Wan2.2",
         "description": "Fallback video family kept behind the adapter contract for future runtime support.",
@@ -6324,6 +6369,40 @@
           "schedulers": ["default"]
         }
       },
+      // candle/CUDA VRAM gate (sc-12402, epic 1788) — ESTIMATED, `measured: false`. **This model does
+      // not render on the candle lane at all**, so there is no peak to measure (sc-12434):
+      //   * its shipped 1280x720 default EXCEEDS both engines' own `MAX_AREA_14B` (704*1280 = 901,120
+      //     px) and is hard-rejected by `validate` — an sc-12308/#1581 regression, tracked as sc-12433;
+      //   * `832x480` (the only advertised bucket the engine admits) OOM'd a 96 GB RTX PRO 6000 BEFORE
+      //     step 1, at **q4** — the lightest tier — with Lightning's CFG-off batch-1 4-step recipe,
+      //     i.e. the cheapest configuration this model has. GPU-proven, sc-12434.
+      //
+      // Derivation (the alternative to a measurement, not a fudge): `peak = weights + B·H·S²·8 bytes`,
+      // the cost of candle-gen-wan's unchunked materialized sdpa (transformer.rs:46 — the sc-6217
+      // chunking Qwen/Krea got was never ported). The weights term is the real ~40 GiB read off the
+      // device pre-denoise. At 832x480x81: S = 21·30·52 = 32,760 tokens x 40 heads ⇒ ~343 GB of
+      // attention — TIER-INDEPENDENT, which is why the whole ladder spans only ~40 GB and no tier
+      // helps. q8/bf16 weights are q4 + the two-expert delta.
+      //
+      // ⚠️ These are LOWER BOUNDS, not predictions. The closed form tracks the 5B closely (predicted
+      // 56 GB vs 54.8 GB measured) but UNDER-predicts the A14B: at 512x320x49 — the one sub-advertised
+      // geometry small enough to actually render — it predicted 65.2 GB and the real measured peak was
+      // **89.5 GB**. The gap is cudarc pool fragmentation, which no closed form captures (and which is
+      // the whole reason this campaign measures instead of models). Under-prediction is harmless HERE
+      // only because every bound already exceeds every GPU in existence: a postage-stamp 512x320 clip
+      // needs 89.5 GB, so the advertised 832x480 is not close.
+      //
+      // Recorded so the fit gate REFUSES this model rather than admitting it: the sc-12344 floor reads
+      // 29.72 GiB, so today a 32 GB card is admitted, pays a ~28 GiB tier download + a ~100 s load, and
+      // then dies in the first attention. An instant honest refusal is strictly better. These numbers
+      // are correct-in-OUTCOME (refuse everywhere) rather than correct-in-magnitude, and they go stale
+      // the moment sc-12434 ports chunking — `measured: false` is the flag to re-measure then, and
+      // sc-12434 owns that task.
+      "candle": {
+        "minMemoryGb": 388,
+        "vramGbByTier": { "q4": 386, "q8": 401, "bf16": 426 },
+        "measured": false
+      },
       "ui": {
         "label": "Wan2.2 14B (T2V)",
         "description": "Wan2.2 A14B text-to-video (high/low-noise mixture-of-experts). Higher fidelity than the 5B model; needs ample VRAM for both experts.",
@@ -6526,6 +6605,23 @@
           "samplers": ["default", "uni_pc", "euler", "dpmpp_2m", "euler_ancestral", "heun", "dpmpp_sde", "ddim"],
           "schedulers": ["default"]
         }
+      },
+      // candle/CUDA VRAM gate (sc-12402, epic 1788) — ESTIMATED, `measured: false`. The image→video
+      // twin of the T2V-A14B block above; see that comment for the derivation, the validated cost
+      // model, and why there is nothing to measure. **This model does not render on the candle lane at
+      // all** (sc-12434): its 1280x720 default is engine-rejected over `MAX_AREA_14B` (sc-12433) and
+      // `832x480` OOMs a 96 GB card before step 1 at the lightest tier.
+      //
+      // Identical numbers to T2V by construction: the I2V experts are the same shape (config
+      // `i2v_14b()` differs only in `in_channels` 36 vs 16 — the 20-channel image-conditioning concat —
+      // which changes the patch embedding, not the 40-layer/40-head attention that IS the peak), and
+      // the hosted tier bytes match to within 0.01% (q4 29,792,232,225 vs 29,788,704,888). The VAE
+      // ENCODER is additionally resident here (`WanVae16::new_with_encoder`, wan14b.rs:331) for the
+      // first-frame latent, which is noise at this scale.
+      "candle": {
+        "minMemoryGb": 388,
+        "vramGbByTier": { "q4": 386, "q8": 401, "bf16": 426 },
+        "measured": false
       },
       "ui": {
         "label": "Wan2.2 14B (I2V)",

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -567,6 +567,110 @@ fn flux2_candle_blocks_drive_the_fit_gate_and_reject() {
     );
 }
 
+/// sc-12402: the shipped Wan `candle` blocks drive the candle VIDEO fit gate end-to-end against the
+/// SHIPPED manifest bytes — both halves of the story's acceptance: a real over-budget tier REFUSED, and
+/// a tier that fits ADMITTED.
+///
+/// The video sibling of [`flux2_candle_blocks_drive_the_fit_gate_and_reject`], and it exists for the
+/// same reason: this guards the DATA half. Dropping `wan_2_2`'s `vramGbByTier` makes
+/// `wan_video_fit_error` fall back to the sc-12344 weights FLOOR, which reads 18.13 GiB against a real
+/// 86.3 GB peak — so the gate would silently go back to admitting a 32 GB card and OOMing mid-denoise.
+/// That regression is invisible without this test: the gate still "works", it just gates on a number
+/// that is 4.4x wrong.
+///
+/// Numbers are MEASURED on an idle RTX PRO 6000 at each model's own shipped default geometry
+/// (sc-12402; see the manifest comment for the harness + the A/B proving they are card-independent).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn wan_candle_blocks_drive_the_video_fit_gate_and_reject() {
+    use crate::vram_gate::{apply_vram_cap, predicted_peak_gb, wan_video_fit_error};
+
+    let wan = builtin_model_entry("wan_2_2");
+    let entry = wan.as_object().expect("wan_2_2 entry object");
+    assert!(
+        entry.get("candle").and_then(Value::as_object).is_some(),
+        "wan_2_2 candle block present (absent ⇒ the video gate falls back to the weights floor, which \
+         under-counts the real peak by 4.4x and admits a card that OOMs)"
+    );
+
+    // Measured (sc-12402): each tier + the gate's 2 GB headroom.
+    let q4 = predicted_peak_gb(entry, "q4").expect("q4 peak measured");
+    let q8 = predicted_peak_gb(entry, "q8").expect("q8 peak measured");
+    let bf16 = predicted_peak_gb(entry, "bf16").expect("bf16 peak measured");
+    assert!((q4 - 88.3).abs() < 1e-6, "q4 86.3 + 2 headroom, got {q4}");
+    assert!((q8 - 90.8).abs() < 1e-6, "q8 88.8 + 2 headroom, got {q8}");
+    assert!((bf16 - 96.1).abs() < 1e-6, "bf16 94.1 + 2 headroom, got {bf16}");
+    // The tier ladder is monotonic, and SHALLOW: every term but the DiT is tier-independent (the f32
+    // UMT5 TE, the f32 z48 VAE, and the tier-blind attention). q8 − q4 is exactly the DiT delta.
+    assert!(q4 < q8 && q8 < bf16, "heavier tier ⇒ heavier peak");
+    assert!(
+        (q8 - q4 - 2.5).abs() < 0.05,
+        "q8 − q4 must stay the measured 2.5 GB DiT delta (5.25 − 2.92 GiB), got {}",
+        q8 - q4
+    );
+    // The whole q4→bf16 ladder is under 8 GB. If this ever widens dramatically, the block was
+    // re-measured against a different geometry (or a chunked attention landed — sc-12434) and every
+    // number here needs revisiting rather than patching.
+    assert!(
+        bf16 - q4 < 10.0,
+        "the 5B ladder spans ~7.8 GB because only the DiT is tier-dependent, got {}",
+        bf16 - q4
+    );
+
+    // The on-disk weights floor for the shipped q4 tier (`estimatedSizeBytes`), for the A/B below.
+    const WAN_5B_Q4_DISK_BYTES: u64 = 17_338_835_457;
+
+    // THE story: an RTX 5090 (32 GB) — the biggest consumer NVIDIA card — is REFUSED before the load +
+    // denoise, where the weights floor admitted it and let it OOM.
+    let rtx_5090 = apply_vram_cap(None, Some(32.0));
+    let message = wan_video_fit_error(
+        "wan_2_2",
+        entry,
+        "q4",
+        WAN_5B_Q4_DISK_BYTES,
+        "0",
+        rtx_5090,
+    )
+    .expect("the measured 86.3 GB peak cannot fit a 32 GB card — refuse before the OOM")
+    .to_string();
+    assert!(message.contains("wan_2_2"), "names the model: {message}");
+    assert!(message.contains("q4"), "names the sized tier: {message}");
+
+    // …and the SAME job is ADMITTED on the 96 GB card it was measured rendering on. A gate that
+    // refuses everything would satisfy the assert above and be worthless.
+    let card96 = apply_vram_cap(None, Some(95.6));
+    assert!(
+        wan_video_fit_error("wan_2_2", entry, "q4", WAN_5B_Q4_DISK_BYTES, "0", card96).is_none(),
+        "q4's measured 88.3 GB need fits a 95.6 GB card — it is the exact configuration sc-12402 \
+         measured rendering, so wall-rejecting it would be the sc-12179 regression"
+    );
+
+    // Both A14B models carry blocks too, so THEIR gate is live. They are `measured: false` —
+    // sibling-scaled, because the candle A14B does not render at any advertised geometry (sc-12434:
+    // 832x480 OOMs a 96 GB card before step 1; the 1280x720 default is engine-rejected, sc-12433). The
+    // gate refusing them everywhere is the TRUE answer until chunking lands, and it turns a ~30 GiB
+    // download + ~100 s load + OOM into an instant refusal.
+    for id in ["wan_2_2_t2v_14b", "wan_2_2_i2v_14b"] {
+        let model = builtin_model_entry(id);
+        let a14b = model.as_object().expect("a14b entry object");
+        assert!(
+            a14b.get("candle").and_then(Value::as_object).is_some(),
+            "{id} candle block present (absent ⇒ the floor admits it on a small card and it OOMs)"
+        );
+        let peak = predicted_peak_gb(a14b, "q4").expect("a14b q4 peak carried");
+        assert!(
+            peak > 96.0,
+            "{id} q4 must not appear to fit ANY existing GPU — sc-12434 proved 832x480 OOMs a 96 GB \
+             card before step 1, got {peak}"
+        );
+        assert!(
+            wan_video_fit_error(id, a14b, "q4", 0, "0", card96).is_some(),
+            "{id} must be refused even on the 96 GB dev box"
+        );
+    }
+    eprintln!("wan candle blocks: 5090 → refused, 96 GB → q4 admitted, A14B → refused everywhere ✓");
+}
+
 /// sc-12130/sc-12131: the shipped Krea base block feeds both stages of the generic Candle gate. This
 /// pins the provider-derived capability handoff and the measured `sequentialPeakGb` values that turn a
 /// small-card staged attempt into a clean reject instead of relying on reactive OOM containment.

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -5002,6 +5002,28 @@ fn candle_wan_tier_complete(dir: &Path, a14b: bool) -> bool {
         && (!a14b || has("transformer_2"))
 }
 
+/// (sc-12402) The `candle.vramGbByTier` manifest key for the tier [`candle_wan_tier_subdir`] actually
+/// resolved — derived from the RESOLVED quant marker, never re-derived from the request.
+///
+/// That is the sc-12090 lesson, which cost a false reject on the image lane: re-deriving the tier from
+/// `advanced.mlxQuantize` sizes the tier the request ASKED for, while the disk-probing resolver may
+/// have clamped to a different one (q8 default → q4 when only q4 is installed). Keying off the marker
+/// the resolver returned means the gate and the loader agree on which tier ran by construction.
+///
+/// `None` ⇒ `bf16`, and that one mapping covers BOTH bf16 shapes: an explicit `bf16/` tier subdir, and
+/// the flat dense `Wan-AI/*-Diffusers` fallback that [`candle_wan_tier_subdir`] declines (the caller
+/// pairs that snapshot with a `None` marker). Wan advertises only `Quant::{Q4, Q8}`
+/// (`supported_quants`, wan14b.rs), so no other variant can reach here; any future one would read
+/// `bf16` — the HEAVIEST row, i.e. conservative.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_wan_tier_key(quant: Option<Quant>) -> &'static str {
+    match quant {
+        Some(Quant::Q4) => "q4",
+        Some(Quant::Q8) => "q8",
+        _ => "bf16",
+    }
+}
+
 /// (sc-10027) Resolve the candle wan quant tier subdir (`q4`/`q8`/`bf16`) + its quant marker under a
 /// `SceneWorks/wan2.2-*-candle` snapshot `root`, per `advanced.mlxQuantize` (default **q8** when
 /// installed, clamping to q4 — epic 10721 / sc-10726 — falling back through the tier order), or `None`
@@ -5420,14 +5442,23 @@ fn mochi_vram_preflight(
     }
 }
 
-/// Live pre-flight Wan VRAM admission check for the candle lane (sc-12344) — the non-Mochi half of this
-/// lane's gate, and the seam [`generate_candle_video`] calls before the load + denoise.
+/// Live pre-flight Wan VRAM admission check for the candle lane — the non-Mochi half of this lane's
+/// gate, and the seam [`generate_candle_video`] calls before the load + denoise.
 ///
-/// Budgets on the on-disk bytes of the components the Wan loader actually reads
-/// ([`crate::vram_gate::wan_weight_bytes`]), which for Wan ARE the resident set: both A14B MoE experts
-/// stay co-resident and every file in each component dir loads. `ltx`/`svd` read `0` there and are
-/// admitted unchanged — their on-disk bytes are not their loaded set, so a floor would wall-reject
-/// working cards (the exemption is recorded on `vram_gate::wan_weight_components`).
+/// Budgets on the tier's **MEASURED peak** (`candle.vramGbByTier[tier_key]`, sc-12402) when the
+/// manifest carries one, and falls back to the sc-12344 on-disk weights FLOOR when it does not — see
+/// [`crate::vram_gate::wan_video_fit_error`], which owns that choice and the reason a measurement
+/// REPLACES the floor rather than composing with it.
+///
+/// The measured peak matters because the floor is wrong in BOTH directions, from one cause: on-disk
+/// bytes are not the loaded set, because `candle-gen-wan` casts dtypes on load (`wan14b.rs:49-52` —
+/// experts fp32→bf16 HALVE on the dense tier, the UMT5 TE bf16→f32 DOUBLES on every tier). The packed
+/// tiers under-count by ~9-11 GiB (which is why a card that cannot fit the job is admitted and then
+/// OOMs — sc-12402's story) and the dense tier over-counts by ~44 GiB.
+///
+/// `ltx`/`svd` carry no `candle` block and read `0` weights, so both paths return `None` and they are
+/// admitted unchanged — their on-disk bytes are not their loaded set either, so any byte-derived floor
+/// would wall-reject working cards (recorded on `vram_gate::wan_weight_components`; sc-12397).
 ///
 /// **Takes and returns `model_dir` rather than borrowing it**, so the gate cannot be deleted without
 /// breaking the build — the same "unskippable by construction" property [`MochiVramPreflight`] gets from
@@ -5440,12 +5471,16 @@ fn mochi_vram_preflight(
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 fn wan_vram_preflight(
     engine_id: &str,
+    manifest_entry: &JsonObject,
+    tier_key: &str,
     model_dir: PathBuf,
     gpu_id: &str,
     budget: Option<crate::vram_gate::VramBudget>,
 ) -> WorkerResult<PathBuf> {
-    match crate::vram_gate::video_weights_fit_error(
+    match crate::vram_gate::wan_video_fit_error(
         engine_id,
+        manifest_entry,
+        tier_key,
         crate::vram_gate::wan_weight_bytes(engine_id, &model_dir),
         gpu_id,
         budget,
@@ -5499,10 +5534,16 @@ async fn candle_video_vram_budget(settings: &Settings) -> Option<crate::vram_gat
 /// driver. Returns the decoded clip + the candle adapter label.
 ///
 /// Every engine passes a VRAM fit gate before the load: Mochi's frame-dependent decode gate (sc-12306),
-/// and the Wan weights-floor gate (sc-12344). `ltx`/`svd` are explicitly EXEMPT — their on-disk bytes are
-/// not their loaded set, so any byte-derived floor would wall-reject working cards; the reason is
-/// recorded on `vram_gate::wan_weight_components`. Neither gate reads `candle.vramGbByTier` (no candle
-/// video model carries a `candle` block, so that lookup would admit unconditionally — sc-12344).
+/// and the Wan gate — the tier's MEASURED `candle.vramGbByTier` peak where the manifest carries one
+/// (sc-12402), else sc-12344's on-disk weights floor. `ltx`/`svd` are explicitly EXEMPT from both: they
+/// carry no `candle` block AND their on-disk bytes are not their loaded set, so any byte-derived floor
+/// would wall-reject working cards; the reason is recorded on `vram_gate::wan_weight_components`.
+///
+/// Mochi keeps its own gate rather than joining the Wan one: its AsymmVAE decode is UNTILED, so its peak
+/// grows linearly in clip length and no per-tier constant can express it (sc-12306). Wan's decode is
+/// budget-TILED (`auto_tiling_budgeted_wan22`) and its peak is owned by the denoise, so a per-tier
+/// constant at the model's default geometry is the honest shape there — the manifest schema's
+/// "video = default frames".
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 async fn generate_candle_video(
     api: &ApiClient,
@@ -5617,13 +5658,17 @@ async fn generate_candle_video_using(
             Some((tier_dir, quant)) => (tier_dir, quant),
             None => (snapshot_dir, None),
         };
-        // The Wan weights-floor VRAM fit gate (sc-12344), the non-Mochi half of this lane's admission
-        // check. Runs on the RESOLVED tier dir (so it sizes the tier that will actually load, not the
-        // manifest's default — the sc-12090 lesson) and BEFORE `candle_ensure_wan_lightning_present`
-        // below, so a card that cannot hold the weights is refused without first paying for the
-        // Lightning fetch. A no-op for `ltx`/`svd`, which are exempt — see `vram_gate::wan_weight_components`.
+        // The Wan VRAM fit gate: the tier's MEASURED peak (sc-12402) when the manifest carries one,
+        // else the sc-12344 weights floor. The non-Mochi half of this lane's admission check. Runs on
+        // the RESOLVED tier (so it sizes the tier that will actually load, not the manifest's default —
+        // the sc-12090 lesson; `candle_wan_tier_key` derives the manifest key from the resolver's own
+        // marker for exactly that reason) and BEFORE `candle_ensure_wan_lightning_present` below, so a
+        // card that cannot fit the job is refused without first paying for the Lightning fetch. A no-op
+        // for `ltx`/`svd`, which are exempt — see `vram_gate::wan_weight_components`.
         let dir = wan_vram_preflight(
             engine_id,
+            &request.model_manifest_entry,
+            candle_wan_tier_key(quant),
             dir,
             &settings.gpu_id,
             candle_video_vram_budget(settings).await,

--- a/crates/sceneworks-worker/src/vram_gate.rs
+++ b/crates/sceneworks-worker/src/vram_gate.rs
@@ -396,15 +396,30 @@ fn mochi_too_big_error(
 // one, which co-locates both experts per (1). Sizing the candle lane off that number would under-predict
 // by a whole expert (~28 GiB at bf16).
 //
-// ## This is a FLOOR — it under-predicts, deliberately
+// ## This is a FLOOR — it under-predicts, deliberately — and it is now the FALLBACK, not the gate
 // It counts weights only: no activation transient, no VAE decode, no attention working set. A MARGINAL
 // job is still admitted and can still CUDA-OOM (catchably, via `classify_engine_error` — not MLX's
-// unmappable `exit(-1)`). That is the honest bound from the data that exists: it refuses the
-// CLEARLY-impossible (wan A14B bf16 ≈ 67 GiB of weights on a 32 GB card — the story's case) rather than
-// promising every admitted job fits. Inventing a per-engine activation fudge factor would be worse than
-// stating the bound; measured `candle.vramGbByTier` blocks are what tighten this (**sc-12402**), and they
-// layer on top via `predicted_peak_gb` with no rework here — that key is already read and simply returns
-// `None` ⇒ `Unknown` ⇒ admit while it is absent.
+// unmappable `exit(-1)`). That was the honest bound from the data that existed before a measurement.
+// [`wan_video_fit_error`] now prefers the MEASURED per-tier peak (`candle.vramGbByTier`, sc-12402) and
+// only falls back here when a model/tier was never measured.
+//
+// ⚠️ **Point (1) above is WRONG for the DENSE tier, and sc-12402 measured how wrong.** "On-disk bytes ARE
+// the loaded set" holds only for the PACKED q4/q8 tiers. `candle-gen-wan` casts dtypes on load
+// (`wan14b.rs:49-52`: `DIT_DTYPE = BF16`, `ENC_DTYPE = F32`, applied per-tensor by `mmap_var_builder`),
+// so the dense `Wan-AI/*-Diffusers` experts — which ship **fp32**, not bf16: `transformer/…index.json`
+// declares `total_size` 57,153,966,336 = 53.2 GiB for ONE 14B expert — HALVE on load, while the UMT5 TE
+// DOUBLES (bf16 10.58 → f32 21.16 GiB) on EVERY tier. Measured error vs the real device set:
+//
+//   * packed q4/q8 — floor UNDER-counts by ~9-11 GiB (the f32 TE). Safe direction: it just admits, the
+//     pre-gate status quo. (It is also nowhere near the real peak: the 5B q4's floor is 18.13 GiB and its
+//     MEASURED peak is 86.3 GB — the denoise's unchunked attention, not the weights, is the ceiling.)
+//   * dense bf16 — floor OVER-counts by ~44 GiB (117.5 GiB summed vs a ~75 GiB device set), which
+//     wall-rejects a 96 GB card that would render. That is the sc-12179 class this gate's note claims
+//     cannot arise here; it can, on this one tier.
+//
+// So the floor is kept for its ORIGINAL job — refusing the clearly-impossible where nothing was measured
+// — and a measurement supersedes it wherever one exists. The dense over-count is why
+// [`wan_video_fit_error`] does NOT `max` the two.
 //
 // Deliberately NOT reusing Mochi's `mochi_decode_peak_gb`: that term is specific to Mochi's untiled
 // AsymmVAE (peak linear in clip length). Wan tiles/chunks differently, so applying it here would
@@ -503,6 +518,84 @@ pub(crate) fn video_weights_fit_error(
             gpu_id,
         )
     })
+}
+
+/// The candle **video** admission decision (sc-12402): budget on the MEASURED per-tier peak
+/// (`candle.vramGbByTier[tier_key]` + [`HEADROOM_GB`], via [`predicted_peak_gb`]) when the manifest
+/// carries one, else fall back to the sc-12344 on-disk weights FLOOR ([`video_weights_fit_error`]).
+///
+/// This is the seam that makes the measured blocks LIVE. Until sc-12402 the video lane called the
+/// floor directly and nothing read `candle.vramGbByTier` — so adding the blocks alone would have been
+/// dead data that reads as coverage (the failure `tests/gpu_and_manifest.rs`'s flux2 test exists to
+/// catch). Pure, like both halves it composes: the caller resolves the budget and the tier.
+///
+/// ## Why a measurement REPLACES the floor rather than composing with it (`max`)
+///
+/// A `max(measured, floor)` looks safer and is not: **the floor OVER-counts the dense tier**, so
+/// maxing would re-introduce the exact wall-reject the measurement exists to remove.
+///
+/// The floor's premise — `wan_weight_components`' "on-disk bytes ARE the loaded set" — holds only for
+/// the PACKED q4/q8 tiers. The dense `Wan-AI/*-Diffusers` snapshot the manifest routes `bf16` to ships
+/// its experts in **fp32** (`transformer/…index.json` declares `total_size` 57,153,966,336 = 53.2 GiB
+/// for ONE 14B expert), and `candle-gen-wan` casts on load — `DIT_DTYPE = BF16`, `ENC_DTYPE = F32`
+/// (wan14b.rs:49-52), applied per-tensor by `mmap_var_builder`. So the experts HALVE (57.2 → 28.6 GB
+/// each) while the UMT5 TE DOUBLES (11.4 → 22.7 GB). Net, the dense floor sums ~117 GiB against a real
+/// ~81 GB resident set and refuses a 96 GB card that renders it. (The packed tiers fail the other way
+/// — the f32 TE doubling makes their floor UNDER-count — which is safe: a floor that under-counts just
+/// admits, the pre-gate status quo.)
+///
+/// A real measurement is not a better proxy for the peak, it IS the peak; deferring to a byte-sum that
+/// is provably wrong about dtype would be superstition. Where no measurement exists the floor is still
+/// the best available signal, so it stays as the fallback.
+///
+/// Missing either signal admits, exactly like [`fit_decision`]'s [`FitDecision::Unknown`]: no budget
+/// (`nvidia-smi` unreadable) ⇒ `None`, and an engine with neither a `candle` block nor countable
+/// weights (`ltx`/`svd`) ⇒ `None` through the floor.
+pub(crate) fn wan_video_fit_error(
+    model_label: &str,
+    manifest_entry: &JsonObject,
+    tier_key: &str,
+    weight_bytes: u64,
+    gpu_id: &str,
+    budget: Option<VramBudget>,
+) -> Option<WorkerError> {
+    // Unmeasured (no `candle` block, or no row for this tier and no `minMemoryGb`) ⇒ the sc-12344
+    // floor, byte-for-byte the shipped behavior.
+    let Some(needed_gb) = predicted_peak_gb(manifest_entry, tier_key) else {
+        return video_weights_fit_error(model_label, weight_bytes, gpu_id, budget);
+    };
+    let budget = budget?;
+    (budget.free_gb + f64::EPSILON < needed_gb)
+        .then(|| video_peak_too_big_error(model_label, tier_key, needed_gb, budget.free_gb, gpu_id))
+}
+
+/// Build the MEASURED-peak candle video rejection (sc-12402). The measured sibling of
+/// [`video_weights_too_big_error`], and worded apart from it on purpose: that one can only honestly
+/// speak about weights, this one is the whole render's ceiling (weights + denoise + the budget-tiled
+/// VAE decode), so it names the render rather than the weights.
+///
+/// Names the TIER, because the tier is the lever that moves this number and the gate now knows which
+/// one it sized. Like the floor's message it does NOT offer "lower the resolution": the measured peak
+/// is a per-tier CONSTANT taken at the model's default geometry (the manifest schema's "video =
+/// default frames"), and Wan's decode is budget-tiled (`auto_tiling_budgeted_wan22`) so the weights
+/// dominate and a smaller clip cannot move the number the user was just shown. That is the same
+/// resolution-blind contract the image lane's `vramGbByTier` gate has always had, and the reason Mochi
+/// needs its own frame-scaled gate instead of this one (its untiled AsymmVAE decode IS the peak).
+fn video_peak_too_big_error(
+    model_label: &str,
+    tier_key: &str,
+    needed_gb: f64,
+    available_gb: f64,
+    gpu_id: &str,
+) -> WorkerError {
+    WorkerError::InvalidPayload(format!(
+        "{model_label} needs ~{needed} GB of VRAM to render at its {tier_key} tier (measured peak: \
+         every component held resident for the whole run — this engine does not stage components — \
+         plus the denoise and VAE-decode transient) but GPU {gpu_id} has ~{available} GB available. \
+         Select a smaller quant tier, or run on a GPU with more VRAM.",
+        needed = needed_gb.round() as i64,
+        available = available_gb.round() as i64,
+    ))
 }
 
 /// The predicted resident FLOOR (GiB) for a candle video job: the on-disk weights every component of
@@ -1199,6 +1292,180 @@ mod tests {
         assert!(wan_weight_bytes("wan2_2_t2v_14b", &populated) > 0);
 
         std::fs::remove_dir_all(&root).ok();
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // The MEASURED per-tier peak supersedes the floor (sc-12402).
+    // -----------------------------------------------------------------------------------------
+
+    /// The shipped `wan_2_2` candle block — MEASURED on an idle RTX PRO 6000 Blackwell (sc-12402) at
+    /// the model's shipped 832x480 / 121-frame / 20-step default. Real numbers, so these tests prove the
+    /// REAL jobs are admitted/refused rather than that arithmetic is arithmetic.
+    ///
+    /// The q8 − q4 delta (88.8 − 86.3 = 2.5 GB) is exactly the q8-vs-q4 DiT delta (5.25 − 2.92 GiB),
+    /// which is the coherence check on the campaign: everything else in the peak is tier-independent
+    /// (the f32 UMT5 TE + the f32 VAE + the denoise attention).
+    fn wan_5b_entry() -> JsonObject {
+        obj(json!({
+            "candle": {
+                "minMemoryGb": 88,
+                "vramGbByTier": { "q4": 86.3, "q8": 88.8, "bf16": 94.1 },
+                "measured": true
+            }
+        }))
+    }
+
+    /// THE story (sc-12402): a tier the weights FLOOR admits, and that then CUDA-OOMs, is now refused.
+    ///
+    /// The 5B q4's floor is 16.13 GiB of on-disk weights + 2 = ~18 GB, so an RTX 5090 (32 GB) is
+    /// ADMITTED today — and the job dies in the denoise, because the MEASURED peak is 86.3 GB (the
+    /// unchunked materialized attention, not the weights: `transformer.rs:46`). The floor under-counts
+    /// by 4.4x, which is not a tuning error but a category error — it counts weights and the peak is
+    /// not weights.
+    ///
+    /// Kills the mutations a compile alone would not:
+    ///   * dropping the `predicted_peak_gb` branch (⇒ back to the floor) ⇒ the 5090 ADMITS;
+    ///   * keying the manifest lookup off the request instead of the RESOLVED tier ⇒ wrong row;
+    ///   * `max`-ing the measured peak with the floor ⇒ still passes here, but fails the dense test below.
+    #[test]
+    fn measured_peak_refuses_a_5b_job_the_weights_floor_would_admit() {
+        let entry = wan_5b_entry();
+        // The on-disk floor for the shipped q4 tier: 16.13 GiB.
+        const WAN_5B_Q4_DISK_BYTES: u64 = 17_315_750_512;
+
+        // Floor alone: ~18 GB needed vs 32 GB free ⇒ admits (the shipped behavior, and the bug).
+        assert!(
+            video_weights_fit_error("wan_2_2", WAN_5B_Q4_DISK_BYTES, "0", rtx_5090()).is_none(),
+            "precondition: the weights floor admits this job on a 5090 — that IS the sc-12402 bug"
+        );
+
+        // Measured peak: 86.3 + 2 headroom = 88.3 GB vs 32 GB ⇒ REFUSED before the load + denoise.
+        let message = wan_video_fit_error(
+            "wan_2_2",
+            &entry,
+            "q4",
+            WAN_5B_Q4_DISK_BYTES,
+            "0",
+            rtx_5090(),
+        )
+        .expect("the measured 86.3 GB peak cannot fit a 32 GB card — refuse before the OOM")
+        .to_string();
+        assert!(message.contains("wan_2_2"), "names the model: {message}");
+        assert!(message.contains("q4"), "names the sized tier: {message}");
+        assert!(
+            message.contains("88") && message.contains("32"),
+            "states what it needs and what the card has: {message}"
+        );
+        // The measured message is about the RENDER, not the weights — the floor's wording would be a
+        // lie here (weights are 16 GiB of an 86 GB peak).
+        assert!(
+            !message.contains("just to hold its weights"),
+            "must not reuse the weights-floor wording for a measured peak: {message}"
+        );
+        // Resolution is NOT offered as a lever: the measured peak is a per-tier constant at the model's
+        // default geometry, so it cannot move the number the user was just shown.
+        assert!(
+            !message.contains("resolution"),
+            "the resolution-blind gate must not send the user to a knob it cannot honor: {message}"
+        );
+    }
+
+    /// The other half of the story's acceptance: a tier that FITS is still ADMITTED. A gate that
+    /// refuses everything would pass the test above and be worthless.
+    #[test]
+    fn measured_peak_admits_a_tier_that_fits_the_card() {
+        let entry = wan_5b_entry();
+        const WAN_5B_Q4_DISK_BYTES: u64 = 17_315_750_512;
+        // The dev box: 96 GB. q4's measured 86.3 + 2 = 88.3 ≤ 95.6 ⇒ ADMIT (and it really does render —
+        // this exact configuration is the sc-12402 measurement).
+        let card96 = apply_vram_cap(None, Some(95.6));
+        assert!(
+            wan_video_fit_error("wan_2_2", &entry, "q4", WAN_5B_Q4_DISK_BYTES, "0", card96)
+                .is_none(),
+            "the measured q4 job renders on this card — the gate must not wall-reject it"
+        );
+        // …and the heavier bf16 row on the SAME card does NOT fit: its measured 94.1 + 2 headroom =
+        // 96.1 just overflows 95.6. Same card, same model, different tier ⇒ opposite verdict: the gate
+        // reads the TIER, not the model. (This is a genuinely narrow 0.5 GB margin, and it is the real
+        // measured one — the 5B's tier ladder spans only ~8 GB because everything but the DiT is
+        // tier-independent, so the tiers really do land this close together.)
+        assert!(
+            wan_video_fit_error("wan_2_2", &entry, "bf16", WAN_5B_Q4_DISK_BYTES, "0", card96)
+                .is_some(),
+            "bf16's measured 94.1 GB peak + 2 headroom overflows a 95.6 GB card — refuse"
+        );
+    }
+
+    /// sc-12402 regression pin: the measured peak REPLACES the floor, it does not compose with it.
+    ///
+    /// The dense `bf16` tier is the case that makes `max(measured, floor)` wrong. `Wan-AI/*-Diffusers`
+    /// ships its experts in **fp32** (~117.5 GiB summed for A14B T2V) and `candle-gen-wan` loads them as
+    /// bf16 (`wan14b.rs:49-52`), so the on-disk floor OVER-counts by ~44 GiB and would wall-reject a
+    /// 96 GB card that renders the job at ~75 GB — the sc-12179 class `wan_weight_components` claims
+    /// cannot arise on this lane. A measurement is not a better proxy for the peak; it IS the peak.
+    #[test]
+    fn a_measurement_supersedes_an_overcounting_dense_floor() {
+        // A14B T2V dense: 117.51 GiB of fp32 on disk, ~75 GB resident once cast to bf16.
+        const WAN_A14B_DENSE_DISK_BYTES: u64 = 126_170_000_000;
+        let entry = obj(json!({
+            "candle": { "vramGbByTier": { "bf16": 75.3 }, "measured": false }
+        }));
+        let card96 = apply_vram_cap(None, Some(95.6));
+
+        // The floor alone WALL-REJECTS this card (117.5 + 2 = ~120 > 95.6) — the bug.
+        assert!(
+            video_weights_fit_error("wan2_2_t2v_14b", WAN_A14B_DENSE_DISK_BYTES, "0", card96)
+                .is_some(),
+            "precondition: the on-disk floor over-counts the fp32 dense tier and wall-rejects a 96 GB card"
+        );
+        // The measured/derived peak admits it: 75.3 + 2 = 77.3 ≤ 95.6.
+        assert!(
+            wan_video_fit_error(
+                "wan2_2_t2v_14b",
+                &entry,
+                "bf16",
+                WAN_A14B_DENSE_DISK_BYTES,
+                "0",
+                card96
+            )
+            .is_none(),
+            "a `max(measured, floor)` would keep the floor's 120 GB over-count and wall-reject here"
+        );
+    }
+
+    /// An unmeasured model keeps the sc-12344 floor EXACTLY — the fallback is not a silent un-gating.
+    #[test]
+    fn an_unmeasured_model_falls_back_to_the_weights_floor() {
+        let no_block = obj(json!({}));
+        const WAN_A14B_BF16_BYTES: u64 = 72_000_000_000;
+
+        // No `candle` block ⇒ the floor decides, byte-identical to `video_weights_fit_error`.
+        let via_wan = wan_video_fit_error(
+            "wan2_2_t2v_14b",
+            &no_block,
+            "bf16",
+            WAN_A14B_BF16_BYTES,
+            "0",
+            rtx_5090(),
+        );
+        let via_floor =
+            video_weights_fit_error("wan2_2_t2v_14b", WAN_A14B_BF16_BYTES, "0", rtx_5090());
+        assert_eq!(
+            via_wan.map(|e| e.to_string()),
+            via_floor.map(|e| e.to_string()),
+            "an unmeasured model must behave exactly as it did before sc-12402"
+        );
+
+        // An exempt engine (0 weights) + no block ⇒ admit, never block without evidence.
+        assert!(
+            wan_video_fit_error("ltx_2_3_distilled", &no_block, "bf16", 0, "0", rtx_5090())
+                .is_none()
+        );
+        // No live budget ⇒ admit, even with a measured row that would overflow.
+        assert!(
+            wan_video_fit_error("wan_2_2", &wan_5b_entry(), "bf16", 0, "0", None).is_none(),
+            "no budget signal ⇒ never block"
+        );
     }
 
     /// Live real-hardware validation (sc-10766): exercises the REAL `nvidia-smi` VRAM reading on GPU 0

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -267,6 +267,50 @@ def test_krea_2_turbo_candle_vram_tiers_match_measured_peaks():
     }
 
 
+def test_wan_2_2_candle_vram_tiers_match_measured_peaks():
+    """sc-12402: never regress the measured 5B peaks to estimates.
+
+    Measured on an idle RTX PRO 6000 at wan_2_2's own shipped default (832x480, 121 frames,
+    20 steps, CFG on) -- the schema's "video = default frames". The peak is the DENOISE
+    (candle-gen-wan's unchunked materialized sdpa); the z48 vae22 decode adds 0.0 GB, which
+    is what makes these card-independent despite the decode tiler budgeting off total VRAM.
+    """
+    manifest = _load_builtin_models_manifest()
+    wan = next(model for model in manifest["models"] if model["id"] == "wan_2_2")
+    candle = wan["candle"]
+
+    assert candle["measured"] is True
+    assert {tier: candle["vramGbByTier"][tier] for tier in ("q4", "q8", "bf16")} == {
+        "q4": 86.3,
+        "q8": 88.8,
+        "bf16": 94.1,
+    }
+    # minMemoryGb gates the default/lightest (q4) tier + the fit gate's 2 GB headroom.
+    assert candle["minMemoryGb"] == 88
+
+
+def test_wan_a14b_candle_vram_tiers_are_flagged_estimated():
+    """sc-12402/sc-12434: the A14B blocks are ESTIMATED and must stay flagged as such.
+
+    The candle A14B does not render at ANY advertised geometry (sc-12434: 832x480 OOMs a 96 GB
+    card before step 1; the 1280x720 default is engine-rejected -- sc-12433), so there is no peak
+    to measure. The blocks exist so the fit gate REFUSES the model instead of admitting it into a
+    ~28 GiB download + ~100 s load + OOM. `measured: false` is the flag to re-measure once sc-12434
+    ports attention chunking -- if that ever flips to true without new numbers, this is the tripwire.
+    """
+    manifest = _load_builtin_models_manifest()
+    for model_id in ("wan_2_2_t2v_14b", "wan_2_2_i2v_14b"):
+        entry = next(m for m in manifest["models"] if m["id"] == model_id)
+        candle = entry["candle"]
+        assert candle["measured"] is False, f"{model_id}: A14B numbers are derived, not measured"
+        # Every tier must exceed any GPU that exists, so the gate refuses on all hardware.
+        for tier, peak in candle["vramGbByTier"].items():
+            assert peak > 96, (
+                f"{model_id} {tier} must not appear to fit a 96 GB card -- sc-12434 proved the "
+                f"lightest tier OOMs one before step 1, got {peak}"
+            )
+
+
 def test_sdxl_manifest_has_mlx_block():
     # sdxl carries an mlx block (no `limits` override here — the MLX SDXL schedule
     # matches the torch EulerDiscrete default, and there's no per-model sampler menu


### PR DESCRIPTION
[sc-12402](https://app.shortcut.com/trefry/story/12402). sc-12344 shipped a weights **floor** for the candle Wan engines (`Σ on-disk bytes + 2`). It counts weights only, so a marginal job was still admitted and still CUDA-OOM'd. This gates on the tier's **measured peak** where one exists, and keeps the floor as the fallback.

Measured with a new harness in [SceneWorks/inference#50](https://github.com/SceneWorks/inference/pull/50) (test-only there — **no pin moves**).

## The wiring is the story, not a detail

sc-12402 assumed measured blocks would "layer on top via `predicted_peak_gb` with no rework". They would not have. The function reads `vramGbByTier`, but **the video lane never called it** — it ran `mochi_fit_error` + `video_weights_fit_error` and nothing else, as its own comment admitted:

> `video_jobs.rs:5504` — "Neither gate reads `candle.vramGbByTier`"

Manifest blocks alone would have been dead data that reads as coverage — exactly the failure `flux2_candle_blocks_drive_the_fit_gate_and_reject` exists to catch. `vram_gate::wan_video_fit_error` is that seam, keyed off `candle_wan_tier_key(quant)` — the tier the resolver actually picked, never the one the request asked for (the sc-12090 lesson).

## Measured — idle RTX PRO 6000 Blackwell (sm_120), each model at its own shipped default

| `wan_2_2` tier | measured peak | floor said | error |
|---|---|---|---|
| q4 | **86.3 GB** | 18.13 GiB | **4.4× UNDER** |
| q8 | **88.8 GB** | 20.45 GiB | 4.3× UNDER |
| bf16 | **94.1 GB** | 33.83 GiB | 2.8× UNDER |

The floor wasn't mistuned — it was **the wrong quantity**. Weights are ~29 GiB of an 86 GB peak. The peak is the **denoise**: candle-gen-wan's sdpa materializes the full `[B,H,S,S]` attention plus an f32 softmax copy (the sc-6217 chunking Qwen and Krea got was never ported to Wan). The z48 vae22 decode adds **0.0 GB**. So a 32 GB 5090 was admitted and died mid-denoise; it's now refused before the load.

That the peak is denoise-owned is also what makes a per-tier **constant** honest here, and it had to be proven — `auto_tiling_budgeted_wan22` budgets `0.85 × TOTAL VRAM`, so the decode expands to fill the card and a measured peak could have described the measuring GPU. Forcing the tiler's budget 81.3 → 12 GiB left the peak **identical** at 86.3 GB (only slower). Card-independent, confirmed.

## A measurement REPLACES the floor — it does not `max` with it

The floor is wrong in **both** directions, because `wan_weight_components`' premise ("on-disk bytes ARE the loaded set") holds only for the packed tiers. candle-gen-wan casts on load (`wan14b.rs:49-52`): dense fp32 experts **halve**, the bf16 UMT5 TE **doubles** to f32.

- **packed q4/q8** — floor UNDER-counts ~9–11 GiB (safe: it just admits)
- **dense bf16** — floor OVER-counts ~44 GiB (117.5 GiB summed vs a ~75 GB device set), **wall-rejecting a 96 GB card that renders it** — the sc-12179 class that gate's own note says cannot arise here. A `max` would have preserved that bug; a regression test pins it.

(The dense repo is fp32, not bf16: its `index.json` declares `total_size` 57,153,966,336 = 53.2 GiB for **one** 14B expert. The story's "bf16 = 72 GB" anchor was an estimate, not a sum.)

## The two A14B models ship `measured: false`

They **do not render at any advertised geometry** ([sc-12434](https://app.shortcut.com/trefry/story/12434), filed): `832x480` OOM'd a 96 GB card **before step 1** at q4 with CFG-off Lightning — the cheapest configuration the model has — and the `1280x720` default is engine-rejected over `MAX_AREA_14B` ([sc-12433](https://app.shortcut.com/trefry/story/12433), filed — an sc-12308/#1581 regression). There is no peak to measure, so the blocks are derived **lower bounds** that make the gate refuse the model everywhere: true until sc-12434 ports chunking, and strictly better than admitting a ~28 GiB download + ~100 s load that ends in an OOM.

## Also corrected

Two in-tree claims this work disproved: `video_jobs.rs`'s "Neither gate reads `candle.vramGbByTier`" and `vram_gate`'s "on-disk bytes ARE the loaded set".

## Testing

- `cargo test -p sceneworks-worker --features backend-candle vram_gate` — **23 passed**, including new pins for both halves of the acceptance (over-budget REFUSED / fitting tier ADMITTED), a pin that a measurement supersedes the over-counting dense floor, and an unmeasured-model fallback pin.
- `wan_candle_blocks_drive_the_video_fit_gate_and_reject` — the flux2-style data-half guard (dropping the blocks silently reverts the gate to a 4.4×-wrong number).
- `pytest tests/test_builtin_manifest_audit.py` — measured 5B numbers can't regress to estimates; the A14B blocks can't silently flip to `measured: true`.
- `cargo clippy -p sceneworks-worker --features backend-candle --all-targets -- -D warnings` clean; `cargo fmt` clean.
- Every number here was produced on real CUDA hardware, not derived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)