### PR TITLE
fix(web): stack quant-tier rows to two lines so narrow model cards don't collide

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5896,14 +5896,34 @@ details[open] > summary.lora-scope-group-heading::before,
 
 .model-tier-row {
   display: grid;
-  /* label | size | install-state badge | per-tier delete (sc-12024). The 4th column is `auto`,
-     so a not-installed row (which renders an empty spacer instead of a button) collapses it. */
-  grid-template-columns: minmax(0, 1fr) auto auto auto;
+  /* Two lines so the tier label never collides with the size/status/action cluster in a narrow
+     model card (cards are as small as 302px — see `.models-card-grid`). Line 1 is the tier
+     checkbox + label; line 2 carries the on-disk size, the install-state badge, and the per-tier
+     action (delete/fix or the empty spacer on a not-installed row, sc-12024). The action column is
+     `1fr` with `justify-self: end`, pinning it to the row's trailing edge. */
+  grid-template-columns: auto auto 1fr;
+  grid-template-areas:
+    "select select select"
+    "size   status action";
   align-items: center;
-  gap: 10px;
+  column-gap: 10px;
+  row-gap: 8px;
   padding: 8px 10px;
   border: 1px solid var(--border);
   border-radius: 8px;
+}
+
+.model-tier-row > .status-badge {
+  grid-area: status;
+}
+
+/* All three trailing variants (delete button, fix button, or the not-installed spacer) share the
+   one action cell so the row's second line stays a stable size | status | action triple. */
+.model-tier-row > .model-tier-delete,
+.model-tier-row > .model-tier-fix,
+.model-tier-row > .model-tier-delete-spacer {
+  grid-area: action;
+  justify-self: end;
 }
 
 /* Compact per-tier delete button (sc-12024): reclaims one installed tier's disk. Inherits
@@ -5950,9 +5970,13 @@ details[open] > summary.lora-scope-group-heading::before,
 }
 
 .model-tier-select {
+  grid-area: select;
   display: flex;
   align-items: center;
   gap: 8px;
+  /* Lets the flex label shrink and wrap inside its grid cell instead of overflowing it and
+     painting over the size/badge columns (the pre-fix collision on narrow cards). */
+  min-width: 0;
   cursor: pointer;
 }
 
@@ -5963,7 +5987,9 @@ details[open] > summary.lora-scope-group-heading::before,
 .model-tier-label {
   display: flex;
   align-items: center;
-  gap: 8px;
+  flex-wrap: wrap;
+  gap: 4px 8px;
+  min-width: 0;
   font-size: 13px;
 }
 
@@ -5993,6 +6019,7 @@ details[open] > summary.lora-scope-group-heading::before,
 }
 
 .model-tier-size {
+  grid-area: size;
   font-family: var(--font-mono);
   font-size: 12px;
   color: var(--text-muted);


### PR DESCRIPTION
## Problem

In the Model Manager, the per-tier quant-download rows ran together on narrow model cards — the size number and the SUGGESTED / install-state badges overlapped the tier label (worst on the highlighted `bf16` row).

**Root cause:** `.model-tier-row` was a single-row 4-column grid (`label | size | status | action`, `minmax(0, 1fr) auto auto auto`). Model cards render at `.models-card-grid`'s `minmax(302px, 1fr)`, so at the 302px minimum the three fixed columns leave ~35px for the label. With no `min-width: 0` on the flex label, it overflowed its near-zero grid cell and painted over the adjacent columns.

## Fix

`apps/web/src/styles.css` — restructure `.model-tier-row` into two lines:

- **Line 1:** tier checkbox + label (Suggested / memory pills now `flex-wrap` instead of overflowing).
- **Line 2:** on-disk size · install-state badge · per-tier action (Delete / Fix / spacer), action pinned to the trailing edge.
- Add `min-width: 0` to `.model-tier-select` / `.model-tier-label` so the label wraps cleanly and can never overlap the columns again.

No JSX or DOM structure change, so it's CSS-only.

## Design note

The rows are now two lines at every card width (previously one line on wide cards). I intentionally avoided a container query since the codebase uses none. If single-line-on-wide is preferred, a container query can restore it — easy follow-up.

## Verification

- All 46 `ModelManagerScreen` tests pass (`vitest run --environment jsdom src/screens/ModelManagerScreen.test.jsx`) — they query by class/descendant, unaffected by the layout change.
- Before/after rendered with the app's real dark-theme CSS at the 302px minimum width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)