### PR TITLE
feat(web): render audio in the shared results zone [sc-13405]

### DIFF
--- a/apps/web/src/components/WorkerProgressCard.jsx
+++ b/apps/web/src/components/WorkerProgressCard.jsx
@@ -226,12 +226,13 @@ function ProgressBar({ status, progress }) {
   );
 }
 
-// Thumbnails region (sc-2084). Four variants — image-grid, video-player,
-// small-row, hidden — covering Image Studio (large grid), Video Studio
-// (single player), Queue + batch (compact row), and Caption/Import (no
-// thumbnails). Interim thumbnails are emitted by image-producing workers in
-// sc-2085; until that ships interimAssets is just empty.
-const THUMBNAIL_VARIANTS = new Set(["image-grid", "video-player", "small-row", "hidden"]);
+// Thumbnails region (sc-2084). Five variants — image-grid, video-player,
+// audio-player, small-row, hidden — covering Image Studio (large grid), Video
+// Studio (single player), Audio Studio (single transport, epic 13400 A5),
+// Queue + batch (compact row), and Caption/Import (no thumbnails). Interim
+// thumbnails are emitted by image-producing workers in sc-2085; until that
+// ships interimAssets is just empty.
+const THUMBNAIL_VARIANTS = new Set(["image-grid", "video-player", "audio-player", "small-row", "hidden"]);
 
 function mergeThumbnails(finalAssets, interimAssets) {
   const finalArray = Array.isArray(finalAssets) ? finalAssets : [];
@@ -376,11 +377,183 @@ function VideoThumbnail({ assets, onThumbnailClick }) {
   );
 }
 
+// Declared clip length (seconds) from the asset's audio file block (duration +
+// sampleRate + channels, epic 13400 A5). Used to seed/label the transport before
+// the live <audio> element reports its own metadata duration, and as the fallback
+// when it never loads. `file.duration` is already in seconds (same convention the
+// video lane uses — see assetPanels' Duration row).
+export function audioAssetDurationSeconds(asset) {
+  const declared = Number(asset?.file?.duration);
+  return Number.isFinite(declared) && declared > 0 ? declared : 0;
+}
+
+// m:ss clock for the transport read-out. Clamps NaN/negative to 0:00.
+function formatClock(seconds) {
+  const total = Number.isFinite(seconds) && seconds > 0 ? Math.floor(seconds) : 0;
+  const mins = Math.floor(total / 60);
+  const secs = total % 60;
+  return `${mins}:${String(secs).padStart(2, "0")}`;
+}
+
+const PlayGlyph = (
+  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+    <path d="M8 5v14l11-7z" />
+  </svg>
+);
+const PauseGlyph = (
+  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+    <path d="M7 5h4v14H7zM13 5h4v14h-4z" />
+  </svg>
+);
+
+// Real audio transport (epic 13400 A5, sc-13405): drives an actual <audio>
+// element (rendered by AssetMedia with native controls OFF and a ref) so the
+// custom play/pause + scrubber genuinely play and seek the clip. The total
+// duration prefers the element's reported metadata duration once loaded, falling
+// back to the asset's declared `file.duration`. All theme tokens — reads
+// correctly in light and dark with no hardcoded colors.
+function AudioTransport({ asset }) {
+  const audioRef = React.useRef(null);
+  const src = assetUrl(asset);
+  const declared = audioAssetDurationSeconds(asset);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(declared);
+
+  // A new source (or a fresh media ticket) resets the transport to the start and
+  // re-seeds the declared duration until the element reports its own.
+  useEffect(() => {
+    setIsPlaying(false);
+    setCurrentTime(0);
+    setDuration(declared);
+  }, [src, declared]);
+
+  const seekMax = duration > 0 ? duration : 0;
+
+  const toggle = () => {
+    const el = audioRef.current;
+    if (isPlaying) {
+      el?.pause?.();
+      setIsPlaying(false);
+    } else {
+      // play() may reject (autoplay policy) or be unimplemented (jsdom); the
+      // onPlay/onPause events keep state authoritative in a real browser.
+      try {
+        const played = el?.play?.();
+        if (played && typeof played.catch === "function") {
+          played.catch(() => setIsPlaying(false));
+        }
+      } catch {
+        /* ignore — state falls back to the media events */
+      }
+      setIsPlaying(true);
+    }
+  };
+
+  const onSeek = (event) => {
+    const next = Number(event.target.value);
+    setCurrentTime(next);
+    const el = audioRef.current;
+    if (el) {
+      el.currentTime = next;
+    }
+  };
+
+  return (
+    <div className="worker-progress-card__audio">
+      <AssetMedia
+        asset={asset}
+        ref={audioRef}
+        controls={false}
+        className="worker-progress-card__audio-el"
+        onLoadedMetadata={(event) => {
+          const real = Number(event.currentTarget?.duration);
+          if (Number.isFinite(real) && real > 0) {
+            setDuration(real);
+          }
+        }}
+        onTimeUpdate={(event) => setCurrentTime(Number(event.currentTarget?.currentTime) || 0)}
+        onPlay={() => setIsPlaying(true)}
+        onPause={() => setIsPlaying(false)}
+        onEnded={() => {
+          setIsPlaying(false);
+          setCurrentTime(0);
+        }}
+      />
+      <button
+        type="button"
+        className="worker-progress-card__audio-play"
+        aria-label={isPlaying ? "Pause" : "Play"}
+        aria-pressed={isPlaying}
+        onClick={toggle}
+      >
+        {isPlaying ? PauseGlyph : PlayGlyph}
+      </button>
+      <input
+        type="range"
+        className="worker-progress-card__audio-scrubber"
+        min={0}
+        max={seekMax}
+        step="0.01"
+        value={Math.min(currentTime, seekMax)}
+        onChange={onSeek}
+        aria-label="Seek"
+        aria-valuetext={`${formatClock(currentTime)} of ${formatClock(duration)}`}
+        disabled={seekMax === 0}
+      />
+      <span className="worker-progress-card__audio-time">
+        <span className="worker-progress-card__audio-time-current">{formatClock(currentTime)}</span>
+        <span aria-hidden="true"> / </span>
+        <span className="worker-progress-card__audio-time-total">{formatClock(duration)}</span>
+      </span>
+    </div>
+  );
+}
+
+function AudioThumbnail({ assets, onThumbnailClick }) {
+  const asset = Array.isArray(assets) ? assets[0] : null;
+  const src = asset ? assetUrl(asset) : "";
+  if (!asset || !src) {
+    return (
+      <div
+        className="worker-progress-card__thumbnails worker-progress-card__thumbnails--audio-player empty"
+        role="group"
+        aria-label="Audio output pending"
+      >
+        <span className="worker-progress-card__audio-placeholder">Generating…</span>
+      </div>
+    );
+  }
+  const interactive = !!onThumbnailClick;
+  return (
+    <div
+      className="worker-progress-card__thumbnails worker-progress-card__thumbnails--audio-player"
+      role="group"
+      aria-label="Job output"
+      onContextMenu={suppressThumbnailContextMenu}
+    >
+      <AudioTransport asset={asset} />
+      {interactive ? (
+        <button
+          type="button"
+          className="worker-progress-card__audio-open"
+          onClick={() => onThumbnailClick(asset)}
+        >
+          Open
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
 function ThumbnailsRegion({ variant, finalAssets, interimAssets, thumbnailGroups, onThumbnailClick, isRunning, expectedCount }) {
   if (variant === "hidden") return null;
   if (!THUMBNAIL_VARIANTS.has(variant)) return null;
   if (variant === "video-player") {
     return <VideoThumbnail assets={finalAssets} onThumbnailClick={onThumbnailClick} />;
+  }
+  if (variant === "audio-player") {
+    return <AudioThumbnail assets={finalAssets} onThumbnailClick={onThumbnailClick} />;
   }
   if (Array.isArray(thumbnailGroups) && thumbnailGroups.some((group) => Array.isArray(group?.assets) && group.assets.length)) {
     return <ThumbnailGroups groups={thumbnailGroups} variant={variant} onThumbnailClick={onThumbnailClick} />;

--- a/apps/web/src/components/WorkerProgressCard.test.jsx
+++ b/apps/web/src/components/WorkerProgressCard.test.jsx
@@ -650,6 +650,158 @@ describe("WorkerProgressCard thumbnails", () => {
   });
 });
 
+// Audio-player variant (SceneWorks Audio Studio, epic 13400 A5 / sc-13405): a
+// completed audio job renders a real transport in the shared results zone — an
+// actual <audio> element driven by a custom play/pause control and a scrubber,
+// with the total duration derived from the asset's audio file block.
+describe("WorkerProgressCard audio-player variant (epic 13400 A5)", () => {
+  let api;
+  let playSpy;
+  let pauseSpy;
+
+  beforeEach(() => {
+    // jsdom doesn't implement media playback; stub so the transport's play/pause
+    // are observable and don't log "Not implemented".
+    playSpy = vi
+      .spyOn(window.HTMLMediaElement.prototype, "play")
+      .mockImplementation(() => Promise.resolve());
+    pauseSpy = vi.spyOn(window.HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    api?.cleanup();
+    api = null;
+    vi.restoreAllMocks();
+  });
+
+  const audioJob = {
+    id: "job-audio",
+    type: "audio_generate",
+    status: "completed",
+    progress: 1,
+    attempts: 1,
+    payload: {},
+  };
+
+  // Completed audio result asset (origin audio_studio) with the audio file block:
+  // duration (seconds) + sampleRate + channels. 65s → the read-out reads "1:05".
+  const audioAsset = {
+    id: "au-1",
+    type: "audio",
+    url: "/api/v1/files/au-1.wav",
+    origin: "audio_studio",
+    file: { path: "assets/au-1.wav", mimeType: "audio/wav", duration: 65, sampleRate: 24000, channels: 1 },
+  };
+
+  it("renders the transport (real <audio> + play control + scrubber) with the derived duration", () => {
+    api = render(
+      <WorkerProgressCard job={audioJob} thumbnailsVariant="audio-player" thumbnailAssets={[audioAsset]} />,
+      makeContext([]),
+    );
+    expect(api.container.querySelector(".worker-progress-card__thumbnails--audio-player")).not.toBeNull();
+    // A real <audio> element drives play/scrub.
+    expect(api.container.querySelector("audio")).not.toBeNull();
+    // Play/pause transport control.
+    const play = api.container.querySelector(".worker-progress-card__audio-play");
+    expect(play).not.toBeNull();
+    expect(play.getAttribute("aria-label")).toBe("Play");
+    // Scrubber (seek), its max seeded from the declared duration.
+    const scrubber = api.container.querySelector("input[type='range'].worker-progress-card__audio-scrubber");
+    expect(scrubber).not.toBeNull();
+    expect(scrubber.getAttribute("max")).toBe("65");
+    // Duration is shown/derived from the asset file block (65s → 1:05).
+    expect(api.container.querySelector(".worker-progress-card__audio-time-total").textContent).toBe("1:05");
+  });
+
+  it("toggles play/pause when the transport control is activated", () => {
+    api = render(
+      <WorkerProgressCard job={audioJob} thumbnailsVariant="audio-player" thumbnailAssets={[audioAsset]} />,
+      makeContext([]),
+    );
+    const play = api.container.querySelector(".worker-progress-card__audio-play");
+    expect(play.getAttribute("aria-pressed")).toBe("false");
+    act(() => {
+      play.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    });
+    expect(playSpy).toHaveBeenCalledTimes(1);
+    expect(play.getAttribute("aria-label")).toBe("Pause");
+    expect(play.getAttribute("aria-pressed")).toBe("true");
+    act(() => {
+      play.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    });
+    expect(pauseSpy).toHaveBeenCalledTimes(1);
+    expect(play.getAttribute("aria-label")).toBe("Play");
+  });
+
+  it("seeks the audio element and updates the read-out when the scrubber changes", () => {
+    api = render(
+      <WorkerProgressCard job={audioJob} thumbnailsVariant="audio-player" thumbnailAssets={[audioAsset]} />,
+      makeContext([]),
+    );
+    const audioEl = api.container.querySelector("audio");
+    // jsdom's currentTime setter is a no-op, so spy on it to prove the seek is
+    // actually written through to the media element.
+    const setCurrentTime = vi.fn();
+    Object.defineProperty(audioEl, "currentTime", { configurable: true, get: () => 0, set: setCurrentTime });
+    const scrubber = api.container.querySelector(".worker-progress-card__audio-scrubber");
+    // Use the native value setter so React's controlled-input value tracker sees a
+    // real change and fires onChange (the repo's slider-test convention).
+    const valueSetter = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(scrubber), "value").set;
+    act(() => {
+      valueSetter.call(scrubber, "30");
+      scrubber.dispatchEvent(new window.Event("input", { bubbles: true }));
+    });
+    expect(setCurrentTime).toHaveBeenCalledWith(30);
+    expect(api.container.querySelector(".worker-progress-card__audio-time-current").textContent).toBe("0:30");
+  });
+
+  it("shows a placeholder while the clip is still rendering (no asset yet)", () => {
+    api = render(
+      <WorkerProgressCard
+        job={{ ...audioJob, status: "running" }}
+        thumbnailsVariant="audio-player"
+        thumbnailAssets={[]}
+      />,
+      makeContext([]),
+    );
+    expect(api.container.querySelector(".worker-progress-card__audio-placeholder")).not.toBeNull();
+    expect(api.container.querySelector("audio")).toBeNull();
+  });
+
+  it("suppresses the native context menu on the audio-player transport (sc-8731)", () => {
+    api = render(
+      <WorkerProgressCard job={audioJob} thumbnailsVariant="audio-player" thumbnailAssets={[audioAsset]} />,
+      makeContext([]),
+    );
+    const wrapper = api.container.querySelector(".worker-progress-card__thumbnails--audio-player");
+    const event = new window.MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    act(() => {
+      wrapper.dispatchEvent(event);
+    });
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("invokes onThumbnailClick from the transport's Open control", () => {
+    const onThumbnailClick = vi.fn();
+    api = render(
+      <WorkerProgressCard
+        job={audioJob}
+        thumbnailsVariant="audio-player"
+        thumbnailAssets={[audioAsset]}
+        onThumbnailClick={onThumbnailClick}
+      />,
+      makeContext([]),
+    );
+    const open = api.container.querySelector(".worker-progress-card__audio-open");
+    expect(open).not.toBeNull();
+    act(() => {
+      open.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    });
+    expect(onThumbnailClick).toHaveBeenCalledTimes(1);
+    expect(onThumbnailClick.mock.calls[0][0].id).toBe("au-1");
+  });
+});
+
 // sc-11961 (S2): the live elapsed-seconds timer is the one piece of WorkerProgressCard
 // that runs continuously (a 1s setInterval) while an in-flight job's card is mounted.
 // Under keep-alive a studio stays mounted while backgrounded, so without gating each

--- a/apps/web/src/components/assetMedia.jsx
+++ b/apps/web/src/components/assetMedia.jsx
@@ -35,6 +35,14 @@ export function assetCanRenderAsVideo(asset) {
   return asset?.type === "video" || asset?.file?.mimeType?.startsWith("video/");
 }
 
+// Audio outputs (SceneWorks Audio Studio, epic 13400 A5). A `type:"audio"` asset
+// (or any file whose mimeType is audio/*) is playable via an <audio> element —
+// there is no poster/thumbnail frame, so the shared results zone renders a
+// transport instead (WorkerProgressCard audio-player variant, sc-13405).
+export function assetCanRenderAsAudio(asset) {
+  return asset?.type === "audio" || asset?.file?.mimeType?.startsWith("audio/");
+}
+
 // Suppress the native WKWebView context menu on grid thumbnails (sc-8731). Right-
 // clicking a thumbnail image in a Tauri webview otherwise pops the OS "Download
 // Image / Copy Image / Share" menu; thumbnails have no custom menu, so we just
@@ -162,6 +170,22 @@ export const AssetMedia = React.forwardRef(function AssetMedia({ asset, classNam
         muted
         playsInline
         poster={posterUrl(asset)}
+        preload="metadata"
+        ref={ref}
+        src={src}
+        {...mediaProps}
+      />
+    );
+  }
+  if (assetCanRenderAsAudio(asset)) {
+    // Audio has no poster/first-frame; render a plain <audio> so the results zone
+    // (and the WorkerProgressCard audio-player transport, which drives this via a
+    // ref with controls off) can play the clip. Mirrors the <video> branch above
+    // for src resolution, controls, preload and ref/prop passthrough.
+    return (
+      <audio
+        className={className}
+        controls={controls}
         preload="metadata"
         ref={ref}
         src={src}

--- a/apps/web/src/components/assetMedia.test.jsx
+++ b/apps/web/src/components/assetMedia.test.jsx
@@ -19,6 +19,15 @@ const videoAsset = {
   projectId: "p1",
 };
 
+const audioAsset = {
+  id: "aud",
+  type: "audio",
+  displayName: "line.wav",
+  origin: "audio_studio",
+  file: { path: "assets/line.wav", mimeType: "audio/wav", duration: 3, sampleRate: 24000, channels: 1 },
+  projectId: "p1",
+};
+
 function fireContextMenu(el) {
   const event = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
   el.dispatchEvent(event);
@@ -71,6 +80,59 @@ describe("thumbnail native context-menu suppression (sc-8731)", () => {
     expect(img).not.toBeNull();
     const event = fireContextMenu(img);
     expect(event.defaultPrevented).toBe(false);
+  });
+});
+
+// AssetMedia audio rendering (SceneWorks Audio Studio, epic 13400 A5 / sc-13405):
+// a type:audio asset renders a playable <audio> element, mirroring the <video>
+// branch — never an <audio> for image/video assets.
+describe("AssetMedia audio rendering (epic 13400 A5)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it("renders a playable <audio> element for a type:audio asset", async () => {
+    await act(() => root.render(<AssetMedia asset={audioAsset} />));
+    const audio = container.querySelector("audio");
+    expect(audio).not.toBeNull();
+    expect(audio.getAttribute("src")).toContain("assets/line.wav");
+    // Audio has no poster/first-frame, so no <img> or <video> is produced.
+    expect(container.querySelector("video")).toBeNull();
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  it("does NOT render an <audio> element for image or video assets", async () => {
+    await act(() => root.render(<AssetMedia asset={imageAsset} />));
+    expect(container.querySelector("audio")).toBeNull();
+    expect(container.querySelector("img")).not.toBeNull();
+
+    await act(() => root.render(<AssetMedia asset={videoAsset} />));
+    expect(container.querySelector("audio")).toBeNull();
+    expect(container.querySelector("video")).not.toBeNull();
+  });
+
+  it("honors controls={false} so a custom transport can drive the element", async () => {
+    await act(() => root.render(<AssetMedia asset={audioAsset} controls={false} />));
+    const audio = container.querySelector("audio");
+    expect(audio).not.toBeNull();
+    expect(audio.hasAttribute("controls")).toBe(false);
+  });
+
+  it("renders an <audio> when only the mimeType marks it as audio (no type)", async () => {
+    const byMime = { id: "m", file: { path: "assets/clip.mp3", mimeType: "audio/mpeg" }, projectId: "p1" };
+    await act(() => root.render(<AssetMedia asset={byMime} />));
+    expect(container.querySelector("audio")).not.toBeNull();
   });
 });
 

--- a/apps/web/src/jobResultAssets.js
+++ b/apps/web/src/jobResultAssets.js
@@ -99,3 +99,12 @@ export function resolveJobResultAssets(job, assets, options = {}) {
   }
   return [];
 }
+
+// Resolve an audio job's result assets against the live catalog so the shared
+// results zone (WorkerProgressCard audio-player variant) can play the finished
+// clip (SceneWorks Audio Studio, epic 13400 A5, sc-13405). Mirrors the video
+// lane exactly: keeps only `type:"audio"` assets and leaves the generationSetId
+// fallback in catalog order (no batch-slot sort — that is image-only).
+export function jobAudioResultAssets(job, assets) {
+  return resolveJobResultAssets(job, assets, { type: "audio" });
+}

--- a/apps/web/src/jobResultAssets.test.js
+++ b/apps/web/src/jobResultAssets.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveJobResultAssets, assetBatchIndex } from "./jobResultAssets.js";
+import { resolveJobResultAssets, assetBatchIndex, jobAudioResultAssets } from "./jobResultAssets.js";
 
 // Characterization tests (sc-8853): these lock in the CURRENT behavior of the
 // four resolver copies this module replaces, proving the unification is
@@ -19,6 +19,9 @@ function img(id, extra = {}) {
 }
 function vid(id, extra = {}) {
   return { id, type: "video", ...extra };
+}
+function aud(id, extra = {}) {
+  return { id, type: "audio", ...extra };
 }
 
 describe("resolveJobResultAssets — assetIds branch", () => {
@@ -150,6 +153,45 @@ describe("resolveJobResultAssets — empty / guard cases", () => {
   it("returns [] when a non-array catalog is passed", () => {
     const job = { result: { generationSetId: "g1" } };
     expect(resolveJobResultAssets(job, undefined, imageOpts)).toEqual([]);
+  });
+});
+
+// jobAudioResultAssets (epic 13400 A5, sc-13405) is the audio twin of the video
+// lane: it wraps resolveJobResultAssets(job, assets, { type: "audio" }), so the
+// shared results zone (WorkerProgressCard audio-player) plays only audio outputs.
+describe("jobAudioResultAssets", () => {
+  it("resolves only audio assets from assetIds (slot order), dropping other types", () => {
+    const catalog = [aud("a"), img("i"), vid("v")];
+    const job = { result: { assetIds: ["v", "a", "i"] } };
+    expect(jobAudioResultAssets(job, catalog).map((x) => x.id)).toEqual(["a"]);
+  });
+
+  it("falls back to the embedded audio result record before the catalog catches up", () => {
+    const job = { result: { assets: [aud("a", { origin: "audio_studio" })] } };
+    const out = jobAudioResultAssets(job, []);
+    expect(out.map((x) => x.id)).toEqual(["a"]);
+    expect(out[0].origin).toBe("audio_studio");
+  });
+
+  it("does NOT resolve a wrong-typed (image/video) job result as audio", () => {
+    const catalog = [img("i"), vid("v")];
+    const job = { result: { assetIds: ["i", "v"] } };
+    expect(jobAudioResultAssets(job, catalog)).toEqual([]);
+  });
+
+  it("keeps the generationSetId audio members in catalog order (no batch sort — audio isn't image)", () => {
+    const catalog = [
+      aud("b", { generationSetId: "g1", batchIndex: 2 }),
+      aud("a", { generationSetId: "g1", batchIndex: 0 }),
+      vid("v", { generationSetId: "g1" }),
+      img("x", { generationSetId: "g2" }),
+    ];
+    const job = { result: { generationSetId: "g1" } };
+    expect(jobAudioResultAssets(job, catalog).map((x) => x.id)).toEqual(["b", "a"]);
+  });
+
+  it("returns [] when the job has no result", () => {
+    expect(jobAudioResultAssets({}, [aud("a")])).toEqual([]);
   });
 });
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -13683,6 +13683,108 @@ details[open] > summary.lora-scope-group-heading::before,
   cursor: pointer;
 }
 
+/* Audio-player variant (SceneWorks Audio Studio, epic 13400 A5 / sc-13405).
+   A single-clip transport: play/pause control + scrubber + m:ss read-out. All
+   theme tokens so it reads correctly in light and dark. */
+.worker-progress-card__thumbnails--audio-player {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.worker-progress-card__audio {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+}
+
+/* The underlying <audio> is driven programmatically (native controls off); it
+   has no visual box, but keep it out of layout explicitly. */
+.worker-progress-card__audio-el {
+  display: none;
+}
+
+.worker-progress-card__audio-play {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--r-pill);
+  background: var(--accent);
+  color: var(--accent-fg);
+  cursor: pointer;
+}
+
+.worker-progress-card__audio-play:hover {
+  background: var(--accent-strong);
+}
+
+.worker-progress-card__audio-play svg {
+  width: 16px;
+  height: 16px;
+  fill: currentColor;
+}
+
+.worker-progress-card__audio-scrubber {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 4px;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.worker-progress-card__audio-scrubber:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.worker-progress-card__audio-time {
+  flex: 0 0 auto;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+}
+
+.worker-progress-card__audio-time-current {
+  color: var(--text);
+}
+
+.worker-progress-card__audio-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 54px;
+  background: color-mix(in oklch, var(--surface) 70%, var(--surface-2));
+  border: 1px dashed var(--border);
+  border-radius: var(--r-md);
+  color: var(--text-muted);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.worker-progress-card__audio-open {
+  flex: 0 0 auto;
+  padding: 6px 12px;
+  border-radius: var(--r-pill);
+  border: 1px solid var(--border);
+  background: color-mix(in oklch, var(--surface-2) 80%, transparent);
+  color: var(--text);
+  font-size: 11px;
+  cursor: pointer;
+}
+
 /* Stacked WorkerProgressCards in Image/Video Studio (sc-2088 / sc-2089).
    The stack wraps active jobs; Recent Assets renders below it. */
 .worker-progress-card-stack {


### PR DESCRIPTION
## [A5] Audio results components — audio-player card + audio element + result-asset resolution

Makes the **shared** results components able to display a completed audio job's clip, so the C1 Speech mode (SceneWorks Audio Studio, epic 13400) can render a playable result. Prior stories (A1–A4) already have audio jobs producing a real `type:"audio"` result asset carrying an audio file block (`duration` + `sampleRate` + `channels`, origin `audio_studio`); this story is the display seam.

### The 3 components

1. **`components/WorkerProgressCard.jsx`** — new `audio-player` variant (added to `THUMBNAIL_VARIANTS`) rendering a real transport via a new `AudioThumbnail` / `AudioTransport`. Wired into `ThumbnailsRegion` next to the `video-player` branch. Empty/rendering state shows a "Generating…" placeholder; optional `onThumbnailClick` surfaces an "Open" control.
2. **`components/assetMedia.jsx`** — `AssetMedia` now renders an `<audio>` element for `type:"audio"` (or `audio/*` mimeType) assets, mirroring the `<video>` branch (src resolution, `controls`, `preload="metadata"`, ref + prop passthrough). New `assetCanRenderAsAudio` helper.
3. **`jobResultAssets.js`** — new exported `jobAudioResultAssets(job, assets)` = `resolveJobResultAssets(job, assets, { type: "audio" })`, the audio twin of the video lane (keeps only audio assets; generationSetId fallback stays in catalog order — no batch sort).

### Transport implementation

A **real `<audio>` element** (rendered by `AssetMedia` with native `controls={false}` and a `ref`) is driven by a **custom play/pause control + a `<input type="range">` scrubber**:
- Play/pause toggles `el.play()/pause()`; `onPlay`/`onPause`/`onEnded` keep state authoritative in a real browser (optimistic set for responsiveness).
- The scrubber's `onChange` writes `el.currentTime` (seek) and updates the read-out.
- **Total duration** prefers the element's reported metadata `duration` once `loadedmetadata` fires, falling back to the asset's declared `file.duration` (seconds — same convention the video lane uses). Read-out is `m:ss / m:ss`.
- Styled entirely with **design-system theme tokens** (`--accent`, `--accent-fg`, `--accent-strong`, `--surface`, `--surface-2`, `--border`, `--text`, `--text-muted`, radii) — **no hardcoded colors**.

### Tests (all green)

- **WorkerProgressCard** (`audio-player` variant, completed audio-job fixture): transport + real `<audio>` render, play/pause toggles (`aria-label`/`aria-pressed`), scrubber **seeks the element** (spied `currentTime` setter) and updates the read-out, **derived duration shown** (65s → `1:05`), placeholder while rendering, native context-menu suppression, `onThumbnailClick` from Open.
- **assetMedia**: renders `<audio>` for a `type:audio` asset (and **NOT** an `<audio>` for image/video assets), honors `controls={false}`, and renders `<audio>` for an audio-only mimeType.
- **jobAudioResultAssets**: resolves audio from assetIds (slot order), embedded-record fallback (origin preserved), **wrong-typed job → not resolved** (discriminating), generationSetId catalog order, no-result guard.

**Verification:** `npm --prefix apps/web run test` → **2121 passing (151 files)**; `npm run web:build` (vite) **green**; `eslint` clean on touched files.

### Light/dark verification — what I did vs deferred

There is **no Audio Studio screen yet** (that is C0/C1), so a full in-studio visual isn't feasible this story. Strongest feasible check performed:
- **(a)** Confirmed the `audio-player` CSS block uses **only theme tokens** — grep for hex/rgb/hsl/white/black in the block returns none.
- **(b)** Rendered the **real component markup** (idle/Play, playing/Pause + Open, and rendering/placeholder states) against the **real `styles.css`** in a browser harness and **screenshotted both `:root` (light) and `[data-theme="dark"]` (dark)**. Both read correctly: accent play/pause (bright teal + dark glyph in dark mode), accent scrubber, readable `m:ss` read-out, dashed placeholder, non-overlapping Open. A layout fix (Open button in flex flow instead of absolute) came out of this check.
- **Deferred to C1:** the definitive in-studio light+dark check against a **real generated WAV** in the Audio Studio results zone, once that screen exists.

Story: [sc-13405]
https://app.shortcut.com/trefry/story/13405

🤖 Generated with [Claude Code](https://claude.com/claude-code)