### PR TITLE
test(worker): tie manifest maxPixels + wan stride to the PINNED engine; bump runtime pin 07.6→07.7 (sc-12409)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -453,7 +453,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -464,7 +464,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -477,7 +477,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -490,7 +490,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -555,7 +555,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -575,7 +575,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -620,7 +620,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -633,7 +633,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen",
  "image",
@@ -721,7 +721,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -738,7 +738,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -751,7 +751,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -762,7 +762,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -772,7 +772,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -802,7 +802,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -832,7 +832,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -844,7 +844,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -891,7 +891,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1186,7 +1186,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -3645,7 +3645,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3658,7 +3658,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3670,7 +3670,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3683,7 +3683,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3735,7 +3735,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3748,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -3758,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3767,7 +3767,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3776,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3789,7 +3789,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3801,7 +3801,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -3813,7 +3813,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -3834,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3860,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3917,7 +3917,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3946,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3956,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -3967,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3981,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4015,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4025,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4038,7 +4038,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4062,7 +4062,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "core-llm",
  "half",
@@ -5603,7 +5603,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5613,7 +5613,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "candle-gen-catalog",
  "candle-llm",
@@ -5623,7 +5623,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "mlx-gen-catalog",
  "mlx-llm",
@@ -5901,7 +5901,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.6#b2974970d8ee38fa3dd96c5593a51d2aa72a85aa"
+source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.6" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.7" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.6" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.7" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.6", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.7", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -210,6 +210,19 @@ mod lora_train_driver;
     )
 ))]
 mod smoke_support;
+// sc-12409: parity guard tying the shipped video manifest's `limits.maxPixels` to the area cap of
+// the ENGINE PINNED by Cargo.toml (mlx via `runtime-macos` on macOS, candle via `runtime-cuda`
+// off-mac under backend-candle). Not a smoke — no weights, no GPU; just the shipped manifest bytes
+// vs the pinned `MAX_AREA_*` const. Gated on the same "engine bundle present" superset as
+// `smoke_support` because it needs a backend crate in scope to read the const.
+#[cfg(all(
+    test,
+    any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    )
+))]
+mod pinned_engine_geometry;
 // Real-weight GPU smoke for the candle SCAIL-2 lane (sc-7078). Test-only + candle-only; never built
 // in normal compiles. Drives the shipped worker conditioning + `crate::inference_runtime::load("scail2_14b")`.
 #[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]

--- a/crates/sceneworks-worker/src/pinned_engine_geometry.rs
+++ b/crates/sceneworks-worker/src/pinned_engine_geometry.rs
@@ -1,0 +1,199 @@
+//! Ties the shipped video manifest's geometry (`limits.maxPixels`, and the wan-family
+//! `requiresDimensionsMultipleOf`) to the constants of the engine that ACTUALLY SHIPS — the one
+//! pinned by `Cargo.toml`'s `runtime-*` tag — instead of to a hand-copied literal.
+//!
+//! **sc-12409.** sc-12308 corrected both the engine cap and the catalog, but the catalog PR
+//! merged first, so `main` advertised a `1280x720` A14B geometry the pinned engine still
+//! rejected (candle `validate()`) or silently refit (mlx). No lane caught it: the
+//! `sceneworks-core` guard [`shipped_manifest_matches_each_engines_real_geometry`] checks the
+//! manifest against the `ENGINE_GEOMETRY` *literals*, and those literals had drifted in lockstep
+//! with the manifest — both internally consistent, both ahead of the binary that ships. The
+//! adjacent `constants.js` mirror had a parity guard (`videoGeometryParity.test.js`) and caught
+//! its half immediately; this is the same class of drift, one layer down, previously unguarded.
+//!
+//! These tests read the real `MAX_AREA_*` / `SIZE_MULTIPLE_14B` constants out of the pinned
+//! backend, so a manifest that gets ahead of the engine — OR a `runtime-*` pin bump that gets
+//! ahead of the manifest — is RED here rather than a silent job-time reject in production.
+//!
+//! They run on whichever backend the current lane compiles, each verifying the binary its own
+//! platform runs:
+//! * **macOS** — mlx, via `runtime-macos` (`macos-mlx.yml`: `cargo test -p sceneworks-worker`).
+//! * **off-mac `backend-candle`** — candle, via `runtime-cuda` (`windows-candle.yml`:
+//!   `cargo test -p sceneworks-worker --features backend-candle`).
+//!
+//! The consts come from the same pinned tag and each backend's `config.rs` documents them as
+//! mirrors of the other, so a single mapping serves both lanes.
+//!
+//! **Scope (sc-12409 point 4 — "does the class generalize?").** `maxPixels` is tied for every
+//! video model. `requiresDimensionsMultipleOf` is tied for the wan 14B grid-16 family only —
+//! that is the axis reachable through the `wan::config` import this test already holds. The
+//! ltx / mochi / svd strides live in other engine crates (each a new, candle-uncompilable-here
+//! import), and the 5B / scail2 `None`-stride needs a different `None == core_default` assertion;
+//! extending the pinned tie to them is tracked in **sc-12587**. Until then those strides stay
+//! guarded only by `ENGINE_GEOMETRY`'s literals in `sceneworks-core`.
+
+// The pinned inference bundle for this platform — the same cfg-selected alias
+// `inference_runtime.rs` uses as its composition root.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use runtime_cuda as platform_runtime;
+#[cfg(target_os = "macos")]
+use runtime_macos as platform_runtime;
+
+// `wan::config` re-exported off the platform bundle's `providers` (present under the default
+// `media` feature). candle-gen-bernini / mlx-gen-bernini and the scail2 engines import this same
+// `MAX_AREA_14B` rather than declaring their own, so it is authoritative for the whole 14B family.
+// `SIZE_MULTIPLE_14B` is the same `pub const ... = 16` on both backends.
+use platform_runtime::providers::wan::config::{MAX_AREA_14B, MAX_AREA_5B, SIZE_MULTIPLE_14B};
+use serde_json::Value;
+
+/// Every video model in the shipped `builtin.models.jsonc`. A model added or removed without
+/// updating this list trips the count guard in each test, so the check cannot silently stop
+/// covering a model — the same tripwire the sibling
+/// [`shipped_manifest_matches_each_engines_real_geometry`] uses (`models.len() == …`).
+const EXPECTED_VIDEO_IDS: &[&str] = &[
+    "ltx_2_3",
+    "ltx_2_3_eros",
+    "svd",
+    "mochi_1",
+    "wan_2_2",
+    "wan_2_2_t2v_14b",
+    "wan_2_2_i2v_14b",
+    "wan_2_2_vace_fun_14b",
+    "bernini",
+    "scail2_14b",
+];
+
+/// The pinned engine area cap a video model's `limits.maxPixels` must equal. Derived from the
+/// engine source (`candle-gen-wan` / `mlx-gen-wan` `config.rs`), NOT read back from the manifest —
+/// that independence is the whole point.
+///
+/// * The 14B family — `wan_2_2_t2v_14b`, `wan_2_2_i2v_14b`, `wan_2_2_vace_fun_14b`, `bernini`,
+///   `scail2_14b` — all validate against [`MAX_AREA_14B`]. bernini and scail2 import that exact
+///   const rather than declaring their own.
+/// * The TI2V-5B (`wan_2_2`) validates against [`MAX_AREA_5B`] (its z48 VAE's 32-px grid, a
+///   genuinely lower budget than the 14B family's).
+/// * `ltx_2_3` / `ltx_2_3_eros` / `svd` / `mochi_1` have no `maxPixels`-expressible area cap in
+///   either backend, so the manifest must NOT invent one — expected `None` (key absent).
+///
+/// An unmapped id panics: adding a video model is a deliberate act that must derive its own cap
+/// from its engine, never inherit one by default.
+fn expected_max_pixels(id: &str) -> Option<u64> {
+    match id {
+        "wan_2_2_t2v_14b"
+        | "wan_2_2_i2v_14b"
+        | "wan_2_2_vace_fun_14b"
+        | "bernini"
+        | "scail2_14b" => Some(MAX_AREA_14B as u64),
+        "wan_2_2" => Some(MAX_AREA_5B as u64),
+        "ltx_2_3" | "ltx_2_3_eros" | "svd" | "mochi_1" => None,
+        other => panic!(
+            "video model {other:?} is not mapped to a pinned engine area cap — derive its \
+             MAX_AREA_* from that model's engine `config.rs` and add it to \
+             `expected_max_pixels`; do not blanket-apply a default (sc-12409)"
+        ),
+    }
+}
+
+/// The pinned engine stride a video model's `requiresDimensionsMultipleOf` must equal, for the
+/// models whose stride this guard ties to a pinned const. `Some(n)` = assert the manifest
+/// declares exactly `n`; a model absent here is not stride-tied yet (see the module note /
+/// sc-12587) and remains covered only by `ENGINE_GEOMETRY`.
+///
+/// The wan 14B grid-16 family renders on the `SIZE_MULTIPLE_14B = 16` lattice: the three A14B ids
+/// through their own engine, and `bernini` through a Wan2.2-T2V-A14B snapshot (patch 2 × vae 8).
+/// `scail2_14b` and the 5B declare no stride (their `None` means "engine stride == core's default
+/// floor"), and ltx / svd / mochi live in other engine crates — all deferred to sc-12587.
+fn pinned_stride(id: &str) -> Option<u64> {
+    match id {
+        "wan_2_2_t2v_14b" | "wan_2_2_i2v_14b" | "wan_2_2_vace_fun_14b" | "bernini" => {
+            Some(SIZE_MULTIPLE_14B as u64)
+        }
+        _ => None,
+    }
+}
+
+/// The `models` array of the SHIPPED `builtin.models.jsonc` — the exact bytes the app embeds and
+/// seeds — filtered to `type == "video"`.
+fn shipped_video_models() -> Vec<Value> {
+    let raw = sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS
+        .iter()
+        .find(|(name, _)| *name == "builtin.models.jsonc")
+        .map(|(_, contents)| *contents)
+        .expect("builtin.models.jsonc present in BUILTIN_MANIFESTS");
+    let manifest: Value = serde_json::from_str(&sceneworks_core::jsonc::strip_jsonc_comments(raw))
+        .expect("builtin.models.jsonc parses as JSON");
+    manifest
+        .get("models")
+        .and_then(Value::as_array)
+        .expect("builtin.models.jsonc has a models array")
+        .iter()
+        .filter(|m| m.get("type").and_then(Value::as_str) == Some("video"))
+        .cloned()
+        .collect()
+}
+
+/// Assert the shipped video set is exactly [`EXPECTED_VIDEO_IDS`] and return each entry's `limits`
+/// object keyed by id. The count guard catches a model added or removed from the manifest so this
+/// test can't silently stop covering one; the per-id lookup catches a rename.
+fn shipped_video_limits() -> std::collections::HashMap<String, Value> {
+    let models = shipped_video_models();
+    assert_eq!(
+        models.len(),
+        EXPECTED_VIDEO_IDS.len(),
+        "a video model was added/removed in builtin.models.jsonc — update EXPECTED_VIDEO_IDS and \
+         map its cap/stride to its engine const (sc-12409); do not let it go unchecked"
+    );
+    EXPECTED_VIDEO_IDS
+        .iter()
+        .map(|id| {
+            let entry = models
+                .iter()
+                .find(|m| m.get("id").and_then(Value::as_str) == Some(*id))
+                .unwrap_or_else(|| panic!("{id} present in builtin.models.jsonc"));
+            let limits = entry
+                .get("limits")
+                .cloned()
+                .unwrap_or_else(|| panic!("{id} declares a limits object"));
+            ((*id).to_owned(), limits)
+        })
+        .collect()
+}
+
+/// For every shipped video model, `limits.maxPixels` must equal the area cap of the engine
+/// PINNED by `Cargo.toml` — not a literal transcribed from it. Flip either side (drift the
+/// manifest, or bump the `runtime-*` pin without the manifest) and this goes RED.
+#[test]
+fn manifest_max_pixels_matches_the_pinned_engine_area_cap() {
+    for (id, limits) in shipped_video_limits() {
+        let declared = limits.get("maxPixels").and_then(Value::as_u64);
+        assert_eq!(
+            declared,
+            expected_max_pixels(&id),
+            "{id}: manifest `limits.maxPixels` disagrees with the PINNED engine's area cap \
+             (this backend: MAX_AREA_14B={MAX_AREA_14B}, MAX_AREA_5B={MAX_AREA_5B}). The catalog \
+             and the `runtime-*` tag in Cargo.toml must move together — see sc-12409."
+        );
+    }
+}
+
+/// For the wan 14B grid-16 family, `limits.requiresDimensionsMultipleOf` must equal the engine's
+/// PINNED `SIZE_MULTIPLE_14B`. Same drift class as the area cap, one axis over; the remaining
+/// video strides are tracked in sc-12587.
+#[test]
+fn manifest_dimension_multiple_matches_the_pinned_engine_stride() {
+    for (id, limits) in shipped_video_limits() {
+        let Some(want) = pinned_stride(&id) else {
+            continue;
+        };
+        let declared = limits
+            .get("requiresDimensionsMultipleOf")
+            .and_then(Value::as_u64);
+        assert_eq!(
+            declared,
+            Some(want),
+            "{id}: manifest `limits.requiresDimensionsMultipleOf` disagrees with the PINNED \
+             engine stride (this backend: SIZE_MULTIPLE_14B={SIZE_MULTIPLE_14B}). The catalog and \
+             the `runtime-*` tag in Cargo.toml must move together — see sc-12409."
+        );
+    }
+}


### PR DESCRIPTION
## What & why

[sc-12409](https://app.shortcut.com/trefry/story/12409) — *Nothing ties the manifest's `maxPixels` to the PINNED engine's cap; `main` silently got ahead of its engine.*

sc-12308 corrected both the engine area cap (inference) and the catalog (this repo), but the **catalog PR merged first**. `main` then advertised a `1280x720` A14B geometry that the pinned `runtime-2026.07.6` engine still **rejected** (candle `validate()`) or **silently refit** (mlx) — a job-time reject, not a compile error, so no lane caught it. The existing `sceneworks-core` guard `shipped_manifest_matches_each_engines_real_geometry` compares the manifest to the `ENGINE_GEOMETRY` **literals**, which had drifted in lockstep with it: both internally consistent, both ahead of the binary that ships.

## Change

**1. Bump the engine pin `runtime-2026.07.6 → runtime-2026.07.7`** (`crates/sceneworks-worker/Cargo.toml`: `sceneworks-gen-core`, `runtime-macos`, `runtime-cuda`). The new tag carries the sc-12308 fix — candle + mlx now agree: `MAX_AREA_14B = 1280·720 = 921,600`, `MAX_AREA_5B = 1280·704 = 901,120`, `SIZE_MULTIPLE_14B = 16`, all clean `pub const`s, and mlx now `reject_over_area` instead of silently refitting. The manifest already advertises those values, so **the pin bump reconciles the skew with no catalog edit**. `Cargo.lock` churn is inference-only (72 crates, one commit rev; no crate add/remove, no non-inference source change).

**2. Add `pinned_engine_geometry.rs`** — worker tests asserting, per video family, that the shipped manifest matches the geometry of the **pinned** engine, read as a real `const` out of the backend that ships:
- `maxPixels` — tied for **every** video model (`wan::config::MAX_AREA_14B` / `MAX_AREA_5B`).
- `requiresDimensionsMultipleOf` — tied for the **wan 14B grid-16 family** (`wan::config::SIZE_MULTIPLE_14B`).
- A count/lookup tripwire over `EXPECTED_VIDEO_IDS` keeps a model from silently dropping out of coverage (same mechanism as the `sceneworks-core` sibling).

It reads the const via a cfg-selected `platform_runtime` alias — mlx through `runtime-macos` on the macOS lane, candle through `runtime-cuda` off-mac under `backend-candle` — so a manifest that gets ahead of the engine, **or a future `runtime-*` pin bump that gets ahead of the manifest**, is RED here instead of a silent production reject. It lives in the worker because that is the only crate with **both** the manifest bytes (via `sceneworks-core`) and the pinned engine const; `sceneworks-core` is engine-agnostic by design and cannot read it.

## Scope covered vs. deferred

- ✅ Story points 1–3 (decide the home / add the maxPixels test / prefer the test over a checklist): done.
- ✅ Point 4 ("does the class generalize?"), reachable slice: the wan-family `requiresDimensionsMultipleOf` tie.
- ⏭️ Point 4, remainder → **[sc-12587](https://app.shortcut.com/trefry/story/12587)** (filed, `relates to` sc-12409): the ltx/svd/mochi strides live in other engine crates, and the 5B/scail2 `None`-stride needs a different `None == core_default` assertion. Surfaced in the module doc-comment, not dropped silently.

## Verification

Runs on `macos-mlx.yml` (`cargo test -p sceneworks-worker`) and `windows-candle.yml` (`cargo test -p sceneworks-worker --features backend-candle`).

- Both guard tests **pass** on the macOS/mlx lane; `npm run rust:check` exits 0; `cargo clippy -p sceneworks-worker --all-targets -- -D warnings` exits 0; `cargo fmt --all --check` exits 0.
- **Mutation-checked both assertions** (reproducing the sc-12308 skew): drifting `wan_2_2_t2v_14b` `maxPixels` 921600→901120 and its stride 16→32 each turn the guard RED with the manifest value on the left and the **pinned 07.7 const** on the right — proving the engine side is read from the pin, not a literal. Reverted after.
- **Candle-lane caveat:** the `backend-candle` half is Windows/CUDA and was **not runnable on this Apple-Silicon box** — validated by inspection (it mirrors the exact `runtime_cuda::providers::<x>::…` import shape already used in `image_jobs.rs`/`inference_runtime.rs`; every path component confirmed against the 07.7 source). CI's `windows-candle.yml` lane is the executor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
