### PR TITLE
feat(web): Audio Models section + capability chips in Models library [sc-13406]

### DIFF
--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -109,6 +109,7 @@ function mlxStatusText(model) {
 const MODEL_TYPE_OPTIONS = [
   { value: "image", label: "Image" },
   { value: "video", label: "Video" },
+  { value: "audio", label: "Audio" },
   { value: "utility", label: "Utility" },
 ];
 
@@ -147,6 +148,44 @@ const CAPABILITY_LABELS = {
 
 function capabilityLabel(capability) {
   return CAPABILITY_LABELS[capability] ?? String(capability).replaceAll("_", " ");
+}
+
+// Audio capability chips (epic 13400 / sc-13406): audio-type models describe what they
+// do through the manifest `audio` sub-block rather than the generic `capabilities[]`, so
+// surface the same at-a-glance chips image/video cards get — derived straight from that
+// sub-block. One chip per PRESENT field (voice bank size, languages, edit modes,
+// multi-speaker); an absent field emits NO chip, so the chips are capability-driven and
+// never per-model. Languages are capped so a many-language model (e.g. ACE-Step's 10)
+// stays a single tidy pill.
+const AUDIO_LANGUAGE_CHIP_MAX = 4;
+
+function audioCapabilityChips(model) {
+  const audio = model?.audio && typeof model.audio === "object" ? model.audio : null;
+  if (!audio) {
+    return [];
+  }
+  const chips = [];
+  const voiceCount = Array.isArray(audio.voices) ? audio.voices.length : 0;
+  if (voiceCount > 0) {
+    chips.push(`${voiceCount} ${voiceCount === 1 ? "voice" : "voices"}`);
+  }
+  const languages = Array.isArray(audio.languages) ? audio.languages.filter(Boolean) : [];
+  if (languages.length) {
+    const shown = languages.slice(0, AUDIO_LANGUAGE_CHIP_MAX).join(", ");
+    chips.push(
+      languages.length > AUDIO_LANGUAGE_CHIP_MAX
+        ? `${shown} +${languages.length - AUDIO_LANGUAGE_CHIP_MAX}`
+        : shown,
+    );
+  }
+  const editModes = Array.isArray(audio.editModes) ? audio.editModes.filter(Boolean) : [];
+  if (editModes.length) {
+    chips.push(`Edit: ${editModes.join(", ")}`);
+  }
+  if (audio.supportsMultiSpeaker === true) {
+    chips.push("Multi-speaker");
+  }
+  return chips;
 }
 
 // Curated "getting started" models, flagged `recommended: true` in the catalog
@@ -1145,6 +1184,9 @@ export function ModelManagerScreen() {
     const downloadSize = downloadSizeText(model);
     const unassociated = !model.family;
     const capabilities = Array.isArray(model.capabilities) ? model.capabilities : [];
+    // Audio-type cards describe themselves via the `audio` sub-block (voice count,
+    // languages, edit modes, multi-speaker) instead of the generic capabilities[].
+    const audioChips = audioCapabilityChips(model);
     const deleteKey = `model:${model.id}`;
     const canDelete = Boolean(onDeleteModel) && model.removable !== false;
     // MLX (macOS) variant: only present when the catalog computed mlxConversionState.
@@ -1201,6 +1243,15 @@ export function ModelManagerScreen() {
             {capabilities.map((capability) => (
               <li className="chip" key={capability}>
                 {capabilityLabel(capability)}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+        {audioChips.length ? (
+          <ul className="model-capabilities model-audio-capabilities">
+            {audioChips.map((chip) => (
+              <li className="chip" key={chip}>
+                {chip}
               </li>
             ))}
           </ul>
@@ -1569,6 +1620,7 @@ export function ModelManagerScreen() {
   const tabDefs = [
     ["image", "Image Models", models.filter((model) => model.type === "image").length],
     ["video", "Video Models", models.filter((model) => model.type === "video").length],
+    ["audio", "Audio Models", models.filter((model) => model.type === "audio").length],
     ["utility", "Utility Models", models.filter((model) => model.type === "utility").length],
     ["lora", "LoRAs", loras.length],
   ];
@@ -1591,7 +1643,7 @@ export function ModelManagerScreen() {
       .filter(modelMatchesFamily);
     const recommended = activeModels.filter(isRecommendedModel);
     const others = activeModels.filter((model) => !isRecommendedModel(model));
-    const typeLabel = { image: "image", video: "video", utility: "utility" }[type] ?? type;
+    const typeLabel = { image: "image", video: "video", audio: "audio", utility: "utility" }[type] ?? type;
     const othersHeading =
       recommended.length > 0 ? `All ${typeLabel} models` : `${typeLabel.charAt(0).toUpperCase()}${typeLabel.slice(1)} models`;
     return { recommended, others, othersHeading };
@@ -1646,6 +1698,7 @@ export function ModelManagerScreen() {
     const groups = [
       ["image", "Image Models"],
       ["video", "Video Models"],
+      ["audio", "Audio Models"],
       ["utility", "Utility Models"],
     ]
       .map(([type, label]) => ({ label, items: searchModelMatches.filter((model) => model.type === type) }))

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -626,8 +626,8 @@ describe("ModelManagerScreen type-grouped layout", () => {
 
   it("renders a tab per model type in fixed order, each scoped to its own type", async () => {
     await render({ models: MODELS });
-    // Four fixed tabs; the model tabs carry a total-count badge (LoRAs has 0 here).
-    expect(tabLabels()).toEqual(["Image Models1", "Video Models1", "Utility Models1", "LoRAs0"]);
+    // Five fixed tabs; the model tabs carry a total-count badge (Audio + LoRAs are 0 here).
+    expect(tabLabels()).toEqual(["Image Models1", "Video Models1", "Audio Models0", "Utility Models1", "LoRAs0"]);
     // The default (Image) tab shows only its own type's card.
     expect(container.querySelectorAll(".model-card").length).toBe(1);
     expect(container.textContent).toContain("Z-Image-Turbo");
@@ -640,9 +640,9 @@ describe("ModelManagerScreen type-grouped layout", () => {
     expect(container.textContent).toContain("Real-ESRGAN");
   });
 
-  it("always shows all four tabs, with a zero count and empty state for an unpopulated type", async () => {
+  it("always shows all five tabs, with a zero count and empty state for an unpopulated type", async () => {
     await render({ models: [MODELS[0]] });
-    expect(tabLabels()).toEqual(["Image Models1", "Video Models0", "Utility Models0", "LoRAs0"]);
+    expect(tabLabels()).toEqual(["Image Models1", "Video Models0", "Audio Models0", "Utility Models0", "LoRAs0"]);
     await selectTab(container, "Video Models");
     expect(container.querySelector(".models-empty")).toBeTruthy();
     expect(container.textContent).toContain("No models match your search.");
@@ -1537,5 +1537,216 @@ describe("ModelManagerScreen model & LoRA delete confirms (sc-12068)", () => {
       expect.objectContaining({ title: "Delete LoRA?", tone: "danger" }),
     );
     expect(deleteLora).toHaveBeenCalledWith(expect.objectContaining({ id: "my_lora" }));
+  });
+});
+
+// sc-13406 (epic 13400 B1): the Models library gains an Audio Models tab alongside
+// Image / Video / Utility. Audio-type cards render the shared install/convert/tier UX
+// (the card renderer is type-agnostic) plus audio-specific capability chips derived from
+// the manifest `audio` sub-block — voice count, languages, edit modes, multi-speaker —
+// with a chip shown ONLY when its underlying field is present (capability-driven).
+describe("ModelManagerScreen Audio Models tab + capability chips (sc-13406)", () => {
+  let container;
+  let root;
+  let ModelManagerScreen;
+  let AppContext;
+
+  beforeEach(async () => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.__TAURI__ = { core: { invoke: vi.fn(async () => null) } };
+    vi.resetModules();
+    ({ AppContext } = await import("../context/AppContext.js"));
+    ({ ModelManagerScreen } = await import("./ModelManagerScreen.jsx"));
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    delete window.__TAURI__;
+    vi.restoreAllMocks();
+  });
+
+  async function render(models) {
+    const value = {
+      activeProject: null,
+      jobs: [],
+      loras: [],
+      models,
+      presets: [],
+      workersById: new Map(),
+      visibleWorkers: [],
+      jobAction: () => {},
+      setActiveView: () => {},
+      deleteLora: () => {},
+      deleteModel: () => {},
+      createModelDownloadJob: () => {},
+      createLoraDownloadJob: () => {},
+      createModelConvertJob: () => {},
+      createLoraImportJob: () => {},
+      createModelImportJob: () => {},
+    };
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={value}>
+          <ModelManagerScreen />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  // Fixtures mirror the seeded `type:"audio"` catalog entries' `audio` sub-block shape.
+  // Kokoro (speech): a voice bank + two languages, no edit modes, single-speaker.
+  const KOKORO = {
+    id: "kokoro_82m",
+    name: "Kokoro 82M (Speech)",
+    type: "audio",
+    family: "kokoro",
+    installState: "missing",
+    recommended: true,
+    audio: {
+      voices: [
+        { id: "af_alloy", label: "Alloy", language: "en-US" },
+        { id: "af_aoede", label: "Aoede", language: "en-US" },
+        { id: "bf_alice", label: "Alice", language: "en-GB" },
+      ],
+      languages: ["en-US", "en-GB"],
+      sampleRates: [24000],
+      maxDurationSecs: 30,
+      supportsMultiSpeaker: false,
+    },
+    ui: { description: "Recommended speech model." },
+  };
+
+  // ACE-Step (music): edit modes + many languages, NO voice bank.
+  const ACE_STEP = {
+    id: "ace_step_v15_turbo",
+    name: "ACE-Step v1.5 XL Turbo (Music)",
+    type: "audio",
+    family: "ace-step",
+    installState: "missing",
+    audio: {
+      languages: ["en", "zh", "ja", "ko", "fr", "de", "es", "it", "pt", "ru"],
+      sampleRates: [48000],
+      maxDurationSecs: 600,
+      editModes: ["inpaint", "repaint", "extend"],
+      conditioning: ["AudioEdit"],
+      supportsMultiSpeaker: false,
+    },
+    ui: { description: "Text-to-music model with audio editing." },
+  };
+
+  // MOSS (sfx): a plain generator — sampleRates only, none of the chip-bearing fields.
+  const MOSS = {
+    id: "moss_sfx_v2",
+    name: "MOSS SoundEffect v2 (SFX)",
+    type: "audio",
+    family: "moss",
+    installState: "missing",
+    audio: {
+      sampleRates: [48000],
+      maxDurationSecs: 30,
+      supportsMultiSpeaker: false,
+    },
+    ui: { description: "Text-to-audio SFX generator." },
+  };
+
+  const IMAGE_MODEL = {
+    id: "z_image_turbo",
+    name: "Z-Image-Turbo",
+    type: "image",
+    family: "z-image",
+    capabilities: ["text_to_image"],
+    installState: "missing",
+  };
+
+  function cardFor(name) {
+    return [...container.querySelectorAll(".model-card")].find((card) => card.textContent.includes(name));
+  }
+  function audioChipsFor(name) {
+    return [...(cardFor(name)?.querySelectorAll(".model-audio-capabilities .chip") ?? [])].map((chip) =>
+      chip.textContent,
+    );
+  }
+
+  it("registers an Audio Models tab with a per-type count that lists only audio models", async () => {
+    await render([IMAGE_MODEL, KOKORO, ACE_STEP, MOSS]);
+    const tabLabels = [...container.querySelectorAll('[role="tab"]')].map((tab) => tab.textContent);
+    // Fixed order: Image, Video, Audio, Utility, LoRAs. Audio carries a total-of-3 badge.
+    expect(tabLabels).toEqual(["Image Models1", "Video Models0", "Audio Models3", "Utility Models0", "LoRAs0"]);
+    // Default (Image) tab shows only the image card, not the audio ones.
+    expect(container.textContent).toContain("Z-Image-Turbo");
+    expect(cardFor("Kokoro 82M (Speech)")).toBeUndefined();
+    // Switch to Audio → all three audio models render, and the image model does not.
+    await selectTab(container, "Audio Models");
+    expect(cardFor("Kokoro 82M (Speech)")).toBeTruthy();
+    expect(cardFor("ACE-Step v1.5 XL Turbo (Music)")).toBeTruthy();
+    expect(cardFor("MOSS SoundEffect v2 (SFX)")).toBeTruthy();
+    expect(cardFor("Z-Image-Turbo")).toBeUndefined();
+  });
+
+  it("surfaces the recommended audio model in the Recommended band on the Audio tab", async () => {
+    await render([KOKORO, ACE_STEP]);
+    await selectTab(container, "Audio Models");
+    const band = container.querySelector(".models-recommended");
+    expect(band).toBeTruthy();
+    expect(band.textContent).toContain("Recommended");
+    // Only the recommended Kokoro floats into the band; ACE-Step sits below it.
+    expect(band.querySelectorAll(".model-card").length).toBe(1);
+    expect(band.textContent).toContain("Kokoro 82M (Speech)");
+    expect(band.querySelector(".model-card-rec-chip")).toBeTruthy();
+  });
+
+  it("derives voice-count + languages chips for a speech model, and no others", async () => {
+    await render([KOKORO]);
+    await selectTab(container, "Audio Models");
+    const chips = audioChipsFor("Kokoro 82M (Speech)");
+    // voices.length (3) → "3 voices"; languages joined → "en-US, en-GB".
+    expect(chips).toContain("3 voices");
+    expect(chips).toContain("en-US, en-GB");
+    // Discriminating: no edit-modes chip and no multi-speaker chip (those fields absent/false).
+    expect(chips.some((chip) => chip.startsWith("Edit:"))).toBe(false);
+    expect(chips).not.toContain("Multi-speaker");
+  });
+
+  it("derives an edit-modes chip for a music model and shows NO voice chip", async () => {
+    await render([ACE_STEP]);
+    await selectTab(container, "Audio Models");
+    const chips = audioChipsFor("ACE-Step v1.5 XL Turbo (Music)");
+    expect(chips).toContain("Edit: inpaint, repaint, extend");
+    // No voice bank → no voice-count chip (discriminating vs the speech model).
+    expect(chips.some((chip) => /voice/.test(chip))).toBe(false);
+    // 10 languages collapse to a single capped pill (first 4 + overflow count).
+    expect(chips).toContain("en, zh, ja, ko +6");
+  });
+
+  it("shows a Multi-speaker chip only when supportsMultiSpeaker is true", async () => {
+    const multi = {
+      ...KOKORO,
+      id: "multi_speaker_tts",
+      name: "Multi Speaker TTS",
+      recommended: false,
+      audio: { ...KOKORO.audio, supportsMultiSpeaker: true },
+    };
+    await render([KOKORO, multi]);
+    await selectTab(container, "Audio Models");
+    // The single-speaker Kokoro fixture never shows the chip…
+    expect(audioChipsFor("Kokoro 82M (Speech)")).not.toContain("Multi-speaker");
+    // …while the multi-speaker model does.
+    expect(audioChipsFor("Multi Speaker TTS")).toContain("Multi-speaker");
+  });
+
+  it("renders no audio capability chips for a plain generator with none of the chip fields", async () => {
+    await render([MOSS]);
+    await selectTab(container, "Audio Models");
+    // MOSS advertises only sampleRates → no voice/language/edit/multi-speaker chips at all.
+    expect(cardFor("MOSS SoundEffect v2 (SFX)")).toBeTruthy();
+    expect(audioChipsFor("MOSS SoundEffect v2 (SFX)")).toEqual([]);
+    expect(cardFor("MOSS SoundEffect v2 (SFX)").querySelector(".model-audio-capabilities")).toBeNull();
   });
 });

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -1641,19 +1641,22 @@ describe("ModelManagerScreen Audio Models tab + capability chips (sc-13406)", ()
     ui: { description: "Text-to-music model with audio editing." },
   };
 
-  // MOSS (sfx): a plain generator — sampleRates only, none of the chip-bearing fields.
-  const MOSS = {
-    id: "moss_sfx_v2",
-    name: "MOSS SoundEffect v2 (SFX)",
+  // OpenVoice V2 (voice clone): a conditioning-only model. It takes a reference audio
+  // clip and exposes NONE of the chip-bearing fields — no voice bank, no languages, no
+  // edit modes, no multi-speaker flag. This mirrors the real zero-chip seeded shape
+  // (OpenVoice V2 / Chatterbox-VE), which carries only `conditioning`.
+  const OPENVOICE = {
+    id: "openvoice_v2",
+    name: "OpenVoice V2 (Voice Clone)",
     type: "audio",
-    family: "moss",
+    family: "openvoice",
     installState: "missing",
     audio: {
-      sampleRates: [48000],
+      sampleRates: [24000],
       maxDurationSecs: 30,
-      supportsMultiSpeaker: false,
+      conditioning: ["ReferenceAudio"],
     },
-    ui: { description: "Text-to-audio SFX generator." },
+    ui: { description: "Voice-clone model conditioned on a reference clip." },
   };
 
   const IMAGE_MODEL = {
@@ -1675,7 +1678,7 @@ describe("ModelManagerScreen Audio Models tab + capability chips (sc-13406)", ()
   }
 
   it("registers an Audio Models tab with a per-type count that lists only audio models", async () => {
-    await render([IMAGE_MODEL, KOKORO, ACE_STEP, MOSS]);
+    await render([IMAGE_MODEL, KOKORO, ACE_STEP, OPENVOICE]);
     const tabLabels = [...container.querySelectorAll('[role="tab"]')].map((tab) => tab.textContent);
     // Fixed order: Image, Video, Audio, Utility, LoRAs. Audio carries a total-of-3 badge.
     expect(tabLabels).toEqual(["Image Models1", "Video Models0", "Audio Models3", "Utility Models0", "LoRAs0"]);
@@ -1686,7 +1689,7 @@ describe("ModelManagerScreen Audio Models tab + capability chips (sc-13406)", ()
     await selectTab(container, "Audio Models");
     expect(cardFor("Kokoro 82M (Speech)")).toBeTruthy();
     expect(cardFor("ACE-Step v1.5 XL Turbo (Music)")).toBeTruthy();
-    expect(cardFor("MOSS SoundEffect v2 (SFX)")).toBeTruthy();
+    expect(cardFor("OpenVoice V2 (Voice Clone)")).toBeTruthy();
     expect(cardFor("Z-Image-Turbo")).toBeUndefined();
   });
 
@@ -1741,12 +1744,12 @@ describe("ModelManagerScreen Audio Models tab + capability chips (sc-13406)", ()
     expect(audioChipsFor("Multi Speaker TTS")).toContain("Multi-speaker");
   });
 
-  it("renders no audio capability chips for a plain generator with none of the chip fields", async () => {
-    await render([MOSS]);
+  it("renders no audio capability chips for a conditioning-only model with none of the chip fields", async () => {
+    await render([OPENVOICE]);
     await selectTab(container, "Audio Models");
-    // MOSS advertises only sampleRates → no voice/language/edit/multi-speaker chips at all.
-    expect(cardFor("MOSS SoundEffect v2 (SFX)")).toBeTruthy();
-    expect(audioChipsFor("MOSS SoundEffect v2 (SFX)")).toEqual([]);
-    expect(cardFor("MOSS SoundEffect v2 (SFX)").querySelector(".model-audio-capabilities")).toBeNull();
+    // OpenVoice V2 carries only `conditioning` (+ sampleRates) → no voice/language/edit/multi-speaker chips at all.
+    expect(cardFor("OpenVoice V2 (Voice Clone)")).toBeTruthy();
+    expect(audioChipsFor("OpenVoice V2 (Voice Clone)")).toEqual([]);
+    expect(cardFor("OpenVoice V2 (Voice Clone)").querySelector(".model-audio-capabilities")).toBeNull();
   });
 });

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5576,6 +5576,22 @@ input.dataset-name-input.boxed:focus {
   white-space: nowrap;
 }
 
+/* Audio capability chips (sc-13406): the audio-type card's at-a-glance capabilities,
+   derived from the model's `audio` sub-block (voice count, languages, edit modes,
+   multi-speaker). Same pill as the generic capability chip, given a subtle accent tint
+   so the audio surface reads distinctly. Reuses the rec-chip's proven accent tokens, so
+   it holds in both light and dark. Must follow `.model-capabilities .chip` (equal
+   specificity) to win on source order. */
+.model-audio-capabilities .chip {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  border-color: transparent;
+}
+
+[data-theme="dark"] .model-audio-capabilities .chip {
+  color: var(--accent);
+}
+
 .lora-family-groups {
   display: grid;
   gap: var(--gap-3);


### PR DESCRIPTION
## Summary

Adds a first-class **Audio Models** tab to the Models library and surfaces audio-specific capability chips on the card, so the five seeded `type:"audio"` catalog entries (Kokoro-82M, MOSS-SoundEffect v2, ACE-Step v1.5 Turbo, OpenVoice V2, Chatterbox-VE) appear alongside Image/Video/Utility with full install/tier state.

Phase A already widened the model-type plumbing and made the card renderer type-agnostic; this B1 slice wires the tab registration + chips.

## Tab registration sites (mirroring how `video` is registered)

`apps/web/src/screens/ModelManagerScreen.jsx`:
- **`MODEL_TYPE_OPTIONS`** — added the `Audio` option (model-import form).
- **`tabDefs`** — added `["audio", "Audio Models", <count>]` (per-type total badge).
- **`modelTabGroups` `typeLabel`** — added `audio` so the "All audio models" heading reads correctly.
- **`renderSearchTabPanel` groups** — added the `["audio", "Audio Models"]` group so cross-type search buckets audio matches.
- The **Recommended band** (`renderRecommendedPicks`), **model-tab panel**, and **card renderer** are type-agnostic, so Kokoro (`recommended: true`) floats into the Recommended band on the Audio tab with no extra code.

## Capability chip derivation

New `audioCapabilityChips(model)` reads the entry `audio` sub-block and emits **one chip per present field only** (capability-driven, never per-model, no empty chips):

| Chip | Source field | Example |
|------|--------------|---------|
| voice count | `audio.voices.length` | `28 voices` |
| languages | `audio.languages` (joined, capped at 4 + overflow) | `en-US, en-GB` / `en, zh, ja, ko +6` |
| edit modes | `audio.editModes` (non-empty) | `Edit: inpaint, repaint, extend` |
| multi-speaker | `audio.supportsMultiSpeaker === true` | `Multi-speaker` |

Chips reuse the shared `.model-capabilities .chip` pill with a subtle accent tint (`.model-audio-capabilities .chip`) via the same `--accent-soft` / `--accent-strong` / `--accent` tokens as the proven `.model-card-rec-chip`, with a `[data-theme="dark"]` override — theme-token-only, so they hold in light and dark.

## Tests

`apps/web/src/screens/ModelManagerScreen.test.jsx` — 6 new tests:
- Audio Models tab registered in fixed order with a per-type count; selecting it lists only audio models.
- Recommended audio model (Kokoro) surfaces in the Recommended band with the ★ chip.
- Kokoro derives voice-count + languages chips and **no** edit/multi-speaker chips (discriminating).
- ACE-Step derives an edit-modes chip and **no** voice chip; 10 languages collapse to `en, zh, ja, ko +6`.
- Multi-speaker chip appears **only** when `supportsMultiSpeaker` is true.
- A plain generator (MOSS: `sampleRates` only) renders **no** audio chips at all.

Updated two pre-existing tab-array assertions to include the new tab.

- Touched test file: **52 passing**.
- Full web suite: **2127 passing** (151 files).
- `npm run web:build`: green.

## Light / dark verification (live browser)

Ran the actual `ModelManagerScreen` in a real browser via the Vite dev server. The already-running dev rust-api serves a stale catalog (no audio), so I pointed the dev server (`VITE_API_BASE_URL`) at a small static mirror that serves `/api/v1/models` parsed **directly from `config/manifests/builtin.models.jsonc`** — i.e. the exact seeded audio entries (Kokoro's real 28-voice bank, ACE-Step's 10 languages + 3 edit modes, etc.). Verified in **both light and dark**:

- Tab bar: `Image Models 6 · Video Models 0 · Audio Models 5 · Utility Models 0 · LoRAs 0`.
- Audio tab: Kokoro in the Recommended band with `28 voices` + `en-US, en-GB` chips, Missing state, size, Download/Protected controls.
- All audio models: MOSS `en, zh`; ACE-Step `en, zh, ja, ko +6` + `Edit: inpaint, repaint, extend`; OpenVoice & Chatterbox with **no** audio chips (only conditioning fields, none chip-bearing).
- Accent-tinted chips render legibly in both themes.

(Verification exercised the real screen + real seeded data via a static manifest mirror because the live dev rust-api catalog is stale; the fresh rust-api was not reseeded.)

## Acceptance

- [x] Audio models appear under an Audio Models tab with install/convert/tier state + capability chips.
- [x] Chips derived from the `audio` sub-block, capability-gated.
- [x] Light + dark verified.

Story: [sc-13406]
https://app.shortcut.com/trefry/story/13406

🤖 Generated with [Claude Code](https://claude.com/claude-code)