### PR TITLE
[A2] Seed audio model entries (Kokoro, MOSS-SFX, ACE-Step, OpenVoice V2, Chatterbox-VE) + licenses [sc-13402]

### DIFF
--- a/apps/desktop/licenses/acestep-v15-turbo/MIT.txt
+++ b/apps/desktop/licenses/acestep-v15-turbo/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 ACE Studio and StepFun
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/desktop/licenses/chatterbox-ve/MIT.txt
+++ b/apps/desktop/licenses/chatterbox-ve/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Resemble AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/desktop/licenses/kokoro-82m/Apache-2.0.txt
+++ b/apps/desktop/licenses/kokoro-82m/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/desktop/licenses/manifest.json
+++ b/apps/desktop/licenses/manifest.json
@@ -91,6 +91,66 @@
         { "label": "LTX-2 Community License", "key": "ltx-2.3-license" },
         { "label": "Google Gemma Terms", "key": "ltx-2.3-gemma" }
       ]
+    },
+    {
+      "id": "kokoro-82m",
+      "name": "Kokoro-82M (Speech)",
+      "publisher": "hexgrad",
+      "license": "Apache-2.0",
+      "homepage": "https://huggingface.co/hexgrad/Kokoro-82M",
+      "platforms": ["macos", "windows", "linux"],
+      "usage": "Text-to-speech model (Audio Studio → Speech). SceneWorks downloads the upstream Apache-2.0 weights on first use from hexgrad/Kokoro-82M and runs them natively (Candle) on every platform. Redistributed with attribution as permitted by Apache-2.0. Permissive — commercial use allowed.",
+      "documents": [
+        { "label": "Apache License 2.0", "key": "kokoro-82m-apache" }
+      ]
+    },
+    {
+      "id": "moss-soundeffect-v2",
+      "name": "MOSS-SoundEffect v2.0 (SFX)",
+      "publisher": "OpenMOSS Team",
+      "license": "Apache-2.0",
+      "homepage": "https://huggingface.co/OpenMOSS-Team/MOSS-SoundEffect-v2.0",
+      "platforms": ["macos", "windows", "linux"],
+      "usage": "Text-to-audio sound-effect / ambience model (Audio Studio → SFX). SceneWorks downloads the upstream Apache-2.0 weights on first use from OpenMOSS-Team/MOSS-SoundEffect-v2.0 and runs them natively (Candle) on every platform. Redistributed with attribution as permitted by Apache-2.0. Permissive — commercial use allowed.",
+      "documents": [
+        { "label": "Apache License 2.0", "key": "moss-soundeffect-v2-apache" }
+      ]
+    },
+    {
+      "id": "acestep-v15-turbo",
+      "name": "ACE-Step v1.5 XL Turbo (Music)",
+      "publisher": "ACE Studio · StepFun",
+      "license": "MIT",
+      "homepage": "https://huggingface.co/ACE-Step/acestep-v15-xl-turbo-diffusers",
+      "platforms": ["macos", "windows", "linux"],
+      "usage": "Text-to-music model with prompted audio editing (Audio Studio → Music). SceneWorks downloads the upstream MIT weights on first use from ACE-Step/acestep-v15-xl-turbo-diffusers and runs them natively (Candle) on every platform. Ships its own Oobleck VAE (no Stability-licensed component). Redistributed with attribution as permitted by MIT. Permissive — commercial use allowed.",
+      "documents": [
+        { "label": "MIT License", "key": "acestep-v15-turbo-mit" }
+      ]
+    },
+    {
+      "id": "openvoice-v2",
+      "name": "OpenVoice V2 (Voice Conversion)",
+      "publisher": "MyShell.ai",
+      "license": "MIT",
+      "homepage": "https://huggingface.co/myshell-ai/OpenVoiceV2",
+      "platforms": ["macos", "windows", "linux"],
+      "usage": "Tone-color voice-conversion model (Audio Studio → VoiceClone). SceneWorks downloads the upstream MIT converter weights on first use from myshell-ai/OpenVoiceV2 and runs them natively (Candle) on every platform. Redistributed with attribution as permitted by MIT. Permissive — commercial use allowed.",
+      "documents": [
+        { "label": "MIT License", "key": "openvoice-v2-mit" }
+      ]
+    },
+    {
+      "id": "chatterbox-ve",
+      "name": "Chatterbox Voice Encoder (Voice Clone)",
+      "publisher": "Resemble AI",
+      "license": "MIT",
+      "homepage": "https://huggingface.co/ResembleAI/chatterbox",
+      "platforms": ["macos", "windows", "linux"],
+      "usage": "Speaker voice-identity encoder for cloned-voice conditioning (Audio Studio → VoiceClone). SceneWorks downloads the upstream MIT ve.safetensors weights on first use from ResembleAI/chatterbox and runs them natively (Candle) on every platform. Redistributed with attribution as permitted by MIT. Permissive — commercial use allowed.",
+      "documents": [
+        { "label": "MIT License", "key": "chatterbox-ve-mit" }
+      ]
     }
   ]
 }

--- a/apps/desktop/licenses/moss-soundeffect-v2/Apache-2.0.txt
+++ b/apps/desktop/licenses/moss-soundeffect-v2/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/desktop/licenses/openvoice-v2/MIT.txt
+++ b/apps/desktop/licenses/openvoice-v2/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 MyShell.ai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -3,7 +3,7 @@ use super::*;
 use sceneworks_core::credentials::normalize_host;
 use sceneworks_core::lora_family::is_hidden_file;
 
-const ALLOWED_MODEL_TYPES: &[&str] = &["image", "video", "utility"];
+const ALLOWED_MODEL_TYPES: &[&str] = &["image", "video", "audio", "utility"];
 const MODEL_SIZE_CACHE_LIMIT: usize = 64;
 // Failed estimates (offline, rate-limited, or size-less repo metadata) are
 // negative-cached so a huggingface.co outage costs one 8s timeout per repo per

--- a/apps/web/public/prompt-guides/acestep-v15-turbo.md
+++ b/apps/web/public/prompt-guides/acestep-v15-turbo.md
@@ -1,0 +1,25 @@
+# ACE-Step v1.5 XL Turbo Music Guide
+
+ACE-Step v1.5 XL Turbo is a **text-to-music** model — describe a piece and it composes and renders it. It powers the Audio Studio **Music** tab and also supports prompted audio editing of an existing clip.
+
+## Installation
+
+ACE-Step runs natively (Candle) on every platform. Install it once from the **Models** screen — it is about 11 GB and downloads into the shared Hugging Face cache from `ACE-Step/acestep-v15-xl-turbo-diffusers` (MIT). It ships its own Oobleck VAE, so there is no separately-licensed audio component.
+
+## Writing the prompt
+
+- Describe genre, mood, instrumentation, and tempo: "dreamy lo-fi hip-hop, mellow Rhodes, vinyl crackle, 80 BPM".
+- Lyrics and prompts in 50+ languages are supported (English, Chinese, Japanese, Korean, French, German, Spanish, Italian, Portuguese, Russian, and more); the language tag is advisory.
+- The turbo checkpoint is guidance-distilled, so it runs fast at a low step count (the reference default is around 8) — no separate CFG scale to tune.
+
+## Editing existing audio
+
+ACE-Step can edit a source clip through three modes:
+
+- **Inpaint** — regenerate a bounded interior span fresh from the prompt.
+- **Repaint** — regenerate a span while conditioning on the surrounding audio for continuity.
+- **Extend** — continue the clip past its end, preserving the original.
+
+## Duration
+
+Output is 48 kHz stereo, up to **10 minutes**. Longer clips cost proportionally more time on CPU.

--- a/apps/web/public/prompt-guides/chatterbox-ve.md
+++ b/apps/web/public/prompt-guides/chatterbox-ve.md
@@ -1,0 +1,19 @@
+# Chatterbox Voice Encoder Guide
+
+The Chatterbox voice encoder (Resemble AI) maps a few seconds of reference audio to a **256-dimensional voice-identity embedding**. That embedding is the identity signal for cloned-voice conditioning — the audio analogue of an ArcFace face embedding feeding InstantID. It is a building block for the Audio Studio **VoiceClone** tab, not a generator on its own.
+
+## Installation
+
+The encoder runs natively (Candle) on every platform. Install it once from the **Models** screen — it is a single ~5.7 MB `ve.safetensors` file that downloads into the shared Hugging Face cache from `ResembleAI/chatterbox` (MIT). Only the voice-encoder weights are fetched, not the full Chatterbox TTS model.
+
+## How it works
+
+This is a **prompt-free** component. You provide one input:
+
+- **Reference audio** — a short clip (a couple of seconds is enough) of the voice to characterize.
+
+The encoder resamples to 16 kHz, extracts mel frames, and produces an L2-normalized speaker vector averaged over short partial utterances. That vector then rides into a cloned-voice generator as its identity conditioning.
+
+## Practical notes
+
+A clean, single-speaker reference produces the most distinctive embedding. Longer or noisier clips do not help — a few clear seconds is the sweet spot.

--- a/apps/web/public/prompt-guides/kokoro-82m.md
+++ b/apps/web/public/prompt-guides/kokoro-82m.md
@@ -1,0 +1,22 @@
+# Kokoro 82M Speech Guide
+
+Kokoro-82M is a compact, high-quality **text-to-speech** model (StyleTTS2 lineage). You give it a script and a voice, and it synthesizes natural speech. It is the recommended model for the Audio Studio **Speech** tab.
+
+## Installation
+
+Kokoro runs natively (Candle) on every platform. Install it once from the **Models** screen — it is about 330 MB (the checkpoint plus the per-voice style packs) and downloads into the shared Hugging Face cache from `hexgrad/Kokoro-82M` (Apache-2.0, ungated).
+
+## Voices
+
+Kokoro ships **28 English voices** — 20 American (`af_*` female, `am_*` male) and 8 British (`bf_*` female, `bm_*` male). The voice prefix picks the pronunciation variant: an American voice uses the US front-end, a British voice the GB front-end. `af_heart` is the default showcase voice.
+
+## Writing the script
+
+- Plain prose works best — write it the way you want it read aloud.
+- Punctuation drives prosody: commas and periods pace the delivery; question marks lift the intonation.
+- Output is 24 kHz mono, up to about **30 seconds** per request. For longer passages, split into multiple clips.
+- An optional target duration nudges the pace (the model derives a speed factor, clamped to 0.5–2.0×).
+
+## Practical notes
+
+Kokoro is single-speaker per request — render each speaker separately for a dialogue. It is small and fast, so iterating on wording and voice is cheap.

--- a/apps/web/public/prompt-guides/moss-soundeffect-v2.md
+++ b/apps/web/public/prompt-guides/moss-soundeffect-v2.md
@@ -1,0 +1,22 @@
+# MOSS SoundEffect v2 Guide
+
+MOSS-SoundEffect v2.0 is a **text-to-audio** model for sound effects and ambience. You describe a sound and it synthesizes it — it is the model behind the Audio Studio **SFX** tab. It is not speech or music; it makes the world's noises.
+
+## Installation
+
+MOSS-SFX runs natively (Candle) on every platform. Install it once from the **Models** screen — it is about 11 GB (a Qwen3-1.7B text encoder, a 1.3B diffusion transformer, and a DAC VAE) and downloads into the shared Hugging Face cache from `OpenMOSS-Team/MOSS-SoundEffect-v2.0` (Apache-2.0).
+
+## Writing the prompt
+
+- Describe the source and its character: "heavy rain on a tin roof", "a distant thunderclap", "footsteps on gravel".
+- Bilingual prompts (English / Chinese) are supported; the language is advisory, not a mode switch.
+- Guidance (CFG) sharpens adherence to the prompt; the reference default is around 4.0, and 1.0 turns guidance off.
+- A negative prompt steers the model away from unwanted qualities.
+
+## Duration
+
+Output is 48 kHz mono, up to **30 seconds**, with 0.1-second-granular duration control. Ask for the length you need directly.
+
+## Practical notes
+
+SFX generation is a diffusion process — more solver steps trade time for fidelity. Layer several short clips in the timeline to build a richer ambience rather than asking for one long busy clip.

--- a/apps/web/public/prompt-guides/openvoice-v2.md
+++ b/apps/web/public/prompt-guides/openvoice-v2.md
@@ -1,0 +1,22 @@
+# OpenVoice V2 Voice Conversion Guide
+
+OpenVoice V2 is a **tone-color voice-conversion** model. It takes source speech and a short reference clip of a target voice, then re-renders the source in the target's timbre while preserving the original content and prosody. It is one of the models behind the Audio Studio **VoiceClone** tab.
+
+## Installation
+
+OpenVoice runs natively (Candle) on every platform. Install it once from the **Models** screen — the converter is about 130 MB and downloads into the shared Hugging Face cache from `myshell-ai/OpenVoiceV2` (MIT).
+
+## How it works
+
+This is a **prompt-free** transform — there is no text prompt. You provide two inputs:
+
+- **Source audio** — the speech whose words and delivery you want to keep.
+- **Target reference** — a few seconds of the voice whose timbre you want to apply.
+
+The converter extracts the target's tone color and transfers it onto the source. Output is 22.05 kHz; it does not resample, so keep the studio's output rate at the model's native rate.
+
+## Practical notes
+
+- A clean, dry reference clip gives the best timbre transfer.
+- A strength control adjusts how strongly the target timbre is applied.
+- Because content and prosody come from the source, record the performance you want first, then convert the voice.

--- a/apps/web/src/data/bundledLicenses.js
+++ b/apps/web/src/data/bundledLicenses.js
@@ -22,6 +22,14 @@ import wanI2vA14bApache from "../../../desktop/licenses/wan2.2-i2v-a14b/Apache-2
 import wanT2vA14bApache from "../../../desktop/licenses/wan2.2-t2v-a14b/Apache-2.0.txt?raw";
 import ltxLicense from "../../../desktop/licenses/ltx-2.3/LTX-2-Community-License.txt?raw";
 import ltxGemma from "../../../desktop/licenses/ltx-2.3/Gemma-Terms.txt?raw";
+// Audio model weights (epic 13400, sc-13402). All permissive (Apache-2.0 / MIT) —
+// downloaded on first use from the upstream Hugging Face repos and run natively
+// (Candle) on every platform.
+import kokoroApache from "../../../desktop/licenses/kokoro-82m/Apache-2.0.txt?raw";
+import mossApache from "../../../desktop/licenses/moss-soundeffect-v2/Apache-2.0.txt?raw";
+import acestepMit from "../../../desktop/licenses/acestep-v15-turbo/MIT.txt?raw";
+import openvoiceMit from "../../../desktop/licenses/openvoice-v2/MIT.txt?raw";
+import chatterboxMit from "../../../desktop/licenses/chatterbox-ve/MIT.txt?raw";
 
 // Maps a manifest document `key` to its imported text. New components: add the
 // files under apps/desktop/licenses/<id>/, list them in manifest.json, and wire
@@ -37,6 +45,11 @@ const DOCUMENT_TEXT = {
   "wan2.2-t2v-a14b-apache": wanT2vA14bApache,
   "ltx-2.3-license": ltxLicense,
   "ltx-2.3-gemma": ltxGemma,
+  "kokoro-82m-apache": kokoroApache,
+  "moss-soundeffect-v2-apache": mossApache,
+  "acestep-v15-turbo-mit": acestepMit,
+  "openvoice-v2-mit": openvoiceMit,
+  "chatterbox-ve-mit": chatterboxMit,
 };
 
 // Resolve each component's document keys to its actual text once, at module load.

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -8214,6 +8214,534 @@
           ]
         }
       }
+    },
+    {
+      "id": "kokoro_82m",
+      "name": "Kokoro 82M (Speech)",
+      "family": "kokoro",
+      "type": "audio",
+      "recommended": true,
+      "macOnly": false,
+      "audio": {
+        "voices": [
+          {
+            "id": "af_alloy",
+            "label": "Alloy",
+            "gender": "female",
+            "accent": "american",
+            "language": "en-US"
+          },
+          {
+            "id": "af_aoede",
+            "label": "Aoede",
+            "gender": "female",
+            "accent": "american",
+            "language": "en-US"
+          },
+          {
+            "id": "af_bella",
+            "label": "Bella",
+            "gender": "female",
+            "accent": "american",
+            "language": "en-US"
+          },
+          {
+            "id": "af_heart",
+            "label": "Heart",
+            "gender": "female",
+            "accent": "american",
+            "language": "en-US"
+          },
+          {
+            "id": "af_jessica",
+            "label": "Jessica",
+            "gender": "female",
+            "accent": "american",
+            "language": "en-US"
+          },
+          {
+            "id": "af_kore",
+            "label": "Kore",
+            "gender": "female",
+            "accent": "american",
+            "language": "en-US"
+          },
+          {
+            "id": "af_nicole",
+            "label": "Nicole",
+            "gender": "female",
+            "accent": "american",
+            "language": "en-US"
+          },
+          {
+            "id": "af_nova",
+            "label": "Nova",
+            "gender": "female",
+            "accent": "american",
+            "language": "en-US"
+          },
+          {
+            "id": "af_river",
+            "label": "River",
+            "gender": "female",
+            "accent": "american",
+            "language": "en-US"
+          },
+          {
+            "id": "af_sarah",
+            "label": "Sarah",
+            "gender": "female",
+            "accent": "american",
+            "language": "en-US"
+          },
+          {
+            "id": "af_sky",
+            "label": "Sky",
+            "gender": "female",
+            "accent": "american",
+            "language": "en-US"
+          },
+          {
+            "id": "am_adam",
+            "label": "Adam",
+            "gender": "male",
+            "accent": "american",
+            "language": "en-US"
+          },
+          {
+            "id": "am_echo",
+            "label": "Echo",
+            "gender": "male",
+            "accent": "american",
+            "language": "en-US"
+          },
+          {
+            "id": "am_eric",
+            "label": "Eric",
+            "gender": "male",
+            "accent": "american",
+            "language": "en-US"
+          },
+          {
+            "id": "am_fenrir",
+            "label": "Fenrir",
+            "gender": "male",
+            "accent": "american",
+            "language": "en-US"
+          },
+          {
+            "id": "am_liam",
+            "label": "Liam",
+            "gender": "male",
+            "accent": "american",
+            "language": "en-US"
+          },
+          {
+            "id": "am_michael",
+            "label": "Michael",
+            "gender": "male",
+            "accent": "american",
+            "language": "en-US"
+          },
+          {
+            "id": "am_onyx",
+            "label": "Onyx",
+            "gender": "male",
+            "accent": "american",
+            "language": "en-US"
+          },
+          {
+            "id": "am_puck",
+            "label": "Puck",
+            "gender": "male",
+            "accent": "american",
+            "language": "en-US"
+          },
+          {
+            "id": "am_santa",
+            "label": "Santa",
+            "gender": "male",
+            "accent": "american",
+            "language": "en-US"
+          },
+          {
+            "id": "bf_alice",
+            "label": "Alice",
+            "gender": "female",
+            "accent": "british",
+            "language": "en-GB"
+          },
+          {
+            "id": "bf_emma",
+            "label": "Emma",
+            "gender": "female",
+            "accent": "british",
+            "language": "en-GB"
+          },
+          {
+            "id": "bf_isabella",
+            "label": "Isabella",
+            "gender": "female",
+            "accent": "british",
+            "language": "en-GB"
+          },
+          {
+            "id": "bf_lily",
+            "label": "Lily",
+            "gender": "female",
+            "accent": "british",
+            "language": "en-GB"
+          },
+          {
+            "id": "bm_daniel",
+            "label": "Daniel",
+            "gender": "male",
+            "accent": "british",
+            "language": "en-GB"
+          },
+          {
+            "id": "bm_fable",
+            "label": "Fable",
+            "gender": "male",
+            "accent": "british",
+            "language": "en-GB"
+          },
+          {
+            "id": "bm_george",
+            "label": "George",
+            "gender": "male",
+            "accent": "british",
+            "language": "en-GB"
+          },
+          {
+            "id": "bm_lewis",
+            "label": "Lewis",
+            "gender": "male",
+            "accent": "british",
+            "language": "en-GB"
+          }
+        ],
+        "languages": [
+          "en-US",
+          "en-GB"
+        ],
+        "sampleRates": [
+          24000
+        ],
+        "maxDurationSecs": 30,
+        "supportsMultiSpeaker": false
+      },
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "hexgrad/Kokoro-82M",
+          "files": [
+            "config.json",
+            "kokoro-v1_0.pth",
+            "voices/*"
+          ],
+          "platforms": [
+            "macos",
+            "windows",
+            "linux"
+          ],
+          "estimatedSizeBytes": 327214577,
+          "footprint": {
+            "diskSizeBytes": 327214577
+          }
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/hexgrad/Kokoro-82M"
+      },
+      "candle": {
+        "minMemoryGb": 2,
+        "measured": false
+      },
+      "licenseUrl": "https://huggingface.co/hexgrad/Kokoro-82M",
+      "ui": {
+        "label": "Kokoro 82M",
+        "description": "Kokoro-82M text-to-speech (StyleTTS2 lineage) — the recommended Speech model. 28 English voices (American + British), 24 kHz mono, up to ~30 s per clip. Candle-native on every platform. Apache-2.0.",
+        "recommendedFor": [
+          "speech"
+        ],
+        "promptGuide": {
+          "title": "Kokoro 82M Speech Guide",
+          "path": "/prompt-guides/kokoro-82m.md",
+          "sources": [
+            {
+              "label": "Kokoro-82M (Hugging Face)",
+              "url": "https://huggingface.co/hexgrad/Kokoro-82M"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "moss_sfx_v2",
+      "name": "MOSS SoundEffect v2 (SFX)",
+      "family": "moss_soundeffect",
+      "type": "audio",
+      "macOnly": false,
+      "audio": {
+        "languages": [
+          "en",
+          "zh"
+        ],
+        "sampleRates": [
+          48000
+        ],
+        "maxDurationSecs": 30,
+        "supportsMultiSpeaker": false
+      },
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "OpenMOSS-Team/MOSS-SoundEffect-v2.0",
+          "files": [
+            "model_index.json",
+            "scheduler/*",
+            "transformer/*",
+            "text_encoder/*",
+            "tokenizer/*",
+            "vae/*"
+          ],
+          "platforms": [
+            "macos",
+            "windows",
+            "linux"
+          ],
+          "estimatedSizeBytes": 11230164877,
+          "footprint": {
+            "diskSizeBytes": 11230164877
+          }
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/OpenMOSS-Team/MOSS-SoundEffect-v2.0"
+      },
+      "candle": {
+        "minMemoryGb": 12,
+        "measured": false
+      },
+      "licenseUrl": "https://huggingface.co/OpenMOSS-Team/MOSS-SoundEffect-v2.0",
+      "ui": {
+        "label": "MOSS SoundEffect v2",
+        "description": "MOSS-SoundEffect v2.0 text-to-audio flow-matching model for sound effects and ambience (Qwen3-1.7B text encoder + 1.3B DiT + DAC VAE). 48 kHz mono, up to 30 s with 0.1 s duration control. Candle-native on every platform. Apache-2.0.",
+        "recommendedFor": [
+          "sound_effect"
+        ],
+        "promptGuide": {
+          "title": "MOSS SoundEffect v2 Guide",
+          "path": "/prompt-guides/moss-soundeffect-v2.md",
+          "sources": [
+            {
+              "label": "MOSS-SoundEffect-v2.0 (Hugging Face)",
+              "url": "https://huggingface.co/OpenMOSS-Team/MOSS-SoundEffect-v2.0"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "acestep_v15_turbo",
+      "name": "ACE-Step v1.5 XL Turbo (Music)",
+      "family": "acestep",
+      "type": "audio",
+      "macOnly": false,
+      "audio": {
+        "languages": [
+          "en",
+          "zh",
+          "ja",
+          "ko",
+          "fr",
+          "de",
+          "es",
+          "it",
+          "pt",
+          "ru"
+        ],
+        "sampleRates": [
+          48000
+        ],
+        "maxDurationSecs": 600,
+        "editModes": [
+          "inpaint",
+          "repaint",
+          "extend"
+        ],
+        "conditioning": [
+          "AudioEdit"
+        ],
+        "supportsMultiSpeaker": false
+      },
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "ACE-Step/acestep-v15-xl-turbo-diffusers",
+          "files": [
+            "model_index.json",
+            "scheduler/*",
+            "transformer/*",
+            "condition_encoder/*",
+            "text_encoder/*",
+            "tokenizer/*",
+            "vae/*",
+            "silence_latent.pt"
+          ],
+          "platforms": [
+            "macos",
+            "windows",
+            "linux"
+          ],
+          "estimatedSizeBytes": 11100883579,
+          "footprint": {
+            "diskSizeBytes": 11100883579
+          }
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/ACE-Step/acestep-v15-xl-turbo-diffusers"
+      },
+      "candle": {
+        "minMemoryGb": 12,
+        "measured": false
+      },
+      "licenseUrl": "https://huggingface.co/ACE-Step/acestep-v15-xl-turbo-diffusers",
+      "ui": {
+        "label": "ACE-Step v1.5 XL Turbo",
+        "description": "ACE-Step v1.5 XL Turbo text-to-music model (guidance-distilled turbo checkpoint, ships its own Oobleck VAE). 48 kHz stereo, up to 10 minutes, with prompted audio editing (inpaint / repaint / extend). Candle-native on every platform. MIT.",
+        "recommendedFor": [
+          "music"
+        ],
+        "promptGuide": {
+          "title": "ACE-Step v1.5 XL Turbo Music Guide",
+          "path": "/prompt-guides/acestep-v15-turbo.md",
+          "sources": [
+            {
+              "label": "ACE-Step v1.5 XL Turbo (Hugging Face)",
+              "url": "https://huggingface.co/ACE-Step/acestep-v15-xl-turbo-diffusers"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "openvoice_v2",
+      "name": "OpenVoice V2 (Voice Conversion)",
+      "family": "openvoice",
+      "type": "audio",
+      "macOnly": false,
+      "audio": {
+        "sampleRates": [
+          22050
+        ],
+        "conditioning": [
+          "ReferenceAudio"
+        ],
+        "supportsMultiSpeaker": false
+      },
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "myshell-ai/OpenVoiceV2",
+          "files": [
+            "converter/config.json",
+            "converter/checkpoint.pth"
+          ],
+          "platforms": [
+            "macos",
+            "windows",
+            "linux"
+          ],
+          "estimatedSizeBytes": 131321328,
+          "footprint": {
+            "diskSizeBytes": 131321328
+          }
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/myshell-ai/OpenVoiceV2"
+      },
+      "candle": {
+        "minMemoryGb": 2,
+        "measured": false
+      },
+      "licenseUrl": "https://huggingface.co/myshell-ai/OpenVoiceV2",
+      "ui": {
+        "label": "OpenVoice V2",
+        "description": "OpenVoice V2 tone-color voice conversion (VITS-family flow converter) — transfers a target voice's timbre onto source speech from a short reference clip while preserving content and prosody. 22.05 kHz output. Candle-native on every platform. MIT.",
+        "recommendedFor": [
+          "voice_clone"
+        ],
+        "promptGuide": {
+          "title": "OpenVoice V2 Voice Conversion Guide",
+          "path": "/prompt-guides/openvoice-v2.md",
+          "sources": [
+            {
+              "label": "OpenVoice V2 (Hugging Face)",
+              "url": "https://huggingface.co/myshell-ai/OpenVoiceV2"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "chatterbox_ve",
+      "name": "Chatterbox Voice Encoder (Voice Clone)",
+      "family": "voice",
+      "type": "audio",
+      "macOnly": false,
+      "audio": {
+        "conditioning": [
+          "VoiceEmbedding"
+        ],
+        "supportsMultiSpeaker": false
+      },
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "ResembleAI/chatterbox",
+          "files": [
+            "ve.safetensors"
+          ],
+          "platforms": [
+            "macos",
+            "windows",
+            "linux"
+          ],
+          "estimatedSizeBytes": 5695784,
+          "footprint": {
+            "diskSizeBytes": 5695784
+          }
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/ResembleAI/chatterbox"
+      },
+      "candle": {
+        "minMemoryGb": 1,
+        "measured": false
+      },
+      "licenseUrl": "https://huggingface.co/ResembleAI/chatterbox",
+      "ui": {
+        "label": "Chatterbox Voice Encoder",
+        "description": "Chatterbox (Resemble AI) GE2E-style speaker voice encoder — maps a few seconds of reference audio to a 256-dim voice-identity embedding for cloned-voice conditioning. 16 kHz reference input; ~5.7 MB. Candle-native on every platform. MIT.",
+        "recommendedFor": [
+          "voice_clone"
+        ],
+        "promptGuide": {
+          "title": "Chatterbox Voice Encoder Guide",
+          "path": "/prompt-guides/chatterbox-ve.md",
+          "sources": [
+            {
+              "label": "Chatterbox (Hugging Face)",
+              "url": "https://huggingface.co/ResembleAI/chatterbox"
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/crates/sceneworks-core/src/builtin_manifests.rs
+++ b/crates/sceneworks-core/src/builtin_manifests.rs
@@ -184,6 +184,65 @@ mod tests {
     }
 
     #[test]
+    fn ships_the_seeded_audio_models_with_populated_capability_blocks() {
+        // sc-13402 (epic 13400): the shipped catalog the API serves carries the five live
+        // audio providers as first-class `type: "audio"` entries, each with a populated
+        // `audio` capability sub-block, and `audio` parses as a first-class ModelKind (not
+        // the Unknown fallback) so the type is accepted end to end.
+        let stripped = crate::jsonc::strip_jsonc_comments(embedded("builtin.models.jsonc"));
+        let manifest: serde_json::Value =
+            serde_json::from_str(&stripped).expect("builtin.models.jsonc parses as JSON");
+        let models = manifest["models"]
+            .as_array()
+            .expect("builtin.models.jsonc has a models array");
+
+        let audio_ids = [
+            "kokoro_82m",
+            "moss_sfx_v2",
+            "acestep_v15_turbo",
+            "openvoice_v2",
+            "chatterbox_ve",
+        ];
+        for id in audio_ids {
+            let entry = models
+                .iter()
+                .find(|m| m["id"].as_str() == Some(id))
+                .unwrap_or_else(|| panic!("seeded audio model {id} missing from the catalog"));
+            let ty = entry["type"].as_str().unwrap_or_default();
+            assert_eq!(ty, "audio", "{id} must be type:audio");
+            // `audio` is a first-class ModelKind, not degraded to Unknown().
+            let kind: crate::contracts::ModelKind =
+                serde_json::from_value(entry["type"].clone()).expect("type deserializes");
+            assert_eq!(
+                kind,
+                crate::contracts::ModelKind::Audio,
+                "{id}: `audio` must parse as ModelKind::Audio, not Unknown"
+            );
+            let audio = entry["audio"]
+                .as_object()
+                .unwrap_or_else(|| panic!("{id} must carry a populated `audio` block"));
+            assert!(!audio.is_empty(), "{id}.audio must not be empty");
+            // Installable/downloadable like image/video models.
+            assert!(
+                entry["downloads"][0]["repo"].as_str().is_some(),
+                "{id} must define a download repo"
+            );
+        }
+
+        // Kokoro is the recommended Speech model and advertises its 28 shipped voices.
+        let kokoro = models
+            .iter()
+            .find(|m| m["id"].as_str() == Some("kokoro_82m"))
+            .expect("kokoro present");
+        assert_eq!(kokoro["recommended"].as_bool(), Some(true));
+        assert_eq!(
+            kokoro["audio"]["voices"].as_array().map(Vec::len),
+            Some(28),
+            "Kokoro advertises its 28 shipped English voices"
+        );
+    }
+
+    #[test]
     fn seeds_every_manifest_into_a_fresh_dir() {
         let temp = tempfile::tempdir().expect("temp dir");
         seed_builtin_manifests(temp.path(), SeedMode::IfMissing).expect("seeding succeeds");

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -597,6 +597,7 @@ string_enum! {
     pub enum ModelKind {
         Image => "image",
         Video => "video",
+        Audio => "audio",
         Utility => "utility",
     }
 }

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -209,6 +209,61 @@ def test_schema_rejects_unknown_model_type():
     assert any("hologram" in error.message or "enum" in error.message for error in errors)
 
 
+# The seeded audio catalog (sc-13402, epic 13400). Each id is a live candle-audio
+# provider registered in `crates/audio/candle-audio-catalog`; the second element is
+# the `audio` capability sub-block key that MUST be populated for the Audio Studio to
+# build its pickers/mode gates without probing the backend.
+_SEEDED_AUDIO_MODELS = {
+    "kokoro_82m": "voices",
+    "moss_sfx_v2": "sampleRates",
+    "acestep_v15_turbo": "editModes",
+    "openvoice_v2": "conditioning",
+    "chatterbox_ve": "conditioning",
+}
+
+
+def test_builtin_manifest_ships_the_seeded_audio_models():
+    """sc-13402: the five live audio providers (Kokoro, MOSS-SFX, ACE-Step,
+    OpenVoice V2, Chatterbox-VE) are seeded as `type: "audio"` entries, each
+    carrying a populated `audio` capability sub-block (not just the schema-legal
+    shape proven by sc-13401, but the ACTUAL shipped entries). Kokoro is the
+    recommended Speech model."""
+    manifest = _load_builtin_models_manifest()
+    by_id = {m.get("id"): m for m in manifest["models"]}
+
+    for model_id, required_cap_key in _SEEDED_AUDIO_MODELS.items():
+        entry = by_id.get(model_id)
+        assert entry is not None, f"seeded audio model {model_id} is missing from the manifest"
+        assert entry.get("type") == "audio", f"{model_id} must be type:audio"
+        audio = entry.get("audio")
+        assert isinstance(audio, dict) and audio, f"{model_id} must carry a populated `audio` block"
+        assert required_cap_key in audio, (
+            f"{model_id}.audio must advertise `{required_cap_key}` (populated from backend "
+            f"Capabilities, not an empty stub)"
+        )
+        # Every audio entry must be installable/downloadable like image/video models.
+        downloads = entry.get("downloads") or []
+        assert downloads and downloads[0].get("repo"), (
+            f"{model_id} must define a download entry with a repo (install/download parity)"
+        )
+        assert entry.get("paths", {}).get("model"), f"{model_id} must define paths.model"
+
+    # Kokoro's real voice surface: the 28 English packs the pinned snapshot ships,
+    # each an object with an `id` (discriminates against an empty/placeholder list).
+    kokoro_voices = by_id["kokoro_82m"]["audio"]["voices"]
+    assert len(kokoro_voices) == 28, "Kokoro advertises its 28 shipped English voices"
+    assert all(isinstance(v, dict) and v.get("id") for v in kokoro_voices)
+    assert by_id["kokoro_82m"].get("recommended") is True, "Kokoro is the recommended Speech model"
+
+    # ACE-Step's real edit surface (Conditioning::AudioEdit → repaint task modes).
+    assert set(by_id["acestep_v15_turbo"]["audio"]["editModes"]) == {
+        "inpaint",
+        "repaint",
+        "extend",
+    }
+    assert "AudioEdit" in by_id["acestep_v15_turbo"]["audio"]["conditioning"]
+
+
 def _duplicate_default_downloads(manifest: dict) -> list[str]:
     """Return model/platform pairs with ambiguous primary download selection."""
     ambiguous: list[str] = []


### PR DESCRIPTION
## Summary

Seeds the five live Candle audio providers into the builtin catalog as first-class `type:"audio"` entries, records their weight licenses on the About → Licenses surface, and widens the Rust type sites so `audio` is an accepted `ModelKind` end to end (the added scope A2 owns).

Capability/download/license values are transcribed from the inference monorepo audio crates at the pinned rev the workspace builds against (`~/.cargo/git/checkouts/inference-49f35a375a576bbb/d68b8b4`), **not invented**.

## Entries added

`config/manifests/builtin.models.jsonc` (re-embedded automatically via `include_str!` in `crates/sceneworks-core/src/builtin_manifests.rs` — no codegen step):

| id | mode | audio caps (from backend `descriptor()`) |
|----|------|-------------------------------------------|
| `kokoro_82m` | Speech (**recommended**) | 28 English voices (grouped by gender/accent), 24 kHz mono, 30 s |
| `moss_sfx_v2` | SFX | 48 kHz mono, en/zh, 30 s |
| `acestep_v15_turbo` | Music | 48 kHz stereo, 10 min, `editModes: inpaint/repaint/extend`, `conditioning: AudioEdit` |
| `openvoice_v2` | Voice conversion | 22.05 kHz, `conditioning: ReferenceAudio` |
| `chatterbox_ve` | Voice-identity encoder | `conditioning: VoiceEmbedding` |

Each entry carries the new `audio` capability sub-block (sc-13401 A1 schema), a `downloads[]` with **real measured footprints** + a `files` allow-list, `paths.model`, a candle memory gate (`measured:false`, estimated), and a `promptGuide`. The `files` allow-list matters: e.g. `ResembleAI/chatterbox` is a ~3 GB repo but the provider only needs the 5.7 MB `ve.safetensors`.

## Capability / download sourcing

Read the provider crates under `crates/audio/`:
- `candle-audio-kokoro/src/model.rs` — `VOICES` (28 advertised English packs), `LANGUAGES`, `SAMPLE_RATE=24000`, `MAX_DURATION_SECS=30`, `HUB_REPO=hexgrad/Kokoro-82M`, `resolve_pinned_snapshot` file set. **Kokoro's shipped snapshot advertises 28 voices, not the upstream 54** — the source explicitly does not advertise non-English packs until their front-ends land, and the pinned snapshot ships exactly those 28.
- `candle-audio-moss-sfx/src/model.rs` — 48 kHz, en/zh, `OpenMOSS-Team/MOSS-SoundEffect-v2.0`.
- `candle-audio-acestep/src/model.rs` — 48 kHz stereo, `AudioEditMode::{Inpaint,Repaint,Extend}` + `ConditioningKind::AudioEdit` (Cover deliberately not advertised — needs quantizer weights the diffusers snapshot omits), `ACE-Step/acestep-v15-xl-turbo-diffusers`.
- `candle-audio-openvoice/src/model.rs` — `AudioTransformKind::VoiceConversion`, 22.05 kHz, `myshell-ai/OpenVoiceV2`.
- `candle-audio-chatterbox-ve/src/model.rs` — `VoiceEmbedder`, `ve.safetensors`, `ResembleAI/chatterbox`.

Footprints measured from the local HF cache over each provider's exact `resolve_pinned_snapshot` file set (Kokoro 327 MB, MOSS 11.2 GB, ACE-Step 11.1 GB, OpenVoice 131 MB, Chatterbox 5.7 MB).

## Rust widening (A2 added scope)

- `crates/sceneworks-core/src/contracts.rs`: `ModelKind` gains `Audio => "audio"` (previously degraded unknown types to `Unknown()`).
- `apps/rust-api/src/models.rs`: `ALLOWED_MODEL_TYPES` gains `"audio"` (the import validator previously hard-rejected it).

## Licenses

All five are **permissive — none non-commercial**: Kokoro & MOSS `Apache-2.0`; ACE-Step, OpenVoice V2 & Chatterbox `MIT`. Added components to `apps/desktop/licenses/manifest.json` (SPDX id + upstream source URL + attribution/usage text), license text files under `apps/desktop/licenses/<id>/`, and wired the document keys in `apps/web/src/data/bundledLicenses.js` (the existing About → Licenses pattern).

## Tests / verification

- `pytest tests/test_builtin_manifest_audit.py` — **20 passed** (added `test_builtin_manifest_ships_the_seeded_audio_models` asserting the five entries ship with populated capability fields + Kokoro's 28 voices + recommended).
- `npm run check` (scaffold), `check:nc-weights`, `check:download-patterns` — green.
- `apps/web` `LicensesScreen.test.jsx` — 6 passed.
- `npm run rust:check` (fmt + clippy + test + build) — **exit 0**, including a new `builtin_manifests.rs` test asserting the shipped catalog carries the five entries and `"audio"` parses as `ModelKind::Audio` (not `Unknown`).
- **Live acceptance proof:** built `sceneworks-rust-api` and curled `GET /api/v1/models` — all 5 audio entries returned with their capability fields (Kokoro `recommended:true` + 28 voice objects, ACE-Step edit modes, etc.), through the **same install/download serve path** as image/video models (`installState`, `downloadable`, `downloadSizeBytes`, `macSupport`, `variants`).

Story: [sc-13402] https://app.shortcut.com/trefry/story/13402

🤖 Generated with [Claude Code](https://claude.com/claude-code)