### PR TITLE
feat(wan): admit the candle A14B on a 32 GB card (q4 measured, sequential offload) — sc-12631

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -453,7 +453,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -464,7 +464,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -477,7 +477,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -490,7 +490,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -555,7 +555,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -575,7 +575,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -620,7 +620,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -633,7 +633,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "image",
@@ -721,7 +721,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -738,7 +738,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -751,7 +751,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -762,7 +762,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -772,7 +772,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -802,7 +802,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -832,7 +832,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -844,7 +844,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -891,7 +891,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1186,7 +1186,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -3645,7 +3645,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3658,7 +3658,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3670,7 +3670,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3683,7 +3683,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3735,7 +3735,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3748,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -3758,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3767,7 +3767,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3776,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3789,7 +3789,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3801,7 +3801,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -3813,7 +3813,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -3834,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3860,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3917,7 +3917,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3946,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3956,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -3967,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3981,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4015,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4025,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4038,7 +4038,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4050,7 +4050,7 @@ dependencies = [
 [[package]]
 name = "mlx-internal-macros"
 version = "0.25.3"
-source = "git+https://github.com/michaeltrefry/mlx-rs?rev=38e1cc1730a11b1e40c2c8ecda01606763a12d51#38e1cc1730a11b1e40c2c8ecda01606763a12d51"
+source = "git+https://github.com/michaeltrefry/mlx-rs?rev=932beb4e60db44d378ffa1fe648defea59b5cbd0#932beb4e60db44d378ffa1fe648defea59b5cbd0"
 dependencies = [
  "darling 0.21.3",
  "itertools 0.14.0",
@@ -4062,7 +4062,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "core-llm",
  "half",
@@ -4074,7 +4074,7 @@ dependencies = [
 [[package]]
 name = "mlx-macros"
 version = "0.25.3"
-source = "git+https://github.com/michaeltrefry/mlx-rs?rev=38e1cc1730a11b1e40c2c8ecda01606763a12d51#38e1cc1730a11b1e40c2c8ecda01606763a12d51"
+source = "git+https://github.com/michaeltrefry/mlx-rs?rev=932beb4e60db44d378ffa1fe648defea59b5cbd0#932beb4e60db44d378ffa1fe648defea59b5cbd0"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -4367,7 +4367,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4896,7 +4896,7 @@ dependencies = [
 [[package]]
 name = "pmetal-mlx-rs"
 version = "0.25.8"
-source = "git+https://github.com/michaeltrefry/mlx-rs?rev=38e1cc1730a11b1e40c2c8ecda01606763a12d51#38e1cc1730a11b1e40c2c8ecda01606763a12d51"
+source = "git+https://github.com/michaeltrefry/mlx-rs?rev=932beb4e60db44d378ffa1fe648defea59b5cbd0#932beb4e60db44d378ffa1fe648defea59b5cbd0"
 dependencies = [
  "dyn-clone",
  "half",
@@ -4919,7 +4919,7 @@ dependencies = [
 [[package]]
 name = "pmetal-mlx-sys"
 version = "0.2.4"
-source = "git+https://github.com/michaeltrefry/mlx-rs?rev=38e1cc1730a11b1e40c2c8ecda01606763a12d51#38e1cc1730a11b1e40c2c8ecda01606763a12d51"
+source = "git+https://github.com/michaeltrefry/mlx-rs?rev=932beb4e60db44d378ffa1fe648defea59b5cbd0#932beb4e60db44d378ffa1fe648defea59b5cbd0"
 dependencies = [
  "bindgen",
  "cc",
@@ -5603,7 +5603,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5613,7 +5613,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen-catalog",
  "candle-llm",
@@ -5623,7 +5623,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen-catalog",
  "mlx-llm",
@@ -5901,7 +5901,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=d64af1ddcd55cefee4cd21e1a3317c69434ee5a3#d64af1ddcd55cefee4cd21e1a3317c69434ee5a3"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -8313,7 +8313,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -453,7 +453,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -464,7 +464,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -477,7 +477,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -490,7 +490,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -555,7 +555,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -575,7 +575,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -620,7 +620,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -633,7 +633,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "image",
@@ -721,7 +721,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -738,7 +738,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -751,7 +751,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -762,7 +762,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -772,7 +772,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -802,7 +802,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -832,7 +832,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -844,7 +844,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -891,7 +891,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1186,7 +1186,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -3645,7 +3645,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3658,7 +3658,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3670,7 +3670,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3683,7 +3683,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3735,7 +3735,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3748,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -3758,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3767,7 +3767,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3776,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3789,7 +3789,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3801,7 +3801,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -3813,7 +3813,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -3834,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3860,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3917,7 +3917,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3946,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3956,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -3967,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3981,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4015,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4025,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4038,7 +4038,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4062,7 +4062,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "core-llm",
  "half",
@@ -4367,7 +4367,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5603,7 +5603,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5613,7 +5613,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "candle-gen-catalog",
  "candle-llm",
@@ -5623,7 +5623,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "mlx-gen-catalog",
  "mlx-llm",
@@ -5901,7 +5901,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=fc1654a97d9891982a2e16338f08083eb16d3cbf#fc1654a97d9891982a2e16338f08083eb16d3cbf"
+source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -8313,7 +8313,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -6391,38 +6391,44 @@
           "schedulers": ["default"]
         }
       },
-      // candle/CUDA VRAM gate (sc-12402, epic 1788) — ESTIMATED, `measured: false`. **This model does
-      // not render on the candle lane at all**, so there is no peak to measure (sc-12434):
-      //   * its shipped 1280x720 default EXCEEDS both engines' own `MAX_AREA_14B` (704*1280 = 901,120
-      //     px) and is hard-rejected by `validate` — an sc-12308/#1581 regression, tracked as sc-12433;
-      //   * `832x480` (the only advertised bucket the engine admits) OOM'd a 96 GB RTX PRO 6000 BEFORE
-      //     step 1, at **q4** — the lightest tier — with Lightning's CFG-off batch-1 4-step recipe,
-      //     i.e. the cheapest configuration this model has. GPU-proven, sc-12434.
+      // candle/CUDA VRAM gate — q4/q8 MEASURED, bf16 DERIVED (sc-12631, after the epic sc-12732 rework
+      // landed the 24 GB path). q4/q8 taken on an idle RTX PRO 6000 (Blackwell sm_120) via the
+      // candle-gen-wan VramProbe at the A14B's shipped 1280x720 / 81f / 4-step Lightning default, in the
+      // SEQUENTIAL-offload residency the model now renders with: the two 14B MoE experts are swapped
+      // one-resident-at-a-time (sc-12733), the bf16 UMT5 TE (sc-12778) is offloaded before denoise, and the
+      // z16 bf16 VAE decode is tiled against free VRAM (sc-12734/12758/12818) — so at most ONE expert +
+      // activations are live. The 24 GB lever was sc-12894 (8x-finer sdpa chunk; the denoise attention was
+      // the floor). q4/q8 are the driver's TRUE concurrent-live peak (`CU_MEMPOOL_ATTR_USED_MEM_HIGH`,
+      // sc-12818) in GiB — the honest figure; nvidia-smi reads the cudarc pool high-water (~27/37 GiB
+      // q4/q8, inflated — the pool never frees) and under-samples the attention transient. Each measured in
+      // its own process. The peak is DENOISE-owned; the VAE decode adds only ~5 GiB.
       //
-      // Derivation (the alternative to a measurement, not a fudge): `peak = weights + B·H·S²·8 bytes`,
-      // the cost of candle-gen-wan's unchunked materialized sdpa (transformer.rs:46 — the sc-6217
-      // chunking Qwen/Krea got was never ported). The weights term is the real ~40 GiB read off the
-      // device pre-denoise. At 832x480x81: S = 21·30·52 = 32,760 tokens x 40 heads ⇒ ~343 GB of
-      // attention — TIER-INDEPENDENT, which is why the whole ladder spans only ~40 GB and no tier
-      // helps. q8/bf16 weights are q4 + the two-expert delta.
+      // This model loads SEQUENTIAL, not resident: both bf16 experts co-resident is ~56 GiB + TE + VAE and
+      // OOMs even a 96 GB card (the pre-rework pathology sc-12730 fixed), so there is no meaningful
+      // resident peak — `video_load_spec` forces `OffloadPolicy::Sequential` for the A14B ids
+      // (`video_jobs::candle_wan_offload_policy`) and these are that SEQUENTIAL peak. The gate is only
+      // truthful because the load is coupled to it (pinned by the gpu_and_manifest tripwire). minMemoryGb
+      // 24 gates the DEFAULT/lightest (q4) tier (22.13 + the gate's 2 GB headroom), which admits a 32 GB
+      // RTX 5090 — the epic sc-12732 target. (The raw 22 GiB q4 peak physically fits a 24 GB card too, but
+      // the conservative headroom targets ~26 GB free, so a 24 GB card is refused — the safe direction.)
       //
-      // ⚠️ These are LOWER BOUNDS, not predictions. The closed form tracks the 5B closely (predicted
-      // 56 GB vs 54.8 GB measured) but UNDER-predicts the A14B: at 512x320x49 — the one sub-advertised
-      // geometry small enough to actually render — it predicted 65.2 GB and the real measured peak was
-      // **89.5 GB**. The gap is cudarc pool fragmentation, which no closed form captures (and which is
-      // the whole reason this campaign measures instead of models). Under-prediction is harmless HERE
-      // only because every bound already exceeds every GPU in existence: a postage-stamp 512x320 clip
-      // needs 89.5 GB, so the advertised 832x480 is not close.
-      //
-      // Recorded so the fit gate REFUSES this model rather than admitting it: the sc-12344 floor reads
-      // 29.72 GiB, so today a 32 GB card is admitted, pays a ~28 GiB tier download + a ~100 s load, and
-      // then dies in the first attention. An instant honest refusal is strictly better. These numbers
-      // are correct-in-OUTCOME (refuse everywhere) rather than correct-in-magnitude, and they go stale
-      // the moment sc-12434 ports chunking — `measured: false` is the flag to re-measure then, and
-      // sc-12434 owns that task.
+      // q8 and bf16 are DEFERRED (the handoff's "admit q4 now, re-measure q8/bf16 before admitting"), so
+      // the block stays `measured: false`:
+      //   * q8's live USED_MEM_HIGH peak measured 27.95 GiB, but its nvidia-smi POOL high-water was 34.4
+      //     GiB — cudarc holds the pool (it never frees to the driver), and whether the pool packs down to
+      //     the live peak under real memory pressure was only ever observed on a 96 GB card. It is gated at
+      //     the pool high-water (34.4) so an opt-in q8 render is refused on a 32 GB card rather than risk a
+      //     mid-denoise OOM there; it admits ~48 GB. Drop q8 to the 27.95 live peak once a ≤32 GB run
+      //     validates the small-card footprint.
+      //   * bf16 is DERIVED, not measured: its dense fp32 `Wan-AI/*-Diffusers` snapshot has no complete
+      //     stageable source (~200 GiB fp32, never fully cached). 56 = one dense bf16 expert (~28.6 GiB) +
+      //     the ~14 GiB activation set the measured tiers share + a fragmentation margin — a CONSERVATIVE
+      //     upper bound that refuses it rather than admit an untested tier that could OOM.
+      // Flipping to `measured: true` (and admitting q8 on 32 GB) needs a ≤32 GB validation + a bf16 stage
+      // (an sc-12631 follow-up).
       "candle": {
-        "minMemoryGb": 388,
-        "vramGbByTier": { "q4": 386, "q8": 401, "bf16": 426 },
+        "minMemoryGb": 24,
+        "vramGbByTier": { "q4": 22.13, "q8": 34.4, "bf16": 56.0 },
         "measured": false
       },
       "ui": {
@@ -6628,21 +6634,21 @@
           "schedulers": ["default"]
         }
       },
-      // candle/CUDA VRAM gate (sc-12402, epic 1788) — ESTIMATED, `measured: false`. The image→video
-      // twin of the T2V-A14B block above; see that comment for the derivation, the validated cost
-      // model, and why there is nothing to measure. **This model does not render on the candle lane at
-      // all** (sc-12434): its 1280x720 default is engine-rejected over `MAX_AREA_14B` (sc-12433) and
-      // `832x480` OOMs a 96 GB card before step 1 at the lightest tier.
-      //
-      // Identical numbers to T2V by construction: the I2V experts are the same shape (config
-      // `i2v_14b()` differs only in `in_channels` 36 vs 16 — the 20-channel image-conditioning concat —
-      // which changes the patch embedding, not the 40-layer/40-head attention that IS the peak), and
-      // the hosted tier bytes match to within 0.01% (q4 29,792,232,225 vs 29,788,704,888). The VAE
-      // ENCODER is additionally resident here (`WanVae16::new_with_encoder`, wan14b.rs:331) for the
-      // first-frame latent, which is noise at this scale.
+      // candle/CUDA VRAM gate (sc-12631, post epic sc-12732). The image→video twin of the T2V-A14B block
+      // above; see that comment for the harness, the SEQUENTIAL-offload residency the numbers are taken
+      // under (`OffloadPolicy::Sequential` forced for the A14B ids), the `USED_MEM_HIGH` methodology, and
+      // the DEFERRAL of q8/bf16 (`measured: false`). Measured at the same 1280x720 / 81f / 4-step Lightning
+      // default. The I2V live peak sits ~0.1 GiB above T2V's: the experts are the same shape (config
+      // `i2v_14b()` differs only in `in_channels` 36 vs 16 — the image concat — not the 40-layer/40-head
+      // attention that IS the peak), and the VAE ENCODER is additionally resident here
+      // (`WanVae16::new_with_encoder`) to latent-encode the first frame. minMemoryGb 24 gates the DEFAULT
+      // (q4) tier + 2 GB headroom → q4 admits a 32 GB card. q8 gated at its nvidia-smi pool high-water 35.6
+      // (live peak 28.02; deferred/refused on 32 pending a ≤32 GB validation, admits ~48 GB); bf16 DERIVED
+      // (56, same conservative bound as T2V), unmeasured. Flipping to `measured: true` is the same
+      // ≤32 GB-validation + bf16-stage follow-up.
       "candle": {
-        "minMemoryGb": 388,
-        "vramGbByTier": { "q4": 386, "q8": 401, "bf16": 426 },
+        "minMemoryGb": 24,
+        "vramGbByTier": { "q4": 22.20, "q8": 35.6, "bf16": 56.0 },
         "measured": false
       },
       "ui": {

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "d64af1ddcd55cefee4cd21e1a3317c69434ee5a3" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "adfdff624bc78dfaaa4687cafc09d1a82ac5983f" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "d64af1ddcd55cefee4cd21e1a3317c69434ee5a3" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "adfdff624bc78dfaaa4687cafc09d1a82ac5983f" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
-mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "38e1cc1730a11b1e40c2c8ecda01606763a12d51" }
+mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "d64af1ddcd55cefee4cd21e1a3317c69434ee5a3", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "adfdff624bc78dfaaa4687cafc09d1a82ac5983f", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/lora_train_driver.rs
+++ b/crates/sceneworks-worker/src/lora_train_driver.rs
@@ -530,7 +530,9 @@ mod driver {
                 let out = generator.generate(&req, &mut |_p| {}).expect("generate");
                 let img = match out {
                     GenerationOutput::Images(mut v) => v.swap_remove(0),
-                    GenerationOutput::Video { .. } => panic!("expected an image"),
+                    GenerationOutput::Video { .. } | GenerationOutput::Audio(_) => {
+                        panic!("expected an image")
+                    }
                 };
                 write_png(&img, &gen_dir.join(format!("{id}_{seed}.png")));
                 written += 1;

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -645,30 +645,66 @@ fn wan_candle_blocks_drive_the_video_fit_gate_and_reject() {
          measured rendering, so wall-rejecting it would be the sc-12179 regression"
     );
 
-    // Both A14B models carry blocks too, so THEIR gate is live. They are `measured: false` —
-    // sibling-scaled, because the candle A14B does not render at any advertised geometry (sc-12434:
-    // 832x480 OOMs a 96 GB card before step 1; the 1280x720 default is engine-rejected, sc-12433). The
-    // gate refusing them everywhere is the TRUE answer until chunking lands, and it turns a ~30 GiB
-    // download + ~100 s load + OOM into an instant refusal.
-    for id in ["wan_2_2_t2v_14b", "wan_2_2_i2v_14b"] {
+    // Both A14B models now carry a MEASURED q4 block (sc-12631, post epic sc-12732): the candle engine
+    // renders one 14B expert at a time (`OffloadPolicy::Sequential`, forced by
+    // `video_jobs::candle_wan_offload_policy`), so its measured USED_MEM_HIGH q4 peak at the 1280x720
+    // Lightning default is ~22 GiB — it FITS a 32 GB RTX 5090, the inverse of the old ~386 GiB OOM-floor
+    // that refused everything. Per the handoff, q8 + bf16 are DEFERRED (conservative bounds — q8 at its
+    // nvidia-smi pool high-water pending a ≤32 GB validation, bf16 derived), so they stay refused on a
+    // 32 GB card and the block is honestly `measured: false`.
+    let card48 = apply_vram_cap(None, Some(48.0));
+    let card32 = apply_vram_cap(None, Some(32.0)); // an RTX 5090 — epic sc-12732's small-card target
+    let card16 = apply_vram_cap(None, Some(16.0));
+    for (id, q4_peak, q8_bound) in [
+        ("wan_2_2_t2v_14b", 22.13, 34.4),
+        ("wan_2_2_i2v_14b", 22.20, 35.6),
+    ] {
         let model = builtin_model_entry(id);
         let a14b = model.as_object().expect("a14b entry object");
+        let q4 = predicted_peak_gb(a14b, "q4").expect("a14b q4 measured");
+        let q8 = predicted_peak_gb(a14b, "q8").expect("a14b q8 carried");
+        let bf16 = predicted_peak_gb(a14b, "bf16").expect("a14b bf16 carried");
+        assert!((q4 - (q4_peak + 2.0)).abs() < 1e-6, "{id} q4 {q4_peak} + 2 headroom, got {q4}");
+        assert!((q8 - (q8_bound + 2.0)).abs() < 1e-6, "{id} q8 {q8_bound} (pool bound) + 2, got {q8}");
+        assert!((bf16 - 58.0).abs() < 1e-6, "{id} bf16 56 (derived) + 2 headroom, got {bf16}");
+        assert!(q4 < q8 && q8 < bf16, "{id}: heavier tier ⇒ heavier peak");
+        assert!(q4 < 32.0, "{id}: the measured q4 default now fits a 32 GB card, not >96");
+        assert!(q8 > 32.0 && bf16 > 32.0, "{id}: q8/bf16 deferred — must stay above a 32 GB card");
+
+        // The live gate. q4 (the default) is ADMITTED on the 96 GB box it was measured rendering on
+        // (wall-rejecting it would be the sc-12179 regression) AND on a 32 GB RTX 5090 — the point of the
+        // rework — but REFUSED on a 16 GB card too small for even the offloaded peak, before the OOM.
         assert!(
-            a14b.get("candle").and_then(Value::as_object).is_some(),
-            "{id} candle block present (absent ⇒ the floor admits it on a small card and it OOMs)"
+            wan_video_fit_error(id, a14b, "q4", 0, "0", card96).is_none(),
+            "{id} q4 (~{q4} GB) must fit the 96 GB dev box it was measured on"
         );
-        let peak = predicted_peak_gb(a14b, "q4").expect("a14b q4 peak carried");
         assert!(
-            peak > 96.0,
-            "{id} q4 must not appear to fit ANY existing GPU — sc-12434 proved 832x480 OOMs a 96 GB \
-             card before step 1, got {peak}"
+            wan_video_fit_error(id, a14b, "q4", 0, "0", card32).is_none(),
+            "{id} q4 (~{q4} GB) must now fit a 32 GB RTX 5090 — the epic sc-12732 target"
         );
         assert!(
-            wan_video_fit_error(id, a14b, "q4", 0, "0", card96).is_some(),
-            "{id} must be refused even on the 96 GB dev box"
+            wan_video_fit_error(id, a14b, "q4", 0, "0", card16).is_some(),
+            "{id} q4 (~{q4} GB) cannot fit a 16 GB card — refuse before the load"
+        );
+        // q8 + bf16 are DEFERRED: refused on a 32 GB card (their conservative bounds exceed it), though
+        // q8 still admits a 48 GB card — an untested tier must not be admitted on an unvalidated number.
+        assert!(
+            wan_video_fit_error(id, a14b, "q8", 0, "0", card32).is_some(),
+            "{id} q8 (~{q8} GB pool bound) must stay refused on a 32 GB card pending a ≤32 GB validation"
+        );
+        assert!(
+            wan_video_fit_error(id, a14b, "q8", 0, "0", card48).is_none(),
+            "{id} q8's conservative bound still fits a 48 GB card"
+        );
+        assert!(
+            wan_video_fit_error(id, a14b, "bf16", 0, "0", card32).is_some(),
+            "{id} bf16 (derived ~58 GB) must stay refused on a 32 GB card until measured"
         );
     }
-    eprintln!("wan candle blocks: 5090 → refused, 96 GB → q4 admitted, A14B → refused everywhere ✓");
+    eprintln!(
+        "wan candle blocks: 5B 5090→refused/96→admitted; A14B q4 measured → 32 GB admitted, 16 GB \
+         refused; q8/bf16 deferred → 32 GB refused ✓"
+    );
 }
 
 /// sc-12130/sc-12131: the shipped Krea base block feeds both stages of the generic Candle gate. This

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -54,7 +54,7 @@ use crate::image_jobs::{classify_adapter, load_reference_image, lora_path};
 ))]
 use gen_core::{
     AdapterSpec, CancelFlag, Conditioning, GenerationOutput, GenerationRequest, Generator,
-    LoadPhase, LoadSpec, Precision, Progress, Quant, WeightsSource,
+    LoadPhase, LoadSpec, OffloadPolicy, Precision, Progress, Quant, WeightsSource,
 };
 // MLX-only contract types (LoRA classification, MoE experts) — the candle video lane uses none of these.
 #[cfg(target_os = "macos")]
@@ -3988,6 +3988,13 @@ struct VideoGenInput {
     /// takes the bespoke uncached load path (`load_from_comfyui_experts`) instead of the registry
     /// snapshot; `None` on every other job.
     comfyui: Option<ComfyuiWanExperts>,
+    /// Residency policy for the load (sc-12631). Defaults to [`OffloadPolicy::Resident`] — the historical
+    /// video behavior (every component held for the whole run). The candle A14B path flips this to
+    /// [`OffloadPolicy::Sequential`] so the two 14B experts are swapped one-resident-at-a-time and the
+    /// measured `candle.vramGbByTier` peak (the SEQUENTIAL working set) is the one actually loaded; see
+    /// `candle_wan_offload_policy`. Left `Resident` on the MLX (macOS) path and the 5B, which the
+    /// manifest still sizes resident.
+    offload_policy: OffloadPolicy,
 }
 
 #[cfg(any(
@@ -4027,6 +4034,7 @@ impl Default for VideoGenInput {
             softness: None,
             text_encoder_dir: None,
             comfyui: None,
+            offload_policy: OffloadPolicy::Resident,
         }
     }
 }
@@ -4053,8 +4061,11 @@ fn video_load_spec(input: &VideoGenInput) -> LoadSpec {
         // LTX's external Gemma-3 text encoder rides the spec (sc-8827); `None` ⇒ the provider's
         // `$LTX_GEMMA_DIR` / `<root>/text_encoder` fallback.
         text_encoder: input.text_encoder_dir.clone().map(WeightsSource::Dir),
-        // Video providers have not wired sequential residency (sc-10821) — stays Resident.
-        offload_policy: Default::default(),
+        // Residency policy (sc-12631). `Resident` for every path historically; the candle A14B flips it
+        // to `Sequential` (`generate_candle_video_using` → `candle_wan_offload_policy`) so the two
+        // 14B experts swap one-at-a-time and the load matches the SEQUENTIAL peak the manifest gate sized.
+        // `apply_residency_policy` (the MLX cache seam) never downgrades a `Sequential` set here.
+        offload_policy: input.offload_policy,
     }
 }
 
@@ -4124,6 +4135,11 @@ fn run_loaded_video_generation(
         }),
         GenerationOutput::Images(_) => Err(WorkerError::Engine(
             "video model returned images, expected video frames".to_owned(),
+        )),
+        // `GenerationOutput::Audio` arrived with the candle-audio lane (sc-12834); no video engine
+        // produces it, so it is as much an engine contract violation here as `Images`.
+        GenerationOutput::Audio(_) => Err(WorkerError::Engine(
+            "video model returned audio, expected video frames".to_owned(),
         )),
     }
 }
@@ -5442,6 +5458,27 @@ fn mochi_vram_preflight(
     }
 }
 
+/// The residency policy the candle load takes for `engine_id` (sc-12631, epic sc-12732). The A14B
+/// T2V/I2V render with [`OffloadPolicy::Sequential`]: their two 14B MoE experts cannot be co-resident on
+/// a target card, so the engine stages TE → high-expert → low-expert → VAE one-resident-at-a-time
+/// (`candle-gen-wan` `render_sequential`). That is the residency the model's measured
+/// `candle.vramGbByTier` peak was taken under (22.1 GiB @ q4 / 1280×720, vs a resident load that OOMs a
+/// 96 GB card), so [`crate::vram_gate::wan_video_fit_error`]'s admission number is only truthful when the
+/// load actually takes this path — [`video_load_spec`] threads it onto the `LoadSpec`, and
+/// `apply_residency_policy` never downgrades a `Sequential` set here.
+///
+/// The dense TI2V-5B stays [`OffloadPolicy::Resident`]: its `candle.vramGbByTier` (46.1 GiB q4,
+/// sc-12631 PR #1598) is the RESIDENT peak, so offloading it would mismatch its sized number. Re-dropping
+/// the 5B onto the offload path the engine already wired (sc-12757) is a tracked follow-up. `ltx`/`svd`
+/// carry no offload lifecycle and stay resident.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn candle_wan_offload_policy(engine_id: &str) -> OffloadPolicy {
+    match engine_id {
+        "wan2_2_t2v_14b" | "wan2_2_i2v_14b" => OffloadPolicy::Sequential,
+        _ => OffloadPolicy::Resident,
+    }
+}
+
 /// Live pre-flight Wan VRAM admission check for the candle lane — the non-Mochi half of this lane's
 /// gate, and the seam [`generate_candle_video`] calls before the load + denoise.
 ///
@@ -5797,6 +5834,10 @@ async fn generate_candle_video_using(
         seed: resolve_video_seed(request) as u64,
         // ltx's Gemma-3 encoder dir rides the LoadSpec (sc-8827); `None` for wan (bundled TE).
         text_encoder_dir: ltx_gemma_dir,
+        // The candle A14B renders with sequential component offload + MoE expert-swap (sc-12631): the
+        // residency the measured `candle.vramGbByTier` peak was taken under, so the gate's admission
+        // number is only truthful when the load actually takes it. `Resident` for the 5B + ltx + svd.
+        offload_policy: candle_wan_offload_policy(engine_id),
         ..VideoGenInput::default()
     };
     let raw_settings = candle_video_raw_settings(request, &repo);
@@ -17399,6 +17440,56 @@ mod tests {
             matches!(video_load_spec(&with_te).text_encoder, Some(WeightsSource::Dir(ref p)) if *p == gemma),
             "text_encoder_dir rides LoadSpec::text_encoder as a Dir source"
         );
+    }
+
+    /// sc-12631: the candle A14B (T2V + I2V) loads with `OffloadPolicy::Sequential` so its two 14B
+    /// experts swap one-resident-at-a-time — the residency its MEASURED `candle.vramGbByTier` peak was
+    /// taken under, and the coupling that makes the gate's admission number truthful. The dense 5B and
+    /// the non-wan video engines stay `Resident`. Both halves are pinned: the policy predicate AND that
+    /// `video_load_spec` actually threads it onto the `LoadSpec` (a decoupled predicate that never
+    /// reached the spec would silently OOM the A14B on the resident path the gate did not size for).
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    #[test]
+    fn candle_a14b_loads_sequential_every_other_video_engine_resident() {
+        for id in ["wan2_2_t2v_14b", "wan2_2_i2v_14b"] {
+            assert_eq!(
+                candle_wan_offload_policy(id),
+                OffloadPolicy::Sequential,
+                "{id} must offload (both 14B experts cannot be co-resident)"
+            );
+            // Mirror `generate_candle_video_using`, which sets the input's policy from the predicate;
+            // this pins that `video_load_spec` then threads it onto the `LoadSpec` (the coupling that
+            // makes the sequential-peak gate truthful).
+            let input = VideoGenInput {
+                engine_id: id,
+                offload_policy: candle_wan_offload_policy(id),
+                ..VideoGenInput::default()
+            };
+            assert_eq!(
+                video_load_spec(&input).offload_policy,
+                OffloadPolicy::Sequential,
+                "{id}: video_load_spec must thread Sequential onto the LoadSpec"
+            );
+        }
+        // The dense 5B is sized RESIDENT in the manifest (46.1 GiB q4), and ltx/svd carry no offload
+        // lifecycle — forcing them sequential would mismatch their sized peak / be a no-op that misleads.
+        for id in ["wan2_2_ti2v_5b", "ltx_2_3_distilled", "svd_xt"] {
+            assert_eq!(
+                candle_wan_offload_policy(id),
+                OffloadPolicy::Resident,
+                "{id} must stay resident"
+            );
+            let input = VideoGenInput {
+                engine_id: id,
+                offload_policy: candle_wan_offload_policy(id),
+                ..VideoGenInput::default()
+            };
+            assert_eq!(
+                video_load_spec(&input).offload_policy,
+                OffloadPolicy::Resident,
+                "{id}: video_load_spec must keep Resident"
+            );
+        }
     }
 
     /// Q8 opt-in detection (sc-5679): `advanced.mlxQuantize: 8` (int or string) → true; absent / Q4

--- a/crates/sceneworks-worker/src/vram_gate.rs
+++ b/crates/sceneworks-worker/src/vram_gate.rs
@@ -367,15 +367,17 @@ fn mochi_too_big_error(
 // bytes of the components the loader actually reads. Three facts make that a sound admission check for
 // **Wan** rather than a guess:
 //
-//  1. **Every candle video engine holds all components resident for the whole run.** All six declare
-//     `supports_sequential_offload: false` (candle-gen-wan lib.rs:417 / wan14b.rs:727 / model_vace.rs:387,
-//     candle-gen-ltx lib.rs:527, candle-gen-svd lib.rs:183, candle-gen-mochi lib.rs:115, at the pinned
-//     `runtime-2026.07.6`), which `video_load_spec`'s "video providers have not wired sequential
-//     residency (sc-10821)" states in-tree. So `resolve_offload(TooBig, false)` is a no-op here and NO
-//     sequential-peak second stage applies — the `candle.sequentialPeakGb` this gate would otherwise
-//     need does not enter the decision at all. In particular the A14B MoE holds **BOTH** experts
-//     co-resident (`Components { high: Arc<_>, low: Arc<_> }`, wan14b.rs:337-343): the denoise picks an
-//     expert per step, it does not swap them out.
+//  1. **The engines this FLOOR still gates hold all components resident for the whole run.** ltx / svd /
+//     mochi and the dense TI2V-5B declare `supports_sequential_offload: false` (candle-gen-ltx /
+//     -svd / -mochi) or are sized by a RESIDENT `candle.vramGbByTier` (the 5B, 46.1 GiB q4), so
+//     `resolve_offload` is a no-op for them and Σweights is a genuine LOWER BOUND. **The A14B T2V/I2V are
+//     the exception as of sc-12631 / epic sc-12732:** the candle engine now stages TE → high-expert →
+//     low-expert → VAE **one-resident-at-a-time** (`render_sequential`, `supports_sequential_offload:
+//     true`) — only ONE 14B expert is live at a time, not both — so it is sized by its MEASURED sequential
+//     `candle.vramGbByTier` peak and this floor never gates it (`wan_video_fit_error` takes the measured
+//     branch), while its load is forced `OffloadPolicy::Sequential`
+//     (`video_jobs::candle_wan_offload_policy`) so the sized peak is the one actually loaded. The floor
+//     stays the fallback for a Wan tier that was never measured.
 //  2. **There is no host paging on CUDA.** Weights that do not fit VRAM cannot be demand-paged the way
 //     MLX's unified pool swaps, so Σweights is a genuine LOWER BOUND on the job's need. This is the
 //     asymmetry that makes the weights floor safe HERE but not on MLX: `mlx_fit_gate::weights_fit_floor`
@@ -392,9 +394,10 @@ fn mochi_too_big_error(
 // ⚠️ **The manifest's `footprint.peakMemoryBytes` for these models is an MLX measurement and MUST NOT be
 // reused here.** `wan_2_2_t2v_14b`'s recorded 24.5 GiB peak sits BELOW its own `diskSizeBytes` because,
 // as that manifest comment says, "A14B is MoE — only ONE 14B expert is resident at a time, not both".
-// That is true of the MLX engine (measured on a 128 GB Mac, sc-10049/epic 10043) and FALSE of the candle
-// one, which co-locates both experts per (1). Sizing the candle lane off that number would under-predict
-// by a whole expert (~28 GiB at bf16).
+// The candle A14B now ALSO holds one expert at a time (sc-12733, per (1)), but that number is still an
+// MLX measurement at a different geometry/dtype and must not be reused: the candle lane is sized by its
+// own MEASURED sequential `candle.vramGbByTier` (sc-12631). (Before sc-12732 the candle engine co-located
+// both experts, which is why the pre-rework floor under-predicted it by a whole ~28 GiB bf16 expert.)
 //
 // ## This is a FLOOR — it under-predicts, deliberately — and it is now the FALLBACK, not the gate
 // It counts weights only: no activation transient, no VAE decode, no attention working set. A MARGINAL
@@ -589,9 +592,9 @@ fn video_peak_too_big_error(
     gpu_id: &str,
 ) -> WorkerError {
     WorkerError::InvalidPayload(format!(
-        "{model_label} needs ~{needed} GB of VRAM to render at its {tier_key} tier (measured peak: \
-         every component held resident for the whole run — this engine does not stage components — \
-         plus the denoise and VAE-decode transient) but GPU {gpu_id} has ~{available} GB available. \
+        "{model_label} needs ~{needed} GB of VRAM to render at its {tier_key} tier (the measured peak of \
+         the whole render — the resident weights plus the denoise and VAE-decode transient, at whatever \
+         component residency the engine uses) but GPU {gpu_id} has ~{available} GB available. \
          Select a smaller quant tier, or run on a GPU with more VRAM.",
         needed = needed_gb.round() as i64,
         available = available_gb.round() as i64,

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -289,26 +289,43 @@ def test_wan_2_2_candle_vram_tiers_match_measured_peaks():
     assert candle["minMemoryGb"] == 48
 
 
-def test_wan_a14b_candle_vram_tiers_are_flagged_estimated():
-    """sc-12402/sc-12434: the A14B blocks are ESTIMATED and must stay flagged as such.
+def test_wan_a14b_candle_q4_measured_admits_32gb_q8_bf16_deferred():
+    """sc-12631 (post epic sc-12732): the A14B q4 candle peak is MEASURED and admits a 32 GB card.
 
-    The candle A14B does not render at ANY advertised geometry (sc-12434: 832x480 OOMs a 96 GB
-    card before step 1; the 1280x720 default is engine-rejected -- sc-12433), so there is no peak
-    to measure. The blocks exist so the fit gate REFUSES the model instead of admitting it into a
-    ~28 GiB download + ~100 s load + OOM. `measured: false` is the flag to re-measure once sc-12434
-    ports attention chunking -- if that ever flips to true without new numbers, this is the tripwire.
+    After the sequential-offload / expert-swap / bf16-TE / free-aware-tiling / finer-sdpa rework, the
+    A14B renders one 14B expert at a time and its measured `USED_MEM_HIGH` q4 peak at the 1280x720/81f/
+    4-step Lightning default is ~22 GiB -- it fits a 32 GB RTX 5090, not the ~386 GiB OOM-floor these
+    blocks used to carry. This is the inverse of the old `..._are_flagged_estimated` tripwire (which
+    asserted every tier exceeds a 96 GB card). (The raw 22 GiB q4 peak physically fits a 24 GB card too,
+    but the gate's 2 GB headroom targets ~26 GB free, so a 24 GB card is refused -- the safe direction.)
+
+    Per the sc-12732 handoff ("admit q4 now, re-measure q8/bf16 before admitting"), q8 and bf16 are
+    DEFERRED, so the block stays `measured: false`. q8's live USED_MEM_HIGH peak was ~28 GiB but its
+    nvidia-smi pool high-water (which cudarc never frees) was ~34-36 GiB and the small-card footprint is
+    unvalidated, so q8 is gated at that conservative pool bound (refused on 32 GB); bf16 is DERIVED (56).
+    Asserting q8/bf16 stay above a 32 GB card stops either regressing to a fits-small-card number before
+    it is validated/measured. Flipping to `measured: true` is a <=32 GB-validation + bf16-stage follow-up.
     """
     manifest = _load_builtin_models_manifest()
-    for model_id in ("wan_2_2_t2v_14b", "wan_2_2_i2v_14b"):
+    expected = {
+        "wan_2_2_t2v_14b": {"q4": 22.13, "q8": 34.4, "bf16": 56.0},
+        "wan_2_2_i2v_14b": {"q4": 22.20, "q8": 35.6, "bf16": 56.0},
+    }
+    for model_id, tiers in expected.items():
         entry = next(m for m in manifest["models"] if m["id"] == model_id)
         candle = entry["candle"]
-        assert candle["measured"] is False, f"{model_id}: A14B numbers are derived, not measured"
-        # Every tier must exceed any GPU that exists, so the gate refuses on all hardware.
-        for tier, peak in candle["vramGbByTier"].items():
-            assert peak > 96, (
-                f"{model_id} {tier} must not appear to fit a 96 GB card -- sc-12434 proved the "
-                f"lightest tier OOMs one before step 1, got {peak}"
-            )
+        # q8/bf16 are deferred (conservative bounds), so the block is honestly flagged estimated.
+        assert candle["measured"] is False, f"{model_id}: q8/bf16 deferred, so measured stays false"
+        assert candle["vramGbByTier"] == tiers, (
+            f"{model_id}: the measured q4 peak (and the conservative q8/bf16 bounds) must not regress, "
+            f"got {candle['vramGbByTier']}"
+        )
+        assert candle["minMemoryGb"] == 24, f"{model_id}: minMemoryGb should gate q4 (~22 + 2)"
+        # The DEFAULT (q4) tier now fits a 32 GB card -- where the old ~388 floor refused every GPU.
+        assert tiers["q4"] + 2 < 32, f"{model_id}: q4 (+headroom) must fit a 32 GB card, got {tiers['q4']}"
+        # q8 + bf16 stay refused on a 32 GB card until validated/measured (deferred, the safe direction).
+        assert tiers["q8"] + 2 > 32, f"{model_id}: q8's conservative bound must not admit a 32 GB card"
+        assert tiers["bf16"] + 2 > 32, f"{model_id}: the derived bf16 bound must not admit a 32 GB card"
 
 
 def test_sdxl_manifest_has_mlx_block():


### PR DESCRIPTION
## What & why

Story: **[sc-12631](https://app.shortcut.com/trefry/story/12631)** — the A14B half of "re-measure `candle.vramGbByTier` for Wan A14B + flip". (The 5B half shipped in #1598.)

Post **epic sc-12732**, the candle Wan2.2 A14B (T2V+I2V) renders **one 14B expert at a time** (sequential offload + expert-swap + bf16 TE + free-aware VAE tiling + the sc-12894 finer sdpa chunk). That rework is on inference `main` but was **not** in the release SceneWorks pinned, so the app-side VRAM gate still refused the A14B on every GPU (an ~386 GiB OOM-floor). This wires the gate to consume the rework: the **default (q4) tier is now admitted on a 32 GB RTX 5090**, measured on the box.

## Measured (idle RTX PRO 6000, `USED_MEM_HIGH`, 1280×720/81f/4-step Lightning, sequential)

| tier | T2V (GiB) | I2V (GiB) | manifest / gate |
|---|---|---|---|
| **q4** | **22.13** | **22.20** | measured live peak → admits a 32 GB card |
| q8 | 27.95 live (pool high-water 34.4) | 28.02 live (35.6) | **deferred** — gated at the pool high-water, refused on 32 GB, admits ~48 GB |
| bf16 | — | — | **deferred** — derived 56 (no stageable dense fp32 source) |

## Key decisions (please sanity-check)

1. **Pin bump `d64af1dd → adfdff62`** (the minimal main SHA with the complete wan rework), via `scripts/bump-inference.mjs`. The direct `mlx-rs` pin was realigned `38e1cc17 → 932beb4e` (adfdff62's inference uses it) so the macOS lane doesn't double-build mlx-rs. Blast radius is larger than "re-measure a manifest" — it also pulls the merged audio P0 (`GenerationOutput::Audio`), i32 VAE guards, qwen3vl bf16 TE — but the co-dev SHA-pin is the sanctioned way to consume inference work.
2. **`measured: false` stays.** Only q4 is a clean measured admission. Per the sc-12732 handoff ("admit q4 now, re-measure q8/bf16 before admitting"), **q8 + bf16 are deferred**:
   - q8's live peak is ~28 GiB, but its nvidia-smi **pool high-water** (cudarc never frees to the driver) was ~34–36 GiB, and whether the pool packs down to the live peak under real pressure was only ever observed on a 96 GB card. Gated at the conservative pool bound so an opt-in q8 render is **refused on 32 GB** (not a mid-denoise OOM); admits ~48 GB. Drop to the live peak once a ≤32 GB run validates it.
   - bf16 can't be measured — the dense fp32 snapshot has no complete stageable source (~200 GiB fp32, missing `transformer_2` in both the stage and the HF cache). Conservative derived bound (56).

   → **The story's literal "flip `measured:true`" is not met** because of q8/bf16; the *goal* (A14B renders on a consumer card via the q4 default) **is** delivered. Needs your sign-off on shipping the honest partial vs chasing q8/bf16 (a ≤32 GB validation + a big bf16 download).
3. **Always-sequential for the A14B.** `candle_wan_offload_policy` forces `OffloadPolicy::Sequential` for the two A14B ids (both bf16 experts co-resident is ~56 GiB + TE + VAE, OOMs even a 96 GB card), threaded via `VideoGenInput` → `video_load_spec`; macOS + the 5B stay Resident.

## Adversarial review — addressed

A fresh-context review returned DO-NOT-SHIP with two HIGH findings; both fixed here:
- **Missing `GenerationOutput::Audio` arm in `lora_train_driver.rs`** (macOS-test-gated, so my CUDA box couldn't catch it — the macos-mlx lane would red). Fixed (+ the video_jobs one).
- **q8-on-32GB OOM risk** (sized off `USED_MEM_HIGH` while "pool never frees"). Resolved by **deferring q8** to the conservative pool bound (refused on 32). Note: q8 is the *opt-in* tier, not the default — the default is q4, which is safe on 32 GB (pool high-water 27 < ~30 free).

Open (LOW, follow-ups): the offload-coupling unit test pins `candle_wan_offload_policy` + `video_load_spec` threading but not the production call site in `generate_candle_video_using` (an `ArmProbe` test could close it); a testkit doc contradiction lives in the inference repo.

## Tests (all green locally on the CUDA box)
- `cargo fmt` ✓ · `cargo clippy -p sceneworks-worker --features backend-candle --all-targets -- -D warnings` ✓
- 26 worker tests ✓ — `vram_gate`, the inverted `wan_candle_blocks_drive_the_video_fit_gate_and_reject` tripwire, and the new `candle_a14b_loads_sequential_every_other_video_engine_resident` coupling test
- `pytest tests/test_builtin_manifest_audit.py` 10/10 ✓ (incl. the inverted A14B tripwire)

## Follow-ups
- Measure q8 + bf16 honestly (a ≤32 GB validation run for q8; a full dense bf16 stage) → then flip `measured: true` and admit q8 on 32 GB.
- Optionally re-drop the **5B** onto the offload path (the engine wired it via sc-12757; it still ships Resident 46.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
