### PR TITLE
feat(web): Video Editor redesign — unified dark NLE (design 2a, sc-12798)

### DIFF
--- a/apps/web/src/components/editor/EditorToolbar.jsx
+++ b/apps/web/src/components/editor/EditorToolbar.jsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { Icon } from "../Icons.jsx";
+
+// The editor's top toolbar (design 2a, epic 12798): app mark + project/timeline
+// identity, undo/redo, the centered MM:SS:FF timecode / duration readout, zoom, and the
+// filled Export button. Timeline switching/creation lives here (the mock has no separate
+// picker) so the existing multi-timeline capability is preserved.
+export function EditorToolbar({
+  projectName,
+  subLabel,
+  timelines = [],
+  selectedTimelineId,
+  onSelectTimeline,
+  onNewTimeline,
+  onUndo,
+  onRedo,
+  canUndo,
+  canRedo,
+  timecode,
+  durationTimecode,
+  zoomPct,
+  onZoomIn,
+  onZoomOut,
+  onSave,
+  saveDisabled,
+  onExport,
+  exportDisabled,
+}) {
+  return (
+    <div className="ve-toolbar">
+      <div className="ve-brand">
+        <span className="ve-mark">
+          <Icon.Video size={14} />
+        </span>
+        <div className="ve-brand-text">
+          <strong>{projectName}</strong>
+          <span className="ve-brand-sub">{subLabel}</span>
+        </div>
+      </div>
+
+      <div className="ve-toolbar-div" />
+
+      <div className="ve-timeline-switch">
+        <select
+          aria-label="Timeline"
+          className="ve-select ve-timeline-select"
+          onChange={(e) => onSelectTimeline?.(e.target.value)}
+          value={selectedTimelineId ?? ""}
+        >
+          <option value="">Select timeline</option>
+          {timelines.map((timeline) => (
+            <option key={timeline.id} value={timeline.id}>
+              {timeline.name}
+            </option>
+          ))}
+        </select>
+        <button className="ve-icon-btn" onClick={onNewTimeline} title="New timeline" type="button">
+          <Icon.Plus size={15} />
+        </button>
+      </div>
+
+      <div className="ve-toolbar-div" />
+
+      <div className="ve-btn-group">
+        <button className="ve-ghost-btn" disabled={!canUndo} onClick={onUndo} title="Undo" type="button">
+          <Icon.ArrowLeft size={15} />
+        </button>
+        <button className="ve-ghost-btn" disabled={!canRedo} onClick={onRedo} title="Redo" type="button">
+          <Icon.ArrowRight size={15} />
+        </button>
+      </div>
+
+      <div className="ve-timecode">
+        <span className="ve-tc-now">{timecode}</span>
+        <span className="ve-tc-total">/ {durationTimecode}</span>
+      </div>
+
+      <div className="ve-toolbar-right">
+        <button className="ve-ghost-btn" onClick={onZoomOut} title="Zoom out" type="button">
+          <Icon.Minus size={15} />
+        </button>
+        <span className="ve-zoom-pct">{zoomPct}</span>
+        <button className="ve-ghost-btn" onClick={onZoomIn} title="Zoom in" type="button">
+          <Icon.Plus size={15} />
+        </button>
+        <button className="ve-ghost-btn" disabled={saveDisabled} onClick={onSave} title="Save timeline" type="button">
+          <Icon.Save size={15} />
+        </button>
+        <button className="ve-export" disabled={exportDisabled} onClick={onExport} type="button">
+          <Icon.Save size={14} />
+          Export
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/editor/GenerationRail.jsx
+++ b/apps/web/src/components/editor/GenerationRail.jsx
@@ -1,0 +1,345 @@
+import React, { useState } from "react";
+import { Icon } from "../Icons.jsx";
+import { LoraPickerSection } from "../../screens/generationStudio.jsx";
+import { tierLabel } from "../../quantTier.js";
+import { MOTIONS } from "./editorUtils.js";
+
+// The right-hand generation-settings rail (design 2a, epic 12798). Presentational: it
+// renders the controls owned by useEditorGeneration (`gen`) plus the contextual header
+// + 2x2 action grid supplied by the screen. Mirrors the Video Studio control set so the
+// same knobs that generate video elsewhere are available in the editor.
+export function GenerationRail({ gen, header, contextActions = [], onGenerate, generateSummary, generateDisabled }) {
+  const [showSave, setShowSave] = useState(false);
+  const [presetName, setPresetName] = useState("");
+  const [saveMsg, setSaveMsg] = useState("");
+  const studio = gen.studio;
+
+  async function handleSavePreset() {
+    if (!presetName.trim()) {
+      return;
+    }
+    const created = await gen.savePreset(presetName);
+    if (created) {
+      setSaveMsg(`Saved “${created.name ?? presetName}”`);
+      setPresetName("");
+      setShowSave(false);
+    } else {
+      setSaveMsg("Could not save preset.");
+    }
+  }
+
+  return (
+    <div className="ve-rail">
+      <div className="ve-rail-head">
+        <p className="ve-rail-eyebrow">{header?.eyebrow ?? "No selection"}</p>
+        <h3 className="ve-rail-title">{header?.title ?? "Timeline"}</h3>
+        <div className="ve-ctx-grid">
+          {contextActions.map((action) => (
+            <button
+              className={`ve-ctx-btn${action.primary ? " primary" : ""}`}
+              disabled={action.disabled}
+              key={action.id}
+              onClick={action.onClick}
+              title={action.title ?? action.label}
+              type="button"
+            >
+              <span>{action.label}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="ve-rail-body">
+        {/* Model + quality */}
+        <div className="ve-section">
+          <div className="ve-section-hd">
+            <Icon.Model size={14} />
+            Model &amp; quality
+          </div>
+          <label className="ve-field">
+            <span className="ve-field-label">Video model</span>
+            <select className="ve-select" onChange={(e) => gen.setModel(e.target.value)} value={gen.model}>
+              {gen.videoModels.map((item) => (
+                <option key={item.id} value={item.id}>
+                  {item.name ?? item.id}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="ve-seg" role="radiogroup" aria-label="Quality">
+            {gen.qualityChoices.map(([value, label]) => (
+              <button
+                aria-checked={gen.quality === value}
+                className={`ve-seg-btn${gen.quality === value ? " active" : ""}`}
+                key={value}
+                onClick={() => gen.setQuality(value)}
+                role="radio"
+                type="button"
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Preset */}
+        <div className="ve-section">
+          <span className="ve-field-label">Preset</span>
+          <div className="ve-preset-row">
+            <select
+              className="ve-select"
+              onChange={(e) => studio.setSelectedPresetId(e.target.value)}
+              value={studio.selectedPresetId ?? "__no_preset__"}
+            >
+              <option value="__no_preset__">— No preset —</option>
+              {studio.availablePresets.map((preset) => (
+                <option key={preset.id} value={preset.id}>
+                  {preset.name ?? preset.id}
+                </option>
+              ))}
+            </select>
+            <button
+              className="ve-icon-btn"
+              onClick={() => setShowSave((open) => !open)}
+              title="Save current settings as a preset"
+              type="button"
+            >
+              <Icon.Save size={15} />
+            </button>
+          </div>
+          {showSave ? (
+            <div className="ve-save-form">
+              <input
+                className="ve-input"
+                onChange={(e) => setPresetName(e.target.value)}
+                placeholder="Preset name"
+                value={presetName}
+              />
+              <button className="ve-mini-btn" disabled={!presetName.trim()} onClick={handleSavePreset} type="button">
+                Save
+              </button>
+            </div>
+          ) : null}
+          {saveMsg ? <p className="ve-hint">{saveMsg}</p> : null}
+        </div>
+
+        {/* Output */}
+        <div className="ve-section">
+          <div className="ve-section-hd">Output</div>
+          <div className="ve-output-grid">
+            <label className="ve-field">
+              <span className="ve-field-label">Resolution</span>
+              <select className="ve-select" onChange={(e) => gen.setResolution(e.target.value)} value={gen.resolution}>
+                {gen.resolutionOptions.map((value) => (
+                  <option key={value} value={value}>
+                    {String(value).replace("x", " × ")}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="ve-field">
+              <span className="ve-field-label">Frame rate</span>
+              <select className="ve-select" onChange={(e) => gen.setFps(Number(e.target.value))} value={gen.fps}>
+                {gen.fpsOptions.map((value) => (
+                  <option key={value} value={value}>
+                    {value} fps
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="ve-field">
+              <span className="ve-field-label">Duration (s)</span>
+              <select className="ve-select" onChange={(e) => gen.setDuration(Number(e.target.value))} value={gen.duration}>
+                {gen.durationOptions.map((value) => (
+                  <option key={value} value={value}>
+                    {value}s
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="ve-field">
+              <span className="ve-field-label">Motion · {gen.motionPct}%</span>
+              <select className="ve-select" onChange={(e) => gen.setMotion(e.target.value)} value={gen.motion}>
+                {MOTIONS.map((value) => (
+                  <option key={value} value={value}>
+                    {value}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        </div>
+
+        {/* LoRAs (reused Video Studio picker) */}
+        <div className="ve-section ve-lora-section">
+          <LoraPickerSection
+            compatibleLoras={studio.compatibleLoras}
+            effectiveLoraWeight={studio.effectiveLoraWeight}
+            loraEmptyMessage={studio.loraEmptyMessage}
+            selectedLoraIds={studio.selectedLoraIds}
+            selectedLoras={studio.selectedLoras}
+            selectedModel={gen.selectedModel}
+            setLoraWeight={studio.setLoraWeight}
+            setShowIncompatibleLoras={studio.setShowIncompatibleLoras}
+            showIncompatibleLoras={studio.showIncompatibleLoras}
+            toggleLora={studio.toggleLora}
+            userSelectedLoraCount={studio.userSelectedLoraCount}
+          />
+        </div>
+
+        {/* Prompt + seed + negative */}
+        <div className="ve-section">
+          <label className="ve-field">
+            <span className="ve-field-label">Prompt</span>
+            <textarea
+              className="ve-textarea"
+              onChange={(e) => gen.setPrompt(e.target.value)}
+              placeholder="Describe the motion to generate…"
+              value={gen.prompt}
+            />
+          </label>
+          <label className="ve-field">
+            <span className="ve-field-label">Seed</span>
+            <div className="ve-preset-row">
+              <input
+                className="ve-input"
+                onChange={(e) => gen.setSeed(e.target.value)}
+                placeholder="random"
+                value={gen.seed}
+              />
+              <button className="ve-icon-btn" onClick={gen.randomizeSeed} title="Randomize seed" type="button">
+                <Icon.Refresh size={15} />
+              </button>
+            </div>
+          </label>
+          <label className="ve-field">
+            <span className="ve-field-label">Negative prompt</span>
+            <textarea
+              className="ve-textarea"
+              onChange={(e) => gen.setNegativePrompt(e.target.value)}
+              value={gen.negativePrompt}
+            />
+          </label>
+        </div>
+
+        {/* Advanced */}
+        <div className="ve-adv">
+          <button className="ve-adv-toggle" onClick={() => gen.setAdvancedOpen((v) => !v)} type="button">
+            <span className="ve-section-hd">
+              <Icon.Sliders size={14} />
+              Advanced
+            </span>
+            <span className="ve-adv-chevron">{gen.advancedOpen ? "▾" : "▸"}</span>
+          </button>
+          {gen.advancedOpen ? (
+            <div className="ve-adv-body">
+              <div className="ve-output-grid">
+                {gen.showSamplerPicker ? (
+                  <label className="ve-field">
+                    <span className="ve-field-label">Sampler</span>
+                    <select className="ve-select" onChange={(e) => gen.setSampler(e.target.value)} value={gen.sampler}>
+                      {gen.samplerOptions.map((value) => (
+                        <option key={value} value={value}>
+                          {value}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ) : null}
+                {gen.showSchedulerPicker ? (
+                  <label className="ve-field">
+                    <span className="ve-field-label">Scheduler</span>
+                    <select className="ve-select" onChange={(e) => gen.setScheduler(e.target.value)} value={gen.scheduler}>
+                      {gen.schedulerOptions.map((value) => (
+                        <option key={value} value={value}>
+                          {value}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ) : null}
+                {gen.showSchedulerPicker && gen.scheduler !== "default" ? (
+                  <label className="ve-field">
+                    <span className="ve-field-label">Scheduler shift</span>
+                    <input
+                      className="ve-input"
+                      max="10"
+                      min="0.1"
+                      onChange={(e) => gen.setSchedulerShift(Number(e.target.value))}
+                      step="0.1"
+                      type="number"
+                      value={gen.schedulerShift}
+                    />
+                  </label>
+                ) : null}
+                <label className="ve-field">
+                  <span className="ve-field-label">Steps</span>
+                  <input
+                    className="ve-input"
+                    disabled={gen.lightningActive}
+                    onChange={(e) => gen.setStepsOverride(e.target.value)}
+                    placeholder={gen.lightningActive ? "4 (Lightning)" : "auto"}
+                    value={gen.lightningActive ? "" : gen.stepsOverride}
+                  />
+                </label>
+                <label className="ve-field">
+                  <span className="ve-field-label">Guidance</span>
+                  <input
+                    className="ve-input"
+                    disabled={gen.lightningActive}
+                    onChange={(e) => gen.setGuidanceOverride(e.target.value)}
+                    placeholder={gen.lightningActive ? "off (Lightning)" : "auto"}
+                    value={gen.lightningActive ? "" : gen.guidanceOverride}
+                  />
+                </label>
+              </div>
+
+              {gen.showTierPicker ? (
+                <div className="ve-field">
+                  <span className="ve-field-label">Generation tier</span>
+                  <div className="ve-chip-row">
+                    {gen.availableTiers.map((tier) => (
+                      <button
+                        className={`ve-chip${gen.quantTier === tier ? " active" : ""}`}
+                        key={tier}
+                        onClick={() => gen.setQuantTier(tier)}
+                        title={tierLabel(tier)}
+                        type="button"
+                      >
+                        {tier.toUpperCase()}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+
+              {gen.showLightning ? (
+                <button
+                  className="ve-toggle-row"
+                  onClick={() => gen.setLightning((v) => !v)}
+                  type="button"
+                >
+                  <span className="ve-toggle-text">
+                    <strong>Lightning (4-step)</strong>
+                    <small>Wan 2.2 A14B fast distilled</small>
+                  </span>
+                  <span className={`ve-switch${gen.lightning ? " on" : ""}`} aria-hidden="true">
+                    <span className="ve-switch-knob" />
+                  </span>
+                </button>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="ve-rail-foot">
+        <button className="ve-generate" disabled={generateDisabled} onClick={onGenerate} type="button">
+          <Icon.Stars size={16} />
+          Generate
+        </button>
+        <p className="ve-gen-summary">{generateSummary}</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/editor/MediaBin.jsx
+++ b/apps/web/src/components/editor/MediaBin.jsx
@@ -1,0 +1,61 @@
+import React, { useState } from "react";
+import { AssetMedia, assetCanRenderAsImage } from "../assetMedia.jsx";
+import { Icon } from "../Icons.jsx";
+import { isAiAsset } from "./editorUtils.js";
+
+// The left media bin (design 2a, epic 12798). Two tabs: "Media" (video + still assets
+// you drop onto the timeline) and "Assets" (the full project media library for preview).
+// Clicking a Media thumbnail adds it to the timeline; the violet sparkle badge marks
+// AI-generated assets (derived from origin/recipe, mirroring the LikenessBadge overlay).
+export function MediaBin({ assets = [], onAddToTrack, onPreview }) {
+  const [tab, setTab] = useState("media");
+
+  const clipAssets = assets.filter(
+    (asset) => asset.type === "video" || asset.file?.mimeType?.startsWith("video/") || assetCanRenderAsImage(asset),
+  );
+  const shown = tab === "media" ? clipAssets : assets;
+
+  function handleClick(asset) {
+    if (tab === "media") {
+      onAddToTrack?.(asset);
+    } else {
+      onPreview?.(asset);
+    }
+  }
+
+  return (
+    <div className="ve-bin">
+      <div className="ve-bin-tabs">
+        <button className={`ve-bin-tab${tab === "media" ? " active" : ""}`} onClick={() => setTab("media")} type="button">
+          Media
+        </button>
+        <button className={`ve-bin-tab${tab === "assets" ? " active" : ""}`} onClick={() => setTab("assets")} type="button">
+          Assets
+        </button>
+      </div>
+      <div className="ve-bin-grid">
+        {shown.length === 0 ? (
+          <div className="ve-bin-empty">No media</div>
+        ) : (
+          shown.slice(0, 60).map((asset) => (
+            <button
+              className="ve-bin-item"
+              key={asset.id}
+              onClick={() => handleClick(asset)}
+              title={tab === "media" ? `Add ${asset.displayName} to timeline` : asset.displayName}
+              type="button"
+            >
+              <AssetMedia asset={asset} className="ve-bin-thumb" controls={false} />
+              {isAiAsset(asset) ? (
+                <span className="ve-ai-badge" aria-label="AI generated">
+                  <Icon.Stars size={10} />
+                </span>
+              ) : null}
+              <span className="ve-bin-name">{asset.displayName}</span>
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/editor/ProgramMonitor.jsx
+++ b/apps/web/src/components/editor/ProgramMonitor.jsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { AssetMedia, assetCanRenderAsVideo } from "../assetMedia.jsx";
+import { Icon } from "../Icons.jsx";
+
+// The center program monitor (design 2a, epic 12798): the 16:9/9:16/1:1 preview of the
+// selected clip with an overlaid label + AI pill + resolution readout, and the transport
+// row (prev / play-pause / next). Playback is driven by the screen's existing effect via
+// the forwarded video ref; the play/pause events flip the screen's isPlaying state.
+export function ProgramMonitor({
+  selectedAsset,
+  aspectClass,
+  clipLabel,
+  isAi,
+  resolutionLabel,
+  isPlaying,
+  onTogglePlay,
+  onPrev,
+  onNext,
+  previewVideoRef,
+  onPlay,
+  onPause,
+  onEnded,
+}) {
+  const canPlay = assetCanRenderAsVideo(selectedAsset);
+
+  return (
+    <div className="ve-monitor">
+      <div className="ve-monitor-stage">
+        <div className={`ve-program ${aspectClass}`}>
+          {selectedAsset ? (
+            <AssetMedia
+              asset={selectedAsset}
+              className="ve-program-media"
+              controls={false}
+              onEnded={onEnded}
+              onPause={onPause}
+              onPlay={onPlay}
+              ref={previewVideoRef}
+            />
+          ) : (
+            <span className="ve-program-empty">Select a timeline item</span>
+          )}
+          {clipLabel ? <span className="ve-program-label">{clipLabel}</span> : null}
+          {isAi ? (
+            <span className="ve-program-ai">
+              <Icon.Stars size={11} />
+              AI clip
+            </span>
+          ) : null}
+          {resolutionLabel ? <span className="ve-program-res">{resolutionLabel}</span> : null}
+        </div>
+      </div>
+      <div className="ve-transport">
+        <button className="ve-transport-btn" onClick={onPrev} title="Previous edit" type="button">
+          <Icon.ArrowLeft size={16} />
+        </button>
+        <button
+          className="ve-play"
+          disabled={!canPlay}
+          onClick={onTogglePlay}
+          title={isPlaying ? "Pause" : "Play"}
+          type="button"
+        >
+          {isPlaying ? <Icon.Pause size={18} /> : <Icon.Play size={18} />}
+        </button>
+        <button className="ve-transport-btn" onClick={onNext} title="Next edit" type="button">
+          <Icon.ArrowRight size={16} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/editor/StoryboardStrip.jsx
+++ b/apps/web/src/components/editor/StoryboardStrip.jsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { AssetMedia, assetCanRenderAsImage } from "../assetMedia.jsx";
+import { Icon } from "../Icons.jsx";
+import { itemDuration } from "../../timeline.js";
+import { formatTimecode } from "../../formatting.js";
+import { clipHue, isAiItem } from "./editorUtils.js";
+
+// The storyboard strip that sits directly above the timeline (design 2a, epic 12798):
+// key-image cards synced to the main-track clips, separated by connectors that read as
+// generated (teal "▸ 1.8s") or pending (violet "＋ generate"). Selecting a card moves the
+// playhead to that key's time and selects its clip.
+//
+// NOTE (backend gap, tracked): there is no persisted per-clip keyframe model yet, so keys
+// are derived from the main-track clips and the "generate across keys" affordance is UI
+// only where the backend can't yet drive it.
+export function StoryboardStrip({ clips = [], assetsById, fps = 30, selectedItemId, onSelectKey, onAddKey }) {
+  const nodes = [];
+  clips.forEach((clip, index) => {
+    nodes.push({ type: "key", clip });
+    if (index < clips.length - 1) {
+      const next = clips[index + 1];
+      const generated = isAiItem(next, assetsById);
+      nodes.push({
+        type: "conn",
+        key: `conn_${clip.id}`,
+        generated,
+        label: generated ? `▸ ${itemDuration(next).toFixed(1)}s` : "＋ generate",
+      });
+    }
+  });
+
+  return (
+    <div className="ve-storyboard">
+      <div className="ve-storyboard-hd">
+        <Icon.Stars size={14} className="ve-ai-icon" />
+        <strong>Storyboard</strong>
+        <span className="ve-storyboard-hint">— key images synced to the timeline; generate the motion between them</span>
+        <span className="ve-storyboard-legend">
+          <span className="ve-legend-dot ve-dot-accent" />
+          done
+          <span className="ve-legend-dot ve-dot-ai" />
+          generate
+        </span>
+      </div>
+      <div className="ve-storyboard-row">
+        {nodes.map((node) => {
+          if (node.type === "conn") {
+            return (
+              <div className="ve-conn" key={node.key}>
+                <span className={`ve-conn-pill${node.generated ? " generated" : " pending"}`}>{node.label}</span>
+              </div>
+            );
+          }
+          const clip = node.clip;
+          const asset = assetsById?.get?.(clip.assetId) ?? null;
+          const showImage = assetCanRenderAsImage(asset);
+          const ai = isAiItem(clip, assetsById);
+          return (
+            <button
+              className={`ve-key${selectedItemId === clip.id ? " selected" : ""}${ai ? " ai" : ""}`}
+              key={clip.id}
+              onClick={() => onSelectKey?.(clip)}
+              style={{ "--key-hue": clipHue(clip.id) }}
+              title={clip.displayName}
+              type="button"
+            >
+              {showImage ? <AssetMedia asset={asset} className="ve-key-media" controls={false} /> : null}
+              <span className="ve-key-tc">{formatTimecode(clip.timelineStart, fps)}</span>
+              <span className="ve-key-label">{clip.displayName}</span>
+            </button>
+          );
+        })}
+        <button className="ve-key-add" onClick={onAddKey} title="Add key image" type="button">
+          <Icon.Plus size={18} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/editor/Timeline.jsx
+++ b/apps/web/src/components/editor/Timeline.jsx
@@ -1,0 +1,356 @@
+import React, { useRef } from "react";
+import { Icon } from "../Icons.jsx";
+import { trackItems } from "../../timeline.js";
+import {
+  BASE_PX_PER_SEC,
+  MAIN_TRACK_ID,
+  OVERLAY_TRACK_ID,
+  buildTicks,
+  itemGeometry,
+  clipHue,
+  isAiItem,
+  waveformPath,
+} from "./editorUtils.js";
+
+// One video clip block on V1/V2 — absolutely positioned by % of duration, gradient fill
+// from a per-clip hue, selection ring, and (for AI clips) a violet outline + sparkle plus
+// boundary keyframe diamonds.
+function ClipBlock({ item, duration, selected, ai, onSelect, onSelectKey }) {
+  const { leftPct, widthPct } = itemGeometry(item, duration);
+  return (
+    <button
+      className={`ve-clip${selected ? " selected" : ""}${ai ? " ai" : ""}`}
+      onClick={() => onSelect(item)}
+      style={{ left: `${leftPct}%`, width: `${widthPct}%`, "--clip-hue": clipHue(item.id) }}
+      title={item.displayName}
+      type="button"
+    >
+      {ai ? (
+        <span className="ve-clip-ai" aria-hidden="true">
+          <Icon.Stars size={9} />
+        </span>
+      ) : null}
+      {/* Boundary keyframe markers for AI clips (no persisted keyframe model yet — these
+          represent the first/last-frame conditioning; tracked as a backend-gap story). */}
+      {ai
+        ? [0.001, 0.999].map((pos, index) => (
+            <span
+              className="ve-keyframe"
+              key={index}
+              onClick={(event) => {
+                event.stopPropagation();
+                onSelectKey?.(item, index);
+              }}
+              style={{ left: `${pos * 100}%` }}
+            />
+          ))
+        : null}
+      <span className="ve-clip-name">{item.displayName}</span>
+    </button>
+  );
+}
+
+// The full NLE timeline (design 2a, epic 12798). Track headers on the left (non-scrolling),
+// the %-positioned lanes on the right (horizontal scroll). Zoom scales the content width
+// only; everything inside is positioned as a percentage of duration.
+export function Timeline({
+  timeline,
+  duration,
+  zoom,
+  snap,
+  onToggleSnap,
+  onZoomIn,
+  onZoomOut,
+  playheadSeconds,
+  onScrub,
+  selectedItemId,
+  selectedGapId,
+  onSelectItem,
+  onSelectGap,
+  onSelectKey,
+  assetsById,
+  trackVisible,
+  trackMuted,
+  trackSoloed,
+  onToggleVisible,
+  onToggleMute,
+  onToggleSolo,
+  onAddAudioTrack,
+  markers = [],
+  onSelectMarker,
+}) {
+  const laneRef = useRef(null);
+  const tracks = timeline?.tracks ?? [];
+  const overlayTrack = tracks.find((t) => t.id === OVERLAY_TRACK_ID || t.kind === "overlay") ?? null;
+  const mainTrack = tracks.find((t) => t.id === MAIN_TRACK_ID || t.kind === "video") ?? null;
+  const audioTracks = tracks.filter((t) => t.kind === "audio");
+
+  const contentWidth = Math.max(640, duration * BASE_PX_PER_SEC * zoom);
+  const ticks = buildTicks(duration);
+  const playheadPct = duration > 0 ? Math.min(100, (playheadSeconds / duration) * 100) : 0;
+
+  const mainItems = mainTrack ? trackItems(mainTrack) : [];
+  const overlayItems = overlayTrack ? trackItems(overlayTrack) : [];
+
+  // Gaps between consecutive main-track clips → dashed "＋ Bridge" zones.
+  const gaps = [];
+  for (let i = 0; i < mainItems.length - 1; i += 1) {
+    const left = mainItems[i];
+    const right = mainItems[i + 1];
+    const gap = Number(right.timelineStart) - Number(left.timelineEnd);
+    if (gap > 0.05 && duration > 0) {
+      gaps.push({
+        id: `gap_${left.id}`,
+        leftItem: left,
+        rightItem: right,
+        leftPct: (Number(left.timelineEnd) / duration) * 100,
+        widthPct: (gap / duration) * 100,
+      });
+    }
+  }
+
+  // Transition badges at contiguous cuts that carry a non-cut transition.
+  const transitions = [];
+  for (let i = 0; i < mainItems.length - 1; i += 1) {
+    const left = mainItems[i];
+    const right = mainItems[i + 1];
+    const contiguous = Math.abs(Number(right.timelineStart) - Number(left.timelineEnd)) <= 0.05;
+    const type = left.transitionOut?.type && left.transitionOut.type !== "cut" ? left.transitionOut.type : right.transitionIn?.type;
+    if (contiguous && type && type !== "cut" && duration > 0) {
+      transitions.push({ id: `trans_${left.id}`, type, leftPct: (Number(right.timelineStart) / duration) * 100 });
+    }
+  }
+
+  function handleRulerMouseDown(event) {
+    const el = laneRef.current;
+    if (!el || duration <= 0) {
+      return;
+    }
+    const rect = el.getBoundingClientRect();
+    const toSeconds = (clientX) => {
+      const ratio = Math.min(1, Math.max(0, (clientX - rect.left) / rect.width));
+      return ratio * duration;
+    };
+    onScrub?.(toSeconds(event.clientX));
+    const onMove = (moveEvent) => onScrub?.(toSeconds(moveEvent.clientX));
+    const onUp = () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  }
+
+  const audioSubLabel = (track, index) => {
+    if (track.name && track.name.toLowerCase() !== "audio") {
+      return track.name;
+    }
+    return ["dialogue", "AI music", "sfx"][index] ?? "audio";
+  };
+  const audioIsAi = (track, index) => /music/i.test(track.name ?? "") || index === 1;
+
+  return (
+    <div className="ve-timeline">
+      <div className="ve-timeline-hd">
+        <strong className="ve-timeline-title">TIMELINE</strong>
+        <div className="ve-timeline-legend">
+          <span className="ve-legend-dot ve-dot-accent" />
+          Clip
+          <span className="ve-legend-dot ve-dot-ai" />
+          AI
+        </div>
+        <div className="ve-timeline-hd-right">
+          <button className={`ve-snap${snap ? " on" : ""}`} onClick={onToggleSnap} type="button">
+            <span className={`ve-switch${snap ? " on" : ""}`} aria-hidden="true">
+              <span className="ve-switch-knob" />
+            </span>
+            Snap
+          </button>
+          <button className="ve-ghost-btn" onClick={onZoomOut} title="Zoom out" type="button">
+            <Icon.Minus size={14} />
+          </button>
+          <button className="ve-ghost-btn" onClick={onZoomIn} title="Zoom in" type="button">
+            <Icon.Plus size={14} />
+          </button>
+        </div>
+      </div>
+
+      <div className="ve-timeline-body">
+        {/* Track headers (non-scrolling) */}
+        <div className="ve-track-heads">
+          <div className="ve-ruler-spacer" />
+          <div className="ve-track-head ve-head-v2">
+            <div className="ve-head-name">
+              <strong>V2</strong>
+              <span className="ve-head-sub">overlay</span>
+            </div>
+            <button
+              className={`ve-track-btn${trackVisible?.[OVERLAY_TRACK_ID] === false ? " off" : ""}`}
+              onClick={() => onToggleVisible?.(OVERLAY_TRACK_ID)}
+              title="Toggle visibility"
+              type="button"
+            >
+              <Icon.Image size={13} />
+            </button>
+          </div>
+          <div className="ve-track-head ve-head-v1">
+            <div className="ve-head-name">
+              <strong>V1</strong>
+              <span className="ve-head-sub">main video</span>
+            </div>
+            <button
+              className={`ve-track-btn${mainTrack && trackVisible?.[mainTrack.id] === false ? " off" : ""}`}
+              onClick={() => onToggleVisible?.(mainTrack?.id)}
+              title="Toggle visibility"
+              type="button"
+            >
+              <Icon.Image size={13} />
+            </button>
+          </div>
+          {audioTracks.map((track, index) => (
+            <div className="ve-track-head ve-head-audio" key={track.id}>
+              <div className="ve-head-name">
+                <strong>
+                  A{index + 1}
+                  {audioIsAi(track, index) ? <Icon.Stars size={10} className="ve-ai-icon" /> : null}
+                </strong>
+                <span className="ve-head-sub">{audioSubLabel(track, index)}</span>
+              </div>
+              <div className="ve-track-mschips">
+                <button
+                  className={`ve-track-chip${trackMuted?.[track.id] ? " on" : ""}`}
+                  onClick={() => onToggleMute?.(track.id)}
+                  title="Mute"
+                  type="button"
+                >
+                  M
+                </button>
+                <button
+                  className={`ve-track-chip${trackSoloed?.[track.id] ? " on" : ""}`}
+                  onClick={() => onToggleSolo?.(track.id)}
+                  title="Solo"
+                  type="button"
+                >
+                  S
+                </button>
+              </div>
+            </div>
+          ))}
+          <button className="ve-add-audio" onClick={onAddAudioTrack} title="Add audio track" type="button">
+            <Icon.Plus size={13} />
+            Audio
+          </button>
+        </div>
+
+        {/* Scrollable lanes */}
+        <div className="ve-lanes-scroll">
+          <div className="ve-lanes" ref={laneRef} style={{ width: `${contentWidth}px` }}>
+            {/* Ruler */}
+            <div className="ve-ruler" onMouseDown={handleRulerMouseDown}>
+              {ticks.map((tick) => (
+                <div
+                  className={`ve-tick${tick.major ? " major" : ""}`}
+                  key={tick.second}
+                  style={{ left: `${tick.leftPct}%` }}
+                >
+                  {tick.major ? <span className="ve-tick-label">{tick.label}</span> : null}
+                </div>
+              ))}
+              {markers.map((marker) => (
+                <div
+                  className="ve-marker"
+                  key={marker.id}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onSelectMarker?.(marker);
+                  }}
+                  style={{ left: `${duration > 0 ? (marker.time / duration) * 100 : 0}%` }}
+                >
+                  <span className="ve-marker-flag">{marker.label}</span>
+                </div>
+              ))}
+            </div>
+
+            {/* V2 overlay lane */}
+            <div className="ve-lane ve-lane-v2">
+              {overlayItems.map((item) => (
+                <ClipBlock
+                  ai={isAiItem(item, assetsById)}
+                  duration={duration}
+                  item={item}
+                  key={item.id}
+                  onSelect={onSelectItem}
+                  onSelectKey={onSelectKey}
+                  selected={selectedItemId === item.id}
+                />
+              ))}
+            </div>
+
+            {/* V1 main video lane */}
+            <div className="ve-lane ve-lane-v1">
+              {gaps.map((gap) => (
+                <button
+                  className={`ve-gap${selectedGapId === gap.id ? " selected" : ""}`}
+                  key={gap.id}
+                  onClick={() => onSelectGap?.(gap)}
+                  style={{ left: `${gap.leftPct}%`, width: `${gap.widthPct}%` }}
+                  type="button"
+                >
+                  <span className="ve-gap-label">
+                    <Icon.Plus size={12} />
+                    Bridge
+                  </span>
+                </button>
+              ))}
+              {mainItems.map((item) => (
+                <ClipBlock
+                  ai={isAiItem(item, assetsById)}
+                  duration={duration}
+                  item={item}
+                  key={item.id}
+                  onSelect={onSelectItem}
+                  onSelectKey={onSelectKey}
+                  selected={selectedItemId === item.id}
+                />
+              ))}
+              {transitions.map((trans) => (
+                <div className="ve-transition" key={trans.id} style={{ left: `${trans.leftPct}%` }} title={trans.type}>
+                  <Icon.Duplicate size={12} />
+                </div>
+              ))}
+            </div>
+
+            {/* Audio lanes */}
+            {audioTracks.map((track, index) => (
+              <div className="ve-lane ve-lane-audio" key={track.id}>
+                {trackItems(track).map((item) => {
+                  const { leftPct, widthPct } = itemGeometry(item, duration);
+                  return (
+                    <button
+                      className={`ve-audio-clip${selectedItemId === item.id ? " selected" : ""}${audioIsAi(track, index) ? " ai" : ""}`}
+                      key={item.id}
+                      onClick={() => onSelectItem(item)}
+                      style={{ left: `${leftPct}%`, width: `${widthPct}%`, "--clip-hue": clipHue(item.id) }}
+                      title={item.displayName}
+                      type="button"
+                    >
+                      <svg className="ve-wave" preserveAspectRatio="none" viewBox="0 0 100 40">
+                        <path d={waveformPath(item.id)} />
+                      </svg>
+                      <span className="ve-clip-name">{item.displayName}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            ))}
+
+            {/* Playhead */}
+            <div className="ve-playhead" style={{ left: `${playheadPct}%` }}>
+              <span className="ve-playhead-handle" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/editor/editorUtils.js
+++ b/apps/web/src/components/editor/editorUtils.js
@@ -1,0 +1,140 @@
+// Shared helpers for the redesigned Video Editor (design 2a, epic 12798).
+// Pure functions + constants used across the editor components — kept out of the
+// screen so the timeline/storyboard/rail can share geometry and provenance logic.
+
+// Timeline geometry: the lane content width is `duration * BASE_PX_PER_SEC * zoom`.
+// Everything inside is positioned by percentage of duration, so zoom only changes the
+// content width (nothing else recomputes). Zoom multiplier ranges ~0.6x–2.6x.
+export const BASE_PX_PER_SEC = 24;
+export const ZOOM_MIN = 0.6;
+export const ZOOM_MAX = 2.6;
+export const ZOOM_STEP = 0.2;
+
+// Track ids the backend ships on a default timeline (project_store.rs
+// default_timeline_tracks): main video, overlay, and one audio track.
+export const MAIN_TRACK_ID = "track_main";
+export const OVERLAY_TRACK_ID = "track_overlay";
+export const AUDIO_TRACK_ID = "track_audio";
+
+// Camera-motion presets mirrored from Video Studio (the real `motion` control is a
+// preset string, not a numeric strength). Kept in sync with VideoStudio's MOTIONS.
+export const MOTIONS = [
+  "static",
+  "slow push-in",
+  "pull out",
+  "pan left",
+  "pan right",
+  "tilt up",
+  "tilt down",
+  "handheld",
+];
+export const DEFAULT_MOTION = "slow push-in";
+
+// Asset origins stamped by the backend when media is generated in a studio. An asset
+// with one of these origins — or (for legacy records with no origin) a generation
+// recipe / batch id — is treated as AI-generated for the violet sparkle affordance.
+const STUDIO_ORIGINS = new Set(["image_studio", "video_studio", "document_studio", "character_studio"]);
+
+export function isAiAsset(asset) {
+  if (!asset) {
+    return false;
+  }
+  if (asset.origin === "upload" || asset.type === "upload") {
+    return false;
+  }
+  if (asset.origin && STUDIO_ORIGINS.has(asset.origin)) {
+    return true;
+  }
+  return Boolean(asset.recipe || asset.generationSetId);
+}
+
+// A timeline item counts as an "AI clip" when its backing asset was generated, or when
+// its version history records a generative source (extension/bridge/replacement).
+export function isAiItem(item, assetsById) {
+  if (!item) {
+    return false;
+  }
+  const asset = assetsById?.get?.(item.assetId) ?? null;
+  if (isAiAsset(asset)) {
+    return true;
+  }
+  const history = Array.isArray(item.versionHistory) ? item.versionHistory : [];
+  return history.some((entry) => ["extension", "bridge", "replacement"].includes(entry?.source));
+}
+
+// A small deterministic hash → 0..1 PRNG seeded by a string, so a clip's waveform /
+// gradient is stable across renders without storing anything.
+function seededRandom(seed) {
+  let h = 2166136261 >>> 0;
+  const text = String(seed ?? "");
+  for (let i = 0; i < text.length; i += 1) {
+    h ^= text.charCodeAt(i);
+    h = Math.imul(h, 16777619) >>> 0;
+  }
+  return () => {
+    h += 0x6d2b79f5;
+    let t = h;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// A per-clip hue derived from its id, so each clip block gets a distinct gradient fill
+// (design: "gradient fill derived from a per-clip hue"). Kept in a pleasant band.
+export function clipHue(seed) {
+  const rand = seededRandom(seed);
+  return Math.round(rand() * 360);
+}
+
+// A mirror-filled waveform silhouette as a single SVG path over a 0 0 100 40 viewBox
+// (design: "waveform drawn as a single SVG <path>, preserveAspectRatio=none"). This is
+// a SYNTHETIC envelope seeded by the clip id — no real audio analysis exists yet
+// (tracked as a backend-gap audit story). `bars` controls the resolution.
+export function waveformPath(seed, bars = 48) {
+  const rand = seededRandom(seed);
+  const step = 100 / bars;
+  const top = [];
+  const bottom = [];
+  for (let i = 0; i <= bars; i += 1) {
+    const x = +(i * step).toFixed(2);
+    // Envelope: a slow swell times a faster jitter, floored so it never flatlines.
+    const swell = 0.35 + 0.5 * Math.abs(Math.sin((i / bars) * Math.PI * 3 + rand() * 2));
+    const jitter = 0.55 + 0.45 * rand();
+    const amp = Math.min(1, swell * jitter);
+    const half = +(amp * 18).toFixed(2);
+    top.push(`${x},${(20 - half).toFixed(2)}`);
+    bottom.push(`${x},${(20 + half).toFixed(2)}`);
+  }
+  bottom.reverse();
+  return `M ${top.join(" L ")} L ${bottom.join(" L ")} Z`;
+}
+
+// Second-granularity ruler ticks across `duration`. Minor tick every second, major
+// tick (with an m:ss label) every 5s. Positions are percentages of duration so the
+// ruler tracks the same %-geometry as the lanes.
+export function buildTicks(duration) {
+  const ticks = [];
+  const total = Math.max(1, Math.ceil(duration));
+  for (let s = 0; s <= total; s += 1) {
+    const major = s % 5 === 0;
+    ticks.push({
+      second: s,
+      major,
+      leftPct: duration > 0 ? Math.min(100, (s / duration) * 100) : 0,
+      label: major ? `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}` : "",
+    });
+  }
+  return ticks;
+}
+
+// Percentage geometry for a clip block given the timeline duration.
+export function itemGeometry(item, duration) {
+  const start = Number(item.timelineStart) || 0;
+  const end = Math.max(start, Number(item.timelineEnd) || start);
+  const span = Math.max(0.0001, duration);
+  return {
+    leftPct: Math.max(0, (start / span) * 100),
+    widthPct: Math.max(0.5, ((end - start) / span) * 100),
+  };
+}

--- a/apps/web/src/components/editor/useEditorGeneration.js
+++ b/apps/web/src/components/editor/useEditorGeneration.js
@@ -1,0 +1,337 @@
+import { useEffect, useMemo, useState } from "react";
+import { qualityChoices } from "../../jobTypes.js";
+import {
+  samplerOptionsFromModel,
+  schedulerOptionsFromModel,
+  samplerDefaultFromModel,
+  schedulerDefaultFromModel,
+  schedulerShiftDefaultFromModel,
+} from "../../samplerOptions.js";
+import { installedTiers, tierQuantize } from "../../quantTier.js";
+import { serializeLora, buildStudioPresetPayload } from "../../presetUtils.js";
+import { WAN_A14B_LIGHTNING_MODEL_IDS } from "../../constants.js";
+import { useGenerationStudio } from "../../screens/generationStudio.jsx";
+import { loadStudioSettings, useStudioSettingsWriter } from "../../hooks/useStudioSettings.js";
+import { MOTIONS, DEFAULT_MOTION } from "./editorUtils.js";
+
+const LTX_VIDEO_MODEL_ID = "ltx_2_3";
+const EDITOR_DEFAULT_TIER = "q4";
+// Preset filtering is by workflow/mode; the editor drives multiple video modes, so it
+// borrows the most common video preset workflow for the availability filter.
+const PRESET_FILTER_MODE = "image_to_video";
+
+const RESOLUTION_FALLBACK = ["1280x720", "768x512", "768x768", "720x1280", "1024x576", "512x768"];
+const FPS_FALLBACK = [24, 25, 30];
+const DURATION_FALLBACK = [4, 6, 8, 10];
+
+// Owns the editor's generation-settings object and reuses the Video Studio machinery
+// (useGenerationStudio for presets + LoRA selection, plus the model-derived option
+// helpers and tier logic) so a clip generated from the editor behaves identically to
+// one generated in Video Studio (epic 12798). Returns everything GenerationRail needs
+// to render, plus buildBasePayload() which the screen merges with the timeline context.
+export function useEditorGeneration({ context }) {
+  const {
+    activeProject,
+    videoModels = [],
+    models = [],
+    loras = [],
+    presets = [],
+    assets = [],
+    characters = [],
+    recentVideoAssets = [],
+    createPreset,
+  } = context;
+
+  const projectId = activeProject?.id ?? null;
+  // Seed from the editor's own scope, falling back to the Video Studio snapshot so the
+  // editor opens with the user's last studio choices but never clobbers that snapshot.
+  const saved = useMemo(() => {
+    const studio = loadStudioSettings("video", projectId);
+    const own = loadStudioSettings("editor-video", projectId);
+    return { ...studio, ...own };
+  }, [projectId]);
+
+  const fallbackModelId = videoModels[0]?.id ?? LTX_VIDEO_MODEL_ID;
+  const [model, setModel] = useState(saved.model ?? fallbackModelId);
+  const [quality, setQuality] = useState(saved.quality ?? "balanced");
+  const [resolution, setResolution] = useState(saved.resolution ?? "1280x720");
+  const [fps, setFps] = useState(saved.fps ?? 24);
+  const [duration, setDuration] = useState(saved.duration ?? 6);
+  const [motion, setMotion] = useState(MOTIONS.includes(saved.motion) ? saved.motion : DEFAULT_MOTION);
+  const [seed, setSeed] = useState(saved.seed ?? "");
+  const [prompt, setPrompt] = useState(saved.prompt ?? "Continue the action, matching motion and lighting");
+  const [negativePrompt, setNegativePrompt] = useState(saved.negativePrompt ?? "");
+  const [sampler, setSampler] = useState(saved.sampler ?? "default");
+  const [scheduler, setScheduler] = useState(saved.scheduler ?? "default");
+  const [schedulerShift, setSchedulerShift] = useState(saved.schedulerShift ?? 3.0);
+  const [stepsOverride, setStepsOverride] = useState(saved.steps ?? "");
+  const [guidanceOverride, setGuidanceOverride] = useState(saved.guidanceScale ?? "");
+  const [quantTier, setQuantTier] = useState(saved.quantTier ?? EDITOR_DEFAULT_TIER);
+  const [lightning, setLightning] = useState(saved.lightning ?? true);
+  const [advancedOpen, setAdvancedOpen] = useState(saved.advancedOpen ?? false);
+
+  const selectedModel = useMemo(
+    () => videoModels.find((item) => item.id === model) ?? videoModels[0] ?? null,
+    [videoModels, model],
+  );
+
+  const studio = useGenerationStudio({
+    mode: PRESET_FILTER_MODE,
+    presets,
+    selectedModel,
+    loras,
+    models: videoModels.length ? videoModels : models,
+    model,
+    setModel,
+    fallbackModelId,
+    characters,
+    characterId: "",
+    setCharacterId: () => {},
+    setCharacterLookId: () => {},
+    assets,
+    latestAssets: recentVideoAssets,
+    trackedLocalJobs: [],
+    initialPresetId: saved.selectedPresetId ?? null,
+    advancedOpen,
+    setAdvancedOpen,
+    initialSelectedLoraIds: saved.selectedLoraIds ?? [],
+    initialLoraWeights: saved.loraWeights ?? {},
+    initialShowIncompatibleLoras: saved.showIncompatibleLoras ?? false,
+    initialGeneralStackIds: saved.generalStackIds ?? [],
+  });
+
+  // Option menus derived from the selected model (null backend → base limits menu).
+  const resolutionOptions = selectedModel?.limits?.resolutions ?? RESOLUTION_FALLBACK;
+  const fpsOptions = selectedModel?.limits?.fps ?? FPS_FALLBACK;
+  const durationOptions = selectedModel?.limits?.durations ?? DURATION_FALLBACK;
+  const samplerOptions = useMemo(() => samplerOptionsFromModel(selectedModel, null), [selectedModel]);
+  const schedulerOptions = useMemo(() => schedulerOptionsFromModel(selectedModel, null), [selectedModel]);
+  const availableTiers = useMemo(
+    () => installedTiers(selectedModel, { convRotEligible: false, nvfp4Eligible: false, defaultQuality: EDITOR_DEFAULT_TIER }),
+    [selectedModel],
+  );
+
+  const showSamplerPicker = samplerOptions.length > 1;
+  const showSchedulerPicker = schedulerOptions.length > 1;
+  const showTierPicker = availableTiers.length > 1;
+  const showLightning = WAN_A14B_LIGHTNING_MODEL_IDS.has(model);
+  const lightningActive = showLightning && lightning;
+
+  // Re-clamp the discrete selects to the current model's menus when the model changes,
+  // and reset sampler/scheduler defaults + tier into range (mirrors VideoStudio's clamp).
+  useEffect(() => {
+    if (!selectedModel) {
+      return;
+    }
+    if (!resolutionOptions.includes(resolution)) {
+      setResolution(selectedModel.defaults?.resolution ?? resolutionOptions[0]);
+    }
+    if (!fpsOptions.includes(Number(fps))) {
+      setFps(selectedModel.defaults?.fps ?? fpsOptions[0]);
+    }
+    if (!durationOptions.includes(Number(duration))) {
+      setDuration(selectedModel.defaults?.duration ?? durationOptions[0]);
+    }
+    if (!samplerOptions.includes(sampler)) {
+      setSampler(samplerDefaultFromModel(selectedModel));
+    }
+    if (!schedulerOptions.includes(scheduler)) {
+      setScheduler(schedulerDefaultFromModel(selectedModel));
+      setSchedulerShift(schedulerShiftDefaultFromModel(selectedModel));
+    }
+    if (availableTiers.length && !availableTiers.includes(quantTier)) {
+      setQuantTier(availableTiers.includes(EDITOR_DEFAULT_TIER) ? EDITOR_DEFAULT_TIER : availableTiers[0]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedModel?.id]);
+
+  const [width, height] = String(resolution).split("x").map(Number);
+  const motionPct = Math.round(((MOTIONS.indexOf(motion) + 1) / MOTIONS.length) * 100);
+
+  // Apply a chosen preset's non-LoRA defaults to the scalar controls (the LoRA seeding
+  // is handled inside useGenerationStudio). Runs on preset change only.
+  const selectedPresetId = studio.selectedPreset?.id ?? null;
+  useEffect(() => {
+    const defaults = studio.selectedPreset?.defaults;
+    if (!defaults) {
+      return;
+    }
+    if (defaults.resolution) setResolution(defaults.resolution);
+    if (defaults.duration != null) setDuration(defaults.duration);
+    if (defaults.fps != null) setFps(defaults.fps);
+    if (defaults.quality) setQuality(defaults.quality);
+    if (defaults.negativePrompt != null) setNegativePrompt(defaults.negativePrompt);
+    if (defaults.motion && MOTIONS.includes(defaults.motion)) setMotion(defaults.motion);
+    if (defaults.sampler) setSampler(defaults.sampler);
+    if (defaults.scheduler) setScheduler(defaults.scheduler);
+    if (defaults.schedulerShift != null) setSchedulerShift(defaults.schedulerShift);
+    if (defaults.steps != null) setStepsOverride(defaults.steps);
+    if (defaults.guidanceScale != null) setGuidanceOverride(defaults.guidanceScale);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedPresetId]);
+
+  function randomizeSeed() {
+    setSeed(String(Math.floor(Math.random() * 1_000_000_000)));
+  }
+
+  // Save the current settings as a reusable preset (createPreset from context). Scope is
+  // "project" when a project is open, else "global". Returns the created preset or null.
+  async function savePreset(name, scope = activeProject ? "project" : "global") {
+    if (!name || !name.trim() || typeof createPreset !== "function") {
+      return null;
+    }
+    const payload = buildStudioPresetPayload({
+      name: name.trim(),
+      scope,
+      mode: PRESET_FILTER_MODE,
+      model,
+      loras: studio.selectedLoras.map((lora) => serializeLora(lora, { weight: studio.effectiveLoraWeight(lora) })),
+      defaults: {
+        resolution,
+        duration: Number(duration),
+        fps: Number(fps),
+        quality,
+        negativePrompt,
+        motion,
+        sampler,
+        scheduler,
+        schedulerShift: Number(schedulerShift),
+        ...(stepsOverride !== "" ? { steps: Number(stepsOverride) } : {}),
+        ...(guidanceOverride !== "" ? { guidanceScale: Number(guidanceOverride) } : {}),
+      },
+    });
+    return createPreset(payload);
+  }
+
+  // Persist the editor's own generation-settings snapshot (separate scope so it never
+  // overwrites the richer Video Studio snapshot). Gated on a loaded catalog (sc-11962).
+  useStudioSettingsWriter(
+    "editor-video",
+    projectId,
+    {
+      model,
+      quality,
+      resolution,
+      fps,
+      duration,
+      motion,
+      seed,
+      prompt,
+      negativePrompt,
+      sampler,
+      scheduler,
+      schedulerShift,
+      steps: stepsOverride,
+      guidanceScale: guidanceOverride,
+      quantTier,
+      lightning,
+      advancedOpen,
+      selectedLoraIds: studio.selectedLoraIds,
+      loraWeights: studio.loraWeights,
+      showIncompatibleLoras: studio.showIncompatibleLoras,
+      selectedPresetId: studio.selectedPresetId,
+      generalStackIds: studio.generalStackIds,
+    },
+    videoModels.length > 0,
+  );
+
+  // The generation fields common to every editor action. The screen merges this with the
+  // per-action mode + source asset + advanced.timelineAction/timelineContext. Blank /
+  // default / non-finite values are omitted so the engine re-derives its own defaults.
+  function buildBasePayload() {
+    const mlxQuantize = tierQuantize(quantTier);
+    const advanced = {
+      resolution,
+      motion,
+      ...(showTierPicker && mlxQuantize !== null ? { mlxQuantize } : {}),
+      ...(sampler && sampler !== "default" ? { sampler } : {}),
+      ...(scheduler && scheduler !== "default" ? { scheduler } : {}),
+      ...(scheduler && scheduler !== "default" && Number.isFinite(Number(schedulerShift))
+        ? { schedulerShift: Number(schedulerShift) }
+        : {}),
+      ...(showLightning ? { lightning } : {}),
+      ...(!lightningActive && stepsOverride !== "" && Number.isFinite(Number(stepsOverride))
+        ? { steps: Number(stepsOverride) }
+        : {}),
+      ...(!lightningActive && guidanceOverride !== "" && Number.isFinite(Number(guidanceOverride))
+        ? { guidanceScale: Number(guidanceOverride) }
+        : {}),
+    };
+    return {
+      model,
+      quality,
+      prompt,
+      duration: Number(duration),
+      fps: Number(fps),
+      width: width || undefined,
+      height: height || undefined,
+      seed: seed === "" ? null : Number(seed),
+      negativePrompt,
+      recipePresetId: studio.selectedPreset?.id ?? null,
+      presetLorasResolvedClientSide: studio.selectedPreset ? true : undefined,
+      loras: studio.selectedLoras.map((lora) => serializeLora(lora, { weight: studio.effectiveLoraWeight(lora) })),
+      advanced,
+    };
+  }
+
+  return {
+    studio,
+    selectedModel,
+    videoModels,
+    // scalar controls
+    model,
+    setModel,
+    quality,
+    setQuality,
+    qualityChoices,
+    resolution,
+    setResolution,
+    resolutionOptions,
+    fps,
+    setFps,
+    fpsOptions,
+    duration,
+    setDuration,
+    durationOptions,
+    motion,
+    setMotion,
+    motionPct,
+    seed,
+    setSeed,
+    randomizeSeed,
+    prompt,
+    setPrompt,
+    negativePrompt,
+    setNegativePrompt,
+    // advanced
+    advancedOpen,
+    setAdvancedOpen,
+    sampler,
+    setSampler,
+    samplerOptions,
+    showSamplerPicker,
+    scheduler,
+    setScheduler,
+    schedulerOptions,
+    showSchedulerPicker,
+    schedulerShift,
+    setSchedulerShift,
+    stepsOverride,
+    setStepsOverride,
+    guidanceOverride,
+    setGuidanceOverride,
+    quantTier,
+    setQuantTier,
+    availableTiers,
+    showTierPicker,
+    lightning,
+    setLightning,
+    showLightning,
+    lightningActive,
+    width,
+    height,
+    // payload + preset save
+    buildBasePayload,
+    savePreset,
+  };
+}

--- a/apps/web/src/formatting.js
+++ b/apps/web/src/formatting.js
@@ -9,6 +9,22 @@ export function formatSeconds(seconds) {
   return minutes > 0 ? `${minutes}m ${remainder}s` : `${remainder}s`;
 }
 
+// Frame-accurate NLE timecode `MM:SS:FF` (Video Editor redesign, epic 12798). The
+// third field is the frame within the current second at the timeline's fps, so the
+// toolbar/ruler read like a pro editor. `fps` falls back to 30 for a nullish/invalid
+// rate; seconds are clamped to >= 0. Frames are floored and clamped to fps-1 so a
+// value sitting exactly on a second boundary never reads as ":30" at 30fps.
+export function formatTimecode(seconds, fps = 30) {
+  const safeFps = Number.isFinite(fps) && fps > 0 ? Math.round(fps) : 30;
+  const total = Math.max(0, Number(seconds) || 0);
+  const whole = Math.floor(total);
+  const minutes = Math.floor(whole / 60);
+  const secs = whole % 60;
+  const frames = Math.min(safeFps - 1, Math.floor((total - whole) * safeFps));
+  const pad = (value) => String(value).padStart(2, "0");
+  return `${pad(minutes)}:${pad(secs)}:${pad(frames)}`;
+}
+
 export function percent(value) {
   return `${Math.round((value ?? 0) * 100)}%`;
 }

--- a/apps/web/src/screens/EditorScreen.jsx
+++ b/apps/web/src/screens/EditorScreen.jsx
@@ -1,28 +1,32 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { AssetMedia, assetCanRenderAsImage, assetCanRenderAsVideo } from "../components/assetMedia.jsx";
-import { WorkPanel } from "../components/WorkPanel.jsx";
-import { formatSeconds } from "../formatting.js";
+import { assetCanRenderAsImage, assetCanRenderAsVideo } from "../components/assetMedia.jsx";
+import { formatTimecode } from "../formatting.js";
 import {
-  aspectOptions,
   ensureItemVersionFields,
   itemDuration,
   sourceTimestampAtPlayhead,
-  speedPresets,
   timelineDuration,
   trackItems,
-  transitionOptions,
 } from "../timeline.js";
 import { useAppStatic } from "../context/AppContext.js";
 import { useScreenActive } from "../context/ScreenActiveContext.js";
 import { appConfirm } from "../appConfirm.jsx";
+import { EditorToolbar } from "../components/editor/EditorToolbar.jsx";
+import { MediaBin } from "../components/editor/MediaBin.jsx";
+import { ProgramMonitor } from "../components/editor/ProgramMonitor.jsx";
+import { GenerationRail } from "../components/editor/GenerationRail.jsx";
+import { StoryboardStrip } from "../components/editor/StoryboardStrip.jsx";
+import { Timeline } from "../components/editor/Timeline.jsx";
+import { useEditorGeneration } from "../components/editor/useEditorGeneration.js";
+import { ZOOM_MIN, ZOOM_MAX, ZOOM_STEP, MAIN_TRACK_ID } from "../components/editor/editorUtils.js";
 
 export function EditorScreen() {
+  const app = useAppStatic();
   const {
     activeProject,
     activeTimeline,
     mediaAssets,
     setPreviewAsset,
-    sendAssetToImage,
     sendAssetToVideo,
     createTimeline,
     extractTimelineFrame,
@@ -34,85 +38,100 @@ export function EditorScreen() {
     setSelectedTimelineId,
     isActiveTimelineDirty,
     timelines,
-  } = useAppStatic();
+  } = app;
   const assets = mediaAssets;
-  const onPreview = setPreviewAsset;
-  const onSendImage = (asset) => sendAssetToImage(asset, "edit_image");
-  const onSendVideo = (asset) => sendAssetToVideo(asset, asset?.type === "video" ? "extend_clip" : "image_to_video");
+  const gen = useEditorGeneration({ context: app });
 
-  const [newTimelineName, setNewTimelineName] = useState("Main timeline");
-  const [newAspectRatio, setNewAspectRatio] = useState("16:9");
   const [selectedItemId, setSelectedItemId] = useState(null);
-  const [addDuration, setAddDuration] = useState(4);
-  const [exportResolution, setExportResolution] = useState(720);
+  const [selectionKind, setSelectionKind] = useState(null); // clip | audio | gap | key | marker
+  const [selectedGap, setSelectedGap] = useState(null);
+  const [selectedMarker, setSelectedMarker] = useState(null);
+  const [playheadSeconds, setPlayheadSeconds] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [zoom, setZoom] = useState(1);
+  const [snap, setSnap] = useState(true);
   const [history, setHistory] = useState([]);
   const [future, setFuture] = useState([]);
-  const [isPlaying, setIsPlaying] = useState(false);
-  const [playheadSeconds, setPlayheadSeconds] = useState(0);
-  const [generationPrompt, setGenerationPrompt] = useState("Continue the action with matching motion and lighting");
-  const [extensionDuration, setExtensionDuration] = useState(4);
+  const [trackVisible, setTrackVisible] = useState({});
+  const [trackMuted, setTrackMuted] = useState({});
+  const [trackSoloed, setTrackSoloed] = useState({});
+  const [markers] = useState([]); // Local UI markers only — no persisted marker model yet (audit).
   const [timelineNotice, setTimelineNotice] = useState("");
   const previewVideoRef = useRef(null);
-  // sc-11961 (S2): under keep-alive this editor stays mounted while backgrounded, so it
-  // can no longer rely on unmount to stop preview playback. `screenActive` is false when
-  // another view is foregrounded; the playback effect below gates on it so a hidden
-  // editor does no continuous video decode/audio work.
   const screenActive = useScreenActive();
 
+  const assetsById = useMemo(() => new Map(assets.map((asset) => [asset.id, asset])), [assets]);
+  const trackKindById = useMemo(() => {
+    const map = new Map();
+    (activeTimeline?.tracks ?? []).forEach((track) => map.set(track.id, track.kind));
+    return map;
+  }, [activeTimeline]);
   const selectedItem = useMemo(() => {
     if (!activeTimeline) {
       return null;
     }
     return activeTimeline.tracks.flatMap((track) => track.items).find((item) => item.id === selectedItemId) ?? null;
   }, [activeTimeline, selectedItemId]);
-  const selectedAsset = useMemo(() => assets.find((asset) => asset.id === selectedItem?.assetId) ?? null, [assets, selectedItem]);
+  const selectedAsset = assetsById.get(selectedItem?.assetId) ?? null;
   const duration = activeTimeline ? timelineDuration(activeTimeline) : 0;
-  const timelineScale = Math.max(12, duration + 4);
-  const mainAssets = assets.filter((asset) => asset.type === "video" || asset.file?.mimeType?.startsWith("video/"));
-  const stillAssets = assets.filter((asset) => assetCanRenderAsImage(asset));
+  const mainTrack = activeTimeline?.tracks?.find((track) => track.id === MAIN_TRACK_ID || track.kind === "video") ?? null;
+  const mainClips = mainTrack ? trackItems(mainTrack) : [];
+  const isSelectedAi = useMemo(() => {
+    const history = selectedItem?.versionHistory ?? [];
+    return history.some((entry) => ["extension", "bridge", "replacement"].includes(entry?.source));
+  }, [selectedItem]);
 
   useEffect(() => {
     setHistory([]);
     setFuture([]);
     setSelectedItemId(null);
+    setSelectionKind(null);
+    setPlayheadSeconds(0);
   }, [activeTimeline?.id]);
 
-  useEffect(() => {
-    if (selectedItem) {
-      setPlayheadSeconds(Number(selectedItem.timelineStart) || 0);
-    }
-    setIsPlaying(false);
-    setTimelineNotice("");
-  }, [selectedItem?.id]);
-
+  // Preview playback: drive the selected clip's <video> only while foregrounded (sc-11961).
   useEffect(() => {
     const video = previewVideoRef.current;
     if (!assetCanRenderAsVideo(selectedAsset) || !video) {
-      setIsPlaying(false);
       return;
     }
-    // Only drive playback while this is the foreground view (sc-11961). When the editor
-    // is backgrounded under keep-alive, pause instead — the <video>'s pause event flips
-    // isPlaying off (onPause), so re-showing the editor lands paused rather than silently
-    // resuming audio/decode work that ran while hidden.
     if (isPlaying && screenActive) {
       video.play().catch(() => setIsPlaying(false));
       return;
     }
     video.pause();
+    // Re-run only when the selected clip changes (by id), not on every asset-object identity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isPlaying, selectedAsset?.id, screenActive]);
 
-  // Keep the global keydown listener mounted once and read live editor state
-  // through a ref, so undo/redo/delete don't re-bind window on every history
-  // or selection change.
+  // Playhead transport: a rAF loop advances the playhead across the whole timeline while
+  // playing, wrapping to 0 at the end. Only runs while foregrounded.
+  useEffect(() => {
+    if (!isPlaying || !screenActive || duration <= 0 || typeof window.requestAnimationFrame !== "function") {
+      return undefined;
+    }
+    let raf = 0;
+    let last = performance.now();
+    const tick = (now) => {
+      const dt = (now - last) / 1000;
+      last = now;
+      setPlayheadSeconds((prev) => {
+        const next = prev + dt;
+        return next >= duration ? 0 : next;
+      });
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [isPlaying, screenActive, duration]);
+
   const shortcutStateRef = useRef({ undo, redo, removeSelectedItem, selectedItemId });
   shortcutStateRef.current = { undo, redo, removeSelectedItem, selectedItemId };
 
   useEffect(() => {
     function onKeyDown(event) {
       const target = event.target;
-      const isTyping = ["INPUT", "TEXTAREA", "SELECT"].includes(target?.tagName);
-      if (isTyping) {
+      if (["INPUT", "TEXTAREA", "SELECT"].includes(target?.tagName)) {
         return;
       }
       const { undo, redo, removeSelectedItem, selectedItemId } = shortcutStateRef.current;
@@ -122,57 +141,20 @@ export function EditorScreen() {
       }
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "z") {
         event.preventDefault();
-        if (event.shiftKey) {
-          redo();
-        } else {
-          undo();
-        }
+        event.shiftKey ? redo() : undo();
       }
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "y") {
         event.preventDefault();
         redo();
       }
-      if (event.key === "Delete" || event.key === "Backspace") {
-        if (selectedItemId) {
-          event.preventDefault();
-          removeSelectedItem();
-        }
+      if ((event.key === "Delete" || event.key === "Backspace") && selectedItemId) {
+        event.preventDefault();
+        removeSelectedItem();
       }
     }
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
   }, []);
-
-  async function submitNewTimeline(event) {
-    event.preventDefault();
-    await createTimeline({ name: newTimelineName, aspectRatio: newAspectRatio, fps: 30 });
-  }
-
-  // sc-11967 (S8): re-selecting a timeline from the dropdown reloads the server copy and
-  // replaces the in-memory working copy, dropping any unsaved structural edits. Guard the
-  // switch when the active timeline is dirty. The <select> is controlled by
-  // `selectedTimelineId`, so returning early (no state change) snaps its value back to the
-  // current timeline. sc-12018 (S8 follow-up): routed through the desktop-safe appConfirm
-  // (a real in-app dialog) rather than the raw window.confirm — window.confirm silently
-  // no-ops inside the Tauri WebView, so the guard would neither confirm nor cancel there.
-  async function handleSelectTimeline(nextId) {
-    if (nextId === selectedTimelineId) {
-      return;
-    }
-    if (isActiveTimelineDirty?.()) {
-      const proceed = await appConfirm({
-        title: "Discard timeline edits?",
-        message: "You have unsaved timeline edits. Switch timelines and discard them?",
-        confirmLabel: "Discard & switch",
-        cancelLabel: "Keep editing",
-        tone: "danger",
-      });
-      if (!proceed) {
-        return;
-      }
-    }
-    setSelectedTimelineId(nextId);
-  }
 
   function commit(nextTimeline) {
     if (!activeTimeline) {
@@ -183,17 +165,19 @@ export function EditorScreen() {
     setActiveTimeline({ ...nextTimeline, duration: timelineDuration(nextTimeline) });
   }
 
-  function updateTimelineItem(itemId, changes) {
-    if (!activeTimeline) {
-      return;
-    }
-    commit({
-      ...activeTimeline,
-      tracks: activeTimeline.tracks.map((track) => ({
-        ...track,
-        items: track.items.map((item) => (item.id === itemId ? normalizeTimelineItem({ ...item, ...changes }) : item)),
-      })),
-    });
+  function normalizeTimelineItem(item) {
+    const start = Number(item.timelineStart) || 0;
+    const end = Math.max(start + 0.1, Number(item.timelineEnd) || start + 0.1);
+    const sourceIn = Number(item.sourceIn) || 0;
+    const sourceOut = Math.max(sourceIn + 0.1, Number(item.sourceOut) || sourceIn + itemDuration(item));
+    return {
+      ...ensureItemVersionFields(item),
+      sourceIn,
+      sourceOut,
+      timelineStart: Math.max(0, start),
+      timelineEnd: end,
+      speed: Math.max(0.1, Number(item.speed) || 1),
+    };
   }
 
   function undo() {
@@ -216,15 +200,15 @@ export function EditorScreen() {
     setActiveTimeline(next);
   }
 
-  function addAssetToTrack(asset, trackId = "track_main") {
+  function addAssetToTrack(asset, trackId = MAIN_TRACK_ID) {
     if (!activeTimeline) {
       return;
     }
     const isStill = asset.type !== "video" && assetCanRenderAsImage(asset);
     const track = activeTimeline.tracks.find((item) => item.id === trackId) ?? activeTimeline.tracks[0];
     const start = Math.max(0, ...track.items.map((item) => item.timelineEnd));
-    const sourceDuration = Number(asset.file?.duration) || Number(addDuration) || 4;
-    const durationSeconds = isStill ? Number(addDuration) || 4 : sourceDuration;
+    const sourceDuration = Number(asset.file?.duration) || 4;
+    const durationSeconds = isStill ? 4 : sourceDuration;
     const item = normalizeTimelineItem({
       id: `item_${crypto.randomUUID().replaceAll("-", "")}`,
       trackId: track.id,
@@ -250,7 +234,24 @@ export function EditorScreen() {
         current.id === track.id ? { ...current, items: [...current.items, item] } : current,
       ),
     });
-    setSelectedItemId(item.id);
+    selectItem(item);
+  }
+
+  function addAudioTrack() {
+    if (!activeTimeline) {
+      return;
+    }
+    const count = activeTimeline.tracks.filter((track) => track.kind === "audio").length;
+    const newTrack = {
+      id: `track_audio_${crypto.randomUUID().replaceAll("-", "")}`,
+      name: `Audio ${count + 1}`,
+      kind: "audio",
+      locked: false,
+      muted: false,
+      items: [],
+    };
+    commit({ ...activeTimeline, tracks: [...activeTimeline.tracks, newTrack] });
+    setTimelineNotice("Audio track added. Note: audio isn't mixed into exports yet (tracked for the backend audit).");
   }
 
   function removeSelectedItem() {
@@ -265,72 +266,100 @@ export function EditorScreen() {
       })),
     });
     setSelectedItemId(null);
+    setSelectionKind(null);
   }
 
-  function changeItemTrack(trackId) {
-    if (!activeTimeline || !selectedItem) {
+  function rippleCloseGap(gap) {
+    if (!activeTimeline || !gap) {
+      return;
+    }
+    const shift = Number(gap.rightItem.timelineStart) - Number(gap.leftItem.timelineEnd);
+    if (shift <= 0) {
       return;
     }
     commit({
       ...activeTimeline,
       tracks: activeTimeline.tracks.map((track) => {
-        if (track.id === selectedItem.trackId) {
-          return { ...track, items: track.items.filter((item) => item.id !== selectedItem.id) };
+        if (track.id !== gap.rightItem.trackId) {
+          return track;
         }
-        if (track.id === trackId) {
-          return { ...track, items: [...track.items, normalizeTimelineItem({ ...selectedItem, trackId })] };
-        }
-        return track;
+        return {
+          ...track,
+          items: track.items.map((item) =>
+            Number(item.timelineStart) >= Number(gap.rightItem.timelineStart)
+              ? { ...item, timelineStart: item.timelineStart - shift, timelineEnd: item.timelineEnd - shift }
+              : item,
+          ),
+        };
       }),
     });
+    setSelectedGap(null);
+    setSelectionKind(null);
   }
 
-  function normalizeTimelineItem(item) {
-    const start = Number(item.timelineStart) || 0;
-    const end = Math.max(start + 0.1, Number(item.timelineEnd) || start + 0.1);
-    const sourceIn = Number(item.sourceIn) || 0;
-    const sourceOut = Math.max(sourceIn + 0.1, Number(item.sourceOut) || sourceIn + itemDuration(item));
-    return {
-      ...ensureItemVersionFields(item),
-      sourceIn,
-      sourceOut,
-      timelineStart: Math.max(0, start),
-      timelineEnd: end,
-      speed: Math.max(0.1, Number(item.speed) || 1),
-    };
+  // ---- selection ----
+  function selectItem(item) {
+    setSelectedItemId(item.id);
+    setSelectionKind(trackKindById.get(item.trackId) === "audio" ? "audio" : "clip");
+    setSelectedGap(null);
+    setSelectedMarker(null);
+    setPlayheadSeconds(Number(item.timelineStart) || 0);
+    setIsPlaying(false);
+    setTimelineNotice("");
+  }
+  function selectStoryboardKey(clip) {
+    selectItem(clip);
+  }
+  function selectKeyframe(item) {
+    setSelectedItemId(item.id);
+    setSelectionKind("key");
+    setSelectedGap(null);
+    setPlayheadSeconds(Number(item.timelineStart) || 0);
+    setIsPlaying(false);
+  }
+  function selectGap(gap) {
+    setSelectedGap(gap);
+    setSelectionKind("gap");
+    setSelectedItemId(null);
+    setSelectedMarker(null);
+    setPlayheadSeconds(Number(gap.leftItem.timelineEnd) || 0);
+    setIsPlaying(false);
+  }
+  function selectMarker(marker) {
+    setSelectedMarker(marker);
+    setSelectionKind("marker");
+    setPlayheadSeconds(Number(marker.time) || 0);
   }
 
-  function selectedTrackItems() {
-    if (!activeTimeline || !selectedItem) {
-      return [];
+  function stepClip(direction) {
+    if (!mainClips.length) {
+      return;
     }
-    const track = activeTimeline.tracks.find((item) => item.id === selectedItem.trackId);
-    return track ? trackItems(track) : [];
+    const index = mainClips.findIndex((item) => item.id === selectedItemId);
+    const nextIndex = index === -1 ? 0 : Math.min(mainClips.length - 1, Math.max(0, index + direction));
+    selectItem(mainClips[nextIndex]);
   }
 
-  function nextItemAfterSelection() {
-    return selectedTrackItems().find((item) => item.timelineStart >= selectedItem.timelineEnd && item.id !== selectedItem.id) ?? null;
-  }
-
-  function generationBaseContext(action, extra = {}) {
+  // ---- generation context ----
+  function generationContext(action, item, extra = {}) {
     return {
       action,
       timelineId: activeTimeline.id,
       timelineName: activeTimeline.name,
-      itemId: selectedItem.id,
-      trackId: selectedItem.trackId,
-      sourceAssetId: selectedItem.assetId,
-      sourceTimestamp: sourceTimestampAtPlayhead(selectedItem, playheadSeconds),
+      itemId: item.id,
+      trackId: item.trackId,
+      sourceAssetId: item.assetId,
+      sourceTimestamp: sourceTimestampAtPlayhead(item, playheadSeconds),
       ...extra,
     };
   }
 
-  async function extractFrame(intendedUse = "reuse") {
+  async function extractFrame() {
     if (!selectedItem || selectedItem.type !== "video") {
       setTimelineNotice("Select a video clip before extracting a frame.");
       return;
     }
-    const job = await extractTimelineFrame({ timeline: activeTimeline, item: selectedItem, playheadSeconds, intendedUse });
+    const job = await extractTimelineFrame({ timeline: activeTimeline, item: selectedItem, playheadSeconds, intendedUse: "reuse" });
     if (job) {
       setTimelineNotice("Frame extraction queued.");
     }
@@ -341,98 +370,82 @@ export function EditorScreen() {
       setTimelineNotice("Select a video clip before extending.");
       return;
     }
-    const duration = Math.min(15, Math.max(1, Number(extensionDuration) || itemDuration(selectedItem)));
+    const base = gen.buildBasePayload();
     const job = await queueTimelineVideoJob({
+      ...base,
       mode: "extend_clip",
-      prompt: generationPrompt,
-      model: "ltx_2_3",
-      duration,
-      fps: activeTimeline.fps,
-      width: activeTimeline.width,
-      height: activeTimeline.height,
-      quality: "balanced",
       sourceClipAssetId: selectedItem.assetId,
-      loras: [],
       advanced: {
-        resolution: `${activeTimeline.width}x${activeTimeline.height}`,
+        ...base.advanced,
         timelineAction: "extend",
-        timelineContext: generationBaseContext("extend", {
+        timelineContext: generationContext("extend", selectedItem, {
           endpointTimestamp: Number(selectedItem.sourceOut) || sourceTimestampAtPlayhead(selectedItem, selectedItem.timelineEnd),
           timelineStart: Number(selectedItem.timelineEnd),
         }),
       },
     });
     if (job) {
-      setTimelineNotice("Extension job queued. The new clip will land after the selection when it completes.");
+      setTimelineNotice("Extension job queued. The new clip lands after the selection when it completes.");
     }
   }
 
-  async function replaceSelectedItem() {
+  async function replaceSelectedItem({ variation = false } = {}) {
     if (!selectedItem) {
       return;
     }
     const isStill = selectedItem.type === "image";
-    const duration = itemDuration(selectedItem);
+    const base = gen.buildBasePayload();
     const job = await queueTimelineVideoJob({
+      ...base,
       mode: isStill ? "image_to_video" : "extend_clip",
-      prompt: generationPrompt,
-      model: "ltx_2_3",
-      duration,
-      fps: activeTimeline.fps,
-      width: activeTimeline.width,
-      height: activeTimeline.height,
-      quality: "balanced",
+      duration: itemDuration(selectedItem),
+      seed: variation ? Math.floor(Math.random() * 1_000_000_000) : base.seed,
       sourceAssetId: isStill ? selectedItem.assetId : null,
       sourceClipAssetId: isStill ? null : selectedItem.assetId,
-      loras: [],
       advanced: {
-        resolution: `${activeTimeline.width}x${activeTimeline.height}`,
+        ...base.advanced,
         timelineAction: "replace",
-        timelineContext: generationBaseContext("replace"),
+        timelineContext: generationContext("replace", selectedItem),
       },
     });
     if (job) {
-      setTimelineNotice("Replacement job queued. The prior asset will stay in this item's version history.");
+      setTimelineNotice(
+        variation
+          ? "Variation queued with a fresh seed. The prior asset stays in this item's version history."
+          : "Replacement job queued. The prior asset stays in this item's version history.",
+      );
     }
   }
 
-  async function bridgeAfterSelectedClip() {
-    if (!selectedItem || selectedItem.type !== "video") {
-      setTimelineNotice("Select the left video clip before generating a bridge.");
+  async function bridgeGap(gap) {
+    const left = gap?.leftItem;
+    const right = gap?.rightItem;
+    if (!left || left.type !== "video" || !right || right.type !== "video") {
+      setTimelineNotice("A bridge needs a video clip on each side of the gap.");
       return;
     }
-    const rightItem = nextItemAfterSelection();
-    if (!rightItem || rightItem.type !== "video") {
-      setTimelineNotice("Place another video clip after this one on the same track first.");
-      return;
-    }
-    const gap = Number(rightItem.timelineStart) - Number(selectedItem.timelineEnd);
-    if (gap <= 0.05) {
+    const gapSeconds = Number(right.timelineStart) - Number(left.timelineEnd);
+    if (gapSeconds <= 0.05) {
       setTimelineNotice("Create space between the clips before generating a bridge.");
       return;
     }
+    const base = gen.buildBasePayload();
     const job = await queueTimelineVideoJob({
+      ...base,
       mode: "video_bridge",
-      prompt: generationPrompt,
-      model: "ltx_2_3",
-      duration: Number(gap.toFixed(2)),
-      fps: activeTimeline.fps,
-      width: activeTimeline.width,
-      height: activeTimeline.height,
-      quality: "balanced",
-      sourceClipAssetId: selectedItem.assetId,
-      bridgeRightClipAssetId: rightItem.assetId,
-      loras: [],
+      duration: Number(gapSeconds.toFixed(2)),
+      sourceClipAssetId: left.assetId,
+      bridgeRightClipAssetId: right.assetId,
       advanced: {
-        resolution: `${activeTimeline.width}x${activeTimeline.height}`,
+        ...base.advanced,
         timelineAction: "bridge",
-        timelineContext: generationBaseContext("bridge", {
-          rightItemId: rightItem.id,
-          rightAssetId: rightItem.assetId,
-          leftTimestamp: Number(selectedItem.sourceOut) || sourceTimestampAtPlayhead(selectedItem, selectedItem.timelineEnd),
-          rightTimestamp: Number(rightItem.sourceIn) || 0,
-          timelineStart: Number(selectedItem.timelineEnd),
-          timelineEnd: Number(rightItem.timelineStart),
+        timelineContext: generationContext("bridge", left, {
+          rightItemId: right.id,
+          rightAssetId: right.assetId,
+          leftTimestamp: Number(left.sourceOut) || sourceTimestampAtPlayhead(left, left.timelineEnd),
+          rightTimestamp: Number(right.sourceIn) || 0,
+          timelineStart: Number(left.timelineEnd),
+          timelineEnd: Number(right.timelineStart),
         }),
       },
     });
@@ -441,362 +454,217 @@ export function EditorScreen() {
     }
   }
 
+  function noticeUnsupported(feature) {
+    setTimelineNotice(`${feature} isn't wired to a backend yet — tracked in the Video Editor audit (epic 12798).`);
+  }
+
+  // ---- timeline switching / creation ----
+  async function handleSelectTimeline(nextId) {
+    if (nextId === selectedTimelineId) {
+      return;
+    }
+    if (isActiveTimelineDirty?.()) {
+      const proceed = await appConfirm({
+        title: "Discard timeline edits?",
+        message: "You have unsaved timeline edits. Switch timelines and discard them?",
+        confirmLabel: "Discard & switch",
+        cancelLabel: "Keep editing",
+        tone: "danger",
+      });
+      if (!proceed) {
+        return;
+      }
+    }
+    setSelectedTimelineId(nextId);
+  }
+
+  async function handleNewTimeline() {
+    const count = timelines.length + 1;
+    await createTimeline({ name: `Timeline ${count}`, aspectRatio: "16:9", fps: 30 });
+  }
+
+  // ---- rail contextual header + actions ----
+  function buildContextActions() {
+    if (selectionKind === "clip" || selectionKind === "key") {
+      if (selectedItem?.type === "image") {
+        return [
+          { id: "animate", label: "Animate", primary: true, onClick: () => replaceSelectedItem() },
+          { id: "send-video", label: "Send to Video", onClick: () => sendAssetToVideo(selectedAsset, "image_to_video") },
+          { id: "variation", label: "Variation", onClick: () => replaceSelectedItem({ variation: true }) },
+          { id: "extract", label: "Extract frame", disabled: true, onClick: () => extractFrame() },
+        ];
+      }
+      return [
+        { id: "extend", label: "Extend clip", primary: true, onClick: extendSelectedClip },
+        { id: "regenerate", label: "Regenerate", onClick: () => replaceSelectedItem() },
+        { id: "extract", label: "Extract frame", onClick: extractFrame },
+        { id: "variation", label: "Variation", onClick: () => replaceSelectedItem({ variation: true }) },
+      ];
+    }
+    if (selectionKind === "gap") {
+      return [
+        { id: "bridge", label: "Generate bridge", primary: true, onClick: () => bridgeGap(selectedGap) },
+        { id: "fill", label: "Generate to fill", onClick: () => bridgeGap(selectedGap) },
+        { id: "ripple", label: "Ripple close gap", onClick: () => rippleCloseGap(selectedGap) },
+      ];
+    }
+    if (selectionKind === "audio") {
+      return [
+        { id: "music", label: "Regenerate music", primary: true, disabled: true, onClick: () => noticeUnsupported("Audio generation") },
+        { id: "match", label: "Match to cut", disabled: true, onClick: () => noticeUnsupported("Match to cut") },
+        { id: "vo", label: "Voiceover", disabled: true, onClick: () => noticeUnsupported("Voiceover") },
+        { id: "duck", label: "Ducking", disabled: true, onClick: () => noticeUnsupported("Ducking") },
+      ];
+    }
+    return [];
+  }
+
+  const contextActions = buildContextActions();
+  const primaryAction = contextActions.find((action) => action.primary && !action.disabled);
+
+  function railHeader() {
+    if (selectionKind === "gap" && selectedGap) {
+      const seconds = (Number(selectedGap.rightItem.timelineStart) - Number(selectedGap.leftItem.timelineEnd)).toFixed(1);
+      return { eyebrow: "GAP", title: `${seconds}s gap` };
+    }
+    if (selectionKind === "audio") {
+      return { eyebrow: "AUDIO", title: selectedItem?.displayName ?? "Audio clip" };
+    }
+    if (selectionKind === "key") {
+      return { eyebrow: "KEYFRAME", title: selectedItem?.displayName ?? "Key image" };
+    }
+    if (selectionKind === "marker" && selectedMarker) {
+      return { eyebrow: "MARKER", title: selectedMarker.label };
+    }
+    if (selectionKind === "clip" && selectedItem) {
+      const eyebrow = isSelectedAi ? "VIDEO · AI CLIP" : selectedItem.type === "image" ? "IMAGE CLIP" : "VIDEO CLIP";
+      return { eyebrow, title: selectedItem.displayName };
+    }
+    return { eyebrow: "NO SELECTION", title: activeTimeline?.name ?? "Timeline" };
+  }
+
+  function toggleMap(setter, key) {
+    if (!key) {
+      return;
+    }
+    setter((current) => ({ ...current, [key]: !current[key] }));
+  }
+
   if (!activeProject) {
     return (
-      <section className="page-frame">
+      <section className="ve-editor ve-editor-empty">
         <div className="empty-panel">Open a project before assembling a timeline.</div>
       </section>
     );
   }
 
+  if (!activeTimeline) {
+    return (
+      <section className="ve-editor ve-editor-empty">
+        <div className="empty-panel">
+          <p>Create a timeline to start editing.</p>
+          <button className="ve-generate" onClick={handleNewTimeline} type="button">
+            New timeline
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  const aspectClass = `ve-aspect-${activeTimeline.aspectRatio.replace(":", "-")}`;
+  const generateSummary = `${gen.duration}s · ${gen.resolution} · ${gen.fps}fps · queues to your GPU`;
+
   return (
-    <section className="page-frame editor-surface">
-      <WorkPanel
-        eyebrow={activeTimeline?.name ?? "Timelines"}
-        hint="Sequence clips on the timeline, scrub through the preview, and export when the cut feels right."
-        actions={
-          <>
-            <button className="secondary-action" disabled={!activeTimeline} onClick={() => saveTimeline(activeTimeline)} type="button">
-              Save
-            </button>
-            <button className="secondary-action" disabled={!history.length} onClick={undo} type="button">
-              Undo
-            </button>
-            <button className="secondary-action" disabled={!future.length} onClick={redo} type="button">
-              Redo
-            </button>
-          </>
-        }
-      >
-        <div className="editor-header">
-          <select onChange={(event) => handleSelectTimeline(event.target.value)} value={selectedTimelineId ?? ""}>
-            <option value="">Select timeline</option>
-            {timelines.map((timeline) => (
-              <option key={timeline.id} value={timeline.id}>
-                {timeline.name}
-              </option>
-            ))}
-          </select>
-        </div>
+    <section className="ve-editor">
+      <EditorToolbar
+        canRedo={future.length > 0}
+        canUndo={history.length > 0}
+        durationTimecode={formatTimecode(duration, activeTimeline.fps)}
+        exportDisabled={!activeTimeline.tracks.some((track) => track.items.length)}
+        onExport={() => exportTimeline(activeTimeline, { resolution: activeTimeline.height, fps: activeTimeline.fps })}
+        onNewTimeline={handleNewTimeline}
+        onRedo={redo}
+        onSave={() => saveTimeline(activeTimeline)}
+        onSelectTimeline={handleSelectTimeline}
+        onUndo={undo}
+        saveDisabled={!activeTimeline}
+        onZoomIn={() => setZoom((z) => Math.min(ZOOM_MAX, +(z + ZOOM_STEP).toFixed(2)))}
+        onZoomOut={() => setZoom((z) => Math.max(ZOOM_MIN, +(z - ZOOM_STEP).toFixed(2)))}
+        projectName={activeTimeline.name}
+        selectedTimelineId={selectedTimelineId}
+        subLabel={`timeline · ${activeTimeline.aspectRatio} · ${activeTimeline.fps}fps`}
+        timecode={formatTimecode(playheadSeconds, activeTimeline.fps)}
+        timelines={timelines}
+        zoomPct={`${Math.round(zoom * 100)}%`}
+      />
 
-        <form className="timeline-create" onSubmit={submitNewTimeline}>
-          <label>
-            Timeline
-            <input onChange={(event) => setNewTimelineName(event.target.value)} value={newTimelineName} />
-          </label>
-          <label>
-            Aspect
-            <select onChange={(event) => setNewAspectRatio(event.target.value)} value={newAspectRatio}>
-              {Object.entries(aspectOptions).map(([value, option]) => (
-                <option key={value} value={value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <button type="submit">New Timeline</button>
-        </form>
-      </WorkPanel>
+      <div className="ve-upper">
+        <MediaBin assets={assets} onAddToTrack={(asset) => addAssetToTrack(asset)} onPreview={(asset) => setPreviewAsset(asset, assets)} />
+        <ProgramMonitor
+          aspectClass={aspectClass}
+          clipLabel={selectedItem ? `${selectedItem.displayName}${isSelectedAi ? " · AI" : ""}` : null}
+          isAi={isSelectedAi}
+          isPlaying={isPlaying}
+          onEnded={() => setIsPlaying(false)}
+          onNext={() => stepClip(1)}
+          onPause={() => setIsPlaying(false)}
+          onPlay={() => setIsPlaying(true)}
+          onPrev={() => stepClip(-1)}
+          onTogglePlay={() => setIsPlaying((value) => !value)}
+          previewVideoRef={previewVideoRef}
+          resolutionLabel={`${activeTimeline.width} × ${activeTimeline.height}`}
+          selectedAsset={selectedAsset}
+        />
+        <GenerationRail
+          contextActions={contextActions}
+          gen={gen}
+          generateDisabled={!activeTimeline}
+          generateSummary={generateSummary}
+          header={railHeader()}
+          onGenerate={() => (primaryAction ? primaryAction.onClick() : setTimelineNotice("Select a clip or gap to generate."))}
+        />
+      </div>
 
-      {activeTimeline ? (
-        <div className="editor-layout">
-          <section className="editor-preview">
-            <div className={`preview-canvas aspect-${activeTimeline.aspectRatio.replace(":", "-")}`}>
-              {selectedAsset ? (
-                <AssetMedia
-                  asset={selectedAsset}
-                  controls={false}
-                  onEnded={() => setIsPlaying(false)}
-                  onPause={() => setIsPlaying(false)}
-                  onPlay={() => setIsPlaying(true)}
-                  ref={previewVideoRef}
-                />
-              ) : (
-                <span>Select a timeline item</span>
-              )}
-            </div>
-            <div className="playback-bar">
-              <button disabled={!assetCanRenderAsVideo(selectedAsset)} onClick={() => setIsPlaying((value) => !value)} type="button">
-                {isPlaying ? "Pause" : "Play"}
-              </button>
-              <span>{formatSeconds(Math.round(duration))}</span>
-              <span>{activeTimeline.aspectRatio}</span>
-              <span>{activeTimeline.fps} fps</span>
-            </div>
-          </section>
+      {timelineNotice ? <p className="ve-notice">{timelineNotice}</p> : null}
 
-          <aside className="editor-inspector">
-            {selectedItem ? (
-              <>
-                <div className="section-heading">
-                  <p className="eyebrow">Clip</p>
-                  <h2>{selectedItem.displayName}</h2>
-                </div>
-                <label>
-                  Track
-                  <select onChange={(event) => changeItemTrack(event.target.value)} value={selectedItem.trackId}>
-                    {activeTimeline.tracks.map((track) => (
-                      <option key={track.id} value={track.id}>
-                        {track.name}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-                <div className="control-grid compact-controls">
-                  <label>
-                    Start
-                    <input
-                      min="0"
-                      onChange={(event) => updateTimelineItem(selectedItem.id, { timelineStart: Number(event.target.value) })}
-                      step="0.1"
-                      type="number"
-                      value={selectedItem.timelineStart}
-                    />
-                  </label>
-                  <label>
-                    End
-                    <input
-                      min="0.1"
-                      onChange={(event) => updateTimelineItem(selectedItem.id, { timelineEnd: Number(event.target.value) })}
-                      step="0.1"
-                      type="number"
-                      value={selectedItem.timelineEnd}
-                    />
-                  </label>
-                  <label>
-                    Source In
-                    <input
-                      min="0"
-                      onChange={(event) => updateTimelineItem(selectedItem.id, { sourceIn: Number(event.target.value) })}
-                      step="0.1"
-                      type="number"
-                      value={selectedItem.sourceIn}
-                    />
-                  </label>
-                  <label>
-                    Source Out
-                    <input
-                      min="0.1"
-                      onChange={(event) => updateTimelineItem(selectedItem.id, { sourceOut: Number(event.target.value) })}
-                      step="0.1"
-                      type="number"
-                      value={selectedItem.sourceOut}
-                    />
-                  </label>
-                </div>
-                <label>
-                  Speed
-                  <select onChange={(event) => updateTimelineItem(selectedItem.id, { speed: Number(event.target.value) })} value={selectedItem.speed}>
-                    {speedPresets.map((speed) => (
-                      <option key={speed} value={speed}>
-                        {speed}x
-                      </option>
-                    ))}
-                    {!speedPresets.includes(Number(selectedItem.speed)) ? <option value={selectedItem.speed}>Custom {selectedItem.speed}x</option> : null}
-                  </select>
-                </label>
-                <label>
-                  Custom speed
-                  <input
-                    min="0.1"
-                    onChange={(event) => updateTimelineItem(selectedItem.id, { speed: Number(event.target.value) })}
-                    step="0.05"
-                    type="number"
-                    value={selectedItem.speed}
-                  />
-                </label>
-                <div className="generation-hook-panel">
-                  <label>
-                    Playhead
-                    <input
-                      max={selectedItem.timelineEnd}
-                      min={selectedItem.timelineStart}
-                      onChange={(event) => setPlayheadSeconds(Number(event.target.value))}
-                      step="0.1"
-                      type="number"
-                      value={playheadSeconds}
-                    />
-                  </label>
-                  <label className="prompt-field">
-                    Generation prompt
-                    <textarea onChange={(event) => setGenerationPrompt(event.target.value)} value={generationPrompt} />
-                  </label>
-                  <label>
-                    Extension duration
-                    <input
-                      max="15"
-                      min="1"
-                      onChange={(event) => setExtensionDuration(Number(event.target.value))}
-                      step="0.5"
-                      type="number"
-                      value={extensionDuration}
-                    />
-                  </label>
-                  <div className="hook-actions">
-                    <button disabled={selectedItem.type !== "video"} onClick={() => extractFrame("reuse")} type="button">
-                      Extract Frame
-                    </button>
-                    <button disabled={selectedItem.type === "video"} onClick={() => onSendImage(selectedAsset)} type="button">
-                      Send Image
-                    </button>
-                    <button onClick={() => onSendVideo(selectedAsset)} type="button">
-                      Send Video
-                    </button>
-                    <button disabled={selectedItem.type !== "video"} onClick={extendSelectedClip} type="button">
-                      Extend
-                    </button>
-                    <button onClick={replaceSelectedItem} type="button">
-                      Replace
-                    </button>
-                    <button disabled={selectedItem.type !== "video"} onClick={bridgeAfterSelectedClip} type="button">
-                      Bridge Gap
-                    </button>
-                  </div>
-                  <div className="version-list">
-                    <strong>{ensureItemVersionFields(selectedItem).versionAssetIds.length} versions</strong>
-                    {ensureItemVersionFields(selectedItem)
-                      .versionAssetIds.slice(-4)
-                      .map((assetId) => (
-                        <button
-                          className={assetId === selectedItem.assetId ? "active" : ""}
-                          key={assetId}
-                          onClick={() => updateTimelineItem(selectedItem.id, { assetId, currentVersionAssetId: assetId })}
-                          type="button"
-                        >
-                          {assetId === selectedItem.assetId ? "Current" : "Restore"} {assetId.slice(-6)}
-                        </button>
-                      ))}
-                  </div>
-                  {timelineNotice ? <p className="inline-warning">{timelineNotice}</p> : null}
-                </div>
-                <label>
-                  Transition in
-                  <select
-                    onChange={(event) =>
-                      updateTimelineItem(selectedItem.id, {
-                        transitionIn: { ...(selectedItem.transitionIn ?? {}), type: event.target.value },
-                      })
-                    }
-                    value={selectedItem.transitionIn?.type ?? "cut"}
-                  >
-                    {transitionOptions.map((transition) => (
-                      <option key={transition} value={transition}>
-                        {transition.replaceAll("_", " ")}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-                <label>
-                  Transition out
-                  <select
-                    onChange={(event) =>
-                      updateTimelineItem(selectedItem.id, {
-                        transitionOut: { ...(selectedItem.transitionOut ?? {}), type: event.target.value },
-                      })
-                    }
-                    value={selectedItem.transitionOut?.type ?? "cut"}
-                  >
-                    {transitionOptions.map((transition) => (
-                      <option key={transition} value={transition}>
-                        {transition.replaceAll("_", " ")}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-                <button className="danger-action" onClick={removeSelectedItem} type="button">
-                  Delete Clip
-                </button>
-              </>
-            ) : (
-              <div className="empty-panel compact-panel">No clip selected</div>
-            )}
-          </aside>
+      <StoryboardStrip
+        assetsById={assetsById}
+        clips={mainClips}
+        fps={activeTimeline.fps}
+        onAddKey={() => noticeUnsupported("Storyboard key images")}
+        onSelectKey={selectStoryboardKey}
+        selectedItemId={selectedItemId}
+      />
 
-          <section className="timeline-panel">
-            <div className="timeline-ruler">
-              <span>0s</span>
-              <span>{formatSeconds(Math.ceil(timelineScale / 2))}</span>
-              <span>{formatSeconds(Math.ceil(timelineScale))}</span>
-            </div>
-            <div className="timeline-tracks">
-              {activeTimeline.tracks.map((track) => (
-                <div className="timeline-track" key={track.id}>
-                  <strong>{track.name}</strong>
-                  <div className="track-lane">
-                    {trackItems(track).map((item) => (
-                      <button
-                        className={selectedItemId === item.id ? "timeline-item active" : "timeline-item"}
-                        key={item.id}
-                        onClick={() => setSelectedItemId(item.id)}
-                        style={{
-                          left: `${(item.timelineStart / timelineScale) * 100}%`,
-                          width: `${Math.max(4, (itemDuration(item) / timelineScale) * 100)}%`,
-                        }}
-                        type="button"
-                      >
-                        <span>{item.displayName}</span>
-                        <small>{item.speed}x</small>
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              ))}
-            </div>
-          </section>
-
-          <aside className="asset-bin">
-            <div className="bin-controls">
-              <label>
-                Still duration
-                <input min="0.5" onChange={(event) => setAddDuration(Number(event.target.value))} step="0.5" type="number" value={addDuration} />
-              </label>
-            </div>
-            <div className="asset-bin-list">
-              {[...mainAssets, ...stillAssets].slice(0, 18).map((asset) => (
-                <article className="bin-asset" key={asset.id}>
-                  <button onClick={() => onPreview(asset, [...mainAssets, ...stillAssets].slice(0, 18))} type="button">
-                    <AssetMedia asset={asset} />
-                  </button>
-                  <strong>{asset.displayName}</strong>
-                  <div className="bin-actions">
-                    <button onClick={() => addAssetToTrack(asset, "track_main")} type="button">
-                      Main
-                    </button>
-                    <button onClick={() => addAssetToTrack(asset, "track_overlay")} type="button">
-                      Overlay
-                    </button>
-                  </div>
-                </article>
-              ))}
-              {assets.length === 0 ? <div className="empty-panel compact-panel">No media assets</div> : null}
-            </div>
-          </aside>
-
-          <form
-            className="export-strip"
-            onSubmit={(event) => {
-              event.preventDefault();
-              exportTimeline(activeTimeline, { resolution: Number(exportResolution), fps: activeTimeline.fps });
-            }}
-          >
-            <label>
-              MP4 height
-              <select onChange={(event) => setExportResolution(Number(event.target.value))} value={exportResolution}>
-                {[640, 720, 1024, 1280].map((resolution) => (
-                  <option key={resolution} value={resolution}>
-                    {resolution}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <button className="primary-action" disabled={!activeTimeline.tracks.some((track) => track.items.length)} type="submit">
-              Export MP4
-            </button>
-          </form>
-        </div>
-      ) : (
-        <div className="empty-panel">Create a timeline to start editing.</div>
-      )}
+      <Timeline
+        assetsById={assetsById}
+        duration={duration}
+        markers={markers}
+        onAddAudioTrack={addAudioTrack}
+        onScrub={(seconds) => {
+          setIsPlaying(false);
+          setPlayheadSeconds(seconds);
+        }}
+        onSelectGap={selectGap}
+        onSelectItem={selectItem}
+        onSelectKey={(item) => selectKeyframe(item)}
+        onSelectMarker={selectMarker}
+        onToggleMute={(id) => toggleMap(setTrackMuted, id)}
+        onToggleSnap={() => setSnap((value) => !value)}
+        onToggleSolo={(id) => toggleMap(setTrackSoloed, id)}
+        onToggleVisible={(id) => toggleMap(setTrackVisible, id)}
+        onZoomIn={() => setZoom((z) => Math.min(ZOOM_MAX, +(z + ZOOM_STEP).toFixed(2)))}
+        onZoomOut={() => setZoom((z) => Math.max(ZOOM_MIN, +(z - ZOOM_STEP).toFixed(2)))}
+        playheadSeconds={playheadSeconds}
+        selectedGapId={selectedGap?.id}
+        selectedItemId={selectedItemId}
+        snap={snap}
+        timeline={activeTimeline}
+        trackMuted={trackMuted}
+        trackSoloed={trackSoloed}
+        trackVisible={trackVisible}
+        zoom={zoom}
+      />
     </section>
   );
 }

--- a/apps/web/src/screens/EditorScreen.test.jsx
+++ b/apps/web/src/screens/EditorScreen.test.jsx
@@ -79,10 +79,10 @@ function render(overrides = {}) {
   return { setSelectedTimelineId };
 }
 
-// The timeline dropdown is the first <select> in the editor header. Firing a native change
+// The timeline dropdown lives in the redesigned toolbar (design 2a). Firing a native change
 // event with a new value routes through the guarded onChange.
 function selectTimeline(nextId) {
-  const select = container.querySelector(".editor-header select");
+  const select = container.querySelector(".ve-timeline-select");
   act(() => {
     select.value = nextId;
     select.dispatchEvent(new Event("change", { bubbles: true }));
@@ -215,9 +215,9 @@ describe("EditorScreen preview playback keep-alive gating (sc-11961)", () => {
 
   // Select the timeline clip (renders the preview <video>) then click Play.
   function selectClipAndPressPlay() {
-    const clip = container.querySelector(".timeline-item");
+    const clip = container.querySelector(".ve-clip");
     act(() => clip.dispatchEvent(new window.MouseEvent("click", { bubbles: true })));
-    const playButton = container.querySelector(".playback-bar button");
+    const playButton = container.querySelector(".ve-play");
     act(() => playButton.dispatchEvent(new window.MouseEvent("click", { bubbles: true })));
   }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -98,6 +98,14 @@
   --accent-soft: oklch(0.94 0.04 var(--accent-h));
   --accent-fg: #ffffff;
 
+  /* AI accent (Video Editor redesign, epic 12798). A fixed violet that distinguishes
+     *generative* affordances from the swappable teal primary — harmonized to the same
+     L/C family. Intentionally hue-locked (300), NOT driven by --accent-h. */
+  --ai: oklch(0.55 0.16 300);
+  --ai-strong: oklch(0.47 0.18 300);
+  --ai-soft: oklch(0.95 0.04 300);
+  --ai-fg: #ffffff;
+
   /* Brand palette — fixed brand colors, theme-independent. */
   --ink: #0f1622;
   --mist: #b9babb;
@@ -143,6 +151,12 @@
   --accent-strong: oklch(0.82 0.12 var(--accent-h));
   --accent-soft: oklch(0.3 0.06 var(--accent-h));
   --accent-fg: oklch(0.16 0.012 240);
+
+  /* AI accent on dark (epic 12798). Brighter violet for the dark NLE surface. */
+  --ai: oklch(0.7 0.15 300);
+  --ai-strong: oklch(0.78 0.16 300);
+  --ai-soft: oklch(0.32 0.08 300);
+  --ai-fg: oklch(0.16 0.012 240);
 
   /* On dark: mark ground → mist (full square reads), seam → ink, wordmark → paper. */
   --logo-ground: var(--mist);
@@ -8759,6 +8773,1261 @@ details[open] > summary.lora-scope-group-heading::before,
   min-height: 30px;
   padding: 5px 10px;
   font-size: 12px;
+}
+
+/* ═══════════════ Video Editor redesign — design 2a (epic 12798) ═══════════════
+   A classic dark NLE recreated with the app's existing tokens. Follows the global
+   theme; the `--ai` violet (added to :root/[data-theme=dark]) marks generative
+   affordances. Full-bleed inside .workspace (mirrors the Image Editor escape hatch). */
+
+.ve-editor {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-ui);
+}
+.workspace > section.ve-editor {
+  flex: 1 1 auto;
+  min-height: 0;
+  margin: 0;
+}
+.workspace > .keep-alive-pane > section.ve-editor {
+  flex: 1 1 auto;
+  min-height: 0;
+  margin: 0;
+}
+.ve-editor-empty {
+  align-items: center;
+  justify-content: center;
+  padding: 60px 24px;
+}
+.ve-editor-empty .empty-panel {
+  display: grid;
+  gap: 14px;
+  justify-items: center;
+}
+.ve-notice {
+  margin: 0;
+  padding: 8px 16px;
+  font-size: 12px;
+  color: var(--ai);
+  background: color-mix(in oklch, var(--ai) 12%, var(--bg-2));
+  border-bottom: 1px solid var(--border);
+}
+
+/* Shared small controls */
+.ve-select,
+.ve-input,
+.ve-textarea {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  padding: 8px 10px;
+  appearance: none;
+}
+.ve-select {
+  height: 36px;
+  cursor: pointer;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: 26px;
+}
+.ve-input {
+  height: 36px;
+}
+.ve-textarea {
+  min-height: 46px;
+  resize: vertical;
+}
+.ve-select:focus,
+.ve-input:focus,
+.ve-textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--shadow-glow);
+}
+.ve-icon-btn {
+  flex: 0 0 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.ve-icon-btn:hover {
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+.ve-ghost-btn {
+  height: 30px;
+  min-width: 30px;
+  display: grid;
+  place-items: center;
+  padding: 0 7px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.ve-ghost-btn:hover:not(:disabled) {
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+.ve-ghost-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+/* On/off switch (Snap, Lightning) */
+.ve-switch {
+  width: 30px;
+  height: 17px;
+  border-radius: var(--r-pill);
+  background: var(--border-strong);
+  position: relative;
+  flex: 0 0 auto;
+  transition: background var(--t-fast);
+}
+.ve-switch.on {
+  background: var(--accent);
+}
+.ve-switch-knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform var(--t-fast);
+}
+.ve-switch.on .ve-switch-knob {
+  transform: translateX(13px);
+}
+
+/* ── Toolbar ── */
+.ve-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  height: 52px;
+  flex: 0 0 auto;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-2);
+}
+.ve-brand {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+}
+.ve-mark {
+  width: 24px;
+  height: 24px;
+  border-radius: var(--r-xs);
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, var(--accent), var(--ai));
+  color: var(--accent-fg);
+}
+.ve-brand-text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.15;
+  min-width: 0;
+}
+.ve-brand-text strong {
+  font-size: 13.5px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ve-brand-sub {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-faint);
+}
+.ve-toolbar-div {
+  width: 1px;
+  height: 26px;
+  background: var(--border);
+  flex: 0 0 auto;
+}
+.ve-timeline-switch {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.ve-timeline-select {
+  height: 32px;
+  width: auto;
+  min-width: 140px;
+  max-width: 200px;
+  font-size: 12px;
+}
+.ve-btn-group {
+  display: flex;
+  gap: 4px;
+}
+.ve-timecode {
+  margin: 0 auto;
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+  font-family: var(--font-mono);
+}
+.ve-tc-now {
+  font-size: 19px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+.ve-tc-total {
+  font-size: 12px;
+  color: var(--text-faint);
+}
+.ve-toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.ve-zoom-pct {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  width: 40px;
+  text-align: center;
+}
+.ve-export {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  height: 34px;
+  padding: 0 15px;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: var(--accent);
+  color: var(--accent-fg);
+  font-weight: 600;
+  font-size: 13px;
+  cursor: pointer;
+}
+.ve-export:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* ── Upper region ── */
+.ve-upper {
+  display: grid;
+  grid-template-columns: 168px minmax(0, 1fr) 350px;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* Media bin */
+.ve-bin {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border-right: 1px solid var(--border);
+  background: var(--bg-2);
+}
+.ve-bin-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 9px 10px 0;
+}
+.ve-bin-tab {
+  font-size: 12px;
+  font-weight: 500;
+  padding: 6px 10px;
+  border: 0;
+  border-radius: var(--r-xs) var(--r-xs) 0 0;
+  background: transparent;
+  color: var(--text-faint);
+  cursor: pointer;
+}
+.ve-bin-tab.active {
+  font-weight: 600;
+  background: var(--surface);
+  color: var(--text);
+}
+.ve-bin-grid {
+  padding: 10px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  overflow: auto;
+  align-content: start;
+}
+.ve-bin-empty {
+  grid-column: 1 / -1;
+  font-size: 11px;
+  color: var(--text-faint);
+  text-align: center;
+  padding: 20px 0;
+}
+.ve-bin-item {
+  position: relative;
+  aspect-ratio: 16 / 10;
+  border: 0;
+  border-radius: var(--r-sm);
+  overflow: hidden;
+  padding: 0;
+  cursor: pointer;
+  background: var(--surface-2);
+}
+.ve-bin-thumb,
+.ve-bin-item .ve-bin-thumb img,
+.ve-bin-item .ve-bin-thumb video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.ve-ai-badge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 16px;
+  height: 16px;
+  border-radius: 5px;
+  background: var(--ai);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  z-index: 2;
+}
+.ve-bin-name {
+  position: absolute;
+  left: 5px;
+  right: 5px;
+  bottom: 4px;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: #fff;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.7);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+}
+
+/* Program monitor */
+.ve-monitor {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  background: radial-gradient(120% 90% at 50% 0%, color-mix(in oklch, var(--accent) 7%, var(--bg)), var(--bg));
+}
+.ve-monitor-stage {
+  flex: 1 1 auto;
+  display: grid;
+  place-items: center;
+  padding: 18px;
+  min-height: 0;
+}
+.ve-program {
+  position: relative;
+  width: min(100%, 640px);
+  max-height: 100%;
+  border-radius: var(--r-md);
+  overflow: hidden;
+  background: linear-gradient(135deg, oklch(0.4 0.09 300), oklch(0.32 0.08 300));
+  box-shadow: var(--shadow-lg);
+}
+.ve-program.ve-aspect-16-9 {
+  aspect-ratio: 16 / 9;
+}
+.ve-program.ve-aspect-9-16 {
+  aspect-ratio: 9 / 16;
+  width: min(100%, 300px);
+}
+.ve-program.ve-aspect-1-1 {
+  aspect-ratio: 1;
+  width: min(100%, 480px);
+}
+.ve-program-media,
+.ve-program-media img,
+.ve-program-media video {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+.ve-program-empty {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 13px;
+}
+.ve-program-label {
+  position: absolute;
+  left: 14px;
+  top: 12px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.85);
+  background: rgba(0, 0, 0, 0.35);
+  padding: 3px 8px;
+  border-radius: var(--r-xs);
+  z-index: 2;
+}
+.ve-program-ai {
+  position: absolute;
+  right: 14px;
+  top: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-weight: 600;
+  font-size: 11px;
+  color: #fff;
+  background: var(--ai);
+  padding: 4px 9px;
+  border-radius: var(--r-pill);
+  z-index: 2;
+}
+.ve-program-res {
+  position: absolute;
+  left: 50%;
+  bottom: 12px;
+  transform: translateX(-50%);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.75);
+  z-index: 2;
+}
+.ve-transport {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  justify-content: center;
+  padding: 8px 0 14px;
+}
+.ve-transport-btn {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--surface);
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.ve-transport-btn:hover {
+  color: var(--text);
+}
+.ve-play {
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  border: 0;
+  background: var(--accent);
+  color: var(--accent-fg);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  box-shadow: 0 4px 16px color-mix(in oklch, var(--accent) 45%, transparent);
+}
+.ve-play:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* ── Generation rail ── */
+.ve-rail {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border-left: 1px solid var(--border);
+  background: var(--bg-2);
+}
+.ve-rail-head {
+  padding: 13px 15px 11px;
+  border-bottom: 1px solid var(--border);
+  flex: 0 0 auto;
+}
+.ve-rail-eyebrow {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ai);
+}
+.ve-rail-title {
+  margin: 2px 0 9px;
+  font-size: 15.5px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ve-ctx-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 7px;
+}
+.ve-ctx-btn {
+  height: 34px;
+  padding: 0 10px;
+  border: 1px solid color-mix(in oklch, var(--ai) 45%, var(--border));
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--ai);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ve-ctx-btn.primary {
+  background: var(--ai);
+  border-color: var(--ai);
+  color: #fff;
+}
+.ve-ctx-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.ve-rail-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 14px 15px;
+  display: grid;
+  gap: 15px;
+  align-content: start;
+}
+.ve-section {
+  display: grid;
+  gap: 9px;
+}
+.ve-section-hd {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+}
+.ve-field {
+  display: grid;
+  gap: 5px;
+}
+.ve-field-label {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.ve-seg {
+  display: flex;
+  gap: 6px;
+}
+.ve-seg-btn {
+  flex: 1;
+  height: 32px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.ve-seg-btn.active {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent-strong);
+}
+[data-theme="dark"] .ve-seg-btn.active {
+  color: var(--accent);
+}
+.ve-preset-row {
+  display: flex;
+  gap: 7px;
+}
+.ve-save-form {
+  display: flex;
+  gap: 7px;
+}
+.ve-mini-btn {
+  flex: 0 0 auto;
+  height: 36px;
+  padding: 0 14px;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: var(--accent);
+  color: var(--accent-fg);
+  font-weight: 600;
+  font-size: 12px;
+  cursor: pointer;
+}
+.ve-mini-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.ve-hint {
+  margin: 0;
+  font-size: 11px;
+  color: var(--text-faint);
+}
+.ve-output-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 9px;
+}
+.ve-chip-row {
+  display: flex;
+  gap: 6px;
+}
+.ve-chip {
+  flex: 1;
+  height: 30px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.ve-chip.active {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent-strong);
+}
+[data-theme="dark"] .ve-chip.active {
+  color: var(--accent);
+}
+.ve-lora-section .lora-picker {
+  display: grid;
+  gap: 8px;
+}
+.ve-adv {
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
+}
+.ve-adv-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  color: var(--text);
+}
+.ve-adv-chevron {
+  font-size: 13px;
+  color: var(--text-faint);
+}
+.ve-adv-body {
+  display: grid;
+  gap: 11px;
+  margin-top: 11px;
+}
+.ve-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 11px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  cursor: pointer;
+}
+.ve-toggle-text {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+}
+.ve-toggle-text strong {
+  font-size: 12px;
+}
+.ve-toggle-text small {
+  font-size: 10.5px;
+  color: var(--text-faint);
+}
+.ve-rail-foot {
+  flex: 0 0 auto;
+  padding: 12px 15px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-2);
+}
+.ve-generate {
+  width: 100%;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  border: 0;
+  border-radius: var(--r-md);
+  background: linear-gradient(135deg, var(--ai), color-mix(in oklch, var(--ai) 60%, var(--accent)));
+  color: #fff;
+  font-weight: 700;
+  font-size: 14px;
+  cursor: pointer;
+  box-shadow: 0 6px 18px color-mix(in oklch, var(--ai) 40%, transparent);
+}
+.ve-generate:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.ve-gen-summary {
+  margin: 8px 0 0;
+  text-align: center;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-faint);
+}
+
+/* ── Storyboard strip ── */
+.ve-storyboard {
+  flex: 0 0 auto;
+  padding: 12px 16px 13px;
+  border-top: 1px solid var(--border);
+  background: radial-gradient(90% 130% at 30% 0%, color-mix(in oklch, var(--ai) 7%, var(--bg-2)), var(--bg-2));
+}
+.ve-storyboard-hd {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.ve-ai-icon {
+  color: var(--ai);
+}
+.ve-storyboard-hd strong {
+  font-size: 12.5px;
+}
+.ve-storyboard-hint {
+  font-size: 11px;
+  color: var(--text-faint);
+}
+.ve-storyboard-legend {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-faint);
+}
+.ve-legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+}
+.ve-dot-accent {
+  background: var(--accent);
+}
+.ve-dot-ai {
+  background: var(--ai);
+  margin-left: 6px;
+}
+.ve-storyboard-row {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  overflow-x: auto;
+  padding-bottom: 2px;
+}
+.ve-conn {
+  display: flex;
+  align-items: center;
+  padding: 0 2px;
+  flex: 0 0 auto;
+}
+.ve-conn-pill {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  padding: 3px 8px;
+  border-radius: var(--r-pill);
+  white-space: nowrap;
+}
+.ve-conn-pill.generated {
+  background: var(--accent);
+  color: var(--accent-fg);
+}
+.ve-conn-pill.pending {
+  background: color-mix(in oklch, var(--ai) 18%, transparent);
+  color: var(--ai);
+  border: 1px dashed color-mix(in oklch, var(--ai) 55%, transparent);
+}
+.ve-key {
+  position: relative;
+  flex: 0 0 auto;
+  width: 132px;
+  height: 96px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  overflow: hidden;
+  cursor: pointer;
+  padding: 0;
+  background: linear-gradient(135deg, oklch(0.5 0.11 var(--key-hue, 260)), oklch(0.36 0.09 var(--key-hue, 260)));
+}
+.ve-key.selected {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--bg-2), 0 0 0 3px var(--accent);
+}
+.ve-key.ai {
+  border-color: color-mix(in oklch, var(--ai) 60%, var(--border));
+}
+.ve-key-media,
+.ve-key-media img,
+.ve-key-media video {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.ve-key-tc {
+  position: absolute;
+  top: 6px;
+  left: 7px;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.4);
+  padding: 2px 6px;
+  border-radius: 5px;
+  z-index: 2;
+}
+.ve-key-label {
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  bottom: 7px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #fff;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.7);
+  text-align: left;
+  z-index: 2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ve-key-add {
+  flex: 0 0 80px;
+  align-self: center;
+  height: 88px;
+  margin-left: 6px;
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--r-md);
+  background: transparent;
+  color: var(--text-faint);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+}
+
+/* ── Timeline ── */
+.ve-timeline {
+  display: flex;
+  flex-direction: column;
+  flex: 0 0 auto;
+  border-top: 1px solid var(--border);
+  background: var(--bg-2);
+}
+.ve-timeline-hd {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  height: 38px;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--border);
+}
+.ve-timeline-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  letter-spacing: 0.02em;
+}
+.ve-timeline-legend {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-faint);
+}
+.ve-timeline-legend .ve-legend-dot {
+  width: 7px;
+  height: 7px;
+}
+.ve-timeline-hd-right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+.ve-snap {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 11.5px;
+  cursor: pointer;
+}
+.ve-timeline-body {
+  display: flex;
+  min-height: 0;
+}
+.ve-track-heads {
+  flex: 0 0 148px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px;
+  border-right: 1px solid var(--border);
+  background: var(--bg);
+}
+.ve-ruler-spacer {
+  height: 30px;
+}
+.ve-track-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+}
+.ve-head-v2 {
+  height: 56px;
+}
+.ve-head-v1 {
+  height: 64px;
+}
+.ve-head-audio {
+  height: 46px;
+}
+.ve-head-name {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.ve-head-name strong {
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.ve-head-sub {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  color: var(--text-faint);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ve-track-btn {
+  width: 24px;
+  height: 24px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: var(--r-xs);
+  background: var(--surface-2);
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.ve-track-btn.off {
+  color: var(--text-faint);
+  opacity: 0.5;
+}
+.ve-track-mschips {
+  display: flex;
+  gap: 3px;
+}
+.ve-track-chip {
+  width: 22px;
+  height: 22px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: var(--r-xs);
+  background: var(--surface-2);
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.ve-track-chip.on {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent-strong);
+}
+.ve-add-audio {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  height: 28px;
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--text-faint);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.ve-lanes-scroll {
+  flex: 1 1 auto;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 8px 8px 12px;
+}
+.ve-lanes {
+  position: relative;
+}
+.ve-ruler {
+  position: relative;
+  height: 30px;
+  cursor: ew-resize;
+  user-select: none;
+  border-bottom: 1px solid var(--border);
+}
+.ve-tick {
+  position: absolute;
+  top: 50%;
+  bottom: 0;
+  width: 1px;
+  background: color-mix(in oklch, var(--text-faint) 30%, transparent);
+}
+.ve-tick.major {
+  top: 0;
+  background: color-mix(in oklch, var(--text-faint) 55%, transparent);
+}
+.ve-tick-label {
+  position: absolute;
+  left: 4px;
+  top: 2px;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  color: var(--text-faint);
+  white-space: nowrap;
+}
+.ve-marker {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 0;
+  z-index: 5;
+  cursor: pointer;
+}
+.ve-marker-flag {
+  position: absolute;
+  top: 3px;
+  left: 0;
+  font-size: 9.5px;
+  font-weight: 600;
+  color: var(--accent-fg);
+  background: var(--warm);
+  padding: 1px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+.ve-lane {
+  position: relative;
+  margin-top: 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--bg-2);
+  overflow: hidden;
+}
+.ve-lane-v2 {
+  height: 56px;
+}
+.ve-lane-v1 {
+  height: 64px;
+}
+.ve-lane-audio {
+  height: 46px;
+}
+.ve-clip {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 7px;
+  padding: 6px 9px;
+  display: flex;
+  align-items: flex-end;
+  overflow: hidden;
+  cursor: pointer;
+  background: linear-gradient(135deg, oklch(0.55 0.12 var(--clip-hue, 200)), oklch(0.42 0.1 var(--clip-hue, 200)));
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+.ve-clip.selected {
+  border: 1.5px solid var(--accent);
+  box-shadow: 0 0 0 2px var(--bg-2), 0 0 0 3px var(--accent);
+}
+.ve-clip.ai {
+  outline: 1.5px solid var(--ai);
+  outline-offset: -1.5px;
+}
+.ve-clip-ai {
+  position: absolute;
+  top: 4px;
+  right: 5px;
+  width: 15px;
+  height: 15px;
+  border-radius: 4px;
+  background: var(--ai);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  z-index: 2;
+}
+.ve-keyframe {
+  position: absolute;
+  top: 50%;
+  width: 9px;
+  height: 9px;
+  background: var(--ai);
+  border: 1px solid #fff;
+  transform: translate(-50%, -50%) rotate(45deg);
+  z-index: 3;
+  cursor: pointer;
+}
+.ve-clip-name {
+  position: relative;
+  z-index: 1;
+  font-size: 11px;
+  font-weight: 600;
+  color: #fff;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ve-gap {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  border: 1px dashed color-mix(in oklch, var(--ai) 55%, transparent);
+  border-radius: 7px;
+  background: repeating-linear-gradient(
+    45deg,
+    color-mix(in oklch, var(--ai) 10%, transparent) 0 6px,
+    transparent 6px 12px
+  );
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+}
+.ve-gap.selected {
+  border-color: var(--ai);
+  box-shadow: 0 0 0 2px color-mix(in oklch, var(--ai) 40%, transparent);
+}
+.ve-gap-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--ai);
+}
+.ve-transition {
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: var(--accent-fg);
+  display: grid;
+  place-items: center;
+  z-index: 4;
+}
+.ve-audio-clip {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  padding: 4px 8px;
+  display: flex;
+  align-items: flex-end;
+  overflow: hidden;
+  cursor: pointer;
+  background: linear-gradient(135deg, oklch(0.5 0.1 var(--clip-hue, 200)), oklch(0.4 0.08 var(--clip-hue, 200)));
+}
+.ve-audio-clip.ai {
+  background: linear-gradient(135deg, oklch(0.5 0.14 300), oklch(0.4 0.12 300));
+}
+.ve-audio-clip.selected {
+  border: 1.5px solid var(--accent);
+  box-shadow: 0 0 0 2px var(--bg-2), 0 0 0 3px var(--accent);
+}
+.ve-wave {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0.85;
+}
+.ve-wave path {
+  fill: rgba(255, 255, 255, 0.55);
+}
+.ve-playhead {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--accent);
+  z-index: 20;
+  pointer-events: none;
+}
+.ve-playhead-handle {
+  position: absolute;
+  top: -1px;
+  left: -6px;
+  width: 14px;
+  height: 12px;
+  border-radius: 3px 3px 6px 6px;
+  background: var(--accent);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+/* Editor responsive: collapse the rail under a narrow viewport */
+@media (max-width: 1100px) {
+  .ve-upper {
+    grid-template-columns: 148px minmax(0, 1fr) 300px;
+  }
 }
 
 /* ---------- Asset tray, picker modal ---------- */


### PR DESCRIPTION
Recreates the delivered **design 2a ("Unified")** Video Editor from `design/Video editor redesign project.zip` as a React screen in `apps/web`, replacing the cramped numeric-grid editor with a classic dark NLE: media bin / program monitor / **full Video-Studio generation rail** across the top, a **storyboard strip directly above** a multi-track timeline (V2/V1 + audio lanes, ruler, playhead, markers, waveforms). Epic [sc-12798](https://app.shortcut.com/trefry/epic/12798).

## What's here
- **New** `apps/web/src/components/editor/`: `EditorToolbar`, `MediaBin` (violet AI sparkle badge), `ProgramMonitor` (reuses the existing keep-alive playback effect), `GenerationRail`, `StoryboardStrip`, `Timeline`, plus `editorUtils.js` (geometry/provenance/waveform helpers) and `useEditorGeneration.js`.
- **Rewrote** `screens/EditorScreen.jsx` to compose them; owns selection (clip/gap/audio/key/marker), playhead + rAF transport, zoom/snap, per-track visibility/mute/solo.
- **Reuses the studio machinery** (`useGenerationStudio`, `LoraPickerSection`, `samplerOptions`/`quantTier` helpers, `serializeLora`, `loadStudioSettings`) so editor generation is identical to Video Studio; persists under a separate `editor-video` scope. The 4 AI actions (extend/replace/bridge/extract) now carry the rail's live model/quality/LoRAs/advanced instead of hardcoded `ltx_2_3`/`balanced`.
- **Tokens/CSS**: added the fixed violet `--ai` token (light+dark) + a `ve-*` block; editor is full-bleed and follows the global theme. Added `formatTimecode()` (MM:SS:FF).
- **Preserved** every prior capability (undo/redo/history, delete, shortcuts, timeline picker/create, manual Save, the sc-11967/sc-12018 dirty-switch guard, sc-11961 keep-alive gating).

Commits map to the epic phases: foundations (tokens/styles/timecode) → components/hook → screen rewrite + test-selector updates.

## Design ⇄ reality reconciliations (followed the 2a *layout*, real control *data*)
- Model list from the live `videoModels` catalog (the README's ids were stale); resolution/fps/duration from `selectedModel.limits`; "Motion %" is the real `motion` preset string; quant chips are real tier values (MLX-lane-gated); reused `LoraPickerSection` over pixel-matching the mock's LoRA rows.

## Backend gaps — built as honest UI, filed for the audit (Backlog under sc-12798)
The design shows things with no backend today. Headline: **export renders only the main video track** (`media_jobs.rs::main_track_items`) — overlay (V2) and all audio are ignored. Also: only one audio track exists, no waveform data, no audio generation, mute/solo/visibility unenforced, no timeline `markers`/item `keyframes`. Audio actions render disabled with a notice; markers render from local state only.
Stories: sc-12807 (audio+export mixing), sc-12808 (waveforms), sc-12809 (mute/solo/visibility), sc-12810 (audio generation), sc-12811 (overlay export), sc-12812 (markers), sc-12813 (storyboard keyframes / generate-across-keys).

## Verification
- `eslint src` 0 errors, `vite build` clean, **1864/1864 web tests pass** (re-verified after merging `main`).
- Browser-verified in **light + dark** via a temporary mock-context harness (API was offline; harness removed): full editor renders with no console errors; selecting the AI clip flips the rail to *VIDEO · AI CLIP* (Extend/Regenerate/Extract/Variation), the monitor shows the AI pill, the playhead jumps to the clip, and the storyboard syncs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
