### PR TITLE
Document Studio: reference-strength slider for grounded interleave (sc-13293)

### DIFF
--- a/apps/web/src/App.library.test.jsx
+++ b/apps/web/src/App.library.test.jsx
@@ -1187,6 +1187,10 @@ describe("SceneWorks app shell", () => {
     expect(payload.height).toBe(1152);
     // Unedited system prompt is not sent (worker uses its own default).
     expect(payload.advanced?.systemMessage).toBeUndefined();
+    // No reference images attached, so no reference-strength slider and no image-guidance
+    // field (the run stays on the worker's plain-generation defaults).
+    expect(container.textContent).not.toContain("Reference strength");
+    expect(payload.advanced?.imageGuidanceScale).toBeUndefined();
 
     // Submitting stacks the run in the studio rather than routing to the Queue.
     await settle();
@@ -1195,6 +1199,85 @@ describe("SceneWorks app shell", () => {
       expect.objectContaining({ id: "job-il-new" }),
     );
     expect(setActiveView).not.toHaveBeenCalledWith("Queue");
+  });
+
+  it("DocumentStudio surfaces reference strength once references are attached and sends imageGuidanceScale", async () => {
+    const createInterleaveJob = vi.fn(() =>
+      Promise.resolve({ id: "job-il-ref", type: "image_interleave", status: "queued" }),
+    );
+    const imageAsset = {
+      id: "img-ref-1",
+      type: "image",
+      displayName: "Hero shot",
+      projectId: "project-1",
+      file: { path: "assets/images/hero.png" },
+      url: "/api/v1/projects/project-1/files/assets/images/hero.png",
+    };
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            assets: [imageAsset],
+            createInterleaveJob,
+            documentLocalJobs: [],
+            gpuOptions: ["auto"],
+            imageModels: [
+              { id: "sensenova_u1_8b", name: "SenseNova-U1 8B", type: "image", capabilities: ["text_to_image", "interleave"] },
+            ],
+            jobAction: () => {},
+            rememberLocalGenerationJob: () => {},
+            setActiveView: () => {},
+            requestedGpu: "auto",
+            setRequestedGpu: () => {},
+          },
+          <DocumentStudio />,
+        ),
+      );
+    });
+    await settle();
+
+    // No references yet → the reference-strength slider is hidden.
+    expect(container.textContent).not.toContain("Reference strength");
+
+    // Attach a reference image through the picker: open it, pick the card, confirm.
+    await act(async () => {
+      [...document.body.querySelectorAll(".asset-picker-head button")]
+        .find((button) => button.textContent === "Add reference images")
+        .click();
+    });
+    await settle();
+    await act(async () => {
+      document.body.querySelector(".asset-picker-card").click();
+    });
+    await act(async () => {
+      [...document.body.querySelectorAll("button")]
+        .find((button) => button.textContent === "Use Selection")
+        .click();
+    });
+    await settle();
+
+    // The slider now appears, defaulting to the neutral 1.00 baseline.
+    expect(container.textContent).toContain("Reference strength");
+    const slider = document.body.querySelector("input[type='range']");
+    expect(slider).not.toBeNull();
+    expect(slider.value).toBe("1");
+
+    // Dial the reference strength up toward the character/identity regime and submit.
+    await changeField(slider, "1.5");
+    await changeField(document.body.querySelector("textarea"), "A brand lookbook grounded in the hero shot");
+    await act(async () => {
+      [...document.body.querySelectorAll("button")]
+        .find((button) => button.textContent.includes("Compose document"))
+        .closest("form")
+        .dispatchEvent(new window.Event("submit", { bubbles: true, cancelable: true }));
+    });
+
+    expect(createInterleaveJob).toHaveBeenCalledTimes(1);
+    const payload = createInterleaveJob.mock.calls[0][0];
+    expect(payload.sourceAssetIds).toEqual(["img-ref-1"]);
+    expect(payload.advanced.imageGuidanceScale).toBe(1.5);
   });
 
   it("DocumentStudio stacks a queued compose run beneath the active document", async () => {

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -33,6 +33,20 @@ export const INTERLEAVE_RESOLUTION_OPTIONS = [
 ];
 export const DEFAULT_INTERLEAVE_RESOLUTION = "2048x1152";
 
+// Reference strength for grounded (it2i) interleave — drives advanced.imageGuidanceScale,
+// which the worker maps to the engine's img_cfg_scale (a CFG weight, not clamped by the
+// backend). 1.0 is the upstream/edit baseline (references are full context, text CFG steers
+// relative to them); higher holds the output tighter to the reference images, lower is more
+// prompt-driven. The engine's own guidance is edit ≈ 1.0, character/identity ≈ 1.5. Range is
+// deliberately tightened to the useful band (0.5–2.5) rather than Character Studio's wider
+// 0.5–4.0 — past ~2.5 an image-CFG weight buys oversaturation, not adherence. Only meaningful
+// when references are attached, so Document Studio only surfaces the slider (and sends the
+// field) then.
+export const DEFAULT_INTERLEAVE_IMAGE_GUIDANCE = 1.0;
+export const INTERLEAVE_IMAGE_GUIDANCE_MIN = 0.5;
+export const INTERLEAVE_IMAGE_GUIDANCE_MAX = 2.5;
+export const INTERLEAVE_IMAGE_GUIDANCE_STEP = 0.1;
+
 // Catalog id of the prompt-refinement / magic-prompt LLM (sc-5605 / sc-6550, builtin.models.jsonc):
 // one coherent Anubis-8B serves BOTH the free-text "Refine my prompt" rewrite AND Ideogram 4's
 // magic-prompt (plain idea -> structured JSON caption) — the sc-6550 bake-off found the old 3B / plain

--- a/apps/web/src/screens/DocumentStudio.jsx
+++ b/apps/web/src/screens/DocumentStudio.jsx
@@ -5,8 +5,12 @@ import { ModelAvailabilityGate } from "../components/ModelAvailabilityGate.jsx";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { WorkPanel } from "../components/WorkPanel.jsx";
 import {
+  DEFAULT_INTERLEAVE_IMAGE_GUIDANCE,
   DEFAULT_INTERLEAVE_RESOLUTION,
   DEFAULT_INTERLEAVE_SYSTEM_MESSAGE,
+  INTERLEAVE_IMAGE_GUIDANCE_MAX,
+  INTERLEAVE_IMAGE_GUIDANCE_MIN,
+  INTERLEAVE_IMAGE_GUIDANCE_STEP,
   INTERLEAVE_RESOLUTION_OPTIONS,
 } from "../constants.js";
 import { useAppContext } from "../context/AppContext.js";
@@ -77,6 +81,7 @@ export function DocumentStudio() {
   const [model, setModel] = useState("");
   const [prompt, setPrompt] = useState("");
   const [sourceAssetIds, setSourceAssetIds] = useState([]);
+  const [imageGuidance, setImageGuidance] = useState(DEFAULT_INTERLEAVE_IMAGE_GUIDANCE);
   const [maxImages, setMaxImages] = useState(MAX_IMAGES_DEFAULT);
   const [resolution, setResolution] = useState(DEFAULT_INTERLEAVE_RESOLUTION);
   const [systemMessage, setSystemMessage] = useState(DEFAULT_INTERLEAVE_SYSTEM_MESSAGE);
@@ -108,6 +113,18 @@ export function DocumentStudio() {
     setSubmitting(true);
     const [width, height] = resolution.split("x").map((value) => Number(value));
     const trimmedSystem = systemMessage.trim();
+    const advanced = {};
+    // Only send the system prompt when edited; blank/default lets the worker use
+    // its own _INTERLEAVE_SYSTEM_MESSAGE.
+    if (trimmedSystem && trimmedSystem !== DEFAULT_INTERLEAVE_SYSTEM_MESSAGE) {
+      advanced.systemMessage = trimmedSystem;
+    }
+    // Reference strength only bites when the model is grounding on reference images
+    // (advanced.imageGuidanceScale → engine img_cfg_scale). Omit it otherwise so an
+    // un-referenced run stays on the worker's plain-generation defaults.
+    if (sourceAssetIds.length > 0) {
+      advanced.imageGuidanceScale = imageGuidance;
+    }
     const job = await createInterleaveJob({
       prompt: prompt.trim(),
       model: model || undefined,
@@ -115,12 +132,7 @@ export function DocumentStudio() {
       width,
       height,
       sourceAssetIds,
-      // Only send the system prompt when edited; blank/default lets the worker use
-      // its own _INTERLEAVE_SYSTEM_MESSAGE.
-      advanced:
-        trimmedSystem && trimmedSystem !== DEFAULT_INTERLEAVE_SYSTEM_MESSAGE
-          ? { systemMessage: trimmedSystem }
-          : {},
+      advanced,
     });
     setSubmitting(false);
     if (job) {
@@ -213,6 +225,27 @@ export function DocumentStudio() {
           onChange={setSourceAssetIds}
           values={sourceAssetIds}
         />
+
+        {sourceAssetIds.length > 0 ? (
+          <label className="field">
+            <span>Reference strength</span>
+            <small>
+              How closely the generated images follow your references. Higher holds tighter to
+              them (identity/composition); lower is more prompt-driven. 1.0 is a neutral edit.
+            </small>
+            <div className="reference-strength">
+              <input
+                max={INTERLEAVE_IMAGE_GUIDANCE_MAX}
+                min={INTERLEAVE_IMAGE_GUIDANCE_MIN}
+                onChange={(event) => setImageGuidance(Number(event.target.value))}
+                step={INTERLEAVE_IMAGE_GUIDANCE_STEP}
+                type="range"
+                value={imageGuidance}
+              />
+              <span>{imageGuidance.toFixed(2)}</span>
+            </div>
+          </label>
+        ) : null}
 
         <label className="field document-system-prompt">
           <span>System prompt</span>


### PR DESCRIPTION
## What

Adds a **Reference strength** slider to Document Studio, shown only when reference images are attached. It exposes the SenseNova-U1 interleave image-guidance knob (`advanced.imageGuidanceScale` → engine `img_cfg_scale`), which was previously pinned at the worker default `1.0` with no UI to change it.

## Why

Reference images in Document Studio are grounded (it2i) conditioning inputs. How strongly the output adheres to them is controlled by `img_cfg_scale` — the engine's own guidance is **edit ≈ 1.0, character/identity ≈ 1.5** — but the UI never sent a non-1.0 value, so every run was stuck at the neutral edit baseline.

This is **frontend-only**. The full triple-branch dual-CFG (cond / image-uncond / full-uncond) already exists in `mlx-gen-sensenova` / `candle-gen-sensenova` `it2i_denoise` and activates automatically whenever `img_cfg_scale != 1.0`. The worker already reads the field (`resolve_interleave_params` → `advanced_float(advanced, "imageGuidanceScale", 1.0)` → `T2iOptions.img_cfg_scale` → `interleave_gen`). No worker/engine change.

## Changes

- **`apps/web/src/constants.js`** — `DEFAULT_INTERLEAVE_IMAGE_GUIDANCE = 1.0`, range **0.5–2.5** (step 0.1). Deliberately tightened from Character Studio's 0.5–4.0 to the useful band; past ~2.5 an image-CFG weight buys oversaturation, not adherence.
- **`apps/web/src/screens/DocumentStudio.jsx`** — slider (existing `.reference-strength` idiom) gated on `sourceAssetIds.length > 0`; `imageGuidanceScale` injected into `advanced` only when references are attached, so un-referenced runs stay on the worker's plain-generation defaults.
- **`apps/web/src/App.library.test.jsx`** — covers both paths: gated-off (no slider, field absent from payload) and attached (slider defaults to `1.00`, dial to `1.5`, payload carries `advanced.imageGuidanceScale: 1.5`).

## Verification

- Web tests green: `App.library.test.jsx` (22) + `constants.test.js` (4); ESLint clean on the changed files.
- No live browser pass — Document Studio is gated behind an installed interleave-capable model (SenseNova-U1) and the worktree preview serves the main checkout, so the unit test drives the real picker → state → submit-payload flow instead.

## Notes

- **Runtime cost, not a code gap:** dialing off 1.0 adds a second (uncond) forward pass per denoise step (~+50% render time). Inherent to CFG; already handled by the engine.
- Text guidance (`guidanceScale`, default 4.0) is also hidden — intentionally not exposed here (out of scope for the reference-adherence ask). Candidate follow-up.

Story: [sc-13293](https://app.shortcut.com/trefry/story/13293)

🤖 Generated with [Claude Code](https://claude.com/claude-code)