### PR TITLE
ci(candle): fail loudly if runner rust toolchain is broken (sc-13166)

### DIFF
--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -90,6 +90,62 @@ jobs:
       CUDA_COMPUTE_CAP: "120"
       CARGO_NET_OFFLINE: "true"
     steps:
+      # sc-13166: fail LOUDLY if this self-hosted runner's rustup shims are broken,
+      # instead of at `cargo fetch` with a cryptic error that reads like a PR failure.
+      # The rust proxies in %USERPROFILE%\.cargo\bin (cargo.exe, rustc.exe, ...) are
+      # 0-byte symlinks to rustup.exe; if rustup.exe is deleted they go dangling and
+      # the next cargo invocation dies ~15s in with the Windows ERROR_NO_ASSOCIATION
+      # ("No application is associated with the specified file for this operation") —
+      # which turned every PR red and forced admin-override merges. This runs as the
+      # job's FIRST step (before checkout — it needs no repo) so a broken toolchain
+      # fails in ~1s with an actionable message + remediation pointer. Validated on
+      # the box against a real dangling-symlink repro (healthy -> exit 0; dangling or
+      # missing cargo.exe -> exit 1 + ::error::).
+      - name: Verify Rust toolchain on runner (pre-flight, sc-13166)
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $cargo = Get-Command cargo.exe -CommandType Application -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+          if (-not $cargo) {
+            Write-Host "::error title=Rust toolchain missing on candle runner::cargo.exe is not on PATH on the self-hosted Windows candle runner. Reinstall rustup so %USERPROFILE%\.cargo\bin\cargo.exe resolves (sc-13166)."
+            exit 1
+          }
+          Write-Host "cargo.exe -> $($cargo.Source)"
+          $out = $null
+          try {
+            # No 2>&1 here: under Stop, merging a native command's stderr wraps it in a
+            # terminating NativeCommandError (PS 5.1). A genuinely un-launchable cargo.exe
+            # still throws before any output, so the catch below still fires; a cargo that
+            # runs but errors is caught by the $LASTEXITCODE check.
+            $out = (& $cargo.Source --version | Out-String).Trim()
+          } catch {
+            # Collapse the multi-line PS error so it stays on one GitHub ::error:: line.
+            $why = ($_.Exception.Message -replace '\s+', ' ').Trim()
+            Write-Host "::error title=Rust toolchain broken on candle runner::Could not execute '$($cargo.Source)' ($why). This is the sc-13166 dangling-rustup-shim failure (ERROR_NO_ASSOCIATION). Restore the toolchain so the shims are real copies of rustup.exe, not dangling symlinks: re-run rustup-init, or 'rustup toolchain install stable --force'."
+            exit 1
+          }
+          if ($LASTEXITCODE -ne 0 -or $out -notmatch '^cargo\s') {
+            $outLine = ($out -replace '\s+', ' ').Trim()
+            Write-Host "::error title=Rust toolchain broken on candle runner::'$($cargo.Source) --version' failed (exit=$LASTEXITCODE) output='$outLine'. See sc-13166: restore the rustup shims as real copies of rustup.exe."
+            exit 1
+          }
+          Write-Host "OK: $out"
+          # rustup is what the shims proxy through; surface its state too. Best-effort and
+          # NEVER fatal: cargo is already confirmed healthy above, so drop back to Continue
+          # (a stderr line from `rustup show` under Stop+2>&1 would otherwise promote to a
+          # terminating NativeCommandError and flake a HEALTHY run red — the opposite of
+          # this step's purpose), guard it, and exit 0 explicitly.
+          $ErrorActionPreference = 'Continue'
+          $rustup = Get-Command rustup.exe -CommandType Application -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+          if ($rustup) {
+            try { (& $rustup.Source show 2>&1 | Out-String).Trim() | Write-Host }
+            catch { Write-Host "rustup show failed (non-fatal): $($_.Exception.Message)" }
+          } else {
+            Write-Host "::warning::rustup.exe not found on PATH (the cargo/rustc shims proxy through it); the toolchain may be fragile (sc-13166)."
+          }
+          exit 0
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Fetch the private inference release
         env:


### PR DESCRIPTION
## What / why

The self-hosted **Windows Candle worker** CI runner (`windows-candle.yml`, job `candle-worker`) was failing ~15s into the **"Fetch the private inference release"** step (`cargo fetch --locked`) on *every* PR with the cryptic Windows error:

```
Program 'cargo.exe' failed to run: No application is associated with the specified file for this operation
```

**Root cause (confirmed live on the box, sc-13166):** the rust proxies in `%USERPROFILE%\.cargo\bin` (`cargo.exe`, `rustc.exe`, …) are 0-byte **symlinks to `rustup.exe`**. `rustup.exe` had been deleted, so all 13 shims went dangling → launching `cargo.exe` throws Windows `ERROR_NO_ASSOCIATION`. It happens before any project code compiles, so it read like a PR failure, turned every PR red, and forced admin-override merges.

## This PR (CI hardening)

Adds a **pre-flight toolchain check** as the job's **first step** (before `checkout` — it needs no repo) so a broken runner fails in ~1s with an actionable message instead of the cryptic fetch-step error:

- `cargo` not on PATH -> `::error::` "Rust toolchain missing on candle runner…"
- `cargo.exe` present but un-launchable (dangling shim) -> caught -> `::error::` naming the sc-13166 dangling-shim cause + remediation.
- Otherwise prints `OK: cargo <ver>` + `rustup show`.

The trailing `rustup show` is best-effort (`Continue` + `try/catch` + explicit `exit 0`) so a stray stderr line can't promote to a terminating `NativeCommandError` and flake a *healthy* run red (the PS 5.1 `2>&1`-on-native trap).

## Validation (on the actual runner box)

| scenario | result |
|---|---|
| healthy toolchain | **exit 0**, prints `OK: cargo 1.95.0` |
| dangling `cargo.exe` symlink (reproduces the *exact* CI error string) | **exit 1** + `::error::` |
| `cargo` not on PATH | **exit 1** + `::error::` |
| tail stderr line (mutation check) | old unguarded tail flakes exit 1; fixed tail -> **exit 0** |

Extracted the exact `run:` block via a YAML parser and ran it through Windows PowerShell 5.1 (the runner's shell) for each case. Editing `windows-candle.yml` is on the lane's `paths` trigger, so **this PR's own candle-worker run exercises the new step on the real runner.**

## Out of band (not in this diff — ops on the runner)

- **Runner repaired durably:** the 13 dangling-prone symlink shims were replaced with real 12.8 MB copies of `rustup.exe` (atomic swap; `cargo`/`rustc`/`rustfmt`/`clippy`/`rustdoc` verified). Real copies remove the single-point-of-failure the symlink->`rustup.exe` arrangement had.
- **Recurrence prevention (needs an admin):** Data Deduplication is **not installed** (the suspected culprit is ruled out) and no Defender quarantine of `.cargo`/`.rustup` was found, but exclusions can't be read without admin. Recommend excluding `%USERPROFILE%\.cargo` and `%USERPROFILE%\.rustup` from Defender as belt-and-suspenders — a security-setting change left for a human to apply.

Fixes sc-13166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
