### PR TITLE
Style thumbnail batch generator script (sc-13135)

### DIFF
--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -45,8 +45,14 @@ export default [
     },
   },
   {
-    // Test files run under Vitest (jsdom) with node + vitest globals.
-    files: ["src/**/*.test.{js,jsx}", "src/**/*.spec.{js,jsx}"],
+    // Test files run under Vitest (jsdom) with node + vitest globals. Covers both the app tests
+    // under src/ and the script tests under scripts/ (e.g. generate-style-thumbnails.test.js).
+    files: [
+      "src/**/*.test.{js,jsx}",
+      "src/**/*.spec.{js,jsx}",
+      "scripts/**/*.test.{js,mjs}",
+      "scripts/**/*.spec.{js,mjs}",
+    ],
     languageOptions: {
       globals: {
         ...globals.browser,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview --host 0.0.0.0",
     "lint": "eslint src",
     "test": "vitest run --environment jsdom",
-    "gen:styles": "node scripts/generate-styles.mjs"
+    "gen:styles": "node scripts/generate-styles.mjs",
+    "gen:style-thumbnails": "node scripts/generate-style-thumbnails.mjs"
   },
   "dependencies": {
     "konva": "^9.3.22",

--- a/apps/web/public/style-thumbs/.gitignore
+++ b/apps/web/public/style-thumbs/.gitignore
@@ -1,0 +1,2 @@
+# Generated at runtime by scripts/generate-style-thumbnails.mjs (sc-13135) — never commit.
+*.png

--- a/apps/web/scripts/generate-style-thumbnails.mjs
+++ b/apps/web/scripts/generate-style-thumbnails.mjs
@@ -19,6 +19,16 @@
 // Notes on --model: the default `z_image_turbo` is a fast, always-available model. Passing
 // `--model krea_2_turbo` gives the tuned "reference look" the picker was designed around, but
 // that model needs a ~20GB manual download first (it is not provisioned by default).
+//
+// Targeting a non-default rust-api: pass `--host <h>` and/or `--port <n>` to compose the base
+// URL, or `--base <url>` to override it wholesale. `--host`/`--port` default to the SAME env
+// vars rust-api reads (apps/rust-api/src/server.rs) — `SCENEWORKS_API_HOST` and
+// `SCENEWORKS_API_PORT` — so a server configured via those env vars is targeted automatically.
+// Resolution order for the base URL:
+//   1. --base <url>                          (verbatim; trailing slash trimmed; wins over all)
+//   2. http://{host}:{port} where
+//        host = --host  | SCENEWORKS_API_HOST | 127.0.0.1
+//        port = --port  | SCENEWORKS_API_PORT | 8000
 
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
@@ -66,13 +76,22 @@ const REPO_ROOT = (() => {
 
 const SIPS_BIN = "/usr/bin/sips";
 
+// Base-URL composition defaults. These mirror the env vars rust-api itself reads
+// (apps/rust-api/src/server.rs): SCENEWORKS_API_HOST / SCENEWORKS_API_PORT.
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_PORT = 8000;
+
 const DEFAULTS = Object.freeze({
   prompt: "a red fox in a snowy forest",
   model: "z_image_turbo",
   seed: 20240719,
   size: 1024,
   thumb: 128,
-  base: "http://127.0.0.1:8000",
+  // base is resolved from --base / --host / --port / env in parseArgs (see resolveBaseUrl); the
+  // raw flag values below start unset so "not provided" is distinguishable from an explicit value.
+  base: undefined,
+  host: undefined,
+  port: undefined,
   out: resolve(REPO_ROOT, "apps/web/public/style-thumbs"),
   project: null,
   keepFull: null,
@@ -145,10 +164,41 @@ export function shouldSkip(path, force) {
 }
 
 /**
- * Parse `--flag value` / `--bool` argv into a resolved options object (DEFAULTS overlaid with
- * overrides). Unknown flags throw so a typo fails loud instead of silently no-op'ing.
+ * Validate a port value (from --port or SCENEWORKS_API_PORT) as a positive integer, throwing a
+ * clear error otherwise. `source` names the origin so the message points at the right knob.
  */
-export function parseArgs(argv) {
+export function parsePort(raw, source) {
+  const str = String(raw).trim();
+  const n = Number.parseInt(str, 10);
+  if (!/^\d+$/.test(str) || !Number.isInteger(n) || n <= 0) {
+    throw new Error(`${source} expects a positive integer port, got "${raw}"`);
+  }
+  return n;
+}
+
+/**
+ * Resolve the rust-api base URL from parsed flags + env. Order (exact):
+ *   1. `base` (from --base) → used verbatim (trailing slash already trimmed).
+ *   2. else `http://{host}:{port}` with host = --host | SCENEWORKS_API_HOST | 127.0.0.1
+ *      and port = --port | SCENEWORKS_API_PORT | 8000.
+ * env is injected (not read from process.env directly) so callers/tests stay pure.
+ */
+export function resolveBaseUrl({ base, host, port } = {}, env = {}) {
+  if (base != null) {
+    return String(base).replace(/\/+$/, "");
+  }
+  const h = host ?? env.SCENEWORKS_API_HOST ?? DEFAULT_HOST;
+  const rawPort = port ?? env.SCENEWORKS_API_PORT ?? DEFAULT_PORT;
+  const p = parsePort(rawPort, port != null ? "--port" : "SCENEWORKS_API_PORT");
+  return `http://${h}:${p}`;
+}
+
+/**
+ * Parse `--flag value` / `--bool` argv into a resolved options object (DEFAULTS overlaid with
+ * overrides). Unknown flags throw so a typo fails loud instead of silently no-op'ing. `env` is
+ * injected so base-URL resolution (resolveBaseUrl) is testable without mutating process.env.
+ */
+export function parseArgs(argv, env = process.env) {
   const opts = { ...DEFAULTS };
   const toInt = (flag, raw) => {
     const n = Number.parseInt(raw, 10);
@@ -189,6 +239,12 @@ export function parseArgs(argv) {
       case "--base":
         opts.base = next().replace(/\/+$/, "");
         break;
+      case "--host":
+        opts.host = next();
+        break;
+      case "--port":
+        opts.port = parsePort(next(), "--port");
+        break;
       case "--out":
         opts.out = next();
         break;
@@ -215,6 +271,8 @@ export function parseArgs(argv) {
         throw new Error(`Unknown flag: ${arg}`);
     }
   }
+  // Collapse --base / --host / --port / env into the single base URL the rest of the script uses.
+  opts.base = resolveBaseUrl({ base: opts.base, host: opts.host, port: opts.port }, env);
   return opts;
 }
 
@@ -382,7 +440,9 @@ function printHelp() {
       "  --size <px>         native gen size, sent as width+height (default: 1024)",
       "  --thumb <px>        final downscaled square size (default: 128)",
       "  --project <id>      target project (omit → auto-create a scratch project)",
-      "  --base <url>        rust-api base (default: http://127.0.0.1:8000)",
+      "  --base <url>        rust-api base URL, verbatim (overrides --host/--port and env)",
+      "  --host <h>          rust-api host (default: $SCENEWORKS_API_HOST or 127.0.0.1)",
+      "  --port <n>          rust-api port (default: $SCENEWORKS_API_PORT or 8000)",
       "  --out <dir>         thumbnail output dir (default: apps/web/public/style-thumbs)",
       "  --keep-full <dir>   also keep native-res PNGs here (default: discard after resize)",
       "  --limit <n>         only process the first N ids (testing)",
@@ -406,7 +466,8 @@ async function main() {
   }
 
   if (opts.dryRun) {
-    console.log(`DRY RUN — ${ids.length} id(s), no network calls, no files written.\n`);
+    console.log(`DRY RUN — ${ids.length} id(s), no network calls, no files written.`);
+    console.log(`target base: ${opts.base}\n`);
     ids.forEach((id, i) => {
       const prompt = composeThumbnailPrompt(id, opts.prompt);
       const payload = buildJobPayload({

--- a/apps/web/scripts/generate-style-thumbnails.mjs
+++ b/apps/web/scripts/generate-style-thumbnails.mjs
@@ -1,0 +1,506 @@
+// sc-13135 — Batch-generate one preview thumbnail per style for the Style picker.
+//
+// There is no UI to do this except 286 manual Image Studio runs (8 group-level "overall"
+// styles + 278 sub-styles). This script drives the local rust-api to generate one image per
+// style id from a SINGLE shared reference prompt + fixed seed (so the STYLE is the only
+// variable), downscales each result to a small square thumb via macOS `sips`, and writes
+// `<out>/<id>.png`. It is resumable (skips ids whose thumb already exists) and never aborts
+// the whole batch on a single failure.
+//
+// The outgoing `prompt` is composed CLIENT-SIDE (composeStyledPrompt + styleTextForId), NOT
+// by sending a `styleId` to the API — so the script works on any API build, current or older,
+// regardless of whether that build knows about the Style axis.
+//
+// Usage (from apps/web):
+//   npm run gen:style-thumbnails -- --dry-run --limit 3      # inspect payloads, no I/O
+//   npm run gen:style-thumbnails -- --project <projectId>    # generate into an existing project
+//   npm run gen:style-thumbnails                             # auto-create a scratch project
+//
+// Notes on --model: the default `z_image_turbo` is a fast, always-available model. Passing
+// `--model krea_2_turbo` gives the tuned "reference look" the picker was designed around, but
+// that model needs a ~20GB manual download first (it is not provisioned by default).
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { basename, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { composeStyledPrompt } from "../src/styleComposer.js";
+
+// styleCatalog.js is the canonical accessor (STYLE_GROUPS + styleTextForId), but it loads
+// styles.json via a bare `import ... from "./styles.json"` with no `with { type: "json" }`
+// attribute — Vite/Vitest resolve that, but plain Node (which runs this CLI) rejects it. So the
+// script loads the SAME styles.json through createRequire (require() reads JSON natively) and
+// reconstructs the two accessors with byte-identical semantics: a sub-style id → its `prompt`, a
+// group id → that group's `description` (sc-13171). The unit test imports the REAL styleTextForId
+// from styleCatalog.js and asserts this reconstruction matches, so any drift fails CI.
+const require = createRequire(import.meta.url);
+const CATALOG = require("../src/data/styles.json");
+export const STYLE_GROUPS = CATALOG.groups;
+
+const STYLE_TEXT_BY_ID = new Map();
+for (const group of STYLE_GROUPS) {
+  STYLE_TEXT_BY_ID.set(group.id, group.description);
+  for (const style of group.styles) {
+    STYLE_TEXT_BY_ID.set(style.id, style.prompt);
+  }
+}
+
+/** Free-text style prompt for a style/group id, or null when unknown (mirrors styleCatalog.js). */
+function styleTextForId(id) {
+  return id ? STYLE_TEXT_BY_ID.get(id) ?? null : null;
+}
+
+// Repo root (this file lives at apps/web/scripts/); the default --out is resolved from here so
+// the script produces the same paths no matter the caller's CWD. Under plain Node import.meta.url
+// is a file: URL; under Vitest it is a virtual scheme fileURLToPath rejects, so fall back to the
+// CWD (apps/web) → repo root. The default out dir is never used for I/O in the tests, only here.
+const REPO_ROOT = (() => {
+  try {
+    return fileURLToPath(new URL("../../../", import.meta.url));
+  } catch {
+    return resolve(process.cwd(), "..", "..");
+  }
+})();
+
+const SIPS_BIN = "/usr/bin/sips";
+
+const DEFAULTS = Object.freeze({
+  prompt: "a red fox in a snowy forest",
+  model: "z_image_turbo",
+  seed: 20240719,
+  size: 1024,
+  thumb: 128,
+  base: "http://127.0.0.1:8000",
+  out: resolve(REPO_ROOT, "apps/web/public/style-thumbs"),
+  project: null,
+  keepFull: null,
+  limit: null,
+  concurrency: 1,
+  dryRun: false,
+  force: false,
+});
+
+// ---------------------------------------------------------------------------
+// Pure logic (exported for the unit test — no I/O in here).
+// ---------------------------------------------------------------------------
+
+/**
+ * Every style id to render, in stable order: for each of the 8 groups, the GROUP id (its
+ * "overall" style, sc-13171) first, then each of that group's sub-style ids. Ids are globally
+ * unique across the catalog, so the flat list has no duplicates (286 total for the shipped data).
+ */
+export function enumerateStyleIds() {
+  const ids = [];
+  for (const group of STYLE_GROUPS) {
+    ids.push(group.id);
+    for (const style of group.styles) {
+      ids.push(style.id);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Compose the exact outgoing `prompt` for one style id, wrapping the shared reference prompt in
+ * the catalog style text. Resolves BOTH sub-style ids and group ids via styleTextForId (a group
+ * id resolves to that group's description). Mirrors what the live studio preview sends.
+ */
+export function composeThumbnailPrompt(id, referencePrompt) {
+  return composeStyledPrompt({ styleText: styleTextForId(id), userPrompt: referencePrompt });
+}
+
+/**
+ * Build the JSON body for POST /api/v1/image/jobs. camelCase; `count: 1` is REQUIRED (the API's
+ * blanket default is 4). width == height == size. A fixed seed keeps the noise identical across
+ * every style so the style text is the only variable.
+ */
+export function buildJobPayload({ id, prompt, model, seed, size, projectId, count = 1 }) {
+  return {
+    projectId,
+    prompt,
+    model,
+    count,
+    width: size,
+    height: size,
+    seed,
+    // Retained for provenance / debugging; the API ignores unknown fields and we compose the
+    // prompt ourselves, so this never changes what is generated.
+    styleId: id,
+  };
+}
+
+/** Final thumbnail path for a style id: `<outDir>/<id>.png`. */
+export function thumbnailPath(outDir, id) {
+  return `${outDir}/${id}.png`;
+}
+
+/** Resumability rule: skip when the thumb already exists and --force was not passed. */
+export function shouldSkip(path, force) {
+  return !force && existsSync(path);
+}
+
+/**
+ * Parse `--flag value` / `--bool` argv into a resolved options object (DEFAULTS overlaid with
+ * overrides). Unknown flags throw so a typo fails loud instead of silently no-op'ing.
+ */
+export function parseArgs(argv) {
+  const opts = { ...DEFAULTS };
+  const toInt = (flag, raw) => {
+    const n = Number.parseInt(raw, 10);
+    if (!Number.isFinite(n)) {
+      throw new Error(`${flag} expects an integer, got "${raw}"`);
+    }
+    return n;
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const v = argv[i + 1];
+      if (v === undefined) {
+        throw new Error(`${arg} expects a value`);
+      }
+      i += 1;
+      return v;
+    };
+    switch (arg) {
+      case "--prompt":
+        opts.prompt = next();
+        break;
+      case "--model":
+        opts.model = next();
+        break;
+      case "--seed":
+        opts.seed = toInt(arg, next());
+        break;
+      case "--size":
+        opts.size = toInt(arg, next());
+        break;
+      case "--thumb":
+        opts.thumb = toInt(arg, next());
+        break;
+      case "--project":
+        opts.project = next();
+        break;
+      case "--base":
+        opts.base = next().replace(/\/+$/, "");
+        break;
+      case "--out":
+        opts.out = next();
+        break;
+      case "--keep-full":
+        opts.keepFull = next();
+        break;
+      case "--limit":
+        opts.limit = toInt(arg, next());
+        break;
+      case "--concurrency":
+        opts.concurrency = toInt(arg, next());
+        break;
+      case "--dry-run":
+        opts.dryRun = true;
+        break;
+      case "--force":
+        opts.force = true;
+        break;
+      case "--help":
+      case "-h":
+        opts.help = true;
+        break;
+      default:
+        throw new Error(`Unknown flag: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// I/O helpers (only reached by main()).
+// ---------------------------------------------------------------------------
+
+const TERMINAL = new Set(["completed", "failed", "canceled", "interrupted"]);
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function requireSips() {
+  if (!existsSync(SIPS_BIN)) {
+    throw new Error(
+      `${SIPS_BIN} not found. This script relies on macOS \`sips\` to downscale thumbnails ` +
+        `(sharp/ffmpeg are not available here). Run on macOS, or add a resize step.`,
+    );
+  }
+}
+
+async function apiFetch(base, path, init) {
+  const res = await fetch(`${base}${path}`, init);
+  return res;
+}
+
+async function assertApiReachable(base) {
+  try {
+    const res = await apiFetch(base, "/api/v1/projects", { method: "GET" });
+    if (!res.ok) {
+      throw new Error(`GET /api/v1/projects → HTTP ${res.status}`);
+    }
+  } catch (err) {
+    throw new Error(
+      `rust-api not reachable at ${base} (${err.message}). Start it (SCENEWORKS_API_PORT ` +
+        `defaults to 8000) or pass --base, or use --dry-run to inspect payloads offline.`,
+    );
+  }
+}
+
+async function createScratchProject(base) {
+  const name = `Style Thumbnails ${new Date().toISOString().slice(0, 19).replace(/[:T]/g, "-")}`;
+  const res = await apiFetch(base, "/api/v1/projects", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+  if (res.status !== 201) {
+    throw new Error(`POST /api/v1/projects → HTTP ${res.status}: ${await res.text()}`);
+  }
+  const summary = await res.json();
+  return summary.id;
+}
+
+async function submitJob(base, payload) {
+  const res = await apiFetch(base, "/api/v1/image/jobs", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (res.status !== 201) {
+    throw new Error(`submit → HTTP ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  }
+  const snap = await res.json();
+  if (!snap?.id) {
+    throw new Error("submit response missing job id");
+  }
+  return snap.id;
+}
+
+async function pollJob(base, jobId, { intervalMs = 1500, timeoutMs = 10 * 60 * 1000 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const res = await apiFetch(base, `/api/v1/jobs/${jobId}`, { method: "GET" });
+    if (!res.ok) {
+      throw new Error(`poll → HTTP ${res.status}`);
+    }
+    const snap = await res.json();
+    if (TERMINAL.has(snap.status)) {
+      return snap;
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`timed out after ${Math.round(timeoutMs / 1000)}s (last status: ${snap.status})`);
+    }
+    await sleep(intervalMs);
+  }
+}
+
+async function downloadImage(base, projectId, relativePath) {
+  const res = await apiFetch(base, `/api/v1/projects/${projectId}/files/${relativePath}`, {
+    method: "GET",
+  });
+  if (!res.ok) {
+    throw new Error(`download → HTTP ${res.status}`);
+  }
+  const buf = Buffer.from(await res.arrayBuffer());
+  if (buf.length === 0) {
+    throw new Error("downloaded image was empty");
+  }
+  return buf;
+}
+
+function resizeToThumb(fullPath, thumbOut, thumbPx) {
+  const result = spawnSync(SIPS_BIN, ["-z", String(thumbPx), String(thumbPx), fullPath, "--out", thumbOut], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    throw new Error(`sips resize failed: ${result.stderr || result.stdout || `exit ${result.status}`}`);
+  }
+}
+
+/**
+ * Generate one thumbnail end-to-end: submit → poll → download → sips-resize → write thumb.
+ * The full-res PNG is written to a temp path, resized, then discarded (unless --keep-full).
+ */
+async function generateOne(opts, id) {
+  const prompt = composeThumbnailPrompt(id, opts.prompt);
+  const payload = buildJobPayload({
+    id,
+    prompt,
+    model: opts.model,
+    seed: opts.seed,
+    size: opts.size,
+    projectId: opts.project,
+  });
+
+  const jobId = await submitJob(opts.base, payload);
+  const snap = await pollJob(opts.base, jobId);
+  if (snap.status !== "completed") {
+    const reason = snap.error || snap.result?.error || snap.status;
+    throw new Error(`job ${snap.status}: ${typeof reason === "string" ? reason : JSON.stringify(reason)}`);
+  }
+
+  const rel = snap.result?.assets?.[0]?.file?.path;
+  if (!rel) {
+    throw new Error("completed job had no result asset file path");
+  }
+  const buf = await downloadImage(opts.base, opts.project, rel);
+
+  const fullPath = opts.keepFull
+    ? `${opts.keepFull}/${id}.png`
+    : `${opts.out}/.${id}.full.png`;
+  writeFileSync(fullPath, buf);
+
+  const thumbOut = thumbnailPath(opts.out, id);
+  try {
+    resizeToThumb(fullPath, thumbOut, opts.thumb);
+  } finally {
+    if (!opts.keepFull) {
+      try {
+        rmSync(fullPath, { force: true });
+      } catch {
+        // best-effort cleanup of the temp full-res file
+      }
+    }
+  }
+}
+
+function printHelp() {
+  console.log(
+    [
+      "generate-style-thumbnails — one preview thumbnail per style (sc-13135)",
+      "",
+      "Flags:",
+      "  --prompt <text>     reference prompt (default: \"a red fox in a snowy forest\")",
+      "  --model <id>        gen model (default: z_image_turbo; krea_2_turbo = tuned look, ~20GB dl)",
+      "  --seed <int>        fixed seed shared across styles (default: 20240719)",
+      "  --size <px>         native gen size, sent as width+height (default: 1024)",
+      "  --thumb <px>        final downscaled square size (default: 128)",
+      "  --project <id>      target project (omit → auto-create a scratch project)",
+      "  --base <url>        rust-api base (default: http://127.0.0.1:8000)",
+      "  --out <dir>         thumbnail output dir (default: apps/web/public/style-thumbs)",
+      "  --keep-full <dir>   also keep native-res PNGs here (default: discard after resize)",
+      "  --limit <n>         only process the first N ids (testing)",
+      "  --concurrency <n>   workers (default: 1, serial — one GPU)",
+      "  --dry-run           compose + print payloads/paths; no network, no files",
+      "  --force             regenerate even if <out>/<id>.png exists (default: skip existing)",
+    ].join("\n"),
+  );
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) {
+    printHelp();
+    return;
+  }
+
+  let ids = enumerateStyleIds();
+  if (opts.limit != null) {
+    ids = ids.slice(0, opts.limit);
+  }
+
+  if (opts.dryRun) {
+    console.log(`DRY RUN — ${ids.length} id(s), no network calls, no files written.\n`);
+    ids.forEach((id, i) => {
+      const prompt = composeThumbnailPrompt(id, opts.prompt);
+      const payload = buildJobPayload({
+        id,
+        prompt,
+        model: opts.model,
+        seed: opts.seed,
+        size: opts.size,
+        projectId: opts.project ?? "<auto-created-at-runtime>",
+      });
+      console.log(`[${i + 1}/${ids.length}] ${id} → ${thumbnailPath(opts.out, id)}`);
+      console.log(`  payload: ${JSON.stringify(payload)}`);
+      console.log(`  prompt:  ${JSON.stringify(prompt)}\n`);
+    });
+    return;
+  }
+
+  requireSips();
+  await assertApiReachable(opts.base);
+
+  if (!opts.project) {
+    opts.project = await createScratchProject(opts.base);
+    console.log(`Auto-created scratch project: ${opts.project}`);
+  }
+
+  mkdirSync(opts.out, { recursive: true });
+  if (opts.keepFull) {
+    mkdirSync(opts.keepFull, { recursive: true });
+  }
+
+  if (opts.concurrency !== 1) {
+    console.warn(`(--concurrency ${opts.concurrency} requested; running serially — one GPU worker.)`);
+  }
+
+  const total = ids.length;
+  let generated = 0;
+  let skipped = 0;
+  const failed = [];
+
+  for (let i = 0; i < total; i += 1) {
+    const id = ids[i];
+    const label = `[${i + 1}/${total}] ${id}`;
+    const thumb = thumbnailPath(opts.out, id);
+
+    if (shouldSkip(thumb, opts.force)) {
+      skipped += 1;
+      console.log(`${label} SKIP (exists)`);
+      continue;
+    }
+
+    let lastErr = null;
+    let ok = false;
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      try {
+        await generateOne(opts, id);
+        ok = true;
+        break;
+      } catch (err) {
+        lastErr = err;
+        if (attempt < 3) {
+          console.warn(`${label} retry ${attempt}/2 after: ${err.message}`);
+          await sleep(1000 * attempt);
+        }
+      }
+    }
+
+    if (ok) {
+      generated += 1;
+      console.log(`${label} ✓`);
+    } else {
+      failed.push({ id, reason: lastErr?.message ?? "unknown" });
+      console.error(`${label} FAIL(${lastErr?.message ?? "unknown"})`);
+    }
+  }
+
+  console.log("\n─── Summary ───");
+  console.log(`generated: ${generated}`);
+  console.log(`skipped:   ${skipped}`);
+  console.log(`failed:    ${failed.length}`);
+  if (failed.length > 0) {
+    console.log("failed ids:");
+    for (const f of failed) {
+      console.log(`  - ${f.id}: ${f.reason}`);
+    }
+  }
+  console.log(`thumbnails: ${opts.out}`);
+
+  if (failed.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+// Only run main() when invoked directly (not when imported by the test).
+if (process.argv[1] && basename(process.argv[1]) === "generate-style-thumbnails.mjs") {
+  main().catch((err) => {
+    console.error(`fatal: ${err.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/apps/web/scripts/generate-style-thumbnails.mjs
+++ b/apps/web/scripts/generate-style-thumbnails.mjs
@@ -116,7 +116,7 @@ export function composeThumbnailPrompt(id, referencePrompt) {
  * blanket default is 4). width == height == size. A fixed seed keeps the noise identical across
  * every style so the style text is the only variable.
  */
-export function buildJobPayload({ id, prompt, model, seed, size, projectId, count = 1 }) {
+export function buildJobPayload({ prompt, model, seed, size, projectId, count = 1 }) {
   return {
     projectId,
     prompt,
@@ -125,9 +125,12 @@ export function buildJobPayload({ id, prompt, model, seed, size, projectId, coun
     width: size,
     height: size,
     seed,
-    // Retained for provenance / debugging; the API ignores unknown fields and we compose the
-    // prompt ourselves, so this never changes what is generated.
-    styleId: id,
+    // We compose the styled prompt CLIENT-SIDE, so we must NOT also send a `styleId`: the
+    // rust-api (sc-13134) folds styleId server-side whenever presetPromptResolvedClientSide is
+    // falsy, which would run compose_styled_prompt AGAIN over an already-composed prompt and
+    // DOUBLE the style. `styleId` is a recognized DTO field — it is NOT ignored. So we omit it
+    // and set the flag, exactly like apps/web/src/imageJobRequest.js does. (sc-13135)
+    presetPromptResolvedClientSide: true,
   };
 }
 
@@ -328,7 +331,6 @@ function resizeToThumb(fullPath, thumbOut, thumbPx) {
 async function generateOne(opts, id) {
   const prompt = composeThumbnailPrompt(id, opts.prompt);
   const payload = buildJobPayload({
-    id,
     prompt,
     model: opts.model,
     seed: opts.seed,
@@ -408,7 +410,6 @@ async function main() {
     ids.forEach((id, i) => {
       const prompt = composeThumbnailPrompt(id, opts.prompt);
       const payload = buildJobPayload({
-        id,
         prompt,
         model: opts.model,
         seed: opts.seed,

--- a/apps/web/scripts/generate-style-thumbnails.test.js
+++ b/apps/web/scripts/generate-style-thumbnails.test.js
@@ -79,6 +79,25 @@ describe("buildJobPayload", () => {
     expect(payload.projectId).toBe("proj-123");
     expect(payload.prompt).toBe(prompt);
   });
+
+  // sc-13135 blocker: the prompt is composed CLIENT-SIDE, so the payload must NOT carry a
+  // `styleId` (a recognized rust-api DTO field, sc-13134) AND must set
+  // presetPromptResolvedClientSide:true. If both are not enforced, the server folds styleId a
+  // second time over the already-styled prompt and DOUBLES the style. This test fails if anyone
+  // re-adds styleId or drops the flag.
+  it("never sends styleId and always sets presetPromptResolvedClientSide:true", () => {
+    const payload = buildJobPayload({
+      id: "ghibli-style",
+      prompt: composeThumbnailPrompt("ghibli-style", REF),
+      model: "z_image_turbo",
+      seed: 20240719,
+      size: 1024,
+      projectId: "proj-123",
+    });
+    expect(Object.prototype.hasOwnProperty.call(payload, "styleId")).toBe(false);
+    expect(payload.styleId).toBeUndefined();
+    expect(payload.presetPromptResolvedClientSide).toBe(true);
+  });
 });
 
 describe("thumbnailPath", () => {

--- a/apps/web/scripts/generate-style-thumbnails.test.js
+++ b/apps/web/scripts/generate-style-thumbnails.test.js
@@ -165,3 +165,58 @@ describe("parseArgs", () => {
     expect(() => parseArgs(["--bogus"])).toThrow(/Unknown flag/);
   });
 });
+
+describe("parseArgs base-URL resolution", () => {
+  // Empty env is injected so these assertions never depend on the real process.env.
+  const EMPTY = {};
+
+  it("defaults to http://127.0.0.1:8000 with no flags and empty env", () => {
+    expect(parseArgs([], EMPTY).base).toBe("http://127.0.0.1:8000");
+  });
+
+  it("--port composes onto the default host", () => {
+    expect(parseArgs(["--port", "8787"], EMPTY).base).toBe("http://127.0.0.1:8787");
+  });
+
+  it("--host + --port compose the full URL", () => {
+    expect(parseArgs(["--host", "192.168.1.50", "--port", "8787"], EMPTY).base).toBe(
+      "http://192.168.1.50:8787",
+    );
+  });
+
+  it("uses SCENEWORKS_API_PORT from injected env when no --port flag", () => {
+    expect(parseArgs([], { SCENEWORKS_API_PORT: "8787" }).base).toBe("http://127.0.0.1:8787");
+  });
+
+  it("uses SCENEWORKS_API_HOST from injected env when no --host flag", () => {
+    expect(parseArgs([], { SCENEWORKS_API_HOST: "10.0.0.9" }).base).toBe("http://10.0.0.9:8000");
+  });
+
+  it("--port flag overrides SCENEWORKS_API_PORT from env", () => {
+    expect(parseArgs(["--port", "9001"], { SCENEWORKS_API_PORT: "8787" }).base).toBe(
+      "http://127.0.0.1:9001",
+    );
+  });
+
+  it("--base overrides host, port, and env entirely", () => {
+    expect(
+      parseArgs(["--base", "http://lan.example:5555", "--host", "192.168.1.50", "--port", "8787"], {
+        SCENEWORKS_API_PORT: "8787",
+        SCENEWORKS_API_HOST: "10.0.0.9",
+      }).base,
+    ).toBe("http://lan.example:5555");
+  });
+
+  it("trims a trailing slash from --base so URL joins don't double-slash", () => {
+    expect(parseArgs(["--base", "http://127.0.0.1:8000/"], EMPTY).base).toBe("http://127.0.0.1:8000");
+  });
+
+  it("throws on a non-numeric --port", () => {
+    expect(() => parseArgs(["--port", "abc"], EMPTY)).toThrow(/positive integer port/);
+  });
+
+  it("throws on a zero / negative --port", () => {
+    expect(() => parseArgs(["--port", "0"], EMPTY)).toThrow(/positive integer port/);
+    expect(() => parseArgs(["--port", "-5"], EMPTY)).toThrow(/positive integer port/);
+  });
+});

--- a/apps/web/scripts/generate-style-thumbnails.test.js
+++ b/apps/web/scripts/generate-style-thumbnails.test.js
@@ -1,0 +1,148 @@
+// sc-13135 — Unit coverage for the pure logic of the style-thumbnail generator. The live
+// submit→poll→download→resize path needs a running rust-api + model/GPU and is not exercised
+// here; these tests pin the deterministic pieces (enumeration, client-side prompt composition,
+// payload shape, path mapping, arg parsing) that must stay correct across API builds.
+import { describe, expect, it } from "vitest";
+
+import { composeStyledPrompt } from "../src/styleComposer.js";
+import { styleTextForId } from "../src/data/styleCatalog.js";
+
+import {
+  buildJobPayload,
+  composeThumbnailPrompt,
+  enumerateStyleIds,
+  parseArgs,
+  shouldSkip,
+  STYLE_GROUPS,
+  thumbnailPath,
+} from "./generate-style-thumbnails.mjs";
+
+const REF = "a red fox in a snowy forest";
+
+describe("enumerateStyleIds", () => {
+  it("returns all 286 ids: 8 group ids + 278 sub-style ids, all unique", () => {
+    const ids = enumerateStyleIds();
+    expect(ids).toHaveLength(286);
+    expect(new Set(ids).size).toBe(286);
+
+    const groupIds = STYLE_GROUPS.map((g) => g.id);
+    expect(groupIds).toHaveLength(8);
+    for (const gid of groupIds) {
+      expect(ids).toContain(gid);
+    }
+
+    const subIds = STYLE_GROUPS.flatMap((g) => g.styles.map((s) => s.id));
+    expect(subIds).toHaveLength(278);
+    for (const sid of subIds) {
+      expect(ids).toContain(sid);
+    }
+  });
+});
+
+describe("composeThumbnailPrompt", () => {
+  it("matches composeStyledPrompt for a SUB-STYLE id and wraps the reference prompt", () => {
+    const id = "ghibli-style";
+    const expected = composeStyledPrompt({ styleText: styleTextForId(id), userPrompt: REF });
+    const actual = composeThumbnailPrompt(id, REF);
+    expect(actual).toBe(expected);
+    expect(actual.startsWith("Style: ")).toBe(true);
+    expect(actual).toContain(`\nDescription: ${REF}`);
+  });
+
+  it("matches composeStyledPrompt for a GROUP id (resolves the group description)", () => {
+    const id = "anime-style"; // a group-level id
+    expect(STYLE_GROUPS.some((g) => g.id === id)).toBe(true);
+    const expected = composeStyledPrompt({ styleText: styleTextForId(id), userPrompt: REF });
+    const actual = composeThumbnailPrompt(id, REF);
+    expect(actual).toBe(expected);
+    expect(actual.startsWith("Style: ")).toBe(true);
+    expect(actual).toContain(`\nDescription: ${REF}`);
+  });
+});
+
+describe("buildJobPayload", () => {
+  it("includes count:1, the fixed seed, width+height=size, model, projectId, and composed prompt", () => {
+    const prompt = composeThumbnailPrompt("ghibli-style", REF);
+    const payload = buildJobPayload({
+      id: "ghibli-style",
+      prompt,
+      model: "z_image_turbo",
+      seed: 20240719,
+      size: 1024,
+      projectId: "proj-123",
+    });
+    expect(payload.count).toBe(1);
+    expect(payload.seed).toBe(20240719);
+    expect(payload.width).toBe(1024);
+    expect(payload.height).toBe(1024);
+    expect(payload.model).toBe("z_image_turbo");
+    expect(payload.projectId).toBe("proj-123");
+    expect(payload.prompt).toBe(prompt);
+  });
+});
+
+describe("thumbnailPath", () => {
+  it("maps id → <out>/<id>.png", () => {
+    expect(thumbnailPath("/tmp/thumbs", "ghibli-style")).toBe("/tmp/thumbs/ghibli-style.png");
+  });
+});
+
+describe("shouldSkip", () => {
+  it("never skips when force is set", () => {
+    expect(shouldSkip("/no/such/file.png", true)).toBe(false);
+  });
+  it("does not skip a non-existent thumb when force is off", () => {
+    expect(shouldSkip("/no/such/file.png", false)).toBe(false);
+  });
+});
+
+describe("parseArgs", () => {
+  it("applies defaults when no flags are passed", () => {
+    const opts = parseArgs([]);
+    expect(opts.prompt).toBe("a red fox in a snowy forest");
+    expect(opts.model).toBe("z_image_turbo");
+    expect(opts.seed).toBe(20240719);
+    expect(opts.size).toBe(1024);
+    expect(opts.thumb).toBe(128);
+    expect(opts.base).toBe("http://127.0.0.1:8000");
+    expect(opts.concurrency).toBe(1);
+    expect(opts.dryRun).toBe(false);
+    expect(opts.force).toBe(false);
+    expect(opts.project).toBeNull();
+    expect(opts.limit).toBeNull();
+  });
+
+  it("respects overrides including --prompt", () => {
+    const opts = parseArgs([
+      "--prompt",
+      "a lighthouse at dusk",
+      "--model",
+      "krea_2_turbo",
+      "--seed",
+      "42",
+      "--size",
+      "512",
+      "--thumb",
+      "64",
+      "--project",
+      "proj-9",
+      "--limit",
+      "3",
+      "--dry-run",
+      "--force",
+    ]);
+    expect(opts.prompt).toBe("a lighthouse at dusk");
+    expect(opts.model).toBe("krea_2_turbo");
+    expect(opts.seed).toBe(42);
+    expect(opts.size).toBe(512);
+    expect(opts.thumb).toBe(64);
+    expect(opts.project).toBe("proj-9");
+    expect(opts.limit).toBe(3);
+    expect(opts.dryRun).toBe(true);
+    expect(opts.force).toBe(true);
+  });
+
+  it("throws on an unknown flag", () => {
+    expect(() => parseArgs(["--bogus"])).toThrow(/Unknown flag/);
+  });
+});


### PR DESCRIPTION
Adds a Node script that batch-generates one preview thumbnail per style by driving the local rust-api — automating what would otherwise be 286 manual generations. This is the **generation** half of [sc-13135](https://app.shortcut.com/trefry/story/13135); wiring the thumbnails into the picker UI (with name-only fallback) is a follow-on.

## What it does
`apps/web/scripts/generate-style-thumbnails.mjs` (run via `npm run gen:style-thumbnails`):
- Enumerates all **286** style entries (278 sub-styles + 8 group-level "overall" styles).
- Composes the prompt **client-side** via `composeStyledPrompt` — `Style: {style text}\nDescription: {reference prompt}` — and sends the full prompt (no `styleId`, `presetPromptResolvedClientSide: true`) so it never double-folds against the server-side `styleId` fold and matches exactly what the picker preview sends.
- Submits `POST /api/v1/image/jobs` (`count: 1`, fixed seed so style is the only variable, native size), polls `GET /api/v1/jobs/{id}` to completion, downloads `result.assets[0].file.path`, and `sips`-resizes to 128×128 → `apps/web/public/style-thumbs/{id}.png` keyed by style id.
- Auto-creates a scratch project (`POST /api/v1/projects`) when `--project` is omitted.
- **Resumable** (skips existing thumbs unless `--force`), retries each id up to 2× then logs + continues, prints per-item progress and an end summary.

## Flags
`--prompt` (default `"a red fox in a snowy forest"`), `--model` (default `z_image_turbo`; `krea_2_turbo` gives the tuned look but needs a ~20GB manual download), `--seed`, `--size` (native, default 1024), `--thumb` (default 128), `--project`, `--base` (default `http://127.0.0.1:8000`), `--out`, `--limit`, `--keep-full`, `--concurrency` (default 1), `--dry-run`, `--force`.

## Usage
Requires rust-api running on :8000 with the chosen model installed. Smoke first, then full run:
```
npm run gen:style-thumbnails -- --limit 1     # one thumbnail
npm run gen:style-thumbnails                  # all 286 (resumable)
```

## Verification
- 11 unit tests on the pure logic (enumeration = 286 unique; client-side compose byte-identical to the real `styleTextForId` for a sub-style AND a group id — mutation-tested drift guard; payload always `count:1` + fixed seed + **no `styleId`** + `presetPromptResolvedClientSide:true`; path mapping; arg parsing). Full web suite **150 files / 2020 tests** green; lint clean.
- `--dry-run --limit 3` verified: correct composed prompts, `count:1`, no `styleId`, flag set, no network/file I/O.
- Independent adversarial review caught a double-fold defect (sent `styleId` alongside the composed prompt → server re-folds → doubled style); fixed + locked with a test.
- Generated PNGs are git-ignored (`public/style-thumbs/*.png`); nothing binary committed.
- **Live generation path unverified** — no running rust-api/model in this environment; recommend a `--limit 1` smoke once the API is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)