### PR TITLE
fix(worker): gate Lens on materialized footprint (sc-11924)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "candle-audio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-core",
  "hf-hub",
@@ -435,20 +435,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "candle-audio-catalog"
+name = "candle-audio-acestep"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-audio",
+ "candle-nn",
+ "core-llm",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "serde",
+ "serde_json",
+ "tokenizers 0.22.2",
+]
+
+[[package]]
+name = "candle-audio-catalog"
+version = "0.0.0"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
+dependencies = [
+ "candle-audio",
+ "candle-audio-acestep",
+ "candle-audio-chatterbox-ve",
+ "candle-audio-clap",
  "candle-audio-kokoro",
  "candle-audio-moss-sfx",
+ "candle-audio-openvoice",
+ "candle-audio-whisper",
  "candle-llm",
+]
+
+[[package]]
+name = "candle-audio-chatterbox-ve"
+version = "0.0.0"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
+dependencies = [
+ "candle-audio",
+ "candle-nn",
+]
+
+[[package]]
+name = "candle-audio-clap"
+version = "0.0.0"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
+dependencies = [
+ "candle-audio",
+ "candle-nn",
+ "core-llm",
+ "serde_json",
+ "tokenizers 0.22.2",
 ]
 
 [[package]]
 name = "candle-audio-kokoro"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -463,7 +504,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-sfx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -471,6 +512,31 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "serde",
+ "serde_json",
+ "tokenizers 0.22.2",
+]
+
+[[package]]
+name = "candle-audio-openvoice"
+version = "0.0.0"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
+dependencies = [
+ "candle-audio",
+ "candle-nn",
+ "core-llm",
+ "serde_json",
+]
+
+[[package]]
+name = "candle-audio-whisper"
+version = "0.0.0"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
+dependencies = [
+ "candle-audio",
+ "candle-nn",
+ "candle-transformers",
+ "core-llm",
+ "rand 0.9.4",
  "serde_json",
  "tokenizers 0.22.2",
 ]
@@ -504,7 +570,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -522,7 +588,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -533,7 +599,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -546,7 +612,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -559,7 +625,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -597,7 +663,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -611,7 +677,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -624,7 +690,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -634,7 +700,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -644,7 +710,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -661,7 +727,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -675,7 +741,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -689,7 +755,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -702,7 +768,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -711,7 +777,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -726,7 +792,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -741,7 +807,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -755,7 +821,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -767,7 +833,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -780,7 +846,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-gen",
  "image",
@@ -790,7 +856,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -807,7 +873,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -820,7 +886,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -831,7 +897,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -841,7 +907,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -855,7 +921,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -871,7 +937,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -890,7 +956,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -901,7 +967,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -913,7 +979,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -923,7 +989,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -935,7 +1001,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -960,7 +1026,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1255,7 +1321,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -3757,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3770,7 +3836,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3782,7 +3848,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3795,7 +3861,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3808,7 +3874,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3847,7 +3913,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3860,7 +3926,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -3870,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3879,7 +3945,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3888,7 +3954,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3901,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3913,7 +3979,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -3925,7 +3991,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -3937,7 +4003,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -3946,7 +4012,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3958,7 +4024,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3972,7 +4038,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3985,7 +4051,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3996,7 +4062,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -4007,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4018,7 +4084,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4029,7 +4095,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4040,7 +4106,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4049,7 +4115,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4058,7 +4124,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4068,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -4079,7 +4145,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4093,7 +4159,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4106,7 +4172,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4116,7 +4182,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4127,7 +4193,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4137,7 +4203,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4150,7 +4216,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4174,7 +4240,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "core-llm",
  "half",
@@ -4485,7 +4551,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5721,7 +5787,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5731,7 +5797,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-audio-catalog",
  "candle-gen-catalog",
@@ -5742,7 +5808,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "candle-audio-catalog",
  "mlx-gen-catalog",
@@ -6021,7 +6087,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3dfa534811da2099d6c9e89e22e9e8e6fa76b12f#3dfa534811da2099d6c9e89e22e9e8e6fa76b12f"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -8439,7 +8505,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "3dfa534811da2099d6c9e89e22e9e8e6fa76b12f" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "d68b8b45" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "3dfa534811da2099d6c9e89e22e9e8e6fa76b12f" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "d68b8b45" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "3dfa534811da2099d6c9e89e22e9e8e6fa76b12f", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "d68b8b45", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/mlx_fit_gate.rs
+++ b/crates/sceneworks-worker/src/mlx_fit_gate.rs
@@ -124,6 +124,9 @@ pub(crate) const MLX_MEMORY_CAP_ENV: &str = "SCENEWORKS_MLX_MEMORY_CAP_GB";
 /// RESOLUTION > 1024² grows the VAE-decode transient past 14 GiB — all four points are 1024², so 18 is
 /// a 1024²-worst-case; a higher-res campaign is a follow-up.
 const HEADROOM_GB: f64 = 18.0;
+/// Lens dense/bf16's measured 1024² activation transient. Its gpt-oss encoder is the only current
+/// MLX family whose architecture-bound transient exceeds the generic calibration (sc-11924).
+const LENS_DENSE_HEADROOM_GB: f64 = 29.88;
 
 /// Reserve (GiB) kept free for macOS + the SceneWorks app + other apps when the WEIGHTS-FIT FLOOR
 /// (sc-12179, GitHub #1544) admits a model whose predicted PEAK exceeds the budget. Deliberately
@@ -172,8 +175,13 @@ pub(crate) fn resolve_budget(real_total_gb: Option<f64>, cap: Option<f64>) -> Op
 
 /// Predicted whole-model peak (GiB) = summed component weight bytes + [`HEADROOM_GB`]. `None` when
 /// `weight_bytes == 0` (nothing measured ⇒ no signal ⇒ never block).
+#[cfg(test)]
 pub(crate) fn predicted_peak_gb(weight_bytes: u64) -> Option<f64> {
-    (weight_bytes > 0).then(|| weight_bytes as f64 / BYTES_PER_GIB + HEADROOM_GB)
+    predicted_peak_gb_with_headroom(weight_bytes, HEADROOM_GB)
+}
+
+fn predicted_peak_gb_with_headroom(weight_bytes: u64, headroom_gb: f64) -> Option<f64> {
+    (weight_bytes > 0).then(|| weight_bytes as f64 / BYTES_PER_GIB + headroom_gb)
 }
 
 /// Decide whether the predicted peak fits the budget. Missing either input ⇒ `Unknown` (never
@@ -199,13 +207,22 @@ pub(crate) fn fit_decision(needed_gb: Option<f64>, budget: Option<MemoryBudget>)
 /// `None` when nothing was measured (`total == 0`). When the text encoders are unmeasured
 /// (`te_bytes == 0`) this equals the resident peak — no claimed saving, so the second-stage overflow
 /// check then rejects exactly as the resident gate would (the safe fallback).
+#[cfg(test)]
 pub(crate) fn predicted_sequential_peak_gb(total_bytes: u64, te_bytes: u64) -> Option<f64> {
+    predicted_sequential_peak_gb_with_headroom(total_bytes, te_bytes, HEADROOM_GB)
+}
+
+fn predicted_sequential_peak_gb_with_headroom(
+    total_bytes: u64,
+    te_bytes: u64,
+    headroom_gb: f64,
+) -> Option<f64> {
     if total_bytes == 0 {
         return None;
     }
     let rest_bytes = total_bytes.saturating_sub(te_bytes);
     let staged_max = te_bytes.max(rest_bytes);
-    Some(staged_max as f64 / BYTES_PER_GIB + HEADROOM_GB)
+    Some(staged_max as f64 / BYTES_PER_GIB + headroom_gb)
 }
 
 /// Second-stage gate for a [`FitDecision::Offload`] (sc-10839): sequential residency was selected
@@ -532,13 +549,36 @@ pub(crate) enum ResidencyOutcome {
 /// (possibly emulated) budget, and whether the provider stages components, choose Resident /
 /// Sequential / Reject (sc-10839). No IO, no globals — the live [`apply_residency_policy`] resolves
 /// those and delegates here.
+#[cfg(test)]
 pub(crate) fn decide_residency(
     total_bytes: u64,
     te_bytes: u64,
     budget: Option<MemoryBudget>,
     sequential_capable: bool,
 ) -> ResidencyOutcome {
-    let base = decide_residency_by_peak(total_bytes, te_bytes, budget, sequential_capable);
+    decide_residency_with_headroom(
+        total_bytes,
+        te_bytes,
+        budget,
+        sequential_capable,
+        HEADROOM_GB,
+    )
+}
+
+fn decide_residency_with_headroom(
+    total_bytes: u64,
+    te_bytes: u64,
+    budget: Option<MemoryBudget>,
+    sequential_capable: bool,
+    headroom_gb: f64,
+) -> ResidencyOutcome {
+    let base = decide_residency_by_peak_with_headroom(
+        total_bytes,
+        te_bytes,
+        budget,
+        sequential_capable,
+        headroom_gb,
+    );
     // Weights-fit floor (sc-12179): a would-be reject is downgraded to a (best-effort) load when the
     // resident weights actually fit — the peak predictor's pageable transient must not categorically
     // exclude a small Mac. Any non-reject outcome stands as-is.
@@ -556,13 +596,33 @@ pub(crate) fn decide_residency(
 /// rejection message's `needed`/`staged` numbers, but it rejects too aggressively on small Macs
 /// because the flat headroom bundles a pageable 1024² activation transient (sc-12179); the caller
 /// folds in [`weights_fit_floor`] before honoring a reject.
+#[cfg(test)]
 fn decide_residency_by_peak(
     total_bytes: u64,
     te_bytes: u64,
     budget: Option<MemoryBudget>,
     sequential_capable: bool,
 ) -> ResidencyOutcome {
-    let resident = fit_decision(predicted_peak_gb(total_bytes), budget);
+    decide_residency_by_peak_with_headroom(
+        total_bytes,
+        te_bytes,
+        budget,
+        sequential_capable,
+        HEADROOM_GB,
+    )
+}
+
+fn decide_residency_by_peak_with_headroom(
+    total_bytes: u64,
+    te_bytes: u64,
+    budget: Option<MemoryBudget>,
+    sequential_capable: bool,
+    headroom_gb: f64,
+) -> ResidencyOutcome {
+    let resident = fit_decision(
+        predicted_peak_gb_with_headroom(total_bytes, headroom_gb),
+        budget,
+    );
     match resolve_offload(resident, sequential_capable) {
         FitDecision::Fits | FitDecision::Unknown => ResidencyOutcome::Resident,
         FitDecision::Offload {
@@ -570,7 +630,8 @@ fn decide_residency_by_peak(
             available_gb,
         } => {
             // Second stage: reject if even the staged max-single-component peak won't fit.
-            let staged = predicted_sequential_peak_gb(total_bytes, te_bytes);
+            let staged =
+                predicted_sequential_peak_gb_with_headroom(total_bytes, te_bytes, headroom_gb);
             match sequential_overflow_gb(staged, budget) {
                 Some(_) => ResidencyOutcome::Reject {
                     needed_gb,
@@ -654,7 +715,7 @@ pub(crate) fn apply_residency_policy(spec: LoadSpec, engine_id: &str) -> WorkerR
     match decide_residency_for_spec(engine_id, &spec) {
         ResidencyOutcome::Resident => Ok(spec),
         ResidencyOutcome::Sequential => {
-            let (total_bytes, te_bytes) = spec_component_bytes(engine_id, &spec);
+            let (total_bytes, te_bytes, _) = spec_component_bytes(engine_id, &spec);
             tracing::info!(
                 event = "mlx_sequential_residency_selected",
                 engine = %engine_id,
@@ -676,17 +737,27 @@ pub(crate) fn apply_residency_policy(spec: LoadSpec, engine_id: &str) -> WorkerR
 /// the `text_encoder*` subdir scan (which reads ZERO for boogu `mllm/`, bernini flat `t5_encoder`,
 /// anima `text_encoders/`, etc.), and folding a separate `spec.control` (qwen_image_control's VACE
 /// branch) into the HEAVY side so the staged split `rest = total − te` counts it on the DiT side.
-fn spec_component_bytes(engine_id: &str, spec: &LoadSpec) -> (u64, u64) {
-    let footprint_te = crate::inference_runtime::media()
+fn spec_component_bytes(engine_id: &str, spec: &LoadSpec) -> (u64, u64, f64) {
+    let footprint = crate::inference_runtime::media()
         .footprint(engine_id, spec)
         .ok()
-        .flatten()
-        .map(|fp| fp.text_encoder);
+        .flatten();
+    let footprint_te = footprint.map(|fp| fp.text_encoder);
+    let mut headroom_gb = HEADROOM_GB;
     let (mut total_bytes, te_bytes) = match &spec.weights {
-        WeightsSource::Dir(dir) => (
-            sum_safetensors_bytes(dir),
-            resolve_text_encoder_bytes(footprint_te, dir),
-        ),
+        WeightsSource::Dir(dir) => {
+            let mut total = sum_safetensors_bytes(dir);
+            let te = resolve_text_encoder_bytes(footprint_te, dir);
+            if matches!(engine_id, "lens" | "lens_turbo") {
+                let disk_te = sum_safetensors_bytes(&dir.join("text_encoder"));
+                let materialized_expansion = te.saturating_sub(disk_te);
+                total = total.saturating_add(materialized_expansion);
+                if spec.quantize.is_none() && packed_quant_bits(dir, "text_encoder").is_none() {
+                    headroom_gb = LENS_DENSE_HEADROOM_GB;
+                }
+            }
+            (total, te)
+        }
         // A single-file source has no diffusers component tree; honor a footprint TE if the provider
         // somehow computed one, else 0 (resident-or-reject only).
         WeightsSource::File(file) => (
@@ -697,7 +768,16 @@ fn spec_component_bytes(engine_id: &str, spec: &LoadSpec) -> (u64, u64) {
     if let Some(control) = &spec.control {
         total_bytes += weights_source_bytes(control);
     }
-    (total_bytes, te_bytes)
+    (total_bytes, te_bytes, headroom_gb)
+}
+
+fn packed_quant_bits(root: &std::path::Path, component: &str) -> Option<i64> {
+    let config = std::fs::read(root.join(component).join("config.json")).ok()?;
+    serde_json::from_slice::<serde_json::Value>(&config)
+        .ok()?
+        .get("quantization")?
+        .get("bits")?
+        .as_i64()
 }
 
 /// The residency outcome (Resident / Sequential / Reject) a `spec` would take against this machine's
@@ -707,12 +787,13 @@ fn spec_component_bytes(engine_id: &str, spec: &LoadSpec) -> (u64, u64) {
 /// gate uses, so the seam's downtier choice and the cache's admission never disagree.
 pub(crate) fn decide_residency_for_spec(engine_id: &str, spec: &LoadSpec) -> ResidencyOutcome {
     let budget = resolve_budget(probe_total_unified_memory_gib(), mlx_memory_cap_gb());
-    let (total_bytes, te_bytes) = spec_component_bytes(engine_id, spec);
-    decide_residency(
+    let (total_bytes, te_bytes, headroom_gb) = spec_component_bytes(engine_id, spec);
+    decide_residency_with_headroom(
         total_bytes,
         te_bytes,
         budget,
         engine_supports_sequential(engine_id),
+        headroom_gb,
     )
 }
 
@@ -800,6 +881,51 @@ mod tests {
         assert_eq!(predicted_peak_gb(bytes), Some(20.0 + HEADROOM_GB));
         // No measurable weights ⇒ no signal.
         assert_eq!(predicted_peak_gb(0), None);
+    }
+
+    #[test]
+    fn lens_dense_calibration_covers_the_measured_full_peak_without_blanket_inflation() {
+        let gib = BYTES_PER_GIB;
+        let lens_materialized = (45.67 * gib).ceil() as u64;
+        let lens_peak = predicted_peak_gb_with_headroom(lens_materialized, LENS_DENSE_HEADROOM_GB)
+            .expect("lens signal");
+        assert!(lens_peak >= 75.55, "{lens_peak} GiB must cover 75.55 GiB");
+
+        // A bf16-on-disk family keeps the generic calculation; no global dense-tier multiplier.
+        let ordinary_bf16 = (28.43 * gib).ceil() as u64;
+        let ordinary_peak = predicted_peak_gb(ordinary_bf16).expect("ordinary signal");
+        assert!((ordinary_peak - 46.43).abs() < 1e-6);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn lens_provider_footprint_expands_only_the_dense_turnkey() {
+        let root = std::env::temp_dir().join(format!(
+            "mlx_fit_gate_sc11924_{}_{}",
+            std::process::id(),
+            line!()
+        ));
+        for (component, bytes) in [("text_encoder", 13), ("transformer", 11), ("vae", 3)] {
+            let dir = root.join(component);
+            std::fs::create_dir_all(&dir).expect("component dir");
+            std::fs::write(dir.join("model.safetensors"), vec![0; bytes]).expect("fixture");
+        }
+        let spec = LoadSpec::new(WeightsSource::Dir(root.clone()));
+        let (dense_total, dense_te, dense_headroom) = spec_component_bytes("lens_turbo", &spec);
+        let expected_te = (30.07 * BYTES_PER_GIB).ceil() as u64;
+        assert_eq!(dense_te, expected_te);
+        assert_eq!(dense_total, expected_te + 14);
+        assert_eq!(dense_headroom, LENS_DENSE_HEADROOM_GB);
+
+        std::fs::write(
+            root.join("text_encoder").join("config.json"),
+            r#"{"quantization":{"bits":8,"group_size":64}}"#,
+        )
+        .expect("packed marker");
+        let (packed_total, packed_te, packed_headroom) = spec_component_bytes("lens_turbo", &spec);
+        assert_eq!((packed_total, packed_te), (27, 13));
+        assert_eq!(packed_headroom, HEADROOM_GB);
+        std::fs::remove_dir_all(root).ok();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- consume provider-reported materialized component bytes in the MLX fit gate
- apply the measured 29.88 GiB transient only to dense, unmarked Lens tiers
- preserve disk-derived handling for measured q4/q8, packed turnkeys, and unrelated families
- pin the paired inference footprint implementation from SceneWorks/inference#134

## Acceptance
- Lens dense materialized weights: 45.67 GiB
- Lens architecture transient: 29.88 GiB
- predicted 1024x1024 peak: 75.55 GiB
- ordinary bf16 families retain the generic 18 GiB headroom

## Validation
- cargo fmt --check -p sceneworks-worker
- focused MLX fit-gate regression tests
- cargo clippy --locked -p sceneworks-worker --all-targets -- -D warnings
- npm run rust:check (worker 876 passed, 167 ignored; sandbox-only nax_guard lacked Metal)
- cargo test --locked -p sceneworks-worker --test nax_guard -- --nocapture outside sandbox (1 passed)
- npm run rust:build

Shortcut: https://app.shortcut.com/trefry/story/11924
Dependency: https://github.com/SceneWorks/inference/pull/134