### PR TITLE
chore(web): widen model-type plumbing for audio (sc-13403)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -819,6 +819,12 @@ export function App() {
     const items = generationModelsForType(models, "video");
     return items.length || models.length ? items : fallbackModels.filter((model) => model.type === "video");
   }, [models]);
+  // Audio models (epic 13400) — same live-catalog-then-fallback split as image/video, consumed by
+  // the Audio Studio (C0/C1). Per-mode eligibility comes from audioModelServesMode.
+  const audioModels = useMemo(() => {
+    const items = generationModelsForType(models, "audio");
+    return items.length || models.length ? items : fallbackModels.filter((model) => model.type === "audio");
+  }, [models]);
   const selectedAsset = useMemo(
     () => assets.find((asset) => asset.id === selectedAssetId) ?? assets[0] ?? null,
     [assets, selectedAssetId],
@@ -2254,6 +2260,7 @@ export function App() {
     // Models / GPU
     imageModels,
     videoModels,
+    audioModels,
     models,
     // Mac UI gating (sc-3486)
     macCapabilities,
@@ -2358,7 +2365,7 @@ export function App() {
     recentVideoAssets, studioLaunch,
     editorLaunch, clearEditorLaunch, sendAssetToImageEditor, sendAssetToImageEdit,
     rememberLocalGenerationJob, personTracks, createPersonDetectionJob,
-    createPersonTrackJob, saveTrackCorrections, imageModels, videoModels, models, macCapabilities,
+    createPersonTrackJob, saveTrackCorrections, imageModels, videoModels, audioModels, models, macCapabilities,
     loras, deleteLora, updateLora, fetchLoraEmbeddedTags, deleteModel, deleteModelVariant, createModelDownloadJob, createLoraDownloadJob, createModelConvertJob,
     createLoraImportJob, createModelImportJob, requestedGpu, setRequestedGpu,
     presets, createPreset, updatePreset, deletePreset, duplicatePreset, token, authenticated,

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -767,4 +767,106 @@ export const fallbackModels = [
       promptGuide: { title: "Wan2.2 VACE-Fun Prompt Guide", path: "/prompt-guides/wan-2-2-t2v-14b.md" },
     },
   },
+  // Audio models (epic 13400 A2/A3) — this mirrors the five `type:"audio"` catalog entries so the
+  // Audio Studio still has a model list when the live catalog (/api/v1/models) is unavailable. Each
+  // entry carries only the `audio` capability fields the UI / eligibility predicates read: `voices`
+  // (speech), `editModes` (music), `conditioning` (voiceclone), and `sampleRates` (generation). See
+  // modelEligibility.js `audioModelServesMode` for the capability→mode mapping.
+  {
+    id: "kokoro_82m",
+    name: "Kokoro 82M (Speech)",
+    type: "audio",
+    recommended: true,
+    macOnly: false,
+    // voices[] present → serves the "speech" mode (only a TTS model ships a voice bank).
+    audio: {
+      voices: [
+        { id: "af_heart", label: "Heart", gender: "female", accent: "american", language: "en-US" },
+        { id: "am_michael", label: "Michael", gender: "male", accent: "american", language: "en-US" },
+        { id: "bf_emma", label: "Emma", gender: "female", accent: "british", language: "en-GB" },
+        { id: "bm_george", label: "George", gender: "male", accent: "british", language: "en-GB" },
+      ],
+      languages: ["en-US", "en-GB"],
+      sampleRates: [24000],
+      maxDurationSecs: 30,
+      supportsMultiSpeaker: false,
+    },
+    ui: {
+      label: "Kokoro 82M",
+      description:
+        "Kokoro-82M text-to-speech (StyleTTS2 lineage) — the recommended Speech model. English voices (American + British), 24 kHz mono, up to ~30 s per clip. Candle-native on every platform. Apache-2.0.",
+    },
+  },
+  {
+    id: "moss_sfx_v2",
+    name: "MOSS SoundEffect v2 (SFX)",
+    type: "audio",
+    macOnly: false,
+    // sampleRates only (no voices / editModes / conditioning) → serves the residual "sfx" mode.
+    audio: {
+      languages: ["en", "zh"],
+      sampleRates: [48000],
+      maxDurationSecs: 30,
+      supportsMultiSpeaker: false,
+    },
+    ui: {
+      label: "MOSS SoundEffect v2",
+      description:
+        "MOSS-SoundEffect v2.0 text-to-audio flow-matching model for sound effects and ambience. 48 kHz mono, up to 30 s. Candle-native on every platform. Apache-2.0.",
+    },
+  },
+  {
+    id: "acestep_v15_turbo",
+    name: "ACE-Step v1.5 XL Turbo (Music)",
+    type: "audio",
+    macOnly: false,
+    // editModes[] present → serves the "music" mode; conditioning "AudioEdit" is a music-edit
+    // signal (NOT a voice-clone signal), so it does not serve "voiceclone".
+    audio: {
+      languages: ["en", "zh", "ja", "ko", "fr", "de", "es", "it", "pt", "ru"],
+      sampleRates: [48000],
+      maxDurationSecs: 600,
+      editModes: ["inpaint", "repaint", "extend"],
+      conditioning: ["AudioEdit"],
+      supportsMultiSpeaker: false,
+    },
+    ui: {
+      label: "ACE-Step v1.5 XL Turbo",
+      description:
+        "ACE-Step v1.5 XL Turbo text-to-music model. 48 kHz stereo, up to 10 minutes, with prompted audio editing (inpaint / repaint / extend). Candle-native on every platform. MIT.",
+    },
+  },
+  {
+    id: "openvoice_v2",
+    name: "OpenVoice V2 (Voice Conversion)",
+    type: "audio",
+    macOnly: false,
+    // conditioning "ReferenceAudio" → serves the "voiceclone" mode.
+    audio: {
+      sampleRates: [22050],
+      conditioning: ["ReferenceAudio"],
+      supportsMultiSpeaker: false,
+    },
+    ui: {
+      label: "OpenVoice V2",
+      description:
+        "OpenVoice V2 tone-color voice conversion — transfers a target voice's timbre onto source speech from a short reference clip. 22.05 kHz output. Candle-native on every platform. MIT.",
+    },
+  },
+  {
+    id: "chatterbox_ve",
+    name: "Chatterbox Voice Encoder (Voice Clone)",
+    type: "audio",
+    macOnly: false,
+    // conditioning "VoiceEmbedding" → serves the "voiceclone" mode (speaker-identity embedder).
+    audio: {
+      conditioning: ["VoiceEmbedding"],
+      supportsMultiSpeaker: false,
+    },
+    ui: {
+      label: "Chatterbox Voice Encoder",
+      description:
+        "Chatterbox (Resemble AI) speaker voice encoder — maps a few seconds of reference audio to a voice-identity embedding for cloned-voice conditioning. Candle-native on every platform. MIT.",
+    },
+  },
 ];

--- a/apps/web/src/modelEligibility.js
+++ b/apps/web/src/modelEligibility.js
@@ -25,6 +25,14 @@ export const VIDEO_MODES = [
   "animate_character",
 ];
 
+// Audio generation modes the Audio Studio exposes (epic 13400 C0/C1 mirror these keys).
+export const AUDIO_MODES = ["speech", "sfx", "music", "voiceclone"];
+
+// Conditioning kinds that mark a voice-clone (voice-conversion / speaker-embedding) model —
+// distinct from ACE-Step's "AudioEdit" conditioning, which is a music-editing signal, not a
+// reference/identity signal. Compared case-insensitively so manifest casing never matters.
+const VOICE_CLONE_CONDITIONING = new Set(["referenceaudio", "voiceembedding"]);
+
 // Image Studio — mirrors ImageStudio.jsx `imageModelServesMode`. A model serves a mode
 // when it declares the capability and, under active Mac gating, that feature is MLX-routed
 // for it (the macModelFeatureBlock calls are no-ops off Mac).
@@ -65,6 +73,71 @@ export function videoModelUsable(model, caps) {
     model?.type === "video" &&
     !macModelBlock(model, caps) &&
     VIDEO_MODES.some((mode) => videoModelServesMode(model, mode, caps))
+  );
+}
+
+// Audio Studio — capability-driven per-mode eligibility, derived from the model's `audio`
+// sub-block (mirrors how videoModelServesMode reads video capabilities; no hardcoded ids).
+// Each seeded model maps to exactly one mode and fails the other three:
+//   * speech     — ships a voice bank (audio.voices[] non-empty). → Kokoro-82M.
+//   * music      — advertises audio-editing ops (audio.editModes[]: inpaint/repaint/extend). → ACE-Step.
+//   * voiceclone — conditions on a reference / speaker-identity embedding
+//                  (audio.conditioning ⊇ ReferenceAudio | VoiceEmbedding). → OpenVoice V2, Chatterbox-VE.
+//                  ACE-Step's conditioning is "AudioEdit" (a music-edit signal), so it does NOT match.
+//   * sfx        — a general text-to-audio generator (audio.sampleRates[]) that is none of the above. → MOSS.
+function audioBlock(model) {
+  return model?.audio && typeof model.audio === "object" ? model.audio : null;
+}
+
+function audioHasVoices(audio) {
+  return Array.isArray(audio?.voices) && audio.voices.length > 0;
+}
+
+function audioHasEditModes(audio) {
+  return Array.isArray(audio?.editModes) && audio.editModes.length > 0;
+}
+
+function audioGenerates(audio) {
+  // A generative (text→waveform) model advertises the sample rates it emits.
+  return Array.isArray(audio?.sampleRates) && audio.sampleRates.length > 0;
+}
+
+function audioHasVoiceCloneConditioning(audio) {
+  const conditioning = Array.isArray(audio?.conditioning) ? audio.conditioning : [];
+  return conditioning.some((kind) => VOICE_CLONE_CONDITIONING.has(String(kind).toLowerCase()));
+}
+
+export function audioModelServesMode(model, mode) {
+  const audio = audioBlock(model);
+  if (!audio) {
+    return false;
+  }
+  if (mode === "speech") {
+    return audioHasVoices(audio);
+  }
+  if (mode === "music") {
+    return audioHasEditModes(audio);
+  }
+  if (mode === "voiceclone") {
+    return audioHasVoiceCloneConditioning(audio);
+  }
+  if (mode === "sfx") {
+    return (
+      audioGenerates(audio) &&
+      !audioHasVoices(audio) &&
+      !audioHasEditModes(audio) &&
+      !audioHasVoiceCloneConditioning(audio)
+    );
+  }
+  return false;
+}
+
+// Usable on Audio Studio: an audio-type model that isn't Mac-blocked and serves ≥1 mode.
+export function audioModelUsable(model, caps) {
+  return (
+    model?.type === "audio" &&
+    !macModelBlock(model, caps) &&
+    AUDIO_MODES.some((mode) => audioModelServesMode(model, mode))
   );
 }
 

--- a/apps/web/src/modelEligibility.test.js
+++ b/apps/web/src/modelEligibility.test.js
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { DEFAULT_MAC_CAPABILITIES } from "./macGating.js";
 import {
+  AUDIO_MODES,
   angleModelUsable,
+  audioModelServesMode,
+  audioModelUsable,
   characterModelUsable,
   documentModelUsable,
   generationModelsForType,
@@ -13,7 +16,7 @@ import {
   videoModelUsable,
   visionCaptionModelUsable,
 } from "./modelEligibility.js";
-import { VISION_CAPTION_MODEL_ID } from "./constants.js";
+import { VISION_CAPTION_MODEL_ID, fallbackModels } from "./constants.js";
 
 const caps = DEFAULT_MAC_CAPABILITIES; // gating off → Mac blocks are no-ops
 
@@ -184,5 +187,116 @@ describe("modelEligibility predicates", () => {
     // No recommended among eligible → fall back to all eligible (not installed).
     const noRec = models.filter((m) => m.id === "plain");
     expect(downloadOffersFor(noRec, imageModelUsable, caps).map((m) => m.id)).toEqual(["plain"]);
+  });
+});
+
+// Audio Studio eligibility (epic 13400, sc-13403). audioModelServesMode is capability-driven: it
+// reads only the model's `audio` sub-block (voices / editModes / conditioning / sampleRates), never
+// the id. The five A2-seeded models must each map to EXACTLY one of speech/sfx/music/voiceclone and
+// fail the other three, so the assertions below discriminate (a model must reject wrong modes).
+describe("audio model eligibility (sc-13403)", () => {
+  // Minimal fixtures mirroring the `audio` sub-blocks of the five seeded catalog models.
+  const kokoro = {
+    id: "kokoro_82m",
+    type: "audio",
+    audio: { voices: [{ id: "af_heart" }, { id: "am_michael" }], sampleRates: [24000], languages: ["en-US"], maxDurationSecs: 30 },
+  };
+  const moss = {
+    id: "moss_sfx_v2",
+    type: "audio",
+    audio: { sampleRates: [48000], languages: ["en", "zh"], maxDurationSecs: 30 },
+  };
+  const acestep = {
+    id: "acestep_v15_turbo",
+    type: "audio",
+    audio: { sampleRates: [48000], editModes: ["inpaint", "repaint", "extend"], conditioning: ["AudioEdit"], maxDurationSecs: 600 },
+  };
+  const openvoice = {
+    id: "openvoice_v2",
+    type: "audio",
+    audio: { sampleRates: [22050], conditioning: ["ReferenceAudio"] },
+  };
+  const chatterbox = {
+    id: "chatterbox_ve",
+    type: "audio",
+    audio: { conditioning: ["VoiceEmbedding"] },
+  };
+
+  const seeded = [
+    ["Kokoro-82M", kokoro, "speech"],
+    ["MOSS-SoundEffect-v2", moss, "sfx"],
+    ["ACE-Step v1.5 Turbo", acestep, "music"],
+    ["OpenVoice V2", openvoice, "voiceclone"],
+    ["Chatterbox-VE", chatterbox, "voiceclone"],
+  ];
+
+  it("exposes the four Audio Studio mode keys in order", () => {
+    expect(AUDIO_MODES).toEqual(["speech", "sfx", "music", "voiceclone"]);
+  });
+
+  it.each(seeded)("%s serves exactly its capability-derived mode and rejects the others", (_label, model, expectedMode) => {
+    expect(audioModelServesMode(model, expectedMode), `${model.id} should serve ${expectedMode}`).toBe(true);
+    for (const mode of AUDIO_MODES.filter((m) => m !== expectedMode)) {
+      expect(audioModelServesMode(model, mode), `${model.id} must NOT serve ${mode}`).toBe(false);
+    }
+  });
+
+  it("ACE-Step is music (editModes) and NOT voiceclone (its conditioning is AudioEdit, not a voice signal)", () => {
+    expect(audioModelServesMode(acestep, "music")).toBe(true);
+    expect(audioModelServesMode(acestep, "voiceclone")).toBe(false);
+    // MOSS is the residual generator (sfx) — not music, because it advertises no editModes.
+    expect(audioModelServesMode(moss, "music")).toBe(false);
+    expect(audioModelServesMode(moss, "sfx")).toBe(true);
+  });
+
+  it("audioModelServesMode is empty-block / unknown-mode safe", () => {
+    expect(audioModelServesMode({ type: "audio" }, "speech")).toBe(false); // no audio block
+    expect(audioModelServesMode({ type: "audio", audio: {} }, "sfx")).toBe(false); // empty block
+    expect(audioModelServesMode(kokoro, "banana")).toBe(false); // unknown mode
+    expect(audioModelServesMode(null, "speech")).toBe(false);
+  });
+
+  it("audioModelUsable matches audio models serving ≥1 mode, rejects other types + non-serving blocks", () => {
+    for (const [, model] of seeded) {
+      expect(audioModelUsable(model, caps), `${model.id} usable`).toBe(true);
+    }
+    // Wrong type → not usable even with an audio block.
+    expect(audioModelUsable({ ...kokoro, type: "video" }, caps)).toBe(false);
+    // Audio type but no serviceable capability (e.g. metadata-only block) → not usable.
+    expect(audioModelUsable({ id: "bare", type: "audio", audio: { languages: ["en"] } }, caps)).toBe(false);
+    expect(audioModelUsable({ id: "none", type: "audio" }, caps)).toBe(false);
+  });
+
+  it("audioModels resolve from a live catalog and from fallbackModels", () => {
+    // Live-catalog fixture: installed audio entries surface; missing/torn/non-audio are excluded.
+    const liveCatalog = [
+      { ...kokoro, installState: "installed" },
+      { ...acestep, installState: "installed", updateAvailable: true },
+      { ...moss, installState: "missing" },
+      { id: "some-video", type: "video", installState: "installed" },
+    ];
+    expect(generationModelsForType(liveCatalog, "audio").map((m) => m.id)).toEqual(["kokoro_82m", "acestep_v15_turbo"]);
+
+    // Fallback mirror: the constants.js audio entries resolve the same five models, and each still
+    // maps to its correct capability-driven mode (proves the fallback carries the discriminating fields).
+    const fallbackAudio = generationModelsForType(fallbackModels, "audio");
+    expect(fallbackAudio.map((m) => m.id).sort()).toEqual(
+      ["acestep_v15_turbo", "chatterbox_ve", "kokoro_82m", "moss_sfx_v2", "openvoice_v2"].sort(),
+    );
+    const expectedMode = {
+      kokoro_82m: "speech",
+      moss_sfx_v2: "sfx",
+      acestep_v15_turbo: "music",
+      openvoice_v2: "voiceclone",
+      chatterbox_ve: "voiceclone",
+    };
+    for (const model of fallbackAudio) {
+      expect(audioModelServesMode(model, expectedMode[model.id]), `fallback ${model.id}`).toBe(true);
+      for (const mode of AUDIO_MODES.filter((m) => m !== expectedMode[model.id])) {
+        expect(audioModelServesMode(model, mode), `fallback ${model.id} must NOT serve ${mode}`).toBe(false);
+      }
+    }
+    // Kokoro is the recommended default in the fallback list.
+    expect(fallbackAudio.find((m) => m.id === "kokoro_82m")?.recommended).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

[A3] Widen the web model-type plumbing so `audio` is a first-class type across the sites that previously enumerated `image | video | utility`. This is the plumbing foundation the Audio Studio (epic 13400, C0/C1) consumes. Builds on A1 (schema `type:"audio"` + `audio` sub-block) and A2 (5 seeded audio models).

## Three sites changed

1. **`apps/web/src/modelEligibility.js`**
   - `audioModelServesMode(model, mode)` — capability-driven per-mode eligibility, derived from the model's `audio` sub-block (mirrors how `videoModelServesMode` reads video capabilities; no hardcoded ids).
   - `audioModelUsable(model, caps)` — mirrors `videoModelUsable` (`type === "audio"` + not Mac-blocked + serves ≥1 mode).
   - Exported `AUDIO_MODES = ["speech", "sfx", "music", "voiceclone"]` (mirrors exported `VIDEO_MODES`) so C0 can mirror the mode keys.
   - `generationModelsForType(models, "audio")` already works (type-generic — confirmed, not duplicated).

2. **`apps/web/src/constants.js`** — added the 5 `type:"audio"` entries to `fallbackModels`, mirroring the A2-seeded catalog. Each carries only the discriminating `audio` fields the UI / eligibility read (`voices` / `editModes` / `conditioning` / `sampleRates`); Kokoro is `recommended: true`. constants.js has no separate type-enumeration constant — `fallbackModels` (filtered by type in App.jsx) is the fallback source.

3. **`apps/web/src/App.jsx`** — added the `audioModels` split (`generationModelsForType(models, "audio")`, live-catalog-then-fallback, mirroring `imageModels`/`videoModels`) and exposed `audioModels` via the `AppStaticContext` value (object literal + dependency array) right next to `videoModels`.

## Capability-driven mode mapping (and why)

The mapping is derived from the `audio` sub-block, **not** from ids — mirroring the video pattern. Each of the 5 seeded models maps to **exactly one** mode and fails the other three:

| Model | Discriminating audio field | Mode |
|---|---|---|
| Kokoro-82M | `voices[]` non-empty (only a TTS model ships a voice bank) | **speech** |
| ACE-Step v1.5 Turbo | `editModes[]` (inpaint/repaint/extend) | **music** |
| OpenVoice V2 | `conditioning ⊇ ReferenceAudio` | **voiceclone** |
| Chatterbox-VE | `conditioning ⊇ VoiceEmbedding` | **voiceclone** |
| MOSS-SoundEffect-v2 | generative (`sampleRates[]`) and none of the above | **sfx** |

Two traps the discriminators handle:
- **ACE-Step must not be voiceclone.** Its `conditioning` is `["AudioEdit"]` — a music-edit signal, not a reference/identity signal — so voiceclone matches only the specific kinds `ReferenceAudio` / `VoiceEmbedding` (case-insensitive), not "conditioning present".
- **MOSS must be sfx, not music.** Both MOSS and ACE-Step are 48 kHz, so sample rate can't discriminate them; `editModes` (which only ACE-Step advertises) is the music signal, and sfx is the residual generative mode (has `sampleRates`, no voices/editModes/voice-conditioning).

## Tests (`apps/web/src/modelEligibility.test.js`)

- Each seeded model serves exactly its mode and **rejects** the other three (discriminating, table-driven).
- Explicit ACE-Step music-not-voiceclone and MOSS sfx-not-music assertions.
- Empty-block / unknown-mode / null safety.
- `audioModelUsable`: all 5 usable; wrong type and metadata-only audio blocks rejected.
- `audioModels` resolve **from a live-catalog fixture** (installed audio entries surface, missing/torn/non-audio excluded) **and from `fallbackModels`** — and each fallback entry still maps to its correct mode (proves the fallback carries the discriminating fields); Kokoro `recommended`.

## Verification

- `modelEligibility.test.js` + `constants.test.js`: **29 passed** (25 eligibility incl. new audio suite, 4 constants).
- `App.models.test.jsx` + `App.shell.test.jsx`: **39 passed** (context change safe).
- `npm run web:build` (vite): **green** (only pre-existing chunk-size / theme-init warnings).

## Out of scope (follow-ups)

- Model-management UI (`ModelManagerScreen.jsx`, `SetupWizard.jsx`) still enumerate `image | video | utility` tabs/labels and would need an `audio` category to surface audio models in management/setup. That's UI work distinct from this A-series plumbing story (three named sites); flagged for the C-series / a dedicated story rather than silently expanded here.

Story: [sc-13403]
https://app.shortcut.com/trefry/story/13403

🤖 Generated with [Claude Code](https://claude.com/claude-code)