### PR TITLE
Add audio model type + audio capability sub-block to manifest schema (sc-13401)

### DIFF
--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -129,7 +129,7 @@
         "properties": {
           "id": { "type": "string", "minLength": 1 },
           "name": { "type": "string", "minLength": 1 },
-          "type": { "type": "string", "enum": ["image", "video", "utility"] },
+          "type": { "type": "string", "enum": ["image", "video", "audio", "utility"] },
           "family": { "type": "string" },
           "adapter": { "type": "string" },
           "capabilities": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
@@ -462,6 +462,79 @@
                 "$ref": "#/$defs/samplerLimits",
                 "x-sceneworks-allow-undeclared": true,
                 "description": "Per-backend candle/CUDA capability override, read by samplerOptionsFromModel(model, \"candle\"). The top-level limits.samplers/schedulers describe the default lane; this narrows/broadens them for the candle path."
+              }
+            }
+          },
+          "audio": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Audio-generation capability metadata (epic 13400, sc-13401) — a per-entry sibling of the mlx/candle backend blocks. It advertises what an audio model (Audio Studio's Speech / Music / SFX / VoiceClone tabs) supports so the studio can build its pickers and mode gates without probing the backend. Populated from the backend Capabilities (epic 12833). Chosen as a dedicated sub-block rather than limits/defaults because those are resolution-shaped and additionalProperties:false, so they would reject audio-shaped fields. Every property is OPTIONAL: a model advertises only the surfaces it actually supports (a bare Speech model may declare only voices/languages, while a full VoiceClone model adds editModes/conditioning).",
+            "properties": {
+              "voices": {
+                "type": "array",
+                "uniqueItems": true,
+                "description": "Selectable speaker voices, as objects so the Audio Studio picker can group by gender / accent / language. Only `id` is required; the optional fields drive grouping and display. Omit entirely for models with no fixed voice set (e.g. a music or SFX model, or a clone-from-reference model).",
+                "items": {
+                  "type": "object",
+                  "required": ["id"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "minLength": 1,
+                      "description": "Backend voice identifier passed through to the generate job."
+                    },
+                    "label": {
+                      "type": "string",
+                      "description": "Human-readable picker label. Falls back to `id` when absent."
+                    },
+                    "gender": {
+                      "type": "string",
+                      "description": "Advisory grouping key for the picker (e.g. \"female\", \"male\", \"neutral\"). Free-form; not a backend gate."
+                    },
+                    "accent": {
+                      "type": "string",
+                      "description": "Advisory grouping key for the picker (e.g. \"american\", \"british\"). Free-form; not a backend gate."
+                    },
+                    "language": {
+                      "type": "string",
+                      "description": "Primary language tag this voice speaks (e.g. \"en-US\"). Advisory grouping key; a subset of the model-level `languages` list."
+                    }
+                  }
+                }
+              },
+              "languages": {
+                "type": "array",
+                "uniqueItems": true,
+                "items": { "type": "string" },
+                "description": "Supported language / locale tags (e.g. \"en-US\", \"en-GB\"). Advisory menu the Audio Studio surfaces; the backend owns actual synthesis support."
+              },
+              "sampleRates": {
+                "type": "array",
+                "uniqueItems": true,
+                "items": { "type": "integer", "minimum": 1 },
+                "description": "Output sample rates in Hz the model can render (e.g. 24000, 48000). Advisory picker menu."
+              },
+              "maxDurationSecs": {
+                "type": "number",
+                "exclusiveMinimum": 0,
+                "description": "Longest clip (seconds) the model can generate in one request. Advisory UI ceiling; backend enforcement is owned by the audio adapter."
+              },
+              "editModes": {
+                "type": "array",
+                "uniqueItems": true,
+                "items": { "type": "string" },
+                "description": "Supported audio edit operations (e.g. \"extend\", \"inpaint\", \"cover\"). Present only for models with an editing surface; absent for pure text-to-audio models."
+              },
+              "supportsMultiSpeaker": {
+                "type": "boolean",
+                "description": "Whether the model can render a multi-speaker turn/dialogue in a single request. Absent/false means single-speaker only."
+              },
+              "conditioning": {
+                "type": "array",
+                "uniqueItems": true,
+                "items": { "type": "string" },
+                "description": "Extra conditioning inputs the model accepts (e.g. \"AudioEdit\", \"ReferenceAudio\", \"VoiceEmbedding\"). Drives which reference/upload controls the Audio Studio exposes."
               }
             }
           },

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -117,6 +117,86 @@ def test_builtin_schema_rejects_an_unknown_closed_model_key():
     assert any("recommendded" in error.message for error in errors)
 
 
+def _sample_audio_model_entry() -> dict:
+    """A representative `type: "audio"` entry exercising every field of the new
+    `audio` capability sub-block (sc-13401, epic 13400). Not a shipped model —
+    real audio entries land in sc-13402 — so it lives in the test, not the
+    builtin manifest.
+    """
+    return {
+        "id": "sample_audio_speech",
+        "name": "Sample Audio Speech",
+        "type": "audio",
+        "audio": {
+            "voices": [
+                {
+                    "id": "af_heart",
+                    "label": "Heart",
+                    "gender": "female",
+                    "accent": "american",
+                    "language": "en-US",
+                },
+                {"id": "bm_george", "gender": "male", "accent": "british"},
+            ],
+            "languages": ["en-US", "en-GB"],
+            "sampleRates": [24000, 48000],
+            "maxDurationSecs": 30.0,
+            "editModes": ["extend", "inpaint", "cover"],
+            "supportsMultiSpeaker": True,
+            "conditioning": ["AudioEdit", "ReferenceAudio", "VoiceEmbedding"],
+        },
+    }
+
+
+def test_schema_accepts_audio_type_and_audio_sub_block():
+    """sc-13401: a `type: "audio"` entry with a populated `audio` sub-block
+    validates against the authoring schema (the new sibling of mlx/candle)."""
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator.check_schema(schema)
+    manifest = {"schemaVersion": 1, "models": [_sample_audio_model_entry()]}
+    errors = list(jsonschema.Draft202012Validator(schema).iter_errors(manifest))
+    assert not errors, "sample audio entry must satisfy the schema:\n" + "\n".join(
+        f"- {'.'.join(map(str, error.absolute_path)) or '<root>'}: {error.message}"
+        for error in errors
+    )
+
+
+def test_schema_rejects_unknown_field_under_audio_sub_block():
+    """Mutation guard: the `audio` block is additionalProperties:false, so a typo
+    / undeclared field under it must fail validation."""
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    entry = _sample_audio_model_entry()
+    entry["audio"]["bogusField"] = True
+    manifest = {"schemaVersion": 1, "models": [entry]}
+    errors = list(jsonschema.Draft202012Validator(schema).iter_errors(manifest))
+    assert any("bogusField" in error.message for error in errors), (
+        "an unknown key under `audio` must be rejected by additionalProperties:false"
+    )
+
+
+def test_schema_rejects_audio_voice_without_id():
+    """A voice object requires `id` so the picker always has a backend key."""
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    entry = _sample_audio_model_entry()
+    entry["audio"]["voices"] = [{"label": "No Id", "gender": "female"}]
+    manifest = {"schemaVersion": 1, "models": [entry]}
+    errors = list(jsonschema.Draft202012Validator(schema).iter_errors(manifest))
+    assert any("id" in error.message for error in errors), (
+        "a voice entry without `id` must be rejected (required within the voice object)"
+    )
+
+
+def test_schema_rejects_unknown_model_type():
+    """Negative control: the `type` enum still rejects an out-of-set value even
+    after `audio` was added, so the enum is not accidentally open."""
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    entry = _sample_audio_model_entry()
+    entry["type"] = "hologram"
+    manifest = {"schemaVersion": 1, "models": [entry]}
+    errors = list(jsonschema.Draft202012Validator(schema).iter_errors(manifest))
+    assert any("hologram" in error.message or "enum" in error.message for error in errors)
+
+
 def _duplicate_default_downloads(manifest: dict) -> list[str]:
     """Return model/platform pairs with ambiguous primary download selection."""
     ambiguous: list[str] = []

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -181,8 +181,20 @@ def test_schema_rejects_audio_voice_without_id():
     entry["audio"]["voices"] = [{"label": "No Id", "gender": "female"}]
     manifest = {"schemaVersion": 1, "models": [entry]}
     errors = list(jsonschema.Draft202012Validator(schema).iter_errors(manifest))
-    assert any("id" in error.message for error in errors), (
-        "a voice entry without `id` must be rejected (required within the voice object)"
+    # Discriminate on the jsonschema error's shape, not a substring of its
+    # message: a loose `"id" in error.message` incidentally matches unrelated
+    # errors (e.g. a type-enum error listing "video", which contains "id"), so
+    # it could false-green under a full schema revert. Pin the `required`
+    # keyword, its `["id"]` value, and the path at the voice item instead — this
+    # only holds while the voice object's `required: ["id"]` is present.
+    assert any(
+        error.validator == "required"
+        and error.validator_value == ["id"]
+        and list(error.absolute_path) == ["models", 0, "audio", "voices", 0]
+        for error in errors
+    ), (
+        "a voice entry without `id` must be rejected by the voice object's "
+        "required:['id'] (a `required` error at models/0/audio/voices/0)"
     )
 
 


### PR DESCRIPTION
## What changed

Extends the model-manifest authoring schema (`packages/schemas/model-manifest.schema.json`) to describe audio models for the SceneWorks Audio Studio (epic 13400):

1. **`type` enum** — adds `"audio"` alongside `image` / `video` / `utility` (~L132).
2. **New `audio` capability sub-block** — a per-entry property, a **sibling of the existing `mlx`/`candle` backend blocks**, mirroring their conventions (`type: object`, `additionalProperties: false`, described fields). Chosen as a dedicated sub-block (not `limits`/`defaults`) because those are resolution-shaped and `additionalProperties: false`, so they would reject audio-shaped fields. Every field is **optional** — a model advertises only what it supports. Fields:
   - `voices[]` — array of **objects** (`id` required; optional `label`/`gender`/`accent`/`language`) so the Audio Studio picker can group by gender/accent/language.
   - `languages[]` (strings, e.g. `en-US`), `sampleRates[]` (ints, Hz), `maxDurationSecs` (number), `editModes[]` (e.g. `extend`/`inpaint`/`cover`), `supportsMultiSpeaker` (bool), `conditioning[]` (e.g. `AudioEdit`/`ReferenceAudio`/`VoiceEmbedding`).
   - Populated from the backend Capabilities (epic 12833).

## Scope covered vs acceptance criteria

- [x] `audio` added to the `type` enum.
- [x] New `audio` sub-block with all required fields, mirroring `mlx`/`candle`.
- [x] Schema validates an audio entry with the new sub-block; existing entries still validate; scaffold check + manifest audit green.
- [x] **No real model entries added** — seeding real audio models is sc-13402 (A2). Schema + tooling + tests only.
- `scripts/check-scaffold.mjs` needed **no change**: it validates manifest roots and does not enumerate the `type` set or ajv-validate each entry, so it neither rejects nor requires the audio changes.

## Tests added (`tests/test_builtin_manifest_audit.py`)

- `test_schema_accepts_audio_type_and_audio_sub_block` — a fully-populated `type:"audio"` entry validates (positive case).
- `test_schema_rejects_unknown_field_under_audio_sub_block` — unknown key under `audio` fails (`additionalProperties:false` mutation guard).
- `test_schema_rejects_audio_voice_without_id` — a voice object without `id` fails.
- `test_schema_rejects_unknown_model_type` — out-of-set `type` still rejected (enum not accidentally opened).

## How verified

- `npm run check` → `SceneWorks scaffold check passed.`
- `pytest tests/test_builtin_manifest_audit.py` (deps pinned to CI: `pytest==9.0.2`, `jsonschema==4.25.1`) → **19 passed** (15 pre-existing + 4 new). The existing `test_builtin_models_manifest_satisfies_authoring_schema` confirms all shipped builtin entries still validate.

## Follow-ups (out of scope for A1 — surfaced, not done)

Downstream mirrors of the model-`type` set that will need `audio` once real audio entries land (sc-13402 / later wiring). None is exercised by A1 since no audio entries are added:
- `apps/rust-api/src/models.rs` `ALLOWED_MODEL_TYPES` (user model-import path) **hard-rejects** an unknown type — needs `"audio"`.
- `crates/sceneworks-core/src/contracts.rs` `ModelKind` string_enum — degrades gracefully via its `Unknown(String)` fallback, but needs an `Audio => "audio"` variant to be first-class.
- `apps/web/src/screens/ModelManagerScreen.jsx` type filter/grouping (image/video/utility) — needs an audio group/label.

Story: [sc-13401]
https://app.shortcut.com/trefry/story/13401

🤖 Generated with [Claude Code](https://claude.com/claude-code)