### PR TITLE
Fix Z-Image Mac availability + torn quant-tier install state (sc-13382, sc-13383)

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1307,6 +1307,25 @@ fn receipt_file_sets(managed_path: &FsPath, repo: &str) -> Vec<ReceiptFileSet> {
         .collect()
 }
 
+/// Whether a snapshot the receipt's files resolve into is an actually LOADABLE install (not merely a
+/// set of files that exist). A backfill (sc-13076) records whatever was on disk, so an interrupted
+/// download left a torn tier — its `model_index.json` + a stray config present, but the
+/// transformer/vae weights missing — whose recorded files all exist yet cannot load. When the
+/// receipt/tier files form a diffusers tier subdir (`["<tier>/*"]`, or a receipt whose files share one
+/// leading dir), require that subdir to pass the same per-component weight check the cache-health path
+/// uses. A non-diffusers set (no `<tier>/model_index.json`, or a flat single-variant filter) keeps the
+/// prior file-existence contract.
+fn snapshot_tier_is_loadable(snapshot: &FsPath, files: &[String]) -> bool {
+    match tier_subdir_name(files) {
+        Some(tier) => {
+            let tier_dir = snapshot.join(&tier);
+            !path_is_readable_file(&tier_dir.join("model_index.json"))
+                || diffusers_snapshot_health(&tier_dir).installed
+        }
+        None => true,
+    }
+}
+
 fn receipt_files_present(data_dir: &FsPath, repo: &str, receipt: &ReceiptFileSet) -> bool {
     !receipt.files.is_empty()
         && huggingface_repo_cache_path(data_dir, repo)
@@ -1319,6 +1338,9 @@ fn receipt_files_present(data_dir: &FsPath, repo: &str, receipt: &ReceiptFileSet
                             .iter()
                             .all(|file| snapshot.join(file).is_file())
                     })
+                    // A torn tier's recorded files all exist but the install can't load — it must not
+                    // count as a "usable stale" install that keeps the model falsely installed.
+                    .filter(|snapshot| snapshot_tier_is_loadable(snapshot, &receipt.files))
                     .collect::<Vec<_>>();
                 receipt
                     .revision
@@ -1354,6 +1376,12 @@ fn backfill_current_receipt(
             let snapshot = crate::huggingface_snapshot_dirs(&root).into_iter().find(|snapshot| {
                 files.iter().all(|pattern| snapshot_contains_pattern(snapshot, pattern))
             })?;
+            // Never manufacture a receipt for a torn tier: a `<tier>/*` glob matches as soon as one
+            // metadata file exists, so backfilling it would record a "complete" install that cannot
+            // load. Require the tier to actually hold its weights before preserving it (sc-13076).
+            if !snapshot_tier_is_loadable(&snapshot, &files) {
+                return None;
+            }
             let resolved = snapshot_files(&snapshot).into_iter()
                 .filter(|file| allow_pattern_matches(file, &files)).collect::<Vec<_>>();
             (!resolved.is_empty()).then(|| json!({
@@ -2611,11 +2639,40 @@ pub(crate) fn huggingface_cache_health(
     HuggingFaceCacheHealth::missing(best_missing)
 }
 
+/// If every pattern in a tier's `files` filter is confined to ONE leading directory — the standard
+/// quant-tier layout `["q8/*"]` → `q8` (also `["bf16/*"]`, `["q4/*"]`) — return that directory.
+/// `None` for a flat single-variant filter (`["*.safetensors"]`, whose leading component is itself a
+/// glob) or patterns that span multiple top-level dirs; those are not a tier subdir and keep the
+/// coarse glob check.
+fn tier_subdir_name(files: &[String]) -> Option<String> {
+    let mut tier: Option<&str> = None;
+    for pattern in files {
+        let (head, rest) = pattern.split_once('/')?;
+        if head.is_empty() || rest.is_empty() || pattern_contains_glob(head) {
+            return None;
+        }
+        match tier {
+            None => tier = Some(head),
+            Some(existing) if existing == head => {}
+            Some(_) => return None,
+        }
+    }
+    tier.map(str::to_owned)
+}
+
+/// The tier a `<dir>/*` whole-subdir glob names (`"q8/*"` → `"q8"`). `None` for any other pattern —
+/// a specific file (`"q8/turbo_lora.safetensors"`) or a non-tier glob — so the coarse presence check
+/// stays authoritative for explicit files.
+fn whole_subdir_glob_tier(pattern: &str) -> Option<&str> {
+    let (head, rest) = pattern.split_once('/')?;
+    (rest == "*" && !head.is_empty() && !pattern_contains_glob(head)).then_some(head)
+}
+
 fn huggingface_filtered_cache_health(
     snapshots: &[PathBuf],
     files: &[String],
 ) -> HuggingFaceCacheHealth {
-    let missing = files
+    let mut missing = files
         .iter()
         .filter(|pattern| {
             !snapshots
@@ -2624,11 +2681,45 @@ fn huggingface_filtered_cache_health(
         })
         .cloned()
         .collect::<Vec<_>>();
+    // Whether the COARSE check found none of the filter's patterns present — the "cleanly absent
+    // tier" signal, captured before the tier-completeness augmentation below can add entries.
+    let coarse_all_absent = missing.len() == files.len();
+
+    // A `<tier>/*` whole-subdir glob is satisfied as soon as a SINGLE file under `<tier>/` exists, so
+    // the coarse check never notices missing weights INSIDE the tier: a torn download (its
+    // `model_index.json` + a config or two present, but the transformer/vae weights gone) reported a
+    // green "Installed" badge, then failed to load at generation (`No such file or directory`). When a
+    // whole-subdir tier is a diffusers pipeline (has `<tier>/model_index.json`), fold its missing
+    // weight-bearing components — the SAME per-component check the non-tiered path uses — into
+    // `missing`, scoped under the tier. Additional explicit patterns (e.g. a `<tier>/lora.safetensors`
+    // co-requisite) are left to the coarse check above, so this never masks an explicitly-listed file.
+    // A cleanly-absent tier (no `<tier>/model_index.json` present) adds nothing and stays MISSING, not
+    // a repairable "incomplete" — so a valid single-quant install raises no spurious repair prompt
+    // (sc-9907/sc-9909).
+    for pattern in files {
+        let Some(tier) = whole_subdir_glob_tier(pattern) else {
+            continue;
+        };
+        let Some(tier_dir) = snapshots
+            .iter()
+            .map(|snapshot| snapshot.join(tier))
+            .find(|dir| path_is_readable_file(&dir.join("model_index.json")))
+        else {
+            continue;
+        };
+        for component in diffusers_snapshot_health(&tier_dir).missing_files {
+            let scoped = format!("{tier}/{component}");
+            if !missing.contains(&scoped) {
+                missing.push(scoped);
+            }
+        }
+    }
+
     if missing.is_empty() {
-        // Every expected file/pattern is present — fully installed.
+        // Every expected file/pattern is present AND (for a diffusers tier) its weights are on disk.
         HuggingFaceCacheHealth::installed()
-    } else if missing.len() == files.len() {
-        // NONE of this filter's expected files are present: the tier is cleanly absent, not torn.
+    } else if coarse_all_absent {
+        // NONE of this filter's expected patterns are present: the tier is cleanly absent, not torn.
         // A quant-matrix model keeps every tier in ONE shared repo cache (bf16/, q8/, q4/ subdirs),
         // so downloading one tier populates the repo snapshot the OTHER tiers' filters also probe.
         // Reporting a not-downloaded tier as `incomplete` is what surfaced a false "Cached files are
@@ -2641,8 +2732,8 @@ fn huggingface_filtered_cache_health(
             missing_files: missing,
         }
     } else {
-        // Some — but not all — expected files are present: a genuinely torn download a re-fetch
-        // should repair.
+        // Some expected files present but not all — an explicit file is absent, or a diffusers tier is
+        // torn (weights missing). A re-fetch repairs it.
         HuggingFaceCacheHealth::missing(missing)
     }
 }
@@ -3429,6 +3520,126 @@ mod variant_install_tests {
         assert_eq!(
             by_variant("q8").footprint.get("peakMemoryBytes"),
             Some(&Value::Null)
+        );
+    }
+
+    /// Seed one quant tier as a diffusers pipeline snapshot: always a `model_index.json` +
+    /// weightless scheduler/tokenizer configs; the transformer/vae/text_encoder weights only when
+    /// `complete`. A `complete: false` tier mirrors a torn download (interrupted, or weights pruned)
+    /// — its files satisfy the coarse `<tier>/*` glob but it cannot load.
+    fn seed_diffusers_tier(data_dir: &FsPath, repo: &str, tier: &str, complete: bool) {
+        let cache = huggingface_repo_cache_path(data_dir, repo).expect("cache path");
+        let root = cache.join("snapshots").join("abc123").join(tier);
+        let write = |rel: &str, body: &str| {
+            let path = root.join(rel);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, body).unwrap();
+        };
+        write(
+            "model_index.json",
+            r#"{
+                "_class_name": "ZImagePipeline",
+                "transformer": ["diffusers", "ZImageTransformer2DModel"],
+                "vae": ["diffusers", "AutoencoderKL"],
+                "text_encoder": ["transformers", "Qwen3Model"],
+                "scheduler": ["diffusers", "FlowMatchEulerDiscreteScheduler"],
+                "tokenizer": ["transformers", "Qwen2Tokenizer"]
+            }"#,
+        );
+        // Weightless components ship only config, present in a torn tier too (this is what makes the
+        // coarse glob match and wrongly report "installed").
+        write("scheduler/scheduler_config.json", "{}");
+        write("tokenizer/tokenizer_config.json", "{}");
+        write("text_encoder/config.json", "{}");
+        if complete {
+            write("transformer/config.json", "{}");
+            write("transformer/model.safetensors", "weights");
+            write("vae/config.json", "{}");
+            write("vae/model.safetensors", "weights");
+            write("text_encoder/model.safetensors", "weights");
+        }
+    }
+
+    /// The regression this fix closes: a torn diffusers tier (its `model_index.json` + a config or two
+    /// present, but the transformer/vae weights missing) satisfied the coarse `<tier>/*` glob and so
+    /// reported a green "Installed" badge — then failed to load at generation with `No such file or
+    /// directory`. A tier must read installed only when its weight-bearing components actually hold
+    /// weights; an absent tier stays a clean "missing", not a repairable "incomplete".
+    #[test]
+    fn torn_diffusers_tier_reads_incomplete_not_installed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path();
+        let repo = "SceneWorks/matrix";
+        let model = quant_matrix_model(repo);
+
+        // q4 complete (loads), q8 torn (metadata only — the transformer weights never arrived),
+        // bf16 never fetched.
+        seed_diffusers_tier(data_dir, repo, "q4", true);
+        seed_diffusers_tier(data_dir, repo, "q8", false);
+
+        let states = model_variant_states(&model, data_dir);
+        let by_variant = |name: &str| states.iter().find(|s| s.variant == name).unwrap();
+
+        assert!(
+            by_variant("q4").installed,
+            "complete q4 tier must read installed"
+        );
+        assert!(
+            !by_variant("q8").installed,
+            "torn q8 tier must NOT read installed just because its metadata files match the glob"
+        );
+        assert!(
+            by_variant("q8").cache_incomplete,
+            "a torn (half-present) tier is a repairable incomplete, not a clean missing"
+        );
+        assert!(
+            !by_variant("bf16").installed && !by_variant("bf16").cache_incomplete,
+            "a never-fetched tier stays a clean missing (no spurious repair prompt — sc-9907)"
+        );
+
+        // Model-level state aggregates: q4 is complete, so the model is installed overall — the torn
+        // q8 must not drag the whole model to incomplete (sc-9907), but it also must not itself count.
+        let state = install_state_for(model_download_context(&model).unwrap(), &model, data_dir);
+        assert!(state.installed, "model installed via the complete q4 tier");
+    }
+
+    /// A model whose ONLY on-disk tier is torn must read NOT installed at the model level — including
+    /// via the "usable stale" receipt path (sc-13076 backfilled a receipt for whatever was on disk,
+    /// so a metadata-only tier produced a receipt whose files all exist yet cannot load).
+    #[test]
+    fn model_with_only_a_torn_tier_is_not_installed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path();
+        let repo = "SceneWorks/matrix";
+        let model = quant_matrix_model(repo);
+
+        // Only q8 present, and torn. Plus a backfilled receipt recording its (weightless) files as if
+        // complete — exactly the shape found on the reporter's disk.
+        seed_diffusers_tier(data_dir, repo, "q8", false);
+        let managed = data_dir.join("models").join(safe_download_dir(repo));
+        std::fs::create_dir_all(&managed).unwrap();
+        std::fs::write(
+            managed.join(".sceneworks-download-complete.json"),
+            serde_json::to_vec(&json!({
+                "repo": repo,
+                "receipts": [{
+                    "repo": repo, "modelId": "matrix_model", "variant": "q8",
+                    "manifestFiles": ["q8/*"],
+                    "resolvedFiles": [
+                        "q8/model_index.json", "q8/scheduler/scheduler_config.json",
+                        "q8/tokenizer/tokenizer_config.json", "q8/text_encoder/config.json"
+                    ],
+                    "backfilled": true
+                }]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let state = install_state_for(model_download_context(&model).unwrap(), &model, data_dir);
+        assert!(
+            !state.installed,
+            "a torn-only install must not read installed via the usable-stale receipt path"
         );
     }
 

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -500,6 +500,20 @@ function ModelTierDownloadPanel({
                 >
                   {deletingItem === `variant:${model.id}:${tier}` ? "Deleting" : "Delete"}
                 </button>
+              ) : incomplete ? (
+                // A torn tier repairs by re-downloading that same tier (sc-13383). One-click Fix wires
+                // straight through the tier install path — no separate select-then-download step — and
+                // disables while a repair job for this tier is already in flight (its status shows in the
+                // badge above and on the button).
+                <button
+                  type="button"
+                  className="model-tier-fix"
+                  disabled={Boolean(activeJob) || licenseAckRequired}
+                  title={incompleteHint}
+                  onClick={() => onDownloadVariant(model, tier)}
+                >
+                  {activeJob ? activeJob.status : "Fix"}
+                </button>
               ) : (
                 <span className="model-tier-delete-spacer" aria-hidden="true" />
               )}

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -97,6 +97,32 @@ const SD3_5_MODEL = {
   ui: { description: "Gated SD3.5 Large model." },
 };
 
+// A quant-matrix model whose q8 tier is TORN (sc-13383): its files are partly present, so the API
+// reports installState "missing" + cacheState "incomplete" with the missing weights named. The
+// complete q4/bf16 siblings keep the MODEL installed, so only the q8 tier row offers repair.
+const TORN_TIER_MODEL = {
+  id: "z_image_turbo",
+  name: "Z-Image-Turbo",
+  type: "image",
+  family: "z-image",
+  installState: "installed",
+  downloadable: true,
+  hasVariantMatrix: true,
+  variants: [
+    { variant: "bf16", installed: true, installState: "installed", cacheState: "complete", downloadSizeBytes: 20538406851 },
+    {
+      variant: "q8",
+      installed: false,
+      installState: "missing",
+      cacheState: "incomplete",
+      downloadSizeBytes: 10998523666,
+      missingRequiredFiles: ["q8/transformer/config.json", "q8/transformer/<weights>", "q8/vae/<weights>"],
+    },
+    { variant: "q4", installed: true, installState: "installed", cacheState: "complete", downloadSizeBytes: 5909406487 },
+  ],
+  ui: { description: "Open model." },
+};
+
 describe("ModelManagerScreen gated-model notice", () => {
   let container;
   let root;
@@ -309,6 +335,27 @@ describe("ModelManagerScreen gated-model notice", () => {
       (button) => button.textContent.startsWith("Download"),
     );
     expect(downloadButton.disabled).toBe(false);
+  });
+
+  it("offers a one-click Fix on a torn tier that repairs by re-downloading it (sc-13383)", async () => {
+    await render([TORN_TIER_MODEL]);
+    const tierRows = [...container.querySelectorAll(".model-tier-row")];
+    const q8Row = tierRows.find((row) => row.textContent.includes("Q8"));
+    expect(q8Row, "q8 tier row renders").toBeTruthy();
+    // The torn tier reads incomplete (not the false "installed" it used to show).
+    expect(q8Row.querySelector(".status-badge.incomplete")).toBeTruthy();
+    const fixButton = [...q8Row.querySelectorAll("button")].find((button) => button.textContent === "Fix");
+    expect(fixButton, "torn tier renders a Fix button").toBeTruthy();
+    expect(fixButton.disabled).toBe(false);
+    // A COMPLETE sibling tier (q4) must NOT show Fix — only the torn one does.
+    const q4Row = tierRows.find((row) => row.textContent.includes("Q4"));
+    expect([...q4Row.querySelectorAll("button")].some((button) => button.textContent === "Fix")).toBe(false);
+    // One click repairs by queuing a download of exactly the q8 tier.
+    await click(fixButton);
+    expect(createModelDownloadJob).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "z_image_turbo" }),
+      { variant: "q8" },
+    );
   });
 });
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5920,6 +5920,29 @@ details[open] > summary.lora-scope-group-heading::before,
   display: block;
 }
 
+/* One-click repair for a torn tier (sc-13383): re-downloads that tier. Soft-accent mirror of the
+   compact `.model-tier-delete`, so it reads as the call-to-action on an `incomplete` row. */
+.model-tier-fix {
+  min-height: 26px;
+  padding: 0 10px;
+  font-size: 12px;
+  white-space: nowrap;
+  border: 1px solid color-mix(in oklch, var(--accent) 45%, var(--border));
+  border-radius: 8px;
+  background: color-mix(in oklch, var(--accent) 12%, var(--surface));
+  color: color-mix(in oklch, var(--accent) 80%, var(--text));
+}
+
+.model-tier-fix:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--accent) 20%, var(--surface));
+  color: var(--accent);
+}
+
+.model-tier-fix:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
 /* The RAM-suggested tier: highlighted so the recommended default reads at a glance. */
 .model-tier-row.suggested {
   border-color: var(--accent, var(--border));

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -535,9 +535,15 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
     // MLX-routed families (grows one family story at a time as each lands real generation in
     // `sceneworks-worker::image_jobs`). CANDLE: SDXL sc-3678, the four families sc-5096.
     ModelCaps::new("z_image_turbo", true, true, false, false, false),
-    // Base (non-distilled, full-CFG) Z-Image (epic 8236, sc-8379 control + sc-8679 txt2img): candle-only
-    // (no MLX row) — the base sibling of `z_image_turbo` on the candle `z_image_diffusers` family.
-    ModelCaps::new("z_image", false, true, false, false, false),
+    // Base (non-distilled, full-CFG) Z-Image (epic 8236, sc-8379 control + sc-8679 txt2img). MLX-routed
+    // on macOS AND candle-routed off-Mac. The worker registers a real `z_image` MLX engine (MODEL_TABLE:
+    // shift-6.0 / ~50-step / real CFG, `mlx_z_image` adapter) plus base strict-control on Mac
+    // (`ImageRoute::ZImageBaseControl`, `WIRED_MLX_POSE_FAMILIES`), and the manifest carries a full `mlx`
+    // block — so a Mac generates base Z-Image in-process just like Turbo. The prior `mlx_routed: false`
+    // here was a wiring gap left by sc-8320/sc-8251 (the base MLX engine + control landed, but this row
+    // and `image_request_mlx_eligible` were never updated), so `model_mac_support` hid the model behind
+    // "Not available on Mac (MLX only)" even though the Mac worker fully supports it.
+    ModelCaps::new("z_image", true, true, false, false, false),
     // `z_image_edit` (epic 3529 / sc-3923): MLX-only edit id on Turbo weights.
     ModelCaps::new("z_image_edit", true, false, false, false, false),
     ModelCaps::new("flux_schnell", true, true, false, false, false),
@@ -1013,6 +1019,7 @@ mod tests {
 
     const EXPECTED_MLX_ROUTED_MODELS: &[&str] = &[
         "z_image_turbo",
+        "z_image",
         "z_image_edit",
         "flux_schnell",
         "flux_dev",

--- a/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
@@ -49,6 +49,7 @@ pub(crate) fn image_request_mlx_eligible(model: &str, payload: &Map<String, Valu
     }
     match model {
         "z_image_turbo" | "z_image_edit" => z_image_mlx_eligible(payload),
+        "z_image" => z_image_base_mlx_eligible(payload),
         "flux_schnell" | "flux_dev" => flux_mlx_eligible(payload),
         "qwen_image" => qwen_mlx_eligible(payload),
         "qwen_image_edit"
@@ -313,6 +314,19 @@ pub(crate) fn z_image_mlx_eligible(payload: &Map<String, Value>) -> bool {
             .is_some_and(|id| !id.trim().is_empty());
     }
     true
+}
+
+/// Base (non-distilled, full-CFG) Z-Image (`z_image`) MLX-routing conditions (epic 8236). Distinct from
+/// [`z_image_mlx_eligible`] because the base has NO dedicated `edit_image` checkpoint — that path is
+/// Turbo-weights-only (`z_image_turbo` edit mode / the `z_image_edit` model). On macOS the base engine
+/// serves plain text-to-image (MODEL_TABLE `z_image`, shift-6.0 / ~50-step / real CFG), reference-guided
+/// img2img-init (`referenceAssetId` + `advanced.strength`, the generic `Conditioning::Reference` path —
+/// NOT `mode=edit_image`), and strict pose/canny/depth control (`ImageRoute::ZImageBaseControl`), all
+/// in-process. So every non-`edit_image` job is eligible; an `edit_image` mode has no base path and stays
+/// off MLX (defensive — the base UI never offers edit; base `z_image` has no `edit_image` capability).
+/// Third-party LyCORIS applies on the core MLX loader (epic 3641), so a LoRA never forces torch.
+pub(crate) fn z_image_base_mlx_eligible(payload: &Map<String, Value>) -> bool {
+    payload.get("mode").and_then(Value::as_str) != Some("edit_image")
 }
 
 /// Chroma (epic 3531, sc-3843) MLX-routing conditions. Chroma is **text-to-image only**

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -3532,6 +3532,12 @@ fn model_mac_support_hides_torch_only_models_keeps_mlx_models() {
     let z_image = model_mac_support("z_image_turbo", "image");
     assert!(z_image.supported);
     assert!(z_image.reason.is_none());
+    // Base (undistilled, full-CFG) Z-Image is MLX-routed on macOS too (real `z_image` MODEL_TABLE
+    // engine + `ZImageBaseControl`), so it must NOT be hidden behind "Not available on Mac" — the
+    // sc-8320/sc-8251 wiring gap this fix closes.
+    let z_image_base = model_mac_support("z_image", "image");
+    assert!(z_image_base.supported);
+    assert!(z_image_base.reason.is_none());
     // Chroma (epic 3531 / sc-3843) is now MLX-routed — all three variants stay in the picker
     // and no longer report an `mlx_unsupported` port-epic gap.
     for id in ["chroma1_hd", "chroma1_base", "chroma1_flash"] {
@@ -3564,6 +3570,13 @@ fn model_mac_support_feature_flags_mirror_routing_without_over_gating() {
     let z_image_edit = model_mac_support("z_image_edit", "image");
     assert!(z_image_edit.supported);
     assert!(z_image_edit.features.edit);
+    // Base Z-Image: pose (base Fun-Controlnet-Union) + reference (generic img2img-init) are MLX, so both
+    // are enabled — but the base has NO `edit_image` checkpoint (that's Turbo-weights-only), so `edit`
+    // must stay FALSE. This discriminates the base arm from Turbo's (which enables edit).
+    let z_image_base = model_mac_support("z_image", "image");
+    assert!(z_image_base.features.pose);
+    assert!(z_image_base.features.reference);
+    assert!(!z_image_base.features.edit);
     // FLUX.1 reference (XLabs IP-Adapter) is ported to MLX (epic 3621) → reference enabled on
     // both variants; edit_image stays off (no FLUX.1 edit on any platform — future Kontext).
     let flux = model_mac_support("flux_dev", "image");


### PR DESCRIPTION
Diagnosed from a report that Z-Image-Turbo failed to generate and base Z-Image showed "Not on Mac". Two distinct, independently-verified fixes (disjoint files, one commit each).

## sc-13382 — Base Z-Image gated "Not available on Mac" despite full macOS MLX support
`IMAGE_MODEL_CAPS` declared `z_image` with `mlx_routed: false` ("candle-only"), so `model_mac_support` hid it behind the Mac-unavailable badge — yet the worker has a real `z_image` MLX engine (`engines.rs` MODEL_TABLE), base strict-control on macOS (`ImageRoute::ZImageBaseControl`, `WIRED_MLX_POSE_FAMILIES`), and a full `mlx` manifest block. A wiring gap from sc-8320/sc-8251 (never in `MLX_ROUTED_MODELS`).

- `z_image` → `mlx_routed: true` (kept `candle_routed: true` for off-Mac).
- New dispatch arm `z_image => z_image_base_mlx_eligible` — base has no `edit_image` checkpoint (Turbo-weights-only), so t2i / reference img2img-init / pose-canny-depth control are eligible, `edit_image` is not.
- Updated `EXPECTED_MLX_ROUTED_MODELS` + discriminating `model_mac_support("z_image")` assertions (supported, pose/reference, **not** edit).

## sc-13383 — Torn quant tier reported "Installed" (follow-up bug on epic 13075)
A `<tier>/*` glob was satisfied by a single metadata file, so a torn diffusers tier (`model_index.json` + configs, no transformer/vae weights) showed a green "Installed" badge and then failed to load with `No such file or directory (os error 2)`. The sc-13076 backfill also recorded the partial files as a "complete" receipt, keeping the model usable-stale.

- `huggingface_filtered_cache_health` folds a diffusers tier subdir's missing weight-bearing components into `missing` — **augmenting** the coarse glob check, so an explicit co-requisite file (e.g. `<tier>/lora.safetensors`) is still verified and a cleanly-absent tier stays MISSING (not a spurious "incomplete", preserving sc-9907/9909).
- `receipt_files_present` + `backfill_current_receipt` gate on the tier actually being loadable — heals already-written torn receipts on read, and stops manufacturing new ones.

## Verification
- `sceneworks-core`: full suite green (704 tests) incl. `routed_model_lists_match_snapshot`, `every_mlx_routed_model_has_a_dispatch_arm`, both `model_mac_support_*`.
- `sceneworks-rust-api`: full lib suite green (310 tests) incl. new `torn_diffusers_tier_reads_incomplete_not_installed`, `model_with_only_a_torn_tier_is_not_installed`, and the preserved `turbo_cache_health_flags_missing_lora_only_when_listed_explicitly` / `catalog_distinguishes_usable_stale_from_torn`.
- `cargo fmt --all --check` clean; `clippy` clean on both crates.

Not addressed here (not code bugs): Turbo "missing from the Model Manager" is the `recommended: true` Recommended band (it renders separately from the "All image models" grid); the reporter's Turbo Q8 / base Z-Image weights are torn/absent on disk and need re-download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)