### PR TITLE
Surface each style's tailored prompt as a per-style hint pill (sc-13366)

### DIFF
--- a/apps/web/src/App.imageStudioStylePreview.test.jsx
+++ b/apps/web/src/App.imageStudioStylePreview.test.jsx
@@ -3,7 +3,7 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { withImageStudioContext, settle } from "./main.testSupport.jsx";
-import { STYLE_GROUPS } from "./data/styleCatalog.js";
+import { STYLE_GROUPS, styleHintForId } from "./data/styleCatalog.js";
 
 // sc-13131 — End-to-end wiring guard for the live Style preview. Renders the real ImageStudio,
 // types a prompt, picks a style through the actual StylePicker, and asserts that the on-screen
@@ -135,6 +135,29 @@ describe("Image Studio — live Style preview parity (sc-13131)", () => {
     const submittedPrompt = await submitAndReadPayloadPrompt();
     // The DoD: what the user SEES is exactly what is SENT.
     expect(shown).toBe(submittedPrompt);
+  });
+
+  it("swaps the suggestion pills for a single tailored style hint when a style is selected (sc-13366)", async () => {
+    await renderStudio();
+    // No style yet → the usual multi-pill scene-suggestion row.
+    const before = [...document.body.querySelectorAll(".suggestion-row .suggestion")];
+    expect(before.length).toBeGreaterThan(1);
+
+    await selectStyle(firstStyle.name);
+
+    // Style selected → exactly ONE pill, carrying that style's tailored subject prompt.
+    const after = [...document.body.querySelectorAll(".suggestion-row .suggestion")];
+    expect(after).toHaveLength(1);
+    const hint = styleHintForId(firstStyle.id);
+    expect(hint).toEqual(expect.any(String));
+    expect(after[0].textContent).toContain(hint);
+
+    // Clicking the hint fills the prompt box (same as any suggestion chip).
+    await act(async () => {
+      after[0].click();
+    });
+    await settle();
+    expect(document.body.querySelector('textarea[aria-label="Prompt"]').value).toBe(hint);
   });
 
   it("blocks a styled batch before submit and identifies every over-cap resolved item", async () => {

--- a/apps/web/src/data/styleCatalog.js
+++ b/apps/web/src/data/styleCatalog.js
@@ -8,6 +8,9 @@
 // the selection state can stay a single string id (clean for saved-state + the sc-13132 recipe
 // rehydration follow-on) while the payload fold still gets the prompt text it needs.
 import catalog from "./styles.json";
+// sc-13366: the per-style tailored subject prompts (also used to generate the preview thumbnails,
+// sc-13135). Surfaced in the Image Studio as a single per-style "Try:" hint when a style is selected.
+import thumbnailPrompts from "./styleThumbnailPrompts.json";
 
 // The 8 authored groups, each `{ id, name, description, styles: [{ id, name, prompt }] }`.
 export const STYLE_GROUPS = catalog.groups;
@@ -71,4 +74,18 @@ export function findStyleById(id) {
  */
 export function styleTextForId(id) {
   return findStyleById(id)?.prompt ?? null;
+}
+
+/**
+ * The tailored subject prompt for a style id (the same prompt used to generate that style's preview
+ * thumbnail — styleThumbnailPrompts.json, sc-13135), or null when the id is empty/unmapped. The
+ * Image Studio surfaces this as a single per-style "Try:" hint (sc-13366): a strong, style-fitting
+ * starting prompt. Resolves both sub-style ids and group ids (the map covers all 286 catalog ids).
+ */
+export function styleHintForId(id) {
+  if (!id) {
+    return null;
+  }
+  const hint = thumbnailPrompts.prompts?.[id];
+  return typeof hint === "string" && hint.trim() ? hint : null;
 }

--- a/apps/web/src/data/styleCatalog.lookup.test.js
+++ b/apps/web/src/data/styleCatalog.lookup.test.js
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import catalog from "./styles.json";
-import { STYLE_GROUPS, findStyleById, styleTextForId } from "./styleCatalog.js";
+import thumbnailPrompts from "./styleThumbnailPrompts.json";
+import { STYLE_GROUPS, findStyleById, styleHintForId, styleTextForId } from "./styleCatalog.js";
 
 // sc-13130: the runtime lookup that bridges the studio's `styleId` selection to the free-text
 // `prompt` the composer consumes. (Catalog-vs-source drift is guarded separately in
@@ -58,5 +59,28 @@ describe("styleCatalog runtime lookup", () => {
     // Combined id-space is fully unique too.
     const combined = [...groupIds, ...subStyleIds];
     expect(new Set(combined).size).toBe(combined.length);
+  });
+
+  // sc-13366: styleHintForId surfaces the per-style tailored prompt as the Image Studio "Try:" hint.
+  it("returns the tailored thumbnail prompt for a sub-style id AND a group id", () => {
+    const subId = catalog.groups[0].styles[0].id;
+    expect(styleHintForId(subId)).toBe(thumbnailPrompts.prompts[subId]);
+    expect(styleHintForId(subId)).toEqual(expect.any(String));
+    const groupId = catalog.groups[0].id;
+    expect(styleHintForId(groupId)).toBe(thumbnailPrompts.prompts[groupId]);
+  });
+
+  it("returns null hint for null / empty / unknown ids", () => {
+    expect(styleHintForId(null)).toBeNull();
+    expect(styleHintForId("")).toBeNull();
+    expect(styleHintForId(undefined)).toBeNull();
+    expect(styleHintForId("not-a-real-style-id")).toBeNull();
+  });
+
+  it("has a tailored hint for every catalog id (map covers the whole catalog)", () => {
+    const ids = [...catalog.groups.map((g) => g.id), ...catalog.groups.flatMap((g) => g.styles.map((s) => s.id))];
+    for (const id of ids) {
+      expect(styleHintForId(id)).toBeTruthy();
+    }
   });
 });

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -167,7 +167,7 @@ import {
 import { FitModeControl, effectiveFitMode } from "../components/FitModeControl.jsx";
 import { StylePicker } from "../components/StylePicker.jsx";
 import { StyledPromptPreview } from "../components/StyledPromptPreview.jsx";
-import { STYLE_GROUPS, styleTextForId } from "../data/styleCatalog.js";
+import { STYLE_GROUPS, styleHintForId, styleTextForId } from "../data/styleCatalog.js";
 import {
   GUIDANCE_METHOD_LABELS,
   SAMPLER_LABELS,
@@ -415,7 +415,15 @@ export function ImageStudio() {
     // Editing the idea clears a stale auto-expand error (sc-6501).
     setSubmitError("");
   };
-  const suggestions = mode === "character_image" ? characterSuggestions : sceneSuggestions;
+  // sc-13366: when a style is selected, replace the generic scene/character suggestion pills with a
+  // single hint pill carrying that style's tailored subject prompt (styleThumbnailPrompts.json) — a
+  // strong, style-fitting starting point. Falls back to the normal suggestions with no style.
+  const styleHint = styleHintForId(styleId);
+  const suggestions = styleHint
+    ? [styleHint]
+    : mode === "character_image"
+      ? characterSuggestions
+      : sceneSuggestions;
   const [count, setCount] = useState(saved.count ?? 4);
 
   // Batch Prompt Processing (epic 9952). Batch mode is orthogonal to the T2I/Edit/


### PR DESCRIPTION
The 286 tailored subject prompts that generate the style thumbnails (sc-13135) also make excellent per-style *starting prompts*. This surfaces them: when a style is selected in the Image Studio, the generic "Try:" suggestion pills collapse to a **single hint pill** carrying that style's tailored prompt; clicking it fills the prompt box (same behavior as the existing suggestion chips).

## Behavior
- No style selected → unchanged (the usual scene/character suggestion pills).
- Style selected (sub-style **or** group id) → one pill = `styleThumbnailPrompts.prompts[styleId]`; e.g. select **Ghibli** → *"A barefoot girl watching a stag drink at a misty forest pond."*
- Falls back to the normal suggestions if a style has no mapped prompt (the map covers all 286, drift-guarded).
- Image Studio only (Video Studio has no suggestion row); free-text models only (row is already `!structuredPromptModel`).

## Changes
- `styleCatalog.js`: `styleHintForId(id)` — resolves a sub-style/group id to its tailored prompt (or null), importing `styleThumbnailPrompts.json`.
- `ImageStudio.jsx`: `suggestions = styleHint ? [styleHint] : (character/scene suggestions)` — the existing `.suggestion-row` render then shows one pill.

## Verification
- Unit tests: `styleHintForId` for sub-style + group id + null/unknown; every catalog id has a hint.
- Integration test (real ImageStudio): no style → multiple pills; select a style → exactly one pill = the tailored prompt; clicking it sets the prompt box.
- Browser-verified (single Ghibli hint pill under the prompt). Full web suite green (2084); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)