### PR TITLE
[sc-13404] Audio job path: /api/v1/audio/jobs + worker routing to the candle audio lane

### DIFF
--- a/apps/rust-api/src/defaults.rs
+++ b/apps/rust-api/src/defaults.rs
@@ -126,6 +126,13 @@ pub(crate) fn default_video_model() -> String {
     "ltx_2_3".to_owned()
 }
 
+/// The default audio model a `POST /api/v1/audio/jobs` resolves when the caller names none
+/// (SceneWorks Audio Studio, epic 13400 / sc-13404). Kokoro-82M is the recommended Speech model
+/// (`recommended: true` in the seeded manifest), 24 kHz mono TTS, Candle-native on every platform.
+pub(crate) fn default_audio_model() -> String {
+    "kokoro_82m".to_owned()
+}
+
 // No `default_video_duration` either, and for a sharper reason than fps: the blanket 6.0 that used
 // to live here is past the `hardMaxDuration` of 7 of the 10 shipped video models, so once sc-12297
 // began enforcing that cap, this default made the API reject its own duration-less requests

--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -875,6 +875,43 @@ pub(crate) struct VideoJobRequest {
     pub(crate) advanced: JsonObject,
 }
 
+/// A `POST /api/v1/audio/jobs` request (SceneWorks Audio Studio, epic 13400 / sc-13404). The audio
+/// analogue of [`VideoJobRequest`]: `prompt` is the script text, and the typed audio knobs (`voice`
+/// / `language` / `targetDurationSecs`) map to the worker-side [`gen_core::AudioParams`] sub-block a
+/// `Modality::Audio` generator reads. Every audio knob is optional — an omitted voice/language
+/// falls back to the model's default (Kokoro's `af_heart`, `en`), and an omitted duration lets the
+/// model synthesize its natural length. `Serialize` too so the whole request round-trips into the
+/// job payload the worker claims (mirroring how the video request is `to_json_object`'d).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AudioJobRequest {
+    pub(crate) project_id: String,
+    #[serde(default)]
+    pub(crate) project_name: Option<String>,
+    pub(crate) prompt: String,
+    #[serde(default = "default_audio_model")]
+    pub(crate) model: String,
+    /// Voice / speaker id (e.g. Kokoro's `af_heart`). `None` ⇒ the model's default voice. Gated
+    /// against the model's advertised `audio.voices` by the worker's shared validation floor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) voice: Option<String>,
+    /// Language code in the manifest's BCP-47 display casing (e.g. `"en-US"`). The worker lowercases
+    /// it to what the Generator accepts (`en` / `en-us` / `en-gb`) — the language-casing seam
+    /// (sc-13404). `None` ⇒ the model derives the accent from the voice id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) language: Option<String>,
+    /// Requested clip length in seconds. `None` ⇒ the model's natural length. Range-checked against
+    /// the model's advertised `audio.maxDurationSecs` by the worker.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) target_duration_secs: Option<f32>,
+    #[serde(default)]
+    pub(crate) seed: Option<i64>,
+    #[serde(default = "default_requested_gpu")]
+    pub(crate) requested_gpu: String,
+    #[serde(default)]
+    pub(crate) advanced: JsonObject,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ModelDownloadRequest {

--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -653,6 +653,59 @@ pub(crate) async fn create_video_job(
     Ok((StatusCode::CREATED, Json(job)))
 }
 
+/// `POST /api/v1/audio/jobs` — the SceneWorks Audio Studio job path (epic 13400 / sc-13404), the
+/// audio analogue of [`create_video_job`]. Validates the request, resolves + injects the model's
+/// merged manifest entry (so the worker never re-parses the jsonc, exactly as the image/video routes
+/// do — sc-1653/sc-12300), asserts the model is an `audio`-type model, and enqueues an
+/// `audio_generate` job. The worker builds the `GenerationRequest { audio: Some(AudioParams{..}) }`
+/// from this payload and dispatches it through the runtime's candle audio registry to the
+/// `Modality::Audio` generator.
+///
+/// Deliberately simpler than the video route: audio has no recipe-preset / LoRA / duration-fps
+/// resolution — its knobs (`voice` / `language` / `targetDurationSecs`) go straight through to the
+/// worker's `AudioParams`, and the model's declared duration/voice/language surface is enforced by
+/// the shared gen-core validation floor at generate time.
+pub(crate) async fn create_audio_job(
+    State(state): State<AppState>,
+    ApiJson(payload): ApiJson<AudioJobRequest>,
+) -> Result<(StatusCode, Json<JobSnapshot>), ApiError> {
+    validate_audio_job(&payload)?;
+    let requested_gpu = payload.requested_gpu.clone();
+    let project_id = Some(payload.project_id.clone());
+    let project_name = payload.project_name.clone();
+    let mut job_payload = to_json_object(&payload)?;
+    job_payload.remove("requestedGpu");
+    // Resolve the model manifest entry here so the audio worker never re-parses the jsonc — Rust owns
+    // manifest parsing/merging (story 1653), mirroring create_image_job / create_video_job. Keyed off
+    // the request model (audio has no preset that could replace it, so payload.model is authoritative).
+    let model_id = payload.model.clone();
+    let model_manifest_entry = resolve_model_manifest_entry(&state, &model_id).await?;
+    // The audio route only serves `type: audio` models. An unknown id resolves to `{}` (no type), and
+    // a mis-typed id (an image/video model posted here) is rejected up front rather than failing deep
+    // in the worker's audio lane with an opaque "no generator registered" — the typed-route contract
+    // (a door per media kind). The seeded audio models all declare `type: audio` (sc-13402).
+    let entry_type = model_manifest_entry
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if entry_type != "audio" {
+        return Err(ApiError::bad_request(format!(
+            "Model {model_id} is not an audio model (type: \"audio\" required)"
+        )));
+    }
+    job_payload.insert("modelManifestEntry".to_owned(), model_manifest_entry);
+    let job = create_generation_job(
+        state,
+        JobType::AudioGenerate,
+        project_id,
+        project_name,
+        job_payload,
+        requested_gpu,
+    )
+    .await?;
+    Ok((StatusCode::CREATED, Json(job)))
+}
+
 /// A resolved `duration` in the payload's `ContractNumber` (= `serde_json::Number`) shape: an
 /// integral value stays integral.
 ///
@@ -701,6 +754,10 @@ pub(crate) fn typed_generation_route(job_type: &JobType) -> Option<&'static str>
         | JobType::VideoExtend
         | JobType::VideoBridge
         | JobType::PersonReplace => Some("/api/v1/video/jobs"),
+        // The audio route resolves + injects the model's manifest entry (sc-13404), so — like the
+        // image/video routes — an `audio_generate` job enqueued raw through the generic
+        // `POST /api/v1/jobs` would reach the worker without its entry. One door per generation kind.
+        JobType::AudioGenerate => Some("/api/v1/audio/jobs"),
         _ => None,
     }
 }

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -123,7 +123,7 @@ use training::{
 };
 mod generation;
 use generation::{
-    create_image_job, create_interleave_job, create_video_job, create_vqa_job,
+    create_audio_job, create_image_job, create_interleave_job, create_video_job, create_vqa_job,
     parse_recipe_preset_resolution, typed_generation_route, JobCatalogSnapshot,
 };
 #[cfg(test)]
@@ -146,8 +146,8 @@ mod tickets;
 use tickets::{create_media_ticket, TicketResponse, TicketStore};
 mod dto;
 use dto::{
-    AccessResponse, AssetPurgeQuery, AssetsQuery, CatalogDeleteQuery, CharacterCreateRequest,
-    CharacterLookRequest, CharacterLookUpdateRequest, CharacterLoraRequest,
+    AccessResponse, AssetPurgeQuery, AssetsQuery, AudioJobRequest, CatalogDeleteQuery,
+    CharacterCreateRequest, CharacterLookRequest, CharacterLookUpdateRequest, CharacterLoraRequest,
     CharacterLoraUpdateRequest, CharacterReferenceRequest, CharacterReferenceUpdateRequest,
     CharacterTestRequest, CharacterUpdateRequest, CharactersQuery, DatasetAnalysisJobRequest,
     DatasetEmbeddingsBody, DatasetFaceAnalysisJobRequest, DatasetFaceRecordsBody,
@@ -1213,6 +1213,7 @@ pub(crate) fn create_app_with_state(
         .route("/api/v1/image/vqa/jobs", post(create_vqa_job))
         .route("/api/v1/image/interleave/jobs", post(create_interleave_job))
         .route("/api/v1/video/jobs", post(create_video_job))
+        .route("/api/v1/audio/jobs", post(create_audio_job))
         .route("/api/v1/prompts/refine", post(create_prompt_refine_job))
         .route(
             "/api/v1/face-likeness/compare",
@@ -2787,6 +2788,35 @@ fn validate_video_job(payload: &VideoJobRequest) -> Result<(), ApiError> {
         )),
         _ => Ok(()),
     }
+}
+
+/// Payload-sanity validation for a `POST /api/v1/audio/jobs` request (sc-13404), the audio analogue
+/// of [`validate_video_job`]. Bounds the script prompt + the `advanced` bag exactly as the image/
+/// video validators do; the model's own advertised audio surface (voices / languages / max
+/// duration) is enforced by the shared gen-core validation floor at generate time, so a *named*
+/// duration is only bounded to the sane blanket here (the model's `audio.maxDurationSecs` is the
+/// real cap the worker applies). Voice/language are not allow-listed here — an unknown value is
+/// rejected by the generator's `validate`, which owns the per-model surface.
+fn validate_audio_job(payload: &AudioJobRequest) -> Result<(), ApiError> {
+    if payload.project_id.is_empty() {
+        return Err(ApiError::bad_request("projectId is required"));
+    }
+    validate_model_id(&payload.model)?;
+    if payload.prompt.trim().is_empty() || payload.prompt.chars().count() > MAX_PROMPT_CHARS {
+        return Err(ApiError::bad_request(
+            "prompt must be between 1 and 4000 characters",
+        ));
+    }
+    // Reuse the shared `advanced`-size guard (audio carries no negative prompt, so pass an empty one).
+    validate_prompt_extras("", &payload.advanced)?;
+    if let Some(target) = payload.target_duration_secs {
+        if !target.is_finite() || !(0.0..=300.0).contains(&target) {
+            return Err(ApiError::bad_request(
+                "targetDurationSecs must be between 0 and 300",
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Upper bound for image width/height. A backstop only — per-model resolution is

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -56,6 +56,9 @@ async fn generic_jobs_route_rejects_generation_types_with_their_typed_route() {
         ("video_extend", "/api/v1/video/jobs"),
         ("video_bridge", "/api/v1/video/jobs"),
         ("person_replace", "/api/v1/video/jobs"),
+        // Audio Studio (sc-13404): the audio route injects the model's manifest entry too, so an
+        // `audio_generate` job enqueued raw through the generic route must be rejected the same way.
+        ("audio_generate", "/api/v1/audio/jobs"),
     ] {
         let (status, body) = request(
             app.clone(),
@@ -237,6 +240,190 @@ async fn create_video_job_rejects_over_length_negative_prompt() {
     assert!(error["detail"]
         .as_str()
         .is_some_and(|detail| detail.contains("negativePrompt")));
+}
+
+/// Seed a minimal audio + non-audio manifest into a test config dir so
+/// `resolve_model_manifest_entry` resolves a real `type: audio` entry for the audio route.
+fn write_audio_manifest(config_dir: &std::path::Path) {
+    std::fs::create_dir_all(config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "models": [
+            {
+              "id": "kokoro_82m",
+              "name": "Kokoro 82M",
+              "family": "kokoro",
+              "type": "audio",
+              "audio": {
+                "voices": [{ "id": "af_heart", "language": "en-US" }, { "id": "bm_george", "language": "en-GB" }],
+                "languages": ["en-US", "en-GB"],
+                "sampleRates": [24000],
+                "maxDurationSecs": 30
+              },
+              "downloads": [
+                { "provider": "huggingface", "repo": "hexgrad/Kokoro-82M", "files": ["config.json", "kokoro-v1_0.pth", "voices/*"] }
+              ],
+              "paths": { "model": "${HF_CACHE}/hexgrad/Kokoro-82M" },
+              "ui": { "label": "Kokoro 82M" }
+            },
+            {
+              "id": "not-audio-img",
+              "name": "Not Audio",
+              "family": "z_image",
+              "type": "image",
+              "capabilities": ["text_to_image"],
+              "downloads": [
+                { "provider": "huggingface", "repo": "owner/not-audio", "files": ["*.safetensors"] }
+              ],
+              "paths": {},
+              "ui": { "label": "Not Audio" }
+            }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin models writes");
+    std::fs::write(
+        config_dir.join("user.models.jsonc"),
+        r#"{ "schemaVersion": 1, "models": [] }"#,
+    )
+    .expect("user models writes");
+}
+
+/// The audio job path (sc-13404): a well-formed `POST /api/v1/audio/jobs` maps the request into an
+/// `audio_generate` job whose payload carries the audio knobs (voice / language / targetDurationSecs
+/// / seed) verbatim and the resolved `type: audio` manifest entry — the audio twin of how the video
+/// route injects `modelManifestEntry`.
+#[tokio::test]
+async fn create_audio_job_maps_request_to_audio_generate_payload() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    write_audio_manifest(&temp_dir.path().join("config/manifests"));
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Audio Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+
+    let (status, job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/audio/jobs",
+        json!({
+            "projectId": project_id,
+            "model": "kokoro_82m",
+            "prompt": "Hello from SceneWorks audio.",
+            "voice": "bm_george",
+            "language": "en-GB",
+            "targetDurationSecs": 4.0,
+            "seed": 7,
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{job}");
+    assert_eq!(job["type"], "audio_generate");
+    let payload = &job["payload"];
+    assert_eq!(payload["model"], "kokoro_82m");
+    assert_eq!(payload["prompt"], "Hello from SceneWorks audio.");
+    assert_eq!(payload["voice"], "bm_george");
+    assert_eq!(payload["language"], "en-GB");
+    assert_eq!(payload["targetDurationSecs"], 4.0);
+    assert_eq!(payload["seed"], 7);
+    // The resolved manifest entry must travel with the job (the worker resolves weights from it),
+    // and it must be THIS model's `type: audio` entry — not `{}` (which would slip a non-audio job
+    // through) — carrying the HF download repo the worker resolves the Kokoro snapshot from.
+    let entry = &payload["modelManifestEntry"];
+    assert_eq!(entry["id"], "kokoro_82m");
+    assert_eq!(entry["type"], "audio");
+    assert_eq!(entry["downloads"][0]["repo"], "hexgrad/Kokoro-82M");
+    // requestedGpu is stripped from the payload (it rides the job envelope), mirroring the video route.
+    assert!(payload.get("requestedGpu").is_none());
+}
+
+/// The audio route is a door for `type: audio` models only: an image/video model posted here is
+/// rejected up front rather than failing deep in the worker's audio lane (sc-13404).
+#[tokio::test]
+async fn create_audio_job_rejects_non_audio_model() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    write_audio_manifest(&temp_dir.path().join("config/manifests"));
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Audio Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+
+    // A path-safe but non-audio model id resolves to a `type: image` entry → rejected.
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/audio/jobs",
+        json!({
+            "projectId": project_id,
+            "model": "not-audio-img",
+            "prompt": "this is not audio",
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert!(body["detail"]
+        .as_str()
+        .is_some_and(|detail| detail.contains("audio")));
+
+    // An unknown model resolves to `{}` (no type) and is rejected for the same reason.
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/audio/jobs",
+        json!({
+            "projectId": project_id,
+            "model": "definitely-not-real",
+            "prompt": "hello",
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+/// The audio validator bounds the script prompt exactly as the image/video validators do (sc-13404).
+#[tokio::test]
+async fn create_audio_job_rejects_empty_prompt() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    write_audio_manifest(&temp_dir.path().join("config/manifests"));
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Audio Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/audio/jobs",
+        json!({
+            "projectId": project_id,
+            "model": "kokoro_82m",
+            "prompt": "   ",
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert!(body["detail"]
+        .as_str()
+        .is_some_and(|detail| detail.contains("prompt")));
 }
 
 // The queue-lifecycle tests below drive `POST /api/v1/jobs` — claim, cancel, retry,

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -55,6 +55,7 @@ import { isDesktop as isDesktopShell, tauriInvoke } from "./runtime.js";
 import {
   buildLocalJobStack,
   isActiveWorker,
+  isAudioGenerationJob,
   isImageGenerationJob,
   isInterleaveJob,
   isPlaceholderOnlyGpuWorker,
@@ -390,7 +391,7 @@ export function App() {
   // once here, stays mounted (hidden) across navigation so its state survives.
   const [visitedKeepAliveViews, setVisitedKeepAliveViews] = useState(() => new Set());
   const [jobs, setJobs] = useState([]);
-  const [localGenerationJobIds, setLocalGenerationJobIds] = useState({ image: [], video: [], document: [] });
+  const [localGenerationJobIds, setLocalGenerationJobIds] = useState({ image: [], video: [], audio: [], document: [] });
   const [workers, setWorkers] = useState([]);
   const [queueSummary, setQueueSummary] = useState(null);
   // Mac UI gating (sc-3486): inert until the capabilities endpoint reports macGatingActive.
@@ -662,6 +663,37 @@ export function App() {
     [token, activeProject, requestedGpu],
   );
 
+  // SceneWorks Audio Studio (epic 13400 / sc-13404): the audio analogue of createVideoJob. POSTs to
+  // the typed /api/v1/audio/jobs endpoint, which resolves + injects the model's manifest entry and
+  // enqueues an `audio_generate` job the worker routes to the candle audio lane. `payload` carries
+  // { modelId → model, prompt, voice, language, targetDurationSecs, seed }.
+  const createAudioJob = useCallback(
+    async (payload) => {
+      if (!activeProject) {
+        setError("Create or open a project first.");
+        return null;
+      }
+      try {
+        const job = await apiFetch("/api/v1/audio/jobs", token, {
+          method: "POST",
+          body: JSON.stringify({
+            ...payload,
+            projectId: activeProject.id,
+            projectName: activeProject.name,
+            requestedGpu,
+          }),
+        });
+        setJobs((items) => upsertJobNewest(items, job));
+        setError("");
+        return job;
+      } catch (err) {
+        setError(err.message);
+        return null;
+      }
+    },
+    [token, activeProject, requestedGpu],
+  );
+
   const {
     characters,
     setCharacters,
@@ -894,6 +926,10 @@ export function App() {
   const videoLocalJobs = useMemo(
     () => buildLocalJobStack(localGenerationJobIds.video, jobs, activeProject?.id, isVideoGenerationJob),
     [activeProject?.id, jobs, localGenerationJobIds.video],
+  );
+  const audioLocalJobs = useMemo(
+    () => buildLocalJobStack(localGenerationJobIds.audio, jobs, activeProject?.id, isAudioGenerationJob),
+    [activeProject?.id, jobs, localGenerationJobIds.audio],
   );
   const documentLocalJobs = useMemo(
     () => buildLocalJobStack(localGenerationJobIds.document, jobs, activeProject?.id, isInterleaveJob),
@@ -2174,6 +2210,7 @@ export function App() {
     filteredJobs,
     imageLocalJobs,
     videoLocalJobs,
+    audioLocalJobs,
     documentLocalJobs,
     // Workers / GPU (high-churn — new identity per worker SSE tick)
     visibleWorkers,
@@ -2181,7 +2218,7 @@ export function App() {
     personReadiness,
     gpuOptions,
   }), [
-    jobs, filteredJobs, imageLocalJobs, videoLocalJobs, documentLocalJobs,
+    jobs, filteredJobs, imageLocalJobs, videoLocalJobs, audioLocalJobs, documentLocalJobs,
     visibleWorkers, workersById, personReadiness, gpuOptions,
   ]);
 
@@ -2235,6 +2272,7 @@ export function App() {
     createVideoJob,
     createVideoUpscaleJob,
     createImageJob,
+    createAudioJob,
     refinePrompt,
     magicPrompt,
     imageCaption,
@@ -2361,7 +2399,7 @@ export function App() {
     updateAssetStatus, updateAssetTags, latestImageAssets,
     jobAction, clearCompletedJobs, clearJob, createVqaJob, createInterleaveJob, createPlaceholderJob,
     jobPrompt, setJobPrompt, projectFilter, setProjectFilter, projects,
-    createVideoJob, createVideoUpscaleJob, createImageJob, refinePrompt, magicPrompt, imageCaption, imageDescribe, compareFaceLikeness, latestVideoAssets, recentImageAssets,
+    createVideoJob, createVideoUpscaleJob, createImageJob, createAudioJob, refinePrompt, magicPrompt, imageCaption, imageDescribe, compareFaceLikeness, latestVideoAssets, recentImageAssets,
     recentVideoAssets, studioLaunch,
     editorLaunch, clearEditorLaunch, sendAssetToImageEditor, sendAssetToImageEdit,
     rememberLocalGenerationJob, personTracks, createPersonDetectionJob,

--- a/apps/web/src/appHelpers.js
+++ b/apps/web/src/appHelpers.js
@@ -43,6 +43,12 @@ export function isVideoGenerationJob(job) {
   return ["video_generate", "video_extend", "video_bridge"].includes(job.type);
 }
 
+// SceneWorks Audio Studio (epic 13400 / sc-13404): the audio-generation job type, the audio twin of
+// isVideoGenerationJob. Powers the `audio` local-job lane (rememberLocalGenerationJob('audio', job)).
+export function isAudioGenerationJob(job) {
+  return job.type === "audio_generate";
+}
+
 export function isInterleaveJob(job) {
   return job.type === "image_interleave";
 }

--- a/apps/web/src/appHelpers.test.js
+++ b/apps/web/src/appHelpers.test.js
@@ -6,6 +6,7 @@ import {
   generatedResultAssetCount,
   hasCapability,
   isActiveWorker,
+  isAudioGenerationJob,
   isImageGenerationJob,
   isInterleaveJob,
   isPlaceholderOnlyGpuWorker,
@@ -48,10 +49,14 @@ describe("worker classification", () => {
 });
 
 describe("job classification + notices", () => {
-  it("classifies image / video / interleave jobs", () => {
+  it("classifies image / video / audio / interleave jobs", () => {
     expect(isImageGenerationJob({ type: "image_generate" })).toBe(true);
     expect(isImageGenerationJob({ type: "video_generate" })).toBe(false);
     expect(isVideoGenerationJob({ type: "video_bridge" })).toBe(true);
+    // SceneWorks Audio Studio (sc-13404): the audio-generation job type.
+    expect(isAudioGenerationJob({ type: "audio_generate" })).toBe(true);
+    expect(isAudioGenerationJob({ type: "video_generate" })).toBe(false);
+    expect(isVideoGenerationJob({ type: "audio_generate" })).toBe(false);
     expect(isInterleaveJob({ type: "image_interleave" })).toBe(true);
     expect(isInterleaveJob({ type: "image_generate" })).toBe(false);
   });
@@ -134,6 +139,21 @@ describe("buildLocalJobStack", () => {
   it("returns an empty stack when there is no active project", () => {
     const jobs = [{ id: "a", type: "image_generate", projectId: "p1", status: "running", createdAt: "2026-01-01T00:00:00Z" }];
     expect(buildLocalJobStack([], jobs, null, isGen)).toEqual([]);
+  });
+
+  it("builds the audio local-job lane from audio_generate jobs only (sc-13404)", () => {
+    // The `audio` lane (rememberLocalGenerationJob('audio', job)) filters with isAudioGenerationJob,
+    // so a co-resident image/video job in the same project never leaks into the audio stack.
+    const jobs = [
+      { id: "speak", type: "audio_generate", projectId: "p1", status: "running", createdAt: "2026-01-03T00:00:00Z" },
+      { id: "pic", type: "image_generate", projectId: "p1", status: "running", createdAt: "2026-01-04T00:00:00Z" },
+      { id: "clip", type: "video_generate", projectId: "p1", status: "running", createdAt: "2026-01-05T00:00:00Z" },
+    ];
+    const stack = buildLocalJobStack(["speak"], jobs, "p1", isAudioGenerationJob);
+    const ids = stack.map((job) => job.id);
+    expect(ids).toContain("speak");
+    expect(ids).not.toContain("pic");
+    expect(ids).not.toContain("clip");
   });
 });
 

--- a/crates/sceneworks-core/src/asset_index.rs
+++ b/crates/sceneworks-core/src/asset_index.rs
@@ -159,6 +159,10 @@ pub(crate) fn derive_origin(mode: &str, asset_type: &str) -> &'static str {
         "upload" => "upload",
         _ => match asset_type {
             "video" => "video_studio",
+            // SceneWorks Audio Studio (epic 13400 / sc-13404) — the audio twin of video_studio, so
+            // a generated Kokoro/TTS clip surfaces with its own origin rather than the image_studio
+            // catch-all.
+            "audio" => "audio_studio",
             "document" => "document_studio",
             _ => "image_studio",
         },

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -220,6 +220,13 @@ string_enum! {
         PersonDetect => "person_detect",
         PersonTrack => "person_track",
         PersonReplace => "person_replace",
+        // Pure audio synthesis (SceneWorks Audio Studio, epic 13400; sc-13404). A candle-native
+        // text-to-audio job (Kokoro TTS today) served through the runtime's dedicated candle audio
+        // lane (`catalog().audio()`, sc-12835) — distinct from the mlx media graph the image/video
+        // job types drive. Routed to a worker advertising `WorkerCapability::AudioGenerate`; the
+        // worker builds a `GenerationRequest` with the typed `AudioParams` sub-block and dispatches
+        // it through the audio registry to the `Modality::Audio` generator.
+        AudioGenerate => "audio_generate",
         // Whole-body DWPose keypoint detection (photo -> body/hands/face) for the
         // Pose Library (epic 2282). onnxruntime-backed like person_detect; advertised
         // by the Python worker, routed via requested_gpu (not in NON_GPU_JOB_TYPES).
@@ -378,6 +385,12 @@ string_enum! {
         PersonDetect => "person_detect",
         PersonTrack => "person_track",
         PersonReplace => "person_replace",
+        // Pure audio synthesis (SceneWorks Audio Studio, epic 13400; sc-13404). Advertised by a
+        // worker that links the runtime's candle audio lane (`catalog().audio()`, sc-12835) — on
+        // macOS the mlx GPU worker, whose `runtime-macos` bundle ships the audio lane default-on
+        // (audio is candle-native on every platform). A worker without the lane never advertises it,
+        // so an `audio_generate` job stays queued rather than mis-claimed. See gpu.rs `mlx_gpu`.
+        AudioGenerate => "audio_generate",
         // Whole-body DWPose keypoint detection (Pose Library, epic 2282). Advertised
         // by the native GPU worker (MLX on macOS / candle off-Mac) when its pose
         // backend is linked; the Rust CPU utility worker never emits it. See

--- a/crates/sceneworks-core/src/jobs_store/routing/gaps.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/gaps.rs
@@ -375,6 +375,13 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
         // is advertised only by `mlx_gpu`, so no torch/candle worker ever claims it.
         JobType::ImageSegment => Ok(()),
 
+        // Pure audio synthesis (SceneWorks Audio Studio, epic 13400 / sc-13404): Kokoro TTS runs
+        // in-process on the runtime's candle audio lane (`catalog().audio()`, shipped default-on in
+        // `runtime-macos`) — audio is candle-native on every platform, so it is not a Python-torch
+        // gap. Its real availability is the worker's `audio_generate` capability advertisement, so it
+        // queues rather than enforce-fails here.
+        JobType::AudioGenerate => Ok(()),
+
         // Real-ESRGAN image upscaling is ported to the Rust worker (sc-3489) and SeedVR2 (the
         // native-MLX one-step diffusion upscaler, epic 4811 / sc-4815) runs in-process via
         // `mlx-gen-seedvr2`, so the upscale tool runs Python-free. The AuraSR engine (`aura-sr`,
@@ -557,6 +564,10 @@ pub fn candle_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
         | JobType::DatasetFaceAnalysis
         // sc-4415: face_likeness_compare on the candle lane (candle-gen-face) routes by capability too.
         | JobType::FaceLikenessCompare
+        // sc-13404: pure audio synthesis (Kokoro TTS) runs on the runtime's candle audio lane off-Mac
+        // too (audio is candle-native on every platform); it routes by the `audio_generate` capability
+        // advertisement rather than enforce-failing here.
+        | JobType::AudioGenerate
         | JobType::Unknown(_) => Ok(()),
     }
 }

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -3676,6 +3676,7 @@ fn build_generated_asset_sidecar(
         });
     let (file, recipe, lineage) = match media_type.as_str() {
         "video" => build_video_sidecar_parts(job_id, fact),
+        "audio" => build_audio_sidecar_parts(job_id, fact),
         "document" => build_document_sidecar_parts(job_id, fact),
         _ => build_image_sidecar_parts(job_id, fact),
     };
@@ -3878,6 +3879,65 @@ fn build_video_sidecar_parts(job_id: &str, fact: &Value) -> (Value, Value, Value
         "replacementMode": get("replacementMode"),
         "sourceTimestamp": Value::Null,
         "timeline": fact.get("timelineContext").cloned().unwrap_or_else(|| json!({})),
+        "jobId": job_id,
+    });
+    (file, recipe, lineage)
+}
+
+/// `(file, recipe, lineage)` for a generated audio asset (SceneWorks Audio Studio, epic 13400 /
+/// sc-13404) — the audio twin of [`build_video_sidecar_parts`]. The worker writes a WAV (via
+/// `write_wav_pcm16`) and reports the measured `duration`/`sampleRate`/`channels` off the produced
+/// `AudioTrack`, so the `file` block is honest about what is on disk; the recipe's
+/// `normalizedSettings` round-trips the ASK (voice / language / targetDuration) so "re-run this
+/// generation" can rebuild the payload. A pure-audio asset has no width/height (unlike an image or
+/// video), so those are null.
+fn build_audio_sidecar_parts(job_id: &str, fact: &Value) -> (Value, Value, Value) {
+    let get = |key: &str| fact.get(key).cloned().unwrap_or(Value::Null);
+    let parents = fact
+        .get("parents")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_else(|| match fact.get("sourceAssetId").and_then(Value::as_str) {
+            Some(source) => vec![Value::String(source.to_owned())],
+            None => Vec::new(),
+        });
+    let file = json!({
+        "path": get("mediaPath"),
+        "mimeType": get("mimeType"),
+        "width": Value::Null,
+        "height": Value::Null,
+        // MEASURED off the produced AudioTrack (the WAV on disk), mirroring the video file block's
+        // encoded facts. `duration` is the clip's real running time in seconds; `sampleRate` and
+        // `channels` describe the PCM the worker wrote.
+        "duration": get("duration"),
+        "fps": Value::Null,
+        "sampleRate": get("sampleRate"),
+        "channels": get("channels"),
+    });
+    let recipe = json!({
+        "mode": get("mode"),
+        "model": get("model"),
+        "adapter": get("adapter"),
+        "prompt": get("prompt"),
+        "negativePrompt": get("negativePrompt"),
+        "seed": get("seed"),
+        "loras": fact.get("loras").cloned().unwrap_or_else(|| json!([])),
+        // The REPLAY record: the audio knobs the user picked (voice / language / requested
+        // duration) so a re-run rebuilds the same request. `sampleRate` records the rate actually
+        // produced (Kokoro's native 24 kHz today).
+        "normalizedSettings": {
+            "voice": get("voice"),
+            "language": get("language"),
+            "targetDurationSecs": get("targetDurationSecs"),
+            "sampleRate": get("sampleRate"),
+            "family": get("family"),
+        },
+        "rawAdapterSettings": fact.get("rawAdapterSettings").cloned().unwrap_or_else(|| json!({})),
+    });
+    let lineage = json!({
+        "parents": parents,
+        "sourceAssetId": get("sourceAssetId"),
+        "sourceTimestamp": Value::Null,
         "jobId": job_id,
     });
     (file, recipe, lineage)
@@ -5829,6 +5889,57 @@ mod tests {
         let asset = build_generated_asset_sidecar("project-1", "job-1", "genset_y", &fact);
         assert_eq!(asset["type"], json!("video"));
         assert_eq!(asset["file"]["mimeType"], json!("video/mp4"));
+    }
+
+    /// sc-13404: an audio fact assembles a `type: "audio"` asset whose `file` block carries the
+    /// measured duration/sampleRate/channels (no width/height/fps) and whose recipe round-trips the
+    /// requested voice/language. Mirrors the video-type derivation test.
+    #[test]
+    fn build_generated_asset_sidecar_assembles_audio() {
+        let fact = json!({
+            "type": "audio",
+            "assetId": "asset_a",
+            "mediaPath": "assets/audios/genset_z/hello.wav",
+            "mimeType": "audio/wav",
+            "duration": 3.25,
+            "sampleRate": 24_000,
+            "channels": 1,
+            "family": "kokoro",
+            "displayName": "Hello from SceneWorks audio.",
+            "model": "kokoro_82m",
+            "adapter": "kokoro",
+            "prompt": "Hello from SceneWorks audio.",
+            "voice": "af_heart",
+            "language": "en-US",
+            "targetDurationSecs": 3.0,
+            "seed": 42,
+        });
+        let asset = build_generated_asset_sidecar("project-1", "job-1", "genset_z", &fact);
+        assert_eq!(asset["type"], json!("audio"));
+        // Origin is derived to the Audio Studio, not the image_studio catch-all.
+        assert_eq!(asset["origin"], json!("audio_studio"));
+        // File block: measured audio facts, no width/height/fps.
+        assert_eq!(asset["file"]["mimeType"], json!("audio/wav"));
+        assert_eq!(asset["file"]["duration"], json!(3.25));
+        assert_eq!(asset["file"]["sampleRate"], json!(24_000));
+        assert_eq!(asset["file"]["channels"], json!(1));
+        assert_eq!(asset["file"]["width"], Value::Null);
+        assert_eq!(asset["file"]["fps"], Value::Null);
+        // Recipe replays the requested knobs.
+        assert_eq!(asset["recipe"]["model"], json!("kokoro_82m"));
+        assert_eq!(
+            asset["recipe"]["normalizedSettings"]["voice"],
+            json!("af_heart")
+        );
+        assert_eq!(
+            asset["recipe"]["normalizedSettings"]["language"],
+            json!("en-US")
+        );
+        assert_eq!(
+            asset["recipe"]["normalizedSettings"]["targetDurationSecs"],
+            json!(3.0)
+        );
+        assert_eq!(asset["lineage"]["jobId"], json!("job-1"));
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/audio_jobs.rs
+++ b/crates/sceneworks-worker/src/audio_jobs.rs
@@ -1,0 +1,619 @@
+//! Pure audio generation — the SceneWorks Audio Studio job path (epic 13400 / sc-13404).
+//!
+//! The audio analogue of [`crate::video_jobs::run_video_generate_job`], deliberately much smaller:
+//! audio has no fit gate, no VRAM gate, no mode/route ladder. `run_audio_generate_job` resolves the
+//! model's cached snapshot dir, loads the generator from the runtime's **candle audio registry**
+//! (`crate::inference_runtime::load_audio` → `catalog().audio()`, a separate lane from the mlx media
+//! graph — sc-12835), builds a [`GenerationRequest`] with the typed [`AudioParams`] sub-block, runs
+//! it on a blocking thread, writes the produced [`AudioTrack`] to a WAV with the shared
+//! [`write_wav_pcm16`] writer (the same one LTX synchronized audio uses), and registers the result
+//! as a `type: "audio"` asset through the ordinary `assetWrites` streaming-result contract — exactly
+//! how a video job registers its clip, so `resolveJobResultAssets` / the library see it as audio.
+//!
+//! The **language-casing seam** (sc-13404): the manifest declares languages in BCP-47 display casing
+//! (`"en-US"`) but the Generator's advertised `audio_languages` are lowercase (`"en"` / `"en-us"` /
+//! `"en-gb"`). [`normalize_audio_language`] lowercases the request's language so the shared gen-core
+//! validation floor accepts it instead of rejecting an advertised value.
+
+use super::*;
+
+use gen_core::{
+    AudioParams, CancelFlag, GenerationOutput, GenerationRequest, LoadSpec, Progress, WeightsSource,
+};
+
+use crate::video_jobs::{write_wav_pcm16, AudioTrack};
+
+const CANCEL_MESSAGE: &str = "Audio generation canceled by user.";
+/// Adapter id recorded on the asset when the manifest declares no family — the audio twin of the
+/// video/image adapter labels.
+const AUDIO_ADAPTER_FALLBACK: &str = "audio";
+
+/// The parsed audio job payload — the audio twin of `VideoRequest`, kept local to the worker (audio
+/// has far fewer knobs than video, so it needs no shared-core struct). Infallible parse: missing
+/// fields fall back to sane defaults and `project_id` may be empty — the preflight rejects that.
+struct AudioRequest {
+    project_id: String,
+    model: String,
+    prompt: String,
+    voice: Option<String>,
+    language: Option<String>,
+    target_duration_secs: Option<f32>,
+    seed: Option<i64>,
+    model_manifest_entry: Value,
+}
+
+impl AudioRequest {
+    fn from_payload(payload: &JsonObject) -> Self {
+        let string = |key: &str| {
+            payload
+                .get(key)
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+        };
+        Self {
+            project_id: string("projectId").unwrap_or_default(),
+            model: string("model").unwrap_or_else(|| "kokoro_82m".to_owned()),
+            prompt: payload
+                .get("prompt")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned(),
+            voice: string("voice"),
+            language: string("language"),
+            target_duration_secs: payload
+                .get("targetDurationSecs")
+                .and_then(Value::as_f64)
+                .map(|value| value as f32),
+            seed: payload.get("seed").and_then(Value::as_i64),
+            model_manifest_entry: payload
+                .get("modelManifestEntry")
+                .cloned()
+                .unwrap_or_else(|| json!({})),
+        }
+    }
+
+    /// The asset's audio family, from the resolved manifest entry when present (Kokoro's `"kokoro"`),
+    /// else a neutral fallback — parity with `resolve_family` on the video path.
+    fn family(&self) -> String {
+        self.model_manifest_entry
+            .get("family")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned)
+            .unwrap_or_else(|| "audio".to_owned())
+    }
+}
+
+/// Per-job invariants for the single audio clip this job produces — the audio twin of `VideoPlan`.
+struct AudioPlan {
+    genset_id: String,
+    asset_id: String,
+    created_at: String,
+    family: String,
+    /// `assets/audios/<genset>/<date>_<model>_<slug>.wav` (project-relative).
+    media_rel: String,
+    /// Absolute path to the media file.
+    media_path: PathBuf,
+}
+
+impl AudioPlan {
+    fn new(request: &AudioRequest, project_path: &Path) -> Self {
+        let genset_id = format!("genset_{}", Uuid::new_v4().simple());
+        let asset_id = fresh_asset_id();
+        let created_at = now_rfc3339();
+        let family = request.family();
+        let slug = slugify(&request.prompt, "audio", Some(42));
+        // Sanitize the untrusted model id before it becomes a path component (F-003 / sc-11159) —
+        // slugify collapses any separator/`..` to a single readable component, mirroring VideoPlan.
+        let model_slug = slugify(&request.model, "model", None);
+        let media_rel = format!(
+            "assets/audios/{genset_id}/{}_{}_{slug}.wav",
+            &created_at[..10],
+            model_slug
+        );
+        let media_path = project_path.join(&media_rel);
+        Self {
+            genset_id,
+            asset_id,
+            created_at,
+            family,
+            media_rel,
+            media_path,
+        }
+    }
+}
+
+/// Map a manifest-cased language (`"en-US"`) to what the audio Generator advertises (`"en"` /
+/// `"en-us"` / `"en-gb"` — lowercase). The shared gen-core validation floor gates the request's
+/// language against the descriptor's `audio_languages` (all lowercase), so passing the manifest's
+/// display casing verbatim would be rejected as an unadvertised value (sc-13404).
+fn normalize_audio_language(language: &str) -> String {
+    language.trim().to_lowercase()
+}
+
+/// Resolve the model's cached snapshot directory from its manifest entry — the Hugging Face repo the
+/// model downloads from (e.g. `hexgrad/Kokoro-82M`, whose snapshot carries `config.json` +
+/// `kokoro-v1_0.pth` + `voices/`). Uses the same `resolve_app_managed_model_dir` seam the other
+/// worker jobs use, so it finds the HF-cache snapshot the manifest's normal install path populated.
+fn resolve_audio_model_dir(settings: &Settings, request: &AudioRequest) -> WorkerResult<PathBuf> {
+    let repo = audio_model_repo(&request.model_manifest_entry).ok_or_else(|| {
+        WorkerError::InvalidPayload(format!(
+            "{}: the model manifest entry declares no Hugging Face download repo, so its audio \
+             weights cannot be resolved.",
+            request.model
+        ))
+    })?;
+    crate::paths::resolve_app_managed_model_dir(settings, &repo, "Audio model")
+}
+
+/// The Hugging Face repo hosting an audio model's weights — the first `huggingface` download entry,
+/// falling back to stripping the `${HF_CACHE}/` prefix off `paths.model`.
+fn audio_model_repo(entry: &Value) -> Option<String> {
+    if let Some(downloads) = entry.get("downloads").and_then(Value::as_array) {
+        for download in downloads {
+            // A download entry with no explicit provider is treated as huggingface (the manifest
+            // default), so a repo without the key is still resolvable.
+            let is_hf = match download.get("provider").and_then(Value::as_str) {
+                Some(provider) => provider == "huggingface",
+                None => true,
+            };
+            if is_hf {
+                if let Some(repo) = download
+                    .get("repo")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|repo| !repo.is_empty())
+                {
+                    return Some(repo.to_owned());
+                }
+            }
+        }
+    }
+    entry
+        .get("paths")
+        .and_then(|paths| paths.get("model"))
+        .and_then(Value::as_str)
+        .and_then(|model| model.strip_prefix("${HF_CACHE}/"))
+        .map(str::trim)
+        .filter(|repo| !repo.is_empty())
+        .map(str::to_owned)
+}
+
+fn audio_preflight(request: &AudioRequest) -> WorkerResult<()> {
+    if request.project_id.is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "projectId is required.".to_owned(),
+        ));
+    }
+    if request.prompt.trim().is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "prompt (the script text) is required.".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) async fn run_audio_generate_job(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<()> {
+    let request = AudioRequest::from_payload(&job.payload);
+    audio_preflight(&request)?;
+    let project =
+        ProjectStore::new(settings.data_dir.clone(), "worker").get_project(&request.project_id)?;
+    let project_path = PathBuf::from(project.path);
+    let plan = AudioPlan::new(&request, &project_path);
+    if let Some(parent) = plan.media_path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+
+    let backend = backend_label(&settings.gpu_id);
+    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+    update_job(
+        api,
+        &job.id,
+        audio_progress(
+            JobStatus::Preparing,
+            ProgressStage::Preparing,
+            0.05,
+            "Preparing audio.",
+            None,
+            backend,
+        ),
+    )
+    .await?;
+
+    check_cancel(api, &job.id, CANCEL_MESSAGE).await?;
+    let model_dir = resolve_audio_model_dir(settings, &request)?;
+
+    update_job(
+        api,
+        &job.id,
+        audio_progress(
+            JobStatus::Running,
+            ProgressStage::Generating,
+            0.2,
+            "Synthesizing audio.",
+            None,
+            backend,
+        ),
+    )
+    .await?;
+
+    // Synthesis (load + generate) is CPU/GPU-bound and synchronous — run it on the blocking pool so
+    // the worker's async runtime stays responsive, and emit periodic keepalive heartbeats + progress
+    // while it runs so a long synthesis (a cold pipeline build, a 30 s clip, or a slow host) is never
+    // flagged stale and marked `interrupted` mid-flight. Mirrors the video path's interval keepalive
+    // for the no-progress cold-load phase.
+    let track = run_audio_synthesis(api, settings, job, backend, &request, model_dir).await?;
+
+    check_cancel(api, &job.id, CANCEL_MESSAGE).await?;
+    update_job(
+        api,
+        &job.id,
+        audio_progress(
+            JobStatus::Saving,
+            ProgressStage::Saving,
+            0.9,
+            "Saving audio.",
+            None,
+            backend,
+        ),
+    )
+    .await?;
+
+    // Measure the produced clip BEFORE the samples move into the WAV writer, so the asset fact
+    // records the honest length/rate of the file on disk (the audio twin of `EncodedClip::measure`).
+    let sample_rate = track.sample_rate.max(1);
+    let channels = track.channels.max(1);
+    let sample_count = track.samples.len();
+    let duration_secs = sample_count as f64 / (sample_rate as f64 * channels as f64);
+    let peak = track
+        .samples
+        .iter()
+        .fold(0.0f32, |max, &sample| max.max(sample.abs()));
+    if sample_count == 0 || peak == 0.0 {
+        return Err(WorkerError::Engine(format!(
+            "{}: the audio generator produced silence ({} samples, peak {peak}) — refusing to \
+             register an empty clip.",
+            request.model, sample_count
+        )));
+    }
+
+    let wav = AudioTrack {
+        samples: track.samples,
+        sample_rate,
+        channels,
+    };
+    let media_path = plan.media_path.clone();
+    tokio::task::spawn_blocking(move || write_wav_pcm16(&wav, &media_path))
+        .await
+        .map_err(|error| WorkerError::Io(std::io::Error::other(error)))??;
+
+    let fact = audio_asset_fact(&plan, &request, sample_rate, channels, duration_secs);
+    let result = audio_streaming_result(&plan, &request, &fact);
+    update_job(
+        api,
+        &job.id,
+        audio_progress(
+            JobStatus::Completed,
+            ProgressStage::Completed,
+            1.0,
+            "Generated audio.",
+            Some(result),
+            backend,
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+/// Keepalive cadence while the blocking synthesis runs (seconds). Comfortably under the API's
+/// default 90 s worker-timeout, so a long synthesis is never swept to `interrupted`.
+const AUDIO_KEEPALIVE_SECS: u64 = 15;
+
+/// Load the audio generator and run one synthesis on a blocking thread, emitting periodic keepalive
+/// heartbeats + progress updates while it runs. Returns the engine [`AudioTrack`] (`gen_core`'s) for
+/// the caller to write + register.
+async fn run_audio_synthesis(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    backend: &str,
+    request: &AudioRequest,
+    model_dir: PathBuf,
+) -> WorkerResult<gen_core::AudioTrack> {
+    let model_id = request.model.clone();
+    let prompt = request.prompt.clone();
+    let voice = request.voice.clone();
+    let language = request.language.as_deref().map(normalize_audio_language);
+    let target_duration = request.target_duration_secs;
+    let seed = request.seed.map(|seed| seed as u64);
+    let handle = tokio::task::spawn_blocking(move || -> WorkerResult<gen_core::AudioTrack> {
+        let spec = LoadSpec::new(WeightsSource::Dir(model_dir));
+        let generator = crate::inference_runtime::load_audio(&model_id, &spec)
+            .map_err(|error| crate::classify_engine_error("audio model load failed", error))?;
+        let req = GenerationRequest {
+            prompt,
+            seed,
+            audio: Some(AudioParams {
+                voice,
+                language,
+                target_duration,
+                ..Default::default()
+            }),
+            cancel: CancelFlag::new(),
+            ..Default::default()
+        };
+        // The Audio Studio progress is driven around this call (Preparing → Generating → Saving);
+        // the per-stage engine callback is a no-op here — the async keepalive below is what keeps the
+        // job alive during synthesis, so the engine progress doesn't need to be forwarded.
+        let mut on_progress = |_progress: Progress| {};
+        let output = generator
+            .generate(&req, &mut on_progress)
+            .map_err(|error| crate::classify_engine_error("audio generation failed", error))?;
+        match output {
+            GenerationOutput::Audio(track) => Ok(track),
+            GenerationOutput::Images(_) => Err(WorkerError::Engine(
+                "audio model returned images, expected an audio track".to_owned(),
+            )),
+            GenerationOutput::Video { .. } => Err(WorkerError::Engine(
+                "audio model returned video, expected an audio track".to_owned(),
+            )),
+        }
+    });
+    tokio::pin!(handle);
+    let mut ticker = tokio::time::interval(Duration::from_secs(AUDIO_KEEPALIVE_SECS));
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    // The first tick fires immediately; skip it so the first keepalive lands one interval in (the
+    // job was already marked Generating by the caller just before this).
+    ticker.tick().await;
+    loop {
+        tokio::select! {
+            result = &mut handle => {
+                return result.map_err(|error| WorkerError::Io(std::io::Error::other(error)))?;
+            }
+            _ = ticker.tick() => {
+                // Best-effort keepalive: a failed heartbeat/update must not abort a synthesis that is
+                // otherwise progressing (the job completes on the next successful post).
+                let _ = heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await;
+                let _ = update_job(
+                    api,
+                    &job.id,
+                    audio_progress(
+                        JobStatus::Running,
+                        ProgressStage::Generating,
+                        0.2,
+                        "Synthesizing audio.",
+                        None,
+                        backend,
+                    ),
+                )
+                .await;
+            }
+        }
+    }
+}
+
+/// The `type: "audio"` asset fact the API persists into a sidecar (via
+/// `project_store::build_audio_sidecar_parts`) — the audio twin of `video_asset_fact`. Carries the
+/// MEASURED clip facts (duration / sampleRate / channels off the produced track) plus the REQUESTED
+/// knobs (voice / language / targetDurationSecs) the replay path round-trips.
+fn audio_asset_fact(
+    plan: &AudioPlan,
+    request: &AudioRequest,
+    sample_rate: u32,
+    channels: u16,
+    duration_secs: f64,
+) -> Value {
+    let title: String = request.prompt.chars().take(56).collect();
+    let title = title.trim();
+    let display_name = if title.is_empty() {
+        "Generated audio".to_owned()
+    } else {
+        title.to_owned()
+    };
+    let adapter = request
+        .model_manifest_entry
+        .get("family")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(AUDIO_ADAPTER_FALLBACK);
+    json!({
+        "type": "audio",
+        "assetId": plan.asset_id,
+        "mediaPath": plan.media_rel,
+        "mimeType": "audio/wav",
+        // MEASURED off the produced track — the honest running time + PCM shape of the WAV on disk.
+        "duration": duration_secs,
+        "sampleRate": sample_rate,
+        "channels": channels,
+        "family": plan.family,
+        "displayName": display_name,
+        "createdAt": plan.created_at,
+        "mode": "text_to_audio",
+        "model": request.model,
+        "adapter": adapter,
+        "prompt": request.prompt,
+        // REQUESTED knobs (the replay record). `null` for an omitted voice/language/duration — the
+        // studio falls back to the model's own defaults, exactly as the video recipe does.
+        "voice": request.voice,
+        "language": request.language,
+        "targetDurationSecs": request.target_duration_secs,
+        "seed": request.seed,
+        "rawAdapterSettings": {
+            "model": request.model,
+            "voice": request.voice,
+            "language": request.language,
+            "targetDurationSecs": request.target_duration_secs,
+            "sampleRate": sample_rate,
+        },
+    })
+}
+
+/// The job-result shape the API streams from: `assetWrites` + the `generationSet` fact — the audio
+/// twin of `streaming_result`. An audio job always reports exactly one asset (`expectedCount` 1).
+fn audio_streaming_result(plan: &AudioPlan, request: &AudioRequest, fact: &Value) -> JsonObject {
+    json!({
+        "generationSetId": plan.genset_id,
+        "expectedCount": 1,
+        "adapter": fact.get("adapter").cloned().unwrap_or(Value::Null),
+        "model": request.model,
+        "generationSet": {
+            "id": plan.genset_id,
+            "mode": "text_to_audio",
+            "model": request.model,
+            "prompt": request.prompt,
+            "count": 1,
+            "createdAt": plan.created_at,
+        },
+        "assetWrites": [fact],
+    })
+    .as_object()
+    .cloned()
+    .expect("json! object literal")
+}
+
+/// Progress payload with the worker's real backend label — mirrors `video_progress`.
+fn audio_progress(
+    status: JobStatus,
+    stage: ProgressStage,
+    progress: f64,
+    message: &str,
+    result: Option<JsonObject>,
+    backend: &str,
+) -> ProgressRequest {
+    ProgressRequest {
+        status,
+        stage,
+        progress: number_from_f64(progress),
+        message: message.to_owned(),
+        error: None,
+        result,
+        eta_seconds: None,
+        peak_gpu_memory_pct: None,
+        peak_gpu_load_pct: None,
+        backend: Some(backend.to_owned()),
+        worker_id: None,
+        extra: BTreeMap::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kokoro_entry() -> Value {
+        json!({
+            "id": "kokoro_82m",
+            "type": "audio",
+            "family": "kokoro",
+            "downloads": [{ "provider": "huggingface", "repo": "hexgrad/Kokoro-82M", "files": ["config.json"] }],
+            "paths": { "model": "${HF_CACHE}/hexgrad/Kokoro-82M" },
+        })
+    }
+
+    fn payload(extra: Value) -> JsonObject {
+        let mut base = json!({
+            "projectId": "project-1",
+            "model": "kokoro_82m",
+            "prompt": "Hello from SceneWorks audio.",
+            "modelManifestEntry": kokoro_entry(),
+        });
+        if let (Some(base), Some(extra)) = (base.as_object_mut(), extra.as_object()) {
+            for (key, value) in extra {
+                base.insert(key.clone(), value.clone());
+            }
+        }
+        base.as_object().cloned().unwrap()
+    }
+
+    #[test]
+    fn from_payload_reads_the_audio_knobs() {
+        let request = AudioRequest::from_payload(&payload(json!({
+            "voice": "bm_george",
+            "language": "en-GB",
+            "targetDurationSecs": 4.5,
+            "seed": 7,
+        })));
+        assert_eq!(request.project_id, "project-1");
+        assert_eq!(request.model, "kokoro_82m");
+        assert_eq!(request.prompt, "Hello from SceneWorks audio.");
+        assert_eq!(request.voice.as_deref(), Some("bm_george"));
+        assert_eq!(request.language.as_deref(), Some("en-GB"));
+        assert_eq!(request.target_duration_secs, Some(4.5));
+        assert_eq!(request.seed, Some(7));
+        assert_eq!(request.family(), "kokoro");
+    }
+
+    #[test]
+    fn language_casing_seam_lowercases_for_the_generator() {
+        // The manifest declares "en-US"/"en-GB"; the Generator advertises lowercase — normalize so
+        // the shared validation floor accepts an advertised value (sc-13404).
+        assert_eq!(normalize_audio_language("en-US"), "en-us");
+        assert_eq!(normalize_audio_language("en-GB"), "en-gb");
+        assert_eq!(normalize_audio_language("en"), "en");
+        assert_eq!(normalize_audio_language("  EN-US "), "en-us");
+    }
+
+    #[test]
+    fn model_repo_prefers_the_huggingface_download_then_paths_model() {
+        assert_eq!(
+            audio_model_repo(&kokoro_entry()).as_deref(),
+            Some("hexgrad/Kokoro-82M")
+        );
+        // Falls back to `paths.model` (stripping the `${HF_CACHE}/` prefix) when downloads are absent.
+        let paths_only = json!({ "paths": { "model": "${HF_CACHE}/hexgrad/Kokoro-82M" } });
+        assert_eq!(
+            audio_model_repo(&paths_only).as_deref(),
+            Some("hexgrad/Kokoro-82M")
+        );
+        // No download repo and no paths.model → None (the handler turns this into a clear error).
+        assert_eq!(audio_model_repo(&json!({ "type": "audio" })), None);
+    }
+
+    #[test]
+    fn preflight_requires_project_and_prompt() {
+        assert!(audio_preflight(&AudioRequest::from_payload(&payload(json!({})))).is_ok());
+        let no_project = AudioRequest::from_payload(&payload(json!({ "projectId": "" })));
+        assert!(audio_preflight(&no_project).is_err());
+        let no_prompt = AudioRequest::from_payload(&payload(json!({ "prompt": "   " })));
+        assert!(audio_preflight(&no_prompt).is_err());
+    }
+
+    #[test]
+    fn asset_fact_carries_measured_and_requested_facts() {
+        let request = AudioRequest::from_payload(&payload(json!({
+            "voice": "af_heart",
+            "language": "en-US",
+            "targetDurationSecs": 3.0,
+            "seed": 42,
+        })));
+        let plan = AudioPlan::new(&request, Path::new("/tmp/project"));
+        let fact = audio_asset_fact(&plan, &request, 24_000, 1, 3.25);
+        assert_eq!(fact["type"], "audio");
+        assert_eq!(fact["mimeType"], "audio/wav");
+        assert_eq!(fact["sampleRate"], 24_000);
+        assert_eq!(fact["channels"], 1);
+        assert_eq!(fact["duration"], 3.25);
+        assert_eq!(fact["voice"], "af_heart");
+        assert_eq!(fact["language"], "en-US");
+        assert_eq!(fact["targetDurationSecs"], 3.0);
+        assert_eq!(fact["seed"], 42);
+        assert_eq!(fact["model"], "kokoro_82m");
+        assert_eq!(fact["adapter"], "kokoro");
+        assert!(fact["mediaPath"]
+            .as_str()
+            .is_some_and(|path| path.starts_with("assets/audios/") && path.ends_with(".wav")));
+        // The streaming result wraps the fact as the sole assetWrite.
+        let result = audio_streaming_result(&plan, &request, &fact);
+        assert_eq!(result["expectedCount"], 1);
+        assert_eq!(result["assetWrites"].as_array().map(Vec::len), Some(1));
+        assert_eq!(result["assetWrites"][0]["type"], "audio");
+    }
+}

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -178,6 +178,17 @@ fn with_candle_capabilities(
                     gpu.capabilities.push(capability);
                 }
             }
+            // Pure audio synthesis (SceneWorks Audio Studio, epic 13400 / sc-13404): audio is
+            // candle-native on every platform, and `runtime-cuda` ships the same audio lane default-on
+            // as `runtime-macos` — so the off-Mac candle worker serves `audio_generate` too when the
+            // lane is linked (`inference_runtime::audio()`). Advertised explicitly like the mlx worker's
+            // carve-out (the audio generators live in a separate registry from the media graph
+            // `registry_capabilities` iterates); a build without the lane never advertises it.
+            if crate::inference_runtime::audio().is_some()
+                && !gpu.capabilities.contains(&WorkerCapability::AudioGenerate)
+            {
+                gpu.capabilities.push(WorkerCapability::AudioGenerate);
+            }
             // The lane marker the routing gate keys off (mirrors the existing `nvidia` marker).
             gpu.capabilities
                 .push(WorkerCapability::Unknown("candle".to_owned()));
@@ -830,6 +841,16 @@ pub(crate) fn mlx_gpu(settings: &Settings) -> DiscoveredGpu {
         WorkerCapability::PersonDetect,
         WorkerCapability::PersonTrack,
     ]);
+    // Pure audio synthesis (SceneWorks Audio Studio, epic 13400 / sc-13404): Kokoro TTS (and future
+    // SFX/music) runs in-process through the runtime's candle audio lane. Advertised ONLY when the
+    // lane is actually linked (`inference_runtime::audio()` — `runtime-macos` ships it default-on, so
+    // this is true on the mlx worker), not registry-derived: the audio generators live in a SEPARATE
+    // registry (`catalog().audio()`) from the mlx media graph that `registry_capabilities` iterates,
+    // so — like the onnx/face carve-outs above — it must be advertised explicitly. A build without
+    // the lane never advertises it, so an `audio_generate` job stays queued rather than mis-claimed.
+    if crate::inference_runtime::audio().is_some() {
+        capabilities.push(WorkerCapability::AudioGenerate);
+    }
     DiscoveredGpu {
         id: "mlx".to_owned(),
         name: "Apple Silicon (MLX)".to_owned(),

--- a/crates/sceneworks-worker/src/inference_runtime.rs
+++ b/crates/sceneworks-worker/src/inference_runtime.rs
@@ -58,6 +58,45 @@ pub(crate) fn media() -> &'static ProviderRegistry {
     }
 }
 
+/// The runtime's dedicated **candle audio** provider registry (SceneWorks Audio Studio, epic 13400 /
+/// sc-13404), or `None` when this build ships no audio lane. Audio is candle-native on every platform
+/// and rides a separate registry from [`media`] (the mlx media graph on macOS): the `runtime-macos`
+/// bundle carries it default-on (`default = ["media", "audio"]`, sc-12835), so the macOS GPU worker
+/// links it without any feature wiring here. The non-native desktop build has no catalog at all, so
+/// it returns `None` (an audio job never routes there — the capability is never advertised).
+pub(crate) fn audio() -> Option<&'static ProviderRegistry> {
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    {
+        catalog().audio()
+    }
+
+    #[cfg(not(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    )))]
+    {
+        None
+    }
+}
+
+/// Load an audio [`Generator`] by id from the runtime's candle audio registry (sc-13404). Errors
+/// clearly when this build ships no audio lane, mirroring how [`load`] resolves a media generator —
+/// the audio worker turns this into a loud job failure rather than a silent no-op.
+pub(crate) fn load_audio(id: &str, spec: &LoadSpec) -> gen_core::Result<Box<dyn Generator>> {
+    audio()
+        .ok_or_else(|| {
+            gen_core::Error::Msg(
+                "no audio lane is linked in this runtime build (the candle audio registry is \
+                 unavailable)"
+                    .to_owned(),
+            )
+        })?
+        .load(id, spec)
+}
+
 pub(crate) fn text() -> &'static TextLlmRegistry {
     #[cfg(any(
         target_os = "macos",

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -146,6 +146,12 @@ mod sensenova_jobs;
 use sensenova_jobs::*;
 mod video_jobs;
 use video_jobs::*;
+// Pure audio generation — the SceneWorks Audio Studio job path (epic 13400 / sc-13404). Compiled on
+// every platform (the dispatch arm is uniform); the actual candle audio lane is resolved through
+// `inference_runtime::load_audio`, which errors clearly on a build that ships no audio registry (a
+// non-native desktop worker never advertises `audio_generate`, so the arm is unreachable there).
+mod audio_jobs;
+use audio_jobs::*;
 // Replace-person mask pipeline (epic 3040, sc-3521): cross-platform mask rasterization /
 // resample / stored-seg-mask load, so the mask-port-vs-Python parity test runs on the
 // Linux CI lane. Its masks are consumed only by the macOS Wan-VACE path in `video_jobs`,
@@ -1251,6 +1257,15 @@ async fn run_utility_job(
             JobType::PersonReplace => run_video_generate_job(api, settings, &job)
                 .await
                 .map_err(|error| ("Person replacement failed.", error)),
+            // Pure audio synthesis (SceneWorks Audio Studio, epic 13400 / sc-13404): Kokoro TTS (and
+            // future SFX/music) served in-process by the runtime's candle audio lane
+            // (`inference_runtime::load_audio` → `catalog().audio()`). Advertised only by a worker
+            // that links the audio registry (the macOS mlx worker, whose `runtime-macos` bundle ships
+            // it default-on); a worker without the lane never advertises `audio_generate`, so this arm
+            // is unreachable there and the job stays queued for a capable worker.
+            JobType::AudioGenerate => run_audio_generate_job(api, settings, &job)
+                .await
+                .map_err(|error| ("Audio generation failed.", error)),
             // Native MLX LoRA/LoKr training (epic 3039, sc-3043/3049), served in-process
             // by the linked mlx-gen engine on the macOS Apple-Silicon GPU worker. The API
             // routes only MLX-native families here (jobs_store::training_job_is_mlx_eligible);

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -310,6 +310,11 @@ fn mlx_gpu_capability_set_matches_expected_full_set() {
         WorkerCapability::VideoUpscale,
         WorkerCapability::PersonDetect,
         WorkerCapability::PersonTrack,
+        // sc-13404: pure audio synthesis (Kokoro TTS) — the `runtime-macos` bundle ships the candle
+        // audio lane default-on (`catalog().audio()`), so mlx_gpu advertises `audio_generate` when the
+        // lane is linked (it always is on Mac). Advertised explicitly like the other carve-outs (the
+        // audio generators live in a separate registry from the media graph registry_capabilities reads).
+        WorkerCapability::AudioGenerate,
     ]
     .into_iter()
     .collect();

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -125,11 +125,13 @@ struct RgbFrame {
     pixels: Vec<u8>,
 }
 
-/// Interleaved PCM audio — the engine's `AudioTrack` (LTX-2.3 synchronized audio).
-struct AudioTrack {
-    samples: Vec<f32>,
-    sample_rate: u32,
-    channels: u16,
+/// Interleaved PCM audio — the engine's `AudioTrack` (LTX-2.3 synchronized audio). `pub(crate)` so
+/// the pure-audio job path (`audio_jobs`, sc-13404) reuses the same shape + the `write_wav_pcm16`
+/// writer below for its Kokoro output rather than duplicating the WAV plumbing.
+pub(crate) struct AudioTrack {
+    pub(crate) samples: Vec<f32>,
+    pub(crate) sample_rate: u32,
+    pub(crate) channels: u16,
 }
 
 /// The native (MLX) video engine a `run_video_generate_job` request routes to — the routing DECISION,
@@ -1126,8 +1128,9 @@ async fn encode_inner(
 }
 
 /// Peak-normalize the f32 PCM to 16-bit and write a canonical WAV. Silence (peak 0)
-/// stays silent rather than dividing by zero.
-fn write_wav_pcm16(audio: &AudioTrack, path: &Path) -> WorkerResult<()> {
+/// stays silent rather than dividing by zero. `pub(crate)` so the pure-audio job path reuses it
+/// (sc-13404).
+pub(crate) fn write_wav_pcm16(audio: &AudioTrack, path: &Path) -> WorkerResult<()> {
     let peak = audio
         .samples
         .iter()


### PR DESCRIPTION
Wires the audio generation request end-to-end (FOUNDATION for the [C1] Audio Studio walking skeleton, epic 13400). Posting a Kokoro job now runs **real candle-audio inference** and returns a completed job with a `type:audio` result asset.

## rust-api
- `POST /api/v1/audio/jobs` → `create_audio_job` (mirror of `create_video_job`): validates the request, resolves + injects the model's merged manifest entry, rejects non-`type:audio` models, and enqueues an `audio_generate` job. New `AudioJobRequest` DTO, `validate_audio_job`, `default_audio_model` (kokoro_82m). Added to `typed_generation_route` so the generic `/api/v1/jobs` route rejects it (a door per generation kind).

## core
- `JobType::AudioGenerate` + `WorkerCapability::AudioGenerate` (`"audio_generate"`).
- `build_audio_sidecar_parts` + `"audio"` → `audio_studio` origin: the asset's `file` block carries the **measured** duration/sampleRate/channels (no width/height/fps) and the recipe replays the requested voice/language/targetDurationSecs.
- `mac_rust_supported` / `candle_supported` treat audio as a native in-process candle job (routes by capability, not a Python-torch gap).

## worker
- New `audio_jobs::run_audio_generate_job`: resolves the HF snapshot dir (`resolve_app_managed_model_dir`), loads the `Modality::Audio` generator via **`inference_runtime::load_audio` → `catalog().audio()`** (a separate registry from the mlx media graph), builds `GenerationRequest { audio: Some(AudioParams{voice, language, target_duration}) }`, runs synthesis on the blocking pool **with periodic keepalive heartbeats**, writes the `AudioTrack` to a WAV via the shared `write_wav_pcm16`, and registers it through the ordinary `assetWrites` streaming-result contract.
- **Language-casing seam**: the manifest's BCP-47 `"en-US"` is lowercased to the Generator-accepted `"en-us"` (the shared validation floor gates against the lowercase advertised surface).
- Advertise `AudioGenerate` on the mlx worker (`mlx_gpu`) **and** the off-Mac candle worker (`with_candle_capabilities`), each gated on the audio lane actually being linked.

## AUDIO_LANE finding
`runtime-macos` **and** `runtime-cuda` both declare `default = ["media", "audio"]` (`audio = ["dep:candle-audio-catalog"]`), so the worker links `catalog().audio()` on both platforms with **no extra feature wiring** — audio is candle-native everywhere. The capability is advertised only when `inference_runtime::audio().is_some()`, so a build without the lane never mis-claims an `audio_generate` job.

## Tests
- `npm run rust:check`: `cargo fmt --all -- --check` clean; `cargo clippy --all-targets -- -D warnings` clean (full workspace); build green.
- rust-api: `create_audio_job_maps_request_to_audio_generate_payload`, `create_audio_job_rejects_non_audio_model`, `create_audio_job_rejects_empty_prompt`, + the generic-route typed-route guard extended with `audio_generate` (313 rust-api tests pass).
- worker: 5 `audio_jobs` unit tests (payload mapping, language-casing seam, repo resolution, preflight, asset fact) + updated `mlx_gpu` capability-set test (881 worker unit tests pass).
- core: `build_generated_asset_sidecar_assembles_audio` + full suite (510 lib + routing tests pass).
- web: `isAudioGenerationJob` + audio local-job-lane test in `appHelpers.test.js` (17 pass); `eslint src/App.jsx src/appHelpers.js` → 0 errors.
- Off-Mac "neither"/candle parity lanes run in CI (Docker unavailable locally); the audio module is all-platform with no macOS-only deps.

## REAL RUN evidence
Built rust-api + the mlx worker, started both, posted a real Kokoro job to `/api/v1/audio/jobs` (`kokoro_82m`, voice `af_heart`, language `en-US`, `targetDurationSecs 4`, seed 7), polled to completion:
- Job **completed** (progress 1.0), result asset `asset_5b185eab…`, `type: "audio"`, origin `audio_studio`.
- WAV: **196,844 bytes**, **24000 Hz**, **mono (1 ch)**, **16-bit**, **98,400 frames = 4.1 s** (matches the 4 s request), peak amplitude **32767**, **84,483 / 98,400 non-zero samples** (real speech, not silence). Sidecar written; `/assets` returns it as a `type:audio` asset.
- The first run surfaced (and this PR fixes) a real gap: no keepalive during the long blocking synthesis flipped the job to `interrupted` before the final `Completed` post — hence the periodic heartbeat.

Story: [sc-13404]
https://app.shortcut.com/trefry/story/13404

🤖 Generated with [Claude Code](https://claude.com/claude-code)