### PR TITLE
Guard styled prompt batches by character budget (sc-13213)

### DIFF
--- a/apps/web/src/App.imageStudioStylePreview.test.jsx
+++ b/apps/web/src/App.imageStudioStylePreview.test.jsx
@@ -20,6 +20,7 @@ describe("Image Studio — live Style preview parity (sc-13131)", () => {
 
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
     container = document.createElement("div");
     document.body.appendChild(container);
     createImageJob = vi.fn(() => Promise.resolve({ id: "image-job-1" }));
@@ -134,6 +135,28 @@ describe("Image Studio — live Style preview parity (sc-13131)", () => {
     const submittedPrompt = await submitAndReadPayloadPrompt();
     // The DoD: what the user SEES is exactly what is SENT.
     expect(shown).toBe(submittedPrompt);
+  });
+
+  it("blocks a styled batch before submit and identifies every over-cap resolved item", async () => {
+    const longPrompt = "x".repeat(3500);
+    window.localStorage.setItem(
+      "sceneworks-studio-image-project-1",
+      JSON.stringify({ batchMode: true, batchPromptsText: `${longPrompt}\nshort\n${longPrompt}` }),
+    );
+    await renderStudio();
+    await selectStyle(firstStyle.name);
+
+    const run = [...document.body.querySelectorAll("button")].find((button) => button.textContent.includes("Run batch"));
+    await act(async () => {
+      run.click();
+    });
+    await settle();
+
+    expect(createImageJob).not.toHaveBeenCalled();
+    const warning = [...document.body.querySelectorAll(".batch-warning")].find((node) =>
+      node.textContent.includes("character limit"),
+    );
+    expect(warning?.textContent).toMatch(/^Batch prompts 1 \(\d+\/4000\), 3 \(\d+\/4000\) exceed/);
   });
 
   it("updates live as the prompt changes, staying equal to the payload", async () => {

--- a/apps/web/src/imageStudioValidation.js
+++ b/apps/web/src/imageStudioValidation.js
@@ -12,6 +12,20 @@ import { presetLoraIssues } from "./generationValidation.js";
 import { promptBudget } from "./styleComposer.js";
 import { issue } from "./validation/issues.js";
 
+export function batchPromptBudgetOverages(composedPrompts = []) {
+  return composedPrompts.flatMap((prompt, index) => {
+    const budget = promptBudget(prompt);
+    return budget.over ? [{ item: index + 1, ...budget }] : [];
+  });
+}
+
+export function batchPromptBudgetMessage(overages = []) {
+  const items = overages.map(({ item, length, max }) => `${item} (${length}/${max})`).join(", ");
+  return `Batch prompt${overages.length === 1 ? "" : "s"} ${items} exceed${
+    overages.length === 1 ? "s" : ""
+  } the character limit — shorten the prompt or pick a shorter style.`;
+}
+
 // Single-image Generate. The conditions whose message already has a home stay OUT of
 // here and remain plain gates in the button's `disabled` expression:
 //   - a structured caption's field errors are listed inside StructuredPromptBuilder;
@@ -95,6 +109,7 @@ export function imageBatchValidation({
   missingKeys = [],
   groupIssues = [],
   resolutionIssues = [],
+  promptBudgetOverages = [],
   minDimension,
   maxDimension,
 } = {}) {
@@ -126,6 +141,9 @@ export function imageBatchValidation({
     issues.push(
       issue.error(null, `A prompt’s [${res.width}×${res.height}] size is out of range — each side must be ${minDimension}–${maxDimension}.`),
     );
+  }
+  if (promptBudgetOverages.length) {
+    issues.push(issue.error(null, batchPromptBudgetMessage(promptBudgetOverages)));
   }
   if (batchTotal === 0) {
     issues.push(issue.requirement("prompts", "Add at least one prompt to run a batch."));

--- a/apps/web/src/imageStudioValidation.test.js
+++ b/apps/web/src/imageStudioValidation.test.js
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import { summarize } from "./validation/issues.js";
-import { imageBatchValidation, imageGenerateValidation } from "./imageStudioValidation.js";
+import {
+  batchPromptBudgetOverages,
+  imageBatchValidation,
+  imageGenerateValidation,
+} from "./imageStudioValidation.js";
 import { composeStyledPrompt, PROMPT_MAX_CHARS } from "./styleComposer.js";
 
 // The two Image Studio CTA gates in the app-wide vocabulary (epic 10649). The kinds are the
@@ -174,6 +178,7 @@ describe("imageBatchValidation", () => {
     missingKeys: [],
     groupIssues: [],
     resolutionIssues: [],
+    promptBudgetOverages: [],
     minDimension: 256,
     maxDimension: 4096,
   };
@@ -199,6 +204,41 @@ describe("imageBatchValidation", () => {
   it("surfaces an out-of-range resolution with the offending size", () => {
     const summary = summarize(imageBatchValidation({ ...whole, resolutionIssues: [{ width: 5000, height: 300 }] }));
     expect(summary.surfaced[0].message).toBe("A prompt’s [5000×300] size is out of range — each side must be 256–4096.");
+  });
+
+  it("blocks at 4001 Unicode scalars, allows 4000, and identifies every offending resolved item", () => {
+    const composedPrompts = [
+      "😀".repeat(PROMPT_MAX_CHARS),
+      "a".repeat(PROMPT_MAX_CHARS + 1),
+      "ok",
+      "😀".repeat(PROMPT_MAX_CHARS + 2),
+    ];
+    const overages = batchPromptBudgetOverages(composedPrompts);
+    expect(overages).toEqual([
+      { item: 2, length: 4001, max: 4000, remaining: -1, over: true },
+      { item: 4, length: 4002, max: 4000, remaining: -2, over: true },
+    ]);
+
+    const summary = summarize(imageBatchValidation({ ...whole, promptBudgetOverages: overages }));
+    expect(summary.ready).toBe(false);
+    expect(summary.surfaced[0].message).toBe(
+      "Batch prompts 2 (4001/4000), 4 (4002/4000) exceed the character limit — shorten the prompt or pick a shorter style.",
+    );
+  });
+
+  it("catches a batch item whose short raw prompt only exceeds the cap after style composition", () => {
+    const rawPrompt = "a fox";
+    const composedPrompt = composeStyledPrompt({
+      styleText: "x".repeat(PROMPT_MAX_CHARS),
+      userPrompt: rawPrompt,
+    });
+    expect([...rawPrompt].length).toBeLessThan(PROMPT_MAX_CHARS);
+    expect([...composedPrompt].length).toBeGreaterThan(PROMPT_MAX_CHARS);
+
+    const overages = batchPromptBudgetOverages([composedPrompt]);
+    expect(overages).toHaveLength(1);
+    expect(overages[0]).toMatchObject({ item: 1, length: [...composedPrompt].length, max: PROMPT_MAX_CHARS });
+    expect(summarize(imageBatchValidation({ ...whole, promptBudgetOverages: overages })).ready).toBe(false);
   });
 
   // The batch panel renders surfaced[0]; the rules must push in the same priority order the

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -119,7 +119,12 @@ import {
 } from "./generationStudio.jsx";
 import { useAppContext } from "../context/AppContext.js";
 import { ModelAvailabilityGate } from "../components/ModelAvailabilityGate.jsx";
-import { imageBatchValidation, imageGenerateValidation } from "../imageStudioValidation.js";
+import {
+  batchPromptBudgetMessage,
+  batchPromptBudgetOverages,
+  imageBatchValidation,
+  imageGenerateValidation,
+} from "../imageStudioValidation.js";
 import { useValidation } from "../validation/useValidation.js";
 import { ValidationSummary } from "../validation/Validation.jsx";
 import {
@@ -2084,6 +2089,19 @@ export function ImageStudio() {
     if (!resolved.length) {
       return;
     }
+    const promptBudgetOverages = batchPromptBudgetOverages(
+      stylePreviewActive && !structuredPromptModel
+        ? resolved.map(({ prompt: resolvedPrompt }) => {
+            const { prompt: cleanPrompt } = parsePromptResolution(resolvedPrompt);
+            return buildBatchJobRequest(cleanPrompt).prompt;
+          })
+        : [],
+    );
+    if (promptBudgetOverages.length) {
+      setBatchError(batchPromptBudgetMessage(promptBudgetOverages));
+      setBatchConfirmPending(false);
+      return;
+    }
     if (dimensionsInvalid) {
       setBatchError("Width and height must each be between 256 and 4096.");
       return;
@@ -2180,6 +2198,9 @@ export function ImageStudio() {
   // auto-write a caption per resolved prompt (sc-9980).
   const batchStructuredExpandBlocked =
     structuredPromptModel && (magicModelMissing || typeof magicPrompt !== "function");
+  const activeStyleText = styleTextForId(styleId);
+  const stylePreviewActive =
+    !structuredPromptModel && typeof activeStyleText === "string" && activeStyleText.trim() !== "";
   // One summary per CTA (epic 10644): the button's `disabled` and the message it owes the
   // user come from the same issue list and cannot drift. Two independent rule sets — the
   // batch's problems must never disable single-image Generate. The drafts gather the
@@ -2195,7 +2216,14 @@ export function ImageStudio() {
       minDimension: MIN_IMAGE_DIMENSION,
       maxDimension: MAX_IMAGE_DIMENSION,
     }),
-    [activeProject, batchStructuredExpandBlocked, batchTotal, batchMissingKeys, batchGroupIssues, batchResolutionIssues],
+    [
+      activeProject,
+      batchStructuredExpandBlocked,
+      batchTotal,
+      batchMissingKeys,
+      batchGroupIssues,
+      batchResolutionIssues,
+    ],
   );
   // sc-13131 / sc-13133: the live composed-prompt preview for the selected Style Catalog entry, and
   // the budget the composed string spends against the backend cap. ANTI-DRIFT: we do NOT re-derive
@@ -2207,9 +2235,6 @@ export function ImageStudio() {
   // free-text models with a style actually selected: the style-row is hidden for structured-caption
   // models (which serialize a caption the composer can't wrap), and a null/empty styleText is a
   // pass-through with nothing extra to preview and no style-composition budget to guard.
-  const activeStyleText = styleTextForId(styleId);
-  const stylePreviewActive =
-    !structuredPromptModel && typeof activeStyleText === "string" && activeStyleText.trim() !== "";
   const styledPreviewPrompt = stylePreviewActive ? buildJobRequest({ promptToSend: prompt }).prompt : null;
   const generateDraft = useMemo(
     () => ({


### PR DESCRIPTION
## Summary
- preflight every resolved styled batch prompt through the same request builder used for submission
- block the complete batch before confirmation or enqueue when any composed prompt exceeds the backend's 4,000-character cap
- identify every offending resolved item with its composed Unicode-scalar length

## Acceptance criteria
- [x] Reuses the shared promptBudget / PROMPT_MAX_CHARS contract
- [x] Measures the exact composed request prompt for each resolved batch item
- [x] Preserves the inclusive 4,000-character boundary and Rust-compatible Unicode-scalar counting
- [x] Blocks before submit and surfaces all offender indexes
- [x] Avoids materializing batch cross-products during render; exhaustive checking remains user-triggered

## Validation
- npm --prefix apps/web test (149 files, 2,012 tests)
- npm --prefix apps/web run lint -- --quiet
- npm --prefix apps/web run build
- mutation check: disabling the overage predicate failed both boundary and composed-prompt regressions
- independent adversarial review: PASS (high confidence)

Shortcut: https://app.shortcut.com/trefry/story/13213