### PR TITLE
fix(web): Image Studio "New batch" — escape stuck-on-Update after persistent-screen restore

### DIFF
--- a/apps/web/src/components/BatchPromptPanel.jsx
+++ b/apps/web/src/components/BatchPromptPanel.jsx
@@ -92,6 +92,7 @@ export default function BatchPromptPanel({
   onScopeChange,
   loadedBatchId = null,
   onSave,
+  onNew,
   onLoad,
   onDelete,
   onImport,
@@ -241,7 +242,17 @@ export default function BatchPromptPanel({
 
       <div className="batch-panel-side">
         <div className="batch-save">
-          <span className="batch-field-label">Save this batch</span>
+          <div className="batch-save-head">
+            <span className="batch-field-label">{loadedBatchId ? "Editing saved batch" : "Save this batch"}</span>
+            {/* Once a saved batch is loaded, the panel stays linked to it (persisted across
+                restarts by the studio snapshot), so Save reads "Update" with no way back to a
+                blank batch. "New batch" unlinks and clears the authoring fields. */}
+            {loadedBatchId && onNew ? (
+              <button className="batch-new-link" disabled={busy} onClick={onNew} type="button">
+                + New batch
+              </button>
+            ) : null}
+          </div>
           <input
             aria-label="Batch name"
             className="batch-name"

--- a/apps/web/src/components/BatchPromptPanel.test.jsx
+++ b/apps/web/src/components/BatchPromptPanel.test.jsx
@@ -131,6 +131,29 @@ describe("BatchPromptPanel (sc-9955)", () => {
     expect(document.body.querySelector(".batch-preview-res").textContent).toBe("832×1216");
   });
 
+  it("shows Save (not Update) and no New-batch link when no batch is loaded", () => {
+    mount({ initialPrompts: "one" });
+    const saveButton = [...document.body.querySelectorAll(".batch-btn")].find((b) => /Save|Update/.test(b.textContent));
+    expect(saveButton.textContent).toContain("Save");
+    expect(document.body.querySelector(".batch-new-link")).toBeNull();
+    expect(document.body.querySelector(".batch-save-head .batch-field-label").textContent).toBe("Save this batch");
+  });
+
+  it("surfaces a New-batch action once a saved batch is loaded, and Save reads Update", () => {
+    mount({ initialPrompts: "one", extra: { loadedBatchId: "b1", onNew: vi.fn() } });
+    const saveButton = [...document.body.querySelectorAll(".batch-btn")].find((b) => /Save|Update/.test(b.textContent));
+    expect(saveButton.textContent).toContain("Update");
+    expect(document.body.querySelector(".batch-save-head .batch-field-label").textContent).toBe("Editing saved batch");
+    expect(document.body.querySelector(".batch-new-link")).toBeTruthy();
+  });
+
+  it("invokes onNew when the New-batch action is clicked", async () => {
+    const onNew = vi.fn();
+    mount({ initialPrompts: "one", extra: { loadedBatchId: "b1", onNew } });
+    await act(async () => document.body.querySelector(".batch-new-link").click());
+    expect(onNew).toHaveBeenCalledTimes(1);
+  });
+
   it("lists saved batches", () => {
     mount({
       batches: [

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -506,6 +506,18 @@ export function ImageStudio() {
     },
     [applyBatchContent],
   );
+
+  // Detach from the loaded batch and clear the authoring fields so the next Save creates a
+  // brand-new batch. Needed because loadedBatchId now persists in the studio snapshot: after
+  // a restart the panel restores its last-loaded batch and Save is stuck on "Update" with no
+  // way back to a blank slate. Scope is left as-is (a user preference, not batch content).
+  const handleNewBatch = useCallback(() => {
+    setBatchPromptsText("");
+    setBatchVariableValues({});
+    setBatchName("");
+    setLoadedBatchId(null);
+    setBatchError("");
+  }, []);
   const [advancedOpen, setAdvancedOpen] = useState(saved.advancedOpen ?? false);
   const [model, setModel] = useState(saved.model ?? imageModels[0]?.id ?? "z_image_turbo");
   const [seed, setSeed] = useState(saved.seed ?? "");
@@ -2278,6 +2290,7 @@ export function ImageStudio() {
                 onScopeChange={setBatchScope}
                 loadedBatchId={loadedBatchId}
                 onSave={handleSaveBatch}
+                onNew={handleNewBatch}
                 onLoad={handleLoadBatch}
                 onDelete={handleDeleteBatch}
                 onImport={handleImportBatch}

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -1987,3 +1987,78 @@ describe("ImageStudio strict-control panel (epic 8236, sc-8245)", () => {
     expect(payload.advanced.controlScale).toBe(0.75);
   });
 });
+
+// Persistent studio screens now snapshot loadedBatchId, so a restart restores a batch that is
+// still "loaded" — Save is stuck on "Update" with no path back to a blank batch. "New batch"
+// unlinks and clears the authoring fields; the cleared state must also persist to the snapshot.
+describe("Image Studio batch — New batch clears a restored loaded batch", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <ImageStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  const batchSaveButton = () =>
+    [...document.body.querySelectorAll(".batch-save .batch-btn")].find((b) => /Save|Update/.test(b.textContent));
+
+  it("restores a loaded batch as Update, then New batch clears it back to a fresh Save", async () => {
+    const savedBatch = { id: "batch-1", name: "Turnaround", scope: "global", prompts: ["a", "b"], variables: [], lastValues: {} };
+    window.localStorage.setItem(
+      "sceneworks-studio-image-project_1",
+      JSON.stringify({
+        mode: "text_to_image",
+        model: "z_image_turbo",
+        batchMode: true,
+        batchName: "Turnaround",
+        batchPromptsText: "a\nb",
+        loadedBatchId: "batch-1",
+      }),
+    );
+
+    await render(
+      baseContext({
+        promptBatches: [savedBatch],
+        createPromptBatch: vi.fn(async () => ({ id: "new" })),
+        updatePromptBatch: vi.fn(async () => ({ id: "batch-1" })),
+        deletePromptBatch: vi.fn(),
+      }),
+    );
+
+    // Restored linked-to-a-saved-batch state: name + prompts filled, Save reads Update.
+    expect(document.body.querySelector(".batch-name").value).toBe("Turnaround");
+    expect(document.body.querySelector(".batch-prompts").value).toBe("a\nb");
+    expect(batchSaveButton().textContent).toContain("Update");
+
+    // Click New batch → unlink + clear the authoring fields, Save flips back to Save.
+    await click(document.body.querySelector(".batch-new-link"));
+
+    expect(document.body.querySelector(".batch-name").value).toBe("");
+    expect(document.body.querySelector(".batch-prompts").value).toBe("");
+    expect(batchSaveButton().textContent).toContain("Save");
+    expect(document.body.querySelector(".batch-new-link")).toBeNull();
+
+    // The cleared state persists so a subsequent restart stays fresh, not re-linked.
+    const snap = JSON.parse(window.localStorage.getItem("sceneworks-studio-image-project_1") || "{}");
+    expect(snap.loadedBatchId ?? null).toBeNull();
+    expect(snap.batchName).toBe("");
+  });
+});

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -13433,6 +13433,28 @@ details[open] > summary.lora-scope-group-heading::before,
   flex-direction: column;
   gap: 8px;
 }
+.batch-save-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+.batch-new-link {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  color: var(--accent);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+.batch-new-link:hover {
+  text-decoration: underline;
+}
+.batch-new-link:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 .batch-name {
   width: 100%;
   font-family: var(--font-ui);


### PR DESCRIPTION
## Problem
With persistent studio screens, the Image Studio Batch panel snapshots `loadedBatchId`. After a restart the panel restores its last-loaded batch, so the Save button is permanently stuck on **Update** — there's no way to detach and create a brand-new batch.

## Fix
- Add a **New batch** action in the batch save section, shown only while a saved batch is loaded. It unlinks the loaded batch (`loadedBatchId → null`) and clears the authoring fields (name, prompts, variables), flipping Save back to **Save** (create-new). Scope is left as-is (a user preference, not batch content).
- The section label switches to **"Editing saved batch"** while linked, so the loaded state is legible.

## Tests
- `BatchPromptPanel.test.jsx`: link is absent with no batch loaded (Save reads "Save"), present once a batch is loaded (Save reads "Update"), and `onNew` fires on click.
- `ImageStudio.test.jsx`: a restored snapshot with `loadedBatchId` renders as **Update**; clicking **New batch** clears name + prompts, flips back to **Save**, and the cleared state persists to the studio snapshot so a subsequent restart stays fresh.

All three affected suites pass (90 tests); eslint clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)