### PR TITLE
test(manifests): enforce constraint contracts (sc-12304)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -1,5 +1,14 @@
 {
   "$schema": "../../packages/schemas/model-manifest.schema.json",
+  // MANIFEST CONTRACT (sc-12304): every constraint-shaped key is classified in
+  // model-manifest.schema.json with `x-sceneworks-contract`:
+  //   binding     — authoritative backend behavior (rejection unless the property's
+  //                 schema description explicitly names deterministic normalization);
+  //   advisory    — deliberately used only to guide UI/selection; never a backend gate;
+  //   descriptive — records facts and does not constrain a request.
+  // Do not add a `limits.*`, backend `limits.*`, or `*.minMemoryGb` key without
+  // adding its schema classification and production readers. The conformance audit in
+  // tests/test_builtin_manifest_audit.py checks the manifest and schema in both directions.
   "schemaVersion": 1,
   "models": [
     {

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://sceneworks.local/schemas/model-manifest.schema.json",
   "title": "SceneWorks Model Manifest",
+  "description": "Authoring schema for the model catalog. Constraint-shaped properties carry x-sceneworks-contract: binding means authoritative backend behavior (rejection unless the property's description explicitly names deterministic normalization), advisory means UI/selection guidance that is deliberately not a backend gate, and descriptive means factual metadata. tests/test_builtin_manifest_audit.py treats these annotations as the gated contract registry (sc-12304).",
   "type": "object",
   "required": ["schemaVersion", "models"],
   "$defs": {
@@ -76,19 +77,25 @@
           "type": "array",
           "minItems": 1,
           "uniqueItems": true,
-          "items": { "$ref": "#/$defs/samplerKey" }
+          "items": { "$ref": "#/$defs/samplerKey" },
+          "x-sceneworks-contract": "advisory",
+          "x-sceneworks-readers": [{ "path": "apps/web/src/samplerOptions.js", "anchor": "limits?.samplers" }]
         },
         "schedulers": {
           "type": "array",
           "minItems": 1,
           "uniqueItems": true,
-          "items": { "$ref": "#/$defs/schedulerKey" }
+          "items": { "$ref": "#/$defs/schedulerKey" },
+          "x-sceneworks-contract": "advisory",
+          "x-sceneworks-readers": [{ "path": "apps/web/src/samplerOptions.js", "anchor": "limits?.schedulers" }]
         },
         "guidanceMethods": {
           "type": "array",
           "minItems": 1,
           "uniqueItems": true,
-          "items": { "$ref": "#/$defs/guidanceMethodKey" }
+          "items": { "$ref": "#/$defs/guidanceMethodKey" },
+          "x-sceneworks-contract": "advisory",
+          "x-sceneworks-readers": [{ "path": "apps/web/src/samplerOptions.js", "anchor": "limits?.guidanceMethods" }]
         }
       }
     }
@@ -115,25 +122,81 @@
           },
           "limits": {
             "type": "object",
-            "description": "Per-model capability lists. Sampler / scheduler / guidance arrays gate the Image / Video Studio dropdowns; omit them to hide the controls.",
+            "description": "Per-model constraints and capability menus. Each property is explicitly classified; never infer enforcement from the word limits.",
             "properties": {
+              "resolutions": {
+                "type": "array", "items": { "type": "string" },
+                "x-sceneworks-contract": "advisory",
+                "x-sceneworks-readers": [{ "path": "apps/web/src/screens/ImageStudio.jsx", "anchor": "selectedModel?.limits?.resolutions" }],
+                "description": "UI/recipe resolution menu. Runtime geometry is governed by the binding stride and pixel constraints."
+              },
+              "count": {
+                "type": "array", "items": { "type": "integer", "minimum": 1 },
+                "x-sceneworks-contract": "advisory",
+                "x-sceneworks-reader-exemption": "sc-12335 owns the deliberate limits.count UI-reader decision",
+                "description": "Image Studio batch-size menu; deliberately not a backend rejection gate (sc-12335)."
+              },
+              "durations": {
+                "type": "array", "items": { "type": "number", "exclusiveMinimum": 0 },
+                "x-sceneworks-contract": "advisory",
+                "x-sceneworks-readers": [{ "path": "apps/web/src/screens/VideoStudio.jsx", "anchor": "selectedModel?.limits?.durations" }],
+                "description": "UI duration menu. The binding hardMaxDuration ceiling owns backend rejection."
+              },
+              "fps": {
+                "type": "array", "items": { "type": "integer", "minimum": 1 },
+                "x-sceneworks-contract": "binding",
+                "x-sceneworks-readers": [{ "path": "crates/sceneworks-core/src/video_request.rs", "anchor": "pub fn allowed_fps" }, { "path": "apps/rust-api/src/generation.rs", "anchor": "if let Some(message) = fps_limit_error(" }, { "path": "crates/sceneworks-worker/src/video_jobs.rs", "anchor": "fps_limit_error(&request.model, request.fps" }],
+                "description": "Allowed render frame rates; API and worker reject off-menu requests."
+              },
+              "hardMaxDuration": {
+                "type": "number", "exclusiveMinimum": 0,
+                "x-sceneworks-contract": "binding",
+                "x-sceneworks-readers": [{ "path": "crates/sceneworks-core/src/video_request.rs", "anchor": "pub fn hard_max_duration" }, { "path": "apps/rust-api/src/generation.rs", "anchor": "if let Some(message) = duration_limit_error(" }, { "path": "crates/sceneworks-worker/src/video_jobs.rs", "anchor": "if let Some(message) = duration_limit_error(" }],
+                "description": "Hard clip-duration ceiling in seconds; API and worker reject rather than clamp."
+              },
+              "maxPixels": {
+                "type": "integer", "minimum": 1,
+                "x-sceneworks-contract": "binding",
+                "x-sceneworks-readers": [{ "path": "crates/sceneworks-core/src/video_request.rs", "anchor": "fn max_pixels_of(" }, { "path": "crates/sceneworks-core/src/video_request.rs", "anchor": "match max_pixels_of(model_manifest_entry)" }],
+                "description": "Maximum rendered pixel area; core fits requested geometry within this ceiling."
+              },
+              "requiresDimensionsMultipleOf": {
+                "type": "integer", "minimum": 1,
+                "x-sceneworks-contract": "binding",
+                "x-sceneworks-readers": [{ "path": "crates/sceneworks-core/src/video_request.rs", "anchor": "fn dimension_multiple_of(" }, { "path": "crates/sceneworks-core/src/video_request.rs", "anchor": "let multiple = dimension_multiple_of(model_manifest_entry)" }],
+                "description": "Required render-dimension stride; core normalizes geometry to this value."
+              },
+              "recommendedMaxDuration": {
+                "type": "number", "exclusiveMinimum": 0,
+                "x-sceneworks-contract": "advisory",
+                "x-sceneworks-readers": [{ "path": "apps/web/src/screens/VideoStudio.jsx", "anchor": "selectedModel.limits.recommendedMaxDuration" }],
+                "description": "Non-blocking UI recommendation; intentionally not enforced."
+              },
               "samplers": {
                 "type": "array",
                 "minItems": 1,
                 "uniqueItems": true,
-                "items": { "$ref": "#/$defs/samplerKey" }
+                "items": { "$ref": "#/$defs/samplerKey" },
+                "x-sceneworks-contract": "advisory",
+                "x-sceneworks-readers": [{ "path": "apps/web/src/samplerOptions.js", "anchor": "limits?.samplers" }]
               },
               "schedulers": {
                 "type": "array",
                 "minItems": 1,
                 "uniqueItems": true,
-                "items": { "$ref": "#/$defs/schedulerKey" }
+                "items": { "$ref": "#/$defs/schedulerKey" },
+                "x-sceneworks-contract": "advisory",
+                "x-sceneworks-readers": [{ "path": "apps/web/src/samplerOptions.js", "anchor": "limits?.schedulers" }]
               },
               "guidanceMethods": {
                 "type": "array",
                 "minItems": 1,
                 "uniqueItems": true,
-                "items": { "$ref": "#/$defs/guidanceMethodKey" }
+                "items": { "$ref": "#/$defs/guidanceMethodKey" },
+                "x-sceneworks-contract": "advisory",
+                "x-sceneworks-allow-undeclared": true,
+                "x-sceneworks-readers": [{ "path": "apps/web/src/samplerOptions.js", "anchor": "limits?.guidanceMethods" }],
+                "description": "Supported backend-neutral guidance menu shape; no builtin model currently needs it."
               }
             }
           },
@@ -179,6 +242,8 @@
               "minMemoryGb": {
                 "type": "integer",
                 "minimum": 1,
+                "x-sceneworks-contract": "advisory",
+                "x-sceneworks-readers": [{ "path": "apps/web/src/screens/ModelManagerScreen.jsx", "anchor": "model.mlx?.minMemoryGb" }],
                 "description": "Minimum unified memory (GB) to run this model on MLX. Mirrors MlxVideoAdapter.estimate_requirements peak_gb."
               },
               "repo": {
@@ -218,6 +283,8 @@
               "minMemoryGb": {
                 "type": "integer",
                 "minimum": 1,
+                "x-sceneworks-contract": "binding",
+                "x-sceneworks-readers": [{ "path": "crates/sceneworks-worker/src/vram_gate.rs", "anchor": "candle.get(\"minMemoryGb\").and_then(json_f64)" }],
                 "description": "Minimum GPU VRAM (GB) to run this model on the candle/CUDA lane — the measured overall-peak of the DEFAULT (lightest, typically q4) hosted tier, plus headroom. This gates the default tier only, matching the established MLX default-tier-gating convention; heavier hosted tiers (q8 / bf16) can exceed this value, and their per-tier measured ceilings live in vramGbByTier. Retires the epic 7982 SD3.5 'minMemoryGb under measured peak' follow-up: this is a real measured CUDA number, not the inherited unified-memory mlx value."
               },
               "vramGbByTier": {
@@ -271,6 +338,7 @@
               },
               "limits": {
                 "$ref": "#/$defs/samplerLimits",
+                "x-sceneworks-allow-undeclared": true,
                 "description": "Per-backend candle/CUDA capability override, read by samplerOptionsFromModel(model, \"candle\"). The top-level limits.samplers/schedulers describe the default lane; this narrows/broadens them for the candle path."
               }
             }

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -39,6 +39,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 MANIFEST_PATH = ROOT / "config" / "manifests" / "builtin.models.jsonc"
+SCHEMA_PATH = ROOT / "packages" / "schemas" / "model-manifest.schema.json"
 
 
 def _strip_jsonc_comments(body: str) -> str:
@@ -88,6 +89,80 @@ def _strip_jsonc_comments(body: str) -> str:
 def _load_builtin_models_manifest() -> dict:
     raw = MANIFEST_PATH.read_text(encoding="utf-8")
     return json.loads(_strip_jsonc_comments(raw))
+
+
+def test_manifest_constraint_contract_registry_is_complete_and_live():
+    """sc-12304: constraint declarations may not silently become decoration.
+
+    The schema is the author-facing registry; this test makes its custom contract
+    annotations a CI gate. It checks both directions (manifest -> registry and
+    registry -> manifest), and binding entries must name production readers that
+    contain the exact key. Advisory/descriptive entries are explicitly allowed not
+    to reject requests, which is materially different from an accidental dead key.
+    """
+    manifest = _load_builtin_models_manifest()
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    model_properties = schema["properties"]["models"]["items"]["properties"]
+
+    declared: set[str] = set()
+    for model in manifest["models"]:
+        declared.update(f"limits.{key}" for key in model.get("limits", {}))
+        for backend in ("mlx", "candle"):
+            block = model.get(backend, {})
+            if "minMemoryGb" in block:
+                declared.add(f"{backend}.minMemoryGb")
+            declared.update(f"{backend}.limits.{key}" for key in block.get("limits", {}))
+
+    limits_properties = model_properties["limits"]["properties"]
+    registry = {f"limits.{key}": value for key, value in limits_properties.items()}
+    for backend in ("mlx", "candle"):
+        backend_properties = model_properties[backend]["properties"]
+        if "minMemoryGb" in backend_properties:
+            registry[f"{backend}.minMemoryGb"] = backend_properties["minMemoryGb"]
+        backend_limits = backend_properties.get("limits", {})
+        if "$ref" in backend_limits:
+            sampler_properties = schema["$defs"]["samplerLimits"]["properties"]
+            for key, value in sampler_properties.items():
+                registry[f"{backend}.limits.{key}"] = value
+
+    allowed_undeclared = {
+        path
+        for path, contract in registry.items()
+        if contract.get("x-sceneworks-allow-undeclared")
+        or (
+            path.startswith("candle.limits.")
+            and model_properties["candle"]["properties"]["limits"].get(
+                "x-sceneworks-allow-undeclared"
+            )
+        )
+    }
+    assert declared <= set(registry) and set(registry) - declared <= allowed_undeclared, (
+        "constraint contract drift: every declared constraint must be registered, "
+        "and every registry entry must be exercised by the builtin manifest; "
+        f"unregistered={sorted(declared - set(registry))}, "
+        f"undeclared={sorted(set(registry) - declared)}"
+    )
+
+    allowed_classes = {"binding", "advisory", "descriptive"}
+    for path, contract in registry.items():
+        classification = contract.get("x-sceneworks-contract")
+        assert classification in allowed_classes, f"{path}: missing/invalid contract classification"
+        readers = contract.get("x-sceneworks-readers", [])
+        exemption = contract.get("x-sceneworks-reader-exemption")
+        assert readers or exemption, (
+            f"{path}: every contract needs anchored production readers or an explicit tracked exemption"
+        )
+        if exemption:
+            assert re.search(r"\bsc-\d+\b", exemption), (
+                f"{path}: reader exemption must cite a tracked Shortcut story"
+            )
+        for reader in readers:
+            assert set(reader) == {"path", "anchor"}, f"{path}: malformed reader metadata"
+            reader_path = ROOT / reader["path"]
+            assert reader_path.is_file(), f"{path}: reader does not exist: {reader['path']}"
+            assert reader["anchor"] in reader_path.read_text(encoding="utf-8"), (
+                f"{path}: reader {reader['path']} no longer contains anchor {reader['anchor']!r}"
+            )
 
 
 def _manifest_brace_walker():


### PR DESCRIPTION
## What does this PR do?

- Classifies every builtin manifest constraint as binding, advisory, or descriptive in the author-facing schema and manifest header.
- Retains `hardMaxDuration` as a binding reject-not-clamp contract backed by its shipped core/API/worker enforcement.
- Adds a bidirectional conformance audit with exact production reader and call-site anchors plus tracked exemptions.

## Related issue

Shortcut: https://app.shortcut.com/trefry/story/12304

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [x] Refactor / chore (no user-facing behavior change)

## How was this tested?

- [x] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [x] Not platform-specific (web UI, docs, shared crate)

- `python3 -m pytest -q -p no:cacheprovider tests/test_builtin_manifest_audit.py` — 11 passed
- `npm run check`
- `git diff --check`
- Independent adversarial review — clean

## Checklist

- [x] I ran `npm run check` (scaffold checks)
- [x] I updated documentation where relevant
- [x] All my commits are signed off
- [x] My PR is focused on a single logical change
