### PR TITLE
test(manifests): enforce model schema contract (sc-12338)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -68,10 +68,10 @@ jobs:
         # pillow / numpy / opencv were only needed by the retired Python worker's
         # adapter tests, deleted in sc-8863; the surviving suite (Rust-API
         # contract/smoke, manifest audits, convert-script unit test) needs only
-        # pytest + httpx.
+        # pytest + httpx + jsonschema (builtin manifest authoring contract).
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest==9.0.2 httpx==0.28.1
+          python -m pip install pytest==9.0.2 httpx==0.28.1 jsonschema==4.25.1
       - name: Run worker test suite
         # Marker expression instead of a hardcoded file list so new test files
         # are picked up automatically; e2e/parity-marked tests run in their own

--- a/apps/rust-api/src/tests/catalog.rs
+++ b/apps/rust-api/src/tests/catalog.rs
@@ -512,7 +512,12 @@ async fn model_and_lora_routes_match_manifest_behavior() {
             {
               "schemaVersion": 1,
               "models": [
-                { "id": "base-model", "name": "User Model", "ui": { "label": "User" } }
+                {
+                  "id": "base-model",
+                  "name": "User Model",
+                  "ui": { "label": "User" },
+                  "customPluginMetadata": { "vendorKey": "preserved" }
+                }
               ]
             }
             "#,
@@ -587,6 +592,9 @@ async fn model_and_lora_routes_match_manifest_behavior() {
     let (status, models) = request(app.clone(), "GET", "/api/v1/models", Value::Null).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(models[0]["name"], "User Model");
+    // sc-12338: schema enforcement is builtin-only. User manifests remain a lenient
+    // extension surface; an unknown custom key must neither brick the route nor be dropped.
+    assert_eq!(models[0]["customPluginMetadata"]["vendorKey"], "preserved");
     assert_eq!(models[0]["adapter"], "z_image_diffusers");
     assert_eq!(models[0]["downloadable"], true);
     assert_eq!(models[0]["downloadSizeBytes"], 12884901888_u64);

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -17,9 +17,11 @@
         "dpmpp_sde",
         "uni_pc",
         "lcm",
-        "ddim"
+        "ddim",
+        "er_sde",
+        "dpmpp_2m_sde"
       ],
-      "description": "Sampler (integration method) from the unified curated framework (epic 7114, decision 2), honored by the native mlx-gen / candle-gen engines. Names match gen-core's Solver registry exactly. \"default\" = the engine's native sampler (no swap). Supersedes the epic-1753 diffusers vocabulary (dpmpp -> dpmpp_2m, unipc -> uni_pc, + euler_ancestral / dpmpp_sde / lcm / ddim)."
+      "description": "Sampler (integration method) advertised by shipped model backends. The unified gen-core names are joined by backend-specific ER-SDE and DPM++ 2M SDE values used by current catalog entries. \"default\" preserves the engine's native sampler."
     },
     "schedulerKey": {
       "type": "string",
@@ -31,9 +33,11 @@
         "exponential",
         "sgm_uniform",
         "beta",
-        "ddim_uniform"
+        "ddim_uniform",
+        "shift",
+        "beta57"
       ],
-      "description": "Sigma schedule from the unified curated framework (epic 7114, decision 2). Names match gen-core's Scheduler registry exactly. \"default\" preserves the engine's native schedule. The epic-1753 \"shift\" pseudo-scheduler is gone — the per-generation time shift is the orthogonal defaults.schedulerShift / advanced.schedulerShift knob, not a scheduler choice."
+      "description": "Sigma schedule advertised by shipped model backends. \"default\" preserves the engine's native schedule; shift and beta57 remain valid for current backend-specific catalog entries."
     },
     "guidanceMethodKey": {
       "type": "string",
@@ -47,13 +51,14 @@
     },
     "quantVariantKey": {
       "type": "string",
-      "enum": ["bf16", "q8", "q4"],
-      "description": "Quantization tier of a downloadable model variant (epic 8506, sc-8508). `bf16` = dense full-precision, `q8` / `q4` = pre-quantized packed tiers. Matches the SceneWorks quant-matrix turnkey subdir names resolved by the worker's standard_tier_subdir. Maps to advanced.mlxQuantize at generation time (bf16 <=> 0/none, q8 <=> 8, q4 <=> 4)."
+      "enum": ["bf16", "q8", "q4", "int8-convrot", "training"],
+      "description": "Download variant identifier. bf16/q8/q4 are standard quant-matrix tiers; int8-convrot is Krea's hosted ConvRot tier; training selects the dedicated Lens training artifact."
     },
     "variantFootprint": {
       "type": "object",
       "description": "Footprint metadata for one downloadable model variant (sc-8508). `diskSizeBytes` is required; the measured-memory fields are OPTIONAL and nullable so a later story (sc-8516) can populate real resident/peak numbers without a schema change. The RAM-suggestion engine (sc-8509/8516) is out of scope here — this only declares the fields it will consume.",
       "required": ["diskSizeBytes"],
+      "additionalProperties": false,
       "properties": {
         "diskSizeBytes": {
           "type": ["integer", "string"],
@@ -69,8 +74,20 @@
         }
       }
     },
+    "numericControl": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": { "type": "string" },
+        "default": { "type": "number" },
+        "min": { "type": "number" },
+        "max": { "type": "number" },
+        "step": { "type": "number", "exclusiveMinimum": 0 }
+      }
+    },
     "samplerLimits": {
       "type": "object",
+      "additionalProperties": false,
       "description": "Per-model sampler / scheduler / guidance capability lists used to gate Image / Video Studio dropdowns. Omit the keys entirely to disable the controls; include single-element [\"default\"] arrays for sealed adapters so the manifest is still self-describing.",
       "properties": {
         "samplers": {
@@ -101,16 +118,57 @@
     }
   },
   "properties": {
+    "$schema": { "type": "string" },
     "schemaVersion": { "type": "integer", "minimum": 1 },
     "models": {
       "type": "array",
       "items": {
         "type": "object",
+        "required": ["id", "name", "type"],
+        "additionalProperties": false,
         "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "name": { "type": "string", "minLength": 1 },
+          "type": { "type": "string", "enum": ["image", "video", "utility"] },
+          "family": { "type": "string" },
+          "adapter": { "type": "string" },
+          "capabilities": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+          "recommended": { "type": "boolean" },
+          "autoDownload": { "type": "boolean" },
+          "macOnly": { "type": "boolean" },
+          "gated": { "type": "boolean" },
+          "credentialHost": { "type": "string" },
+          "licenseUrl": { "type": "string", "format": "uri" },
+          "nonCommercial": { "type": "boolean" },
+          "promptless": { "type": "boolean" },
+          "structuredPrompt": { "type": "boolean" },
+          "minMemoryGb": { "type": "integer", "minimum": 1 },
+          "paths": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": { "model": { "type": "string" } }
+          },
+          "loraCompatibility": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "families": { "type": "array", "items": { "type": "string" } },
+              "types": { "type": "array", "items": { "type": "string" } }
+            }
+          },
+          "quantization": { "type": "object" },
           "defaults": {
             "type": "object",
+            "additionalProperties": false,
             "description": "Model defaults surfaced as form initial values in the studios. Sampler / scheduler defaults are read by the UI (the worker just honors whatever rides on advanced).",
             "properties": {
+              "count": { "type": "integer", "minimum": 1 },
+              "duration": { "type": "number", "exclusiveMinimum": 0 },
+              "fps": { "type": "integer", "minimum": 1 },
+              "guidanceScale": { "type": "number" },
+              "quality": { "type": "string" },
+              "resolution": { "type": "string", "pattern": "^[0-9]+x[0-9]+$" },
+              "steps": { "type": "integer", "minimum": 1 },
               "sampler": { "$ref": "#/$defs/samplerKey" },
               "scheduler": { "$ref": "#/$defs/schedulerKey" },
               "schedulerShift": {
@@ -122,6 +180,7 @@
           },
           "limits": {
             "type": "object",
+            "additionalProperties": false,
             "description": "Per-model constraints and capability menus. Each property is explicitly classified; never infer enforcement from the word limits.",
             "properties": {
               "resolutions": {
@@ -202,12 +261,58 @@
           },
           "ui": {
             "type": "object",
+            "additionalProperties": false,
             "description": "Display metadata for model catalog and studio surfaces.",
             "properties": {
+              "label": { "type": "string" },
+              "description": { "type": "string" },
+              "durationHint": { "type": "string" },
+              "promptHint": { "type": "string" },
+              "defaultPrompt": { "type": "string" },
+              "defaultNegativePrompt": { "type": "string" },
+              "recommendedFor": { "type": "array", "items": { "type": "string" } },
+              "controlModes": { "type": "array", "items": { "type": "string" } },
+              "viewAngles": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["id", "label"],
+                  "additionalProperties": false,
+                  "properties": { "id": { "type": "string" }, "label": { "type": "string" } }
+                }
+              },
+              "img2img": { "type": "boolean" },
+              "multiReference": { "type": "boolean" },
+              "poseLibrary": { "type": "boolean" },
+              "poseControlScale": { "type": "boolean" },
+              "controlOverlay": { "type": "boolean" },
+              "precisionToggle": { "type": "boolean" },
+              "promptEnhance": { "type": "boolean" },
+              "hideReferenceStrength": { "type": "boolean" },
+              "referenceStrengthDefault": { "type": "number" },
+              "controlScale": { "$ref": "#/$defs/numericControl" },
+              "identityStructure": { "$ref": "#/$defs/numericControl" },
+              "img2imgStrength": { "$ref": "#/$defs/numericControl" },
+              "textStyleGain": { "$ref": "#/$defs/numericControl" },
+              "variationStrength": { "$ref": "#/$defs/numericControl" },
+              "editReferences": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "secondaryHint": { "type": "string" },
+                  "secondaryLabel": { "type": "string" }
+                }
+              },
+              "pid": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": { "checkpointId": { "type": "string" } }
+              },
               "promptGuide": {
                 "type": "object",
                 "description": "Static Markdown prompt guide shown near prompt entry for this model.",
                 "required": ["title", "path"],
+                "additionalProperties": false,
                 "properties": {
                   "title": {
                     "type": "string",
@@ -225,6 +330,7 @@
                     "items": {
                       "type": "object",
                       "required": ["label", "url"],
+                      "additionalProperties": false,
                       "properties": {
                         "label": { "type": "string", "minLength": 1 },
                         "url": { "type": "string", "format": "uri" }
@@ -237,8 +343,22 @@
           },
           "mlx": {
             "type": "object",
+            "additionalProperties": false,
             "description": "macOS/Apple-Silicon MLX variant metadata (desktop only). Surfaced by the Model Manager to show MLX availability, conversion status, and the minimum unified-memory tier. Inference repos/paths are owned by the Python MlxVideoAdapter; these mirror them for catalog display.",
             "properties": {
+              "quantize": { "type": "integer", "minimum": 1 },
+              "minQualityTier": { "type": "string" },
+              "converter": { "type": "string" },
+              "convertSourceFile": { "type": "string" },
+              "convertBaseRepo": { "type": "string" },
+              "autoDistillLora": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "stage1Strength": { "type": "number" },
+                  "stage2Strength": { "type": "number" }
+                }
+              },
               "minMemoryGb": {
                 "type": "integer",
                 "minimum": 1,
@@ -278,6 +398,7 @@
           },
           "candle": {
             "type": "object",
+            "additionalProperties": false,
             "description": "candle/CUDA (Windows/Linux) variant metadata — the discrete-VRAM sibling of the mlx block (epic 9083, sc-9094). CUDA cards do NOT share system RAM the way Apple unified memory does, so the candle lane needs its OWN measured VRAM gate: the mlx.minMemoryGb (unified-memory OS peak on a Mac) does not describe the VRAM a discrete GPU must hold. Populated from the candle-gen VramProbe harness (sc-9094) at 1024² (video = default frames).",
             "properties": {
               "minMemoryGb": {
@@ -303,6 +424,7 @@
               },
               "control": {
                 "type": "object",
+                "additionalProperties": false,
                 "description": "Pose-ControlNet lane VRAM fit ladder numbers (sc-11754, epic 8459 → epic 10765), keyed by BASE quant tier. Present only for a model with a bespoke trained control branch (Krea 2 Turbo). The control lane loads the base at the installed tier PLUS the ~6.6 GB bf16 control branch, so its render peak exceeds the txt2img vramGbByTier and needs its own numbers; the worker's krea_control_fit gate reads these vs live/capped free VRAM and engages the cheapest sufficient rung only when constrained.",
                 "properties": {
                   "peakGbByTier": {
@@ -345,19 +467,11 @@
           },
           "downloads": {
             "type": "array",
-            "description": "Download entries are usually PICK-ONE alternates for the same model: at most one may be marked default: true (else the first supported entry is used); a quant matrix (epic 8506, sc-8508) lists each tier (bf16 / Q8 / Q4) as a separate same-repo entry distinguished by `files`/`variant`; OS alternates are distinguished by `platforms`. Entries flagged `coRequisite: true` are the exception — FETCH-ALL dependencies (e.g. a decoder checkpoint plus its shared caption encoder) that install alongside the primary and gate its install state (sc-9696).",
-            "contains": {
-              "type": "object",
-              "properties": {
-                "default": { "const": true }
-              },
-              "required": ["default"]
-            },
-            "minContains": 0,
-            "maxContains": 1,
+            "description": "Download entries are usually PICK-ONE alternates for the same model: at most one applicable non-co-requisite may be marked default: true per OS (else the first supported entry is used). tests/test_builtin_manifest_audit.py enforces that platform-aware invariant because JSON Schema cannot compare overlapping platform sets. A quant matrix (epic 8506, sc-8508) lists each tier as a separate same-repo entry distinguished by files/variant; OS alternates are distinguished by platforms. Entries flagged coRequisite: true are FETCH-ALL dependencies installed alongside the primary (sc-9696).",
             "items": {
               "type": "object",
               "required": ["provider", "repo"],
+              "additionalProperties": false,
               "properties": {
                 "provider": {
                   "type": "string",
@@ -391,6 +505,11 @@
                   "type": "array",
                   "items": { "type": "string" },
                   "description": "Optional allow-list of provider file patterns included in the download."
+                },
+                "platforms": {
+                  "type": "array",
+                  "items": { "type": "string", "enum": ["macos", "linux", "windows"] },
+                  "uniqueItems": true
                 }
               }
             }
@@ -409,5 +528,6 @@
         }
       }
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -37,6 +37,8 @@ import json
 import re
 from pathlib import Path
 
+import jsonschema
+
 ROOT = Path(__file__).resolve().parents[1]
 MANIFEST_PATH = ROOT / "config" / "manifests" / "builtin.models.jsonc"
 SCHEMA_PATH = ROOT / "packages" / "schemas" / "model-manifest.schema.json"
@@ -89,6 +91,69 @@ def _strip_jsonc_comments(body: str) -> str:
 def _load_builtin_models_manifest() -> dict:
     raw = MANIFEST_PATH.read_text(encoding="utf-8")
     return json.loads(_strip_jsonc_comments(raw))
+
+
+def test_builtin_models_manifest_satisfies_authoring_schema():
+    """sc-12338: the builtin catalog's $schema is an enforced CI contract."""
+    manifest = _load_builtin_models_manifest()
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator.check_schema(schema)
+    errors = sorted(
+        jsonschema.Draft202012Validator(schema).iter_errors(manifest),
+        key=lambda error: list(error.absolute_path),
+    )
+    assert not errors, "builtin.models.jsonc violates model-manifest.schema.json:\n" + "\n".join(
+        f"- {'.'.join(map(str, error.absolute_path)) or '<root>'}: {error.message}"
+        for error in errors
+    )
+
+
+def test_builtin_schema_rejects_an_unknown_closed_model_key():
+    """Mutation guard: a typo/decorative builtin key must make the CI gate fail."""
+    manifest = _load_builtin_models_manifest()
+    manifest["models"][0]["recommendded"] = True
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    errors = list(jsonschema.Draft202012Validator(schema).iter_errors(manifest))
+    assert any("recommendded" in error.message for error in errors)
+
+
+def _duplicate_default_downloads(manifest: dict) -> list[str]:
+    """Return model/platform pairs with ambiguous primary download selection."""
+    ambiguous: list[str] = []
+    for model in manifest["models"]:
+        downloads = model.get("downloads", [])
+        for platform in ("macos", "windows", "linux"):
+            defaults = [
+                download
+                for download in downloads
+                if download.get("default") is True
+                and download.get("coRequisite") is not True
+                and (
+                    "platforms" not in download
+                    or platform in download.get("platforms", [])
+                )
+            ]
+            if len(defaults) > 1:
+                ambiguous.append(f"{model['id']}:{platform}")
+    return ambiguous
+
+
+def test_builtin_download_defaults_are_unique_per_platform():
+    """A model may have one primary default per OS, never two applicable defaults."""
+    assert not _duplicate_default_downloads(_load_builtin_models_manifest())
+
+
+def test_download_default_guard_rejects_an_ambiguous_platform_mutation():
+    """Mutation guard for the platform-aware replacement of schema maxContains."""
+    manifest = _load_builtin_models_manifest()
+    model = next(model for model in manifest["models"] if model["id"] == "wan_2_2")
+    windows_download = next(
+        download
+        for download in model["downloads"]
+        if download.get("variant") == "q8" and "windows" in download.get("platforms", [])
+    )
+    windows_download["default"] = True
+    assert _duplicate_default_downloads(manifest) == ["wan_2_2:windows", "wan_2_2:linux"]
 
 
 def test_manifest_constraint_contract_registry_is_complete_and_live():


### PR DESCRIPTION
## Summary
- validate builtin.models.jsonc against its Draft 2020-12 schema in the existing Python CI lane
- complete and close known manifest object shapes while preserving intentionally dynamic resources
- preserve the sc-12304 contract registry and add platform-aware default-download drift guards
- prove user.models.jsonc remains lenient for unknown extension metadata

## Acceptance criteria
- [x] builtin manifest schema violations fail CI
- [x] schema covers the classified constraint registry and reconciled captionStyle declarations
- [x] schema/registry drift and ambiguous per-platform defaults are mutation-tested
- [x] unknown user-manifest keys do not brick or disappear from the models route

## Validation
- 15 focused manifest audit tests passed
- 20 non-e2e Python tests passed; 17 deselected
- focused rust-api catalog route test passed
- mutation checks failed when model unknown-key strictness was disabled and when duplicate applicable defaults were introduced
- npm run rust:check passed unsandboxed, including Metal nax guard
- npm run check passed
- independent adversarial review: PASS, high confidence

Shortcut: https://app.shortcut.com/trefry/story/12338