### PR TITLE
feat(queue): cancel all pending jobs in one action (sc-13448)

### DIFF
--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -403,6 +403,38 @@ pub(crate) async fn clear_jobs(
     }))
 }
 
+/// Cancel every pending (not-yet-started) item in the queue (sc-13448) — the bulk
+/// analog of the per-job cancel fast path. A `queued` / `pending_caption` job has no
+/// worker to acknowledge the cancel, so each is flipped straight to terminal
+/// `canceled` in one pass (see `JobsStore::cancel_pending_jobs`), optionally scoped
+/// to one project via the request body (matching the queue's project filter). Active
+/// (worker-owned) jobs are left untouched — those cancel one at a time so the owning
+/// worker acknowledges. Broadcasts `job.updated` per canceled job so every SSE client
+/// flips the card, plus one queue refresh, and returns the updated snapshots so the
+/// acting client updates instantly.
+pub(crate) async fn cancel_pending_jobs(
+    State(state): State<AppState>,
+    ApiJson(payload): ApiJson<CancelPendingJobsRequest>,
+) -> Result<Json<CancelPendingJobsResponse>, ApiError> {
+    let jobs = store_call(state.clone(), move |store, _timeout| {
+        store.cancel_pending_jobs(payload.project_id.as_deref())
+    })
+    .await?;
+    // Per-job `job.updated` so every subscriber's card flips to Cancelled (the queue
+    // summary alone only updates counts, not individual cards), then one queue refresh
+    // for the status counts. The pending set is bounded by what a user queued, so the
+    // fan-out is small.
+    for job in &jobs {
+        publish(&state, "job.updated", job);
+    }
+    publish_queue(&state).await?;
+    Ok(Json(CancelPendingJobsResponse {
+        canceled: jobs.len(),
+        jobs,
+        extra: Default::default(),
+    }))
+}
+
 /// Clear a single completed item from the queue (sc-12231, issue #1556) — the
 /// per-card "×" dismiss. Soft-hides one terminal job (see `JobsStore::clear_job`)
 /// so it drops off the queue list + counts while its row (and generated assets)

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -20,11 +20,12 @@ use axum::{Json, Router};
 use futures_util::future::join_all;
 use parking_lot::Mutex;
 use sceneworks_core::contracts::{
-    ClaimRequest, ClaimResponse, ClearJobsRequest, ClearJobsResponse, ContractNumber,
-    DuplicateJobRequest, GenerationMetrics, GenerationMetricsRow, ImageUpscaleRequest,
-    JobCreateRequest, JobSnapshot, JobStatus, JobType, JsonObject, ProgressRequest, QueueSummary,
-    RetryJobRequest, WorkerCapability, WorkerHeartbeatRequest, WorkerRegisterRequest,
-    WorkerSnapshot, WorkerStatus, WorkerTerminationRequest,
+    CancelPendingJobsRequest, CancelPendingJobsResponse, ClaimRequest, ClaimResponse,
+    ClearJobsRequest, ClearJobsResponse, ContractNumber, DuplicateJobRequest, GenerationMetrics,
+    GenerationMetricsRow, ImageUpscaleRequest, JobCreateRequest, JobSnapshot, JobStatus, JobType,
+    JsonObject, ProgressRequest, QueueSummary, RetryJobRequest, WorkerCapability,
+    WorkerHeartbeatRequest, WorkerRegisterRequest, WorkerSnapshot, WorkerStatus,
+    WorkerTerminationRequest,
 };
 use sceneworks_core::hf_home::{huggingface_hub_cache_dir, huggingface_repo_cache_path};
 use sceneworks_core::image_request::{
@@ -131,8 +132,9 @@ use generation::{validate_interleave_job, validate_vqa_job};
 mod ideogram;
 mod jobs;
 use jobs::{
-    cancel_job, claim_job, clear_job, clear_jobs, create_job, duplicate_job, get_job,
-    get_job_metrics, list_jobs, list_metrics, retry_job, update_job_progress, upsert_job_metrics,
+    cancel_job, cancel_pending_jobs, claim_job, clear_job, clear_jobs, create_job, duplicate_job,
+    get_job, get_job_metrics, list_jobs, list_metrics, retry_job, update_job_progress,
+    upsert_job_metrics,
 };
 mod workers;
 use workers::{
@@ -1328,6 +1330,9 @@ pub(crate) fn create_app_with_state(
         // Clear completed items from the queue (sc-12231, issue #1556). A static
         // segment like `/claim`, so it takes priority over `/jobs/:job_id`.
         .route("/api/v1/jobs/clear", post(clear_jobs))
+        // Cancel every pending (queued / pending_caption) item at once (sc-13448).
+        // Static segment like `/clear`, so it takes priority over `/jobs/:job_id`.
+        .route("/api/v1/jobs/cancel-pending", post(cancel_pending_jobs))
         .route("/api/v1/jobs/events", get(job_events))
         .route("/api/v1/jobs/events/ticket", post(create_event_ticket))
         // Media ticket (sc-8810): auth-protected mint endpoint; the ticket is honored

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -607,6 +607,106 @@ async fn clear_jobs_scopes_to_the_requested_project() {
 }
 
 #[tokio::test]
+async fn cancel_pending_jobs_cancels_every_queued_item_but_not_active_ones() {
+    // sc-13448: POST /api/v1/jobs/cancel-pending flips every pending (queued) job to
+    // terminal `canceled` in one call, returns the updated snapshots, and leaves a
+    // worker-owned (active) job running.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    // Register a worker + create three jobs, then claim one so it is active.
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/workers/register",
+        json!({
+            "workerId": "worker-1",
+            "gpuId": "gpu-0",
+            "gpuName": "GPU 0",
+            "capabilities": ["image_detail"],
+            "loadedModels": []
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let mut ids = Vec::new();
+    for prompt in ["one", "two", "three"] {
+        let (_, job) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/jobs",
+            json!({
+                "type": "image_detail",
+                "projectId": "project-1",
+                "projectName": "Project 1",
+                "payload": { "prompt": prompt },
+                "requestedGpu": "auto"
+            }),
+        )
+        .await;
+        ids.push(job["id"].as_str().expect("job id").to_owned());
+    }
+
+    // Claim the oldest job — it becomes active (Preparing) and worker-owned.
+    let (_, claimed) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/jobs/claim",
+        json!({ "workerId": "worker-1" }),
+    )
+    .await;
+    let active_id = claimed["job"]["id"]
+        .as_str()
+        .expect("claimed id")
+        .to_owned();
+    assert_eq!(claimed["job"]["status"], "preparing");
+
+    // Cancel all pending (empty body == all projects). The two still-queued jobs are
+    // canceled; the active job is not.
+    let (status, canceled) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/jobs/cancel-pending",
+        json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(canceled["canceled"], 2);
+    let canceled_jobs = canceled["jobs"].as_array().expect("jobs array");
+    assert_eq!(canceled_jobs.len(), 2);
+    for job in canceled_jobs {
+        assert_eq!(job["status"], "canceled");
+        assert_eq!(job["stage"], "canceled");
+        assert_eq!(job["cancelRequested"], true);
+        assert_eq!(job["message"], "Canceled before a worker started.");
+        assert!(job["canceledAt"].is_string());
+        assert_ne!(job["id"], json!(active_id));
+    }
+
+    // The active job is untouched: still preparing, no cancel requested.
+    let (_, active) = request(
+        app.clone(),
+        "GET",
+        &format!("/api/v1/jobs/{active_id}"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(active["status"], "preparing");
+    assert_eq!(active["cancelRequested"], false);
+
+    // Status counts: two canceled, none queued, the active one still in flight.
+    let (_, queue) = request(app.clone(), "GET", "/api/v1/queue", Value::Null).await;
+    assert_eq!(queue["counts"]["canceled"], 2);
+    assert_eq!(queue["counts"]["queued"], 0);
+
+    // A second sweep cancels nothing — no pending jobs remain.
+    let (status, again) = request(app, "POST", "/api/v1/jobs/cancel-pending", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(again["canceled"], 0);
+}
+
+#[tokio::test]
 async fn clear_single_job_soft_hides_only_that_terminal_job() {
     // sc-12231 / issue #1556: POST /api/v1/jobs/:id/clear (the per-card ×) drops one
     // terminal job from the queue and leaves its siblings alone.

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -2113,6 +2113,32 @@ export function App() {
     [token],
   );
 
+  // Cancel every pending (not-yet-started) item in the queue (sc-13448). The server
+  // flips each queued / pending_caption job straight to terminal `canceled` and
+  // returns the updated snapshots; upsert them so the cards flip to "Cancelled"
+  // immediately without waiting for the SSE round-trip. Scoped to the active project
+  // filter so it cancels exactly what the operator sees ("all" cancels every
+  // project) — mirroring Clear completed. Active/running jobs are untouched.
+  const cancelPendingJobs = useCallback(
+    async (projectId) => {
+      try {
+        const body = projectId && projectId !== "all" ? { projectId } : {};
+        const response = await apiFetch("/api/v1/jobs/cancel-pending", token, {
+          method: "POST",
+          body: JSON.stringify(body),
+        });
+        const canceled = response?.jobs ?? [];
+        if (canceled.length) {
+          setJobs((items) => canceled.reduce((acc, job) => upsertJobNewest(acc, job), items));
+        }
+        setError("");
+      } catch (err) {
+        setError(err.message);
+      }
+    },
+    [token],
+  );
+
   // Clear a single completed item from the queue (issue #1556 / sc-12231) — the
   // per-card "×". The server soft-hides just this terminal job; drop it from the
   // live list on success so the card disappears immediately.
@@ -2221,6 +2247,7 @@ export function App() {
     // Job actions (creation/control — stable callbacks, NOT the churning jobs list)
     jobAction,
     clearCompletedJobs,
+    cancelPendingJobs,
     clearJob,
     createVqaJob,
     createInterleaveJob,
@@ -2359,7 +2386,7 @@ export function App() {
     createTimeline, saveTimeline, exportTimeline, extractTimelineFrame, queueTimelineVideoJob,
     assets, selectedAsset, selectedAssetId, setSelectedAssetId, deleteAsset, purgeAsset, moveAssetToLibrary, moveAssetToCharacter, importAsset,
     updateAssetStatus, updateAssetTags, latestImageAssets,
-    jobAction, clearCompletedJobs, clearJob, createVqaJob, createInterleaveJob, createPlaceholderJob,
+    jobAction, clearCompletedJobs, cancelPendingJobs, clearJob, createVqaJob, createInterleaveJob, createPlaceholderJob,
     jobPrompt, setJobPrompt, projectFilter, setProjectFilter, projects,
     createVideoJob, createVideoUpscaleJob, createImageJob, refinePrompt, magicPrompt, imageCaption, imageDescribe, compareFaceLikeness, latestVideoAssets, recentImageAssets,
     recentVideoAssets, studioLaunch,

--- a/apps/web/src/App.queue.test.jsx
+++ b/apps/web/src/App.queue.test.jsx
@@ -499,6 +499,84 @@ describe("SceneWorks app shell", () => {
     expect(clearButton.disabled).toBe(true);
   });
 
+  it("cancels all pending queue items scoped to the active project filter (sc-13448)", async () => {
+    const cancelPendingJobs = vi.fn(() => Promise.resolve());
+    const job = (id, status) => ({
+      id,
+      type: "image_generate",
+      status,
+      stage: status,
+      progress: status === "running" ? 0.3 : 0,
+      projectId: "project-1",
+      projectName: "Project 1",
+      requestedGpu: "auto",
+      payload: { prompt: id },
+      attempts: 1,
+    });
+    const baseProps = {
+      activeProject: { id: "project-1", name: "Project 1" },
+      cancelPendingJobs,
+      createPlaceholderJob: (event) => event.preventDefault(),
+      gpuOptions: ["auto", "0"],
+      jobAction: () => {},
+      jobPrompt: "",
+      projectFilter: "project-1",
+      projects: [{ id: "project-1", name: "Project 1" }],
+      requestedGpu: "auto",
+      setJobPrompt: () => {},
+      setProjectFilter: () => {},
+      setRequestedGpu: () => {},
+      visibleWorkers: [],
+    };
+    const findCancelButton = () =>
+      [...document.body.querySelectorAll("button")].find((button) =>
+        button.textContent.startsWith("Cancel pending"),
+      );
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            ...baseProps,
+            // Two pending jobs (queued + pending_caption) and one running (active).
+            filteredJobs: [
+              job("job-queued", "queued"),
+              { ...job("job-caption", "pending_caption"), stage: "pending_caption" },
+              { ...job("job-running", "running"), stage: "generating" },
+            ],
+          },
+          <QueueScreen />,
+        ),
+      );
+    });
+
+    // The button surfaces the pending count and is enabled.
+    let cancelButton = findCancelButton();
+    expect(cancelButton).toBeTruthy();
+    expect(cancelButton.textContent).toBe("Cancel pending (2)");
+    expect(cancelButton.disabled).toBe(false);
+
+    await act(async () => {
+      cancelButton.click();
+    });
+    // Scoped to the active project filter, matching what the operator sees.
+    expect(cancelPendingJobs).toHaveBeenCalledWith("project-1");
+
+    // With nothing pending in view, the action disables and drops the count.
+    await act(async () => {
+      root.render(
+        withAppContext(
+          { ...baseProps, filteredJobs: [{ ...job("job-running", "running"), stage: "generating" }] },
+          <QueueScreen />,
+        ),
+      );
+    });
+    cancelButton = findCancelButton();
+    expect(cancelButton.textContent).toBe("Cancel pending");
+    expect(cancelButton.disabled).toBe(true);
+  });
+
   it("dismisses an individual completed queue item via the per-card × (issue #1556)", async () => {
     const clearJob = vi.fn(() => Promise.resolve());
     const completedJob = {

--- a/apps/web/src/jobTypes.js
+++ b/apps/web/src/jobTypes.js
@@ -34,6 +34,12 @@ export const NON_GPU_JOB_TYPES = new Set([
 // Terminal job statuses (no further progress expected).
 export const terminalStatuses = new Set(["completed", "failed", "canceled", "interrupted"]);
 
+// Pending statuses: accepted but not yet owned by a worker (still waiting in the
+// queue). These are exactly the jobs the bulk "Cancel pending" action terminates
+// immediately — mirrors the backend cancel fast path / PENDING_STATUSES
+// (queued + pending_caption).
+export const pendingStatuses = new Set(["queued", "pending_caption"]);
+
 // Statuses that surface job actions (retry/repeat/cancel) in the queue.
 export const actionStatuses = new Set(["failed", "canceled", "interrupted", "completed"]);
 

--- a/apps/web/src/screens/QueueScreen.jsx
+++ b/apps/web/src/screens/QueueScreen.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { terminalStatuses } from "../constants.js";
-import { GPU_REQUIRED_JOB_TYPES, NON_GPU_JOB_TYPES } from "../jobTypes.js";
+import { GPU_REQUIRED_JOB_TYPES, NON_GPU_JOB_TYPES, pendingStatuses } from "../jobTypes.js";
 import { useAppContext } from "../context/AppContext.js";
 import { resolveJobResultAssets } from "../jobResultAssets.js";
 import { WorkPanel } from "../components/WorkPanel.jsx";
@@ -187,6 +187,7 @@ export function QueueScreen() {
   const {
     activeProject,
     assets = [],
+    cancelPendingJobs,
     clearCompletedJobs,
     clearJob,
     createPlaceholderJob,
@@ -214,6 +215,13 @@ export function QueueScreen() {
   // button so it disables when there's nothing to clear.
   const completedCount = useMemo(
     () => filteredJobs.filter((job) => terminalStatuses.has(job.status)).length,
+    [filteredJobs],
+  );
+  // "Cancel pending" (sc-13448): how many of the jobs in view are pending
+  // (queued / pending_caption) and thus bulk-cancelable. Gates the button so it
+  // disables when there's nothing to cancel.
+  const pendingCount = useMemo(
+    () => filteredJobs.filter((job) => pendingStatuses.has(job.status)).length,
     [filteredJobs],
   );
   return (
@@ -248,6 +256,19 @@ export function QueueScreen() {
             </option>
           ))}
         </select>
+        {/* Cancel all pending items in the queue (sc-13448). Scoped to the current
+            project filter; disabled when nothing in view is pending. Cancels only
+            not-yet-started (queued / pending_caption) jobs — running jobs are left
+            to the per-card Cancel so the owning worker acknowledges. */}
+        <button
+          className="queue-cancel-pending"
+          disabled={pendingCount === 0 || !cancelPendingJobs}
+          onClick={() => cancelPendingJobs?.(projectFilter)}
+          title="Cancel all pending (not-yet-started) jobs in the queue"
+          type="button"
+        >
+          Cancel pending{pendingCount > 0 ? ` (${pendingCount})` : ""}
+        </button>
         {/* Clear completed items from the queue (issue #1556). Scoped to the
             current project filter; disabled when nothing in view is terminal. */}
         <button

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -12355,10 +12355,12 @@ details[open] > summary.lora-scope-group-heading::before,
   gap: 10px;
 }
 
-/* "Clear completed" (issue #1556) rides at the trailing edge of the queue tools
-   row — a subtle secondary control next to the project filter. */
+/* "Cancel pending" (sc-13448) + "Clear completed" (issue #1556) ride at the
+   trailing edge of the queue tools row — subtle secondary controls next to the
+   project filter. `margin-left: auto` on the first of the pair anchors the group
+   to the right; the flex `gap` spaces them. */
+.queue-cancel-pending,
 .queue-clear-completed {
-  margin-left: auto;
   min-height: var(--control-h);
   padding: 0 14px;
   border: 1px solid var(--border);
@@ -12370,11 +12372,17 @@ details[open] > summary.lora-scope-group-heading::before,
   white-space: nowrap;
 }
 
+.queue-cancel-pending {
+  margin-left: auto;
+}
+
+.queue-cancel-pending:hover:not(:disabled),
 .queue-clear-completed:hover:not(:disabled) {
   border-color: var(--border-strong);
   background: var(--surface-hover);
 }
 
+.queue-cancel-pending:disabled,
 .queue-clear-completed:disabled {
   opacity: 0.5;
   cursor: not-allowed;

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -1134,6 +1134,33 @@ pub struct ClearJobsResponse {
     pub extra: ExtraFields,
 }
 
+/// Body for `POST /api/v1/jobs/cancel-pending` (sc-13448) — the "Cancel pending"
+/// queue action, the bulk analog of the per-job cancel fast path. `project_id`
+/// scopes the cancel to one workspace (matching the queue's project filter);
+/// omitted / null cancels every project's pending (`queued` / `pending_caption`)
+/// jobs. All fields optional so an empty `{}` body is valid.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CancelPendingJobsRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    #[serde(flatten)]
+    pub extra: ExtraFields,
+}
+
+/// Response for `POST /api/v1/jobs/cancel-pending` (sc-13448): how many pending jobs
+/// were canceled and their updated snapshots (now terminal `canceled`), so the
+/// acting client upserts the flipped cards into its live queue immediately without
+/// waiting for the SSE round-trip.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CancelPendingJobsResponse {
+    pub canceled: usize,
+    pub jobs: Vec<JobSnapshot>,
+    #[serde(flatten)]
+    pub extra: ExtraFields,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SidecarPatterns {

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -48,6 +48,12 @@ pub const ACTIVE_STATUSES: &[&str] = &[
     "saving",
 ];
 pub const TERMINAL_STATUSES: &[&str] = &["completed", "failed", "canceled", "interrupted"];
+/// Pending (accepted-but-not-yet-worker-owned) statuses: a job in one of these is
+/// waiting in the queue with no worker to acknowledge a cancel, so it can be
+/// terminated immediately. Exactly the two statuses the `cancel_job` fast path — and
+/// the bulk [`JobsStore::cancel_pending_jobs`] — flip straight to terminal `canceled`.
+/// Kept in lockstep with that fast-path branch and the web `pendingStatuses` set.
+pub const PENDING_STATUSES: &[&str] = &["queued", "pending_caption"];
 pub const JOB_STATUSES: &[&str] = &[
     "queued",
     // Accepted-but-not-yet-claimable: awaiting the API-side async payload rewrite (Ideogram 4
@@ -117,6 +123,22 @@ fn terminal_statuses_sql() -> &'static str {
     static SQL: OnceLock<String> = OnceLock::new();
     SQL.get_or_init(|| {
         TERMINAL_STATUSES
+            .iter()
+            .map(|status| format!("'{status}'"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    })
+}
+
+/// The pending statuses as a quoted SQL list for `status in (...)` filters, derived
+/// once from [`PENDING_STATUSES`] — same anti-drift rationale as
+/// [`terminal_statuses_sql`]. Used to select the not-yet-started jobs the bulk
+/// [`JobsStore::cancel_pending_jobs`] terminates. Values are crate constants, never
+/// user input, so direct interpolation is safe.
+fn pending_statuses_sql() -> &'static str {
+    static SQL: OnceLock<String> = OnceLock::new();
+    SQL.get_or_init(|| {
+        PENDING_STATUSES
             .iter()
             .map(|status| format!("'{status}'"))
             .collect::<Vec<_>>()
@@ -922,6 +944,94 @@ impl JobsStore {
         let job = self.get_job_on_connection(&transaction, job_id)?;
         transaction.commit()?;
         Ok(job)
+    }
+
+    /// Bulk-cancel every PENDING (not-yet-worker-owned) job — the fleet analog of the
+    /// `queued`/`pending_caption` fast path in [`cancel_job`] (issue: "cancel ALL
+    /// pending jobs"). Optionally scoped to one project (matching the queue's project
+    /// filter); omitted / `None` cancels every project's pending jobs. Each matching
+    /// row goes straight to terminal `canceled` in one UPDATE — no worker owns it to
+    /// acknowledge — and the updated snapshots are returned newest first so the caller
+    /// can broadcast `job.updated` per job and hand the acting client the flipped
+    /// cards immediately.
+    ///
+    /// Deliberately scoped to `queued` + `pending_caption` ([`PENDING_STATUSES`])
+    /// ONLY. An active (worker-owned) job needs cooperative acknowledgement and is
+    /// left untouched — cancel those one at a time via [`cancel_job`] so the owning
+    /// worker self-terminates; already-terminal jobs never match either. The
+    /// `pending_caption` guarded promotion (sc-9120) only ever advances a row that is
+    /// STILL `pending_caption`, so flipping it to `canceled` here can't be resurrected
+    /// — same race-free reasoning as the single-job fast path.
+    pub fn cancel_pending_jobs(
+        &self,
+        project_id: Option<&str>,
+    ) -> JobsStoreResult<Vec<JobSnapshot>> {
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+
+        // Collect the ids first (scoped so the borrowed statement drops before the
+        // UPDATE runs on the same transaction), mirroring `clear_terminal_jobs`.
+        let mut select_sql = format!(
+            "select id from jobs where status in ({pending})",
+            pending = pending_statuses_sql()
+        );
+        let mut bindings: Vec<Box<dyn ToSql>> = Vec::new();
+        if let Some(project_id) = project_id {
+            select_sql.push_str(" and project_id = ?");
+            bindings.push(Box::new(project_id.to_owned()));
+        }
+        select_sql.push_str(" order by created_at desc");
+        let pending_ids: Vec<String> = {
+            let mut statement = transaction.prepare(&select_sql)?;
+            let rows = statement.query_map(params_from_iter(bindings.iter()), |row| {
+                row.get::<_, String>(0)
+            })?;
+            let mut ids = Vec::new();
+            for row in rows {
+                ids.push(row?);
+            }
+            ids
+        };
+
+        if !pending_ids.is_empty() {
+            let now = utc_now();
+            // Same terminal transition as the `cancel_job` fast path (lines above),
+            // applied set-wide. The `status in (...)` guard is re-checked inside the
+            // UPDATE so a row that just left the pending stage under a concurrent
+            // writer is skipped rather than clobbered.
+            let mut update_sql = format!(
+                "
+                update jobs
+                   set status = 'canceled',
+                       stage = 'canceled',
+                       progress = 1,
+                       cancel_requested = 1,
+                       message = 'Canceled before a worker started.',
+                       canceled_at = ?,
+                       completed_at = ?,
+                       updated_at = ?
+                 where status in ({pending})
+                ",
+                pending = pending_statuses_sql()
+            );
+            let mut update_bindings: Vec<Box<dyn ToSql>> =
+                vec![Box::new(now.clone()), Box::new(now.clone()), Box::new(now)];
+            if let Some(project_id) = project_id {
+                update_sql.push_str(" and project_id = ?");
+                update_bindings.push(Box::new(project_id.to_owned()));
+            }
+            transaction.execute(&update_sql, params_from_iter(update_bindings.iter()))?;
+        }
+
+        // Re-read the updated snapshots (newest first) so callers broadcast the real
+        // post-cancel state, not the stale pre-update rows.
+        let mut canceled = Vec::with_capacity(pending_ids.len());
+        for id in &pending_ids {
+            canceled.push(self.get_job_on_connection(&transaction, id)?);
+        }
+        transaction.commit()?;
+        Ok(canceled)
     }
 
     pub fn retry_job(&self, job_id: &str, request: RetryJob) -> JobsStoreResult<JobSnapshot> {

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -385,6 +385,101 @@ fn clear_job_rejects_a_non_terminal_job() {
     assert_eq!(listed[0].id, queued.id);
 }
 
+#[test]
+fn cancel_pending_jobs_cancels_only_not_yet_started_jobs() {
+    // sc-13448: "Cancel pending" flips every queued / pending_caption job straight to
+    // terminal `canceled`, while leaving worker-owned (active) and already-terminal
+    // jobs untouched.
+    let store = store("cancel-pending-mix");
+    register_image_worker(&store);
+
+    // Two queued jobs and one pending_caption job — all "pending" (no worker owns
+    // them). A claimed job (active/Preparing) and an already-canceled job round out
+    // the mix to prove the scope boundary.
+    let queued_a = store
+        .create_job(image_job(object(json!({ "prompt": "wait a" }))))
+        .expect("creates");
+    let queued_b = store
+        .create_job(image_job(object(json!({ "prompt": "wait b" }))))
+        .expect("creates");
+    let pending_caption = store
+        .create_job(pending_caption_job(
+            json!({ "prompt": "a fox", "model": "ideogram_4" }),
+        ))
+        .expect("creates");
+    // Claim one job so it becomes worker-owned/active (Preparing).
+    let active = store
+        .claim_next_job("worker-1")
+        .expect("claim runs")
+        .expect("claimed");
+    assert_eq!(active.status, JobStatus::Preparing);
+    // A job canceled ahead of time is already terminal.
+    let already = store
+        .create_job(image_job(object(json!({ "prompt": "stop" }))))
+        .expect("creates");
+    store.cancel_job(&already.id).expect("cancels");
+
+    let canceled = store
+        .cancel_pending_jobs(None)
+        .expect("cancels pending jobs");
+    let canceled_ids: Vec<String> = canceled.iter().map(|job| job.id.clone()).collect();
+
+    // Exactly the two queued jobs + the pending_caption job were canceled — the
+    // active job is NOT among them (claim consumed queued_a; queued_b + the
+    // pending_caption remain pending).
+    assert_eq!(canceled.len(), 2);
+    assert!(canceled_ids.contains(&queued_b.id));
+    assert!(canceled_ids.contains(&pending_caption.id));
+    assert!(!canceled_ids.contains(&active.id));
+    assert!(!canceled_ids.contains(&already.id));
+    // Every returned snapshot is the real post-cancel terminal state.
+    for job in &canceled {
+        assert_eq!(job.status, JobStatus::Canceled);
+        assert_eq!(job.stage, ProgressStage::Canceled);
+        assert!(job.cancel_requested);
+        assert!(job.canceled_at.is_some());
+    }
+    // queued_a was the one claimed into `active`.
+    assert_eq!(active.id, queued_a.id);
+
+    // The active job is untouched: still Preparing, no cancel requested.
+    let active_after = store.get_job(&active.id).expect("active reload");
+    assert_eq!(active_after.status, JobStatus::Preparing);
+    assert!(!active_after.cancel_requested);
+
+    // A second sweep is a no-op — nothing pending remains.
+    assert!(store
+        .cancel_pending_jobs(None)
+        .expect("second sweep")
+        .is_empty());
+}
+
+#[test]
+fn cancel_pending_jobs_scopes_to_one_project() {
+    // sc-13448: the bulk cancel honors the queue's project filter — cancelling one
+    // project's pending jobs must never touch another project's queue.
+    let store = store("cancel-pending-scope");
+    let job_in = |project: &str, prompt: &str| CreateJob {
+        project_id: Some(project.to_owned()),
+        ..image_job(object(json!({ "prompt": prompt })))
+    };
+
+    let a = store.create_job(job_in("project-a", "a")).expect("creates");
+    let b = store.create_job(job_in("project-b", "b")).expect("creates");
+
+    let canceled = store
+        .cancel_pending_jobs(Some("project-a"))
+        .expect("cancels project-a");
+    assert_eq!(canceled.len(), 1);
+    assert_eq!(canceled[0].id, a.id);
+    assert_eq!(canceled[0].status, JobStatus::Canceled);
+
+    // project-b's queued job is untouched (still queued).
+    let b_after = store.get_job(&b.id).expect("b reload");
+    assert_eq!(b_after.status, JobStatus::Queued);
+    assert!(!b_after.cancel_requested);
+}
+
 /// An Ideogram auto-caption image job (sc-9120). Created NON-claimable in `pending_caption`.
 fn pending_caption_job(payload: Value) -> CreateJob {
     CreateJob {


### PR DESCRIPTION
## Problem
When a burst of jobs is queued, pending items pile up and get stuck. The only way to clear them was to cancel each job one at a time via the per-card **Cancel** — there was no bulk action.

## What this adds
A **"Cancel pending (N)"** button in the Queue toolbar (next to "Clear completed") that cancels every not-yet-started job in one click. Scoped to the current project filter (`All projects` cancels every project's pending jobs); disabled when nothing is pending.

## Scope
"Pending" = `queued` + `pending_caption` — the statuses **no worker owns yet**. They have nothing to acknowledge a cancel, so they flip **straight to terminal `canceled`** (reusing the exact fast path the per-job cancel already uses). Active/running (worker-owned) jobs are intentionally left to the per-card cooperative cancel so the owning worker acknowledges and frees the GPU cleanly.

## Changes
- **Store** (`jobs_store.rs`) — `cancel_pending_jobs(project_id)`, bulk analog of `cancel_job`'s fast path (select→update→re-read, like `clear_terminal_jobs`); `PENDING_STATUSES` const + `pending_statuses_sql()` helper (anti-drift, mirrors the web `pendingStatuses` set).
- **Contracts** — `CancelPendingJobsRequest` / `CancelPendingJobsResponse`.
- **API** (`jobs.rs`, `lib.rs`) — `POST /api/v1/jobs/cancel-pending`; publishes `job.updated` per canceled job (so every SSE client flips the card) + one queue refresh; returns the updated snapshots.
- **Web** (`jobTypes.js`, `App.jsx`, `QueueScreen.jsx`, `styles.css`) — `cancelPendingJobs` action (upserts returned snapshots → cards flip to Cancelled) + the button.

## Testing
- `cargo test -p sceneworks-core --test jobs_store cancel_pending` → **2/2** (mixed-status scope + project scoping; asserts active job untouched + idempotent second sweep).
- `cargo test -p sceneworks-rust-api cancel_pending` → **1/1** (end-to-end HTTP: register worker → 3 jobs → claim 1 → POST → 2 canceled, active still `preparing`, counts, idempotent).
- `apps/web` full suite → **2105/2105** (incl. new QueueScreen render/interaction test).
- `cargo fmt --all -- --check` clean; `cargo clippy -p sceneworks-core -p sceneworks-rust-api --all-targets` clean (0 warnings).

Shortcut: [sc-13448](https://app.shortcut.com/trefry/story/13448)

🤖 Generated with [Claude Code](https://claude.com/claude-code)