### PR TITLE
ci(runner): build self-hosted Windows lanes off the real toolchain bin (sc-13166)

### DIFF
--- a/.github/actions/prepare-rust-runner/action.yml
+++ b/.github/actions/prepare-rust-runner/action.yml
@@ -1,0 +1,118 @@
+name: Prepare Rust toolchain on self-hosted runner
+description: >
+  Make the self-hosted Windows/CUDA runner build against the REAL rustup toolchain
+  bin (the actual cargo/rustc/clippy binaries + their sibling DLLs) instead of the
+  fragile %USERPROFILE%\.cargo\bin rustup proxies, and fail loudly with an actionable
+  message if no usable toolchain is installed. See sc-13166.
+
+# WHY THIS EXISTS (sc-13166)
+# --------------------------
+# rustup's Windows proxies in %USERPROFILE%\.cargo\bin (cargo.exe, rustc.exe,
+# clippy-driver.exe, ... 13 of them) are 0-byte SYMLINKS to rustup.exe (rustup
+# dispatches by argv[0]). On this box that indirection is a recurring single point
+# of failure with TWO distinct failure modes, both of which turn the self-hosted
+# lanes red with a cryptic error that reads like a PR-code failure:
+#
+#   1. DANGLING shim: rustup self-updates and Defender (or something) deletes
+#      rustup.exe; every proxy now points at nothing, so `cargo` dies with the
+#      Windows ERROR_NO_ASSOCIATION ("No application is associated with the
+#      specified file for this operation"). Seen with rustup.exe entirely absent.
+#   2. SYMLINK-in-service-context: even when rustup.exe is present, launching a
+#      *symlinked* .exe from the runner's Windows-service token throws the same
+#      ERROR_NO_ASSOCIATION. An interactive Git Bash follows the symlink fine, so a
+#      green interactive `cargo --version` does NOT mean the runner is healthy.
+#
+# The earlier sc-13166 mitigation (rewrite the proxies as real copies of rustup.exe)
+# does not survive a rustup self-update, which recreates the symlinks — so the lane
+# kept going red "after a while" and forced admin-override merges.
+#
+# The real toolchain under %USERPROFILE%\.rustup\toolchains\<tc>\bin is immune to
+# both modes: those are the REAL cargo/rustc/clippy binaries (not symlinks, not
+# rustup proxies), sitting next to the rustc_driver / std DLLs they load. So this
+# action resolves that bin dir, verifies its cargo actually launches, and prepends
+# it to PATH for the rest of the job. The lane then never dispatches through
+# .cargo\bin at all, and neither failure mode can touch it. (We deliberately do NOT
+# try to "heal" .cargo\bin by copying the toolchain binaries in: rustc.exe/
+# clippy-driver.exe/rustdoc.exe are thin launchers that load rustc_driver-*.dll /
+# std-*.dll from their OWN directory, so a copy without those DLLs would break — and
+# re-symlinking is the very thing that fails in the service context.)
+runs:
+  using: composite
+  steps:
+    - name: Select & verify the real Rust toolchain bin (sc-13166)
+      shell: powershell
+      run: |
+        $ErrorActionPreference = 'Stop'
+
+        # rustup's homes are overridable by env; honor them, else the rustup defaults.
+        $rustupHome = if ($env:RUSTUP_HOME) { $env:RUSTUP_HOME } else { Join-Path $env:USERPROFILE '.rustup' }
+        $cargoHome  = if ($env:CARGO_HOME)  { $env:CARGO_HOME }  else { Join-Path $env:USERPROFILE '.cargo' }
+        $toolchainsDir = Join-Path $rustupHome 'toolchains'
+
+        # Resolve the real toolchain bin. Prefer the default toolchain rustup recorded
+        # in settings.toml (what the proxy would dispatch `stable` to); fall back to the
+        # most-recently-written installed toolchain that actually has a real cargo.exe.
+        $binDir = $null
+        $settings = Join-Path $rustupHome 'settings.toml'
+        if (Test-Path $settings) {
+          $m = Select-String -Path $settings -Pattern '^\s*default_toolchain\s*=\s*"(.+?)"' -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+          if ($m) {
+            $cand = Join-Path (Join-Path $toolchainsDir $m.Matches[0].Groups[1].Value) 'bin'
+            if (Test-Path (Join-Path $cand 'cargo.exe')) { $binDir = $cand }
+          }
+        }
+        if (-not $binDir -and (Test-Path $toolchainsDir)) {
+          $binDir = Get-ChildItem $toolchainsDir -Directory |
+            Sort-Object LastWriteTime -Descending |
+            ForEach-Object { Join-Path $_.FullName 'bin' } |
+            Where-Object { Test-Path (Join-Path $_ 'cargo.exe') } |
+            Select-Object -First 1
+        }
+        if (-not $binDir) {
+          Write-Host "::error title=Rust toolchain missing on candle runner::No installed rustup toolchain with a real cargo.exe under '$toolchainsDir'. Reinstall Rust on the self-hosted cuda box: run rustup-init (https://win.rustup.rs) then 'rustup toolchain install stable' (sc-13166)."
+          exit 1
+        }
+
+        $cargo = Join-Path $binDir 'cargo.exe'
+        Write-Host "Real toolchain cargo: $cargo"
+
+        # Verify it launches. This is a REAL binary (not a rustup proxy symlink), so it
+        # cannot hit the dangling-shim / symlink-in-service-context ERROR_NO_ASSOCIATION
+        # that kills %USERPROFILE%\.cargo\bin\cargo.exe. No `2>&1` on the native call:
+        # under Stop, merging a native command's stderr wraps it in a terminating
+        # NativeCommandError (PS 5.1) and would flake a healthy run.
+        $out = $null
+        try {
+          $out = (& $cargo --version | Out-String).Trim()
+        } catch {
+          $why = ($_.Exception.Message -replace '\s+', ' ').Trim()
+          Write-Host "::error title=Rust toolchain broken on candle runner::Could not execute '$cargo' ($why). Reinstall the toolchain on the box: 'rustup toolchain install stable --force' (sc-13166)."
+          exit 1
+        }
+        if ($LASTEXITCODE -ne 0 -or $out -notmatch '^cargo\s') {
+          $outLine = ($out -replace '\s+', ' ').Trim()
+          Write-Host "::error title=Rust toolchain broken on candle runner::'$cargo --version' failed (exit=$LASTEXITCODE) output='$outLine'. See sc-13166: reinstall the pinned toolchain."
+          exit 1
+        }
+        Write-Host "OK: $out"
+
+        # Prepend the real toolchain bin so every later step's cargo/rustc/clippy resolves
+        # here FIRST, ahead of the fragile .cargo\bin proxies. $GITHUB_PATH prepends, and
+        # the entry survives the `call vcvars64.bat` cmd steps (vcvars only appends).
+        Add-Content -Path $env:GITHUB_PATH -Value $binDir
+
+        # Informational only (never fatal): surface a broken .cargo\bin so the box's
+        # INTERACTIVE cargo (used by dev + sibling sessions) gets repaired too. CI itself
+        # is already immune via the PATH prepend above.
+        $ErrorActionPreference = 'Continue'
+        $proxyCargo = Join-Path $cargoHome 'bin\cargo.exe'
+        if (Test-Path $proxyCargo) {
+          $i = Get-Item $proxyCargo -Force
+          if (($i.Attributes -band [IO.FileAttributes]::ReparsePoint) -or $i.Length -eq 0) {
+            Write-Host "::warning title=Fragile .cargo\bin on candle runner::'$proxyCargo' is a $([int]$i.Length)-byte reparse point (rustup proxy). This CI lane is unaffected (it uses '$binDir'), but interactive 'cargo' on the box is broken until rustup is reinstalled + Defender excludes .cargo/.rustup (sc-13166)."
+          }
+        } else {
+          Write-Host "::warning title=Fragile .cargo\bin on candle runner::'$proxyCargo' is missing (rustup was deleted). This CI lane is unaffected (it uses '$binDir'), but interactive 'cargo' on the box is broken until rustup is reinstalled (sc-13166)."
+        }
+        exit 0

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -139,6 +139,13 @@ jobs:
       CARGO_NET_OFFLINE: "true"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # sc-13166: same self-hosted cuda box as windows-candle.yml — point this lane at
+      # the real rustup toolchain bin (prepended to PATH) so it never dispatches through
+      # the fragile %USERPROFILE%\.cargo\bin proxies that go dangling on rustup
+      # self-update/deletion and fail with ERROR_NO_ASSOCIATION. package-windows is
+      # main + dispatch only, so this failure reddens `main` rather than PRs, but the
+      # remedy is identical. See .github/actions/prepare-rust-runner.
+      - uses: ./.github/actions/prepare-rust-runner
       - name: Fetch the private inference release
         env:
           CARGO_NET_OFFLINE: "false"

--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -90,63 +90,16 @@ jobs:
       CUDA_COMPUTE_CAP: "120"
       CARGO_NET_OFFLINE: "true"
     steps:
-      # sc-13166: fail LOUDLY if this self-hosted runner's rustup shims are broken,
-      # instead of at `cargo fetch` with a cryptic error that reads like a PR failure.
-      # The rust proxies in %USERPROFILE%\.cargo\bin (cargo.exe, rustc.exe, ...) are
-      # 0-byte symlinks to rustup.exe; if rustup.exe is deleted they go dangling and
-      # the next cargo invocation dies ~15s in with the Windows ERROR_NO_ASSOCIATION
-      # ("No application is associated with the specified file for this operation") —
-      # which turned every PR red and forced admin-override merges. This runs as the
-      # job's FIRST step (before checkout — it needs no repo) so a broken toolchain
-      # fails in ~1s with an actionable message + remediation pointer. Validated on
-      # the box against a real dangling-symlink repro (healthy -> exit 0; dangling or
-      # missing cargo.exe -> exit 1 + ::error::).
-      - name: Verify Rust toolchain on runner (pre-flight, sc-13166)
-        shell: powershell
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $cargo = Get-Command cargo.exe -CommandType Application -ErrorAction SilentlyContinue |
-            Select-Object -First 1
-          if (-not $cargo) {
-            Write-Host "::error title=Rust toolchain missing on candle runner::cargo.exe is not on PATH on the self-hosted Windows candle runner. Reinstall rustup so %USERPROFILE%\.cargo\bin\cargo.exe resolves (sc-13166)."
-            exit 1
-          }
-          Write-Host "cargo.exe -> $($cargo.Source)"
-          $out = $null
-          try {
-            # No 2>&1 here: under Stop, merging a native command's stderr wraps it in a
-            # terminating NativeCommandError (PS 5.1). A genuinely un-launchable cargo.exe
-            # still throws before any output, so the catch below still fires; a cargo that
-            # runs but errors is caught by the $LASTEXITCODE check.
-            $out = (& $cargo.Source --version | Out-String).Trim()
-          } catch {
-            # Collapse the multi-line PS error so it stays on one GitHub ::error:: line.
-            $why = ($_.Exception.Message -replace '\s+', ' ').Trim()
-            Write-Host "::error title=Rust toolchain broken on candle runner::Could not execute '$($cargo.Source)' ($why). This is the sc-13166 dangling-rustup-shim failure (ERROR_NO_ASSOCIATION). Restore the toolchain so the shims are real copies of rustup.exe, not dangling symlinks: re-run rustup-init, or 'rustup toolchain install stable --force'."
-            exit 1
-          }
-          if ($LASTEXITCODE -ne 0 -or $out -notmatch '^cargo\s') {
-            $outLine = ($out -replace '\s+', ' ').Trim()
-            Write-Host "::error title=Rust toolchain broken on candle runner::'$($cargo.Source) --version' failed (exit=$LASTEXITCODE) output='$outLine'. See sc-13166: restore the rustup shims as real copies of rustup.exe."
-            exit 1
-          }
-          Write-Host "OK: $out"
-          # rustup is what the shims proxy through; surface its state too. Best-effort and
-          # NEVER fatal: cargo is already confirmed healthy above, so drop back to Continue
-          # (a stderr line from `rustup show` under Stop+2>&1 would otherwise promote to a
-          # terminating NativeCommandError and flake a HEALTHY run red — the opposite of
-          # this step's purpose), guard it, and exit 0 explicitly.
-          $ErrorActionPreference = 'Continue'
-          $rustup = Get-Command rustup.exe -CommandType Application -ErrorAction SilentlyContinue |
-            Select-Object -First 1
-          if ($rustup) {
-            try { (& $rustup.Source show 2>&1 | Out-String).Trim() | Write-Host }
-            catch { Write-Host "rustup show failed (non-fatal): $($_.Exception.Message)" }
-          } else {
-            Write-Host "::warning::rustup.exe not found on PATH (the cargo/rustc shims proxy through it); the toolchain may be fragile (sc-13166)."
-          }
-          exit 0
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # sc-13166: point this lane at the REAL rustup toolchain bin and prepend it to
+      # PATH, so cargo/rustc/clippy never dispatch through the fragile
+      # %USERPROFILE%\.cargo\bin proxies (0-byte symlinks -> rustup.exe that go dangling
+      # when rustup self-updates or its rustup.exe is deleted, or that fail to launch as
+      # symlinks in the runner's Windows-service context — both surface as the cryptic
+      # Windows ERROR_NO_ASSOCIATION at `cargo fetch` and turned every PR red, forcing
+      # admin-override merges). The action fails loudly with an actionable message if no
+      # usable toolchain is installed. See .github/actions/prepare-rust-runner.
+      - uses: ./.github/actions/prepare-rust-runner
       - name: Fetch the private inference release
         env:
           CARGO_NET_OFFLINE: "false"


### PR DESCRIPTION
## Problem

The self-hosted `cuda` box "starts failing every PR after a while" with:

```
Could not execute 'C:\Users\Michael\.cargo\bin\cargo.exe' (Program 'cargo.exe' failed to run:
The system cannot find the file specified ...)
Error: Process completed with exit code 1
```

`%USERPROFILE%\.cargo\bin`'s rust proxies (`cargo.exe`, `rustc.exe`, `clippy-driver.exe`, … 13 of them) are **0-byte symlinks to `rustup.exe`**. That indirection breaks the candle lanes two ways, both surfacing as the cryptic Windows `ERROR_NO_ASSOCIATION`:

1. **Dangling shim** — rustup self-updates and `rustup.exe` gets deleted; every proxy points at nothing. *(Confirmed live: on the box right now all 13 proxies are dangling and `rustup.exe` is gone entirely.)*
2. **Symlink-in-service-context** — even with `rustup.exe` present, launching a *symlinked* `.exe` under the runner's Windows-service token throws the same error (an interactive Git Bash follows the symlink fine, so a green interactive `cargo --version` doesn't mean the runner is healthy).

The prior sc-13166 mitigation (rewrite the shims as real copies of `rustup.exe`) **does not survive a rustup self-update**, which recreates the symlinks — so it kept recurring and forcing admin-override merges. The actual deleter of `rustup.exe` stays unidentified (Defender shows no detection history), so a fix must be root-cause-agnostic.

## Fix

New shared composite action **`.github/actions/prepare-rust-runner`** that:
- Resolves the **real** rustup toolchain bin under `~/.rustup/toolchains/<tc>/bin` — the actual `cargo`/`rustc`/`clippy` binaries sitting next to the `rustc_driver`/`std` DLLs they load. These are **never symlinks and never dangle**.
- Verifies its `cargo` actually launches (fails loudly with an actionable `::error::` only if no usable toolchain is installed).
- **Prepends that bin to `PATH`** (via `$GITHUB_PATH`) so the lane never dispatches through the fragile `.cargo\bin` proxies — immune to *both* failure modes.
- Emits a non-fatal `::warning::` when `.cargo\bin` is broken, so the box's interactive cargo gets repaired too.

Wired into both self-hosted Windows jobs on the box:
- `windows-candle.yml → candle-worker` (PR + main) — the PR-reddening lane.
- `desktop-windows.yml → package-windows` (main + dispatch) — same box/fragility; reddens `main`.

> Why not "heal" `.cargo\bin` by copying the toolchain binaries in? `rustc.exe`/`clippy-driver.exe`/`rustdoc.exe` are thin launchers that load `rustc_driver-*.dll` / `std-*.dll` from their **own** directory, so copies without those DLLs would break — and re-symlinking is the exact thing that fails in the service context.

## Validation

Ran the action's logic on the box **in its currently-broken state** (all proxies dangling, `rustup.exe` absent):
- Resolves `1.96.0-x86_64-pc-windows-msvc`; `cargo`, `rustc`, `clippy-driver`, `cargo clippy`, `cargo fmt` all launch from the toolchain bin (DLLs resolve).
- After the PATH prepend, `cargo` resolves to the **real** toolchain binary ahead of the dangling proxy. ✅

Because `pull_request` runs use the workflow+action from the PR head, **this PR's own `windows-candle` run exercises the fix end-to-end.**

## Follow-up (box hygiene — human, out of this PR's scope)

CI is now immune regardless, but interactive `cargo`/`rustup` on the box is currently broken. To restore it and stop the recurrence at the source: reinstall rustup (`rustup-init`), then `rustup set auto-self-update disable`, and add Defender exclusions for `~/.cargo` + `~/.rustup` (admin/security setting → must be done by a human).

🤖 Generated with [Claude Code](https://claude.com/claude-code)