### PR TITLE
fix(catalog,worker): guard image-lane geometry against the pinned engine + trim SANA/SenseNova over-advertised buckets (sc-12384)

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -236,7 +236,9 @@ export const fallbackModels = [
     // face-locked options — sc-2015 spike measured outfit + accessories +
     // tattoos preserved across new scenes, face may drift.
     capabilities: ["text_to_image", "edit_image", "character_image", "vqa", "interleave"],
-    limits: { resolutions: ["2048x2048", "2720x1536", "2496x1664", "2368x1760", "1536x2720", "1664x2496", "1760x2368"] },
+    // ≤2048 per side — the engine caps each side at 2048 and the former 2720/2496/2368 buckets were
+    // silently squashed to a wrong aspect (sc-12384). Same aspect ladder, fit to the real envelope.
+    limits: { resolutions: ["2048x2048", "2048x1152", "1152x2048", "1888x1248", "1248x1888", "1760x1312", "1312x1760"] },
     ui: {
       description: "Unified multimodal model (NEO-unify, ~16B); native text-to-image and instruction editing with strong text rendering and infographics. In Character Studio, drives a wardrobe-preserving reference flow — outfit + accessories + tattoos + hair color carry through to new scenes, but face geometry may drift. Pick InstantID or PuLID-FLUX for face-locked identity. Heavy (~42GB bf16); CUDA or 96GB+ Apple Silicon.",
       promptGuide: { title: "SenseNova-U1 8B Prompt Guide", path: "/prompt-guides/sensenova-u1-8b.md" },
@@ -252,7 +254,9 @@ export const fallbackModels = [
     // character_image (sc-2016): same wardrobe-preserving reference flow as the
     // base 8B target, on the 8-step distilled variant (~50s/image vs ~4.6 min).
     capabilities: ["text_to_image", "edit_image", "character_image"],
-    limits: { resolutions: ["2048x2048", "2720x1536", "2496x1664", "2368x1760", "1536x2720", "1664x2496", "1760x2368"] },
+    // ≤2048 per side — the engine caps each side at 2048 and the former 2720/2496/2368 buckets were
+    // silently squashed to a wrong aspect (sc-12384). Same aspect ladder, fit to the real envelope.
+    limits: { resolutions: ["2048x2048", "2048x1152", "1152x2048", "1888x1248", "1248x1888", "1760x1312", "1312x1760"] },
     ui: {
       description: "8-step distilled SenseNova-U1; ~5-6x faster text-to-image, editing, and Character Studio reference (~50s/image on MPS) at a small quality trade-off. Same wardrobe-preserving reference tradeoff as the base 8B (carries outfit + accessories across new scenes; face may drift). Shares the base 8B weights; a ~0.4GB distill LoRA downloads automatically. Distilled editing is experimental — use the base model for max-quality reference work.",
       promptGuide: { title: "SenseNova-U1 8B Fast Prompt Guide", path: "/prompt-guides/sensenova-u1-8b-fast.md" },

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1134,11 +1134,17 @@
         "schedulerShift": 3.0
       },
       "limits": {
-        // SenseNova-U1 renders at fixed trained buckets and degrades off them.
-        // These are the true output sizes; the adapter snaps any request to the
-        // nearest bucket by aspect ratio. (Panorama buckets 2:1/1:2/3:1/1:3 exist
-        // upstream but are omitted here.)
-        "resolutions": ["2048x2048", "2720x1536", "2496x1664", "2368x1760", "1536x2720", "1664x2496", "1760x2368"],
+        // SenseNova-U1 renders at fixed trained buckets and degrades off them. Its engine caps EACH
+        // SIDE at 2048 (descriptor max_size = 2048, the [256, 2048] generation envelope; CELL=32).
+        // The former 2720/2496/2368 buckets exceeded that cap — the bespoke worker path
+        // (`image_jobs::sensenova::sensenova_dim`) silently clamped each side to 2048 INDEPENDENTLY,
+        // so e.g. 2720x1536 (16:9) rendered as 2048x1536 (4:3): a wrong-aspect image, not the
+        // advertised size. Trimmed to ≤2048 buckets that hold the same aspect ladder (16:9 / 3:2 / 4:3
+        // landscape + portrait), 32-aligned, mirroring the model's own INTERLEAVE_RESOLUTION_OPTIONS
+        // (constants.js) — every advertised size now renders at that exact size (sc-12384, guarded by
+        // `shipped_image_geometry_is_within_the_pinned_engine_envelope`). Larger native buckets would
+        // need the engine's max_size raised + a real-weight validation, tracked separately.
+        "resolutions": ["2048x2048", "2048x1152", "1152x2048", "1888x1248", "1248x1888", "1760x1312", "1312x1760"],
         "count": [1, 2, 4],
         "samplers": ["default"],
         "schedulers": ["default"]
@@ -1245,7 +1251,7 @@
         "schedulerShift": 3.0
       },
       "limits": {
-        "resolutions": ["2048x2048", "2720x1536", "2496x1664", "2368x1760", "1536x2720", "1664x2496", "1760x2368"],
+        "resolutions": ["2048x2048", "2048x1152", "1152x2048", "1888x1248", "1248x1888", "1760x1312", "1312x1760"],
         "count": [1, 2, 4],
         "samplers": ["default"],
         "schedulers": ["default"]
@@ -1337,7 +1343,7 @@
       "limits": {
         // Same trained buckets as the base model; true output sizes (the adapter
         // snaps any request to the nearest bucket by aspect ratio).
-        "resolutions": ["2048x2048", "2720x1536", "2496x1664", "2368x1760", "1536x2720", "1664x2496", "1760x2368"],
+        "resolutions": ["2048x2048", "2048x1152", "1152x2048", "1888x1248", "1248x1888", "1760x1312", "1312x1760"],
         "count": [1, 2, 4],
         "samplers": ["default"],
         "schedulers": ["default"]
@@ -1446,7 +1452,7 @@
         "schedulerShift": 3.0
       },
       "limits": {
-        "resolutions": ["2048x2048", "2720x1536", "2496x1664", "2368x1760", "1536x2720", "1664x2496", "1760x2368"],
+        "resolutions": ["2048x2048", "2048x1152", "1152x2048", "1888x1248", "1248x1888", "1760x1312", "1312x1760"],
         "count": [1, 2, 4],
         "samplers": ["default"],
         "schedulers": ["default"]
@@ -4219,12 +4225,18 @@
         "schedulerShift": 3.0
       },
       "limits": {
-        // 32× DC-AE divisor → W×H must be multiples of 32 (descriptor RES_MULTIPLE). Native 1024².
+        // 32× DC-AE divisor → W×H must be multiples of 32 (descriptor RES_MULTIPLE). 1024² ONLY:
+        // SANA-1600M is the "1024px" model — its engine caps EACH SIDE at 1024 (descriptor max_size =
+        // RES_MAX = 1024), the validated DC-AE envelope (mlx-gen-sana `max_size_is_the_validated_1024_
+        // envelope`; the f32 DC-AE decode is monolithic, un-tiled). The old 1152/896/1216/832 buckets
+        // exceed 1024 per side and HARD-ERROR before any weights load — off-catalog, never rendered.
+        // Trimmed to 1024² so every advertised bucket is legal (sc-12384, guarded by
+        // `shipped_image_geometry_is_within_the_pinned_engine_envelope`).
         // SANA routes the per-generation sampler/scheduler knobs through the unified flow framework
         // (epic 7114), so it advertises the full curated flow menu. "default" is the native
         // flow-match Euler loop. The `sana_1600m` descriptor advertises curated_sampler_names()/
         // curated_scheduler_names(); the engines.rs drift guard checks this list is a subset.
-        "resolutions": ["1024x1024", "1152x896", "896x1152", "1216x832", "832x1216"],
+        "resolutions": ["1024x1024"],
         "count": [1, 2, 4],
         "samplers": ["default", "euler", "euler_ancestral", "heun", "dpmpp_2m", "dpmpp_sde", "uni_pc", "lcm", "ddim"],
         "schedulers": ["default", "normal", "simple", "karras", "exponential", "sgm_uniform", "beta", "ddim_uniform"]
@@ -4373,13 +4385,15 @@
         "schedulerShift": 3.0
       },
       "limits": {
-        // 32× DC-AE divisor → W×H must be multiples of 32 (descriptor RES_MULTIPLE). Native 1024².
+        // 32× DC-AE divisor → W×H must be multiples of 32 (descriptor RES_MULTIPLE). 1024² ONLY —
+        // same validated per-side 1024 DC-AE envelope as base SANA (sc-12384); the old non-square
+        // buckets exceeded it and hard-errored. See `sana_1600m` above for the full rationale.
         // Sprint's native loop is the SCM/TrigFlow few-step consistency sampler — a DEDICATED loop, NOT
         // a curated epic-7114 `Solver`. Unlike base SANA, the Sprint descriptor (`sprint_descriptor()`
         // in mlx-gen-sana) advertises ONLY the engine-default sentinel for both axes (and NO guidance
         // methods — CFG-free embedded-scalar guidance). The engines.rs drift guard requires this list to
         // be a SUBSET of the descriptor's honored set, so it must be exactly ["default"].
-        "resolutions": ["1024x1024", "1152x896", "896x1152", "1216x832", "832x1216"],
+        "resolutions": ["1024x1024"],
         "count": [1, 2, 4],
         "samplers": ["default"],
         "schedulers": ["default"]

--- a/crates/sceneworks-core/src/image_request.rs
+++ b/crates/sceneworks-core/src/image_request.rs
@@ -6,6 +6,21 @@
 //! and `model_manifest_entry` maps pass through verbatim (they carry per-family knobs
 //! like steps/guidanceScale/mlxQuantize/poses/angleSet/controlScale/referenceStrength
 //! and the resolved model manifest entry), so adding a family needs no DTO change.
+//!
+//! **Geometry, deliberately un-normalized (sc-12384).** Unlike the video request
+//! ([`crate::video_request`], which floors dims to `limits.requiresDimensionsMultipleOf`
+//! and fits them into `limits.maxPixels` via `normalized_dimensions`), the image lane
+//! applies NO stride/area refit — `width`/`height` are only sanity-clamped to
+//! `256..=4096` and handed to the engine as-is. The engine is the single authority on
+//! image geometry: it rejects an illegal size loudly rather than the app silently
+//! substituting a different one (the failure mode a refit twin would reintroduce — cf.
+//! the per-side clamp `image_jobs::sensenova::sensenova_dim` was doing to over-cap
+//! SenseNova buckets before sc-12384 trimmed them). What keeps that contract honest is
+//! not a runtime normalize but a build-time guard: every image model's advertised
+//! `limits.resolutions` + default must fit its PINNED engine's `[min_size, max_size]`
+//! envelope, asserted by `sceneworks_worker::engines`'s
+//! `shipped_image_geometry_is_within_the_pinned_engine_envelope`. So the manifest may
+//! only advertise buckets the engine honors, and no app-layer refit is needed or wanted.
 
 use serde_json::Value;
 

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -1464,6 +1464,204 @@ mod tests {
         }
     }
 
+    /// Every image model in the shipped `builtin.models.jsonc`. A model added, removed, or renamed
+    /// without updating this list trips the count tripwire in
+    /// [`shipped_image_geometry_is_within_the_pinned_engine_envelope`], so a new image model cannot
+    /// silently ship with its advertised geometry unchecked against its engine (sc-12384 — the image
+    /// twin of [`pinned_engine_geometry`]'s `EXPECTED_VIDEO_IDS`). Backend-independent: this is the
+    /// full catalog set, and each id is size-checked on whichever backend(s) resolve its engine.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    const EXPECTED_IMAGE_IDS: &[&str] = &[
+        "z_image_turbo",
+        "z_image",
+        "z_image_edit",
+        "qwen_image",
+        "qwen_image_edit_2511",
+        "qwen_image_edit_2511_lightning",
+        "lens",
+        "lens_turbo",
+        "sensenova_u1_8b",
+        "sensenova_u1_8b_infographic_v2",
+        "sensenova_u1_8b_fast",
+        "sensenova_u1_8b_infographic_v2_fast",
+        "flux_schnell",
+        "flux_dev",
+        "ideogram_4",
+        "ideogram_4_turbo",
+        "boogu_image",
+        "boogu_image_turbo",
+        "boogu_image_edit",
+        "krea_2_turbo",
+        "krea_2_raw",
+        "flux2_klein_9b",
+        "flux2_klein_9b_kv",
+        "flux2_klein_9b_true_v2",
+        "flux2_dev",
+        "chroma1_hd",
+        "chroma1_base",
+        "chroma1_flash",
+        "kolors",
+        "sd3_5_large",
+        "sd3_5_large_turbo",
+        "sd3_5_medium",
+        "sana_1600m",
+        "sana_sprint_1600m",
+        "anima_base",
+        "anima_aesthetic",
+        "anima_turbo",
+        "sdxl",
+        "realvisxl",
+        "realvisxl_lightning",
+        "illustrious_xl_v1",
+        "illustrious_xl_v2",
+        "instantid_realvisxl",
+        "pulid_flux_dev",
+        "bernini_image",
+    ];
+
+    /// The backend-effective default resolution (`<backend>.defaults.resolution` overriding the base
+    /// `defaults.resolution`) — the scalar companion to [`effective_list`], which handles the
+    /// per-backend list axes. `None` when the model declares no default at all.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    fn effective_default_resolution(model: &serde_json::Value, backend: &str) -> Option<String> {
+        let pick = |scope: &serde_json::Value| {
+            scope
+                .get("defaults")
+                .and_then(|d| d.get("resolution"))
+                .and_then(|r| r.as_str())
+                .map(str::to_owned)
+        };
+        model.get(backend).and_then(pick).or_else(|| pick(model))
+    }
+
+    /// sc-12384 — the image-lane twin of [`shipped_manifest_matches_each_engines_real_geometry`]
+    /// (sc-12294, video) and [`pinned_engine_geometry`] (sc-12409): every image model's advertised
+    /// geometry — each `limits.resolutions` bucket AND the shipped `defaults.resolution` — must be
+    /// LEGAL on the engine that actually ships, the one pinned by `Cargo.toml`'s `runtime-*` tag.
+    ///
+    /// The bug this closes: `bernini_image`'s own 1024² default was engine-rejected on candle and
+    /// nothing caught it, because `limits.maxPixels` / `requiresDimensionsMultipleOf` are read only
+    /// on the VIDEO request path (`video_request.rs`) — an image model's manifest buckets were an
+    /// unchecked claim. This asserts them against the PINNED descriptor's `[min_size, max_size]`
+    /// envelope (each provider sets those from its own `RES_MIN`/`RES_MAX` const), so a catalog
+    /// bucket that overshoots an engine's envelope — OR a `runtime-*` pin bump that narrows one —
+    /// is RED here instead of a silent job-time reject (candle) or wrong-aspect refit (mlx).
+    ///
+    /// It found two live over-advertisements when written: SANA (its per-side 1024 DC-AE envelope
+    /// — the 1152/1216 buckets hard-error) and SenseNova (per-side 2048 — the 2720/2496/2368 buckets
+    /// were silently squashed to a wrong aspect by `image_jobs::sensenova::sensenova_dim`). Both were
+    /// trimmed catalog-side; the fix is the catalog, because each engine cap is deliberate (SANA's is
+    /// test-pinned, `max_size_is_the_validated_1024_envelope`).
+    ///
+    /// Runs on whichever backend the current lane compiles — mlx on macOS CI, candle on the
+    /// `backend-candle` Windows CI — each checking the binary its own platform ships. A model that
+    /// registers on only one backend is size-checked on that backend's lane (every shipped image
+    /// model registers on at least one); the count tripwire is backend-independent, so a new image
+    /// model must still be assessed on both.
+    ///
+    /// SCOPE: the `[min, max]` size envelope — the axis `Capabilities` exposes, and the axis both
+    /// live bugs sat on. The per-engine ÷8/÷16/÷32 STRIDE is checked inside each engine's `validate`
+    /// and is NOT on `Capabilities`; every current image bucket is on-stride, so tying image strides
+    /// to a pinned const (as sc-12409 did for the wan-14B family, and sc-12587 tracks for the
+    /// remaining VIDEO strides) is a coverage extension tracked in sc-12612 — the image twin — not a
+    /// live miss.
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn shipped_image_geometry_is_within_the_pinned_engine_envelope() {
+        let backend = if cfg!(target_os = "macos") {
+            "mlx"
+        } else {
+            "candle"
+        };
+        let manifest = parse_builtin_models();
+        let models = manifest["models"].as_array().expect("models array");
+        let image_models: Vec<&serde_json::Value> = models
+            .iter()
+            .filter(|m| m["type"].as_str() == Some("image"))
+            .collect();
+
+        // Count/rename tripwire (backend-independent): the shipped image set must be exactly
+        // EXPECTED_IMAGE_IDS. A new or renamed image model is RED here until it is added — and thereby
+        // consciously assessed against its engine's envelope — rather than shipping unguarded.
+        let mut shipped_ids: Vec<&str> = image_models
+            .iter()
+            .filter_map(|m| m["id"].as_str())
+            .collect();
+        shipped_ids.sort_unstable();
+        let mut expected = EXPECTED_IMAGE_IDS.to_vec();
+        expected.sort_unstable();
+        assert_eq!(
+            shipped_ids, expected,
+            "the shipped image-model set changed — add the new/renamed id to EXPECTED_IMAGE_IDS and \
+             confirm its advertised buckets + default fit its engine's [min_size, max_size] envelope \
+             (sc-12384); do not let a new image model ship with unchecked geometry"
+        );
+
+        let mut checked = 0usize;
+        for model in image_models {
+            let id = model["id"].as_str().expect("image model has an id");
+            // The PINNED engine's size envelope on THIS backend, or skip: a model that registers only
+            // on the other backend (a mac-only edit lane on the candle lane) or runs through a bespoke
+            // provider with no gen-core descriptor (InstantID; candle PuLID) is size-checked on the
+            // lane that does resolve it — the count tripwire above still forces every id to be listed.
+            let Some(resolved) = mlx_model(id) else {
+                continue;
+            };
+            let min = resolved.descriptor.capabilities.min_size;
+            let max = resolved.descriptor.capabilities.max_size;
+
+            // The backend-effective advertised buckets, plus the backend-effective default (which the
+            // picker preselects and sc-12400's `default_resolution` now hands the engine verbatim).
+            let buckets = effective_list(model, backend, "resolutions").unwrap_or_default();
+            let default = effective_default_resolution(model, backend);
+            assert!(
+                !buckets.is_empty() || default.is_some(),
+                "{id}: resolves engine {:?} on {backend} but advertises no resolutions or default \
+                 to check — an image model with a real engine must declare its geometry",
+                resolved.engine_id()
+            );
+            // The default must itself be one of the advertised buckets — a default the picker can't
+            // land on is a UI bug (mirrors the video guard's `default is one of its buckets` check).
+            if let Some(default) = &default {
+                assert!(
+                    buckets.iter().any(|b| b == default),
+                    "{id}: default resolution {default} is not one of its advertised buckets \
+                     {buckets:?} — the picker preselects a size the user cannot re-select (sc-12384)"
+                );
+            }
+            // Every advertised bucket AND the default is a claim the engine must honor: each must sit
+            // inside the PINNED engine's [min_size, max_size] envelope, on both axes.
+            for res in buckets.iter().chain(default.iter()) {
+                let (w, h) = res
+                    .split_once('x')
+                    .and_then(|(w, h)| Some((w.parse::<u32>().ok()?, h.parse::<u32>().ok()?)))
+                    .unwrap_or_else(|| panic!("{id}: malformed resolution {res:?}"));
+                assert!(
+                    (min..=max).contains(&w) && (min..=max).contains(&h),
+                    "{id}: advertised {res} is outside its PINNED engine's size envelope \
+                     [{min}, {max}] on the {backend} backend — the catalog advertises a bucket the \
+                     shipped engine rejects (candle) or silently refits (mlx). Trim the catalog, or \
+                     move the `runtime-*` pin and the catalog in lockstep (sc-12384)."
+                );
+            }
+            checked += 1;
+        }
+        assert!(
+            checked > 0,
+            "no image model resolved an engine on the {backend} backend — the guard would be \
+             vacuously green; a linked provider registry is required (macos/backend-candle)"
+        );
+    }
+
     /// sc-11991 (epic 1788): `mochi_1` resolves through THIS module to a real gen-core descriptor on
     /// the active backend — the story's acceptance criterion, asserted directly.
     ///


### PR DESCRIPTION
## Problem (sc-12384)

The image request path reads **neither** `limits.maxPixels` nor `requiresDimensionsMultipleOf` (only `video_request.rs` does), so every image model's advertised `limits.resolutions` was an **unchecked claim**. That is how `bernini_image`'s own `1024x1024` default shipped engine-rejected on candle and nothing caught it (found + fixed engine-side by sc-12308, now pinned in `runtime-2026.07.7`). This story closes the class: nothing related an image model's advertised geometry to its engine's real constraints.

## Audit — all 45 image models vs the pinned engine

Two more **live** over-advertisements, each a distinct failure mode:

| Model | Engine envelope | Advertised | Was happening |
|---|---|---|---|
| **SANA** (`sana_1600m`, `sana_sprint_1600m`) | per-side **1024** (test-pinned DC-AE envelope; it's the "1024px" model) | `1152x896`, `896x1152`, `1216x832`, `832x1216` | **hard-error** before any weights load |
| **SenseNova** (4 ids) | per-side **2048** | `2720x1536`, `2496x1664`, `2368x1760` + portraits | **silently squashed** per-side by `sensenova_dim` → wrong aspect (e.g. 16:9 rendered 4:3) |

Everything else (z-image, qwen, flux, flux2, chroma, kolors, sd3, sdxl/realvisxl/illustrious, anima, boogu, krea, lens, ideogram, pulid, bernini_image) fits its engine and is unchanged. Both fixes are **catalog-side** — each engine cap is deliberate (SANA's is pinned by `max_size_is_the_validated_1024_envelope`), so the honest fix is to stop advertising what the engine refuses.

## Changes

- **`config/manifests/builtin.models.jsonc`** — SANA → `1024x1024`; SenseNova (4 entries) → a `<=2048` ladder holding the same 16:9 / 3:2 / 4:3 aspects, mirroring the model's own upstream `INTERLEAVE_RESOLUTION_OPTIONS`. Comments explain why.
- **`apps/web/src/constants.js`** — the 2 SenseNova mirror entries moved in lockstep.
- **`crates/sceneworks-worker/src/engines.rs`** — new guard `shipped_image_geometry_is_within_the_pinned_engine_envelope`: every image model's advertised buckets **+ default** must sit inside its **PINNED** descriptor's `[min_size, max_size]` on the active backend; default must itself be a bucket; a count/rename tripwire (`EXPECTED_IMAGE_IDS`) forces a new image model to be assessed. Descriptor-driven, so it ties the catalog to the shipped binary — a `runtime-*` pin bump that narrows an envelope is also RED. This is the image twin of sc-12409's `pinned_engine_geometry` (video).
- **`crates/sceneworks-core/src/image_request.rs`** — records the design decision (AC #1): the image lane is **deliberately un-normalized**. The engine is the sole geometry authority; the catalog stays honest via the guard; no app-layer stride/area refit — that refit *is* the `sensenova_dim` silent-substitution class this removes.

## Design call (AC #1)

**Engine-side validation is the contract for images; do not add a `normalized_dimensions` twin.** The one existing app-layer image normalizer (`sensenova_dim`) is exactly the bug — it silently turned an advertised bucket into a differently-shaped picture. An engine reject is loud and attributable; a refit reintroduces the failure mode. So the app's obligation is to advertise only legal buckets, enforced at build time.

## Scope / follow-up

Covers the **size envelope** — the axis `Capabilities` exposes and the axis both live bugs sat on. Per-engine **stride** (÷8/÷16/÷32) is checked inside each engine's `validate`, not on `Capabilities`; every current bucket is on-stride, so tying image strides to a pinned const (cross-repo, inference-first — same shape as the video sc-12587) is tracked in **sc-12612**.

## Validation

- **GPU-validated on the real pinned candle runtime** (`runtime-2026.07.7`, `--features backend-candle`): the guard **passes** (all 45 image models resolved + checked), and **fails** on an injected illegal SANA bucket with `1152x896 is outside its PINNED engine's size envelope [256, 1024]` — a genuine mutation-kill reading the real descriptor, not a literal.
- `cargo clippy -p sceneworks-worker --features backend-candle --tests -- -D warnings`: clean.
- `cargo fmt` clean (worker + core).
- Full web vitest: **1875 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)