### PR TITLE
feat(web): inline row detail + 100-row pagination on Generation Stats

### DIFF
--- a/apps/web/src/screens/StatsScreen.jsx
+++ b/apps/web/src/screens/StatsScreen.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { WorkPanel } from "../components/WorkPanel.jsx";
 import {
   Bar,
@@ -268,25 +268,39 @@ function StatsCharts({ rows }) {
   );
 }
 
+const PAGE_SIZE = 100;
+
 export function StatsScreen() {
   const { token } = useAppStatic();
   const { rows, loading, error, refresh } = useGenerationMetrics({ token });
   const [filters, setFilters] = useState({ type: "", model: "", quant: "", status: "" });
   const [sort, setSort] = useState({ key: "createdAt", dir: "desc" });
   const [selectedId, setSelectedId] = useState(null);
+  const [page, setPage] = useState(1);
 
   const options = useMemo(() => deriveFilterOptions(rows), [rows]);
   const filtered = useMemo(() => filterRows(rows, filters), [rows, filters]);
   const sorted = useMemo(() => sortRows(filtered, sort), [filtered, sort]);
   const kpis = useMemo(() => computeKpis(filtered), [filtered]);
-  const selected = useMemo(
-    () => sorted.find((r) => r.jobId === selectedId) ?? null,
-    [sorted, selectedId],
+
+  const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
+  // Clamp when the row count shrinks (e.g. a filter drops the current page away).
+  useEffect(() => {
+    setPage((prev) => Math.min(prev, totalPages));
+  }, [totalPages]);
+  const pageStart = (page - 1) * PAGE_SIZE;
+  const pageRows = useMemo(
+    () => sorted.slice(pageStart, pageStart + PAGE_SIZE),
+    [sorted, pageStart],
   );
 
-  const setFilter = (key, value) => setFilters((prev) => ({ ...prev, [key]: value }));
+  const setFilter = (key, value) => {
+    setFilters((prev) => ({ ...prev, [key]: value }));
+    setPage(1);
+  };
   const toggleSort = (key) => {
     if (!key) return;
+    setPage(1);
     setSort((prev) =>
       prev.key === key
         ? { key, dir: prev.dir === "asc" ? "desc" : "asc" }
@@ -374,24 +388,32 @@ export function StatsScreen() {
             </tr>
           </thead>
           <tbody>
-            {sorted.map((r) => (
-              <tr
-                key={r.jobId}
-                className={r.jobId === selectedId ? "selected" : ""}
-                onClick={() => setSelectedId(r.jobId)}
-              >
-                {COLUMNS.map((col) => (
-                  <td key={col.label} className={col.numeric ? "num mono" : ""}>
-                    {col.key === "status" ? (
-                      <span className={`stats-pill stats-pill-${statusTone(r.status)}`}>
-                        {r.status ?? "—"}
-                      </span>
-                    ) : (
-                      col.get(r)
-                    )}
-                  </td>
-                ))}
-              </tr>
+            {pageRows.map((r) => (
+              <React.Fragment key={r.jobId}>
+                <tr
+                  className={r.jobId === selectedId ? "selected" : ""}
+                  onClick={() => setSelectedId((prev) => (prev === r.jobId ? null : r.jobId))}
+                >
+                  {COLUMNS.map((col) => (
+                    <td key={col.label} className={col.numeric ? "num mono" : ""}>
+                      {col.key === "status" ? (
+                        <span className={`stats-pill stats-pill-${statusTone(r.status)}`}>
+                          {r.status ?? "—"}
+                        </span>
+                      ) : (
+                        col.get(r)
+                      )}
+                    </td>
+                  ))}
+                </tr>
+                {r.jobId === selectedId ? (
+                  <tr className="stats-detail-row">
+                    <td colSpan={COLUMNS.length}>
+                      <RunDetail row={r} onClose={() => setSelectedId(null)} />
+                    </td>
+                  </tr>
+                ) : null}
+              </React.Fragment>
             ))}
             {!sorted.length && !loading ? (
               <tr>
@@ -404,7 +426,29 @@ export function StatsScreen() {
         </table>
       </div>
 
-      {selected ? <RunDetail row={selected} onClose={() => setSelectedId(null)} /> : null}
+      {totalPages > 1 ? (
+        <div className="stats-pagination">
+          <button
+            type="button"
+            className="stats-page-btn"
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page <= 1}
+          >
+            Previous
+          </button>
+          <span className="stats-page-info">
+            {pageStart + 1}–{Math.min(pageStart + PAGE_SIZE, sorted.length)} of {sorted.length}
+          </span>
+          <button
+            type="button"
+            className="stats-page-btn"
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            disabled={page >= totalPages}
+          >
+            Next
+          </button>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/screens/StatsScreen.test.jsx
+++ b/apps/web/src/screens/StatsScreen.test.jsx
@@ -1,41 +1,50 @@
 import React from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AppContext } from "../context/AppContext.js";
+
+// Mutable feed so individual tests can swap in their own rows before rendering.
+// vi.hoisted runs before the (hoisted) vi.mock factory, so the mock can close
+// over it.
+const feed = vi.hoisted(() => ({ rows: [] }));
+
+function makeRow(i) {
+  return {
+    jobId: `job-${i}`,
+    type: "image_generate",
+    status: "completed",
+    createdAt: `2026-07-01T10:00:00Z`,
+    metrics: {
+      model: "qwen_image",
+      quantLabel: "q8",
+      sampler: "default",
+      scheduler: "default",
+      guidanceScale: 4.0,
+      steps: 20,
+      imageCount: 2,
+      totalMs: 9400,
+      loadMs: 2100,
+      sampleMs: 6400,
+      decodeMs: 900,
+      peakMemoryPct: 71,
+      peakMemoryBytes: 12_884_901_888,
+      peakGpuLoadPct: 88,
+      backend: "mlx",
+      width: 1024,
+      height: 1024,
+      seed: 42,
+    },
+  };
+}
+
+const SINGLE_ROW = makeRow("a");
 
 // Deterministic metrics feed so the render needs no network.
 vi.mock("../hooks/useGenerationMetrics.js", () => ({
   useGenerationMetrics: () => ({
-    rows: [
-      {
-        jobId: "job-a",
-        type: "image_generate",
-        status: "completed",
-        createdAt: "2026-07-01T10:00:00Z",
-        metrics: {
-          model: "qwen_image",
-          quantLabel: "q8",
-          sampler: "default",
-          scheduler: "default",
-          guidanceScale: 4.0,
-          steps: 20,
-          imageCount: 2,
-          totalMs: 9400,
-          loadMs: 2100,
-          sampleMs: 6400,
-          decodeMs: 900,
-          peakMemoryPct: 71,
-          peakMemoryBytes: 12_884_901_888,
-          peakGpuLoadPct: 88,
-          backend: "mlx",
-          width: 1024,
-          height: 1024,
-          seed: 42,
-        },
-      },
-    ],
+    rows: feed.rows,
     loading: false,
     error: "",
     refresh: () => {},
@@ -56,6 +65,10 @@ const { StatsScreen } = await import("./StatsScreen.jsx");
 let container;
 let root;
 
+beforeEach(() => {
+  feed.rows = [SINGLE_ROW];
+});
+
 afterEach(() => {
   act(() => root?.unmount());
   container?.remove();
@@ -74,6 +87,14 @@ function render() {
   });
 }
 
+function clickRow(index = 0) {
+  const row = container.querySelectorAll(".stats-table tbody tr:not(.stats-detail-row)")[index];
+  act(() => {
+    row.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  return row;
+}
+
 describe("StatsScreen", () => {
   it("renders a row per metrics record with model, quant, and formatted timing", () => {
     render();
@@ -82,18 +103,67 @@ describe("StatsScreen", () => {
     expect(text).toContain("q8");
     expect(text).toContain("9.4s"); // totalMs formatted
     expect(text).toContain("Runs"); // KPI label
-    expect(container.querySelectorAll(".stats-table tbody tr").length).toBe(1);
+    expect(
+      container.querySelectorAll(".stats-table tbody tr:not(.stats-detail-row)").length,
+    ).toBe(1);
   });
 
   it("opens the run-detail panel on row click", () => {
     render();
-    const row = container.querySelector(".stats-table tbody tr");
-    act(() => {
-      row.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
+    clickRow();
     expect(container.querySelector(".stats-detail")).not.toBeNull();
     expect(container.textContent).toContain("Run detail");
     expect(container.textContent).toContain("mlx"); // backend surfaced in detail
     expect(container.textContent).toContain("Per image"); // per-image breakdown (sc-10426)
+  });
+
+  it("expands the detail inline as the row directly after the selected row", () => {
+    render();
+    const row = clickRow();
+    const next = row.nextElementSibling;
+    expect(next).not.toBeNull();
+    expect(next.classList.contains("stats-detail-row")).toBe(true);
+    expect(next.querySelector(".stats-detail")).not.toBeNull();
+    // The detail cell spans the full column count.
+    const headerCols = container.querySelectorAll(".stats-table thead th").length;
+    expect(Number(next.querySelector("td").getAttribute("colspan"))).toBe(headerCols);
+  });
+
+  it("collapses the detail when the selected row is clicked again", () => {
+    render();
+    clickRow();
+    expect(container.querySelector(".stats-detail-row")).not.toBeNull();
+    clickRow(); // toggle off
+    expect(container.querySelector(".stats-detail-row")).toBeNull();
+  });
+
+  it("pages the list by 100 rows with working next/previous controls", () => {
+    feed.rows = Array.from({ length: 150 }, (_, i) => makeRow(i));
+    render();
+
+    const dataRows = () =>
+      container.querySelectorAll(".stats-table tbody tr:not(.stats-detail-row)").length;
+
+    // Page 1: first 100 rows, range summary, Next enabled / Previous disabled.
+    expect(dataRows()).toBe(100);
+    expect(container.textContent).toContain("1–100 of 150");
+    const [prev, next] = container.querySelectorAll(".stats-page-btn");
+    expect(prev.disabled).toBe(true);
+    expect(next.disabled).toBe(false);
+
+    // Advance to page 2: remaining 50 rows, Next now disabled.
+    act(() => {
+      next.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(dataRows()).toBe(50);
+    expect(container.textContent).toContain("101–150 of 150");
+    const [prev2, next2] = container.querySelectorAll(".stats-page-btn");
+    expect(prev2.disabled).toBe(false);
+    expect(next2.disabled).toBe(true);
+  });
+
+  it("hides pagination controls when a single page suffices", () => {
+    render();
+    expect(container.querySelector(".stats-pagination")).toBeNull();
   });
 });

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -13900,6 +13900,34 @@ details[open] > summary.lora-scope-group-heading::before,
   font-variant-numeric: tabular-nums;
   word-break: break-word;
 }
+/* Detail expands inline directly under its selected row: full-bleed, flush,
+   no rounded corners or side borders so it reads as part of that row. */
+.stats-detail-row > td {
+  padding: 0;
+  background: var(--surface-2);
+}
+.stats-detail-row .stats-detail {
+  margin: 0;
+  border-left: none;
+  border-right: none;
+  border-radius: 0;
+}
+.stats-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  margin: 14px 0 4px;
+  font-size: 12.5px;
+  color: var(--text-muted);
+}
+.stats-page-info {
+  font-variant-numeric: tabular-nums;
+}
+.stats-page-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
 .stats-charts {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));


### PR DESCRIPTION
## Summary

The Generation Stats list can get very long, which pushed the per-run **detail panel** to the bottom of the page where it was effectively hidden. This makes the detail **expand inline directly under the selected row**, and makes the list **pageable by 100 rows**.

### Changes
- **Inline detail expansion** — selecting a row now renders the `RunDetail` panel as a full-width row immediately beneath it (flush, full-bleed, no rounded corners so it reads as part of the row). Clicking the selected row again collapses it. The old bottom-of-page panel is removed.
- **Pagination (100/page)** — the table renders a 100-row slice with `Previous · <range> of <total> · Next` controls that only appear when there's more than one page. Changing a filter or sort resets to page 1; the page index is clamped when a filter shrinks the result set so you never land on an empty page.
- **CSS** — new `.stats-detail-row` and `.stats-pagination` rules, using existing theme tokens only (so dark mode adapts automatically).

### Testing
- `StatsScreen.test.jsx` extended: inline detail is the adjacent sibling row with correct `colspan`, toggle-collapse, 100-row paging with working Next/Previous + range label, and pagination hidden for a single page. **6/6 pass.**
- `eslint` clean, `vite build` clean.
- Verified in a live browser render: detail sits flush under the selected row with the list continuing below; pagination control renders centered with correct disabled states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)