### PR TITLE
chore(worker): pin inference bf16-TE (fc1654a9) + re-measure krea int8-convrot VRAM gate (sc-12828)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -453,7 +453,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -464,7 +464,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -477,7 +477,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -490,7 +490,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -555,7 +555,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -575,7 +575,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -620,7 +620,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -633,7 +633,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen",
  "image",
@@ -721,7 +721,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -738,7 +738,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -751,7 +751,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -762,7 +762,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -772,7 +772,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -802,7 +802,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -832,7 +832,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -844,7 +844,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -891,7 +891,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1186,7 +1186,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -3645,7 +3645,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3658,7 +3658,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3670,7 +3670,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3683,7 +3683,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3735,7 +3735,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3748,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -3758,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3767,7 +3767,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3776,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3789,7 +3789,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3801,7 +3801,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -3813,7 +3813,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -3834,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3860,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3917,7 +3917,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3946,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3956,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -3967,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3981,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4015,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4025,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4038,7 +4038,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4050,7 +4050,7 @@ dependencies = [
 [[package]]
 name = "mlx-internal-macros"
 version = "0.25.3"
-source = "git+https://github.com/michaeltrefry/mlx-rs?rev=38e1cc1730a11b1e40c2c8ecda01606763a12d51#38e1cc1730a11b1e40c2c8ecda01606763a12d51"
+source = "git+https://github.com/michaeltrefry/mlx-rs?rev=932beb4e60db44d378ffa1fe648defea59b5cbd0#932beb4e60db44d378ffa1fe648defea59b5cbd0"
 dependencies = [
  "darling 0.21.3",
  "itertools 0.14.0",
@@ -4062,7 +4062,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "core-llm",
  "half",
@@ -4074,7 +4074,7 @@ dependencies = [
 [[package]]
 name = "mlx-macros"
 version = "0.25.3"
-source = "git+https://github.com/michaeltrefry/mlx-rs?rev=38e1cc1730a11b1e40c2c8ecda01606763a12d51#38e1cc1730a11b1e40c2c8ecda01606763a12d51"
+source = "git+https://github.com/michaeltrefry/mlx-rs?rev=932beb4e60db44d378ffa1fe648defea59b5cbd0#932beb4e60db44d378ffa1fe648defea59b5cbd0"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -4367,7 +4367,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4896,7 +4896,7 @@ dependencies = [
 [[package]]
 name = "pmetal-mlx-rs"
 version = "0.25.8"
-source = "git+https://github.com/michaeltrefry/mlx-rs?rev=38e1cc1730a11b1e40c2c8ecda01606763a12d51#38e1cc1730a11b1e40c2c8ecda01606763a12d51"
+source = "git+https://github.com/michaeltrefry/mlx-rs?rev=932beb4e60db44d378ffa1fe648defea59b5cbd0#932beb4e60db44d378ffa1fe648defea59b5cbd0"
 dependencies = [
  "dyn-clone",
  "half",
@@ -4919,7 +4919,7 @@ dependencies = [
 [[package]]
 name = "pmetal-mlx-sys"
 version = "0.2.4"
-source = "git+https://github.com/michaeltrefry/mlx-rs?rev=38e1cc1730a11b1e40c2c8ecda01606763a12d51#38e1cc1730a11b1e40c2c8ecda01606763a12d51"
+source = "git+https://github.com/michaeltrefry/mlx-rs?rev=932beb4e60db44d378ffa1fe648defea59b5cbd0#932beb4e60db44d378ffa1fe648defea59b5cbd0"
 dependencies = [
  "bindgen",
  "cc",
@@ -5603,7 +5603,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5613,7 +5613,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "candle-gen-catalog",
  "candle-llm",
@@ -5623,7 +5623,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "mlx-gen-catalog",
  "mlx-llm",
@@ -5901,7 +5901,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -8313,7 +8313,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2539,7 +2539,17 @@
         // Gates the `int8-convrot` variant through the SAME per-tier memory-eligibility path as
         // q4/q8/bf16 (the third of the three ConvRot gates; the candle lane + sm_89 compute-cap are the
         // worker's `int8_convrot` capability).
-        "vramGbByTier": { "q4": 26.4, "q8": 35.9, "bf16": 55.6, "int8-convrot": 42.9 },
+        // sc-12828 RE-MEASURED int8-convrot: 42.9 → 34.7 GB. The pinned inference (fc1654a9, PR #101)
+        // now stores the Qwen3-VL TE bf16 (f32 compute, bit-identical) instead of at f32, so the f32-TE
+        // co-resident buffer this ConvRot RESIDENT peak was inflated by is halved. Measured on that
+        // pinned build, exclusive sm_120, 1024²/8-step seed 42: steady 29.76 → 21.5 GB, overall-peak
+        // 42.9 → 34.7 GB — a constant 8.2 GB shift = the 15.6 → 7.4 GB dense TE reduction, landing
+        // int8-convrot right next to q8 as the sc-12425 note predicted ("once the TE drops the two tiers
+        // match"). q4/q8/bf16 also now run the bf16 TE and carry ~8.2 GB less RESIDENT, but stay at their
+        // (still-safe, now-conservative) f32-TE figures pending their OWN direct re-measure — a derived
+        // subtraction is unsafe for a fit-gate (resident↔sequential don't compose arithmetically; an
+        // under-prediction OOMs). sc-12828 follow-up re-measures q4/q8/bf16 + ideogram/boogu directly.
+        "vramGbByTier": { "q4": 26.4, "q8": 35.9, "bf16": 55.6, "int8-convrot": 34.7 },
         // sc-12131 / sc-10856 second-stage gate: measured largest working set after the text phase has
         // been dropped. `int8-convrot` = 28.6 GB (sc-12425, measured sm_120 1024²/8-step, byte-identical
         // pixels resident vs sequential) — it lands next to q8's 29.5 because the int8 DiT is the same

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "d64af1ddcd55cefee4cd21e1a3317c69434ee5a3" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "fc1654a97d9891982a2e16338f08083eb16d3cbf" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "d64af1ddcd55cefee4cd21e1a3317c69434ee5a3" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "fc1654a97d9891982a2e16338f08083eb16d3cbf" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
-mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
+mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "d64af1ddcd55cefee4cd21e1a3317c69434ee5a3", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "fc1654a97d9891982a2e16338f08083eb16d3cbf", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/lora_train_driver.rs
+++ b/crates/sceneworks-worker/src/lora_train_driver.rs
@@ -530,7 +530,9 @@ mod driver {
                 let out = generator.generate(&req, &mut |_p| {}).expect("generate");
                 let img = match out {
                     GenerationOutput::Images(mut v) => v.swap_remove(0),
-                    GenerationOutput::Video { .. } => panic!("expected an image"),
+                    GenerationOutput::Video { .. } | GenerationOutput::Audio(_) => {
+                        panic!("expected an image")
+                    }
                 };
                 write_png(&img, &gen_dir.join(format!("{id}_{seed}.png")));
                 written += 1;

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -4125,6 +4125,9 @@ fn run_loaded_video_generation(
         GenerationOutput::Images(_) => Err(WorkerError::Engine(
             "video model returned images, expected video frames".to_owned(),
         )),
+        GenerationOutput::Audio(_) => Err(WorkerError::Engine(
+            "video model returned audio, expected video frames".to_owned(),
+        )),
     }
 }
 


### PR DESCRIPTION
## What

Bumps the SceneWorks inference pin `d64af1dd → fc1654a9` — [SceneWorks/inference#101](https://github.com/SceneWorks/inference/pull/101): the candle **Krea / Ideogram / Boogu** Qwen3-VL text encoders now **store bf16 / compute f32** (bit-identical, half the resident TE) — and re-measures the one candle-exclusive VRAM gate the win directly, measurably lowers:

```
krea_2_turbo.candle.vramGbByTier.int8-convrot: 42.9 → 34.7 GB
```

## Measured, not estimated

On the pinned bf16-TE build (`krea-convrot-vram` example, exclusive sm_120, 1024²/8-step, seed 42):
- steady (resident): **29.76 → 21.5 GB**
- overall-peak (`vramGbByTier`): **42.9 → 34.7 GB**

A constant **8.2 GB** shift = the 15.6 → 7.4 GB dense Qwen3-VL-4B TE reduction. 34.7 now lands right next to q8's 35.9 — exactly what the sc-12425 manifest note predicted ("once the TE drops the two tiers match"). `vramGbByTier` is under the `candle` block (read by `vram_gate::predicted_peak_gb`), a candle/CUDA gate — MLX is gated separately, no cross-backend risk. The gate reduction is only valid once the worker runs the bf16-TE code, so it's bundled **atomically** with the pin bump.

## Deliberately conservative

`q4/q8/bf16` also carry the f32-TE tax and now run the bf16 TE, but stay at their (safe, now slightly conservative) f32-TE figures pending their **own direct** re-measure — a derived subtraction is unsafe for a fit-gate (resident↔sequential don't compose arithmetically; an under-prediction OOMs). A follow-up re-measures those + ideogram/boogu directly.

## mlx-rs alignment

The pin bump pulls inference's **mlx-rs 0.32.0** (sc-12747), so the macOS-only direct `mlx-rs` pin is aligned `38e1cc17 → 932beb4e` (single `pmetal-mlx-rs` resolution — the bump's skew check passes). The candle (Windows/Linux) build does not include `mlx-rs` (it's under `cfg(target_os = "macos")`); the macOS mlx build is CI-validated.

Story: sc-12828 (scope #3, the post-merge manifest tail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)