### PR TITLE
sc-13108: finish bf16-TE VRAM catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,12 +249,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -407,6 +422,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-audio"
+version = "0.0.0"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+dependencies = [
+ "candle-core",
+ "hf-hub",
+ "libc",
+ "sceneworks-gen-core",
+ "sha2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "candle-audio-catalog"
+version = "0.0.0"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+dependencies = [
+ "candle-audio",
+ "candle-audio-kokoro",
+ "candle-audio-moss-sfx",
+ "candle-llm",
+]
+
+[[package]]
+name = "candle-audio-kokoro"
+version = "0.0.0"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+dependencies = [
+ "candle-audio",
+ "candle-nn",
+ "core-llm",
+ "misaki-rs",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "serde_json",
+ "zip 7.2.0",
+]
+
+[[package]]
+name = "candle-audio-moss-sfx"
+version = "0.0.0"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+dependencies = [
+ "candle-audio",
+ "candle-nn",
+ "core-llm",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "serde",
+ "serde_json",
+ "tokenizers 0.22.2",
+]
+
+[[package]]
 name = "candle-core"
 version = "0.10.2"
 source = "git+https://github.com/huggingface/candle?rev=1e6aa85e867eb007cba1b8bae517a10d1aaf0c0d#1e6aa85e867eb007cba1b8bae517a10d1aaf0c0d"
@@ -435,7 +504,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -453,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -464,7 +533,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -477,7 +546,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -490,7 +559,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -528,7 +597,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -542,7 +611,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -555,7 +624,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -565,7 +634,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -575,7 +644,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -592,7 +661,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -606,7 +675,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -620,7 +689,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -633,7 +702,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -642,7 +711,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -657,7 +726,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -672,7 +741,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -686,7 +755,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -698,7 +767,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -711,7 +780,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-gen",
  "image",
@@ -721,7 +790,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -738,7 +807,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -751,7 +820,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -762,7 +831,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -772,7 +841,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -786,7 +855,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -802,7 +871,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -821,7 +890,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -832,7 +901,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -844,7 +913,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -854,7 +923,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -866,7 +935,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -891,7 +960,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -923,7 +992,7 @@ dependencies = [
  "byteorder",
  "candle-core",
  "candle-nn",
- "fancy-regex",
+ "fancy-regex 0.17.0",
  "num-traits",
  "rand 0.9.4",
  "rayon",
@@ -1186,7 +1255,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -1672,7 +1741,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "cssparser",
  "foldhash 0.2.0",
  "html5ever",
@@ -1854,11 +1923,22 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
 ]
@@ -3334,6 +3414,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "language-tokenizer"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9d23ae923f144698673d87d508ee7cd8627ddae99c23549a43525c4f7a4a23"
+dependencies = [
+ "num_enum",
+ "strsim",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.18",
+ "unicode-normalization",
+ "unicode-segmentation",
+ "waken_snowball",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3643,9 +3739,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "misaki-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e93650257ef50ccc74057b6248912e844b8874d9c7dfdd145d91f65deef095e"
+dependencies = [
+ "fancy-regex 0.13.0",
+ "language-tokenizer",
+ "log",
+ "num2words",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3658,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3670,7 +3782,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3683,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3696,7 +3808,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3735,7 +3847,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3748,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -3758,7 +3870,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3767,7 +3879,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3776,7 +3888,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3789,7 +3901,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3801,7 +3913,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -3813,7 +3925,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3825,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -3834,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3846,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3860,7 +3972,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3873,7 +3985,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3884,7 +3996,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3895,7 +4007,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3906,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3917,7 +4029,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3928,7 +4040,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3937,7 +4049,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3946,7 +4058,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3956,7 +4068,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -3967,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3981,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3994,7 +4106,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4004,7 +4116,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4015,7 +4127,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4025,7 +4137,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4038,7 +4150,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4062,7 +4174,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "core-llm",
  "half",
@@ -4342,6 +4454,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num2words"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f9771c0512b6a954a62b5106cc000bb5d77b1f60a792b5f70f531b84baefff"
+
+[[package]]
 name = "num_cpus"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4367,7 +4485,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5603,7 +5721,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5613,8 +5731,9 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
+ "candle-audio-catalog",
  "candle-gen-catalog",
  "candle-llm",
  "runtime-catalog",
@@ -5623,8 +5742,9 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
+ "candle-audio-catalog",
  "mlx-gen-catalog",
  "mlx-llm",
  "runtime-catalog",
@@ -5901,7 +6021,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=adfdff624bc78dfaaa4687cafc09d1a82ac5983f#adfdff624bc78dfaaa4687cafc09d1a82ac5983f"
+source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -7973,6 +8093,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "waken_snowball"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16a3e068c98d5736c4b5d2dfc0ab9f3b1dcb8f9dbc5a22bde166550c5d3788c0"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8313,7 +8439,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2692,14 +2692,13 @@
       },
       // candle/CUDA VRAM gate (sc-9094/sc-12131, epic 9083 → epic 10765) — MEASURED on an RTX PRO
       // 6000 (Blackwell sm_120) at 1024²/8-step with the rendered-device two-process probe. Resident
-      // peaks are q4 26.4, q8 35.9, bf16 55.6 GB. Sequential residency encodes/drops Qwen3-VL before
-      // loading the DiT and peaks at q4 22.7, q8 29.5, bf16 39.8 GB; every resident/sequential pair was
-      // byte-identical. minMemoryGb 32 covers the common q4 resident lane with headroom. INT8-ConvRot
-      // remains an unmeasured non-shipping estimate and defers to resident.
+      // peaks are q4 25.7, q8 35.2, bf16 47.2 GB. Sequential residency encodes/drops Qwen3-VL before
+      // loading the DiT and peaks at q4 21.9, q8 29.4, bf16 39.4 GB; every resident/sequential pair was
+      // byte-identical. minMemoryGb 32 covers the common q4 resident lane with headroom.
       "candle": {
         "minMemoryGb": 32,
         // sc-12425: the INT8-ConvRot tier's RESIDENT VRAM ceiling, now MEASURED (sc-12381) — 42.9 GB
-        // overall-peak on an exclusive sm_120 at 1024²/8-step, the same shape q4's 26.4 was taken at.
+        // overall-peak on an exclusive sm_120 at 1024²/8-step, the same shape used for the standard tiers.
         // This is the TE-CO-RESIDENT peak; the tier's efficient footprint is `sequentialPeakGb` (28.6).
         //
         // It replaces sc-9300's estimate of 31.0, which was wrong by 11.9 GB. That estimate blamed "the

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2052,14 +2052,14 @@
       },
       // candle/CUDA VRAM gate (sc-9094, epic 9083) — MEASURED on an RTX PRO 6000 (Blackwell sm_120) at
       // 1024²/10-step via the candle-gen nvidia-smi peak monitor: q4 packed overall-peak 38.5 GB (the
-      // two-DiT Ideogram path). minMemoryGb 46 gates the DEFAULT (q4) tier and covers it with headroom;
-      // q8 ESTIMATED (~44 GB). bf16 (sc-9650, off-Mac dense tier) MEASURED ~80 GB overall-peak (RTX PRO
-      // 6000, 1024²/48-step — the two dense-bf16 DiTs dominate); a 96 GB-card tier, small cards see it
-      // gated by its `vramGbByTier` ceiling.
+      // two-DiT Ideogram path). sc-13108 directly re-measured every tier on the pinned bf16-TE build,
+      // exclusive RTX PRO 6000 Blackwell sm_120, 1024²/48-step seed 42: q4 38.5, q8 55.3, bf16 74.1 GB.
+      // The prior q8 estimate (44 GB) underpredicted by 11.3 GB; these observed overall peaks now gate
+      // the exact installed tier. minMemoryGb 46 gates the DEFAULT (q4) tier with headroom.
       "candle": {
         "minMemoryGb": 46,
-        "vramGbByTier": { "q4": 38.5, "q8": 44.0, "bf16": 80.0 },
-        "measured": false
+        "vramGbByTier": { "q4": 38.5, "q8": 55.3, "bf16": 74.1 },
+        "measured": true
       },
       // Ideogram Non-Commercial Model Agreement (gated): accept the license at the source repo and
       // add a Hugging Face token under Settings → Service credentials before downloading. NOTE: the
@@ -2206,14 +2206,14 @@
         "repo": "SceneWorks/ideogram-4-mlx"
       },
       // candle/CUDA VRAM gate (sc-9654). Turbo is CFG-free single-DiT, so it runs LIGHTER than the two-DiT
-      // base: bf16 MEASURED ~46 GB overall-peak on an RTX PRO 6000 (sm_120, 1024²/8-step) vs the base's ~80
-      // GB. q4/q8 ESTIMATED below the base's (24/28 vs base 38.5/44 — the MLX active floor is ~24 GiB Q4),
-      // pending a candle measurement. bf16 is a large-card tier; small cards see it gated by its
-      // `vramGbByTier` ceiling. minMemoryGb 30 gates the default (q4) tier with headroom.
+      // base. sc-13108 directly measured every tier on the pinned bf16-TE build, exclusive RTX PRO 6000
+      // Blackwell sm_120, 1024²/8-step seed 42: q4 33.5, q8 43.9, bf16 56.3 GB. The old q4/q8 estimates
+      // (24/28) were unsafe by 9.5/15.9 GB; the prior bf16 claim (46) was also 10.3 GB low. Gate only on
+      // these observed overall peaks. minMemoryGb 30 remains the broad model-availability floor.
       "candle": {
         "minMemoryGb": 30,
-        "vramGbByTier": { "q4": 24.0, "q8": 28.0, "bf16": 46.0 },
-        "measured": false
+        "vramGbByTier": { "q4": 33.5, "q8": 43.9, "bf16": 56.3 },
+        "measured": true
       },
       "gated": true,
       "credentialHost": "huggingface.co",
@@ -2322,14 +2322,13 @@
         "quantize": 8,
         "repo": "SceneWorks/boogu-image-mlx"
       },
-      // candle/CUDA VRAM gate (sc-9094, epic 9083) — ESTIMATED (measured:false): the Boogu Turbo q4
-      // sibling MEASURED 32.7 GB @1024² on candle/CUDA; Base runs the same DiT with more steps + a
-      // heavier schedule, so q4 is scaled to ~38 GB (mlx Base Q8 ~35.5 vs Turbo close-in-size). Tracked
-      // for a Base measurement. minMemoryGb 44 with headroom.
+      // Direct sc-13108 CUDA probes on RTX PRO 6000 Blackwell, exclusive GPU, 1024², seed 42,
+      // native 50-step Base path: q4 31.68 GB and bf16 54.40 GB from a 0.02 GB baseline.
+      // minMemoryGb 44 preserves the existing packed-tier headroom.
       "candle": {
         "minMemoryGb": 44,
-        "vramGbByTier": { "q4": 38.0, "bf16": 52.0 },
-        "measured": false
+        "vramGbByTier": { "q4": 31.7, "bf16": 54.4 },
+        "measured": true
       },
       "licenseUrl": "https://huggingface.co/Boogu/Boogu-Image-0.1-Base",
       "ui": {
@@ -2424,14 +2423,13 @@
         "quantize": 8,
         "repo": "SceneWorks/boogu-image-mlx"
       },
-      // candle/CUDA VRAM gate (sc-9094, epic 9083) — MEASURED on an RTX PRO 6000 (Blackwell sm_120) at
-      // 1024²/8-step via the candle-gen nvidia-smi peak monitor: q4 packed (group-32, sc-9410) overall
-      // peak 32.7 GB. minMemoryGb 40 covers it with headroom; bf16 ESTIMATED (~48 GB) pending
-      // measurement.
+      // Direct sc-13108 CUDA probes on RTX PRO 6000 Blackwell, exclusive GPU, 1024², seed 42,
+      // native 4-step Turbo path: q4 31.58 GB and bf16 54.46 GB from a 0.02 GB baseline.
+      // minMemoryGb 40 preserves the existing packed-tier headroom.
       "candle": {
         "minMemoryGb": 40,
-        "vramGbByTier": { "q4": 32.7, "bf16": 48.0 },
-        "measured": false
+        "vramGbByTier": { "q4": 31.6, "bf16": 54.5 },
+        "measured": true
       },
       "licenseUrl": "https://huggingface.co/Boogu/Boogu-Image-0.1-Turbo",
       "ui": {
@@ -2730,19 +2728,17 @@
         // pinned build, exclusive sm_120, 1024²/8-step seed 42: steady 29.76 → 21.5 GB, overall-peak
         // 42.9 → 34.7 GB — a constant 8.2 GB shift = the 15.6 → 7.4 GB dense TE reduction, landing
         // int8-convrot right next to q8 as the sc-12425 note predicted ("once the TE drops the two tiers
-        // match"). q4/q8/bf16 also now run the bf16 TE and carry ~8.2 GB less RESIDENT, but stay at their
-        // (still-safe, now-conservative) f32-TE figures pending their OWN direct re-measure — a derived
-        // subtraction is unsafe for a fit-gate (resident↔sequential don't compose arithmetically; an
-        // under-prediction OOMs). sc-12828 follow-up re-measures q4/q8/bf16 + ideogram/boogu directly.
-        "vramGbByTier": { "q4": 26.4, "q8": 35.9, "bf16": 55.6, "int8-convrot": 34.7 },
+        // match").
+        // sc-13108 directly re-measured the standard tiers on the pinned bf16-TE build, exclusive
+        // RTX PRO 6000 Blackwell sm_120, 1024²/8-step seed 42. Resident/sequential raw pixels were
+        // byte-identical per tier. q4/q8 fall only 0.7 GB because their TEs are packed; the dense bf16
+        // tier realizes the full win (55.6 → 47.2 GB). These are measured peaks, not derived shifts.
+        "vramGbByTier": { "q4": 25.7, "q8": 35.2, "bf16": 47.2, "int8-convrot": 34.7 },
         // sc-12131 / sc-10856 second-stage gate: measured largest working set after the text phase has
-        // been dropped. `int8-convrot` = 28.6 GB (sc-12425, measured sm_120 1024²/8-step, byte-identical
-        // pixels resident vs sequential) — it lands next to q8's 29.5 because the int8 DiT is the same
-        // size as q8's, so once the shared 15.6 GB f32 Qwen3-VL TE drops the two tiers cost the same. Its
-        // RESIDENT peak (`vramGbByTier` above, 42.9) is higher than q8's 35.9 ONLY because ConvRot holds
-        // that f32 TE co-resident; sequential residency (the pinned rev honors ConvRot's offload policy)
-        // erases the gap. So on a card too small for 42.9 the worker falls back to this 28.6.
-        "sequentialPeakGb": { "q4": 22.7, "q8": 29.5, "bf16": 39.8, "int8-convrot": 28.6 },
+        // been dropped. sc-13108 directly measured q4/q8/bf16 at 21.9/29.4/39.4 GB; sc-12425 measured
+        // int8-convrot at 28.6 GB with resident/sequential byte-identical pixels. The int8 and q8 DiTs
+        // remain close in size once their text encoders are dropped, so their sequential peaks converge.
+        "sequentialPeakGb": { "q4": 21.9, "q8": 29.4, "bf16": 39.4, "int8-convrot": 28.6 },
         "measured": true,
         // Pose-ControlNet lane VRAM fit ladder (sc-11754, epic 8459 → epic 10765). The control lane loads
         // the base at the installed tier PLUS the trained ~6.6 GB bf16 control branch, so its render peak

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "adfdff624bc78dfaaa4687cafc09d1a82ac5983f" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "3dfa534811da2099d6c9e89e22e9e8e6fa76b12f" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "adfdff624bc78dfaaa4687cafc09d1a82ac5983f" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "3dfa534811da2099d6c9e89e22e9e8e6fa76b12f" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "adfdff624bc78dfaaa4687cafc09d1a82ac5983f", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "3dfa534811da2099d6c9e89e22e9e8e6fa76b12f", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -742,14 +742,14 @@ fn krea_candle_block_drives_the_registry_and_second_stage_gate() {
     let q4_resident = predicted_peak_gb(entry, "q4").expect("q4 resident peak");
     let q4_sequential =
         predicted_sequential_peak_gb(entry, "q4").expect("q4 sequential peak");
-    assert!((q4_resident - 28.4).abs() < 1e-6);
-    assert!((q4_sequential - 24.7).abs() < 1e-6);
-    assert!((predicted_sequential_peak_gb(entry, "q8").unwrap() - 31.5).abs() < 1e-6);
-    assert!((predicted_sequential_peak_gb(entry, "bf16").unwrap() - 41.8).abs() < 1e-6);
+    assert!((q4_resident - 27.7).abs() < 1e-6);
+    assert!((q4_sequential - 23.9).abs() < 1e-6);
+    assert!((predicted_sequential_peak_gb(entry, "q8").unwrap() - 31.4).abs() < 1e-6);
+    assert!((predicted_sequential_peak_gb(entry, "bf16").unwrap() - 41.4).abs() < 1e-6);
     // sc-12425: int8-convrot has a measured sequential peak (28.6 + 2.0 headroom = 30.6). It was `None`
     // while the ConvRot lane was pinned Resident; the runtime now honors ConvRot sequential residency
     // (inference PR #67, in the pinned rev d64af1dd) so it drops the 15.6 GB f32 TE like every other
-    // Turbo request. 30.6 sits next to q8's 31.5 — once the shared TE drops, the same-size int8 DiT costs
+    // Turbo request. 30.6 sits next to q8's 31.4 — once the shared TE drops, the same-size int8 DiT costs
     // the same as q8. The lockstep is satisfied: this row and the runtime that honors it are pinned
     // together (a future pin bump BELOW #67 would re-break it — the runtime would run the 42.9 resident
     // peak while the worker predicts 30.6).
@@ -768,7 +768,7 @@ fn krea_candle_block_drives_the_registry_and_second_stage_gate() {
     let card12 = apply_vram_cap(None, Some(12.0));
     assert_eq!(
         sequential_overflow_gb(Some(q4_sequential), card12),
-        Some(24.7)
+        Some(23.9)
     );
 }
 

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -253,7 +253,7 @@ def test_z_image_turbo_manifest_has_mlx_block():
 
 
 def test_krea_2_turbo_candle_vram_tiers_match_measured_peaks():
-    """sc-12126: never regress the measured q8/bf16 peaks to estimates."""
+    """sc-12126/sc-13108: never regress the directly measured standard-tier peaks."""
     manifest = _load_builtin_models_manifest()
     krea = next(model for model in manifest["models"] if model["id"] == "krea_2_turbo")
     measured_tiers = {
@@ -261,9 +261,9 @@ def test_krea_2_turbo_candle_vram_tiers_match_measured_peaks():
     }
 
     assert measured_tiers == {
-        "q4": 26.4,
-        "q8": 35.9,
-        "bf16": 55.6,
+        "q4": 25.7,
+        "q8": 35.2,
+        "bf16": 47.2,
     }
 
 


### PR DESCRIPTION
Completes sc-13108 in SceneWorks. Records direct exclusive-GPU 1024² measurements for Krea q4/q8/bf16 resident and sequential, Ideogram Base/Turbo q4/q8/bf16, and Boogu Base/Turbo q4/bf16; replaces unsafe estimates with observed tier gates and measured provenance; and pins merged inference PR #120 at 3dfa534811da2099d6c9e89e22e9e8e6fa76b12f. Validation: scaffold, NC-weight guard, live download-pattern check, inference-pin self-test, full Windows Candle clippy/check suite, direct renders, byte-identical Krea resident/sequential outputs, and independent adversarial review PASS.