### PR TITLE
chore(worker): run tier_key_from_resolved_dir test on the candle lane (sc-12829)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -7829,26 +7829,6 @@ mod quant_tier_reconcile_tests {
         assert_eq!(tier_quant_from_resolved_dir(root), None);
     }
 
-    /// sc-12090: the tier-NAME reader the candle VRAM gate uses to budget/name the on-disk tier. Same
-    /// basename mapping as [`tier_quant_from_resolved_dir`] (which now delegates to it), so a q4-only
-    /// install is gated at `q4`, never the manifest's `q8` default.
-    #[test]
-    fn tier_key_from_resolved_dir_reads_the_on_disk_tier() {
-        let root = std::path::Path::new("/models/krea-2-turbo-mlx");
-        assert_eq!(tier_key_from_resolved_dir(&root.join("q4")), Some("q4"));
-        assert_eq!(tier_key_from_resolved_dir(&root.join("q8")), Some("q8"));
-        assert_eq!(tier_key_from_resolved_dir(&root.join("bf16")), Some("bf16"));
-        // Boogu `<variant>-<tier>` suffix + the bare `<variant>` packed Q8 default.
-        assert_eq!(tier_key_from_resolved_dir(&root.join("base-q4")), Some("q4"));
-        assert_eq!(
-            tier_key_from_resolved_dir(&root.join("turbo-bf16")),
-            Some("bf16")
-        );
-        assert_eq!(tier_key_from_resolved_dir(&root.join("edit")), Some("q8"));
-        // Unrecognized basename (repo root / modelPath) → None; the gate keeps its manifest key.
-        assert_eq!(tier_key_from_resolved_dir(root), None);
-    }
-
     /// The end-to-end reconcile is macOS-only (the MLX generate path). When the resolved tier matches
     /// the request it's a pass-through; when it differs it records the tier that ran, and the
     /// dense-TE guard keeps the load quant `None` while still correcting the recorded bits.
@@ -8089,6 +8069,32 @@ mod capability_downtier_tests {
             gate_tier_key(false, convrot_base, &advanced, &entry, false),
             "bf16"
         );
+    }
+
+    /// sc-12090 / sc-12829: the basename → tier-NAME reader the candle VRAM gate keys off —
+    /// `generate_candle_stream` → `gate_tier_key` fallback and the sc-12090 disk-probe path
+    /// ([`resolve_tier_dir`] / `installed_tier_keys`) both resolve the on-disk tier through
+    /// [`tier_key_from_resolved_dir`]. That fn is `any(macos, candle)`, so its coverage lives HERE (this
+    /// cross-lane module), NOT in the `#[cfg(target_os = "macos")]` `quant_tier_reconcile_tests` where it
+    /// would compile out on the candle lane — leaving the exact basename→tier mapping the gate depends on
+    /// unexercised on `candle-worker`. A regression (e.g. a new Boogu `<variant>-<tier>` shape) now goes
+    /// RED on both lanes, not just the Mac runner. (`gate_tier_key`/`installed_tier_keys` are candle-only,
+    /// so they're named as plain code — only the cross-lane fns exist on both of this module's lanes.)
+    #[test]
+    fn tier_key_from_resolved_dir_reads_the_on_disk_tier() {
+        let root = std::path::Path::new("/models/krea-2-turbo-mlx");
+        assert_eq!(tier_key_from_resolved_dir(&root.join("q4")), Some("q4"));
+        assert_eq!(tier_key_from_resolved_dir(&root.join("q8")), Some("q8"));
+        assert_eq!(tier_key_from_resolved_dir(&root.join("bf16")), Some("bf16"));
+        // Boogu `<variant>-<tier>` suffix + the bare `<variant>` packed Q8 default.
+        assert_eq!(tier_key_from_resolved_dir(&root.join("base-q4")), Some("q4"));
+        assert_eq!(
+            tier_key_from_resolved_dir(&root.join("turbo-bf16")),
+            Some("bf16")
+        );
+        assert_eq!(tier_key_from_resolved_dir(&root.join("edit")), Some("q8"));
+        // Unrecognized basename (repo root / modelPath) → None; the gate keeps its manifest key.
+        assert_eq!(tier_key_from_resolved_dir(root), None);
     }
 
     fn too_big(needed: f64, avail: f64) -> TierFit {


### PR DESCRIPTION
## Story
[sc-12829](https://app.shortcut.com/trefry/story/12829) — *tier_key_from_resolved_dir is tested macOS-only, but the fn runs on the candle VRAM gate* (chore / test-hygiene). Epic 9083.

## The gap
`crates/sceneworks-worker/src/image_jobs/base.rs`:
- `fn tier_key_from_resolved_dir` is `#[cfg(any(target_os = "macos", feature = "backend-candle"))]` — compiled on **both** lanes and **used on the candle lane**: the candle VRAM fit-gate resolves the on-disk tier through it (`generate_candle_stream` → `gate_tier_key` fallback, and the sc-12090 disk-probe path via `resolve_tier_dir`).
- Its only test, `tier_key_from_resolved_dir_reads_the_on_disk_tier`, lived inside `mod quant_tier_reconcile_tests`, which is `#[cfg(target_os = "macos")]` — **macOS-only**. So a candle-lane basename→tier regression (e.g. a new Boogu `<variant>-<tier>` folder shape) would ship green on the `candle-worker` CI lane.

## The fix
Move the test into the **existing** cross-lane `capability_downtier_tests` module (`#[cfg(all(test, any(target_os = "macos", feature = "backend-candle")))]`), matching the function's own cfg so it runs on **both** the MLX and candle lanes. This follows the sc-12425 precedent — the neighboring `gate_tier_key_names_convrot_by_identity_never_q8` test was moved to this same module for the identical cfg reason.

- The moved test carries **no function-level cfg** (unlike the convrot neighbor, which calls candle-only `gate_tier_key`/`vram_gate`): it calls only the cross-lane `tier_key_from_resolved_dir`, so the module gate alone is correct.
- Docstring intra-doc-links only the cross-lane fns (`resolve_tier_dir`, `tier_key_from_resolved_dir`); the candle-only `gate_tier_key`/`installed_tier_keys` are named as plain code.
- Test assertions are **byte-identical** to the original — no coverage weakening.

## Audit (scope item 3)
`tier_key_from_resolved_dir` was the **only** cross-lane (`any(macos, candle)`) base.rs fn whose sole unit test lived in a macOS-only module. The other macOS-only test module, `mlx_downtier_emulation_tests`, uses `mlx_tier_fit` (genuinely MLX-only); its cross-lane fns (`choose_downtier`/`TierFit`/`DowntierPick`) are already covered in `capability_downtier_tests`. Nothing else to move.

## Validation
- Candle lane (this box, MSVC 14.44 + `CUDA_COMPUTE_CAP=120`):
  `cargo test -p sceneworks-worker --lib --features backend-candle tier_key_from_resolved_dir_reads_the_on_disk_tier` → **1 passed** (now under `image_jobs::capability_downtier_tests::`, previously not compiled into the candle test binary at all).
- `cargo fmt` clean.
- macOS lane greenness is confirmed by the `nax-worker` CI lane (can't run macOS locally); the test body is unchanged and `capability_downtier_tests` already compiles on macOS.

Relates sc-12425 (the cfg-trap it mirrors), sc-9607 (the base.rs include cfg), sc-12090 (the disk-probe path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)