### PR TITLE
feat(web): Audio Studio screen shell + nav registration [sc-13407]

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -14,6 +14,7 @@ import { ModelManagerScreen } from "./screens/ModelManagerScreen.jsx";
 import { ImageStudio } from "./screens/ImageStudio.jsx";
 import { DocumentStudio } from "./screens/DocumentStudio.jsx";
 import { VideoStudio } from "./screens/VideoStudio.jsx";
+import { AudioStudio } from "./screens/AudioStudio.jsx";
 import { TrainingDataSetsLibrary, TrainingStudio } from "./screens/TrainingStudio.jsx";
 import { CharacterStudio } from "./screens/CharacterStudio.jsx";
 import { EditorScreen } from "./screens/EditorScreen.jsx";
@@ -91,6 +92,7 @@ export const KEEP_ALIVE_VIEWS = Object.freeze(
   new Set([
     "Image",
     "Video",
+    "Audio",
     "Characters",
     "Document",
     "Train",
@@ -123,12 +125,16 @@ function KeepAlivePane({ active, children }) {
 // Empty in unconfigured contexts (e.g. some test paths); the footer is hidden then.
 const APP_VERSION = import.meta.env.VITE_APP_VERSION ?? "";
 
-const navSections = [
+// Exported so the nav registration (Workspace / Library / System sections) is assertable in
+// unit tests without rendering the whole App (epic 13400 C0 mirrors the KEEP_ALIVE_VIEWS export).
+export const navSections = [
   {
     label: "Workspace",
     items: [
       { id: "Image", icon: Icon.Image },
       { id: "Video", icon: Icon.Video },
+      // Audio Studio (epic 13400) is a generative studio — it sits with Image/Video in Workspace.
+      { id: "Audio", icon: Icon.Audio },
       // Character Studio is a generative studio (sc-2300) — it sits with Image/Video,
       // below Video and above Training, not in the Library section.
       { id: "Characters", icon: Icon.Character },
@@ -161,7 +167,8 @@ const navSections = [
   },
 ];
 
-const viewTitles = {
+// Exported alongside navSections so a view's title/blurb registration is unit-testable.
+export const viewTitles = {
   Library: { title: "Assets", blurb: "Browse stills and clips across all your projects." },
   LibraryDataSets: { title: "Data Sets", blurb: "Create and caption training datasets." },
   Poses: { title: "Pose Library", blurb: "Manage whole-body pose skeletons and create new ones from photos." },
@@ -171,6 +178,7 @@ const viewTitles = {
   },
   Image: { title: "Image Studio", blurb: "Describe what you want — we'll render variations side by side." },
   Video: { title: "Video Studio", blurb: "Bring stills to life, or render new clips from scratch." },
+  Audio: { title: "Audio Studio", blurb: "Generate speech, music and sound effects — or clone a voice." },
   Document: { title: "Document Studio", blurb: "Generate interleaved text-image documents — guides, storyboards, tutorials." },
   Train: { title: "Training Studio", blurb: "Build datasets and prepare LoRA training plans." },
   Editor: { title: "Video Editor", blurb: "Cut, sequence and export your timeline." },
@@ -2627,6 +2635,12 @@ export function App() {
         {keepAliveMounted("Video") ? (
           <KeepAlivePane active={activeView === "Video"}>
             <VideoStudio key={activeProject?.id ?? "default"} />
+          </KeepAlivePane>
+        ) : null}
+
+        {keepAliveMounted("Audio") ? (
+          <KeepAlivePane active={activeView === "Audio"}>
+            <AudioStudio key={activeProject?.id ?? "default"} />
           </KeepAlivePane>
         ) : null}
 

--- a/apps/web/src/components/Icons.jsx
+++ b/apps/web/src/components/Icons.jsx
@@ -24,6 +24,8 @@ export const Icon = {
   Image: (p) => <I {...p} d="M4 5h16v14H4zM4 16l5-5 4 4 3-3 4 4" />,
   ImageEditor: (p) => <I {...p} d="M7 2v15a1 1 0 001 1h15M2 7h15a1 1 0 011 1v15" />,
   Video: (p) => <I {...p} d="M3 6h12v12H3zM15 9l6-3v12l-6-3z" />,
+  // Audio Studio (epic 13400) — a centered waveform glyph (rising/falling bars around a baseline).
+  Audio: (p) => <I {...p} d="M4 10v4M7 7v10M10 4v16M13 8v8M16 6v12M19 10v4" />,
   Editor: (p) => <I {...p} d="M3 8h18M3 12h12M3 16h18M16 10l4 2-4 2z" />,
   Train: (p) => <I {...p} d="M5 19V5M12 19V5M19 19V5M3 9h4M10 15h4M17 11h4" />,
   Character: (p) => <I {...p} d="M12 12a4 4 0 100-8 4 4 0 000 8zM4 20a8 8 0 0116 0" />,

--- a/apps/web/src/components/WorkerProgressCard.jsx
+++ b/apps/web/src/components/WorkerProgressCard.jsx
@@ -56,6 +56,7 @@ const JOB_TYPE_CHIP = {
   video_extend: "Generate Video",
   video_bridge: "Generate Video",
   video_upscale: "Upscale Video",
+  audio_generate: "Generate Audio",
   person_replace: "Person Replace",
   lora_train: "Training Run",
   training_caption: "Dataset Captioning",
@@ -138,6 +139,8 @@ export function deriveJobTitle(job) {
       return `Generate Video — ${truncatePrompt(payload.prompt ?? "") || "(no prompt)"}`;
     case "video_upscale":
       return `Upscale Video — ${payload.displayName || "source clip"}`;
+    case "audio_generate":
+      return `Generate Audio — ${truncatePrompt(payload.prompt ?? "") || "(no prompt)"}`;
     case "person_replace":
       return `Person Replace — ${truncatePrompt(payload.prompt ?? "") || "(no prompt)"}`;
     default:

--- a/apps/web/src/modelEligibility.js
+++ b/apps/web/src/modelEligibility.js
@@ -26,7 +26,7 @@ export const VIDEO_MODES = [
 ];
 
 // Audio generation modes the Audio Studio exposes (epic 13400 C0/C1 mirror these keys).
-export const AUDIO_MODES = ["speech", "sfx", "music", "voiceclone"];
+export const AUDIO_MODES = ["speech", "music", "sfx", "voiceclone"];
 
 // Conditioning kinds that mark a voice-clone (voice-conversion / speaker-embedding) model —
 // distinct from ACE-Step's "AudioEdit" conditioning, which is a music-editing signal, not a

--- a/apps/web/src/modelEligibility.test.js
+++ b/apps/web/src/modelEligibility.test.js
@@ -231,7 +231,7 @@ describe("audio model eligibility (sc-13403)", () => {
   ];
 
   it("exposes the four Audio Studio mode keys in order", () => {
-    expect(AUDIO_MODES).toEqual(["speech", "sfx", "music", "voiceclone"]);
+    expect(AUDIO_MODES).toEqual(["speech", "music", "sfx", "voiceclone"]);
   });
 
   it.each(seeded)("%s serves exactly its capability-derived mode and rejects the others", (_label, model, expectedMode) => {

--- a/apps/web/src/screens/AudioStudio.jsx
+++ b/apps/web/src/screens/AudioStudio.jsx
@@ -1,0 +1,435 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Icon } from "../components/Icons.jsx";
+import { AdvancedSection } from "../components/AdvancedSection.jsx";
+import { WorkPanel } from "../components/WorkPanel.jsx";
+import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
+import { ModelAvailabilityGate } from "../components/ModelAvailabilityGate.jsx";
+import { useAppContext } from "../context/AppContext.js";
+import {
+  AUDIO_MODES,
+  audioModelServesMode,
+  audioModelUsable,
+  downloadOffersFor,
+} from "../modelEligibility.js";
+import { loadStudioSettings, useStudioSettingsWriter } from "../hooks/useStudioSettings.js";
+import { jobAudioResultAssets } from "../jobResultAssets.js";
+
+// SceneWorks Audio Studio — the navigable shell (epic 13400, C0 / sc-13407). This screen mirrors
+// the canonical studio shell (VideoStudio.jsx): page-frame > WorkPanel + .mode-tabs + AdvancedSection
+// + .studio-results, gated by ModelAvailabilityGate. The four modes (speech / sfx / music /
+// voiceclone) come from AUDIO_MODES so the tab set and the eligibility predicates can't drift.
+//
+// Every settings/advanced field is CAPABILITY-DRIVEN — it reads the selected model's `audio`
+// sub-block (voices / languages / editModes / sampleRates / conditioning / maxDurationSecs), never a
+// hardcoded list. audioModelServesMode is the single source of truth for which model serves which
+// mode (Speech = ships a voice bank, Music = advertises edit ops, Voice Clone = reference/embedding
+// conditioning, Sound FX = residual text→audio generator).
+//
+// SCOPE (C0): the navigable shell only. The Generate CTA renders but its real submission —
+// createAudioJob → rememberLocalGenerationJob('audio', job) → the results stack below — is wired by
+// C1 (Speech, sc-13408) and the mode-specific stories after it. The audioLocalJobs results zone is
+// already wired to the shared audio-player card (A5, sc-13405), so once C1 enqueues jobs they surface
+// here with no further shell change.
+
+// Tab labels per the epic, keyed by the AUDIO_MODES ids so the ordering follows that array.
+const MODE_LABELS = {
+  speech: "Speech",
+  sfx: "Sound FX",
+  music: "Music",
+  voiceclone: "Voice Clone",
+};
+
+// Per-mode prompt placeholder. Named so the shell reads sensibly before C1 wires generation.
+const MODE_PLACEHOLDER = {
+  speech: "Type the words to speak…",
+  sfx: "Describe the sound — a door creak, distant thunder, footsteps on gravel…",
+  music: "Describe the music — mood, instruments, tempo, genre…",
+  voiceclone: "Type the words to speak in the cloned voice…",
+};
+
+// Modes that emit a fixed-length waveform, so a length control (clamped to the model's
+// audio.maxDurationSecs) applies. Voice Clone follows its reference clip's length.
+const DURATION_MODES = new Set(["speech", "sfx", "music"]);
+// Fallback target length before the model's cap is known; always clamped to maxDurationSecs.
+const DEFAULT_TARGET_DURATION_SECS = 10;
+
+export function AudioStudio() {
+  const {
+    activeProject,
+    assets = [],
+    audioModels = [],
+    models = [],
+    jobs = [],
+    audioLocalJobs = [],
+    jobAction,
+    createModelDownloadJob,
+    setActiveView,
+    setPreviewAsset,
+    macCapabilities,
+  } = useAppContext();
+
+  // Last-used settings for this workspace, restored on mount. The component is keyed by workspace in
+  // App.jsx, so this reads the right snapshot per workspace (mirrors Image / Video).
+  const saved = useMemo(
+    () => loadStudioSettings("audio", activeProject?.id ?? null),
+    [activeProject?.id],
+  );
+
+  const [mode, setMode] = useState(saved.mode ?? AUDIO_MODES[0]);
+  const [model, setModel] = useState(saved.model ?? audioModels[0]?.id ?? "");
+  const [prompt, setPrompt] = useState(saved.prompt ?? "");
+  const [voice, setVoice] = useState(saved.voice ?? "");
+  const [language, setLanguage] = useState(saved.language ?? "");
+  const [editMode, setEditMode] = useState(saved.editMode ?? "");
+  const [targetDurationSecs, setTargetDurationSecs] = useState(
+    saved.targetDurationSecs ?? DEFAULT_TARGET_DURATION_SECS,
+  );
+  const [seed, setSeed] = useState(saved.seed ?? "");
+  const [advancedOpen, setAdvancedOpen] = useState(saved.advancedOpen ?? false);
+
+  // Models gated on the selected tab (mirrors VideoStudio.jsx): a model "serves" a mode when its
+  // audio capability block matches (audioModelServesMode). The tabs, the picker and the snap effect
+  // all derive from this so the user is never trapped on a mode whose model can't serve the others.
+  const modelServesMode = (item, value) => audioModelServesMode(item, value);
+  const modelsForMode = (value) => audioModels.filter((item) => modelServesMode(item, value));
+  const selectedModel = audioModels.find((item) => item.id === model) ?? audioModels[0] ?? null;
+
+  // Model-availability gate: `ready` follows the picker (audioModels is live-catalog-then-fallback in
+  // App.jsx — empty only once the catalog has loaded with no installed audio model). Offers come from
+  // the full catalog via audioModelUsable, recommended-first.
+  const modelReady = audioModels.length > 0;
+  const modelOffers = useMemo(
+    () => downloadOffersFor(models, audioModelUsable, macCapabilities),
+    [models, macCapabilities],
+  );
+  const modelDownloadJobs = useMemo(
+    () => (jobs ?? []).filter((job) => job.type === "model_download"),
+    [jobs],
+  );
+
+  // The selected model's audio capabilities — the single source every field below reads from. Never
+  // hardcoded: an absent sub-block simply hides the dependent control.
+  const audio = selectedModel?.audio && typeof selectedModel.audio === "object" ? selectedModel.audio : {};
+  const voices = Array.isArray(audio.voices) ? audio.voices : [];
+  const languages = Array.isArray(audio.languages) ? audio.languages : [];
+  const editModes = Array.isArray(audio.editModes) ? audio.editModes : [];
+  const sampleRates = Array.isArray(audio.sampleRates) ? audio.sampleRates : [];
+  const conditioning = Array.isArray(audio.conditioning) ? audio.conditioning : [];
+  const maxDurationSecs = Number.isFinite(audio.maxDurationSecs) ? audio.maxDurationSecs : null;
+
+  // Which capability-driven controls the active mode surfaces. Speech leads with the full
+  // voice/language/length triad C1 builds on; the other modes show a capability-driven scaffold.
+  const showVoice = mode === "speech" && voices.length > 0;
+  const showLanguage = DURATION_MODES.has(mode) && languages.length > 0;
+  const showDuration = DURATION_MODES.has(mode) && maxDurationSecs != null;
+  const showEditModes = mode === "music" && editModes.length > 0;
+  const showConditioning = mode === "voiceclone" && conditioning.length > 0;
+
+  // Snap the model to one that serves the active mode (mirrors VideoStudio). A no-op when the current
+  // model already serves the mode, or when nothing serves it (a reduced catalog).
+  useEffect(() => {
+    if (modelServesMode(selectedModel, mode)) {
+      return;
+    }
+    const fallback = modelsForMode(mode)[0];
+    if (fallback && fallback.id !== model) {
+      setModel(fallback.id);
+    }
+    // modelServesMode / modelsForMode close over audioModels, captured below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, model, selectedModel, audioModels]);
+
+  // Re-seed the capability-bound selections whenever the model changes, clamped to what the new
+  // model actually advertises (mirrors VideoStudio's duration/resolution/fps clamp). Keeps a restored
+  // snapshot value when the new model still offers it; otherwise falls back to the model's first
+  // option, so a value from a previous model can never persist onto one that lacks it.
+  useEffect(() => {
+    if (!selectedModel) {
+      return;
+    }
+    setVoice((current) => (voices.some((item) => item.id === current) ? current : voices[0]?.id ?? ""));
+    setLanguage((current) => (languages.includes(current) ? current : languages[0] ?? ""));
+    setEditMode((current) => (editModes.includes(current) ? current : editModes[0] ?? ""));
+    setTargetDurationSecs((current) => {
+      if (maxDurationSecs == null) {
+        return current;
+      }
+      const value = Number(current);
+      if (Number.isFinite(value) && value > 0 && value <= maxDurationSecs) {
+        return current;
+      }
+      return Math.min(DEFAULT_TARGET_DURATION_SECS, maxDurationSecs);
+    });
+    // The capability arrays are derived from selectedModel; keying on its id is the intended clamp.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedModel?.id]);
+
+  // Per-workspace stickiness (sc-11964 pattern). Suppressed until the audio catalog has loaded so a
+  // transient default can't overwrite the restored snapshot mid-settle.
+  useStudioSettingsWriter(
+    "audio",
+    activeProject?.id ?? null,
+    {
+      mode,
+      model,
+      prompt,
+      voice,
+      language,
+      editMode,
+      targetDurationSecs,
+      seed,
+      advancedOpen,
+    },
+    audioModels.length > 0,
+  );
+
+  // A human-readable capability summary (sample rate + max length) so the capability-driven nature of
+  // the settings is visible at a glance and survives a model switch. Cheap enough to build inline.
+  const capabilitySummary = [
+    sampleRates.length
+      ? sampleRates.map((rate) => `${Math.round(Number(rate) / 100) / 10} kHz`).join(" / ")
+      : null,
+    maxDurationSecs != null ? `up to ${maxDurationSecs}s` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  const onOpenQueue = () => setActiveView("Queue");
+  const onCancelJob = (job) => jobAction?.(job, "cancel");
+  const onPreview = (asset, scope) => setPreviewAsset?.(asset, scope);
+
+  function submit(event) {
+    event.preventDefault();
+    // C0 is the navigable shell only. C1 (Speech, sc-13408) wires this to createAudioJob →
+    // rememberLocalGenerationJob('audio', job), which surfaces the run in the audioLocalJobs stack
+    // below (already rendered here via the shared audio-player card, A5 / sc-13405). The mode-specific
+    // stories (C2 Sound FX, C3 Music, C4 Voice Clone) extend the same submit per mode.
+  }
+
+  // The model list the picker offers: those that serve the active mode, falling back to the full
+  // available list if none do (a reduced catalog) so the picker is never empty.
+  const pickerModels = modelsForMode(mode).length ? modelsForMode(mode) : audioModels;
+
+  return (
+    <ModelAvailabilityGate
+      ready={modelReady}
+      title="Audio Studio needs an audio model"
+      description="Download a recommended audio model to start generating speech, music and sound."
+      offers={modelOffers}
+      downloadJobs={modelDownloadJobs}
+      onDownload={createModelDownloadJob}
+      onOpenModels={() => setActiveView("Models")}
+      onOpenQueue={onOpenQueue}
+      onCancelJob={onCancelJob}
+    >
+      <section className="page-frame audio-studio">
+        <form className="studio-shell" onSubmit={submit}>
+          <WorkPanel className="studio-work-panel">
+            <div className="prompt-hero-top">
+              <div className="mode-tabs mode-control" role="tablist" aria-label="Audio mode">
+                {AUDIO_MODES.map((value) => {
+                  // Disabled only when no available model serves this mode — and never the active tab,
+                  // so the user can always switch away (mirrors VideoStudio's mode-level gating).
+                  const blocked = value !== mode && modelsForMode(value).length === 0;
+                  const active = mode === value;
+                  return (
+                    <button
+                      className={active ? "mode-tab active" : "mode-tab"}
+                      key={value}
+                      role="tab"
+                      aria-selected={active}
+                      onClick={() => setMode(value)}
+                      type="button"
+                      disabled={blocked}
+                      title={blocked ? "No installed model supports this mode." : undefined}
+                    >
+                      {MODE_LABELS[value] ?? value}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="prompt-input-row">
+              <textarea
+                aria-label="Prompt"
+                className="prompt-input"
+                onChange={(event) => setPrompt(event.target.value)}
+                placeholder={MODE_PLACEHOLDER[mode] ?? "Describe the audio…"}
+                value={prompt}
+              />
+              {/* C0: the CTA renders as the shell's primary action; C1 (sc-13408) wires the real
+                  submission. Kept type="submit" so the form shape matches the other studios. */}
+              <button className="prompt-cta" type="submit">
+                <Icon.Sparkle size={14} />
+                Generate
+              </button>
+            </div>
+
+            <div className="settings-bar">
+              <div className="settings-bar-row">
+                <label className="settings-field settings-field-model">
+                  Model
+                  <select onChange={(event) => setModel(event.target.value)} value={model}>
+                    {/* Models gated on the selected tab: only those that serve the active mode,
+                        falling back to the full list so the picker is never empty. */}
+                    {pickerModels.map((item) => (
+                      <option key={item.id} value={item.id}>
+                        {item.name ?? item.ui?.label ?? item.id}
+                      </option>
+                    ))}
+                  </select>
+                  {capabilitySummary ? (
+                    <span className="field-hint" role="note">
+                      {capabilitySummary}
+                    </span>
+                  ) : null}
+                </label>
+
+                {/* Speech: the voice bank the selected model ships (audio.voices). C1 builds on this. */}
+                {showVoice ? (
+                  <label className="settings-field settings-field-voice">
+                    Voice
+                    <select onChange={(event) => setVoice(event.target.value)} value={voice}>
+                      {voices.map((item) => (
+                        <option key={item.id} value={item.id}>
+                          {item.label ?? item.id}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ) : null}
+
+                {/* Language options the model advertises (audio.languages). */}
+                {showLanguage ? (
+                  <label className="settings-field settings-field-language">
+                    Language
+                    <select onChange={(event) => setLanguage(event.target.value)} value={language}>
+                      {languages.map((value) => (
+                        <option key={value} value={value}>
+                          {value}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ) : null}
+
+                {/* Length, capped to the model's audio.maxDurationSecs (never a hardcoded ceiling). */}
+                {showDuration ? (
+                  <label className="settings-field settings-field-duration">
+                    Length (s)
+                    <input
+                      max={maxDurationSecs}
+                      min="1"
+                      onChange={(event) => setTargetDurationSecs(event.target.value)}
+                      step="1"
+                      type="number"
+                      value={targetDurationSecs}
+                    />
+                  </label>
+                ) : null}
+              </div>
+
+              {/* Music editing ops the model advertises (audio.editModes) — capability-driven scaffold
+                  the C3 story builds on. */}
+              {showEditModes ? (
+                <div className="settings-bar-styles">
+                  <span className="settings-bar-label">Edit</span>
+                  <div className="preset-chips">
+                    {editModes.map((value) => (
+                      <button
+                        className={editMode === value ? "preset-chip active" : "preset-chip"}
+                        key={value}
+                        onClick={() => setEditMode(value)}
+                        type="button"
+                      >
+                        {value}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+
+            {/* Voice Clone conditioning scaffold — surfaced from audio.conditioning. Reference upload +
+                cloned-speech wiring is a later mode story (C4); this shows the model's capability. */}
+            {showConditioning ? (
+              <p className="helper-copy">
+                This model conditions on a reference voice ({conditioning.join(", ")}). Reference
+                upload and cloned-speech generation arrive in a later update.
+              </p>
+            ) : null}
+
+            <AdvancedSection
+              hint="cleared values → model default"
+              onToggle={() => setAdvancedOpen((value) => !value)}
+              open={advancedOpen}
+            >
+              <div className="advanced-panel">
+                <label>
+                  Seed
+                  <input
+                    onChange={(event) => setSeed(event.target.value)}
+                    placeholder="Random"
+                    type="number"
+                    value={seed}
+                  />
+                </label>
+                {/* Sample-rate readout when the model advertises more than one; a single rate is shown
+                    in the capability summary above. Capability-driven, never hardcoded. */}
+                {sampleRates.length > 1 ? (
+                  <label>
+                    Sample rate
+                    <select disabled value={String(sampleRates[0])}>
+                      {sampleRates.map((rate) => (
+                        <option key={rate} value={String(rate)}>
+                          {rate} Hz
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ) : null}
+              </div>
+            </AdvancedSection>
+          </WorkPanel>
+
+          <div className="studio-results">
+            <section className="review-panel">
+              <div className="review-panel-head">
+                <h2>Latest audio</h2>
+                <span className="kbd-hint">
+                  <kbd>⌘</kbd>
+                  <kbd>↵</kbd>
+                  to generate
+                </span>
+              </div>
+              {/* Results zone — empty in C0. Once C1 enqueues audio jobs (via
+                  rememberLocalGenerationJob('audio', job)) they surface here through the shared
+                  audio-player card (A5 / sc-13405); nothing else in the shell changes. */}
+              {audioLocalJobs.length ? (
+                <div className="worker-progress-card-stack local-job-stack">
+                  {audioLocalJobs.map((job) => {
+                    const jobAssets = jobAudioResultAssets(job, assets);
+                    return (
+                      <WorkerProgressCard
+                        key={job.id}
+                        job={job}
+                        thumbnailsVariant="audio-player"
+                        thumbnailAssets={jobAssets}
+                        onThumbnailClick={(asset) => onPreview(asset, jobAssets)}
+                        onCancel={onCancelJob}
+                        onOpenQueue={onOpenQueue}
+                      />
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="empty-panel">No audio yet</div>
+              )}
+            </section>
+          </div>
+        </form>
+      </section>
+    </ModelAvailabilityGate>
+  );
+}

--- a/apps/web/src/screens/AudioStudio.test.jsx
+++ b/apps/web/src/screens/AudioStudio.test.jsx
@@ -1,0 +1,247 @@
+import React, { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { click, mountRoot, unmountRoot } from "../testUtils/dom.js";
+
+vi.mock("../api.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    apiFetch: vi.fn(async () => ({})),
+  };
+});
+
+import { AppContext } from "../context/AppContext.js";
+import { AudioStudio } from "./AudioStudio.jsx";
+import { KEEP_ALIVE_VIEWS, navSections, viewTitles } from "../App.jsx";
+
+// Fixture audio models mirroring the seeded `type:"audio"` catalog entries (constants.js). Each
+// carries only the `audio` sub-block the eligibility predicates + UI read — voices (speech),
+// languages, maxDurationSecs, sampleRates, editModes (music), conditioning (voiceclone).
+const KOKORO = {
+  id: "kokoro_82m",
+  name: "Kokoro 82M (Speech)",
+  type: "audio",
+  recommended: true,
+  audio: {
+    voices: [
+      { id: "af_heart", label: "Heart" },
+      { id: "am_michael", label: "Michael" },
+      { id: "bf_emma", label: "Emma" },
+    ],
+    languages: ["en-US", "en-GB"],
+    sampleRates: [24000],
+    maxDurationSecs: 30,
+  },
+  ui: { label: "Kokoro 82M" },
+};
+
+const MOSS = {
+  id: "moss_sfx_v2",
+  name: "MOSS SoundEffect v2 (SFX)",
+  type: "audio",
+  audio: { languages: ["en", "zh"], sampleRates: [48000], maxDurationSecs: 30 },
+  ui: { label: "MOSS SoundEffect v2" },
+};
+
+const ACESTEP = {
+  id: "acestep_v15_turbo",
+  name: "ACE-Step v1.5 XL Turbo (Music)",
+  type: "audio",
+  audio: {
+    languages: ["en", "zh"],
+    sampleRates: [48000],
+    maxDurationSecs: 600,
+    editModes: ["inpaint", "repaint", "extend"],
+    conditioning: ["AudioEdit"],
+  },
+  ui: { label: "ACE-Step v1.5 XL Turbo" },
+};
+
+const OPENVOICE = {
+  id: "openvoice_v2",
+  name: "OpenVoice V2 (Voice Conversion)",
+  type: "audio",
+  audio: { sampleRates: [22050], conditioning: ["ReferenceAudio"] },
+  ui: { label: "OpenVoice V2" },
+};
+
+const ALL_AUDIO = [KOKORO, MOSS, ACESTEP, OPENVOICE];
+
+function baseContext(overrides = {}) {
+  return {
+    token: "test-token",
+    activeProject: { id: "project_1", name: "My Project" },
+    assets: [],
+    audioModels: ALL_AUDIO,
+    models: ALL_AUDIO,
+    jobs: [],
+    audioLocalJobs: [],
+    jobAction: vi.fn(),
+    createModelDownloadJob: vi.fn(),
+    setActiveView: vi.fn(),
+    setPreviewAsset: vi.fn(),
+    macCapabilities: undefined,
+    ...overrides,
+  };
+}
+
+const buttonWithText = (root, text) =>
+  [...root.querySelectorAll("button")].find((b) => b.textContent.trim() === text);
+const modeTabs = (container) => container.querySelector(".mode-control");
+const modeTab = (container, label) => buttonWithText(modeTabs(container), label);
+const modelSelect = (container) => container.querySelector(".settings-field-model select");
+const fieldByLabelStart = (container, label) =>
+  [...container.querySelectorAll(".settings-bar label")].find((el) =>
+    el.textContent.trim().startsWith(label),
+  );
+
+describe("AudioStudio shell (sc-13407)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <AudioStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  it("renders the four mode tabs in AUDIO_MODES order", async () => {
+    await render(baseContext());
+    const labels = [...modeTabs(container).querySelectorAll(".mode-tab")].map((b) => b.textContent.trim());
+    expect(labels).toEqual(["Speech", "Sound FX", "Music", "Voice Clone"]);
+  });
+
+  it("shows an initially empty results zone", async () => {
+    await render(baseContext());
+    const results = container.querySelector(".studio-results");
+    expect(results).toBeTruthy();
+    expect(results.textContent).toContain("No audio yet");
+    // No job cards until generation is wired (C1).
+    expect(results.querySelector(".worker-progress-card")).toBeNull();
+  });
+
+  it("switches the active tab on click and snaps the model to one that serves it", async () => {
+    await render(baseContext());
+
+    // Opens on Speech (AUDIO_MODES[0]) — served by Kokoro.
+    expect(modeTab(container, "Speech").className).toContain("active");
+    expect(modelSelect(container).value).toBe("kokoro_82m");
+
+    // Music is served only by ACE-Step, so switching snaps the model.
+    await click(modeTab(container, "Music"));
+    expect(modeTab(container, "Music").className).toContain("active");
+    expect(modelSelect(container).value).toBe("acestep_v15_turbo");
+  });
+
+  it("drives the Speech settings from the selected model's audio Capabilities, not a hardcoded list", async () => {
+    await render(baseContext());
+
+    // Voice options come straight from KOKORO.audio.voices.
+    const voiceSelect = fieldByLabelStart(container, "Voice").querySelector("select");
+    expect([...voiceSelect.options].map((o) => o.value)).toEqual(["af_heart", "am_michael", "bf_emma"]);
+
+    // Language options come from KOKORO.audio.languages.
+    const langSelect = fieldByLabelStart(container, "Language").querySelector("select");
+    expect([...langSelect.options].map((o) => o.value)).toEqual(["en-US", "en-GB"]);
+
+    // Length is capped to KOKORO.audio.maxDurationSecs (30), never a hardcoded ceiling.
+    const lengthInput = fieldByLabelStart(container, "Length").querySelector("input");
+    expect(lengthInput.getAttribute("max")).toBe("30");
+  });
+
+  it("reflects a DIFFERENT model's capabilities — proving the fields aren't hardcoded", async () => {
+    // A speech model whose voice bank + languages + cap differ from Kokoro's.
+    const altSpeech = {
+      id: "alt_speech",
+      name: "Alt Speech",
+      type: "audio",
+      audio: {
+        voices: [{ id: "nova", label: "Nova" }],
+        languages: ["fr-FR"],
+        sampleRates: [16000],
+        maxDurationSecs: 12,
+      },
+      ui: { label: "Alt Speech" },
+    };
+    await render(baseContext({ audioModels: [altSpeech], models: [altSpeech] }));
+
+    const voiceSelect = fieldByLabelStart(container, "Voice").querySelector("select");
+    expect([...voiceSelect.options].map((o) => o.value)).toEqual(["nova"]);
+    const langSelect = fieldByLabelStart(container, "Language").querySelector("select");
+    expect([...langSelect.options].map((o) => o.value)).toEqual(["fr-FR"]);
+    expect(fieldByLabelStart(container, "Length").querySelector("input").getAttribute("max")).toBe("12");
+  });
+
+  it("surfaces the Music edit ops from audio.editModes as a capability-driven scaffold", async () => {
+    await render(baseContext());
+    await click(modeTab(container, "Music"));
+
+    const editChips = [...container.querySelectorAll(".settings-bar-styles .preset-chip")].map((b) =>
+      b.textContent.trim(),
+    );
+    expect(editChips).toEqual(["inpaint", "repaint", "extend"]);
+    // Music has no voice bank, so the Speech-only voice field is absent.
+    expect(fieldByLabelStart(container, "Voice")).toBeFalsy();
+  });
+
+  it("surfaces the Voice Clone conditioning scaffold from audio.conditioning", async () => {
+    await render(baseContext());
+    await click(modeTab(container, "Voice Clone"));
+
+    // Snaps to a conditioning model (OpenVoice), and shows the reference-voice scaffold copy.
+    expect(modelSelect(container).value).toBe("openvoice_v2");
+    expect(container.textContent).toContain("ReferenceAudio");
+  });
+
+  it("renders the studio body when an audio model is installed (gate open)", async () => {
+    await render(baseContext());
+    expect(container.querySelector(".audio-studio")).toBeTruthy();
+    expect(container.querySelector(".model-availability-gate")).toBeNull();
+  });
+
+  it("renders the ModelAvailabilityGate when no audio model is installed", async () => {
+    // audioModels empty models the "catalog loaded, nothing installed" state (App.jsx fallback only
+    // applies when the whole catalog is empty). The offers come from the full `models` catalog.
+    await render(baseContext({ audioModels: [], models: ALL_AUDIO }));
+    expect(container.querySelector(".model-availability-gate")).toBeTruthy();
+    expect(container.querySelector(".audio-studio")).toBeNull();
+    expect(container.textContent).toContain("Audio Studio needs an audio model");
+  });
+});
+
+describe("Audio nav registration (sc-13407)", () => {
+  it("registers Audio in KEEP_ALIVE_VIEWS", () => {
+    expect(KEEP_ALIVE_VIEWS.has("Audio")).toBe(true);
+  });
+
+  it("registers an Audio view title + blurb", () => {
+    expect(viewTitles.Audio).toBeTruthy();
+    expect(viewTitles.Audio.title).toBe("Audio Studio");
+    expect(typeof viewTitles.Audio.blurb).toBe("string");
+    expect(viewTitles.Audio.blurb.length).toBeGreaterThan(0);
+  });
+
+  it("registers Audio in the Workspace nav section with an icon", () => {
+    const workspace = navSections.find((section) => section.label === "Workspace");
+    expect(workspace).toBeTruthy();
+    const audioItem = workspace.items.find((item) => item.id === "Audio");
+    expect(audioItem).toBeTruthy();
+    expect(audioItem.icon).toBeTruthy();
+  });
+});

--- a/apps/web/src/screens/AudioStudio.test.jsx
+++ b/apps/web/src/screens/AudioStudio.test.jsx
@@ -124,7 +124,7 @@ describe("AudioStudio shell (sc-13407)", () => {
   it("renders the four mode tabs in AUDIO_MODES order", async () => {
     await render(baseContext());
     const labels = [...modeTabs(container).querySelectorAll(".mode-tab")].map((b) => b.textContent.trim());
-    expect(labels).toEqual(["Speech", "Sound FX", "Music", "Voice Clone"]);
+    expect(labels).toEqual(["Speech", "Music", "Sound FX", "Voice Clone"]);
   });
 
   it("shows an initially empty results zone", async () => {


### PR DESCRIPTION
## Summary

[C0] of epic 13400 — scaffold the **SceneWorks Audio Studio** as a navigable shell on the canonical studio frame (faithful mirror of `VideoStudio.jsx`). This is the FOUNDATION the mode stories (C1 Speech, C2 Sound FX, C3 Music, C4 Voice Clone) build on. No real generation is wired here — see *Left for C1*.

## The screen shell (`apps/web/src/screens/AudioStudio.jsx`)

- `page-frame` > `WorkPanel` (`studio-work-panel`) + `.mode-tabs` **[Speech / Sound FX / Music / Voice Clone]** (order from `AUDIO_MODES`, labels per the epic) + `AdvancedSection` + an **empty** `.studio-results` zone ("No audio yet").
- Wrapped in `ModelAvailabilityGate` — shows the download offer (recommended-first) when no audio model is installed.
- Model selector over `audioModels`, gated to models that serve the active mode (`audioModelServesMode`), snapping the model on a mode switch — same pattern as Video.

## Capability-driven (never hardcoded)

Every settings/advanced field reads the **selected model's `audio` sub-block**:
- **Speech** — `audio.voices[]` → Voice picker, `audio.languages[]` → Language, `audio.maxDurationSecs` → Length cap (the full triad C1 builds on).
- **Music** — `audio.editModes[]` → inpaint/repaint/extend chips (scaffold).
- **Voice Clone** — `audio.conditioning[]` → reference-voice scaffold note.
- **Sound FX** — residual generator (length + language).
- A capability summary line (`sampleRates` + `maxDurationSecs`, e.g. "24 kHz · up to 30s") renders from the model's block.

A model-change effect clamps voice/language/edit-mode/length to what the new model advertises. Per-workspace stickiness via `loadStudioSettings('audio', projectId)` + `useStudioSettingsWriter` (suppressed until the catalog loads).

## Nav registration (`apps/web/src/App.jsx`)

- `viewTitles.Audio` (title + blurb)
- `KEEP_ALIVE_VIEWS` — added `"Audio"`
- `navSections` — Workspace section, between Video and Characters
- Render switch — `KeepAlivePane active={activeView === "Audio"}` with `<AudioStudio key={activeProject?.id}>`
- `Icon.Audio` (waveform glyph) in `components/Icons.jsx`
- Exported `navSections` / `viewTitles` so registration is unit-testable (mirrors the existing `KEEP_ALIVE_VIEWS` export).
- Added the `audio_generate` `JOB_TYPE_CHIP` + `deriveJobTitle` entry in `WorkerProgressCard.jsx` (fallback-title gap flagged in A5).

## Left for C1 (Speech, sc-13408)

The Generate CTA renders but its `onSubmit` is a documented no-op. Wiring **Generate → `createAudioJob` → `rememberLocalGenerationJob('audio', job)` → the `audioLocalJobs` results stack** (already rendered here via the shared audio-player card from A5) is C1's job. The results zone is present and forward-compatible: it surfaces jobs the moment C1 enqueues them, with no shell change.

## Tests

- `apps/web/src/screens/AudioStudio.test.jsx` — **12 tests**: four tabs in order; empty results zone; tab switch + model snap; Speech voice/language/length driven from a fixture's `audio` block (plus a **distinct-model fixture** proving the fields aren't hardcoded); Music `editModes` chips; Voice Clone conditioning scaffold; gate renders with no model and not with one; nav registration asserts on `KEEP_ALIVE_VIEWS` / `viewTitles` / `navSections`.
- Full web suite green: **152 files / 2139 tests**. `npm run web:build` green. Touched-file lint clean (0 errors).

## Light/dark verification

CI is down (expired runner certs); local is the gate. The full app's access gate needs the rust-api backend (unavailable here), so I verified the real component + real global CSS + real `navSections`/`Icon.Audio` nav strip in a real browser via a throwaway Vite harness (since removed), in **both themes and both gate states**:
- **Light** — studio shell (Speech: Kokoro voices/language/length + "24 kHz · up to 30s"); switching to **Music** snaps the model to ACE-Step, drops the Voice field, and shows the inpaint/repaint/extend edit chips + "48 kHz · up to 600s"; and the **gate**.
- **Dark** — studio shell (Music) and the **gate** — all surfaces/text/accents themed correctly.

Icon.Audio (waveform) shows in the Workspace nav next to "Audio Studio" (active), between Video and Characters.

Story: [sc-13407]
https://app.shortcut.com/trefry/story/13407

🤖 Generated with [Claude Code](https://claude.com/claude-code)