### PR TITLE
fix(api): honor each image model's declared defaults.count (sc-12427 follow-up)

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -624,8 +624,13 @@ pub(crate) struct ImageJobRequest {
     pub(crate) negative_prompt: String,
     #[serde(default = "default_image_model")]
     pub(crate) model: String,
-    #[serde(default = "default_image_count")]
-    pub(crate) count: u32,
+    /// Batch size, or `None` when the caller named none — resolved from the model's declared
+    /// `defaults.count` in `create_image_job`, not from a blanket 4 that **29 of the 45** image
+    /// models contradict with `count: 1` (sc-12427 follow-up).
+    ///
+    /// `CharacterTestRequest` keeps the blanket: its route resolves no `modelManifestEntry`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) count: Option<u32>,
     #[serde(default)]
     pub(crate) seed: Option<i64>,
     /// Output geometry, or `None` per side when the caller named none — resolved from the model's

--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -59,6 +59,16 @@ pub(crate) async fn create_image_job(
         if !job_payload.contains_key("height") {
             job_payload.insert("height".to_owned(), Value::from(default_height));
         }
+        // `defaults.count`, the resolution key's other half — 29 of the 45 image models declare
+        // `count: 1` against this layer's blanket 4. Reading only the geometry made the bare call
+        // WORSE, not better: sensenova_u1_8b declares `2048x2048` AND `count: 1`, so honoring the
+        // size alone took `generate_image(model = "sensenova_u1_8b", prompt = …)` from 4x1024² to
+        // 4x2048² — 4x the pixels — where the model asks for 1x2048², i.e. the original cost at the
+        // correct geometry. One intent, two keys; reading half of it is what over-charged.
+        if !job_payload.contains_key("count") {
+            let count = image_default_count(entry).unwrap_or(4);
+            job_payload.insert("count".to_owned(), Value::from(count));
+        }
     }
     job_payload.insert("modelManifestEntry".to_owned(), model_manifest_entry);
     validate_job_lora_compatibility_with(
@@ -79,11 +89,16 @@ pub(crate) async fn create_image_job(
     )
     .await?;
     if payload.seed.is_none() {
+        // `job_payload["count"]` is the resolved count — the block above writes the model's declared
+        // `defaults.count` whenever the caller named none, so the seed batch matches what actually
+        // renders. The fallback only survives for a manifest entry that is not an object (an
+        // unknown model resolves to `{}`, which IS one), where the caller's own count, then the
+        // blanket, is all there is.
         let count = job_payload
             .get("count")
             .and_then(Value::as_u64)
             .and_then(|value| u32::try_from(value).ok())
-            .unwrap_or(payload.count);
+            .unwrap_or_else(|| payload.count.unwrap_or_else(default_image_count));
         job_payload.insert("seeds".to_owned(), random_image_seeds(count));
     }
     // Create in `pending_caption` when an async caption is pending, else the default `queued`. The

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -27,7 +27,9 @@ use sceneworks_core::contracts::{
     WorkerSnapshot, WorkerStatus, WorkerTerminationRequest,
 };
 use sceneworks_core::hf_home::{huggingface_hub_cache_dir, huggingface_repo_cache_path};
-use sceneworks_core::image_request::default_resolution as image_default_resolution;
+use sceneworks_core::image_request::{
+    default_count as image_default_count, default_resolution as image_default_resolution,
+};
 use sceneworks_core::jobs_store::{
     candle_supported, mac_capabilities, mac_rust_supported, model_mac_support, CreateJob,
     DuplicateJob, JobsStore, JobsStoreError, MacCapabilities, ProgressUpdate, RegisterWorker,
@@ -2590,8 +2592,12 @@ fn validate_image_job(payload: &ImageJobRequest) -> Result<(), ApiError> {
     {
         return Err(ApiError::bad_request("Unsupported image mode"));
     }
-    if !(1..=8).contains(&payload.count) {
-        return Err(ApiError::bad_request("count must be between 1 and 8"));
+    // Only a *named* count is bounded here: an omitted one resolves to the model's declared
+    // `defaults.count` in `create_image_job`, like the size below.
+    if let Some(count) = payload.count {
+        if !(1..=8).contains(&count) {
+            return Err(ApiError::bad_request("count must be between 1 and 8"));
+        }
     }
     // Only a *named* dimension is bounded here: an omitted side is resolved from the model's
     // declared `defaults.resolution` in `create_image_job` (sc-12400), the same shape as the video

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -4152,18 +4152,29 @@ async fn an_image_request_naming_no_size_renders_the_models_own_declared_resolut
     .await;
     let project_id = project["id"].as_str().expect("project id");
 
-    // The two models the blanket was WRONG for, plus a model it happened to match. Listing the
-    // coincidental match alongside the victims is what keeps this a per-model assertion rather than
-    // "the route returns 1024".
-    for (model, want_w, want_h) in [
-        // 2048x2048 declared: the blanket rendered these at HALF resolution, on the
-        // text/infographic family where pixels are the entire point.
-        ("sensenova_u1_8b", 2048, 2048),
-        ("sensenova_u1_8b_fast", 2048, 2048),
-        // 768x768 declared.
-        ("chroma1_flash", 768, 768),
-        // 1024x1024 declared — the blanket was right here by coincidence, not by design.
-        ("flux1_schnell", 1024, 1024),
+    // A matrix that pins each axis INDEPENDENTLY. `defaults.resolution` and `defaults.count` are
+    // read by separate code, so a fixture where the two always agree cannot tell a working pair
+    // from one reader quietly carrying the other.
+    //
+    // Every id here is verified to exist. The first cut used `flux1_schnell`, which is NOT a model
+    // (it is `flux_schnell`): it resolved to `{}`, took the unknown-model blanket, and passed —
+    // green, while testing nothing about a declared default. **A typo'd id is a silent no-op in
+    // this test by construction**, which is exactly why the control row must be a REAL model whose
+    // declarations happen to equal the blankets.
+    for (model, want_w, want_h, want_count) in [
+        // BOTH axes discriminate. 2048x2048 + count 1: the blankets rendered this at HALF
+        // resolution and FOUR times over, on the text/infographic family where pixels are the
+        // entire point — and honoring only the size made the bare call 4x MORE expensive.
+        ("sensenova_u1_8b", 2048, 2048, 1),
+        ("sensenova_u1_8b_fast", 2048, 2048, 1),
+        // COUNT discriminates, resolution coincides — red if the count reader is dropped, green if
+        // only the size reader works.
+        ("z_image", 1024, 1024, 1),
+        // RESOLUTION discriminates, count coincides — the mirror image.
+        ("chroma1_flash", 768, 768, 4),
+        // NEITHER discriminates: a real model whose declarations equal both blankets. Keeps the
+        // rows above from passing for a reader that returns some other model's values.
+        ("z_image_turbo", 1024, 1024, 4),
     ] {
         let (status, body) = request(
             app.clone(),
@@ -4186,6 +4197,19 @@ async fn an_image_request_naming_no_size_renders_the_models_own_declared_resolut
             (Some(want_w), Some(want_h)),
             "{model}: a size-less request must enqueue the model's declared defaults.resolution: \
              {body}"
+        );
+        assert_eq!(
+            body["payload"]["count"].as_u64(),
+            Some(want_count),
+            "{model}: a count-less request must enqueue the model's declared defaults.count, not \
+             the blanket 4: {body}"
+        );
+        // The seed batch is generated from the RESOLVED count, so it must agree — otherwise a
+        // count-1 model would still carry four seeds and the payload would contradict itself.
+        assert_eq!(
+            body["payload"]["seeds"].as_array().map(Vec::len),
+            Some(want_count as usize),
+            "{model}: one seed per image actually rendered: {body}"
         );
     }
 

--- a/crates/sceneworks-core/src/image_request.rs
+++ b/crates/sceneworks-core/src/image_request.rs
@@ -28,6 +28,46 @@ pub(crate) const FIT_MODES: [&str; 4] = ["crop", "pad", "outpaint", "stretch"];
 /// historical blanket, kept for models that declare no `defaults.resolution`.
 const DEFAULT_DIMENSION: u32 = 1024;
 
+/// The batch size used when neither the caller nor the model's manifest entry names one — the
+/// historical blanket, kept for models that declare no `defaults.count`.
+const DEFAULT_COUNT: u32 = 4;
+
+/// The payload-sanity bounds on batch size. NOT a model's limit: that is `limits.count`, which is
+/// still unread (sc-12335 — a menu, and a separate question from this default).
+const MIN_COUNT: u32 = 1;
+const MAX_COUNT: u32 = 8;
+
+/// `defaults.count` from a resolved manifest entry, or `None` for the blanket [`DEFAULT_COUNT`].
+///
+/// The fifth and last dead `defaults.*` key, and the widest: **29 of the 45** image models declare
+/// `defaults.count: 1` while the API blanket-defaulted to **4**, so a caller that named no count got
+/// four images from a model that asks for one.
+///
+/// It matters most on exactly the family sc-12427 just moved: `sensenova_u1_8b` declares
+/// `2048x2048` **and** `count: 1`. Honoring only the resolution took a bare
+/// `generate_image(model = "sensenova_u1_8b", prompt = …)` from `4 x 1024²` to `4 x 2048²` — **4x
+/// the pixels of what shipped before**, where the model's own declaration is `1 x 2048²`, i.e. the
+/// original cost at the correct geometry. The two keys are one intent; reading half of it made the
+/// bare call more expensive rather than more correct.
+///
+/// Zero web blast radius, for the same reason as every other key here: the studio always SENDS a
+/// count (`ImageStudio.jsx:1950`), so it is a caller that names a value and never reaches this
+/// path. That the studio *seeds* its own control with a hardcoded 4 rather than the model's
+/// declaration is a separate, user-visible question — it belongs to `limits.count` / sc-12335, not
+/// to this default.
+///
+/// Same never-invent-from-a-typo posture as its siblings: a declared count outside
+/// [`MIN_COUNT`]`..=`[`MAX_COUNT`] is not a batch anyone meant, so it falls back to the blanket.
+pub fn default_count(model_manifest_entry: &JsonObject) -> Option<u32> {
+    model_manifest_entry
+        .get("defaults")
+        .and_then(Value::as_object)
+        .and_then(|defaults| defaults.get("count"))
+        .and_then(Value::as_u64)
+        .filter(|count| (u64::from(MIN_COUNT)..=u64::from(MAX_COUNT)).contains(count))
+        .map(|count| count as u32)
+}
+
 /// The payload-sanity bounds on either dimension (the Python `safe_int` clamp). Deliberately wider
 /// than the video lane's 1920 ceiling: image models legitimately render at 2048 (the sensenova U1
 /// family declares `2048x2048`), which is why [`default_resolution`] takes its bounds rather than
@@ -102,13 +142,14 @@ impl ImageRequest {
         let model_manifest_entry = object_or_empty(payload, "modelManifestEntry");
         let (default_width, default_height) = default_resolution(&model_manifest_entry)
             .unwrap_or((DEFAULT_DIMENSION, DEFAULT_DIMENSION));
+        let default_count = default_count(&model_manifest_entry).unwrap_or(DEFAULT_COUNT);
         Self {
             project_id: string_or(payload, "projectId", ""),
             mode: nonempty_string_or(payload, "mode", DEFAULT_MODE),
             prompt: string_or(payload, "prompt", ""),
             negative_prompt: string_or(payload, "negativePrompt", ""),
             model: nonempty_string_or(payload, "model", DEFAULT_MODEL),
-            count: clamped_u32(payload.get("count"), 4, 1, 8),
+            count: clamped_u32(payload.get("count"), default_count, MIN_COUNT, MAX_COUNT),
             seed: optional_i64(payload, "seed"),
             seeds: int_array(payload, "seeds"),
             width: clamped_u32(


### PR DESCRIPTION
Follow-up to [#1587](https://github.com/SceneWorks/SceneWorks/pull/1587) / [sc-12427](https://app.shortcut.com/trefry/story/12427). Epic 12334. **This is a loose end of my own merged PR, not an independent find.**

## The bug

**29 of the 45 image models declare `defaults.count: 1`**; the API blanket-defaulted to **4**. Verified by driving the real route:

```
sensenova_u1_8b: count=4 size=2048x2048   ← declares count: 1
z_image:         count=4                  ← declares count: 1
z_image_turbo:   count=4                  ← declares count: 4 ✓ (coincidence)
```

## Why it's urgent: #1587 made the bare call *worse*

`sensenova_u1_8b` declares **`2048x2048` AND `count: 1`**. Honoring only the resolution took a bare `generate_image(model="sensenova_u1_8b", prompt="…")`:

| | pixels |
|---|---|
| before #1587 | 4 × 1024² = **4.19M** |
| after #1587 (shipped) | 4 × 2048² = **16.8M** ← 4× more expensive |
| the model's own declaration | 1 × 2048² = **4.19M** ← original cost, correct geometry |

The two keys are **one intent**. Reading half of it made the bare call more expensive rather than more correct. This PR restores the cost to exactly what it was before #1587, at the geometry the model asks for.

## Zero web blast radius

The studio **always sends `count`** (`ImageStudio.jsx:1950`), so it is a caller-that-names-a-value and never reaches the default path — the same reason every key in this sweep was web-safe. I initially thought fixing the API alone would create a web/API divergence; checking the submit path showed that was wrong.

That the studio *seeds* its own control with a hardcoded 4 rather than the model's declaration is a **separate, user-visible question** that belongs to `limits.count` / [sc-12335](https://app.shortcut.com/trefry/story/12335) — which owns the count menu and already records that framing. Deliberately untouched.

Also fixed: the seed batch now derives from the resolved count, so a count-1 model no longer carries four seeds contradicting its own payload.

## ⚠️ Two fixture errors this caught — one already shipped in #1587

1. **`chroma1_flash` declares `count: 4`, not 1** — I'd transcribed from a truncated dump. The test was red until I read the real manifest.
2. **`flux1_schnell` is not a model** (it's `flux_schnell`). #1587's test used that id as its "declares 1024×1024" control, so it resolved to `{}` and passed via the **unknown-model blanket** — green, while asserting nothing about a declared default. **A typo'd id is a silent no-op in this test by construction**, which is precisely why the control row must be a real model. Fixed here.

## The fixture is now a matrix pinning each axis independently

The two keys are read by separate code, so a fixture where they always agree can't distinguish a working pair from one reader carrying the other:

| model | resolution | count | discriminates |
|---|---|---|---|
| `sensenova_u1_8b` | 2048×2048 | 1 | **both** |
| `z_image` | 1024×1024 | 1 | count only |
| `chroma1_flash` | 768×768 | 4 | resolution only |
| `z_image_turbo` | 1024×1024 | 4 | neither — real control |

| Mutation | Result |
|---|---|
| `default_count` → `None` (= the shipped bug) | **RED** |
| `default_resolution` → `None` | **RED** (count reader doesn't mask it) |
| drop the API count write-back only | **RED** |

## ⚠️ Behavior change

Raw API / MCP callers that **omit** count (UI unaffected): 29 models 4 → 1 image; the other 16 unchanged. Each adopts the batch the manifest declares — and for sensenova this is a **cost reduction**, undoing the 4× #1587 introduced.

## Verification

- `npm run rust:check` — exit 0, 21 suites
- core 495 · api 293 · web 1875 — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)