### PR TITLE
feat(loras): upgrade Krea 2 Identity Edit LoRA to v1.2

### DIFF
--- a/config/manifests/builtin.loras.jsonc
+++ b/config/manifests/builtin.loras.jsonc
@@ -110,9 +110,16 @@
       // distinct RoPE frame AND grounds the Qwen3-VL vision tower. `conditioningRole: image_edit` makes
       // selecting it auto-activate that dual-conditioning edit recipe (the base can't edit without it);
       // on a plain t2i job the weights do nothing. Referenced directly from the author's HF repo (NO
-      // re-host / NO bundle); downloaded on demand when selected. Default variant is rank-128 (v1.1);
-      // the repo also ships an r64 (smaller) file. Krea 2 Community License (commercial < $1M/yr) — the
-      // same license we already ship Krea 2 Raw/Turbo under, so no new gating beyond the base.
+      // re-host / NO bundle); downloaded on demand when selected. Pinned to v1.2
+      // (`krea2_identity_edit_v1_2.safetensors`, ~1.83 GB), the author-recommended default: better face
+      // likeness on restaged subjects and higher fidelity from a 1024 hi-res training pass, up from the
+      // earlier v1.1 rank-128 file (`_v1_1_r128`, ~914 MB). v1.2 ships full-rank only — no r64/r128
+      // variant — and our additive-LoRA core reads the rank from the tensor shapes at load, so the
+      // higher rank is a drop-in with no code change. (The v1.2 "nodes" the model card mentions —
+      // `ref_boost`, `fit` geometry — are ComfyUI workflow conveniences, not part of the safetensors;
+      // our dual-conditioning edit recipe applies the weights directly and doesn't need them.) Krea 2
+      // Community License (commercial < $1M/yr) — the same license we already ship Krea 2 Raw/Turbo
+      // under, so no new gating beyond the base.
       "id": "krea2_identity_edit",
       "name": "Krea 2 Identity Edit",
       "family": "krea_2",
@@ -123,7 +130,7 @@
       "source": {
         "provider": "huggingface",
         "repo": "conradlocke/krea2-identity-edit",
-        "file": "krea2_identity_edit_v1_1_r128.safetensors"
+        "file": "krea2_identity_edit_v1_2.safetensors"
       }
     }
   ]

--- a/crates/sceneworks-worker/src/tests/media_and_paths.rs
+++ b/crates/sceneworks-worker/src/tests/media_and_paths.rs
@@ -276,7 +276,7 @@ fn lora_paths_keep_safetensors_extension_for_hf_blob_symlink() {
     std::fs::create_dir_all(&snapshot).expect("snapshot dir creates");
     let blob = blobs.join("78b403a45024d51c24b618046ec1176c346416951f8f4c6c707d1b337ae1d40f");
     std::fs::write(&blob, b"adapter").expect("blob writes");
-    let link = snapshot.join("krea2_identity_edit_v1_1_r128.safetensors");
+    let link = snapshot.join("krea2_identity_edit_v1_2.safetensors");
     std::os::unix::fs::symlink(&blob, &link).expect("snapshot symlink creates");
 
     let mut settings = test_settings("http://127.0.0.1".to_owned(), None);


### PR DESCRIPTION
## What

Repin the builtin `krea2_identity_edit` LoRA source from the older rank-128 file to the author's new **v1.2** release:

| | file | rank | size |
|---|---|---|---|
| before | `krea2_identity_edit_v1_1_r128.safetensors` | 128 | ~914 MB |
| after | `krea2_identity_edit_v1_2.safetensors` | 256 (full) | ~1.83 GB |

v1.2 (`conradlocke/krea2-identity-edit`, published 2026-07-17) is the author-recommended default — **better face likeness on restaged subjects and higher fidelity from a 1024 hi-res training pass**. It ships full-rank only (no r64/r128 variant).

## Why it's a safe drop-in

Validated against the **on-disk safetensors headers** (both files in the HF cache), not just file names:

- **Identical 256-module set, identical key naming** — `diffusion_model.blocks.*.{attn.wq/wk/wv/wo/gate, mlp.up/gate/down}.lora_A/lora_B.weight`, F16, 512 tensors in both.
- Only the **rank (128 → 256)** and the **weight values** change.
- Our additive-LoRA core (`AdaptLinear`) reads rank from the tensor shapes at load, so all 256 modules map with **zero skipped layers** — no key-naming drift, no silent layer loss. No code change needed to consume the higher rank.
- The v1.2 `ref_boost` / `fit`-geometry "nodes" the model card mentions are **ComfyUI workflow conveniences, not part of the safetensors** — our own dual-conditioning (Kontext-style) edit recipe applies the weights directly and doesn't need them.

VRAM: the adapter roughly doubles (~914 MB → ~1.83 GB of F16 LoRA weights) — negligible on our fit ladder.

## Changes

- `config/manifests/builtin.loras.jsonc` — repin `source.file` to `krea2_identity_edit_v1_2.safetensors`; refresh the explanatory comment.
- `crates/sceneworks-worker/src/tests/media_and_paths.rs` — align the `#[cfg(unix)]` HF-cache path-normalization fixture filename with the new pin (cosmetic; the test exercises generic symlink→blob path handling).

## Testing

- Manifest parses; `source` resolves to the v1.2 file.
- Header-level structural parity confirmed vs the current r128 file (identical modules/keys/dtype).
- Not yet run through a live GPU edit render — the edit recipe code is unchanged and already ships with v1.1_r128, and the LoRA is a verified structural drop-in. Happy to do a full Krea 2 edit render as a final gate if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)