### PR TITLE
chore(models): backfill exact SenseNova V3 tier sizes (re-host published) (sc-13097/13098)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1298,32 +1298,31 @@
         // SceneWorks pre-built MLX quant-matrix turnkey (epic 13095, S2): a public/ungated re-host of
         // sensenova/SenseNova-U1-8B-MoT-Infographic-V3 built with the same `prequantize_turnkey` harness
         // as V2. Per-tier subdirs (each a complete from_snapshot tree): q4/ (default), q8/, bf16/.
-        // NOTE: byte sizes below are V2's on-disk measurements as a near-identical PLACEHOLDER (V3 is
-        // tensor-identical); re-measure the hosted V3 repo per subdir and backfill after S2 upload.
+        // Byte sizes are EXACT on-disk measurements of the built/hosted V3 tiers (epic 13095 S2).
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-infographic-v3-mlx",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
-          "estimatedSizeBytes": 11824526363,
-          "footprint": { "diskSizeBytes": 11824526363, "residentMemoryBytes": null, "peakMemoryBytes": null }
+          "estimatedSizeBytes": 11824378614,
+          "footprint": { "diskSizeBytes": 11824378614, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-infographic-v3-mlx",
           "variant": "q8",
           "files": ["q8/*"],
-          "estimatedSizeBytes": 19927923905,
-          "footprint": { "diskSizeBytes": 19927923905, "residentMemoryBytes": null, "peakMemoryBytes": null }
+          "estimatedSizeBytes": 19927776248,
+          "footprint": { "diskSizeBytes": 19927776248, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-infographic-v3-mlx",
           "variant": "bf16",
           "files": ["bf16/*"],
-          "estimatedSizeBytes": 35121744859,
-          "footprint": { "diskSizeBytes": 35121744859, "residentMemoryBytes": null, "peakMemoryBytes": null }
+          "estimatedSizeBytes": 35121597119,
+          "footprint": { "diskSizeBytes": 35121597119, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {
@@ -1597,32 +1596,31 @@
       "adapter": "sensenova_u1",
       "capabilities": ["text_to_image", "edit_image", "character_image"],
       "downloads": [
-        // NOTE: byte sizes are V2-fast on-disk measurements as a near-identical PLACEHOLDER (tensor-
-        // identical); re-measure the hosted V3-fast repo per subdir and backfill after S3 upload.
+        // Byte sizes are EXACT on-disk measurements of the built/hosted V3-fast tiers (epic 13095 S3).
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-infographic-v3-fast-mlx",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
-          "estimatedSizeBytes": 11824526409,
-          "footprint": { "diskSizeBytes": 11824526409, "residentMemoryBytes": null, "peakMemoryBytes": null }
+          "estimatedSizeBytes": 11824378215,
+          "footprint": { "diskSizeBytes": 11824378215, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-infographic-v3-fast-mlx",
           "variant": "q8",
           "files": ["q8/*"],
-          "estimatedSizeBytes": 19927924235,
-          "footprint": { "diskSizeBytes": 19927924235, "residentMemoryBytes": null, "peakMemoryBytes": null }
+          "estimatedSizeBytes": 19927776291,
+          "footprint": { "diskSizeBytes": 19927776291, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-infographic-v3-fast-mlx",
           "variant": "bf16",
           "files": ["bf16/*"],
-          "estimatedSizeBytes": 35121633249,
-          "footprint": { "diskSizeBytes": 35121633249, "residentMemoryBytes": null, "peakMemoryBytes": null }
+          "estimatedSizeBytes": 35121485601,
+          "footprint": { "diskSizeBytes": 35121485601, "residentMemoryBytes": null, "peakMemoryBytes": null }
         }
       ],
       "paths": {


### PR DESCRIPTION
Backfills the exact on-disk tier byte sizes for SenseNova-U1 Infographic **V3**, now that the quant-matrix re-host is built, validated, and **published** to the two public SceneWorks HF repos the manifest (merged in #1606) already points at. Epic [sc-13095](https://app.shortcut.com/trefry/epic/13095).

## What's now live on HF
- [`SceneWorks/sensenova-u1-8b-infographic-v3-mlx`](https://huggingface.co/SceneWorks/sensenova-u1-8b-infographic-v3-mlx) — q4 (default) / q8 / bf16
- [`SceneWorks/sensenova-u1-8b-infographic-v3-fast-mlx`](https://huggingface.co/SceneWorks/sensenova-u1-8b-infographic-v3-fast-mlx) — q4 / q8 / bf16, distill-merged

Both public, Apache-2.0, with model cards.

## This diff
Replaces the V2-placeholder `estimatedSizeBytes` / `footprint.diskSizeBytes` for all 6 V3 tiers with **exact on-disk measurements**, verified against the HF tree API:

| tier | base | fast |
|---|---|---|
| q4 | 11,824,378,614 | 11,824,378,215 |
| q8 | 19,927,776,248 | 19,927,776,291 |
| bf16 | 35,121,597,119 | 35,121,485,601 |

## How the tiers were built & validated (sc-13097/13098/13099)
- **Converter:** `mlx-gen-sensenova::convert::prequantize_turnkey` (base) / `prequantize_fast_turnkey` (fast), same harness as V2. Build rev has zero `convert.rs`/`quant.rs` drift from the app-pinned inference rev, so the tiers are byte-format-identical to what the app loads.
- **Tokenizer:** V3's tokenizer inputs (incl. config.json) are byte-identical to V2, so V2's proven `tokenizer.json` was reused (verified by sha256).
- **Fast merge:** V1 8-step distill LoRA merged at **296/296** gen-path targets — identical to V2 — with the `distill_merged.json` marker.
- **Load+render:** base q4 and fast q4 load via the app's `provider_registry().load()` path and render non-degenerate.
- **8-step quality:** a full 2048² infographic from the fast tier at 8 steps renders crisp, correctly-spelled dense text and the exact prompted layout — the flagged unknown is resolved.

Data-only change (6 number pairs); CI validates manifest structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)