### PR TITLE
feat(audio): Sound FX mode — real MOSS-SFX v2 generation end-to-end [sc-13409]

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -875,13 +875,18 @@ pub(crate) struct VideoJobRequest {
     pub(crate) advanced: JsonObject,
 }
 
-/// A `POST /api/v1/audio/jobs` request (SceneWorks Audio Studio, epic 13400 / sc-13404). The audio
-/// analogue of [`VideoJobRequest`]: `prompt` is the script text, and the typed audio knobs (`voice`
-/// / `language` / `targetDurationSecs`) map to the worker-side [`gen_core::AudioParams`] sub-block a
-/// `Modality::Audio` generator reads. Every audio knob is optional — an omitted voice/language
-/// falls back to the model's default (Kokoro's `af_heart`, `en`), and an omitted duration lets the
-/// model synthesize its natural length. `Serialize` too so the whole request round-trips into the
-/// job payload the worker claims (mirroring how the video request is `to_json_object`'d).
+/// A `POST /api/v1/audio/jobs` request (SceneWorks Audio Studio, epic 13400 / sc-13404 + sc-13409).
+/// The audio analogue of [`VideoJobRequest`]: `prompt` is the script/sound description, and the typed
+/// audio knobs (`voice` / `language` / `targetDurationSecs`) map to the worker-side
+/// [`gen_core::AudioParams`] sub-block a `Modality::Audio` generator reads. Diffusion-audio models
+/// (MOSS-SoundEffect, the Sound FX mode) additionally read the sampling knobs `guidance` (CFG scale)
+/// and `steps` off the *top-level* [`gen_core::GenerationRequest`] — not `AudioParams` — so those two
+/// are carried here and mapped onto the request by the worker (sc-13409). Every audio knob is optional
+/// — an omitted voice/language falls back to the model's default (Kokoro's `af_heart`, `en`), an
+/// omitted duration lets the model synthesize its natural length, and an omitted guidance/steps lets
+/// the model use its own sampler default (MOSS: CFG 4.0 / 100 steps). `Serialize` too so the whole
+/// request round-trips into the job payload the worker claims (mirroring how the video request is
+/// `to_json_object`'d).
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct AudioJobRequest {
@@ -904,6 +909,18 @@ pub(crate) struct AudioJobRequest {
     /// the model's advertised `audio.maxDurationSecs` by the worker.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) target_duration_secs: Option<f32>,
+    /// CFG guidance scale for diffusion-audio models (Sound FX / MOSS-SoundEffect). Rides the
+    /// top-level [`gen_core::GenerationRequest::guidance`] the worker builds. `None` ⇒ the model's
+    /// default (MOSS: 4.0). Bounded to a blanket sane range here; the model's advertised guidance
+    /// range is the real gate the generator's `validate` applies (sc-13409).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) guidance: Option<f32>,
+    /// Solver step count for diffusion-audio models (Sound FX / MOSS-SoundEffect). Rides the
+    /// top-level [`gen_core::GenerationRequest::steps`]. `None` ⇒ the model's default (MOSS: 100).
+    /// Bounded to a blanket sane ceiling here; the model's advertised step ceiling is the real gate
+    /// the generator's `validate` applies (sc-13409).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) steps: Option<u32>,
     #[serde(default)]
     pub(crate) seed: Option<i64>,
     #[serde(default = "default_requested_gpu")]

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -2821,6 +2821,22 @@ fn validate_audio_job(payload: &AudioJobRequest) -> Result<(), ApiError> {
             ));
         }
     }
+    // Diffusion-audio sampling knobs (Sound FX / MOSS-SoundEffect, sc-13409). Bounded to a blanket
+    // sane range here — the same "API blanket vs. model's real cap" split the duration uses: the
+    // generator's `validate` owns the per-model guidance range (MOSS: 1.0..=20.0) and step ceiling
+    // (MOSS: 1000), so this only rejects nonsense (NaN / non-positive / absurdly large) up front.
+    if let Some(guidance) = payload.guidance {
+        if !guidance.is_finite() || !(0.0..=100.0).contains(&guidance) {
+            return Err(ApiError::bad_request(
+                "guidance (CFG scale) must be between 0 and 100",
+            ));
+        }
+    }
+    if let Some(steps) = payload.steps {
+        if !(1..=10_000).contains(&steps) {
+            return Err(ApiError::bad_request("steps must be between 1 and 10000"));
+        }
+    }
     Ok(())
 }
 

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -270,6 +270,22 @@ fn write_audio_manifest(config_dir: &std::path::Path) {
               "ui": { "label": "Kokoro 82M" }
             },
             {
+              "id": "moss_sfx_v2",
+              "name": "MOSS SoundEffect v2 (SFX)",
+              "family": "moss_soundeffect",
+              "type": "audio",
+              "audio": {
+                "languages": ["en", "zh"],
+                "sampleRates": [48000],
+                "maxDurationSecs": 30
+              },
+              "downloads": [
+                { "provider": "huggingface", "repo": "OpenMOSS-Team/MOSS-SoundEffect-v2.0", "files": ["model_index.json"] }
+              ],
+              "paths": { "model": "${HF_CACHE}/OpenMOSS-Team/MOSS-SoundEffect-v2.0" },
+              "ui": { "label": "MOSS SoundEffect v2" }
+            },
+            {
               "id": "not-audio-img",
               "name": "Not Audio",
               "family": "z_image",
@@ -344,6 +360,99 @@ async fn create_audio_job_maps_request_to_audio_generate_payload() {
     assert_eq!(entry["downloads"][0]["repo"], "hexgrad/Kokoro-82M");
     // requestedGpu is stripped from the payload (it rides the job envelope), mirroring the video route.
     assert!(payload.get("requestedGpu").is_none());
+}
+
+/// The Sound FX path (MOSS-SoundEffect, sc-13409): a well-formed SFX `POST /api/v1/audio/jobs`
+/// carries the diffusion sampling knobs (`guidance` = CFG scale, `steps`) through to the worker
+/// payload verbatim alongside the shared audio knobs, and injects the resolved MOSS `type: audio`
+/// manifest entry — so the worker can map guidance/steps onto the top-level GenerationRequest. No
+/// voice is sent (MOSS advertises no voice surface).
+#[tokio::test]
+async fn create_audio_job_maps_sfx_sampling_knobs() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    write_audio_manifest(&temp_dir.path().join("config/manifests"));
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "SFX Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+
+    let (status, job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/audio/jobs",
+        json!({
+            "projectId": project_id,
+            "model": "moss_sfx_v2",
+            "prompt": "a heavy wooden door creaking open",
+            "language": "en",
+            "targetDurationSecs": 3.0,
+            "guidance": 6.5,
+            "steps": 60,
+            "seed": 11,
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{job}");
+    assert_eq!(job["type"], "audio_generate");
+    let payload = &job["payload"];
+    assert_eq!(payload["model"], "moss_sfx_v2");
+    assert_eq!(payload["prompt"], "a heavy wooden door creaking open");
+    assert_eq!(payload["language"], "en");
+    assert_eq!(payload["targetDurationSecs"], 3.0);
+    // The SFX sampling knobs ride through to the worker payload (which maps them onto the top-level
+    // GenerationRequest's guidance/steps — not AudioParams).
+    assert_eq!(payload["guidance"], 6.5);
+    assert_eq!(payload["steps"], 60);
+    assert_eq!(payload["seed"], 11);
+    // No voice on an SFX request; the MOSS manifest entry travels for weight resolution.
+    assert!(payload.get("voice").is_none());
+    let entry = &payload["modelManifestEntry"];
+    assert_eq!(entry["id"], "moss_sfx_v2");
+    assert_eq!(entry["type"], "audio");
+    assert_eq!(
+        entry["downloads"][0]["repo"],
+        "OpenMOSS-Team/MOSS-SoundEffect-v2.0"
+    );
+}
+
+/// The audio validator rejects out-of-blanket sampling knobs up front (sc-13409) — the API blanket
+/// (guidance 0..=100, steps 1..=10000); the per-model range (MOSS: guidance 1..=20, steps ≤1000) is
+/// the generator's own `validate` at generate time.
+#[tokio::test]
+async fn create_audio_job_rejects_nonsense_sampling_knobs() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    write_audio_manifest(&temp_dir.path().join("config/manifests"));
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "SFX Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/audio/jobs",
+        json!({
+            "projectId": project_id,
+            "model": "moss_sfx_v2",
+            "prompt": "thunder",
+            "steps": 0,
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert!(body["detail"]
+        .as_str()
+        .is_some_and(|detail| detail.contains("steps")));
 }
 
 /// The audio route is a door for `type: audio` models only: an image/video model posted here is

--- a/apps/web/src/screens/AudioStudio.jsx
+++ b/apps/web/src/screens/AudioStudio.jsx
@@ -25,12 +25,15 @@ import { jobAudioResultAssets } from "../jobResultAssets.js";
 // mode (Speech = ships a voice bank, Music = advertises edit ops, Voice Clone = reference/embedding
 // conditioning, Sound FX = residual text→audio generator).
 //
-// SCOPE (C1, sc-13408): the Speech (TTS) mode is fully wired — the Generate CTA submits the script +
-// capability-driven voice/language/length/seed through createAudioJob → rememberLocalGenerationJob(
-// 'audio', job), which surfaces the run in the audioLocalJobs stack below via the shared audio-player
-// card (A5, sc-13405). The other three modes (C2 Sound FX, C3 Music, C4 Voice Clone) keep the C0
-// scaffold: their fields render capability-driven, but submit stays inert until their own stories
-// land (the Generate CTA is disabled off the Speech tab rather than being a silent no-op).
+// SCOPE (C1 sc-13408 + C2 sc-13409): Speech (TTS) and Sound FX are both fully wired — the Generate CTA
+// submits the prompt + capability-driven knobs through createAudioJob → rememberLocalGenerationJob(
+// 'audio', job), surfacing the run in the audioLocalJobs stack below via the shared audio-player card
+// (A5, sc-13405). Speech carries voice/language/length/seed; Sound FX (MOSS-SoundEffect v2) carries the
+// prompt + length/language + the diffusion sampling knobs guidance(CFG)/steps/seed — MOSS advertises no
+// voice surface, so none is sent (the shared gen-core floor would reject an explicit voice). The
+// remaining modes (C3 Music, C4 Voice Clone) keep the C0 scaffold: their fields render capability-driven,
+// but submit stays inert until their stories land (the Generate CTA is disabled off a wired tab rather
+// than being a silent no-op).
 
 // Tab labels per the epic, keyed by the AUDIO_MODES ids so the ordering follows that array.
 const MODE_LABELS = {
@@ -51,6 +54,17 @@ const MODE_PLACEHOLDER = {
 // Modes that emit a fixed-length waveform, so a length control (clamped to the model's
 // audio.maxDurationSecs) applies. Voice Clone follows its reference clip's length.
 const DURATION_MODES = new Set(["speech", "sfx", "music"]);
+// Modes whose Generate CTA is fully wired to createAudioJob (Speech C1 sc-13408, Sound FX C2 sc-13409).
+// The remaining modes keep the C0 scaffold — their CTA stays disabled rather than a silent no-op — until
+// their own stories land, so this set is the single guard both `canGenerate` and `submit` read.
+const WIRED_MODES = new Set(["speech", "sfx"]);
+// Modes that expose the diffusion sampling knobs (CFG guidance + solver steps) in the advanced panel.
+// Sound FX runs the MOSS-SoundEffect flow-matching pipeline, which reads guidance/steps off the
+// top-level request; Speech (Kokoro) is not a diffusion model and ignores them, so it hides them. This
+// is mode-gated rather than manifest-gated because MOSS is the sole SFX model and the `audio` sub-block
+// carries no per-knob range to drive it — a future non-diffusion SFX model would move this to a
+// capability flag (mirrors how showVoice/showEditModes gate on their mode + a capability array).
+const SAMPLING_KNOB_MODES = new Set(["sfx"]);
 // Fallback target length before the model's cap is known; always clamped to maxDurationSecs.
 const DEFAULT_TARGET_DURATION_SECS = 10;
 
@@ -127,6 +141,10 @@ export function AudioStudio() {
     saved.targetDurationSecs ?? DEFAULT_TARGET_DURATION_SECS,
   );
   const [seed, setSeed] = useState(saved.seed ?? "");
+  // Sound FX (MOSS-SoundEffect) diffusion sampling knobs — the CFG guidance scale and the solver step
+  // count. Empty ⇒ the model's own default (MOSS: CFG 4.0 / 100 steps), matching the advanced hint.
+  const [guidance, setGuidance] = useState(saved.guidance ?? "");
+  const [steps, setSteps] = useState(saved.steps ?? "");
   const [advancedOpen, setAdvancedOpen] = useState(saved.advancedOpen ?? false);
   // Guards a Speech run in flight so a second submit (double-click / ⌘↵) can't double-enqueue
   // (mirrors VideoStudio's `submitting`). Cleared in submit's finally.
@@ -169,15 +187,21 @@ export function AudioStudio() {
   const showDuration = DURATION_MODES.has(mode) && maxDurationSecs != null;
   const showEditModes = mode === "music" && editModes.length > 0;
   const showConditioning = mode === "voiceclone" && conditioning.length > 0;
+  // The CFG guidance + steps advanced knobs surface only on the diffusion-audio (Sound FX) modes the
+  // selected model actually runs through a sampler — the model's `supports_guidance` surface. See
+  // SAMPLING_KNOB_MODES for why this is mode-gated today.
+  const showSamplingKnobs = SAMPLING_KNOB_MODES.has(mode);
 
   // The voice picker's <optgroup> structure — derived from the selected model's voice bank, grouped
   // by accent + gender (sc-13408). Rebuilt only when the bank changes.
   const voiceGroups = useMemo(() => groupVoicesByGenderAccent(voices), [voices]);
 
-  // Generate is guarded (never a silent no-op): a run needs a non-empty script, an installed model,
-  // and no run already in flight. The empty-script guard is the DoD's "disable on empty script".
-  const scriptReady = prompt.trim().length > 0;
-  const canGenerate = mode === "speech" && modelReady && Boolean(model) && scriptReady && !submitting;
+  // Generate is guarded (never a silent no-op): a run needs a wired mode, a non-empty prompt, an
+  // installed model, and no run already in flight. The empty-prompt guard is the DoD's "disable on
+  // empty prompt"; the WIRED_MODES gate keeps the still-scaffold tabs (Music / Voice Clone) inert.
+  const promptReady = prompt.trim().length > 0;
+  const canGenerate =
+    WIRED_MODES.has(mode) && modelReady && Boolean(model) && promptReady && !submitting;
 
   // Snap the model to one that serves the active mode (mirrors VideoStudio). A no-op when the current
   // model already serves the mode, or when nothing serves it (a reduced catalog).
@@ -232,6 +256,8 @@ export function AudioStudio() {
       editMode,
       targetDurationSecs,
       seed,
+      guidance,
+      steps,
       advancedOpen,
     },
     audioModels.length > 0,
@@ -257,10 +283,10 @@ export function AudioStudio() {
     if (submitting) {
       return;
     }
-    // C1 (Speech, sc-13408) wires Speech only. The mode-specific stories after it (C2 Sound FX,
-    // C3 Music, C4 Voice Clone) extend this per mode — until they land those tabs keep the C0
-    // scaffold, so their submit is intentionally inert.
-    if (mode !== "speech" || !canGenerate) {
+    // Only the wired modes submit (Speech C1 sc-13408, Sound FX C2 sc-13409); Music / Voice Clone
+    // keep the C0 scaffold, so their submit is intentionally inert. `canGenerate` also covers the
+    // empty-prompt / no-model / in-flight guards, so a direct form submit can never slip past them.
+    if (!canGenerate) {
       return;
     }
     setSubmitting(true);
@@ -275,17 +301,27 @@ export function AudioStudio() {
           : undefined;
       // The audio route deserializes `model` (not `modelId`) and reads the typed knobs verbatim
       // (apps/rust-api/src/dto.rs AudioJobRequest → crates/sceneworks-worker/src/audio_jobs.rs). The
-      // language-casing seam (en-US → en-us) is handled server-side. Voice/language are omitted when
-      // unset so the model falls back to its own default (Kokoro's af_heart / en). Mirrors how
-      // VideoStudio builds createVideoJob's payload from its settings.
-      const job = await createAudioJob?.({
+      // language-casing seam (en-US → en-us) is handled server-side. Language is omitted when unset so
+      // the model derives its own default. Mirrors how VideoStudio builds createVideoJob's payload.
+      const payload = {
         model,
         prompt: prompt.trim(),
-        voice: voice || undefined,
         language: language || undefined,
         targetDurationSecs: clampedDuration,
         seed: seed === "" ? null : Number(seed),
-      });
+      };
+      if (mode === "speech") {
+        // Speech (Kokoro) ships a voice bank; omitted when unset so the model falls back to af_heart.
+        payload.voice = voice || undefined;
+      } else if (mode === "sfx") {
+        // Sound FX (MOSS-SoundEffect) — the CFG guidance scale + solver steps ride the top-level
+        // request the diffusion pipeline reads. Cleared ⇒ omitted so the model uses its own default
+        // (CFG 4.0 / 100 steps); the shared gen-core floor range-checks any value we do send. No
+        // `voice` is sent — MOSS advertises no voice surface and the floor rejects one.
+        payload.guidance = guidance === "" ? undefined : Number(guidance);
+        payload.steps = steps === "" ? undefined : Number(steps);
+      }
+      const job = await createAudioJob?.(payload);
       if (job) {
         // Land the run in the audio local-job lane so it stacks in .studio-results via the shared
         // audio-player card (A5 / sc-13405) — the audio twin of rememberLocalGenerationJob('video').
@@ -483,6 +519,36 @@ export function AudioStudio() {
                     value={seed}
                   />
                 </label>
+                {/* Sound FX diffusion sampling knobs (MOSS-SoundEffect). Guidance is the CFG scale and
+                    Steps is the solver step count — both ride the top-level request the flow-matching
+                    pipeline reads. Cleared ⇒ the model's own default; the gen-core floor range-checks
+                    any value sent, so no hardcoded ceiling is baked into the input. */}
+                {showSamplingKnobs ? (
+                  <label>
+                    Guidance (CFG)
+                    <input
+                      min="1"
+                      onChange={(event) => setGuidance(event.target.value)}
+                      placeholder="Model default"
+                      step="0.5"
+                      type="number"
+                      value={guidance}
+                    />
+                  </label>
+                ) : null}
+                {showSamplingKnobs ? (
+                  <label>
+                    Steps
+                    <input
+                      min="1"
+                      onChange={(event) => setSteps(event.target.value)}
+                      placeholder="Model default"
+                      step="1"
+                      type="number"
+                      value={steps}
+                    />
+                  </label>
+                ) : null}
                 {/* Sample rate the model emits at (audio.sampleRates). Capability-driven, never
                     hardcoded — and read-only: the output rate is a fixed property of the model's
                     vocoder (Kokoro is 24 kHz mono), not a request knob the audio route accepts, so it

--- a/apps/web/src/screens/AudioStudio.test.jsx
+++ b/apps/web/src/screens/AudioStudio.test.jsx
@@ -438,15 +438,16 @@ describe("AudioStudio Speech generation (sc-13408)", () => {
     expect(results.textContent).not.toContain("No audio yet");
   });
 
-  it("does not submit on a non-Speech tab (SFX/Music/Voice Clone stay scaffold)", async () => {
+  it("does not submit on a still-scaffold tab (Music / Voice Clone stay inert)", async () => {
     const createAudioJob = vi.fn(async () => ({ id: "nope" }));
     await render(
       baseContext({ createAudioJob, rememberLocalGenerationJob: vi.fn() }),
     );
-    // Music is served only by ACE-Step in the base fixture; switch to it, type a script.
+    // Music is served only by ACE-Step in the base fixture; switch to it, type a script. (Speech and
+    // Sound FX are wired — C1/C2 — so Music/Voice Clone are the remaining scaffold tabs.)
     await click(modeTab(container, "Music"));
     await setTextarea(container.querySelector(".prompt-input"), "some music");
-    // The CTA is disabled off the Speech tab, and a direct form submit is a no-op there.
+    // The CTA is disabled off a wired tab, and a direct form submit is a no-op there.
     expect(generateButton(container).disabled).toBe(true);
     await act(async () => {
       container
@@ -454,6 +455,162 @@ describe("AudioStudio Speech generation (sc-13408)", () => {
         .dispatchEvent(new window.Event("submit", { bubbles: true, cancelable: true }));
     });
     expect(createAudioJob).not.toHaveBeenCalled();
+  });
+});
+
+describe("AudioStudio Sound FX generation (sc-13409)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <AudioStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  const generateButton = (root) => buttonWithText(root, "Generate");
+  const advancedFieldByLabel = (root, label) =>
+    [...root.querySelectorAll(".advanced-panel label")].find((el) =>
+      el.textContent.trim().startsWith(label),
+    );
+  const setTextarea = async (el, value) => {
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype,
+        "value",
+      ).set;
+      setter.call(el, value);
+      el.dispatchEvent(new window.Event("input", { bubbles: true }));
+    });
+  };
+  const setSelect = async (el, value) => {
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLSelectElement.prototype,
+        "value",
+      ).set;
+      setter.call(el, value);
+      el.dispatchEvent(new window.Event("change", { bubbles: true }));
+    });
+  };
+  const setNumber = async (el, value) => {
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      ).set;
+      setter.call(el, value);
+      el.dispatchEvent(new window.Event("input", { bubbles: true }));
+    });
+  };
+  const submitForm = async () => {
+    await act(async () => {
+      container
+        .querySelector("form")
+        .dispatchEvent(new window.Event("submit", { bubbles: true, cancelable: true }));
+    });
+  };
+
+  it("Generate is disabled on an empty SFX prompt and enabled once a description is typed", async () => {
+    await render(baseContext({ createAudioJob: vi.fn(), rememberLocalGenerationJob: vi.fn() }));
+    // Switch to Sound FX — the base fixture snaps the model to MOSS (the sole SFX model).
+    await click(modeTab(container, "Sound FX"));
+    expect(modelSelect(container).value).toBe("moss_sfx_v2");
+
+    // Empty default prompt → the guard disables the CTA (never a silent no-op).
+    expect(generateButton(container).disabled).toBe(true);
+    await setTextarea(container.querySelector(".prompt-input"), "a heavy wooden door creaking open");
+    expect(generateButton(container).disabled).toBe(false);
+  });
+
+  it("surfaces the CFG guidance + steps sampling knobs only on the Sound FX tab, not on Speech", async () => {
+    await render(baseContext({ createAudioJob: vi.fn() }));
+    // Speech (Kokoro) is not a diffusion model — no guidance/steps knobs.
+    await click(container.querySelector(".advanced-section-toggle"));
+    expect(advancedFieldByLabel(container, "Guidance")).toBeFalsy();
+    expect(advancedFieldByLabel(container, "Steps")).toBeFalsy();
+
+    // Sound FX (MOSS) exposes both — the diffusion sampling surface.
+    await click(modeTab(container, "Sound FX"));
+    expect(advancedFieldByLabel(container, "Guidance")).toBeTruthy();
+    expect(advancedFieldByLabel(container, "Steps")).toBeTruthy();
+    // MOSS ships no voice bank, so the Speech-only voice field never appears on SFX.
+    expect(fieldByLabelStart(container, "Voice")).toBeFalsy();
+  });
+
+  it("submitting the Sound FX form calls createAudioJob with the SFX-derived payload, then remembers the job", async () => {
+    const job = { id: "sfx-job-1", type: "audio_generate", status: "queued" };
+    const createAudioJob = vi.fn(async () => job);
+    const rememberLocalGenerationJob = vi.fn();
+    await render(baseContext({ createAudioJob, rememberLocalGenerationJob }));
+
+    await click(modeTab(container, "Sound FX"));
+    await setTextarea(container.querySelector(".prompt-input"), "a heavy wooden door creaking open");
+    // Non-default values so the assertions discriminate (a hardcoded payload would not follow them).
+    await setSelect(fieldByLabelStart(container, "Language").querySelector("select"), "zh");
+    await setNumber(fieldByLabelStart(container, "Length").querySelector("input"), "4");
+    await click(container.querySelector(".advanced-section-toggle"));
+    await setNumber(advancedFieldByLabel(container, "Seed").querySelector("input"), "11");
+    await setNumber(advancedFieldByLabel(container, "Guidance").querySelector("input"), "6.5");
+    await setNumber(advancedFieldByLabel(container, "Steps").querySelector("input"), "60");
+
+    await submitForm();
+
+    expect(createAudioJob).toHaveBeenCalledTimes(1);
+    const payload = createAudioJob.mock.calls[0][0];
+    expect(payload.model).toBe("moss_sfx_v2");
+    expect(payload.prompt).toBe("a heavy wooden door creaking open");
+    expect(payload.language).toBe("zh");
+    expect(payload.targetDurationSecs).toBe(4);
+    expect(payload.guidance).toBe(6.5);
+    expect(payload.steps).toBe(60);
+    expect(payload.seed).toBe(11);
+    // MOSS advertises no voice surface, so the SFX payload never carries one.
+    expect(payload.voice).toBeUndefined();
+    // The returned job lands in the audio local-job lane so it stacks in the results zone.
+    expect(rememberLocalGenerationJob).toHaveBeenCalledWith("audio", job);
+  });
+
+  it("omits guidance/steps when cleared so the model falls back to its own sampler default", async () => {
+    const createAudioJob = vi.fn(async () => ({ id: "sfx-job-default" }));
+    await render(baseContext({ createAudioJob, rememberLocalGenerationJob: vi.fn() }));
+
+    await click(modeTab(container, "Sound FX"));
+    await setTextarea(container.querySelector(".prompt-input"), "gentle rain on a tin roof");
+    // Leave guidance/steps untouched (empty) — they must not be sent.
+    await submitForm();
+
+    const payload = createAudioJob.mock.calls[0][0];
+    expect(payload.model).toBe("moss_sfx_v2");
+    expect(payload.guidance).toBeUndefined();
+    expect(payload.steps).toBeUndefined();
+  });
+
+  it("clamps the requested SFX length to the model's advertised cap", async () => {
+    const createAudioJob = vi.fn(async () => ({ id: "sfx-clamp" }));
+    await render(baseContext({ createAudioJob, rememberLocalGenerationJob: vi.fn() }));
+    await click(modeTab(container, "Sound FX"));
+    await setTextarea(container.querySelector(".prompt-input"), "over the cap");
+    await setNumber(fieldByLabelStart(container, "Length").querySelector("input"), "999");
+    await submitForm();
+    // MOSS advertises maxDurationSecs 30 — the submit clamps to it, never a hardcoded ceiling.
+    expect(createAudioJob.mock.calls[0][0].targetDurationSecs).toBe(30);
   });
 });
 

--- a/crates/sceneworks-worker/src/audio_jobs.rs
+++ b/crates/sceneworks-worker/src/audio_jobs.rs
@@ -38,6 +38,13 @@ struct AudioRequest {
     voice: Option<String>,
     language: Option<String>,
     target_duration_secs: Option<f32>,
+    /// CFG guidance scale for diffusion-audio models (Sound FX / MOSS-SoundEffect). Rides the
+    /// top-level `GenerationRequest::guidance` — NOT `AudioParams` (sc-13409). `None` ⇒ the model's
+    /// sampler default.
+    guidance: Option<f32>,
+    /// Solver step count for diffusion-audio models. Rides the top-level `GenerationRequest::steps`.
+    /// `None` ⇒ the model's sampler default.
+    steps: Option<u32>,
     seed: Option<i64>,
     model_manifest_entry: Value,
 }
@@ -66,6 +73,14 @@ impl AudioRequest {
                 .get("targetDurationSecs")
                 .and_then(Value::as_f64)
                 .map(|value| value as f32),
+            guidance: payload
+                .get("guidance")
+                .and_then(Value::as_f64)
+                .map(|value| value as f32),
+            steps: payload
+                .get("steps")
+                .and_then(Value::as_u64)
+                .map(|value| value as u32),
             seed: payload.get("seed").and_then(Value::as_i64),
             model_manifest_entry: payload
                 .get("modelManifestEntry")
@@ -332,6 +347,13 @@ async fn run_audio_synthesis(
     let voice = request.voice.clone();
     let language = request.language.as_deref().map(normalize_audio_language);
     let target_duration = request.target_duration_secs;
+    // Diffusion-audio sampling knobs (Sound FX / MOSS-SoundEffect, sc-13409). These live on the
+    // top-level GenerationRequest — the flow-matching pipeline reads `req.guidance` (CFG scale) and
+    // `req.steps`, not `AudioParams`. `None` ⇒ the generator's own sampler default; the shared
+    // gen-core floor range-checks any value we pass. A TTS model (Kokoro) ignores them entirely, so
+    // Speech jobs — which never carry them — are unaffected.
+    let guidance = request.guidance;
+    let steps = request.steps;
     let seed = request.seed.map(|seed| seed as u64);
     let handle = tokio::task::spawn_blocking(move || -> WorkerResult<gen_core::AudioTrack> {
         let spec = LoadSpec::new(WeightsSource::Dir(model_dir));
@@ -340,6 +362,8 @@ async fn run_audio_synthesis(
         let req = GenerationRequest {
             prompt,
             seed,
+            steps,
+            guidance,
             audio: Some(AudioParams {
                 voice,
                 language,
@@ -441,16 +465,21 @@ fn audio_asset_fact(
         "adapter": adapter,
         "prompt": request.prompt,
         // REQUESTED knobs (the replay record). `null` for an omitted voice/language/duration — the
-        // studio falls back to the model's own defaults, exactly as the video recipe does.
+        // studio falls back to the model's own defaults, exactly as the video recipe does. `guidance`
+        // / `steps` are the Sound FX (diffusion) sampling knobs; `null` for a TTS run that carries none.
         "voice": request.voice,
         "language": request.language,
         "targetDurationSecs": request.target_duration_secs,
+        "guidance": request.guidance,
+        "steps": request.steps,
         "seed": request.seed,
         "rawAdapterSettings": {
             "model": request.model,
             "voice": request.voice,
             "language": request.language,
             "targetDurationSecs": request.target_duration_secs,
+            "guidance": request.guidance,
+            "steps": request.steps,
             "sampleRate": sample_rate,
         },
     })
@@ -549,6 +578,33 @@ mod tests {
         assert_eq!(request.target_duration_secs, Some(4.5));
         assert_eq!(request.seed, Some(7));
         assert_eq!(request.family(), "kokoro");
+        // A TTS payload carries no diffusion sampling knobs → None (the generator's own defaults).
+        assert_eq!(request.guidance, None);
+        assert_eq!(request.steps, None);
+    }
+
+    #[test]
+    fn from_payload_reads_the_sfx_sampling_knobs() {
+        // The Sound FX path (MOSS-SoundEffect, sc-13409) additionally carries guidance (CFG scale) +
+        // steps, which the worker maps onto the top-level GenerationRequest — not AudioParams.
+        let request = AudioRequest::from_payload(&payload(json!({
+            "model": "moss_sfx_v2",
+            "prompt": "a heavy wooden door creaking open",
+            "language": "en",
+            "targetDurationSecs": 3.0,
+            "guidance": 6.5,
+            "steps": 60,
+            "seed": 11,
+        })));
+        assert_eq!(request.model, "moss_sfx_v2");
+        assert_eq!(request.prompt, "a heavy wooden door creaking open");
+        assert_eq!(request.language.as_deref(), Some("en"));
+        assert_eq!(request.target_duration_secs, Some(3.0));
+        assert_eq!(request.guidance, Some(6.5));
+        assert_eq!(request.steps, Some(60));
+        assert_eq!(request.seed, Some(11));
+        // SFX carries no voice — MOSS advertises no voice surface.
+        assert_eq!(request.voice, None);
     }
 
     #[test]
@@ -607,6 +663,9 @@ mod tests {
         assert_eq!(fact["seed"], 42);
         assert_eq!(fact["model"], "kokoro_82m");
         assert_eq!(fact["adapter"], "kokoro");
+        // A TTS run carries no diffusion sampling knobs → null in the replay record.
+        assert!(fact["guidance"].is_null());
+        assert!(fact["steps"].is_null());
         assert!(fact["mediaPath"]
             .as_str()
             .is_some_and(|path| path.starts_with("assets/audios/") && path.ends_with(".wav")));
@@ -615,5 +674,28 @@ mod tests {
         assert_eq!(result["expectedCount"], 1);
         assert_eq!(result["assetWrites"].as_array().map(Vec::len), Some(1));
         assert_eq!(result["assetWrites"][0]["type"], "audio");
+    }
+
+    #[test]
+    fn sfx_asset_fact_records_the_sampling_knobs_for_replay() {
+        // A Sound FX run records its CFG guidance + steps in both the top-level replay record and
+        // rawAdapterSettings, so a re-generate round-trips the exact sampler settings (sc-13409).
+        let request = AudioRequest::from_payload(&payload(json!({
+            "model": "moss_sfx_v2",
+            "prompt": "distant rolling thunder over a field",
+            "language": "en",
+            "targetDurationSecs": 5.0,
+            "guidance": 7.0,
+            "steps": 80,
+            "seed": 99,
+        })));
+        let plan = AudioPlan::new(&request, Path::new("/tmp/project"));
+        let fact = audio_asset_fact(&plan, &request, 48_000, 1, 5.0);
+        assert_eq!(fact["sampleRate"], 48_000);
+        assert_eq!(fact["guidance"], 7.0);
+        assert_eq!(fact["steps"], 80);
+        assert!(fact["voice"].is_null(), "SFX carries no voice");
+        assert_eq!(fact["rawAdapterSettings"]["guidance"], 7.0);
+        assert_eq!(fact["rawAdapterSettings"]["steps"], 80);
     }
 }


### PR DESCRIPTION
## Summary

Wires the SceneWorks Audio Studio **Sound FX** tab to real **MOSS-SoundEffect v2** synthesis, mirroring the C1 Speech wiring (sc-13408). The Generate CTA now submits a describe-the-sound prompt + length + advanced sampling knobs through `createAudioJob` → `rememberLocalGenerationJob('audio', job)`, and the run surfaces in the results zone via the shared audio-player card. Speech behavior is unchanged.

Story: [sc-13409] · https://app.shortcut.com/trefry/story/13409

## SFX fields (capability-driven)

- **Describe-the-sound prompt** (textarea) + **Generate**.
- **Length (s)** capped at the model's `audio.maxDurationSecs` (MOSS: 30) — never a hardcoded ceiling.
- **Language** — MOSS advertises `en`/`zh`, so the capability-driven picker renders + is sent.
- **Advanced**: **Guidance (CFG)** + **Steps** (new, gated to SFX mode) plus the existing **Seed**. Cleared ⇒ the model's own default (MOSS: CFG 4.0 / 100 steps).
- **No category field** — nothing in the model/`Capabilities` advertises categories, so none is invented.
- **No voice** is sent for SFX — MOSS advertises no voice surface and the shared gen-core floor would reject one.

Guards: Generate disabled on empty prompt / no installed model / in-flight; Music & Voice Clone stay scaffold.

## Backend param extension (the design question)

`AudioParams` carried only `{voice, language, target_duration, …}` — **no cfg/steps/category**. The MOSS generator reads **`steps`** and **`guidance`** (CFG scale) off the **top-level `GenerationRequest`**, not `AudioParams` (duration still comes from `AudioParams::target_duration`). There is **no category** surface anywhere (`Capabilities` has none; the manifest has none). So the path was extended to carry the two knobs MOSS actually consumes:

- **`AudioJobRequest` DTO** (`apps/rust-api/src/dto.rs`): `+ guidance: Option<f32>`, `+ steps: Option<u32>`, with blanket sanity validation in `validate_audio_job` (`lib.rs`) — the model's real range (MOSS guidance 1..=20, steps ≤1000) is enforced by the generator's own `validate` at generate time, matching the existing "API blanket vs. model cap" split used for duration.
- **Worker** (`crates/sceneworks-worker/src/audio_jobs.rs`): `AudioRequest` reads `guidance`/`steps` and sets them on the top-level `GenerationRequest` handed to the MOSS generator; both are recorded in the asset fact + `rawAdapterSettings` for replay. **Kokoro (Speech) ignores `steps`/`guidance`**, and Speech never sends them, so Speech is unaffected.
- **`createAudioJob`** (web) already spreads the payload, so the new keys flow through with no App.jsx change.

## Tests

- **Web vitest** (`AudioStudio.test.jsx`, +5 SFX tests, 23 total green): SFX submit calls `createAudioJob` with the SFX-derived payload (discriminating non-default cfg 6.5 / steps 60 / length 4 / seed 11, `language: zh`, no `voice`) → job remembered in the audio lane; guidance/steps knobs render only on SFX, not Speech; omitted-when-cleared; length clamp to the advertised cap; disabled-on-empty-prompt. Speech tests stay green.
- **rust-api** (`tests/jobs.rs`): `create_audio_job_maps_sfx_sampling_knobs` (payload carries guidance/steps + injects the MOSS manifest entry, no voice) + `create_audio_job_rejects_nonsense_sampling_knobs`.
- **Worker** (`audio_jobs.rs`): `from_payload_reads_the_sfx_sampling_knobs`, `sfx_asset_fact_records_the_sampling_knobs_for_replay`, plus TTS-carries-none assertions.
- `npm run rust:check` (fmt + clippy -D warnings + test + build) green; `npm --prefix apps/web run test` + `npm run web:build` green.

## Real-inference proof (DoD — API level, no browser)

Started `sceneworks-rust-api` + the mlx GPU worker (which advertises `audio_generate`) against a sandboxed HOME with the real HF cache (MOSS weights present at pinned SHA `e35df4d8…`). POSTed a real MOSS job and polled to completion, then stopped both servers:

- Request: `"a heavy wooden door creaking open"`, `targetDurationSecs 2.0`, **`guidance 3.0`**, **`steps 25`**, `seed 7` → job `completed`.
- Produced WAV: **48000 Hz** mono PCM16, **2.000 s**, 96000 frames, **95998/96000 non-zero samples**, peak 32767, RMS 8505 — a real audible clip, not silence.
- Asset sidecar recorded the replay knobs: **`guidance: 3.0`, `steps: 25`**, `seed: 7`, `sampleRate: 48000`, `duration: 2.0` — proving the new plumbing reaches the generator and round-trips for replay.

(MOSS runs f32 on CPU — the audio lane ships CPU-first — so the run took ~37 min; correct, just heavy.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)