### PR TITLE
build: pin inference by main SHA for rapid dev + bump-inference.mjs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -453,7 +453,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -464,7 +464,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -477,7 +477,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -490,7 +490,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -555,7 +555,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -575,7 +575,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -620,7 +620,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -633,7 +633,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen",
  "image",
@@ -721,7 +721,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -738,7 +738,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -751,7 +751,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -762,7 +762,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -772,7 +772,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -802,7 +802,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -832,7 +832,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -844,7 +844,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -891,7 +891,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1186,7 +1186,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -3645,7 +3645,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3658,7 +3658,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3670,7 +3670,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3683,7 +3683,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3735,7 +3735,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3748,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -3758,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3767,7 +3767,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3776,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3789,7 +3789,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3801,7 +3801,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -3813,7 +3813,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -3834,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3860,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3917,7 +3917,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3946,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3956,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -3967,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3981,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4015,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4025,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4038,7 +4038,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4062,7 +4062,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "core-llm",
  "half",
@@ -4367,7 +4367,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5603,7 +5603,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5613,7 +5613,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "candle-gen-catalog",
  "candle-llm",
@@ -5623,7 +5623,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "mlx-gen-catalog",
  "mlx-llm",
@@ -5901,7 +5901,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?tag=runtime-2026.07.7#496e4543e459cf21c663b68d0adb88e74668796c"
+source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -8313,7 +8313,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.7" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "d64af1ddcd55cefee4cd21e1a3317c69434ee5a3" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.7" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "d64af1ddcd55cefee4cd21e1a3317c69434ee5a3" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", tag = "runtime-2026.07.7", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "d64af1ddcd55cefee4cd21e1a3317c69434ee5a3", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "check:download-patterns": "node scripts/check-download-patterns.mjs",
     "hooks:install": "git config core.hooksPath scripts/git-hooks",
     "check:docker:rust-api": "node scripts/check-docker-api-runtime.mjs",
+    "bump:inference": "node scripts/bump-inference.mjs",
+    "bump:inference:self-test": "node scripts/bump-inference.mjs --self-test",
     "rust:fmt": "cargo fmt --all -- --check",
     "rust:lint": "cargo clippy --all-targets -- -D warnings",
     "rust:test": "cargo test",

--- a/scripts/bump-inference.mjs
+++ b/scripts/bump-inference.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+// Bump SceneWorks' inference pin to a commit on inference `main`, so day-to-day development tracks
+// inference by SHA instead of waiting on a cut `runtime-*` release. Inference is co-developed and
+// SceneWorks is its only consumer, so a formal release does not belong on the critical path between
+// the two repos -- releases stay for durable/shareable snapshots (inference's cut_release.py).
+//
+// The pins live in crates/sceneworks-worker/Cargo.toml: sceneworks-gen-core + the runtime-macos /
+// runtime-cuda bundles, all on https://github.com/SceneWorks/inference. This rewrites each of those
+// `tag = "..."` / `rev = "..."` pins to `rev = "<sha>"` and regenerates the lockfile.
+//
+// The direct `mlx-rs` pin (michaeltrefry/mlx-rs, a DIFFERENT url) is intentionally left alone -- but
+// it must resolve to the same fork the pinned inference uses or Cargo builds two mlx-rs and the
+// Array types diverge. After the bump this verifies no gen-core OR mlx-rs skew (reusing the repo's
+// own check-gen-core-skew.sh) and fails loudly if the direct mlx-rs pin needs realigning.
+//
+//   node scripts/bump-inference.mjs                 # bump to latest inference main, update lock, verify
+//   node scripts/bump-inference.mjs --dry-run       # show the target SHA, write nothing
+//   node scripts/bump-inference.mjs --sha <sha40>   # pin a specific inference revision
+//   node scripts/bump-inference.mjs --self-test     # exercise the pin rewrite on canned input
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const MANIFEST = join(repoRoot, "crates/sceneworks-worker/Cargo.toml");
+const INFERENCE_GIT = "https://github.com/SceneWorks/inference";
+const INFERENCE_CRATES = ["sceneworks-gen-core", "runtime-macos", "runtime-cuda"];
+const SHA_RE = /^[0-9a-f]{40}$/;
+
+// --- pure: rewrite the inference pins to rev=<sha> (self-tested; no fs/network) ---------------
+
+function repin(manifestText, sha) {
+  let inferenceLines = 0;
+  let rewrote = 0;
+  const out = manifestText.split("\n").map((line) => {
+    // Only lines that pin the inference git repo. The direct mlx-rs pin uses another url, so it is
+    // never matched here -- alignment of that pin is verified after the bump, not rewritten.
+    if (!line.includes(INFERENCE_GIT)) return line;
+    inferenceLines += 1;
+    return line.replace(/\b(?:tag|rev)\s*=\s*"[^"]*"/, () => {
+      rewrote += 1;
+      return `rev = "${sha}"`;
+    });
+  });
+  if (inferenceLines === 0) {
+    throw new Error(`no inference pins found (looked for ${INFERENCE_GIT} in ${MANIFEST})`);
+  }
+  if (rewrote !== inferenceLines) {
+    throw new Error(`expected to rewrite ${inferenceLines} inference pin(s), rewrote ${rewrote}`);
+  }
+  return out.join("\n");
+}
+
+// --- git / cargo orchestration ----------------------------------------------------------------
+
+function latestInferenceSha() {
+  const out = execFileSync("git", ["ls-remote", INFERENCE_GIT, "HEAD"], { encoding: "utf8" });
+  const sha = (out.split(/\s+/)[0] || "").trim();
+  if (!SHA_RE.test(sha)) throw new Error(`git ls-remote returned no SHA: ${out.trim()}`);
+  return sha;
+}
+
+function cargoUpdate() {
+  const spec = INFERENCE_CRATES.flatMap((crate) => ["-p", crate]);
+  console.log(`$ cargo update ${spec.join(" ")}`);
+  execFileSync("cargo", ["update", ...spec], { cwd: repoRoot, stdio: "inherit" });
+}
+
+function distinctResolutions(crate) {
+  // One `cargo tree` over both platform bundles (--target all), so macOS + CUDA resolutions are
+  // visible even off-macOS -- the same data source check-gen-core-skew.sh uses.
+  const tree = execFileSync(
+    "cargo",
+    ["tree", "-p", "sceneworks-worker", "--features", "backend-candle", "--target", "all", "--prefix", "none"],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+  return new Set(
+    tree
+      .split("\n")
+      .map((l) => l.replace(/\s*\(\*\)\s*$/, "").trim())
+      .filter((l) => l.includes(crate)),
+  );
+}
+
+function verifyNoSkew() {
+  // gen-core: reuse the repo's own CI-wired guard verbatim.
+  console.log("$ bash scripts/check-gen-core-skew.sh sceneworks-worker --features backend-candle");
+  execFileSync("bash", ["scripts/check-gen-core-skew.sh", "sceneworks-worker", "--features", "backend-candle"], {
+    cwd: repoRoot,
+    stdio: "inherit",
+  });
+  // mlx-rs: SceneWorks pins pmetal-mlx-rs directly; it has no dedicated guard, so confirm the bumped
+  // inference did not pull a different fork revision.
+  const mlx = distinctResolutions("pmetal-mlx-rs");
+  if (mlx.size > 1) {
+    throw new Error(
+      `mlx-rs skew: ${mlx.size} pmetal-mlx-rs resolutions after the bump:\n  ${[...mlx].join("\n  ")}\n` +
+        "Align the direct mlx-rs pin in crates/sceneworks-worker/Cargo.toml with the fork this " +
+        "inference revision uses.",
+    );
+  }
+  console.log(`OK: one pmetal-mlx-rs resolution (${[...mlx][0] ?? "not found"})`);
+}
+
+// --- self-test --------------------------------------------------------------------------------
+
+function selfTest() {
+  let rc = 0;
+  const SHA = "a".repeat(40);
+  const check = (name, ok) => {
+    console.log(`  ${ok ? "ok" : "FAIL"}: ${name}`);
+    if (!ok) rc = 1;
+  };
+
+  check(
+    "tag pin becomes rev",
+    repin(`gc = { git = "${INFERENCE_GIT}", tag = "runtime-2026.07.7" }`, SHA) ===
+      `gc = { git = "${INFERENCE_GIT}", rev = "${SHA}" }`,
+  );
+  check(
+    "rev pin bumps and keeps trailing options",
+    repin(`rt = { git = "${INFERENCE_GIT}", rev = "bbbb", optional = true }`, SHA) ===
+      `rt = { git = "${INFERENCE_GIT}", rev = "${SHA}", optional = true }`,
+  );
+  const mlx = `mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc17" }`;
+  check(
+    "direct mlx-rs pin (other url) is left untouched",
+    repin(`rt = { git = "${INFERENCE_GIT}", tag = "x" }\n${mlx}`, SHA).includes(mlx),
+  );
+  check(
+    "every inference pin moves",
+    (repin(
+      `a = { git = "${INFERENCE_GIT}", tag = "x" }\nb = { git = "${INFERENCE_GIT}", rev = "y" }`,
+      SHA,
+    ).match(new RegExp(`rev = "${SHA}"`, "g")) || []).length === 2,
+  );
+  let threw = false;
+  try {
+    repin(`foo = "bar"`, SHA);
+  } catch {
+    threw = true;
+  }
+  check("throws when no inference pin is present", threw);
+
+  console.log(rc === 0 ? "self-test: PASS" : "self-test: FAIL");
+  process.exit(rc);
+}
+
+// --- entrypoint -------------------------------------------------------------------------------
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.includes("--self-test")) return selfTest();
+
+  const dryRun = args.includes("--dry-run");
+  const shaIdx = args.indexOf("--sha");
+  const sha = shaIdx >= 0 ? (args[shaIdx + 1] || "") : latestInferenceSha();
+  if (!SHA_RE.test(sha)) {
+    console.error(`bump-inference: not a 40-char commit SHA: ${sha}`);
+    process.exit(2);
+  }
+
+  const current = readFileSync(MANIFEST, "utf8");
+  const bumped = repin(current, sha);
+  if (bumped === current) {
+    console.log(`bump-inference: already pinned at ${sha}`);
+    return;
+  }
+  console.log(`bump-inference: pinning inference (${INFERENCE_CRATES.join(", ")}) -> ${sha}`);
+  if (dryRun) {
+    console.log("bump-inference: dry run, no files written");
+    return;
+  }
+  writeFileSync(MANIFEST, bumped);
+  console.log("  wrote crates/sceneworks-worker/Cargo.toml");
+  cargoUpdate();
+  verifyNoSkew();
+  console.log("bump-inference: done");
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(`bump-inference: ${err?.message ?? err}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Why

SceneWorks is the **sole consumer** of the co-developed `inference` repo. Pinning by `runtime-*` **tag** meant every inference change SceneWorks needed was gated behind cutting a release — putting the release process on the critical path between two tightly-coupled repos and slowing development to a crawl.

## What

Repoint the three inference pins in `crates/sceneworks-worker/Cargo.toml` from a tag to the current inference `main` **SHA**:

```
sceneworks-gen-core = { git = ".../inference", rev = "d64af1dd…" }   # was tag = "runtime-2026.07.7"
runtime-macos       = { git = ".../inference", rev = "d64af1dd…" }
runtime-cuda        = { git = ".../inference", rev = "d64af1dd…", optional = true }
```

SceneWorks now tracks inference by commit, gated only by **SceneWorks' own CI**. Formal `runtime-*` releases (inference's `cut_release.py`) stay for durable/shareable snapshots — they're no longer a prerequisite for consuming new inference work. Releases and rapid dev now coexist; the release is just off the critical path.

## `scripts/bump-inference.mjs`

Automates future bumps (`npm run bump:inference`):
1. resolve latest inference `main` (`git ls-remote`)
2. rewrite the inference pins to `rev=<sha>`
3. `cargo update` the inference crates
4. **verify no skew**

**Skew-aware**, not bump-and-hope: the direct `mlx-rs` pin (`michaeltrefry/mlx-rs` — a *different* url, so it's never rewritten here) must resolve to the same fork the pinned inference uses, or Cargo builds two `mlx-rs` and the `Array` types diverge. The script reuses the repo's own `check-gen-core-skew.sh` **and** asserts a single `pmetal-mlx-rs` resolution, failing loudly if the direct pin needs realigning. `--dry-run` previews; `--self-test` covers the rewrite logic (matching the house `.mjs`/`--self-test` convention).

## Verified

- Repoint + `cargo update` landed every inference crate on `d64af1dd`.
- `check-gen-core-skew.sh sceneworks-worker --features backend-candle` → **one** `sceneworks-gen-core` resolution.
- **one** `pmetal-mlx-rs` at `38e1cc17`, aligned with the direct pin (inference `main` still uses that fork rev, so this repoint is skew-safe).
- `--self-test` passes.

## Notes / follow-ups
- Only `crates/sceneworks-worker` pins inference directly (`sceneworks-rust-api` gets gen-core transitively — the CI skew check already covers it).
- Optional: wire `npm run bump:inference:self-test` into `check.yml` next to the existing gen-core skew self-test.
- No CI workflows changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)