### PR TITLE
fix(web): scope Image Studio source picker Assets tab to non-character images

### DIFF
--- a/apps/web/src/components/AssetPicker.jsx
+++ b/apps/web/src/components/AssetPicker.jsx
@@ -311,14 +311,19 @@ function ImageEditSourcePickerModal({ assets, characters, importAsset, initialSe
     () => assets.filter((asset) => assetMatchesCharacter(asset, characterId, selectedCharacter)),
     [assets, characterId, selectedCharacter],
   );
-  const allCharacterAssetCount = useMemo(
+  // The Assets tab shows the project library *minus* images that already belong
+  // to a character — those live on the Character tab. Splitting the library this
+  // way is the whole point of the two tabs; without this exclusion every
+  // character asset appeared on both tabs, so "Assets" looked unfiltered.
+  const nonCharacterAssets = useMemo(
     () =>
-      assets.filter((asset) =>
-        characters.some((character) => assetMatchesCharacter(asset, character.id, character)),
-      ).length,
+      assets.filter(
+        (asset) => !characters.some((character) => assetMatchesCharacter(asset, character.id, character)),
+      ),
     [assets, characters],
   );
-  const tabAssets = tab === "character" ? characterAssets : assets;
+  const allCharacterAssetCount = assets.length - nonCharacterAssets.length;
+  const tabAssets = tab === "character" ? characterAssets : nonCharacterAssets;
   const searchIndex = useMemo(() => assetSearchIndex(tabAssets), [tabAssets]);
   const visibleAssets = useMemo(() => filterPickerAssets(tabAssets, query, searchIndex), [tabAssets, query, searchIndex]);
 
@@ -393,7 +398,7 @@ function ImageEditSourcePickerModal({ assets, characters, importAsset, initialSe
               type="button"
             >
               {label}
-              {key === "assets" ? <span>{assets.length}</span> : null}
+              {key === "assets" ? <span>{nonCharacterAssets.length}</span> : null}
               {key === "character" ? <span>{allCharacterAssetCount}</span> : null}
             </button>
           ))}

--- a/apps/web/src/components/AssetPicker.test.jsx
+++ b/apps/web/src/components/AssetPicker.test.jsx
@@ -56,3 +56,95 @@ describe("ImageEditSourcePickerField clear affordance", () => {
     expect(buttonByLabel("Remove")).toBeFalsy();
   });
 });
+
+// The source picker splits the project library into two disjoint tabs: "Assets"
+// (general images) and "Character" (images that already belong to a character).
+// The Assets tab must EXCLUDE character-owned images — otherwise every character
+// asset shows up on both tabs and the split does nothing (the "not filtering"
+// bug: the Assets tab was rendering the whole library).
+describe("ImageEditSourcePickerField Assets tab excludes character assets", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render(ui) {
+    await act(async () => root.render(ui));
+  }
+
+  const click = async (el) =>
+    act(async () => el.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+
+  // Modal portals to document.body, so grid/tab queries target the document.
+  const gridTitles = () =>
+    [...document.body.querySelectorAll('.asset-picker-grid [role="option"] strong')].map((el) =>
+      el.textContent.trim(),
+    );
+  const tabBadge = (label) => {
+    const tab = [...document.body.querySelectorAll('[role="tab"]')].find((b) =>
+      b.textContent.startsWith(label),
+    );
+    return tab?.querySelector("span")?.textContent ?? null;
+  };
+
+  const asset = (id, displayName, extra = {}) => ({
+    id,
+    type: "image",
+    projectId: "p1",
+    url: `/${id}.png`,
+    displayName,
+    ...extra,
+  });
+
+  // a1: plain project image (belongs to no character) → Assets tab only.
+  // a2: generated FOR character c1 (recipe) → Character tab only.
+  // a3: an approved reference of c1 → Character tab only.
+  const assets = [
+    asset("a1", "Plain One"),
+    asset("a2", "Hero Gen", { recipe: { normalizedSettings: { characterId: "c1" } } }),
+    asset("a3", "Hero Ref"),
+  ];
+  const characters = [{ id: "c1", name: "Hero", approvedReferences: [{ assetId: "a3" }], references: [] }];
+
+  it("shows only non-character images on the Assets tab and moves the rest to Character", async () => {
+    await render(
+      <ImageEditSourcePickerField
+        assets={assets}
+        buttonLabel="Select reference image"
+        characters={characters}
+        clearable
+        label="Reference image"
+        onChange={() => {}}
+        projectId="p1"
+        value=""
+      />,
+    );
+
+    const openButton = container.querySelector('button[aria-haspopup="dialog"]');
+    await click(openButton);
+
+    // Assets tab is the default. Only the non-character image is listed; the two
+    // character-owned images are excluded.
+    expect(gridTitles()).toEqual(["Plain One"]);
+    expect(tabBadge("Assets")).toBe("1");
+    expect(tabBadge("Character")).toBe("2");
+
+    // The Character tab (defaulting to the first character) holds the two excluded images.
+    const characterTab = [...document.body.querySelectorAll('[role="tab"]')].find((b) =>
+      b.textContent.startsWith("Character"),
+    );
+    await click(characterTab);
+    expect(gridTitles().sort()).toEqual(["Hero Gen", "Hero Ref"]);
+  });
+});


### PR DESCRIPTION
## Problem

In Image Studio, opening the reference/source image picker shows an **Assets** tab and a **Character** tab. The Assets tab was rendering the *entire* project image library — including every image that already belongs to a character — so it looked like it "wasn't filtering." Character-owned images appeared on both tabs, defeating the point of the split.

## Root cause

In `ImageEditSourcePickerModal` (`apps/web/src/components/AssetPicker.jsx`), the Character tab filtered via `assetMatchesCharacter`, but the Assets tab fell back to the raw `assets` list:

```js
const tabAssets = tab === "character" ? characterAssets : assets;
```

## Fix

- The **Assets** tab now shows the project library **minus** any image that belongs to a character (matched by recipe `characterId`, `metadata.characterReferences`, or a character's approved/reference lists) — those stay on the **Character** tab.
- The Assets count badge now reflects the scoped count.
- `allCharacterAssetCount` is derived from the same partition (`assets.length − nonCharacterAssets.length`) instead of a second full pass over the list.

No change to the caller in `ImageStudio.jsx`; the partition lives in the one place that owns the two tabs.

## Testing

- Added a regression test in `AssetPicker.test.jsx` asserting the Assets tab lists only the non-character image while the two character-owned images move to the Character tab (with correct badge counts). Verified it fails against the pre-fix behavior.
- `vitest run` (4 passed) and `eslint src` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)