### PR TITLE
fix(worker): give tests one offline Settings seam and stop the remaining env writers leaking (sc-12380)

### DIFF
--- a/crates/sceneworks-worker/src/footprint_measure.rs
+++ b/crates/sceneworks-worker/src/footprint_measure.rs
@@ -565,6 +565,12 @@ fn fit_gate_ab_illustrious_q8() {
         te as f64 / gib,
     );
 
+    // This test re-points the cap several times, so it holds the crate-wide env lock for the whole
+    // body rather than scoping each write. Binding `EnvVars` (rather than the bare lock) also means
+    // the cap's PRIOR value is restored on drop — including on a panicking assertion below, which the
+    // hand-rolled `remove_var` at the end could not do, and which is not the same thing as removing
+    // it (an operator's own cap would have been silently deleted) (sc-12380).
+    let _env = crate::test_env::EnvVars::set(&[(MLX_MEMORY_CAP_ENV, "")]);
     let set_cap = |gb: f64| std::env::set_var(MLX_MEMORY_CAP_ENV, format!("{gb}"));
 
     // (C) cap BELOW the staged peak ⇒ reject even one-component-at-a-time, with the actionable message.
@@ -623,6 +629,5 @@ fn fit_gate_ab_illustrious_q8() {
     println!(
         "[ab] RESIDENT generation ok (render std {std:.1}) — calibrated HEADROOM_GB confirmed through the real gate"
     );
-
-    std::env::remove_var(MLX_MEMORY_CAP_ENV);
+    // The cap is restored (not merely removed) when `_env` drops at end of scope.
 }

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -1490,10 +1490,20 @@ fn pulid_flux_real_weights_holds_identity() {
         assert!(p.exists(), "missing PuLID weight: {}", p.display());
     }
     // Fill the engine's env-var weight seam from the local caches (exactly what
-    // `generate_pulid_flux_stream` does before the cached load).
-    std::env::set_var("PULID_FLUX_WEIGHTS", &pulid_adapter);
-    std::env::set_var("PULID_EVA_WEIGHTS", &eva);
-    std::env::set_var("PULID_FACE_WEIGHTS_DIR", &bundle);
+    // `generate_pulid_flux_stream` does before the cached load). Through the crate-wide seam so the
+    // three vars are RESTORED on drop — the bare `set_var`s this replaces leaked them into every
+    // later test in the process, and took no lock while doing it (sc-12380).
+    let _env = EnvVars::set(&[
+        (
+            "PULID_FLUX_WEIGHTS",
+            pulid_adapter.to_str().expect("utf-8 pulid adapter path"),
+        ),
+        ("PULID_EVA_WEIGHTS", eva.to_str().expect("utf-8 eva path")),
+        (
+            "PULID_FACE_WEIGHTS_DIR",
+            bundle.to_str().expect("utf-8 face bundle dir"),
+        ),
+    ]);
 
     // Reference face: a portrait PNG (`SCENEWORKS_TEST_FACE`) if present, else the real face image
     // embedded in the face-align golden (`<bundle>/face_align_goldens.safetensors`, the same
@@ -6310,10 +6320,19 @@ fn flux_ip_reference_worker_e2e() {
             .unwrap_or_else(|| panic!("a complete {repo} snapshot with {needs}"))
     }
 
-    // Point the worker's HF-cache resolver + Settings at the real cache + a temp data dir.
-    std::env::set_var("HF_HUB_CACHE", hf_cache());
+    // Point the worker's HF-cache resolver + Settings at the real cache + a temp data dir. Through
+    // the crate-wide seam so both are restored on drop (these were bare `set_var`s that leaked, and
+    // `SCENEWORKS_DATA_DIR` in particular re-points every later `Settings::from_env()` in the
+    // process). This one deliberately reads the REAL cache — the point of the E2E — so it pins
+    // rather than isolates (sc-12380).
     let data = tempfile::tempdir().unwrap();
-    std::env::set_var("SCENEWORKS_DATA_DIR", data.path());
+    let _env = EnvVars::set(&[
+        ("HF_HUB_CACHE", hf_cache().as_str()),
+        (
+            "SCENEWORKS_DATA_DIR",
+            data.path().to_str().expect("utf-8 temp data dir"),
+        ),
+    ]);
     let settings = Settings::from_env();
 
     // (1) The worker's OWN staging fn, against the real cache (the net-new sc-3625 fs logic).

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -3538,8 +3538,13 @@ mod person_track_e2e_tests {
         // Isolated scratch: a throwaway data dir (weights + frame cache resolve under it).
         let scratch = std::env::temp_dir().join("sw-person-track-e2e");
         let _ = std::fs::remove_dir_all(&scratch);
-        // `ensure_*_weights` resolve their cache under `settings.data_dir`.
-        std::env::set_var("SCENEWORKS_DATA_DIR", scratch.join("data"));
+        // `ensure_*_weights` resolve their cache under `settings.data_dir`. Through the crate-wide
+        // seam so the value is RESTORED on drop: this used to `set_var` with no restore at all, which
+        // leaked the scratch dir into every later `Settings::from_env()` in the process (sc-12380).
+        let _env = crate::test_env::EnvVars::set(&[(
+            "SCENEWORKS_DATA_DIR",
+            scratch.join("data").to_str().expect("utf-8 scratch dir"),
+        )]);
         let settings = crate::Settings::from_env();
 
         let duration = staged_duration();
@@ -3657,7 +3662,11 @@ mod person_track_e2e_tests {
         };
         let scratch = std::env::temp_dir().join("sw-person-track-e2e-sam3");
         let _ = std::fs::remove_dir_all(&scratch);
-        std::env::set_var("SCENEWORKS_DATA_DIR", scratch.join("data"));
+        // Restored on drop — see the twin above (sc-12380).
+        let _env = crate::test_env::EnvVars::set(&[(
+            "SCENEWORKS_DATA_DIR",
+            scratch.join("data").to_str().expect("utf-8 scratch dir"),
+        )]);
         let settings = crate::Settings::from_env();
         let duration = staged_duration();
         let timestamps = crate::person_track::sample_timestamps(duration);

--- a/crates/sceneworks-worker/src/mlx_fit_gate.rs
+++ b/crates/sceneworks-worker/src/mlx_fit_gate.rs
@@ -1333,9 +1333,12 @@ mod tests {
         };
 
         // Emulate an 8 GB Mac through the same env the epic added for exactly this (sc-10835).
-        std::env::set_var(MLX_MEMORY_CAP_ENV, "8");
-        let outcome = residency_for_dir("z_image_turbo", &q4);
-        std::env::remove_var(MLX_MEMORY_CAP_ENV);
+        // Through the crate-wide seam: `set_var` is process-global, and the hand-rolled
+        // set/`remove_var` pair this replaces both skipped the lock AND left the cap set for the rest
+        // of the process if the assertion below panicked between them (sc-12380).
+        let outcome = crate::test_env::temp_env_var(MLX_MEMORY_CAP_ENV, "8", || {
+            residency_for_dir("z_image_turbo", &q4)
+        });
 
         eprintln!("live gate on {} @ 8 GB → {outcome:?}", q4.display());
         assert_eq!(

--- a/crates/sceneworks-worker/src/person_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/person_jobs/tests.rs
@@ -750,10 +750,12 @@ fn f011_test_settings(data_dir: PathBuf) -> Settings {
 #[test]
 fn resolve_detector_weights_env_pin_missing_errors_and_unset_falls_through() {
     let key = "SCENEWORKS_PERSON_DETECTOR_WEIGHTS";
-    let _env_guard = crate::test_env::env_lock();
+    // Holds the lock for the whole staged mutation AND restores the operator's prior value on drop —
+    // including if an assertion below panics, which the hand-rolled restore tail could not. The body
+    // re-points `key` freely inside the guard.
+    let _env = crate::test_env::EnvVars::set(&[(key, "")]);
     let dir = tempfile::tempdir().expect("tempdir");
     let settings = f011_test_settings(dir.path().to_path_buf());
-    let prior = std::env::var_os(key);
 
     // Set but missing → loud InvalidPayload naming the key.
     std::env::set_var(
@@ -773,9 +775,5 @@ fn resolve_detector_weights_env_pin_missing_errors_and_unset_falls_through() {
         matches!(unset, Ok(None)),
         "an unset detector pin must fall through to Ok(None), got {unset:?}"
     );
-
-    match prior {
-        Some(value) => std::env::set_var(key, value),
-        None => std::env::remove_var(key),
-    }
+    // `_env` restores the prior value on drop.
 }

--- a/crates/sceneworks-worker/src/person_segment.rs
+++ b/crates/sceneworks-worker/src/person_segment.rs
@@ -509,10 +509,12 @@ mod tests {
     #[test]
     fn resolve_segmenter_weights_env_pin_missing_errors_and_unset_falls_through() {
         let key = "SCENEWORKS_SAM2_WEIGHTS";
-        let _env_guard = crate::test_env::env_lock();
+        // Holds the lock for the whole staged mutation AND restores the operator's prior value on
+        // drop — including if an assertion below panics, which the hand-rolled restore tail could
+        // not. The body re-points `key` freely inside the guard.
+        let _env = crate::test_env::EnvVars::set(&[(key, "")]);
         let dir = tempfile::tempdir().expect("tempdir");
         let settings = f011_test_settings(dir.path().to_path_buf());
-        let prior = std::env::var_os(key);
 
         std::env::set_var(key, "/nonexistent/sam2/does-not-exist.safetensors");
         let missing = resolve_segmenter_weights(&settings);
@@ -527,10 +529,6 @@ mod tests {
             matches!(unset, Ok(None)),
             "an unset SAM2 pin must fall through to Ok(None), got {unset:?}"
         );
-
-        match prior {
-            Some(value) => std::env::set_var(key, value),
-            None => std::env::remove_var(key),
-        }
+        // `_env` restores the prior value on drop.
     }
 }

--- a/crates/sceneworks-worker/src/person_segment_sam3_common.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3_common.rs
@@ -691,10 +691,12 @@ mod tests {
     #[test]
     fn resolve_segmenter_weights_env_pin_missing_and_incomplete_error_unset_falls_through() {
         let key = "SCENEWORKS_SAM3_WEIGHTS";
-        let _env_guard = crate::test_env::env_lock();
+        // Holds the lock for the whole staged mutation AND restores the operator's prior value on
+        // drop — including if an assertion below panics, which the hand-rolled restore tail could
+        // not. The body re-points `key` freely inside the guard.
+        let _env = crate::test_env::EnvVars::set(&[(key, "")]);
         let dir = tempfile::tempdir().expect("tempdir");
         let settings = f011_test_settings(dir.path().to_path_buf());
-        let prior = std::env::var_os(key);
 
         // (a) pinned path does not exist at all → loud, via resolve_env_file_pin.
         std::env::set_var(key, dir.path().join("nonexistent-sam3-dir"));
@@ -722,10 +724,6 @@ mod tests {
             matches!(unset, Ok(None)),
             "an unset SAM3 pin must fall through to Ok(None), got {unset:?}"
         );
-
-        match prior {
-            Some(value) => std::env::set_var(key, value),
-            None => std::env::remove_var(key),
-        }
+        // `_env` restores the prior value on drop.
     }
 }

--- a/crates/sceneworks-worker/src/test_env.rs
+++ b/crates/sceneworks-worker/src/test_env.rs
@@ -103,3 +103,70 @@ pub(crate) fn temp_env_vars<T>(vars: &[(&str, &str)], body: impl FnOnce() -> T) 
     let _vars = EnvVars::set(vars);
     body()
 }
+
+/// An unroutable URL. Port 0 is never listened on, so a request fails immediately and locally
+/// instead of depending on a stub's fidelity — a test that reaches the network fails loudly.
+pub(crate) const OFFLINE_URL: &str = "http://127.0.0.1:0";
+
+/// [`Settings`] with EVERY network field pinned unroutable. **Use this instead of
+/// `Settings::from_env()` in any test whose path could reach a download**, keeping the
+/// `..offline_settings()` spread last so the fields you do pin still win:
+///
+/// ```ignore
+/// let settings = Settings { data_dir: fixture, ..offline_settings() };
+/// ```
+///
+/// `Settings::from_env()` defaults `api_url` to the real local API and `huggingface_base_url` to the
+/// real `https://huggingface.co`, and a `..Settings::from_env()` spread silently inherits BOTH for
+/// every field the test did not think to name. The two are NOT interchangeable, which is the trap:
+/// a tier fetch dials `huggingface_base_url` (`HuggingFaceSnapshot::resolve` →
+/// `{base_url}/api/models/…/tree/…`) while `api_url` only carries progress/heartbeat. Pin only
+/// `api_url` and the failure path still goes red — but only after really resolving the tree against
+/// the live hub, and for a public repo that resolve SUCCEEDS, so bytes can start landing first.
+///
+/// That exact bug shipped twice (#1577, then sc-12380 one field over), and a third site was found
+/// mid-fix pinning `api_url` alone and saved only by an early-out upstream. Three of four call sites
+/// remembered both; one did not. Hence a helper that cannot forget, rather than four comments asking
+/// people to remember.
+///
+/// This pins struct fields only. The HF **cache dir** is a separate axis that a pinned `data_dir`
+/// does NOT make hermetic — `huggingface_hub_cache_dir` reads `HF_HUB_CACHE` /
+/// `HUGGINGFACE_HUB_CACHE` / `HF_HOME` BEFORE `data_dir` — so a test that resolves a cache must also
+/// pin those via [`EnvVars::set`].
+pub(crate) fn offline_settings() -> crate::Settings {
+    crate::Settings {
+        api_url: OFFLINE_URL.to_owned(),
+        huggingface_base_url: OFFLINE_URL.to_owned(),
+        ..crate::Settings::from_env()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// [`offline_settings`] must move every network field OFF its real default. The `assert_ne`s are
+    /// the load-bearing half: asserting only `== OFFLINE_URL` would still pass if someone
+    /// "simplified" the helper to `Settings::from_env()` on a box where the env happens to hold that
+    /// value, and it is dropping a pin — not the constant — that this exists to catch.
+    #[test]
+    fn offline_settings_pins_every_network_field_off_its_real_default() {
+        let offline = offline_settings();
+
+        assert_eq!(offline.api_url, OFFLINE_URL, "api_url must be unroutable");
+        assert_eq!(
+            offline.huggingface_base_url, OFFLINE_URL,
+            "huggingface_base_url is what a tier fetch dials — it must be unroutable"
+        );
+        assert_ne!(
+            offline.huggingface_base_url,
+            crate::DEFAULT_HUGGINGFACE_BASE_URL,
+            "the real hub must never survive into a test's Settings"
+        );
+        assert_ne!(
+            offline.api_url,
+            crate::DEFAULT_API_URL,
+            "the real API must never survive into a test's Settings"
+        );
+    }
+}

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -12589,9 +12589,7 @@ mod tests {
     ) -> WorkerResult<(DecodedVideo, Value)> {
         let settings = Settings {
             data_dir: root.join("unused-data-dir"),
-            api_url: "http://127.0.0.1:0".to_owned(),
-            huggingface_base_url: "http://127.0.0.1:0".to_owned(),
-            ..Settings::from_env()
+            ..offline_settings()
         };
         let job = mochi_job_snapshot();
         let loader = probe.loader();
@@ -12896,13 +12894,11 @@ mod tests {
         let hub = mochi_hf_cache_shared_only("arm_precheck");
         let probe = ArmProbe::default();
         let request = mochi_request(json!({ "mlxQuantize": 8 }));
+        // `offline_settings` pins BOTH `api_url` and the `huggingface_base_url` the tier fetch
+        // actually dials — see above, and its own doc comment.
         let settings = Settings {
             data_dir: hub.join("unused-data-dir"),
-            api_url: "http://127.0.0.1:0".to_owned(),
-            // The URL the tier fetch actually dials — see above. Unroutable ⇒ the failure path can
-            // never reach the real hub.
-            huggingface_base_url: "http://127.0.0.1:0".to_owned(),
-            ..Settings::from_env()
+            ..offline_settings()
         };
         let job = mochi_job_snapshot();
         let loader = probe.loader();
@@ -12961,10 +12957,13 @@ mod tests {
         let root = mochi_root("arm_lattice_candle", &["q4"], true);
         let probe = ArmProbe::default();
         let request = mochi_request(json!({}));
+        // This pinned `api_url` alone until sc-12380. It never dialed the hub only because an empty
+        // `advanced` makes `mochi_wants_q8`/`_bf16` false, so `ensure_mochi_*_present` early-outs
+        // before the fetch — i.e. it was one request-shape change away from the #1577 bug.
+        // `offline_settings` pins `huggingface_base_url` too, so it cannot come back.
         let settings = Settings {
             data_dir: root.join("unused-data-dir"),
-            api_url: "http://127.0.0.1:0".to_owned(),
-            ..Settings::from_env()
+            ..offline_settings()
         };
         let job = mochi_job_snapshot();
         let loader = probe.loader();
@@ -13035,13 +13034,11 @@ mod tests {
         let hub = mochi_hf_cache_shared_only("candle_arm_precheck");
         let probe = ArmProbe::default();
         let request = mochi_request(json!({ "mlxQuantize": 8 }));
+        // `offline_settings` pins BOTH `api_url` and the `huggingface_base_url` the tier fetch
+        // actually dials, so the failure path can never reach the real hub.
         let settings = Settings {
             data_dir: hub.join("unused-data-dir"),
-            api_url: "http://127.0.0.1:0".to_owned(),
-            // The URL the tier fetch actually dials — unroutable ⇒ the failure path can never reach
-            // the real hub.
-            huggingface_base_url: "http://127.0.0.1:0".to_owned(),
-            ..Settings::from_env()
+            ..offline_settings()
         };
         let job = mochi_job_snapshot();
         let loader = probe.loader();
@@ -13446,11 +13443,16 @@ mod tests {
     // Gated to match the consumers exactly. The parity lane builds this crate with NEITHER backend
     // and runs `clippy -D warnings` over the test target, so an import held under a wider cfg than
     // its users is an `unused_imports` error there rather than a warning.
+    // `offline_settings` is the one way to build a `Settings` for a test whose path could reach a
+    // download: it pins every network field unroutable, so no call site has to remember that
+    // `huggingface_base_url` (not `api_url`) is what a tier fetch dials. See its doc comment.
+    // Its consumers include the candle Mochi twins, so it rides the same `any(macos, candle)` gate
+    // as the helpers above rather than the macOS-only one below.
     #[cfg(any(
         target_os = "macos",
         all(not(target_os = "macos"), feature = "backend-candle")
     ))]
-    use crate::test_env::{temp_env_var, temp_env_vars};
+    use crate::test_env::{offline_settings, temp_env_var, temp_env_vars};
 
     // Only the macOS-gated eros fixture pins a var for a whole test body — see the cfg note above.
     #[cfg(target_os = "macos")]
@@ -14757,7 +14759,10 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[tokio::test]
     async fn bernini_conditioning_enforces_required_media() {
-        let settings = Settings::from_env();
+        // Offline: this builds a real `ApiClient`, and the guards under test are all that stand
+        // between it and the network. Pinned so a regression that moves a guard AFTER the I/O fails
+        // locally and loudly instead of dialing the real API/hub (sc-12380).
+        let settings = offline_settings();
         let api = ApiClient::new(&settings);
         let job: JobSnapshot = serde_json::from_value(json!({
             "id": "job-bernini-1",
@@ -15070,7 +15075,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[tokio::test]
     async fn scail2_conditioning_guards_fire_before_io() {
-        let settings = Settings::from_env();
+        // "before_io" is the whole claim of this test — `offline_settings` is what makes a broken
+        // claim fail locally rather than reach the real API/hub (sc-12380).
+        let settings = offline_settings();
         let api = ApiClient::new(&settings);
         let job: JobSnapshot = serde_json::from_value(json!({
             "id": "job-scail2-1",
@@ -18384,7 +18391,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[tokio::test]
     async fn video_clip_conditioning_requires_ic_lora() {
-        let settings = Settings::from_env();
+        // The IC-LoRA gate returning before any I/O is the claim; pin the network fields so a
+        // regression that breaks it fails locally instead of dialing out (sc-12380).
+        let settings = offline_settings();
         let api = ApiClient::new(&settings);
         // The IC-LoRA gate is the resolver's first check, so it returns before touching `job`
         // / the api / disk — a minimal snapshot suffices.


### PR DESCRIPTION
Follow-through on the [sc-12380](https://app.shortcut.com/trefry/story/12380) audit. [#1590](https://github.com/SceneWorks/SceneWorks/pull/1590) fixed the instances; this removes the two ways they keep coming back. **Both items I had offered as “say the word” follow-ups — they were the assignment, so they are done here rather than filed.**

## 1. `offline_settings()` — so no call site has to remember

`Settings::from_env()` defaults `api_url` to the real local API and `huggingface_base_url` to the real `https://huggingface.co`; a `..Settings::from_env()` spread silently inherits **both**. They are not interchangeable — a tier fetch dials `huggingface_base_url`, `api_url` only carries progress/heartbeat. Pin only `api_url` and the failure path still goes red, but only after resolving the tree against the live hub; for a public repo that resolve **succeeds**, so bytes start landing first.

That bug shipped **twice** (#1577, then sc-12380 one field over). Auditing the rest found a **third**: `generate_candle_video_using_hands_the_engine_the_mochi_lattice_frame_count` pinned `api_url` alone, saved only by an upstream early-out (empty `advanced` ⇒ `mochi_wants_q8` false) — one request-shape change from being live. Three of four sites remembered both; one did not. That is a remembered invariant, so it gets replaced with an enforced one.

Replaces the four hand-pinned literals and the three bare `Settings::from_env()` sites that build a real `ApiClient` and are guarded only by “the check fires before I/O” continuing to hold (`scail2_conditioning_guards_fire_before_io` and friends).

Its guard test asserts the fields are moved **off their real defaults**, not merely set to a constant. Mutation-tested — both caught:

| mutation | result |
|---|---|
| drop the `huggingface_base_url` pin | **FAIL** — `left: "https://huggingface.co"` |
| “simplify” the helper to `Settings::from_env()` | **FAIL** — `left: "http://localhost:8000"` |

## 2. The remaining writers leaked — my “harmless because `#[ignore]`d” call was wrong

I scoped these out of #1590 as ignored-and-therefore-harmless. That was wrong on its own terms: several had **no restore at all**, so running one leaks for the rest of the process.

- `media_jobs` ×2 — `set_var("SCENEWORKS_DATA_DIR", scratch)` never restored ⇒ re-points every later `Settings::from_env()` in the process.
- `image_jobs` PULID (3 vars) + flux-ip e2e (`HF_HUB_CACHE`, `SCENEWORKS_DATA_DIR`) — same.
- `footprint_measure` — its `remove_var` only runs if no assertion panics first, and *removing is not restoring* (an operator’s own cap was silently deleted).
- `mlx_fit_gate` — set/remove pair, same panic hole.
- the three `person_*` pin tests — took the lock after #1590 but still hand-rolled the restore tail, so a panicking assert still leaked.

`EnvVars` restores on `Drop`, closing the panic hole for all of them. The only raw `set_var` left in the crate is `ort_cuda.rs` — Windows-only **production** code with a documented init-time soundness argument, correctly not a test seam.

## Verified
- macOS **862 passed / 0 failed**; both sc-12380 repros still 3/3 green.
- The formerly-latent candle twin green against a hand-built **hostile ambient HF cache** (via `HF_HOME`).
- `clippy -D warnings` clean on **macOS**, **parity** (linux, neither backend) and **candle-worker** (linux, `backend-candle`); `fmt` clean.
- The candle lane caught a real break mid-work — the import was gated macOS-only while two consumers are the candle twins. The superset-cfg rule earning its keep again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)